### PR TITLE
Potential fix for code scanning alert no. 3: Replacement of a substring with itself

### DIFF
--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -131,7 +131,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
 
                       const CardContent = (
                         <>
-                          <div className={`absolute -top-10 -right-10 w-32 h-32 rounded-full blur-[40px] opacity-20 group-hover:opacity-40 transition-opacity ${style.bg.replace('bg-', 'bg-')}`} />
+                          <div className={`absolute -top-10 -right-10 w-32 h-32 rounded-full blur-[40px] opacity-20 group-hover:opacity-40 transition-opacity ${style.bg}`} />
                           
                           <div className="relative z-10 flex flex-col h-full p-5 gap-4">
                             <div className="space-y-3">


### PR DESCRIPTION
Potential fix for [https://github.com/szubster/dexhelper/security/code-scanning/3](https://github.com/szubster/dexhelper/security/code-scanning/3)

In general, to fix “replacement of a substring with itself” issues, either remove the unnecessary `replace` call (if no transformation is needed) or correct the replacement string so that it performs the intended transformation. Here, the specific problematic expression is:

```tsx
${style.bg.replace('bg-', 'bg-')}
```

Since the replacement substring is identical to the search substring, this call is a no-op. There is no evidence elsewhere in the snippet that this particular background class needs to be changed; `style.bg` already appears to hold the correct Tailwind class. The safest behavior‑preserving fix is to remove the `.replace('bg-', 'bg-')` and interpolate `style.bg` directly.

The change is localized to file `src/components/AssistantPanel.tsx`, around line 134. No new imports, helper methods, or definitions are needed; we only simplify the string template for the `className` on the `div` that renders the blurred background circle.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
