### PR TITLE
🎨 Palette: Add aria-labels to icon-only and card buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-13 - Added aria-label to icon-only buttons
+**Learning:** For accessibility, ensure all icon-only interactive elements (like buttons) include an `aria-label` attribute, as relying solely on the `title` attribute is insufficient for screen readers. In Dexhelper, several key interactive elements like the Assistant Panel debug toggle, Pokedex Cards, and Storage Grid cards lacked proper screen reader announcements despite having visual cues or titles.
+**Action:** Always add `aria-label` attributes to icon-only buttons and interactive card elements that act as links or triggers, ensuring the label clearly describes the action or destination (e.g., `aria-label={"View details for " + pokemon.name}`).

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -105,6 +105,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
               onClick={() => setShowDebug(!showDebug)}
               className={`rounded-xl border p-2 transition-all ${showDebug ? 'border-amber-500/50 bg-amber-500/20 text-amber-400' : 'border-zinc-700 bg-zinc-800 text-zinc-500 hover:text-zinc-300'}`}
               title="Toggle Debug Mode"
+              aria-label="Toggle Debug Mode"
             >
               <Bug size={18} />
             </button>

--- a/src/components/PokedexCard.tsx
+++ b/src/components/PokedexCard.tsx
@@ -46,6 +46,7 @@ export function PokedexCard({
   return (
     <button
       type="button"
+      aria-label={`View details for ${pokemon.name}`}
       data-testid="pokedex-card"
       data-pokemon-id={pokemon.id}
       onClick={() => navigate({ to: `/pokemon/${pokemon.id}`, search: { from: '/' } })}

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -84,6 +84,7 @@ export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: 
                   return (
                     <button
                       type="button"
+                      aria-label={`View details for ${pokemon.name} in ${location}`}
                       // biome-ignore lint/suspicious/noArrayIndexKey: Array index is stable and required for duplicates
                       key={`${location}-${p.speciesId}-${idx}`}
                       onClick={() => navigate({ to: `/pokemon/${pokemon.id}`, search: { from: '/storage' } })}


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to icon-only buttons and interactive cards throughout the application, specifically targeting the Debug Toggle in the Assistant Panel, the Pokedex Cards, and the Storage Grid Cards.

### 🎯 Why
Icon-only buttons and interactive elements that lack clear text content are inaccessible to screen readers. While some had `title` attributes, these are often insufficient or completely ignored by assistive technologies. Adding descriptive `aria-label`s ensures that all users, regardless of how they navigate the app, understand the purpose and destination of these interactions.

### 📸 Before/After
*(No visual changes - purely an accessibility enhancement)*

### ♿ Accessibility
- Added `aria-label="Toggle Debug Mode"` to the Assistant Panel debug toggle button.
- Added `aria-label={"View details for " + pokemon.name}` to Pokedex Grid cards.
- Added `aria-label={"View details for " + pokemon.name + " in " + location}` to Storage Grid cards.
- Screen readers will now announce the specific action or Pokémon destination when focusing on these interactive elements.

---
*PR created automatically by Jules for task [3149457879431187405](https://jules.google.com/task/3149457879431187405) started by @szubster*