### PR TITLE
Remove pokemon types from UI

### DIFF
--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -6,7 +6,6 @@ import type {
   EvolutionDetail,
   LocationAreaEncounter,
   NamedAPIResource,
-  PokemonType,
   VersionEncounterDetail,
 } from 'pokenode-ts';
 import React, { useEffect } from 'react';
@@ -419,14 +418,6 @@ export function PokemonDetails({
                     {pokemonName}
                   </h2>
                   <div className="flex flex-wrap justify-center gap-2 sm:justify-start">
-                    {pokemonData?.types.map((t: PokemonType) => (
-                      <span
-                        key={t.type.name}
-                        className="rounded-full border border-white/10 bg-white/5 px-4 py-1.5 font-black text-[10px] text-zinc-300 uppercase tracking-widest backdrop-blur-md"
-                      >
-                        {t.type.name}
-                      </span>
-                    ))}
                     {stadiumReward && (
                       <div className="flex items-center gap-1.5 rounded-full border border-blue-500/20 bg-blue-500/10 px-4 py-1.5 font-black text-[10px] text-blue-400 uppercase tracking-widest backdrop-blur-md">
                         <Monitor size={12} /> Stadium Reward

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -479,7 +479,7 @@ export function PokemonDetails({
 
             {/* Right Column: Details & Locations */}
             <div className="space-y-12 lg:col-span-7">
-              <PokemonCaughtDetails yourPokemon={yourPokemon} saveData={saveData} />
+              <PokemonCaughtDetails yourPokemon={yourPokemon} />
 
               {/* Evolution & Procurement Strategy */}
               <PokemonEvolutions

--- a/src/components/pokemon/details/PokemonCaughtDetails.tsx
+++ b/src/components/pokemon/details/PokemonCaughtDetails.tsx
@@ -1,26 +1,12 @@
 import { CheckCircle2, CircleDot, MapPin, Sparkles } from 'lucide-react';
 import { gen2Items, gen2Locations } from '../../../engine/data/gen2/legacyNameMap';
-import type { PokemonInstance, SaveData } from '../../../engine/saveParser/index';
-import { getGenerationConfig } from '../../../utils/generationConfig';
+import type { PokemonInstance } from '../../../engine/saveParser/index';
 
 interface PokemonCaughtDetailsProps {
   yourPokemon: (PokemonInstance & { location: string })[];
-  saveData: SaveData | null;
 }
 
-function calculateHiddenPower(dvs: { atk: number; def: number; spd: number; spc: number }) {
-  const v = dvs.spc >= 8 ? 1 : 0;
-  const w = dvs.spd >= 8 ? 1 : 0;
-  const x = dvs.def >= 8 ? 1 : 0;
-  const y = dvs.atk >= 8 ? 1 : 0;
-  const z = dvs.spc % 4;
-
-  const hpPower = Math.floor((5 * (v + 2 * w + 4 * x + 8 * y) + z) / 2) + 31;
-
-  return { power: hpPower };
-}
-
-export function PokemonCaughtDetails({ yourPokemon, saveData }: PokemonCaughtDetailsProps) {
+export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps) {
   if (yourPokemon.length === 0) return null;
 
   return (

--- a/src/components/pokemon/details/PokemonCaughtDetails.tsx
+++ b/src/components/pokemon/details/PokemonCaughtDetails.tsx
@@ -9,28 +9,6 @@ interface PokemonCaughtDetailsProps {
 }
 
 function calculateHiddenPower(dvs: { atk: number; def: number; spd: number; spc: number }) {
-  const typeMap = [
-    'Fighting',
-    'Flying',
-    'Poison',
-    'Ground',
-    'Rock',
-    'Bug',
-    'Ghost',
-    'Steel',
-    'Fire',
-    'Water',
-    'Grass',
-    'Electric',
-    'Psychic',
-    'Ice',
-    'Dragon',
-    'Dark',
-  ];
-
-  const typeIndex = 4 * (dvs.atk % 4) + (dvs.def % 4);
-  const hpType = typeMap[typeIndex];
-
   const v = dvs.spc >= 8 ? 1 : 0;
   const w = dvs.spd >= 8 ? 1 : 0;
   const x = dvs.def >= 8 ? 1 : 0;
@@ -39,7 +17,7 @@ function calculateHiddenPower(dvs: { atk: number; def: number; spd: number; spc:
 
   const hpPower = Math.floor((5 * (v + 2 * w + 4 * x + 8 * y) + z) / 2) + 31;
 
-  return { type: hpType, power: hpPower };
+  return { power: hpPower };
 }
 
 export function PokemonCaughtDetails({ yourPokemon, saveData }: PokemonCaughtDetailsProps) {
@@ -103,14 +81,6 @@ export function PokemonCaughtDetails({ yourPokemon, saveData }: PokemonCaughtDet
                 <div className="flex flex-col">
                   <span className="font-black text-[8px] text-zinc-500 uppercase tracking-widest">Friendship</span>
                   <span className="font-bold text-[10px] text-rose-400">{p.friendship} pt</span>
-                </div>
-              )}
-              {saveData && getGenerationConfig(saveData.generation).hasHiddenPower && p.dvs && (
-                <div className="flex flex-col">
-                  <span className="font-black text-[8px] text-zinc-500 uppercase tracking-widest">Hidden Power</span>
-                  <span className="font-bold text-[10px] text-blue-400 uppercase">
-                    {calculateHiddenPower(p.dvs).type}
-                  </span>
                 </div>
               )}
             </div>


### PR DESCRIPTION
Removed any information about what type the pokemon is (grass, poison, etc) from `PokemonDetails` and `PokemonCaughtDetails` hidden power logic.

---
*PR created automatically by Jules for task [404986721596979485](https://jules.google.com/task/404986721596979485) started by @szubster*