### PR TITLE
🧪 [testing improvement] add tests for getMapGraph factory

### DIFF
--- a/src/engine/mapGraph/index.test.ts
+++ b/src/engine/mapGraph/index.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UnifiedLocation } from '../../db/schema';
+import { getDistanceToMap, getOutdoorMapId } from './gen1Graph';
+import { getMapGraph } from './index';
+
+vi.mock('./gen1Graph', () => ({
+  getDistanceToMap: vi.fn(),
+  getOutdoorMapId: vi.fn(),
+}));
+
+describe('getMapGraph', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null for an unsupported generation', () => {
+    expect(getMapGraph(2)).toBeNull();
+    expect(getMapGraph(99)).toBeNull();
+  });
+
+  it('returns a MapGraph for generation 1', () => {
+    const graph = getMapGraph(1);
+    expect(graph).not.toBeNull();
+    expect(typeof graph?.getDistanceToMap).toBe('function');
+    expect(typeof graph?.resolveOutdoorMapId).toBe('function');
+  });
+
+  it('delegates getDistanceToMap to gen1Graph for generation 1', () => {
+    const graph = getMapGraph(1);
+    const mockLocations: UnifiedLocation[] = [];
+
+    vi.mocked(getDistanceToMap).mockReturnValueOnce({ distance: 5, name: 'Test' });
+
+    const result = graph?.getDistanceToMap(mockLocations, 1, 2);
+
+    expect(getDistanceToMap).toHaveBeenCalledWith(mockLocations, 1, 2);
+    expect(getDistanceToMap).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ distance: 5, name: 'Test' });
+  });
+
+  it('delegates resolveOutdoorMapId to gen1Graph getOutdoorMapId for generation 1', () => {
+    const graph = getMapGraph(1);
+    const mockLocations: UnifiedLocation[] = [];
+
+    vi.mocked(getOutdoorMapId).mockReturnValueOnce(42);
+
+    const result = graph?.resolveOutdoorMapId(mockLocations, 10);
+
+    expect(getOutdoorMapId).toHaveBeenCalledWith(mockLocations, 10);
+    expect(getOutdoorMapId).toHaveBeenCalledTimes(1);
+    expect(result).toBe(42);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing unit tests for the `getMapGraph` factory function in `src/engine/mapGraph/index.ts`.
📊 **Coverage:** What scenarios are now tested:
- `getMapGraph` returns `null` for unsupported generations (e.g., 2, 99).
- `getMapGraph` returns a valid `MapGraph` object for generation 1.
- `getDistanceToMap` on the returned graph successfully delegates to the underlying `gen1Graph.getDistanceToMap` implementation.
- `resolveOutdoorMapId` on the returned graph successfully delegates to the underlying `gen1Graph.getOutdoorMapId` implementation.
✨ **Result:** The improvement in test coverage: The `src/engine/mapGraph/index.ts` factory and router logic is now fully covered by unit tests, increasing the reliability of map routing logic.

---
*PR created automatically by Jules for task [12094894433349599874](https://jules.google.com/task/12094894433349599874) started by @szubster*