### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/szubster/dexhelper/security/code-scanning/5](https://github.com/szubster/dexhelper/security/code-scanning/5)

To fix this, explicitly define restricted GITHUB_TOKEN permissions for the workflow. The jobs only need to read the repository contents (for `actions/checkout`) and do not require any write scopes, nor special scopes like `pull-requests` or `issues`. The safest and simplest fix is to add a root‑level `permissions` block granting `contents: read`, which then applies to both `e2e` and `ct` jobs.

Concretely, in `.github/workflows/playwright.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name:` declaration (before `on:`), so it applies to all jobs. No additional imports, methods, or definitions are required, and no existing steps need to change. This documents and enforces least privilege without altering the workflow’s functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
