### PR TITLE
🧪 [testing improvement] Add error handling test for pokeapi evolution fetch in suggestionEngine

### DIFF
--- a/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
+++ b/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
@@ -1,0 +1,60 @@
+import type { MockInstance } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { pokeapi } from '../../../utils/pokeapi';
+import type { SaveData } from '../../saveParser/index';
+import { fetchAssistantApiData } from '../suggestionEngine';
+
+describe('fetchAssistantApiData', () => {
+  let consoleErrorSpy: MockInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should handle pokeapi evolution fetch failure gracefully in partyPromises', async () => {
+    const mockSaveData = {
+      generation: 1,
+      currentMapId: 0,
+      party: [1, 2], // Bulbasaur and Ivysaur
+    } as unknown as SaveData;
+
+    vi.spyOn(pokeapi, 'resource').mockImplementation(async (url: string) => {
+      // Mock successful fetch for local area
+      if (url.includes('location-area')) return { pokemon_encounters: [] };
+
+      // Mock missing encounters
+      if (url.includes('/pokemon/')) return [];
+
+      // Mock species fetch
+      if (url.includes('/pokemon-species/1')) {
+        return { evolution_chain: { url: 'chain1' } };
+      }
+      if (url.includes('/pokemon-species/2')) {
+        return { evolution_chain: { url: 'chain2' } };
+      }
+
+      // Mock chain fetch: throw for chain1, succeed for chain2
+      if (url === 'chain1') {
+        throw new Error('Network failure');
+      }
+      if (url === 'chain2') {
+        return { id: 2, chain: { species: { url: '.../2/' }, evolves_to: [] } };
+      }
+
+      return {};
+    });
+
+    const result = await fetchAssistantApiData(mockSaveData, []);
+
+    // It should have logged the error
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Evo fetch failed', 1, expect.any(Error));
+
+    // It should have continued and fetched chain2
+    expect(result.partyEvolutions[2]).toBeDefined();
+    expect(result.partyEvolutions[1]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
🎯 **What:** The suggestion engine orchestrates multiple concurrent `pokeapi.resource` network fetches to gather evolution chains for the user's current party (`partyPromises`). If an individual request fails, it is wrapped in a try/catch. However, there was a testing gap where the error handling and execution resumption were not explicitly tested.

📊 **Coverage:** Added `src/engine/assistant/__tests__/fetchAssistantApiData.test.ts` which successfully intercepts `pokeapi.resource` and mocks it to throw an error for the first party member's evolution chain fetch while returning successfully for the second member. The test asserts that `console.error` is invoked appropriately with the error object and ID, and confirms the `partyEvolutions` map correctly contains data for the valid second Pokémon while being undefined for the first. This proves that an error inside the map safely continues to process other elements without blocking.

✨ **Result:** Increased confidence in the suggestion engine's error resilience. Network instability from PokeAPI during evolution lookups is now proven to degrade gracefully rather than breaking the entire assistant pipeline.

---
*PR created automatically by Jules for task [5415321382893207772](https://jules.google.com/task/5415321382893207772) started by @szubster*