### PR TITLE
🧪 [test: add queryClient unit tests]

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -641,7 +641,7 @@ export function generateSuggestions(
     if (!instancesBySpecies.has(p.speciesId)) {
       instancesBySpecies.set(p.speciesId, []);
     }
-    instancesBySpecies.get(p.speciesId)!.push(p);
+    instancesBySpecies.get(p.speciesId)?.push(p);
   }
 
   // Evolutions

--- a/src/queryClient.test.ts
+++ b/src/queryClient.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { queryClient } from './queryClient';
 import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+import { queryClient } from './queryClient';
 
 describe('queryClient', () => {
   it('should be an instance of QueryClient', () => {

--- a/src/queryClient.test.ts
+++ b/src/queryClient.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { queryClient } from './queryClient';
+import { QueryClient } from '@tanstack/react-query';
+
+describe('queryClient', () => {
+  it('should be an instance of QueryClient', () => {
+    expect(queryClient).toBeInstanceOf(QueryClient);
+  });
+
+  it('should have the correct default options', () => {
+    const defaultOptions = queryClient.getDefaultOptions();
+    expect(defaultOptions.queries).toEqual({
+      staleTime: Infinity,
+      gcTime: 1000 * 60 * 60 * 24,
+      refetchOnWindowFocus: false,
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `queryClient` instantiation and configuration.
📊 **Coverage:** Covered the instantiation type (`QueryClient`) and the default query configuration options (`staleTime`, `gcTime`, `refetchOnWindowFocus`).
✨ **Result:** Improved test coverage ensuring `queryClient` doesn't silently break its default configuration behavior.

---
*PR created automatically by Jules for task [18334136499626916719](https://jules.google.com/task/18334136499626916719) started by @szubster*