### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main", "master"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/szubster/dexhelper/security/code-scanning/2](https://github.com/szubster/dexhelper/security/code-scanning/2)

To fix this, explicitly declare a minimal `permissions` block so the `GITHUB_TOKEN` is limited according to the workflow’s needs. Since this CI workflow only checks out code and runs local Node/npm commands, it only requires read access to repository contents. The most straightforward fix is to add `permissions: contents: read` at the workflow root, applying to all jobs.

Concretely, in `.github/workflows/ci.yml`, add a `permissions:` section near the top-level (e.g., between the `on:` block and the `jobs:` block). This will restrict all jobs that don’t define their own permissions. No imports or other definitions are needed; it is a pure YAML configuration change. Existing functionality (checkout, setup-node, npm commands) will continue to work with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
