### PR TITLE
⚡ Bolt: Optimize API Data Fetching via Local Memoization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-15 - [React.memo in large lists]
 **Learning:** Re-evaluating filtered datasets like `finalPokemon` triggers parent grid re-renders. For large lists like Gen 2 (up to 251 items), missing `React.memo` on list item components (`PokedexCard`) forces all children to re-render despite stable props.
 **Action:** Use `React.memo` to wrap item components inside list grids to decouple child rendering from parent dataset recalculations.
+
+## 2024-05-18 - [Optimizing Concurrent API Calls with local memoization]
+**Learning:** In suggestionEngine.ts, mapping concurrent fetches directly inside a large loop via `Promise.all` created significant scheduling overhead. It fetched identical API chains (like the Bulbasaur/Ivysaur/Venusaur evolution chain) repeatedly because there was no shared cache during the Promise loop generation.
+**Action:** Implemented a local `Map<string, Promise<any>>` to wrap and cache the outgoing fetch promises. This locally deduplicates concurrent network requests, eliminating redundant fetch executions during parallel data loading.

--- a/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
+++ b/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
@@ -57,4 +57,174 @@ describe('fetchAssistantApiData', () => {
     expect(result.partyEvolutions[2]).toBeDefined();
     expect(result.partyEvolutions[1]).toBeUndefined();
   });
+
+  it('should handle pokeapi missingEncounters fetch failure gracefully', async () => {
+    const mockSaveData = {
+      generation: 1,
+      currentMapId: 0,
+      party: [],
+    } as unknown as SaveData;
+
+    vi.spyOn(pokeapi, 'resource').mockImplementation(async (url: string) => {
+      if (url.includes('location-area')) return { pokemon_encounters: [] };
+
+      if (url.includes('/pokemon/1/encounters')) {
+        throw new Error('Encounter network failure');
+      }
+
+      if (url.includes('/pokemon-species/1')) {
+        return { evolution_chain: { url: 'chain1' } };
+      }
+      if (url === 'chain1') {
+        return { id: 1, chain: { species: { url: '.../1/' }, evolves_to: [] } };
+      }
+
+      return {};
+    });
+
+    const result = await fetchAssistantApiData(mockSaveData, [1]);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Encounter fetch failed', 1, expect.any(Error));
+    expect(result.missingEncounters[1]).toEqual([]);
+    expect(result.missingChains[1]).toBeDefined(); // Chain should still load
+  });
+
+  it('should handle pokeapi missingChains fetch failure gracefully', async () => {
+    const mockSaveData = {
+      generation: 1,
+      currentMapId: 0,
+      party: [],
+    } as unknown as SaveData;
+
+    vi.spyOn(pokeapi, 'resource').mockImplementation(async (url: string) => {
+      if (url.includes('location-area')) return { pokemon_encounters: [] };
+
+      if (url.includes('/pokemon/1/encounters')) {
+        return [{ location_area: { name: 'area', url: 'area' }, version_details: [] }];
+      }
+
+      if (url.includes('/pokemon-species/1')) {
+        return { evolution_chain: { url: 'chain1' } };
+      }
+      if (url === 'chain1') {
+        throw new Error('Chain network failure');
+      }
+
+      return {};
+    });
+
+    const result = await fetchAssistantApiData(mockSaveData, [1]);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Missing chain fetch failed', 1, expect.any(Error));
+    expect(result.missingEncounters[1]).toBeDefined(); // Encounter should still load
+    expect(result.missingEncounters[1].length).toBe(1);
+    expect(result.missingChains[1]).toBeUndefined();
+  });
+
+  it('should handle pokeapi local area fetch failure gracefully', async () => {
+    const mockSaveData = {
+      generation: 1,
+      currentMapId: 1,
+      party: [],
+    } as unknown as SaveData;
+
+    vi.spyOn(pokeapi, 'resource').mockImplementation(async (url: string) => {
+      if (url.includes('location-area')) throw new Error('Local area network failure');
+      return {};
+    });
+
+    const result = await fetchAssistantApiData(mockSaveData, []);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Local area fetch failed', expect.any(Error));
+    expect(result.localEncounters).toEqual([]);
+  });
+
+  it('should handle pokeapi gift fetch failure gracefully', async () => {
+    const mockSaveData = {
+      generation: 1,
+      currentMapId: 0,
+      party: [],
+    } as unknown as SaveData;
+
+    vi.spyOn(pokeapi, 'resource').mockImplementation(async (url: string) => {
+      if (url.includes('location-area')) return { pokemon_encounters: [] };
+      if (url.includes('/pokemon-species/133')) { // Eevee
+        return { evolution_chain: { url: 'chain133' } };
+      }
+      if (url === 'chain133') {
+        throw new Error('Gift chain network failure');
+      }
+      return {};
+    });
+
+    const result = await fetchAssistantApiData(mockSaveData, []);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Gift fetch failed', 133, expect.any(Error));
+    expect(result.giftChains[133]).toBeUndefined();
+  });
+
+  it('should deduplicate network requests using resourceCache', async () => {
+    const mockSaveData = {
+      generation: 1,
+      currentMapId: 0,
+      party: [1, 2, 3], // Bulbasaur, Ivysaur, Venusaur all share the same chain
+    } as unknown as SaveData;
+
+    const resourceSpy = vi.spyOn(pokeapi, 'resource').mockImplementation(async (url: string) => {
+      if (url.includes('location-area')) return { pokemon_encounters: [] };
+      if (url.includes('/pokemon-species/1')) return { evolution_chain: { url: 'chain_bulbasaur' } };
+      if (url.includes('/pokemon-species/2')) return { evolution_chain: { url: 'chain_bulbasaur' } };
+      if (url.includes('/pokemon-species/3')) return { evolution_chain: { url: 'chain_bulbasaur' } };
+      if (url === 'chain_bulbasaur') return { id: 1, chain: { species: { url: '.../1/' }, evolves_to: [] } };
+      return {};
+    });
+
+    await fetchAssistantApiData(mockSaveData, []);
+
+    // It should have called the chain URL exactly once because it is cached
+    const chainCalls = resourceSpy.mock.calls.filter(call => call[0] === 'chain_bulbasaur');
+    expect(chainCalls.length).toBe(1);
+  });
+
+  it('should handle pokeapi ancestor fetch failure gracefully', async () => {
+    const mockSaveData = {
+      generation: 1,
+      currentMapId: 0,
+      party: [],
+    } as unknown as SaveData;
+
+    vi.spyOn(pokeapi, 'resource').mockImplementation(async (url: string) => {
+      if (url.includes('location-area')) return { pokemon_encounters: [] };
+
+      // Target pokemon 2
+      if (url.includes('/pokemon/2/encounters')) return [];
+      if (url.includes('/pokemon-species/2')) return { evolution_chain: { url: 'chain2' } };
+
+      if (url === 'chain2') {
+        return {
+          id: 1,
+          chain: {
+            species: { url: 'https://pokeapi.co/api/v2/pokemon-species/1/' },
+            evolves_to: [
+              {
+                species: { url: 'https://pokeapi.co/api/v2/pokemon-species/2/' },
+                evolves_to: []
+              }
+            ]
+          }
+        };
+      }
+
+      if (url.includes('/pokemon/1/encounters')) {
+         throw new Error('Ancestor encounter fetch failed');
+      }
+
+      return {};
+    });
+
+    const result = await fetchAssistantApiData(mockSaveData, [2]);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Ancestor fetch failed', 1, expect.any(Error));
+    expect(result.ancestralEncounters[2][1]).toEqual([]);
+  });
 });

--- a/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
+++ b/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
@@ -117,7 +117,7 @@ describe('fetchAssistantApiData', () => {
 
     expect(consoleErrorSpy).toHaveBeenCalledWith('Missing chain fetch failed', 1, expect.any(Error));
     expect(result.missingEncounters[1]).toBeDefined(); // Encounter should still load
-    expect(result.missingEncounters[1].length).toBe(1);
+    expect(result.missingEncounters[1]?.length).toBe(1);
     expect(result.missingChains[1]).toBeUndefined();
   });
 
@@ -148,7 +148,8 @@ describe('fetchAssistantApiData', () => {
 
     vi.spyOn(pokeapi, 'resource').mockImplementation(async (url: string) => {
       if (url.includes('location-area')) return { pokemon_encounters: [] };
-      if (url.includes('/pokemon-species/133')) { // Eevee
+      if (url.includes('/pokemon-species/133')) {
+        // Eevee
         return { evolution_chain: { url: 'chain133' } };
       }
       if (url === 'chain133') {
@@ -182,7 +183,7 @@ describe('fetchAssistantApiData', () => {
     await fetchAssistantApiData(mockSaveData, []);
 
     // It should have called the chain URL exactly once because it is cached
-    const chainCalls = resourceSpy.mock.calls.filter(call => call[0] === 'chain_bulbasaur');
+    const chainCalls = resourceSpy.mock.calls.filter((call) => call[0] === 'chain_bulbasaur');
     expect(chainCalls.length).toBe(1);
   });
 
@@ -208,15 +209,15 @@ describe('fetchAssistantApiData', () => {
             evolves_to: [
               {
                 species: { url: 'https://pokeapi.co/api/v2/pokemon-species/2/' },
-                evolves_to: []
-              }
-            ]
-          }
+                evolves_to: [],
+              },
+            ],
+          },
         };
       }
 
       if (url.includes('/pokemon/1/encounters')) {
-         throw new Error('Ancestor encounter fetch failed');
+        throw new Error('Ancestor encounter fetch failed');
       }
 
       return {};
@@ -225,6 +226,6 @@ describe('fetchAssistantApiData', () => {
     const result = await fetchAssistantApiData(mockSaveData, [2]);
 
     expect(consoleErrorSpy).toHaveBeenCalledWith('Ancestor fetch failed', 1, expect.any(Error));
-    expect(result.ancestralEncounters[2][1]).toEqual([]);
+    expect(result.ancestralEncounters[2]?.[1]).toEqual([]);
   });
 });

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -79,10 +79,22 @@ export async function fetchAssistantApiData(saveData: SaveData, queryTargets: nu
     localSlug = 'new-bark-town-area';
   }
 
+  // ⚡ Bolt: Cache and deduplicate in-flight network promises to avoid redundant API calls
+  // Impact: Reduces duplicate network requests when fetching shared resources (like evolution chains)
+  // biome-ignore lint/suspicious/noExplicitAny: Cache value can be different Pokeapi objects
+  const resourceCache = new Map<string, Promise<any>>();
+  const getResource = (url: string) => {
+    if (!resourceCache.has(url)) {
+      resourceCache.set(url, pokeapi.resource(url));
+    }
+    // biome-ignore lint/style/noNonNullAssertion: Set on previous line
+    return resourceCache.get(url)!;
+  };
+
   let localEncounters: PokemonEncounter[] = [];
   if (localSlug) {
     try {
-      const areaData = await pokeapi.resource(`https://pokeapi.co/api/v2/location-area/${localSlug}`);
+      const areaData = await getResource(`https://pokeapi.co/api/v2/location-area/${localSlug}`);
       localEncounters = areaData.pokemon_encounters || [];
     } catch (e) {
       console.error('Local area fetch failed', e);
@@ -93,44 +105,51 @@ export async function fetchAssistantApiData(saveData: SaveData, queryTargets: nu
   const missingChains: Record<number, EvolutionChain> = {};
   const ancestralEncounters: Record<number, Record<number, LocationAreaEncounter[]>> = {};
 
-  const missingPromises = queryTargets.map(async (pid: number) => {
-    try {
-      const [encs, species] = await Promise.all([
-        pokeapi.resource(`https://pokeapi.co/api/v2/pokemon/${pid}/encounters`),
-        pokeapi.resource(`https://pokeapi.co/api/v2/pokemon-species/${pid}`),
-      ]);
-      missingEncounters[pid] = encs;
+  const missingPromises = queryTargets.map((pid: number) => {
+    const encPromise = getResource(`https://pokeapi.co/api/v2/pokemon/${pid}/encounters`)
+      .then((encs) => {
+        missingEncounters[pid] = encs;
+      })
+      .catch((e) => {
+        console.error('Encounter fetch failed', pid, e);
+        missingEncounters[pid] = [];
+      });
 
-      const chain = await pokeapi.resource(species.evolution_chain.url);
-      missingChains[pid] = chain;
-    } catch (_e) {
-      missingEncounters[pid] = [];
-    }
+    const chainPromise = getResource(`https://pokeapi.co/api/v2/pokemon-species/${pid}`)
+      .then((species) => getResource(species.evolution_chain.url))
+      .then((chain) => {
+        missingChains[pid] = chain;
+      })
+      .catch((e) => {
+        console.error('Missing chain fetch failed', pid, e);
+      });
+
+    return Promise.all([encPromise, chainPromise]);
   });
 
   const partyEvolutions: Record<number, EvolutionChain> = {};
-  const partyPromises = (saveData.party || []).map(async (pid: number) => {
-    try {
-      const species = await pokeapi.resource(`https://pokeapi.co/api/v2/pokemon-species/${pid}`);
-      const chainUrl = species.evolution_chain.url;
-      const chain = await pokeapi.resource(chainUrl);
-      partyEvolutions[pid] = chain;
-    } catch (e) {
-      console.error('Evo fetch failed', pid, e);
-    }
+  const partyPromises = (saveData.party || []).map((pid: number) => {
+    return getResource(`https://pokeapi.co/api/v2/pokemon-species/${pid}`)
+      .then((species) => getResource(species.evolution_chain.url))
+      .then((chain) => {
+        partyEvolutions[pid] = chain;
+      })
+      .catch((e) => {
+        console.error('Evo fetch failed', pid, e);
+      });
   });
 
   const giftChains: Record<number, EvolutionChain> = {};
-  const giftPromises = Object.keys(STATIC_GIFT_DATA).map(async (pidStr) => {
+  const giftPromises = Object.keys(STATIC_GIFT_DATA).map((pidStr) => {
     const pid = parseInt(pidStr, 10);
-    try {
-      const species = await pokeapi.resource(`https://pokeapi.co/api/v2/pokemon-species/${pid}`);
-      const chainUrl = species.evolution_chain.url;
-      const chain = await pokeapi.resource(chainUrl);
-      giftChains[pid] = chain;
-    } catch (e) {
-      console.error('Gift fetch failed', pid, e);
-    }
+    return getResource(`https://pokeapi.co/api/v2/pokemon-species/${pid}`)
+      .then((species) => getResource(species.evolution_chain.url))
+      .then((chain) => {
+        giftChains[pid] = chain;
+      })
+      .catch((e) => {
+        console.error('Gift fetch failed', pid, e);
+      });
   });
 
   await Promise.all([...missingPromises, ...partyPromises, ...giftPromises]);
@@ -152,12 +171,15 @@ export async function fetchAssistantApiData(saveData: SaveData, queryTargets: nu
 
   const ancestorData: Record<number, LocationAreaEncounter[]> = {};
   await Promise.all(
-    Array.from(uniqueAncestors).map(async (aid) => {
-      try {
-        ancestorData[aid] = await pokeapi.resource(`https://pokeapi.co/api/v2/pokemon/${aid}/encounters`);
-      } catch (_e) {
-        ancestorData[aid] = [];
-      }
+    Array.from(uniqueAncestors).map((aid) => {
+      return getResource(`https://pokeapi.co/api/v2/pokemon/${aid}/encounters`)
+        .then((encs) => {
+          ancestorData[aid] = encs;
+        })
+        .catch((e) => {
+          console.error('Ancestor fetch failed', aid, e);
+          ancestorData[aid] = [];
+        });
     }),
   );
 


### PR DESCRIPTION
💡 **What**: Added a local `Map<string, Promise<any>>` cache to deduplicate and cache in-flight network requests during the initialization phase of `fetchAssistantApiData`. Decoupled independent `.then()` promise chains (encounters and evolution chains) instead of using blocking sequential or grouped `Promise.all` steps.
🎯 **Why**: When mapping through missing Pokemon, identical resources (like the evolution chain for Bulbasaur and Ivysaur) were fetched multiple times redundantly because `Promise.all` had no shared network cache context. Waiting for slower encounters calls artificially throttled the fetch speed for chain URLs.
📊 **Impact**: Massively reduces redundant network requests to PokeAPI, speeding up the Assistant suggestion load times and decreasing bandwidth usage.
🔬 **Measurement**: Verify using Network tab during app load or test suite speed.

---
*PR created automatically by Jules for task [3890308001572201815](https://jules.google.com/task/3890308001572201815) started by @szubster*