### PR TITLE
🧹 Remove leftover console log from ServiceWorker registration

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,8 +8,8 @@ import './index.css';
 // Register Service Worker (production only — SW breaks Vite HMR in dev)
 if (import.meta.env.PROD && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch(err => {
-      console.error('ServiceWorker registration failed: ', err);
+    navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch(() => {
+      // Intentionally ignore registration errors as they are non-critical
     });
   });
 }


### PR DESCRIPTION
🎯 **What:** Removed leftover logging (`console.error`) from the ServiceWorker registration error handler in `src/main.tsx`, leaving the catch block empty with an explanatory comment.
💡 **Why:** As noted in the task, removing a leftover logging statement is a trivial and risk-free way to improve code cleanliness. It prevents polluting the production console with non-critical ServiceWorker registration errors.
✅ **Verification:** Ran the full test suite (`npm test`), and all 41 tests passed successfully.
✨ **Result:** The codebase no longer contains the leftover logging statement in `src/main.tsx`, leading to a cleaner console output in production.

---
*PR created automatically by Jules for task [15213863309694201844](https://jules.google.com/task/15213863309694201844) started by @szubster*