### PR TITLE
🧹 fix: remove leftover console log from service worker registration

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,8 +9,8 @@ import './index.css';
 // Register Service Worker (production only — SW breaks Vite HMR in dev)
 if (import.meta.env.PROD && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch(err => {
-      console.error('ServiceWorker registration failed: ', err);
+    navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch(() => {
+      // Ignore registration failures silently
     });
   });
 }


### PR DESCRIPTION
🎯 **What:** Removed the leftover `console.error` inside the Service Worker registration catch block in `src/main.tsx`. The empty block was retained to handle promise rejections gracefully.
💡 **Why:** Improves code health by eliminating unnecessary logging in production.
✅ **Verification:** Verified by running the vitest test suite which confirmed all tests passed.
✨ **Result:** Cleaned up the codebase without affecting any application functionality.

---
*PR created automatically by Jules for task [1405953000445946182](https://jules.google.com/task/1405953000445946182) started by @szubster*