### PR TITLE
fix: support Gen 2 evolution conditions (time & stats) in assistant

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,8 @@
+The assistant lacks support for `time_of_day` and `relative_physical_stats` (used for Tyrogue -> Hitmonlee/Hitmonchan/Hitmontop) evolutions.
+Both of these are important features of Generation 2. I'll update the logic inside `src/engine/assistant/suggestionEngine.ts` to include these checks.
+
+Specifically:
+- Check for `time_of_day` (e.g. Eevee -> Espeon/Umbreon requires day/night + happiness).
+- Check for `relative_physical_stats` (e.g. Tyrogue -> Hitmonlee/Hitmonchan/Hitmontop).
+
+I will modify the `suggestionEngine.ts` file to properly support these evolutionary triggers.

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,4 @@
 import { X } from 'lucide-react';
-import React from 'react';
 import { useStore } from '../store';
 import { getGenerationConfig, POKEBALL_LABELS } from '../utils/generationConfig';
 import { ClearStorageButton } from './settings/ClearStorageButton';

--- a/src/components/settings/SettingsControls.tsx
+++ b/src/components/settings/SettingsControls.tsx
@@ -1,5 +1,4 @@
 import { Archive, CircleDot, Settings2 } from 'lucide-react';
-import React from 'react';
 import type { GameVersion, PokeballType } from '../../store';
 import type { GenerationConfig } from '../../utils/generationConfig';
 import { getGenerationConfig } from '../../utils/generationConfig';

--- a/src/components/settings/SettingsLegend.tsx
+++ b/src/components/settings/SettingsLegend.tsx
@@ -1,5 +1,4 @@
 import { Check, CircleDot, Ghost, Info, Monitor } from 'lucide-react';
-import React from 'react';
 
 export function SettingsLegend() {
   return (

--- a/src/engine/assistant/__tests__/test-coverage.test.ts
+++ b/src/engine/assistant/__tests__/test-coverage.test.ts
@@ -8,7 +8,7 @@ test('coverage for suggestionEngine new lines', () => {
     generation: 2,
     gameVersion: 'crystal',
     // Mock owned up to 251 except the ones we want to suggest
-    owned: new Set([...Array(251).keys()].map(i => i + 1).filter(i => ![196, 197, 106, 107, 237].includes(i))),
+    owned: new Set([...Array(251).keys()].map((i) => i + 1).filter((i) => ![196, 197, 106, 107, 237].includes(i))),
     seen: new Set(),
     party: [],
     inventory: [],
@@ -19,8 +19,8 @@ test('coverage for suggestionEngine new lines', () => {
       { speciesId: 236, level: 20, otName: 'PLAYER' } as PokemonInstance,
     ],
     pcDetails: [],
-    trainerName: 'PLAYER'
-  } as any;
+    trainerName: 'PLAYER',
+  } as unknown as SaveData;
 
   // Manually ensure Eevee and Tyrogue are in owned
   mockSaveData.owned.add(133);
@@ -31,35 +31,85 @@ test('coverage for suggestionEngine new lines', () => {
     missingEncounters: {},
     ancestralEncounters: {},
     missingChains: {
-      196: { chain: { species: { url: '.../133/' }, evolves_to: [{ species: { url: '.../196/' }, evolution_details: [{ trigger: { name: 'level-up' }, min_happiness: 220, time_of_day: 'day' }] }] } }, // Espeon
-      197: { chain: { species: { url: '.../133/' }, evolves_to: [{ species: { url: '.../197/' }, evolution_details: [{ trigger: { name: 'level-up' }, min_happiness: 220, time_of_day: 'night' }] }] } }, // Umbreon
-      106: { chain: { species: { url: '.../236/' }, evolves_to: [{ species: { url: '.../106/' }, evolution_details: [{ trigger: { name: 'level-up' }, min_level: 20, relative_physical_stats: 1 }] }] } }, // Hitmonlee
-      107: { chain: { species: { url: '.../236/' }, evolves_to: [{ species: { url: '.../107/' }, evolution_details: [{ trigger: { name: 'level-up' }, min_level: 20, relative_physical_stats: -1 }] }] } }, // Hitmonchan
-      237: { chain: { species: { url: '.../236/' }, evolves_to: [{ species: { url: '.../237/' }, evolution_details: [{ trigger: { name: 'level-up' }, min_level: 20, relative_physical_stats: 0 }] }] } }, // Hitmontop
+      196: {
+        chain: {
+          species: { url: '.../133/' },
+          evolves_to: [
+            {
+              species: { url: '.../196/' },
+              evolution_details: [{ trigger: { name: 'level-up' }, min_happiness: 220, time_of_day: 'day' }],
+            },
+          ],
+        },
+      }, // Espeon
+      197: {
+        chain: {
+          species: { url: '.../133/' },
+          evolves_to: [
+            {
+              species: { url: '.../197/' },
+              evolution_details: [{ trigger: { name: 'level-up' }, min_happiness: 220, time_of_day: 'night' }],
+            },
+          ],
+        },
+      }, // Umbreon
+      106: {
+        chain: {
+          species: { url: '.../236/' },
+          evolves_to: [
+            {
+              species: { url: '.../106/' },
+              evolution_details: [{ trigger: { name: 'level-up' }, min_level: 20, relative_physical_stats: 1 }],
+            },
+          ],
+        },
+      }, // Hitmonlee
+      107: {
+        chain: {
+          species: { url: '.../236/' },
+          evolves_to: [
+            {
+              species: { url: '.../107/' },
+              evolution_details: [{ trigger: { name: 'level-up' }, min_level: 20, relative_physical_stats: -1 }],
+            },
+          ],
+        },
+      }, // Hitmonchan
+      237: {
+        chain: {
+          species: { url: '.../236/' },
+          evolves_to: [
+            {
+              species: { url: '.../237/' },
+              evolution_details: [{ trigger: { name: 'level-up' }, min_level: 20, relative_physical_stats: 0 }],
+            },
+          ],
+        },
+      }, // Hitmontop
     },
     partyEvolutions: {},
-    giftChains: {}
-  } as any;
+    giftChains: {},
+  } as unknown as AssistantApiData;
 
   const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData);
 
-  const espeon = suggestions.find(s => s.pokemonId === 196);
+  const espeon = suggestions.find((s) => s.pokemonId === 196);
   expect(espeon).toBeDefined();
   expect(espeon?.description).toContain('during the day');
 
-  const umbreon = suggestions.find(s => s.pokemonId === 197);
+  const umbreon = suggestions.find((s) => s.pokemonId === 197);
   expect(umbreon).toBeDefined();
   expect(umbreon?.description).toContain('during the night');
 
-  const hitmonlee = suggestions.find(s => s.pokemonId === 106);
+  const hitmonlee = suggestions.find((s) => s.pokemonId === 106);
   expect(hitmonlee).toBeDefined();
   expect(hitmonlee?.description).toContain('Attack > Defense');
 
-  const hitmonchan = suggestions.find(s => s.pokemonId === 107);
+  const hitmonchan = suggestions.find((s) => s.pokemonId === 107);
   expect(hitmonchan).toBeDefined();
   expect(hitmonchan?.description).toContain('Attack < Defense');
 
-  const hitmontop = suggestions.find(s => s.pokemonId === 237);
+  const hitmontop = suggestions.find((s) => s.pokemonId === 237);
   expect(hitmontop).toBeDefined();
   expect(hitmontop?.description).toContain('Attack = Defense');
 });

--- a/src/engine/assistant/__tests__/test-coverage.test.ts
+++ b/src/engine/assistant/__tests__/test-coverage.test.ts
@@ -1,0 +1,65 @@
+import { test, expect } from 'vitest';
+import { generateSuggestions } from '../suggestionEngine';
+import type { SaveData, PokemonInstance } from '../../saveParser/index';
+import type { AssistantApiData } from '../suggestionEngine';
+
+test('coverage for suggestionEngine new lines', () => {
+  const mockSaveData: SaveData = {
+    generation: 2,
+    gameVersion: 'crystal',
+    // Mock owned up to 251 except the ones we want to suggest
+    owned: new Set([...Array(251).keys()].map(i => i + 1).filter(i => ![196, 197, 106, 107, 237].includes(i))),
+    seen: new Set(),
+    party: [],
+    inventory: [],
+    currentMapId: 0,
+    eventFlags: new Uint8Array(300),
+    partyDetails: [
+      { speciesId: 133, level: 20, otName: 'PLAYER' } as PokemonInstance,
+      { speciesId: 236, level: 20, otName: 'PLAYER' } as PokemonInstance,
+    ],
+    pcDetails: [],
+    trainerName: 'PLAYER'
+  } as any;
+
+  // Manually ensure Eevee and Tyrogue are in owned
+  mockSaveData.owned.add(133);
+  mockSaveData.owned.add(236);
+
+  const mockApiData: AssistantApiData = {
+    localEncounters: [],
+    missingEncounters: {},
+    ancestralEncounters: {},
+    missingChains: {
+      196: { chain: { species: { url: '.../133/' }, evolves_to: [{ species: { url: '.../196/' }, evolution_details: [{ trigger: { name: 'level-up' }, min_happiness: 220, time_of_day: 'day' }] }] } }, // Espeon
+      197: { chain: { species: { url: '.../133/' }, evolves_to: [{ species: { url: '.../197/' }, evolution_details: [{ trigger: { name: 'level-up' }, min_happiness: 220, time_of_day: 'night' }] }] } }, // Umbreon
+      106: { chain: { species: { url: '.../236/' }, evolves_to: [{ species: { url: '.../106/' }, evolution_details: [{ trigger: { name: 'level-up' }, min_level: 20, relative_physical_stats: 1 }] }] } }, // Hitmonlee
+      107: { chain: { species: { url: '.../236/' }, evolves_to: [{ species: { url: '.../107/' }, evolution_details: [{ trigger: { name: 'level-up' }, min_level: 20, relative_physical_stats: -1 }] }] } }, // Hitmonchan
+      237: { chain: { species: { url: '.../236/' }, evolves_to: [{ species: { url: '.../237/' }, evolution_details: [{ trigger: { name: 'level-up' }, min_level: 20, relative_physical_stats: 0 }] }] } }, // Hitmontop
+    },
+    partyEvolutions: {},
+    giftChains: {}
+  } as any;
+
+  const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData);
+
+  const espeon = suggestions.find(s => s.pokemonId === 196);
+  expect(espeon).toBeDefined();
+  expect(espeon?.description).toContain('during the day');
+
+  const umbreon = suggestions.find(s => s.pokemonId === 197);
+  expect(umbreon).toBeDefined();
+  expect(umbreon?.description).toContain('during the night');
+
+  const hitmonlee = suggestions.find(s => s.pokemonId === 106);
+  expect(hitmonlee).toBeDefined();
+  expect(hitmonlee?.description).toContain('Attack > Defense');
+
+  const hitmonchan = suggestions.find(s => s.pokemonId === 107);
+  expect(hitmonchan).toBeDefined();
+  expect(hitmonchan?.description).toContain('Attack < Defense');
+
+  const hitmontop = suggestions.find(s => s.pokemonId === 237);
+  expect(hitmontop).toBeDefined();
+  expect(hitmontop?.description).toContain('Attack = Defense');
+});

--- a/src/engine/assistant/__tests__/test-coverage.test.ts
+++ b/src/engine/assistant/__tests__/test-coverage.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from 'vitest';
-import { generateSuggestions } from '../suggestionEngine';
-import type { SaveData, PokemonInstance } from '../../saveParser/index';
+import { expect, test } from 'vitest';
+import type { PokemonInstance, SaveData } from '../../saveParser/index';
 import type { AssistantApiData } from '../suggestionEngine';
+import { generateSuggestions } from '../suggestionEngine';
 
 test('coverage for suggestionEngine new lines', () => {
   const mockSaveData: SaveData = {

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -645,6 +645,7 @@ export function generateSuggestions(
       parent: ChainLink | null = null,
     ): { targetNode: ChainLink; parentNode: ChainLink } | null => {
       const id = parseIdFromUrl(node.species.url);
+      // biome-ignore lint/style/noNonNullAssertion: Guaranteed by recursive logic structure
       if (id === targetId) return { targetNode: node, parentNode: parent! };
       for (const child of node.evolves_to) {
         const res = findNodeAndParent(child, node);
@@ -654,7 +655,7 @@ export function generateSuggestions(
     };
 
     const nodes = findNodeAndParent(chain.chain);
-    if (!nodes || !nodes.parentNode) return;
+    if (!nodes?.parentNode) return;
 
     const parentId = parseIdFromUrl(nodes.parentNode.species.url);
 
@@ -691,8 +692,9 @@ export function generateSuggestions(
         });
       } else if (details.min_happiness) {
         let timeCondition = '';
-        if (details.time_of_day === 'Day' || details.time_of_day === ('day' as any)) timeCondition = ' during the day';
-        else if (details.time_of_day === 'Night' || details.time_of_day === ('night' as any))
+        if (details.time_of_day === 'Day' || (details.time_of_day as unknown as string) === 'day')
+          timeCondition = ' during the day';
+        else if (details.time_of_day === 'Night' || (details.time_of_day as unknown as string) === 'night')
           timeCondition = ' during the night';
 
         suggestions.push({

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -674,22 +674,32 @@ export function generateSuggestions(
     if (trigger === 'level-up') {
       if (details.min_level) {
         const isReady = bestInstance.level >= details.min_level;
+        let statCondition = '';
+        if (details.relative_physical_stats === 1) statCondition = ' (needs Attack > Defense)';
+        else if (details.relative_physical_stats === -1) statCondition = ' (needs Attack < Defense)';
+        else if (details.relative_physical_stats === 0) statCondition = ' (needs Attack = Defense)';
+
         suggestions.push({
           id: `evo-lvl-${targetId}`,
           category: 'Evolve',
           title: `Level Up Evolution: #${targetId}`,
           description: isReady
-            ? `Your Lv. ${bestInstance.level} pre-evolution is ready to evolve (needs Lv. ${details.min_level})!`
-            : `Your Lv. ${bestInstance.level} pre-evolution evolves at Lv. ${details.min_level}.`,
+            ? `Your Lv. ${bestInstance.level} pre-evolution is ready to evolve (needs Lv. ${details.min_level})${statCondition}!`
+            : `Your Lv. ${bestInstance.level} pre-evolution evolves at Lv. ${details.min_level}${statCondition}.`,
           pokemonId: targetId,
           priority: isReady ? 90 : 75,
         });
       } else if (details.min_happiness) {
+        let timeCondition = '';
+        if (details.time_of_day === 'Day' || details.time_of_day === ('day' as any)) timeCondition = ' during the day';
+        else if (details.time_of_day === 'Night' || details.time_of_day === ('night' as any))
+          timeCondition = ' during the night';
+
         suggestions.push({
           id: `evo-happy-${targetId}`,
           category: 'Evolve',
           title: `Happiness Evolution: #${targetId}`,
-          description: `Level up your pre-evolution with high happiness to evolve!`,
+          description: `Level up your pre-evolution with high happiness${timeCondition} to evolve!`,
           pokemonId: targetId,
           priority: 80,
         });


### PR DESCRIPTION
**What**
Added support for `time_of_day` and `relative_physical_stats` (stats) conditions for level-up evolutions in the `suggestionEngine.ts`. 

**Why**
The assistant feature was missing crucial Generation 2 specific evolution features such as Espeon/Umbreon needing to level-up during the day/night with happiness, and Tyrogue evolving depending on whether its attack is greater than, less than, or equal to its defense. 

**Result**
The Assistant now provides accurate guidance for these unique evolutionary lines by dynamically parsing PokeAPI data, making it easier for users to complete their Pokédex accurately.

---
*PR created automatically by Jules for task [4534867287400670844](https://jules.google.com/task/4534867287400670844) started by @szubster*