### PR TITLE
🎨 Palette: Improve PokemonCatchProbability accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,6 @@
 ## 2024-04-11 - Focus Visible Styles for Retro Buttons
 **Learning:** The custom retro-button class and other interactive elements in this design system do not have default keyboard focus indicators. Tabbing through the interface without them makes the app inaccessible to keyboard users.
 **Action:** Always add `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` to interactive elements to ensure a consistent, themed focus state.
+## 2024-04-12 - Custom Segmented Control ARIA Roles
+**Learning:** When creating custom segmented controls with mutually exclusive options, using `role="switch"` is incorrect as switches imply an on/off state. `role="group"` is also too generic. A segmented control is conceptually a set of radio buttons.
+**Action:** Use `role="radiogroup"` for the container and `role="radio"` for the individual buttons, along with `aria-checked={boolean}` and proper `aria-label`s on the container, to ensure screen readers correctly interpret the mutually exclusive selection pattern.

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,4 @@
 import { X } from 'lucide-react';
-import React from 'react';
 import { useStore } from '../store';
 import { getGenerationConfig, POKEBALL_LABELS } from '../utils/generationConfig';
 import { ClearStorageButton } from './settings/ClearStorageButton';

--- a/src/components/pokemon/details/PokemonCatchProbability.tsx
+++ b/src/components/pokemon/details/PokemonCatchProbability.tsx
@@ -39,22 +39,23 @@ export function PokemonCatchProbability({ catchRate, effectivePokeball }: Pokemo
             min="1"
             max="100"
             value={hpPercent}
+            aria-label="Target HP Percentage"
             onChange={(e) => setHpPercent(Number(e.target.value))}
-            className="h-2 w-full cursor-pointer appearance-none rounded-full border border-white/5 bg-black/40 accent-emerald-500"
+            className="h-2 w-full cursor-pointer appearance-none rounded-full border border-white/5 bg-black/40 accent-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
           />
         </div>
 
-        {/* biome-ignore lint/a11y/useSemanticElements: custom segmented control */}
-        <div className="grid grid-cols-3 gap-2" role="group" aria-label="Target Status">
+        <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Target Status">
           {[
             { id: 'none' as StatusType, label: 'Healthy' },
             { id: 'paralyze_burn_poison' as StatusType, label: 'Debuff' },
             { id: 'sleep_freeze' as StatusType, label: 'Incapacitated' },
           ].map((item) => (
+            // biome-ignore lint/a11y/useSemanticElements: custom segmented control using radio role
             <button
               type="button"
               key={item.id}
-              role="switch"
+              role="radio"
               aria-checked={status === item.id}
               onClick={() => setStatus(item.id)}
               className={cn(

--- a/src/components/settings/SettingsControls.tsx
+++ b/src/components/settings/SettingsControls.tsx
@@ -1,5 +1,4 @@
 import { Archive, CircleDot, Settings2 } from 'lucide-react';
-import React from 'react';
 import type { GameVersion, PokeballType } from '../../store';
 import type { GenerationConfig } from '../../utils/generationConfig';
 import { getGenerationConfig } from '../../utils/generationConfig';

--- a/src/components/settings/SettingsLegend.tsx
+++ b/src/components/settings/SettingsLegend.tsx
@@ -1,5 +1,4 @@
 import { Check, CircleDot, Ghost, Info, Monitor } from 'lucide-react';
-import React from 'react';
 
 export function SettingsLegend() {
   return (

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -654,7 +654,7 @@ export function generateSuggestions(
     };
 
     const nodes = findNodeAndParent(chain.chain);
-    if (!nodes || !nodes.parentNode) return;
+    if (!nodes?.parentNode) return;
 
     const parentId = parseIdFromUrl(nodes.parentNode.species.url);
 


### PR DESCRIPTION
### 💡 What:
Improved accessibility in `PokemonCatchProbability.tsx` by adding missing labels, focus states, and correcting ARIA roles for the segmented control.

### 🎯 Why:
- The range input lacked an accessible name, making it difficult for screen reader users to understand its purpose.
- The range input lacked keyboard focus visibility, harming keyboard navigation.
- The segmented control was using `role="switch"` which incorrectly implies independent on/off toggles, whereas it actually functions as mutually exclusive radio buttons.

### 📸 Before/After:
_Visually identical, but structurally more accessible. A verification script has been run to ensure no visual regressions._

### ♿ Accessibility:
- Added `aria-label="Target HP Percentage"` to the range input.
- Added Tailwind `focus-visible` classes to the range input.
- Updated segmented control to use `role="radiogroup"` and `role="radio"`.

---
*PR created automatically by Jules for task [15535484118149037128](https://jules.google.com/task/15535484118149037128) started by @szubster*