### PR TITLE
chore: strict biome enforcement and CI consolidation

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -2,9 +2,9 @@ name: Biome Verification
 
 on:
   push:
-    branches: ["main", "master"]
+    branches: ["main"]
   pull_request:
-    branches: ["main", "master"]
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -2,9 +2,9 @@ name: Biome Verification
 
 on:
   push:
-    branches: [main]
+    branches: ["main", "master"]
   pull_request:
-    branches: [main]
+    branches: ["main", "master"]
 
 permissions:
   contents: read
@@ -22,4 +22,4 @@ jobs:
           version: latest
 
       - name: Run Biome
-        run: biome ci .
+        run: biome ci --error-on-warnings .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
         
-      - name: Lint
-        run: npm run lint
+      - name: Type Check
+        run: npm run type-check
 
       - name: Test
         run: npm test -- --coverage --reporter=junit --outputFile=test-report.junit.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["main", "master"]
+    branches: ["main"]
   pull_request:
-    branches: ["main", "master"]
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/.serena/memories/infrastructure/analysis_tools.md
+++ b/.serena/memories/infrastructure/analysis_tools.md
@@ -1,0 +1,11 @@
+# Project Infrastructure - Bundle Analysis and Coverage
+
+- **BundleMon**: Restored in April 2026. Configured in `.bundlemonrc.json`. It monitors the sizes of `dist/assets/index-*.js` (limit 650KB) and `dist/assets/style-*.css` (limit 100KB). It runs in the CI workflow `ci.yml`.
+- **Codecov**: Integrated for test coverage and bundle analysis.
+  - Test coverage is reported by `vitest` using `c8`.
+  - Bundle analysis is handled by `@codecov/vite-plugin` in `vite.config.ts`.
+- Both tools are currently running in parallel as of April 12, 2026.
+- **Biome**: Unified linter and formatter.
+  - Configured in `biome.jsonc`.
+  - Enforcement Level: **Strict (Errors only)**. All violations, including warnings and nursery rules (e.g., `useSortedClasses`), are treated as errors.
+  - Integration: Runs in CI via `npm run lint` which calls `biome check --error-on-warnings`.

--- a/.serena/memories/infrastructure/biome_migration_status.md
+++ b/.serena/memories/infrastructure/biome_migration_status.md
@@ -22,3 +22,4 @@ The project has transitioned from no formal linting/formatting to a unified tool
 
 ## Future Phases
 - **Phase 8**: UI Baseline Stabilization / Enablement of `a11y` rules (Currently marked as TODO in `biome.jsonc`).
+- **Phase 9 (Completed)**: Enforce Errors. Escalated all violations to error severity in CI/CD via `package.json` and config.

--- a/.serena/memories/onboarding/style_and_conventions.md
+++ b/.serena/memories/onboarding/style_and_conventions.md
@@ -28,7 +28,9 @@ Following the project's `testing_rules.md`:
 - **No Placeholders**: Never use placeholder images. Use `generate_image` or real assets.
 - **Animations**: Implement subtle micro-animations and interactive transitions (hover effects, smooth state changes) to make the UI feel "alive".
 
-## Code Formatting
+## Code Analysis and Formatting
 
-- Relies on Vite/TypeScript defaults.
-- Always run `npm run lint` (`tsc --noEmit`) to verify types.
+- **Biome**: Primary linter and formatter.
+  - All CI checks and Git Hooks are strictly enforced to treat both errors and warnings as failures (using `--error-on-warnings`).
+  - **Zero-Diagnostic Policy**: Even though `info` level diagnostics do not block the build, you MUST manually verify them during every check and fix them to maintain a zero-diagnostic state.
+- **TypeScript**: Always run `npm run lint` (`tsc --noEmit`) to verify types.

--- a/.serena/memories/onboarding/task_completion_guidelines.md
+++ b/.serena/memories/onboarding/task_completion_guidelines.md
@@ -12,8 +12,9 @@ Before finalizing any task, the following steps must be completed:
     - Ensure tests handle uninitialized state using `initializeWithSave`.
     - Verify that no existing tests or visual regressions are broken.
 
-3.  **Type Safety**:
-    - Run `npm run lint` (`tsc --noEmit`) to ensure no TypeScript errors were introduced.
+3.  **Analysis and Type Safety**:
+    - Run `npm run lint` which triggers Type Checking (`tsc`) and Biome Checks (`biome check`).
+    - **Zero-Diagnostic Policy**: All Biome errors and warnings must be addressed. Additionally, you MUST manually verify and fix any `info` level diagnostics to ensure a completely clean output.
 
 4.  **Visual Verification**:
     - For UI changes, ensure Argos screenshot tests are updated or added where necessary.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -29,7 +29,7 @@
       "recommended": true,
       "nursery": {
         "useSortedClasses": {
-          "level": "warn",
+          "level": "error",
           "options": {
             "functions": ["clsx", "twMerge", "cn"]
           }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,7 @@ pre-commit:
   commands:
     biome-check:
       glob: "*.{js,ts,jsx,tsx,json,css}"
-      run: npx --no-install biome check --write --no-errors-on-unmatched {staged_files}
+      run: npx --no-install biome check --write --error-on-warnings --no-errors-on-unmatched {staged_files}
       stage_fixed: true
       fail_on_changes: ci
     type-check:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:analyze": "ANALYZE=true vite build",
     "preview": "vite preview",
     "clean": "rm -rf dist",
-    "lint": "tsc --noEmit && npm run check:biome",
+    "lint": "npm run type-check && npm run check:biome",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
@@ -20,6 +20,7 @@
     "lint:biome": "biome lint --error-on-warnings .",
     "format:biome": "biome format .",
     "check:biome": "biome check --error-on-warnings .",
+    "type-check": "tsc --noEmit",
     "check:fix": "biome check --write --unsafe .",
     "postinstall": "lefthook install"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:analyze": "ANALYZE=true vite build",
     "preview": "vite preview",
     "clean": "rm -rf dist",
-    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit && npm run check:biome",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",


### PR DESCRIPTION
This PR finalizes the Biome enforcement policy by:
1. Moving all Biome CI checks to `.github/workflows/biome.yml` and adding `--error-on-warnings` for strict enforcement.
2. Cleaning up `.github/workflows/ci.yml` to focus on type-checking (`tsc --noEmit`) and testing.
3. Adding `--error-on-warnings` to Lefthook pre-commit hooks.
4. Updating project guidelines to include a mandatory Zero-Diagnostic verify-and-fix policy for `info` level diagnostics.
5. Organizing `package.json` scripts for better clarity between local and CI usage.