### PR TITLE
🎨 Palette: [UX improvement] Improve file upload accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2026-04-07 - Inline Confirmation for Destructive Actions
 **Learning:** Destructive actions inside easily dismissible modals are prone to accidental clicks. Adding an inline confirmation step prevents data loss without forcing the user out of their current context.
 **Action:** Always implement a two-step inline confirmation (e.g., 'Delete' -> 'Cancel' / 'Confirm') for data-clearing actions within dialogs.
+
+## 2024-05-18 - [File Upload Input Accessibility]
+**Learning:** Using `className="hidden"` on `<input type="file">` elements within a `<label>` hides them completely from the accessibility tree, making it impossible for screen reader users to understand or interact with the file input properly, and preventing keyboard focus.
+**Action:** Instead of `className="hidden"`, use Tailwind's `className="sr-only"` combined with `tabIndex={-1}`. `sr-only` keeps the element accessible to screen readers but visually hidden. `tabIndex={-1}` ensures the input itself doesn't receive redundant keyboard focus (since its wrapping `<label>` is naturally focusable or can be made focusable, often using `focus-within:ring-*` to show visual feedback when the hidden input receives internal focus).

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -206,19 +206,19 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                   <Settings2 size={20} />
                 </button>
                 <label
-                  className="p-3 bg-white/5 hover:bg-white/10 text-zinc-400 hover:text-white rounded-2xl border border-white/5 cursor-pointer transition-all flex items-center justify-center retro-button"
+                  className="p-3 bg-white/5 hover:bg-white/10 text-zinc-400 hover:text-white rounded-2xl border border-white/5 cursor-pointer transition-all flex items-center justify-center retro-button focus-within:ring-2 focus-within:ring-white focus-within:ring-offset-2 focus-within:ring-offset-zinc-950"
                   title="Import New Save"
                 >
                   <RefreshCw size={20} />
-                  <input type="file" accept=".sav" className="hidden" onChange={handleFileUpload} />
+                  <input type="file" accept=".sav" className="sr-only" onChange={handleFileUpload} />
                 </label>
               </div>
             </div>
           ) : (
-            <label className="w-full sm:w-auto inline-flex items-center justify-center gap-4 bg-[var(--theme-primary)] hover:bg-[var(--theme-primary)]/90 text-white px-10 py-4 rounded-2xl cursor-pointer transition-all duration-300 hover:scale-105 active:scale-95 shadow-[0_20px_40px_rgba(var(--theme-primary-rgb),0.2)] font-black uppercase tracking-widest text-[11px] border-b-4 border-black/20 animate-in slide-in-from-bottom-2 fade-in">
+            <label className="w-full sm:w-auto inline-flex items-center justify-center gap-4 bg-[var(--theme-primary)] hover:bg-[var(--theme-primary)]/90 text-white px-10 py-4 rounded-2xl cursor-pointer transition-all duration-300 hover:scale-105 active:scale-95 shadow-[0_20px_40px_rgba(var(--theme-primary-rgb),0.2)] font-black uppercase tracking-widest text-[11px] border-b-4 border-black/20 animate-in slide-in-from-bottom-2 fade-in focus-within:outline-none focus-within:ring-2 focus-within:ring-[var(--theme-primary)] focus-within:ring-offset-2 focus-within:ring-offset-zinc-950">
               <Upload size={20} />
               Initialize Pokedex
-              <input type="file" accept=".sav" className="hidden" onChange={handleFileUpload} />
+              <input type="file" accept=".sav" className="sr-only" onChange={handleFileUpload} />
             </label>
           )}
         </header>


### PR DESCRIPTION
**💡 What:** Replaced `className="hidden"` with `className="sr-only"` on the hidden file inputs used for save initialization and importing, and added `focus-within` visual states to their wrapping `<label>` elements.

**🎯 Why:** Users navigating via keyboard could not focus the file upload buttons because `className="hidden"` completely removes elements from the DOM accessibility tree and tab order. Because the labels wrap the inputs, they can still visually look like styled buttons while maintaining full keyboard support. 

**📸 Before/After:** Before, tabbing through the top-nav would skip right past the upload inputs. After, pressing Tab correctly navigates onto the styled `<label>` component (both on the "Initialize Pokedex" empty state and the header "Import New Save" button) displaying a visible focus ring outline via `focus-within:ring-2 focus-within:ring-white focus-within:ring-offset-2 focus-within:ring-offset-zinc-950`.

**♿ Accessibility:** Keyboard navigability restored. Screen readers can now properly announce the upload element natively, eliminating an invisible keyboard trap.

---
*PR created automatically by Jules for task [11558600970657029307](https://jules.google.com/task/11558600970657029307) started by @szubster*