### PR TITLE
🧪 [testing improvement] Add missing error handling test for pokeapi fetch in suggestionEngine

### DIFF
--- a/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
+++ b/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi, afterEach } from 'vitest';
-import { fetchAssistantApiData } from '../suggestionEngine';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { pokeapi } from '../../../utils/pokeapi';
 import type { SaveData } from '../../saveParser/index';
+import { fetchAssistantApiData } from '../suggestionEngine';
 
 vi.mock('../../../utils/pokeapi', () => ({
   pokeapi: {

--- a/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
+++ b/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { fetchAssistantApiData } from '../suggestionEngine';
+import { pokeapi } from '../../../utils/pokeapi';
+import type { SaveData } from '../../saveParser/index';
+
+vi.mock('../../../utils/pokeapi', () => ({
+  pokeapi: {
+    resource: vi.fn(),
+  },
+}));
+
+describe('fetchAssistantApiData', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should log an error and continue when local area fetch fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Make pokeapi.resource throw an error for the local area fetch
+    vi.mocked(pokeapi.resource).mockRejectedValueOnce(new Error('Network error'));
+
+    const mockSaveData: SaveData = {
+      generation: 2,
+      gameVersion: 'crystal',
+      owned: new Set(),
+      seen: new Set(),
+      party: [],
+      inventory: [],
+      currentMapId: 0,
+      eventFlags: new Uint8Array(300),
+      partyDetails: [],
+      pcDetails: [],
+      trainerName: 'PLAYER',
+    } as unknown as SaveData;
+
+    const queryTargets: number[] = [];
+
+    const result = await fetchAssistantApiData(mockSaveData, queryTargets);
+
+    // Verify console.error was called with expected arguments
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Local area fetch failed', expect.any(Error));
+
+    // Verify it continues and localEncounters is empty
+    expect(result.localEncounters).toEqual([]);
+
+    // Cleanup
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -641,7 +641,7 @@ export function generateSuggestions(
     if (!instancesBySpecies.has(p.speciesId)) {
       instancesBySpecies.set(p.speciesId, []);
     }
-    instancesBySpecies.get(p.speciesId)!.push(p);
+    instancesBySpecies.get(p.speciesId)?.push(p);
   }
 
   // Evolutions


### PR DESCRIPTION
🎯 **What:** The `suggestionEngine.ts`'s `fetchAssistantApiData` gracefully catches failures from `pokeapi.resource` for local areas, but this behavior wasn't unit tested.

📊 **Coverage:** A new test case now verifies that if the pokeapi call fails (using a rejected mock promise), the `console.error` logs the exact error format expected, and execution continues smoothly with an empty `localEncounters` array.

✨ **Result:** Improved test coverage around network edge cases in the suggestion engine, guaranteeing that minor API outages don't break the entire fetch logic unobserved.

---
*PR created automatically by Jules for task [5155867085255874234](https://jules.google.com/task/5155867085255874234) started by @szubster*