### PR TITLE
feat: enable special strategy suggestions in assistant

### DIFF
--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -126,6 +126,10 @@ export function generateSuggestions(
   const displayVersionId = POKE_VERSION_MAP[displayVersion] || 1;
   const queryTargets = missingIds.slice(0, 100);
 
+  // Special Strategy-Specific Suggestions (e.g. Box full warning)
+  const specialSuggestions = strategy.getSpecialSuggestions(saveData, missingIds);
+  suggestions.push(...specialSuggestions);
+
   const localPids: number[] = [];
   // A. Catch logic
   if (apiData.localEncounters && apiData.localEncounters.length > 0 && apiData.localAid) {


### PR DESCRIPTION
Adds missing special suggestions (like PC box full warnings) to the assistant feature by properly invoking the current generation's AssistantStrategy.

---
*PR created automatically by Jules for task [5681582306130220128](https://jules.google.com/task/5681582306130220128) started by @szubster*