### PR TITLE
🧪 [Test getUnobtainableReason logic]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.3",
         "bundlemon": "^3.1.0",
         "pokenode-ts": "^1.20.0",
         "rollup-plugin-visualizer": "^7.0.1",
@@ -382,6 +383,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -2467,6 +2478,65 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.3.tgz",
+      "integrity": "sha512-/MBdrkA8t6hbdCWFKs09dPik774xvs4Z6L4bycdCxYNLHM8oZuRyosumQMG19LUlBsB6GeVpL1q4kFFazvyKGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.3",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.3",
+        "vitest": "4.1.3"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.3.tgz",
+      "integrity": "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.3.tgz",
+      "integrity": "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.3",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -2680,6 +2750,25 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3765,6 +3854,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3915,6 +4011,45 @@
       "license": "Unlicense",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jiti": {
@@ -4292,6 +4427,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.3",
     "bundlemon": "^3.1.0",
     "pokenode-ts": "^1.20.0",
     "rollup-plugin-visualizer": "^7.0.1",

--- a/src/engine/exclusives/__tests__/gen1Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen1Exclusives.test.ts
@@ -45,8 +45,36 @@ describe('gen1Exclusives', () => {
         expect(reason).toBeNull();
       });
 
+      it('should lock Bulbasaur (1) if Ivysaur (2) is owned but Bulbasaur is not', () => {
+        const ownedSet = new Set([2]); // Own Ivysaur
+        const reason = getUnobtainableReason(1, 'red', 1, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('Pre-evolution missed');
+      });
+
+      it('should lock Squirtle (7) if Wartortle (8) is owned but Squirtle is not', () => {
+        const ownedSet = new Set([8]); // Own Wartortle
+        const reason = getUnobtainableReason(7, 'red', 1, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('Pre-evolution missed');
+      });
+
       it('should lock Eevee (133) if an evolution (Vaporeon 134) is owned but Eevee is not', () => {
         const ownedSet = new Set([134]); // Own Vaporeon
+        const reason = getUnobtainableReason(133, 'red', 1, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('Pre-evolution missed');
+      });
+
+      it('should lock Eevee (133) if an evolution (Jolteon 135) is owned but Eevee is not', () => {
+        const ownedSet = new Set([135]); // Own Jolteon
+        const reason = getUnobtainableReason(133, 'red', 1, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('Pre-evolution missed');
+      });
+
+      it('should lock Eevee (133) if an evolution (Flareon 136) is owned but Eevee is not', () => {
+        const ownedSet = new Set([136]); // Own Flareon
         const reason = getUnobtainableReason(133, 'red', 1, ownedSet);
         expect(typeof reason).toBe('string');
         expect(reason).toContain('Pre-evolution missed');
@@ -99,6 +127,34 @@ describe('gen1Exclusives', () => {
       it('should lock Kabuto (140) if Omastar (139) is owned', () => {
         const ownedSet = new Set([139]); // Own Omastar
         const reason = getUnobtainableReason(140, 'red', 1, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('other Fossil');
+      });
+
+      it('should lock Omastar (139) if Kabuto (140) is owned', () => {
+        const ownedSet = new Set([140]); // Own Kabuto
+        const reason = getUnobtainableReason(139, 'red', 1, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('other Fossil');
+      });
+
+      it('should lock Omastar (139) if Kabutops (141) is owned', () => {
+        const ownedSet = new Set([141]); // Own Kabutops
+        const reason = getUnobtainableReason(139, 'red', 1, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('other Fossil');
+      });
+
+      it('should lock Kabutops (141) if Omanyte (138) is owned', () => {
+        const ownedSet = new Set([138]); // Own Omanyte
+        const reason = getUnobtainableReason(141, 'red', 1, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('other Fossil');
+      });
+
+      it('should lock Kabutops (141) if Omastar (139) is owned', () => {
+        const ownedSet = new Set([139]); // Own Omastar
+        const reason = getUnobtainableReason(141, 'red', 1, ownedSet);
         expect(typeof reason).toBe('string');
         expect(reason).toContain('other Fossil');
       });


### PR DESCRIPTION
🎯 **What:** Expanded test coverage for `getUnobtainableReason` in Gen 1 to cover all permutations of hardcoded logic for starters, eeveelutions, and fossil evolutions.
📊 **Coverage:** Added test cases for Bulbasaur (1), Squirtle (7), Jolteon (135) and Flareon (136) locking Eevee, as well as fossil evolution lockouts (Omastar and Kabutops).
✨ **Result:** Improved test reliability by ensuring all branches of mutually exclusive and one-time choices logic correctly handle all associated Pokémon IDs.

---
*PR created automatically by Jules for task [7990005013939583728](https://jules.google.com/task/7990005013939583728) started by @szubster*