### PR TITLE
⚡ Bolt: Add React.memo to PokedexCard

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-04-12 - [O(N) Operations inside loop]
 **Learning:** In suggestionEngine.ts, filtering `allInstances` inside the queryTargets loop repeatedly creates new arrays for every missing Pokemon. This causes O(N*M) complexity.
 **Action:** Process `allInstances` outside the loop into a Map to achieve O(1) lookups.
+
+## 2024-05-15 - [React.memo in large lists]
+**Learning:** Re-evaluating filtered datasets like `finalPokemon` triggers parent grid re-renders. For large lists like Gen 2 (up to 251 items), missing `React.memo` on list item components (`PokedexCard`) forces all children to re-render despite stable props.
+**Action:** Use `React.memo` to wrap item components inside list grids to decouple child rendering from parent dataset recalculations.

--- a/src/components/PokedexCard.tsx
+++ b/src/components/PokedexCard.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from '@tanstack/react-router';
 import { ChevronRight, CircleDot, Monitor, Sparkles } from 'lucide-react';
+import React from 'react';
 import type { SaveData } from '../engine/saveParser';
 import { cn } from '../utils/cn';
 import { getGenerationConfig } from '../utils/generationConfig';
@@ -15,7 +16,9 @@ export interface PokedexCardProps {
   genConfig: ReturnType<typeof getGenerationConfig> | null;
 }
 
-export function PokedexCard({
+// ⚡ Bolt: Wrapped PokedexCard in React.memo to prevent unnecessary re-renders when parent PokedexGrid updates.
+// This prevents up to 251 (Gen 2 max dex) unneeded DOM re-evaluations on every search keystroke, significantly reducing main thread blocking time.
+export const PokedexCard = React.memo(function PokedexCard({
   pokemon,
   idx,
   saveData,
@@ -174,4 +177,4 @@ export function PokedexCard({
       </div>
     </button>
   );
-}
+});


### PR DESCRIPTION
💡 **What:** 
Wrapped the `PokedexCard` component in `React.memo()`.

🎯 **Why:** 
When the user types in the search filter, the parent `PokedexGrid` re-renders and re-evaluates `finalPokemon`. Without `React.memo`, this forces React to re-render all visible `PokedexCard` components (up to 251 for Gen 2), even though their individual props (like `saveData`, `pokemon`, `genConfig`) haven't changed. This causes significant main thread blocking and typing jank.

📊 **Impact:** 
Significantly reduces main thread blocking time during list filtering by completely skipping the reconciliation process for up to 251 list items whose props have not changed. This results in much smoother typing in the search bar.

🔬 **Measurement:** 
Run the app, type rapidly in the search bar. Using React DevTools Profiler, observe that `PokedexCard` components no longer render when typing.

---
*PR created automatically by Jules for task [7613306447075836344](https://jules.google.com/task/7613306447075836344) started by @szubster*