### PR TITLE
feat: migrate map location script to TS and enforce strict type safety

### DIFF
--- a/.serena/memories/infrastructure/analysis_tools.md
+++ b/.serena/memories/infrastructure/analysis_tools.md
@@ -9,3 +9,8 @@
   - Configured in `biome.jsonc`.
   - Enforcement Level: **Strict (Errors only)**. All violations, including warnings and nursery rules (e.g., `useSortedClasses`), are treated as errors.
   - Integration: Runs in CI via `pnpm lint` which calls `biome check --error-on-warnings`.
+
+## TypeScript Configuration
+- **allowJs**: Disabled (`false`) as of April 15, 2026. The project is strictly TypeScript-only.
+- **Scripts**: All scripts in `scripts/` are written in TypeScript and executed using Node's native support (`--experimental-strip-types`).
+- **Type Checking**: Enforced via `pnpm type-check` (`tsc --noEmit`).

--- a/data/db/metadata.json
+++ b/data/db/metadata.json
@@ -1,4 +1,4 @@
 {
   "sourceSha": "e04d66670bc28dfb8703f732f6a38e3604af93b1",
-  "generatedAt": "2026-04-15T20:10:00.812Z"
+  "generatedAt": "2026-04-15T21:42:00.933Z"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "dev": "vite --port=3000 --host=0.0.0.0",
     "data:gen": "node --experimental-strip-types scripts/generate-pokedata.ts",
+    "data:gen-maps": "node --experimental-strip-types scripts/generateMapLocations.ts",
     "build": "vite build",
     "build:analyze": "ANALYZE=true vite build",
     "preview": "vite preview",
@@ -48,6 +49,8 @@
     "@tailwindcss/typography": "0.5.19",
     "@tailwindcss/vite": "4.2.2",
     "@tanstack/router-plugin": "^1.167.22",
+    "@tsconfig/strictest": "^2.0.8",
+    "@tsconfig/vite-react": "^7.0.2",
     "@types/crypto-js": "^4.2.2",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from '@playwright/test';
-import path from 'path';
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -12,14 +11,14 @@ export default defineConfig({
     },
   },
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  forbidOnly: !!process.env['CI'],
+  retries: process.env['CI'] ? 2 : 0,
   workers: 1,
   reporter: [
     ['html', { open: 'never' }],
     ['@argos-ci/playwright/reporter', {
-      uploadToArgos: !!process.env.CI,
-      buildName: process.env.ARGOS_BUILD_NAME || 'E2E',
+      uploadToArgos: !!process.env['CI'],
+      buildName: process.env['ARGOS_BUILD_NAME'] || 'E2E',
       ignoreUploadFailures: true,
     }]
   ],
@@ -73,9 +72,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: process.env.CI ? 'pnpm build && pnpm preview --port 3000' : 'pnpm dev',
+    command: process.env['CI'] ? 'pnpm build && pnpm preview --port 3000' : 'pnpm dev',
     port: 3000,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !process.env['CI'],
     timeout: 120000,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,12 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.167.22
         version: 1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+      '@tsconfig/strictest':
+        specifier: ^2.0.8
+        version: 2.0.8
+      '@tsconfig/vite-react':
+        specifier: ^7.0.2
+        version: 7.0.2
       '@types/crypto-js':
         specifier: ^4.2.2
         version: 4.2.2
@@ -1555,6 +1561,12 @@ packages:
     resolution: {integrity: sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ==}
     engines: {node: '>=20.19'}
     hasBin: true
+
+  '@tsconfig/strictest@2.0.8':
+    resolution: {integrity: sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw==}
+
+  '@tsconfig/vite-react@7.0.2':
+    resolution: {integrity: sha512-lEj4y5SPRcH+bjw0tyuxrEnPqQUwfQzBKgd1YamD9xyet9zLwh2gwy5F8w/Nxg5DjdgYVjjKo5aLJUf0BTDz4w==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -4983,6 +4995,10 @@ snapshots:
   '@tanstack/store@0.9.3': {}
 
   '@tanstack/virtual-file-routes@1.161.7': {}
+
+  '@tsconfig/strictest@2.0.8': {}
+
+  '@tsconfig/vite-react@7.0.2': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/scripts/generate-pokedata.ts
+++ b/scripts/generate-pokedata.ts
@@ -1,13 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import crypto from 'node:crypto';
 import { execSync, execFileSync } from 'node:child_process';
 import { 
   type CompactChainLink, 
-  type CompactEncounterDetail, 
-  type LocationAreaEncounters, 
+  type CompactEncounterDetail,
   type PokemonMetadata, 
-  type PokeDataExport,
   type GenericLocation,
   type SpecificArea,
   type CompactEncounter,
@@ -78,7 +75,7 @@ function sortObj(obj: any, order: string[]): any {
 }
 
 async function main() {
-  const force = process.argv.includes('--force');
+  // const _force = process.argv.includes('--force');
   console.log('--- PokéAPI Data Pipeline (GitHub Source) ---');
 
   // 1. Get Latest Commit SHA
@@ -135,7 +132,7 @@ async function main() {
     const encounterPath = path.join(dataPath, `pokemon/${i}/encounters/index.json`);
     const eData = readJson(encounterPath) || [];
 
-    const chainId = parseInt(sData.evolution_chain.url.split('/').filter(Boolean).pop() || '0', 10);
+    // const _chainId = parseInt(sData.evolution_chain.url.split('/').filter(Boolean).pop() || '0', 10);
     pokemon.push(sortObj({
       id: pData.id,
       n: sData.names.find((n: PokeApiName) => n.language.name === 'en')?.name || sData.name,
@@ -283,8 +280,8 @@ async function main() {
         evolves_to: link.evolves_to.map(l => mapLink(l, id)),
         details: link.evolution_details.map((ed) => ({
           tr: EVO_TRIGGER_MAP[ed.trigger.name] || 0,
-          min_l: ed.min_level || undefined,
-          min_h: ed.min_happiness || undefined,
+          min_l: ed.min_level ?? undefined,
+          min_h: ed.min_happiness ?? undefined,
           item: ed.item ? parseInt(ed.item.url.split('/').filter(Boolean).pop() || '0', 10) : undefined,
           held: ed.held_item ? parseInt(ed.held_item.url.split('/').filter(Boolean).pop() || '0', 10) : undefined,
           time: ed.time_of_day === 'day' ? 1 : ed.time_of_day === 'night' ? 2 : undefined,

--- a/scripts/generateMapLocations.ts
+++ b/scripts/generateMapLocations.ts
@@ -1,7 +1,7 @@
-const fs = require('fs');
-const https = require('https');
+import fs from 'node:fs';
+import https from 'node:https';
 
-function download(url) {
+function download(url: string): Promise<string> {
   return new Promise((resolve, reject) => {
     https.get(url, (res) => {
       let data = '';
@@ -11,8 +11,14 @@ function download(url) {
   });
 }
 
-function capitalize(str) {
+function capitalize(str: string): string {
   return str.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(' ');
+}
+
+interface Gen1MapInfo {
+  name: string;
+  id: number;
+  group: string | null;
 }
 
 async function run() {
@@ -28,13 +34,16 @@ async function run() {
   // === GEN 1 ===
   console.log('Generating Gen 1 mapping...');
 
-  const gen1MapToLocation = {};
-  const indoorGroupToName = {};
+  const gen1MapToLocation: Record<number, Gen1MapInfo> = {};
+  const indoorGroupToName: Record<string, string> = {};
 
   // Parse indoor groups
   const indoorMatches = [...gen1TownMapEntries.matchAll(/indoor_map\s+(\w+),\s*\d+,\s*\d+,\s*(\w+)/g)];
   for (const match of indoorMatches) {
-    let [_, group, name] = match;
+    const group = match[1];
+    let name = match[2];
+    if (!group || !name) continue;
+
     if (name.endsWith('Name')) name = name.slice(0, -4);
 
     if (name === 'SeaCottage') name = 'Sea Cottage';
@@ -50,8 +59,8 @@ async function run() {
 
   // Parse outdoor maps manually for gen 1 based on actual file ordering
 
-  let activeGroup = null;
-  let mapsSinceLastGroup = [];
+  let activeGroup: string | null = null;
+  let mapsSinceLastGroup: number[] = [];
   let currentMapConstId = 0;
 
   const gen1Lines = gen1MapConstants.split('\n');
@@ -63,6 +72,8 @@ async function run() {
     const mapConstMatch = line.match(/^\s*map_const\s+(\w+),/);
     if (mapConstMatch) {
       let mapName = mapConstMatch[1];
+      if (!mapName) continue;
+      
       gen1MapToLocation[currentMapConstId] = { name: mapName, id: currentMapConstId, group: null };
 
       // Before FIRST_INDOOR_MAP (roughly map ID 37), maps are just outdoor
@@ -71,7 +82,7 @@ async function run() {
            // Capitalize nicely: e.g. ROUTE_1 -> Route 1
            mapName = mapName.replace(/_/g, ' ');
            mapName = mapName.split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(' ');
-           gen1MapToLocation[currentMapConstId].group = mapName;
+           gen1MapToLocation[currentMapConstId]!.group = mapName;
         }
       } else {
         mapsSinceLastGroup.push(currentMapConstId);
@@ -81,28 +92,37 @@ async function run() {
 
     const endGroupMatch = line.match(/^\s*end_indoor_group\s+(\w+)/);
     if (endGroupMatch) {
-      activeGroup = endGroupMatch[1];
+      activeGroup = endGroupMatch[1] ?? null;
       for (const id of mapsSinceLastGroup) {
-        if (gen1MapToLocation[id]) {
-          gen1MapToLocation[id].group = activeGroup;
+        const item = gen1MapToLocation[id];
+        if (item) {
+          item.group = activeGroup;
         }
       }
       mapsSinceLastGroup = [];
     }
   }
 
-  for (const id in gen1MapToLocation) {
-    if (!gen1MapToLocation[id].group) {
-        let mapName = gen1MapToLocation[id].name;
+  for (const idStr in gen1MapToLocation) {
+    const id = parseInt(idStr);
+    const item = gen1MapToLocation[id];
+    if (item && !item.group) {
+        let mapName = item.name;
         mapName = mapName.replace(/_/g, ' ');
         mapName = mapName.split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(' ');
-        gen1MapToLocation[id].group = mapName;
+        item.group = mapName;
     }
   }
 
-  const finalGen1Mapping = {};
-  for (const id in gen1MapToLocation) {
-     let group = gen1MapToLocation[id].group;
+  const finalGen1Mapping: Record<number, string> = {};
+  for (const idStr in gen1MapToLocation) {
+     const id = parseInt(idStr);
+     const item = gen1MapToLocation[id];
+     if (!item) continue;
+     
+     const group = item.group;
+     if (!group) continue;
+     
      let finalName = indoorGroupToName[group] || capitalize(group.replace(/ /g, '_'));
      // Clean up
      finalName = finalName.replace(/ \d+$/, '');
@@ -133,12 +153,14 @@ async function run() {
   // === GEN 2 ===
   console.log('Generating Gen 2 mapping...');
 
-  const gen2LandmarkConstToName = {};
+  const gen2LandmarkConstToName: Record<string, { id: number, name: string }> = {};
   let currentLandmarkId2 = 0;
   for (const line of gen2LandmarksLines.split('\n')) {
     const match = line.match(/^\s*const\s+(LANDMARK_\w+)/);
     if (match) {
        const constName = match[1];
+       if (!constName) continue;
+       
        let name = constName.replace('LANDMARK_', '');
        name = capitalize(name);
        if (name === 'Special') {
@@ -168,7 +190,7 @@ async function run() {
     }
   }
 
-  const finalGen2Mapping = {};
+  const finalGen2Mapping: Record<number, Record<number, string>> = {};
 
   let currentGroup2 = 0;
   let mapIdInGroup = 1;
@@ -184,6 +206,7 @@ async function run() {
       const mapConstMatch = line.match(/^\s*map_const\s+(\w+),/);
       if (mapConstMatch) {
          const mapName = mapConstMatch[1];
+         if (!mapName) continue;
 
          const mapNameRegexStr = mapName.replace(/_/g, '');
          const mapRegex = new RegExp(`^\\s*map\\s+${mapNameRegexStr}\\s*,[^,]*,[^,]*,\\s*(LANDMARK_\\w+)`, 'im');
@@ -192,18 +215,20 @@ async function run() {
          let landmarkName = "Unknown";
          if (mapAsmMatch) {
              const landmarkConst = mapAsmMatch[1];
-             if (gen2LandmarkConstToName[landmarkConst]) {
-                 landmarkName = gen2LandmarkConstToName[landmarkConst].name;
+             if (landmarkConst && gen2LandmarkConstToName[landmarkConst]) {
+                 landmarkName = gen2LandmarkConstToName[landmarkConst]!.name;
              }
          }
 
-         finalGen2Mapping[currentGroup2][mapIdInGroup] = landmarkName;
+         if (finalGen2Mapping[currentGroup2]) {
+             finalGen2Mapping[currentGroup2]![mapIdInGroup] = landmarkName;
+         }
          mapIdInGroup++;
       }
   }
 
-  const finalGen2Landmarks = {};
-  for (const [key, value] of Object.entries(gen2LandmarkConstToName)) {
+  const finalGen2Landmarks: Record<number, string> = {};
+  for (const value of Object.values(gen2LandmarkConstToName)) {
     finalGen2Landmarks[value.id] = value.name;
   }
   // Gen 2 location catch maps 126 to Event/Gift and 127 to Special

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -143,7 +143,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
               );
             })
             .map(([category, items]) => {
-              const defaultStyle = CATEGORY_STYLES.Utility as { icon: React.ReactNode; color: string; bg: string };
+              const defaultStyle = CATEGORY_STYLES['Utility'] as { icon: React.ReactNode; color: string; bg: string };
               const catStyle = CATEGORY_STYLES[category] ?? defaultStyle;
 
               return (
@@ -163,7 +163,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
                     className={`fade-in grid animate-in gap-6 duration-500 ${category === 'Catch' ? 'grid-cols-1 lg:grid-cols-2' : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'}`}
                   >
                     {items.map((s, idx) => {
-                      const defaultStyle = CATEGORY_STYLES.Utility as {
+                      const defaultStyle = CATEGORY_STYLES['Utility'] as {
                         icon: React.ReactNode;
                         color: string;
                         bg: string;

--- a/src/components/PokedexCard.tsx
+++ b/src/components/PokedexCard.tsx
@@ -38,7 +38,6 @@ export const PokedexCard = React.memo(function PokedexCard({
   const isSeenInDex = saveData ? saveData.seen.has(pokemon.id) : false;
 
   const isOwned = saveData ? (isLivingDex ? hasInStorage : isOwnedInDex || hasInStorage) : false;
-  const _hadButLost = saveData ? isOwnedInDex && !hasInStorage : false;
 
   const isSeen = saveData ? isSeenInDex || isOwned || hasInStorage : false;
   const isUnseen = saveData && !isSeen;

--- a/src/components/assistant/AssistantSuggestionCard.tsx
+++ b/src/components/assistant/AssistantSuggestionCard.tsx
@@ -12,7 +12,7 @@ interface AssistantSuggestionCardProps {
   showDebug: boolean;
   saveData: SaveData;
   getPokemonName: (id: number) => string;
-  areaNames?: Record<number, string>;
+  areaNames?: Record<number, string> | undefined;
 }
 
 export function AssistantSuggestionCard({

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -130,18 +130,18 @@ export interface InverseLocationIndex {
 
 export interface CompactEvolutionDetail {
   tr: number; // trigger (EVO_TRIGGER)
-  min_l?: number; // min_level
-  min_h?: number; // min_happiness
-  item?: number; // item id
-  held?: number; // held item id
-  time?: number; // 1: day, 2: night
+  min_l?: number | undefined; // min_level
+  min_h?: number | undefined; // min_happiness
+  item?: number | undefined; // item id
+  held?: number | undefined; // held item id
+  time?: number | undefined; // 1: day, 2: night
 }
 
 export interface CompactChainLink {
   id: number; // species id
   evolves_to: CompactChainLink[];
   details: CompactEvolutionDetail[];
-  ef?: number; // evolves from species id
+  ef?: number | undefined; // evolves from species id
 }
 
 export interface PokemonMetadata {

--- a/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
+++ b/src/engine/assistant/__tests__/fetchAssistantApiData.test.ts
@@ -1,5 +1,5 @@
 import 'fake-indexeddb/auto';
-import { beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dexDataLoader } from '../../../db/DexDataLoader';
 import { pokeDB } from '../../../db/PokeDB';
 import type { PokemonMetadata } from '../../../db/schema';
@@ -7,10 +7,8 @@ import type { SaveData } from '../../saveParser/index';
 import { fetchAssistantApiData } from '../suggestionEngine';
 
 describe('fetchAssistantApiData', () => {
-  let _consoleErrorSpy: MockInstance;
-
   beforeEach(() => {
-    _consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   it('should handle evolution fetch failure gracefully', async () => {

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -1,7 +1,6 @@
 import { dexDataLoader } from '../../db/DexDataLoader';
 import { pokeDB } from '../../db/PokeDB';
 import {
-  type CompactChainLink,
   ENCOUNTER_METHOD,
   EVO_TRIGGER,
   type GenericLocation,
@@ -26,14 +25,6 @@ export interface AssistantApiData {
   areaNames: Record<number, string>;
   allLocations: GenericLocation[];
   allAreas: SpecificArea[];
-}
-
-/**
- * Helper function to find all Pokemon IDs in an evolution chain.
- * Note: Since we now use localized chains, we walk the evolves_to tree from the current node.
- */
-function _getChainIds(node: { id: number; evolves_to: CompactChainLink[] }): number[] {
-  return [node.id, ...node.evolves_to.flatMap(_getChainIds)];
 }
 
 /**

--- a/src/engine/exclusives/gen1Exclusives.ts
+++ b/src/engine/exclusives/gen1Exclusives.ts
@@ -73,6 +73,7 @@ export function getUnobtainableReason(
     // Also, if you picked the OTHER choice, you can't get this one.
     // For hitmons: If evaluating 106, and you own 107 but not 106, it's locked.
     // Actually, fossils and hitmons are mutually exclusive choices.
+    return null;
   };
 
   const lockObj =

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -5,19 +5,21 @@ export interface PokemonInstance {
   speciesId: number;
   level: number;
   isShiny: boolean;
-  item?: number;
+  item?: number | undefined;
   moves: number[];
-  friendship?: number;
-  pokerus?: number;
-  caughtData?: {
-    time: 'Morning' | 'Day' | 'Night' | 'Unknown';
-    level: number;
-    location: number;
-    locationName?: string;
-  };
-  otName?: string;
+  friendship?: number | undefined;
+  pokerus?: number | undefined;
+  caughtData?:
+    | {
+        time: 'Morning' | 'Day' | 'Night' | 'Unknown';
+        level: number;
+        location: number;
+        locationName?: string | undefined;
+      }
+    | undefined;
+  otName?: string | undefined;
   storageLocation: string;
-  slot?: number; // 1-indexed slot in party or box
+  slot?: number | undefined; // 1-indexed slot in party or box
 }
 
 export interface SaveData {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -8,7 +8,7 @@ import { useStore } from '../store';
 import { pokemonListQueryOptions } from '../utils/pokemonQueries';
 
 const TanStackRouterDevtools =
-  process.env.NODE_ENV === 'production' || !!window.navigator.webdriver
+  process.env['NODE_ENV'] === 'production' || !!window.navigator.webdriver
     ? () => null // Render nothing in production or automated tests
     : React.lazy(() =>
         import('@tanstack/react-router-devtools').then((res) => ({

--- a/src/routes/pokemon.$pokemonId.tsx
+++ b/src/routes/pokemon.$pokemonId.tsx
@@ -7,7 +7,7 @@ import { pokemonListQueryOptions } from '../utils/pokemonQueries';
 export const Route = createFileRoute('/pokemon/$pokemonId')({
   validateSearch: (search: Record<string, unknown>) => {
     return {
-      from: (search.from as string) || '/',
+      from: (search['from'] as string) || '/',
     };
   },
   component: PokemonPage,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,11 @@
 {
+  "extends": [
+    "@tsconfig/vite-react/tsconfig.json",
+    "@tsconfig/strictest/tsconfig.json"
+  ],
   "compilerOptions": {
-    "target": "ES2022",
-    "experimentalDecorators": true,
-    "useDefineForClassFields": false,
-    "module": "ESNext",
-    "lib": [
-      "ES2022",
-      "DOM",
-      "DOM.Iterable"
-    ],
-    "skipLibCheck": true,
-    "moduleResolution": "bundler",
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "allowJs": true,
-    "jsx": "react-jsx",
     "paths": {
-      "@/*": [
-        "./*"
-      ]
-    },
-    "allowImportingTsExtensions": true,
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "noEmit": true
+      "@/*": ["./*"]
+    }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,19 +2,18 @@ import { tanstackRouter } from '@tanstack/router-plugin/vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { codecovVitePlugin } from "@codecov/vite-plugin";
 import { VitePWA } from 'vite-plugin-pwa';
 
 import { pokedataPlugin } from './vite-plugins/pokedata-plugin';
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, '.', '');
+export default defineConfig(() => {
   const sourceDir = path.resolve(__dirname, 'data/db');
 
   return {
-    base: process.env.CF_PAGES === 'true' ? '/' : '/dexhelper/',
+    base: process.env['CF_PAGES'] === 'true' ? '/' : '/dexhelper/',
     plugins: [
       pokedataPlugin({ sourceDir }),
       tanstackRouter(),
@@ -57,16 +56,16 @@ export default defineConfig(({ mode }) => {
           ],
         },
       }),
-      process.env.ANALYZE === 'true' && visualizer({
+      process.env['ANALYZE'] === 'true' && visualizer({
         filename: 'stats.html',
         open: false,
         gzipSize: true,
         brotliSize: true,
       }),
       codecovVitePlugin({
-        enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+        enableBundleAnalysis: process.env['CODECOV_TOKEN'] !== undefined,
         bundleName: "dexhelper",
-        uploadToken: process.env.CODECOV_TOKEN,
+        uploadToken: process.env['CODECOV_TOKEN'] ?? '',
         gitService: "github",
       }),
     ].filter(Boolean),
@@ -76,19 +75,19 @@ export default defineConfig(({ mode }) => {
       },
     },
     build: {
-      sourcemap: process.env.ANALYZE === 'true',
+      sourcemap: process.env['ANALYZE'] === 'true',
       cssCodeSplit: false,
       reportCompressedSize: true,
       rollupOptions: {
         output: {
-          manualChunks: undefined, // Ensure single chunk is prioritized where possible
+          // manualChunks: undefined,
         },
       },
     },
     server: {
       // HMR is disabled in AI Studio via DISABLE_HMR env var.
       // Do not modify—file watching is disabled to prevent flickering during agent edits.
-      hmr: process.env.DISABLE_HMR !== 'true',
+      hmr: process.env['DISABLE_HMR'] !== 'true',
     },
     test: {
       globals: true,


### PR DESCRIPTION
## Summary
This PR completes the migration of the Map Locations generation script to TypeScript and enables a stricter project configuration by disabling JavaScript support in the source tree (`allowJs: false`).

## Changes
- **Migrated Script**: Ported `scripts/generateMapLocations.cjs` to `scripts/generateMapLocations.ts`.
- **Infrastructure**: Added `data:gen-maps` script to `package.json` for easy data generation.
- **TSConfig**: Removed `"allowJs": true` from `tsconfig.json`.
- **Type Safety**: Fixed various "implicit any" and "possibly undefined" errors in scripts and core logic to align with `@tsconfig/strictest`.

## Memory Context (Memories)
- **Infrastructure (infrastructure/analysis_tools)**:
  - `allowJs` is now disabled.
  - All source scripts are TypeScript and run with `--experimental-strip-types`.
  - Stricter type checking is enforced across the board.
- **Migration Status (status/migration_summary_april_2026)**:
  - Aligns with the "Offline-First" and "Lean Data" milestones by purging more legacy JS patterns.
  - Contributes to "Infrastructure Refinement" by hardening the data generation pipeline.

## Verification
- `npm run data:gen-maps` succeeds and generates identical data.
- `pnpm type-check` passes project-wide.