### PR TITLE
chore: add @tanstack/react-query-devtools for improved developer insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.99.0",
+    "@tanstack/react-query-devtools": "^5.99.0",
     "@tanstack/react-router": "^1.168.19",
     "@tanstack/react-router-devtools": "^1.166.13",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.99.0
         version: 5.99.0(react@19.2.5)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.99.0
+        version: 5.99.0(@tanstack/react-query@5.99.0(react@19.2.5))(react@19.2.5)
       '@tanstack/react-router':
         specifier: ^1.168.19
         version: 1.168.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -913,6 +916,15 @@ packages:
 
   '@tanstack/query-core@5.99.0':
     resolution: {integrity: sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==}
+
+  '@tanstack/query-devtools@5.99.0':
+    resolution: {integrity: sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==}
+
+  '@tanstack/react-query-devtools@5.99.0':
+    resolution: {integrity: sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.99.0
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.99.0':
     resolution: {integrity: sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==}
@@ -2836,6 +2848,14 @@ snapshots:
   '@tanstack/history@1.161.6': {}
 
   '@tanstack/query-core@5.99.0': {}
+
+  '@tanstack/query-devtools@5.99.0': {}
+
+  '@tanstack/react-query-devtools@5.99.0(@tanstack/react-query@5.99.0(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-devtools': 5.99.0
+      '@tanstack/react-query': 5.99.0(react@19.2.5)
+      react: 19.2.5
 
   '@tanstack/react-query@5.99.0(react@19.2.5)':
     dependencies:

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -14,6 +14,15 @@ const TanStackRouterDevtools =
         })),
       );
 
+const ReactQueryDevtools =
+  process.env.NODE_ENV === 'production' || !!window.navigator.webdriver
+    ? () => null // Render nothing in production or automated tests
+    : React.lazy(() =>
+        import('@tanstack/react-query-devtools').then((res) => ({
+          default: res.ReactQueryDevtools,
+        })),
+      );
+
 export interface RootContext {
   queryClient: QueryClient;
 }
@@ -39,6 +48,7 @@ function RootComponent() {
       <Outlet />
       <Suspense>
         <TanStackRouterDevtools />
+        <ReactQueryDevtools />
       </Suspense>
     </AppLayout>
   );


### PR DESCRIPTION
This pull request introduces `@tanstack/react-query-devtools` to the project to significantly improve developer insights into query cache, background syncing, and active network requests without altering the user-facing application functionality.

**What was done:**
- Installed `@tanstack/react-query-devtools` alongside the existing `@tanstack/react-query` dependency.
- Configured dynamic lazy-loading inside `src/routes/__root.tsx`.
- Ensured zero impact on the production bundle or automated environments by stripping it out when `process.env.NODE_ENV === 'production'` or `window.navigator.webdriver` is true.

---
*PR created automatically by Jules for task [12674427179993545048](https://jules.google.com/task/12674427179993545048) started by @szubster*