### PR TITLE
Fix Argos upload failures

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     ['@argos-ci/playwright/reporter', {
       uploadToArgos: !!process.env.CI,
       buildName: process.env.ARGOS_BUILD_NAME || 'E2E',
+      ignoreUploadFailures: true,
     }]
   ],
   use: {


### PR DESCRIPTION
Added `ignoreUploadFailures: true` flag in the Argos reporter options in `playwright.config.ts`. This will prevent the test suite from failing if the upload to Argos fails due to the screenshot limit.

---
*PR created automatically by Jules for task [17901004379643692202](https://jules.google.com/task/17901004379643692202) started by @szubster*