### PR TITLE
🧹 Fix: Leftover console.log in ServiceWorker registration

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ import './index.css';
 if (import.meta.env.PROD && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch(err => {
-      console.log('ServiceWorker registration failed: ', err);
+      console.error('ServiceWorker registration failed: ', err);
     });
   });
 }


### PR DESCRIPTION
🎯 **What:** Replaced `console.log` with `console.error` in the ServiceWorker registration `catch` block in `src/main.tsx`.
💡 **Why:** Improving error handling consistency by using the appropriate log level for failures. This aligns with other error handling patterns in the codebase.
✅ **Verification:** Verified using `grep` that no `console.log` remains in `src/`.
✨ **Result:** Enhanced code health by ensuring registration errors are correctly categorized as errors in the browser console.

---
*PR created automatically by Jules for task [14852995704513623647](https://jules.google.com/task/14852995704513623647) started by @szubster*