### PR TITLE
chore: add @tanstack/react-query-devtools for developer insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.97.0",
+    "@tanstack/react-query-devtools": "^5.99.0",
     "@tanstack/react-router": "^1.168.10",
     "@tanstack/react-router-devtools": "^1.166.11",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.97.0
         version: 5.97.0(react@19.2.5)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.99.0
+        version: 5.99.0(@tanstack/react-query@5.97.0(react@19.2.5))(react@19.2.5)
       '@tanstack/react-router':
         specifier: ^1.168.10
         version: 1.168.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -913,6 +916,15 @@ packages:
 
   '@tanstack/query-core@5.97.0':
     resolution: {integrity: sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg==}
+
+  '@tanstack/query-devtools@5.99.0':
+    resolution: {integrity: sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==}
+
+  '@tanstack/react-query-devtools@5.99.0':
+    resolution: {integrity: sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.99.0
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.97.0':
     resolution: {integrity: sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ==}
@@ -2860,6 +2872,14 @@ snapshots:
   '@tanstack/history@1.161.6': {}
 
   '@tanstack/query-core@5.97.0': {}
+
+  '@tanstack/query-devtools@5.99.0': {}
+
+  '@tanstack/react-query-devtools@5.99.0(@tanstack/react-query@5.97.0(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-devtools': 5.99.0
+      '@tanstack/react-query': 5.97.0(react@19.2.5)
+      react: 19.2.5
 
   '@tanstack/react-query@5.97.0(react@19.2.5)':
     dependencies:

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -14,6 +14,15 @@ const TanStackRouterDevtools =
         })),
       );
 
+const ReactQueryDevtools =
+  process.env.NODE_ENV === 'production' || !!window.navigator.webdriver
+    ? () => null // Render nothing in production or automated tests
+    : React.lazy(() =>
+        import('@tanstack/react-query-devtools').then((res) => ({
+          default: res.ReactQueryDevtools,
+        })),
+      );
+
 export interface RootContext {
   queryClient: QueryClient;
 }
@@ -39,6 +48,7 @@ function RootComponent() {
       <Outlet />
       <Suspense>
         <TanStackRouterDevtools />
+        <ReactQueryDevtools />
       </Suspense>
     </AppLayout>
   );


### PR DESCRIPTION
**What**
Added `@tanstack/react-query-devtools` to the project and integrated it within the root layout.

**Why**
The app already utilizes `@tanstack/react-query`, but lacks the official developer tools. To provide better developer insights without adding bloat in production, this adds the `ReactQueryDevtools` component alongside the existing `TanStackRouterDevtools`, dynamically loading only in non-production, non-webdriver environments.

**Verification**
- Checked `package.json` for proper dependency setup.
- Ran `pnpm type-check` and `pnpm check:biome` via `pnpm lint`. No errors.
- Ran unit tests via `npx vitest run`. All tests passed.
- Ran End-to-End tests via `pnpm test:e2e` and confirmed zero breakage.

**Result**
Developers will now have access to a rich query explorer when running the application locally.

---
*PR created automatically by Jules for task [13444831857153520576](https://jules.google.com/task/13444831857153520576) started by @szubster*