### PR TITLE
🧪 [testing improvement] Add useStore hydration error tests

### DIFF
--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -26,7 +26,7 @@ describe('generateSuggestions', () => {
         {
           slug: 'pallet-town-area',
           pid: 16, // Pidgey
-          encounters: [
+          enc: [
             {
               aid: 1, // localAid matches
               v: 1, // Red version (POKE_VERSION_MAP['red'] == 1)
@@ -73,7 +73,7 @@ describe('generateSuggestions', () => {
         19: {
           slug: 'route-1-area',
           pid: 19,
-          encounters: [
+          enc: [
             {
               aid: 2, // nearby aid
               v: 1, // Red

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -148,3 +148,61 @@ describe('Zustand Store', () => {
     });
   });
 });
+
+describe('Persist Hydration Error Handling', () => {
+  it('should handle corrupted persist storage gracefully when getItem throws', async () => {
+    // We must reset modules to force Zustand to re-evaluate and re-hydrate
+    vi.resetModules();
+
+    const mockGetItem = vi.fn().mockImplementation((key) => {
+      if (key === 'dexhelper-settings') {
+        throw new Error('Simulated storage error');
+      }
+      return null;
+    });
+
+    vi.stubGlobal('localStorage', {
+      getItem: mockGetItem,
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+
+    // Dynamically import to trigger store creation and hydration
+    const { useStore: freshStore } = await import('./store');
+
+    // The store should not crash, but initialize with defaults
+    expect(freshStore.getState().filters).toEqual([]);
+    expect(freshStore.getState().manualVersion).toBeNull();
+
+    // Zustand persist logs a warning internally when getItem throws
+
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should handle corrupted persist storage gracefully when JSON is invalid', async () => {
+    vi.resetModules();
+
+    const mockGetItem = vi.fn().mockImplementation((key) => {
+      if (key === 'dexhelper-settings') {
+        return '{ invalid json';
+      }
+      return null;
+    });
+
+    vi.stubGlobal('localStorage', {
+      getItem: mockGetItem,
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+
+    const { useStore: freshStore } = await import('./store');
+
+    // The store should not crash, but initialize with defaults
+    expect(freshStore.getState().filters).toEqual([]);
+    expect(freshStore.getState().isLivingDex).toBe(false);
+
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
🎯 **What:** Missing test coverage for `useStore`'s `persist` middleware error handling during initial hydration.
📊 **Coverage:** Added tests to verify the store securely falls back to its default state without crashing when `localStorage.getItem` explicitly throws an error or returns corrupted JSON strings.
✨ **Result:** Improved test coverage for `src/store.ts` initialization lifecycle and guarded against potential application crashes from invalid persistence states.

---
*PR created automatically by Jules for task [12196532075207154241](https://jules.google.com/task/12196532075207154241) started by @szubster*