### PR TITLE
Refactor suggestion engine to use AssistantStrategy

### DIFF
--- a/fix_graph_import.py
+++ b/fix_graph_import.py
@@ -1,0 +1,9 @@
+import re
+
+with open('src/engine/assistant/suggestionEngine.ts', 'r') as f:
+    content = f.read()
+
+content = re.sub(r"import \{ getDistanceToMap \} from '\.\./mapGraph/gen1Graph';\n", "", content)
+
+with open('src/engine/assistant/suggestionEngine.ts', 'w') as f:
+    f.write(content)

--- a/replace_imports.py
+++ b/replace_imports.py
@@ -1,0 +1,20 @@
+import re
+
+with open('src/engine/assistant/suggestionEngine.ts', 'r') as f:
+    content = f.read()
+
+# Add getStrategy import
+content = re.sub(
+    r"import type \{ EncounterDetail, RejectedSuggestion, Suggestion \} from './strategies/types';",
+    "import type { EncounterDetail, RejectedSuggestion, Suggestion } from './strategies/types';\nimport { getStrategy } from './strategies/index';",
+    content
+)
+
+# Remove unused imports
+content = re.sub(r"GEN1_MAP_TO_SLUG,\n\s*", "", content)
+content = re.sub(r"import \{ getUnobtainableReason \} from '\.\./exclusives/gen1Exclusives';\n", "", content)
+content = re.sub(r"getDistanceToMap,\s*", "", content)
+content = re.sub(r"import \{\s*\} from '\.\./mapGraph/gen1Graph';\n", "", content)
+
+with open('src/engine/assistant/suggestionEngine.ts', 'w') as f:
+    f.write(content)

--- a/src/engine/assistant/strategies/gen1Strategy.ts
+++ b/src/engine/assistant/strategies/gen1Strategy.ts
@@ -56,9 +56,42 @@ export const gen1Strategy: AssistantStrategy = {
     return suggestions;
   },
 
-  isInternallyObtainable(_baseId: number, _version: string): boolean {
-    // Gen 1 doesn't have breeding, so obtainability is purely based on
-    // encounter data + static encounters. The main engine handles this.
-    return true;
+  isInternallyObtainable(baseId: number, version: string): boolean {
+    const isInternalObtainable = [
+      1,
+      4,
+      7, // Gen 1 Starters
+      152,
+      155,
+      158, // Gen 2 Starters
+      131,
+      133, // Lapras, Eevee
+      138,
+      140,
+      142, // Fossils
+      106,
+      107, // Hitmons
+      143,
+      144,
+      145,
+      146,
+      150, // Gen 1 Legendaries/Snorlax
+      130,
+      185,
+      245,
+      249,
+      250, // Gen 2 Statics
+    ].includes(baseId);
+
+    if (isInternalObtainable) {
+      const isYellow = version === 'yellow';
+      const isRedBlueStarter = [1, 4, 7].includes(baseId);
+      if (isRedBlueStarter) {
+        if (isYellow) return true;
+      } else {
+        return true;
+      }
+    }
+    return false;
   },
 };

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -7,17 +7,10 @@ import type {
 } from 'pokenode-ts';
 import { getGenerationConfig } from '../../utils/generationConfig';
 import { pokeapi } from '../../utils/pokeapi';
-import {
-  GEN1_ITEMS,
-  GEN1_MAP_TO_SLUG,
-  OBEDIENCE_CAPS,
-  STATIC_GIFT_DATA,
-  STATIC_NPC_TRADE_DATA,
-} from '../data/gen1/assistantData';
+import { GEN1_ITEMS, OBEDIENCE_CAPS, STATIC_GIFT_DATA, STATIC_NPC_TRADE_DATA } from '../data/gen1/assistantData';
 import { gen2Items } from '../data/gen2/legacyNameMap';
-import { getUnobtainableReason } from '../exclusives/gen1Exclusives';
-import { getDistanceToMap } from '../mapGraph/gen1Graph';
 import type { PokemonInstance, SaveData } from '../saveParser/index';
+import { getStrategy } from './strategies/index';
 import type { EncounterDetail, RejectedSuggestion, Suggestion } from './strategies/types';
 
 /** Data returned by fetchAssistantApiData */
@@ -71,13 +64,8 @@ function getAncestors(node: ChainLink, target: number, path: number[] = []): num
  * This is decoupled from the React hook for easier testing.
  */
 export async function fetchAssistantApiData(saveData: SaveData, queryTargets: number[]) {
-  let localSlug = '';
-  if (saveData.generation === 1) {
-    localSlug = GEN1_MAP_TO_SLUG[saveData.currentMapId] || '';
-  } else {
-    // For Gen 2+, use a default slug (map graph is Gen 1-only for now)
-    localSlug = 'new-bark-town-area';
-  }
+  const strategy = getStrategy(saveData.generation);
+  const localSlug = strategy.resolveMapSlug(saveData);
 
   let localEncounters: PokemonEncounter[] = [];
   if (localSlug) {
@@ -195,6 +183,7 @@ export function generateSuggestions(
   if (!saveData || !apiData) return { suggestions, debug: { rejected } };
 
   const genConfig = getGenerationConfig(saveData.generation);
+  const strategy = getStrategy(saveData.generation);
   const maxDex = genConfig.maxDex;
   const missingIds: number[] = [];
 
@@ -226,7 +215,7 @@ export function generateSuggestions(
   const displayVersion = effectiveVersion === 'unknown' ? genConfig.defaultVersion : effectiveVersion;
   const queryTargets = missingIds.slice(0, 100);
 
-  const _localSlug = saveData.generation === 1 ? GEN1_MAP_TO_SLUG[saveData.currentMapId] || '' : 'new-bark-town-area';
+  const _localSlug = strategy.resolveMapSlug(saveData);
 
   // A. Catch logic
   if (apiData.localEncounters) {
@@ -308,7 +297,7 @@ export function generateSuggestions(
       }
 
       const encounters = apiData.missingEncounters[pid] || [];
-      const logicReason = getUnobtainableReason(pid, displayVersion || 'red', ownedCount, ownedSet);
+      const logicReason = strategy.getUnobtainableReason(pid, displayVersion || 'red', ownedCount, ownedSet);
       if (logicReason) {
         rejected.push({ pokemonId: pid, reason: logicReason, code: 'CHOICE_TAKEN' });
         suggestions.push({
@@ -347,40 +336,10 @@ export function generateSuggestions(
         if (!isCatchableSomewhere) {
           const chain = apiData.missingChains?.[pid];
           const baseId = chain ? parseIdFromUrl(chain.chain.species.url) : pid;
-          const isInternalObtainable = [
-            1,
-            4,
-            7, // Gen 1 Starters
-            152,
-            155,
-            158, // Gen 2 Starters
-            131,
-            133, // Lapras, Eevee
-            138,
-            140,
-            142, // Fossils
-            106,
-            107, // Hitmons
-            143,
-            144,
-            145,
-            146,
-            150, // Gen 1 Legendaries/Snorlax
-            130,
-            185,
-            245,
-            249,
-            250, // Gen 2 Statics
-          ].includes(baseId);
+          const isInternalObtainable = strategy.isInternallyObtainable(baseId, displayVersion || 'red');
 
           if (isInternalObtainable) {
-            const isYellow = displayVersion === 'yellow';
-            const isRedBlueStarter = [1, 4, 7].includes(baseId);
-            if (isRedBlueStarter) {
-              if (isYellow) isCatchableSomewhere = true;
-            } else {
-              isCatchableSomewhere = true;
-            }
+            isCatchableSomewhere = true;
           }
         }
       }
@@ -430,7 +389,7 @@ export function generateSuggestions(
       for (const enc of versionEncounters) {
         const targetAreaSlug = enc.location_area.name;
         if (!locationMap[targetAreaSlug]) {
-          const route = getDistanceToMap(saveData.currentMapId, targetAreaSlug);
+          const route = strategy.getMapDistance(saveData.currentMapId, targetAreaSlug);
           if (route)
             locationMap[targetAreaSlug] = {
               name: route.name,
@@ -598,26 +557,9 @@ export function generateSuggestions(
     }
   }
 
-  // Box Full
-  if (saveData.generation === 1) {
-    if (saveData.currentBoxCount >= 20) {
-      suggestions.push({
-        id: 'utility-box-full',
-        category: 'Utility',
-        title: 'CRITICAL: PC Box Full!',
-        description: "Your current PC box is at 20/20. Switch boxes via Bill's PC.",
-        priority: 150,
-      });
-    } else if (saveData.currentBoxCount >= 18) {
-      suggestions.push({
-        id: 'utility-box-near-full',
-        category: 'Utility',
-        title: 'PC Box Almost Full',
-        description: `${20 - saveData.currentBoxCount} slots remaining.`,
-        priority: 95,
-      });
-    }
-  }
+  // Special Suggestions (Box Full, etc.)
+  const specialSuggestions = strategy.getSpecialSuggestions(saveData, missingIds);
+  suggestions.push(...specialSuggestions);
 
   // Obedience
   const totalBadges =


### PR DESCRIPTION
This change refactors the core `suggestionEngine.ts` to properly utilize the `AssistantStrategy` pattern. The suggestion engine previously had a lot of hardcoded Generation 1 logic mixed with general logic (like hardcoded map resolution arrays, unobtainability checks, and special generation-specific Box Full logic).

This PR removes those hardcoded Generation 1 assumptions and instead delegates them to the `strategy` object obtained via `getStrategy(saveData.generation)`.

Fixes:
- Hardcoded Gen 1 ID checks and map arrays in `suggestionEngine`
- Improves modularity for supporting Gen 2+ by delegating behavior to Generation-specific strategies.

---
*PR created automatically by Jules for task [4350592464556395779](https://jules.google.com/task/4350592464556395779) started by @szubster*