### PR TITLE
🧪 Add test coverage for PokeAPI client error handling

### DIFF
--- a/src/utils/pokeapi.test.ts
+++ b/src/utils/pokeapi.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { pokeapi } from './pokeapi';
+
+describe('pokeapi', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe('success cases', () => {
+    it('returns json on successful fetch', async () => {
+      const mockData = { name: 'bulbasaur' };
+      (global.fetch as any).mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      });
+
+      const result = await pokeapi.getPokemonByName('bulbasaur');
+      expect(result).toEqual(mockData);
+      expect(global.fetch).toHaveBeenCalledWith('https://pokeapi.co/api/v2/pokemon/bulbasaur');
+    });
+  });
+
+  describe('error handling', () => {
+    it('getPokemonsList throws when response is not ok', async () => {
+      (global.fetch as any).mockResolvedValue({
+        ok: false,
+      });
+
+      await expect(pokeapi.getPokemonsList({ limit: 10, offset: 0 })).rejects.toThrow('Network response was not ok');
+    });
+
+    it('getPokemonEncounterAreasByName throws when response is not ok', async () => {
+      (global.fetch as any).mockResolvedValue({
+        ok: false,
+      });
+
+      await expect(pokeapi.getPokemonEncounterAreasByName('pikachu')).rejects.toThrow('Network response was not ok');
+    });
+
+    it('getPokemonByName throws when response is not ok', async () => {
+      (global.fetch as any).mockResolvedValue({
+        ok: false,
+      });
+
+      await expect(pokeapi.getPokemonByName('mewtwo')).rejects.toThrow('Network response was not ok');
+    });
+
+    it('getPokemonSpeciesByName throws when response is not ok', async () => {
+      (global.fetch as any).mockResolvedValue({
+        ok: false,
+      });
+
+      await expect(pokeapi.getPokemonSpeciesByName(151)).rejects.toThrow('Network response was not ok');
+    });
+
+    it('resource throws when response is not ok', async () => {
+      (global.fetch as any).mockResolvedValue({
+        ok: false,
+      });
+
+      await expect(pokeapi.resource('https://pokeapi.co/api/v2/evolution-chain/1/')).rejects.toThrow('Network response was not ok');
+    });
+
+    it('getItem throws when response is not ok', async () => {
+      (global.fetch as any).mockResolvedValue({
+        ok: false,
+      });
+
+      await expect(pokeapi.getItem(1)).rejects.toThrow('Network response was not ok');
+    });
+
+    it('getLocationArea throws when response is not ok', async () => {
+      (global.fetch as any).mockResolvedValue({
+        ok: false,
+      });
+
+      await expect(pokeapi.getLocationArea('pallet-town-area')).rejects.toThrow('Network response was not ok');
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added Vitest unit tests to the undocumented `src/utils/pokeapi.ts` API wrapper client to guarantee the implementation catches network failures properly.

📊 **Coverage:** Mocked `global.fetch` to simulate standard API data retrieval across all endpoints. Validated both error throwing on `{ ok: false }` for all 7 exported methods (`getPokemonsList`, `getPokemonEncounterAreasByName`, `getPokemonByName`, `getPokemonSpeciesByName`, `resource`, `getItem`, `getLocationArea`), as well as a success case path.

✨ **Result:** Enhanced test coverage provides greater confidence in our API interactions and prevents regressions during future refactoring of `src/utils/pokeapi.ts`.

---
*PR created automatically by Jules for task [4146503747626285575](https://jules.google.com/task/4146503747626285575) started by @szubster*