### PR TITLE
🎨 Palette: Add focus-visible styles to filter buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,3 +11,6 @@
 ## 2024-05-18 - [File Upload Input Accessibility]
 **Learning:** Using `className="hidden"` on `<input type="file">` elements within a `<label>` hides them completely from the accessibility tree, making it impossible for screen reader users to understand or interact with the file input properly, and preventing keyboard focus.
 **Action:** Instead of `className="hidden"`, use Tailwind's `className="sr-only"` combined with `tabIndex={-1}`. `sr-only` keeps the element accessible to screen readers but visually hidden. `tabIndex={-1}` ensures the input itself doesn't receive redundant keyboard focus (since its wrapping `<label>` is naturally focusable or can be made focusable, often using `focus-within:ring-*` to show visual feedback when the hidden input receives internal focus).
+## 2024-04-11 - Focus Visible Styles for Retro Buttons
+**Learning:** The custom retro-button class and other interactive elements in this design system do not have default keyboard focus indicators. Tabbing through the interface without them makes the app inaccessible to keyboard users.
+**Action:** Always add `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` to interactive elements to ensure a consistent, themed focus state.

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -52,7 +52,7 @@ export function SearchAndFilters() {
             onClick={() => setFilters([])}
             aria-pressed={filtersSet.size === 0}
             className={cn(
-              'retro-button relative flex shrink-0 items-center gap-3 overflow-hidden rounded-2xl border-2 px-5 py-3 font-black text-[10px] uppercase tracking-widest transition-all',
+              'retro-button relative flex shrink-0 items-center gap-3 overflow-hidden rounded-2xl border-2 px-5 py-3 font-black text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
               filtersSet.size === 0
                 ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)] text-white shadow-[0_10px_20px_rgba(var(--theme-primary-rgb),0.3)]'
                 : 'border-white/5 bg-zinc-900 text-zinc-500 hover:bg-zinc-800 hover:text-white',
@@ -70,7 +70,7 @@ export function SearchAndFilters() {
               aria-pressed={filtersSet.has(f)}
               data-testid={`filter-${f}`}
               className={cn(
-                'retro-button relative flex shrink-0 items-center gap-3 overflow-hidden rounded-2xl border-2 px-5 py-3 font-black text-[10px] uppercase tracking-widest transition-all',
+                'retro-button relative flex shrink-0 items-center gap-3 overflow-hidden rounded-2xl border-2 px-5 py-3 font-black text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
                 filtersSet.has(f)
                   ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)] text-white shadow-[0_10px_20px_rgba(var(--theme-primary-rgb),0.3)]'
                   : 'border-white/5 bg-zinc-900 text-zinc-500 hover:bg-zinc-800 hover:text-white',


### PR DESCRIPTION
**What:** Added `focus-visible` styles to the filter buttons ("All", "Secured", "Missing", "Dex Only") in the `SearchAndFilters` component.

**Why:** The `retro-button` class does not provide a default focus indicator, making it difficult for keyboard users to see which filter is currently focused when tabbing through the interface. This change improves keyboard navigation accessibility.

**Before/After:**
*(Before)* Tabbing through the filter buttons provided no visual feedback.
*(After)* Tabbing through the filter buttons now displays a clear, themed focus ring around the active button.

**Accessibility:** Improves keyboard navigation by ensuring all interactive filter buttons have a distinct, visible focus state.

---
*PR created automatically by Jules for task [10706838455247418353](https://jules.google.com/task/10706838455247418353) started by @szubster*