### PR TITLE
🧹 [code health] Remove console.log from tests

### DIFF
--- a/src/engine/assistant/__tests__/suggestionEngine.repro.test.ts
+++ b/src/engine/assistant/__tests__/suggestionEngine.repro.test.ts
@@ -7,14 +7,11 @@ describe('suggestionEngine - Jynx Double Suggestion Repro', () => {
   const savPath = resolve(__dirname, '../../../../tests/fixtures/yellow-2026-03-30.sav');
 
   it('should load and parse the save file', () => {
-    console.log('Path:', savPath);
     expect(existsSync(savPath)).toBe(true);
 
     const buffer = readFileSync(savPath);
-    console.log('Loaded, size:', buffer.byteLength);
 
     const saveData = parseSaveFile(buffer.buffer);
-    console.log('Parsed. Version:', saveData.gameVersion, 'Trainer:', saveData.trainerName);
 
     expect(saveData.generation).toBe(1);
     expect(saveData.gameVersion).toBe('yellow');

--- a/src/engine/saveParser/repro.test.ts
+++ b/src/engine/saveParser/repro.test.ts
@@ -9,14 +9,6 @@ describe('Yellow Save Repro', () => {
     const buffer = fs.readFileSync(savePath);
     const saveData = parseSaveFile(buffer.buffer);
 
-    console.log('Parsed Save Data:', {
-      trainerName: saveData.trainerName,
-      gameVersion: saveData.gameVersion,
-      currentMapId: saveData.currentMapId,
-      currentMapName: saveData.currentMapName,
-      ownedSize: saveData.owned.size,
-    });
-
     expect(saveData.gameVersion).toBe('yellow');
 
     // We can't easily run generateSuggestions because it's async and calls PokeAPI.


### PR DESCRIPTION
🎯 **What:** Removed `console.log` statements from `src/engine/assistant/__tests__/suggestionEngine.repro.test.ts` and `src/engine/saveParser/repro.test.ts`.
💡 **Why:** To improve code maintainability and remove unnecessary noise from the test suite output.
✅ **Verification:** Verified the removal with `cat` and ran `npx vitest run` to ensure all 102 tests still pass and no regressions were introduced.
✨ **Result:** Cleaner test files and less noise during test execution without affecting test behavior.

---
*PR created automatically by Jules for task [9941086818694082888](https://jules.google.com/task/9941086818694082888) started by @szubster*