### PR TITLE
Fix Red/Blue starter catchable logic in suggestion engine

### DIFF
--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -376,8 +376,11 @@ export function generateSuggestions(
           if (isInternalObtainable) {
             const isYellow = displayVersion === 'yellow';
             const isRedBlueStarter = [1, 4, 7].includes(baseId);
-            if (isYellow && isRedBlueStarter) isCatchableSomewhere = true;
-            else if (isInternalObtainable) isCatchableSomewhere = true;
+            if (isRedBlueStarter) {
+              if (isYellow) isCatchableSomewhere = true;
+            } else {
+              isCatchableSomewhere = true;
+            }
           }
         }
       }


### PR DESCRIPTION
I have identified and fixed a logic bug in `src/engine/assistant/suggestionEngine.ts` where Red/Blue starter Pokémon were incorrectly being marked as catchable in Red and Blue versions instead of correctly being marked as version exclusive (requiring a trade). The condition evaluating `isInternalObtainable` had a tautology with its fallback `else if` branch.

**What:**
Fixed the version exclusivity logic for Red/Blue starters inside `suggestionEngine.ts`.

**Why:**
The previous code used an `else if (isInternalObtainable)` fallback inside an `if (isInternalObtainable)` block. This caused Red/Blue starters (which are in the `isInternalObtainable` list) to fall through and incorrectly be marked as `isCatchableSomewhere = true` in Red and Blue, which led to missing trade suggestions for these starters.

**Verification:**
Manually tested the condition logic via isolated scratch scripts to verify the bug, and ran the full unit test suite via `npx vitest run` to ensure no regressions. All tests pass successfully.

---
*PR created automatically by Jules for task [5522864603245360215](https://jules.google.com/task/5522864603245360215) started by @szubster*