### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-03 - Missing ARIA Labels on Icon-Only Buttons
+**Learning:** Discovered that several icon-only buttons throughout the app (search clear, modal closes, settings) lacked `aria-label` attributes. This is a common pattern in modern UI development where icons are visually obvious but completely invisible to screen readers, creating significant accessibility barriers.
+**Action:** Always verify that buttons containing only icons (like from `lucide-react`) have descriptive `aria-label` attributes to ensure screen reader compatibility.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -200,6 +200,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                 <div className="flex gap-2">
                   <button
                     onClick={() => setIsSettingsOpen(true)}
+                    aria-label="System Settings"
                     className="p-3 bg-white/5 hover:bg-white/10 text-zinc-400 hover:text-white rounded-2xl border border-white/5 transition-all flex items-center justify-center retro-button"
                     title="System Settings"
                   >

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -466,6 +466,7 @@ export function PokemonDetails({ pokemonId, pokemonName, gameVersion, saveData, 
 
             <button 
               onClick={onClose}
+              aria-label="Close details"
               className="absolute top-6 right-6 sm:relative sm:top-auto sm:right-auto p-4 bg-white/5 hover:bg-white/10 border border-white/10 rounded-2xl transition-all group active:scale-95"
             >
               <X size={24} className="text-zinc-400 group-hover:text-white transition-colors" />

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -27,6 +27,7 @@ export function SearchAndFilters() {
           <input
             type="text"
             placeholder="Search Pokedex by name or ID..."
+            aria-label="Search Pokedex by name or ID"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="w-full glass-card bg-zinc-900/40 border-white/5 rounded-2xl py-4 pl-14 pr-12 text-xs font-black text-white placeholder:text-zinc-600 focus:border-[var(--theme-primary)]/50 focus:bg-zinc-900/60 outline-none transition-all shadow-[inset_0_2px_10px_rgba(0,0,0,0.5)] tracking-widest uppercase font-mono"
@@ -34,6 +35,7 @@ export function SearchAndFilters() {
           {searchTerm && (
             <button
               onClick={() => setSearchTerm('')}
+              aria-label="Clear search"
               className="absolute right-4 top-1/2 -translate-y-1/2 p-2 text-zinc-500 hover:text-white hover:bg-white/5 rounded-xl transition-all"
             >
               <X size={14} />

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -49,7 +49,7 @@ export function SettingsModal() {
               <h2 className="text-2xl font-display font-black uppercase tracking-tight">Menu</h2>
               <p className="text-[10px] font-bold text-zinc-500 uppercase tracking-widest mt-1">Configure your experience</p>
             </div>
-            <button onClick={() => setIsSettingsOpen(false)} className="p-3 bg-zinc-800 hover:bg-zinc-700 rounded-full transition-colors text-zinc-400">
+            <button onClick={() => setIsSettingsOpen(false)} aria-label="Close settings" className="p-3 bg-zinc-800 hover:bg-zinc-700 rounded-full transition-colors text-zinc-400">
               <X size={20} />
             </button>
           </div>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to icon-only buttons throughout the app, including the settings button, modal close buttons, search clear button, and the search input.
🎯 Why: Icon-only buttons without an `aria-label` are inaccessible to screen reader users, creating an accessibility barrier. This improves the app's overall UX by ensuring these components are semantically meaningful to assistive technologies.
♿ Accessibility: Ensures that users navigating via screen reader receive accurate feedback on what each interactive element does.

---
*PR created automatically by Jules for task [11563553478706453207](https://jules.google.com/task/11563553478706453207) started by @szubster*