### PR TITLE
🧪 Test getGenerationConfig fallback behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-example",
+  "name": "dexhelper",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-example",
+      "name": "dexhelper",
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.96.1",

--- a/src/utils/generationConfig.test.ts
+++ b/src/utils/generationConfig.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { getGenerationConfig, GENERATION_CONFIGS } from './generationConfig';
+
+describe('getGenerationConfig', () => {
+  it('should return the correct configuration for an existing generation (Gen 1)', () => {
+    const config = getGenerationConfig(1);
+    expect(config).toBe(GENERATION_CONFIGS[1]);
+    expect(config.id).toBe(1);
+  });
+
+  it('should return the correct configuration for an existing generation (Gen 2)', () => {
+    const config = getGenerationConfig(2);
+    expect(config).toBe(GENERATION_CONFIGS[2]);
+    expect(config.id).toBe(2);
+  });
+
+  it('should fall back to Gen 1 configuration for an unknown generation (e.g. Gen 3)', () => {
+    const config = getGenerationConfig(3);
+    // Since Gen 3 is not yet implemented/registered, it should return Gen 1 fallback.
+    expect(config).toBe(GENERATION_CONFIGS[1]);
+  });
+
+  it('should fall back to Gen 1 configuration for generation 0', () => {
+    const config = getGenerationConfig(0);
+    expect(config).toBe(GENERATION_CONFIGS[1]);
+  });
+
+  it('should fall back to Gen 1 configuration for negative generation numbers', () => {
+    const config = getGenerationConfig(-1);
+    expect(config).toBe(GENERATION_CONFIGS[1]);
+  });
+
+  it('should fall back to Gen 1 configuration for an arbitrarily large generation number', () => {
+    const config = getGenerationConfig(999);
+    expect(config).toBe(GENERATION_CONFIGS[1]);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added tests to cover `getGenerationConfig` in `src/utils/generationConfig.ts` to ensure the correct behavior of the fallback to Gen 1 configuration for unknown or missing generation IDs.
📊 **Coverage:** Covered happy paths (Gen 1, Gen 2) as well as various edge cases and error conditions (unknown gen like Gen 3, generation 0, negative generation numbers, and arbitrarily large generation numbers).
✨ **Result:** Increased code coverage by completely unit testing `getGenerationConfig`'s fallback behavior, making the code more robust against regressions.

---
*PR created automatically by Jules for task [15237542466758989704](https://jules.google.com/task/15237542466758989704) started by @szubster*