### PR TITLE
refactor(a11y): modernize interactive elements and roles

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -35,15 +35,6 @@
           }
         }
       },
-      "a11y": {
-        // TODO: Re-evaluate and enable accessibility rules in the future once UI baseline is solid
-        "useKeyWithClickEvents": "off",
-        "useButtonType": "off",
-        "useAltText": "off",
-        "useKeyWithMouseEvents": "off",
-        "useAnchorContent": "off",
-        "noStaticElementInteractions": "off"
-      },
       "complexity": {
         // Allow hexadecimal number literals for object keys, parsing binary saves depends on mapping hex addresses
         "useSimpleNumberKeys": "off"

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -179,6 +179,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
               </div>
 
               <button
+                type="button"
                 onClick={() => setIsVersionModalOpen(true)}
                 className={cn(
                   'group zoom-in-95 fade-in relative animate-in overflow-hidden rounded-2xl border px-5 py-2.5 font-black text-[11px] uppercase tracking-widest transition-all duration-500',
@@ -198,6 +199,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
 
               <div className="flex gap-2">
                 <button
+                  type="button"
                   onClick={() => setIsSettingsOpen(true)}
                   aria-label="System Settings"
                   className="retro-button flex items-center justify-center rounded-2xl border border-white/5 bg-white/5 p-3 text-zinc-400 transition-all hover:bg-white/10 hover:text-white"

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -101,6 +101,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
               AI Assistant
             </h2>
             <button
+              type="button"
               onClick={() => setShowDebug(!showDebug)}
               className={`rounded-xl border p-2 transition-all ${showDebug ? 'border-amber-500/50 bg-amber-500/20 text-amber-400' : 'border-zinc-700 bg-zinc-800 text-zinc-500 hover:text-zinc-300'}`}
               title="Toggle Debug Mode"

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -71,6 +71,7 @@ export function BottomNav() {
         </Link>
 
         <button
+          type="button"
           onClick={() => setIsSettingsOpen(true)}
           aria-label="Open settings menu"
           className="flex flex-col items-center gap-1 py-1 text-zinc-500 transition-all duration-300"

--- a/src/components/PokedexGrid.tsx
+++ b/src/components/PokedexGrid.tsx
@@ -83,13 +83,14 @@ export function PokedexGrid({ pokemonList }: { pokemonList: { id: number; name: 
         const isShiny = shinySpeciesIds.has(pokemon.id);
 
         return (
-          <div
+          <button
+            type="button"
             data-testid="pokedex-card"
             data-pokemon-id={pokemon.id}
             key={pokemon.id}
             onClick={() => navigate({ to: `/pokemon/${pokemon.id}`, search: { from: '/' } })}
             className={cn(
-              'group relative cursor-pointer rounded-3xl border-2 p-4 transition-all duration-500 hover:scale-[1.02] active:scale-[0.98]',
+              'group relative w-full cursor-pointer rounded-3xl border-2 p-4 text-left transition-all duration-500 hover:scale-[1.02] active:scale-[0.98]',
               hasInStorage
                 ? 'border-emerald-500/30 bg-zinc-900 hover:border-emerald-500/50 hover:shadow-[0_0_30px_rgba(16,185,129,0.15)]'
                 : 'border-white/5 bg-zinc-900 hover:border-white/10 hover:shadow-[0_0_30px_rgba(255,255,255,0.05)]',
@@ -215,7 +216,7 @@ export function PokedexGrid({ pokemonList }: { pokemonList: { id: number; name: 
             <div className="absolute right-[-10px] bottom-[-10px] p-4 opacity-0 transition-opacity group-hover:opacity-100">
               <ChevronRight size={14} className="text-[var(--theme-primary)]" />
             </div>
-          </div>
+          </button>
         );
       })}
     </div>

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -379,13 +379,11 @@ export function PokemonDetails({
   const isShiny = yourPokemon.some((p) => p.isShiny);
 
   return (
-    <div
-      className="fade-in fixed inset-0 z-50 flex animate-in items-end justify-center p-0 duration-300 sm:items-center sm:p-4"
-      onClick={onClose}
-    >
-      <div className="absolute inset-0 bg-black/90 backdrop-blur-xl" />
+    <div className="fade-in fixed inset-0 z-50 flex animate-in items-end justify-center p-0 duration-300 sm:items-center sm:p-4">
+      <div aria-hidden="true" className="absolute inset-0 bg-black/90 backdrop-blur-xl" onClick={onClose} />
       <div
-        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
         className="slide-in-from-bottom-[100%] sm:zoom-in-95 relative flex h-[95vh] w-full animate-in flex-col overflow-hidden rounded-t-[2.5rem] border-white/10 border-t bg-zinc-950/90 shadow-2xl duration-500 ease-out sm:h-[85vh] sm:max-w-5xl sm:rounded-[3rem] sm:border"
       >
         {/* Scanline Overlay */}
@@ -470,6 +468,7 @@ export function PokemonDetails({
             </div>
 
             <button
+              type="button"
               onClick={onClose}
               aria-label="Close details"
               className="group absolute top-6 right-6 rounded-2xl border border-white/10 bg-white/5 p-4 transition-all hover:bg-white/10 active:scale-95 sm:relative sm:top-auto sm:right-auto"

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -33,6 +33,7 @@ export function SearchAndFilters() {
           />
           {searchTerm && (
             <button
+              type="button"
               onClick={() => setSearchTerm('')}
               aria-label="Clear search"
               className="absolute top-1/2 right-4 -translate-y-1/2 rounded-xl p-2 text-zinc-500 transition-all hover:bg-white/5 hover:text-white"
@@ -47,6 +48,7 @@ export function SearchAndFilters() {
         {/* Filter Buttons designed as Retro Console Switches */}
         <div className="no-scrollbar flex gap-2 overflow-x-auto px-1 pb-2">
           <button
+            type="button"
             onClick={() => setFilters([])}
             aria-pressed={filtersSet.size === 0}
             className={cn(
@@ -62,6 +64,7 @@ export function SearchAndFilters() {
 
           {(['secured', 'missing', 'dex-only'] as FilterType[]).map((f) => (
             <button
+              type="button"
               key={f}
               onClick={() => toggleFilter(f)}
               aria-pressed={filtersSet.has(f)}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -85,6 +85,7 @@ function SettingsControls({
           <span className="font-bold text-xs uppercase tracking-wider">Living Dex</span>
         </div>
         <button
+          type="button"
           role="switch"
           aria-checked={isLivingDex}
           aria-label="Toggle Living Dex Mode"
@@ -128,12 +129,14 @@ function ClearStorageButton({ onClear }: { onClear: () => void }) {
     return (
       <div className="fade-in zoom-in-95 flex w-full animate-in gap-2 duration-200">
         <button
+          type="button"
           onClick={() => setIsConfirming(false)}
           className="flex-1 rounded-2xl border border-zinc-700 bg-zinc-800 p-5 font-bold text-[10px] text-zinc-300 uppercase tracking-widest transition-all hover:bg-zinc-700"
         >
           Cancel
         </button>
         <button
+          type="button"
           onClick={onClear}
           className="group flex flex-1 items-center justify-center gap-2 rounded-2xl border border-red-500 bg-red-600 p-5 font-bold text-[10px] text-white uppercase tracking-widest transition-all hover:bg-red-500"
         >
@@ -146,6 +149,7 @@ function ClearStorageButton({ onClear }: { onClear: () => void }) {
 
   return (
     <button
+      type="button"
       onClick={() => setIsConfirming(true)}
       className="group fade-in zoom-in-95 flex w-full animate-in items-center justify-center gap-3 rounded-2xl border border-red-600/20 bg-red-600/10 p-5 font-bold text-[10px] text-red-500 uppercase tracking-widest transition-all duration-200 hover:bg-red-600/20"
     >
@@ -180,6 +184,7 @@ export function SettingsModal() {
   return (
     <div className="fixed inset-0 z-[60] flex items-end justify-center p-0 sm:items-center sm:p-4">
       <div
+        aria-hidden="true"
         className="fade-in absolute inset-0 animate-in bg-black/80 backdrop-blur-sm duration-300"
         onClick={() => setIsSettingsOpen(false)}
       />
@@ -192,6 +197,7 @@ export function SettingsModal() {
             </p>
           </div>
           <button
+            type="button"
             onClick={() => setIsSettingsOpen(false)}
             aria-label="Close settings"
             className="rounded-full bg-zinc-800 p-3 text-zinc-400 transition-colors hover:bg-zinc-700"

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -82,11 +82,12 @@ export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: 
                   }
 
                   return (
-                    <div
+                    <button
+                      type="button"
                       // biome-ignore lint/suspicious/noArrayIndexKey: Array index is stable and required for duplicates
                       key={`${location}-${p.speciesId}-${idx}`}
                       onClick={() => navigate({ to: `/pokemon/${pokemon.id}`, search: { from: '/storage' } })}
-                      className={`relative flex cursor-pointer flex-col items-center rounded-2xl p-5 transition-all duration-200 hover:-translate-y-1 active:scale-95 ${cardStyle}`}
+                      className={`relative flex w-full cursor-pointer flex-col items-center rounded-2xl p-5 text-left transition-all duration-200 hover:-translate-y-1 active:scale-95 ${cardStyle}`}
                     >
                       <div className="absolute top-3 left-3 font-bold font-mono text-[10px] text-zinc-600">
                         LV.{p.level}
@@ -110,7 +111,7 @@ export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: 
                       <div className="w-full truncate px-1 text-center font-bold text-[10px] text-zinc-100 uppercase tracking-wider">
                         {pokemon.name}
                       </div>
-                    </div>
+                    </button>
                   );
                 })
               )}

--- a/src/components/VersionModal.tsx
+++ b/src/components/VersionModal.tsx
@@ -31,6 +31,7 @@ export function VersionModal() {
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           {versions.map((v) => (
             <button
+              type="button"
               key={v.id}
               onClick={() => {
                 setManualVersion(v.id as GameVersion);

--- a/src/components/pokemon/details/PokemonEvolutions.tsx
+++ b/src/components/pokemon/details/PokemonEvolutions.tsx
@@ -61,6 +61,7 @@ export function PokemonEvolutions({
               <>
                 {' '}
                 <button
+                  type="button"
                   onClick={() => onNavigate(evoReq.fromId, evoReq.fromName)}
                   className="text-red-400 underline decoration-red-500/30 underline-offset-4 transition-colors hover:text-white"
                 >
@@ -105,6 +106,7 @@ export function PokemonEvolutions({
           <div className="relative z-10 font-bold text-xs text-zinc-300 leading-relaxed">
             FROM{' '}
             <button
+              type="button"
               onClick={() => onNavigate(evoReq.fromId, evoReq.fromName)}
               className="text-white underline decoration-purple-500/30 underline-offset-4 transition-colors hover:text-purple-400"
             >
@@ -136,6 +138,7 @@ export function PokemonEvolutions({
               <div key={evo.id} className="font-bold text-xs text-zinc-300 leading-relaxed">
                 TO{' '}
                 <button
+                  type="button"
                   onClick={() => onNavigate(evo.id, evo.name)}
                   className="text-white underline decoration-blue-500/30 underline-offset-4 transition-colors hover:text-blue-400"
                 >
@@ -161,6 +164,7 @@ export function PokemonEvolutions({
             {breedingInfo.parentNames.map((name: string, i: number) => (
               <React.Fragment key={name}>
                 <button
+                  type="button"
                   onClick={() => {
                     const id = breedingInfo.parentIds[i];
                     if (id) onNavigate(id, name);


### PR DESCRIPTION
Resolves Biome a11y linter rules logically without relying on `biome-ignore`.

### Changes Summary
- Transformed Pokedex and Storage interactive list items from `<div onClick>` to standard `<button type="button">`.
- Addressed static element interaction and click+keyboard interaction errors cleanly by applying `aria-hidden="true"` on overlay/backdrop elements that are visual-only.
- Assigned `role="dialog"` and `aria-modal="true"` to custom UI dialogues for robust standard alignment and compliance.
- Removed the disabled biome checks globally in `biome.jsonc` to keep CI strict on valid a11y rules.