### PR TITLE
🎨 Palette: Improve location suggestions UX and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-13 - Added aria-label to icon-only buttons
 **Learning:** For accessibility, ensure all icon-only interactive elements (like buttons) include an `aria-label` attribute, as relying solely on the `title` attribute is insufficient for screen readers. In Dexhelper, several key interactive elements like the Assistant Panel debug toggle, Pokedex Cards, and Storage Grid cards lacked proper screen reader announcements despite having visual cues or titles.
 **Action:** Always add `aria-label` attributes to icon-only buttons and interactive card elements that act as links or triggers, ensuring the label clearly describes the action or destination (e.g., `aria-label={"View details for " + pokemon.name}`).
+
+## 2026-04-16 - Consistent Keyboard Navigation Focus Styles
+**Learning:** Some custom UI elements, like mapped list buttons or dynamically rendered list items (e.g., in LocationSuggestions), can easily omit standard focus indicators when custom styling is heavily applied, making keyboard navigation difficult or invisible.
+**Action:** Always ensure dynamic, mapped, or custom buttons explicitly include focus visible utilities (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950`) to match the application's global focus style.

--- a/src/components/LocationSuggestions.tsx
+++ b/src/components/LocationSuggestions.tsx
@@ -1,4 +1,4 @@
-import { MapPin, Search } from 'lucide-react';
+import { MapPin, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { pokeDB } from '../db/PokeDB';
 import type { GenericLocation } from '../db/schema';
@@ -49,9 +49,10 @@ export function LocationSuggestions() {
           <button
             type="button"
             onClick={() => setSelectedLocationId(null)}
-            className="ml-1 rounded-full p-0.5 transition-colors hover:bg-[var(--theme-primary)] hover:text-white"
+            aria-label="Clear location filter"
+            className="ml-1 rounded-full p-0.5 transition-colors hover:bg-[var(--theme-primary)] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
           >
-            <Search size={10} />
+            <X size={10} />
           </button>
         </div>
       </div>
@@ -71,7 +72,7 @@ export function LocationSuggestions() {
               setSearchTerm('');
               setIsOpen(false);
             }}
-            className="group flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left transition-all hover:bg-[var(--theme-primary)]/10"
+            className="group flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left transition-all hover:bg-[var(--theme-primary)]/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
           >
             <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/5 bg-zinc-900 text-zinc-500 transition-colors duration-300 group-hover:bg-[var(--theme-primary)] group-hover:text-white">
               <MapPin size={14} />


### PR DESCRIPTION
💡 What: The clear location filter button icon was updated from a Search icon to an X icon, added an aria-label, and applied consistent keyboard focus rings to the location suggestion elements.
🎯 Why: The original "Search" icon for the clear action was confusing. Furthermore, users navigating via keyboard could not see which location suggestion they had focused, and the clear button lacked a screen-reader-friendly label.
📸 Before/After: Verified via e2e automated screenshots showing the new X icon and focus rings.
♿ Accessibility: Improved keyboard navigation by adding explicit `focus-visible` ring utilities to mapped location suggestion buttons, and improved screen reader context by adding an `aria-label` to the clear button.

---
*PR created automatically by Jules for task [13214246068418361609](https://jules.google.com/task/13214246068418361609) started by @szubster*