### PR TITLE
🧪 [Testing Improvement: Add syncData tests for PokeDB]

### DIFF
--- a/src/db/__tests__/PokeDB.test.ts
+++ b/src/db/__tests__/PokeDB.test.ts
@@ -44,6 +44,96 @@ describe('PokeDB', () => {
     await tx.done;
   });
 
+
+  it('skips fetch if IndexedDB has the same build hash', async () => {
+    const db = await getDB();
+    const tx = db.transaction(DB_CONFIG.STORES.METADATA, 'readwrite');
+    await tx.objectStore(DB_CONFIG.STORES.METADATA).put({ key: 'hash', value: __POKEDATA_HASH__ });
+    await tx.done;
+
+    vi.mocked(fetch).mockClear();
+    await pokeDB.sync();
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('resets syncPromise if fetch fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error'
+    } as Response);
+
+    await expect(pokeDB.sync()).rejects.toThrow('Failed to fetch pokedata.json: 500 Internal Server Error');
+
+    // Verify it was reset by calling again with a successful fetch
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ hash: 'test-hash-2', poke: [], enc: [], loc: [] })
+    } as Response);
+
+    await pokeDB.sync();
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    errorSpy.mockRestore();
+  });
+
+  it('skips parsing and updates metadata if fetched data hash matches existing DB hash', async () => {
+    const db = await getDB();
+    const tx = db.transaction(DB_CONFIG.STORES.METADATA, 'readwrite');
+    await tx.objectStore(DB_CONFIG.STORES.METADATA).put({ key: 'hash', value: 'old-hash' });
+    await tx.done;
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ hash: 'old-hash', poke: [], enc: [], loc: [] })
+    } as Response);
+
+    const transactionSpy = vi.spyOn(db, 'transaction');
+
+    await pokeDB.sync();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const allStoreNames = [DB_CONFIG.STORES.POKEMON, DB_CONFIG.STORES.ENCOUNTERS, DB_CONFIG.STORES.LOCATIONS, DB_CONFIG.STORES.METADATA];
+    expect(transactionSpy).not.toHaveBeenCalledWith(allStoreNames, 'readwrite');
+
+    transactionSpy.mockRestore();
+  });
+
+  it('deduplicates concurrent sync requests', async () => {
+    vi.mocked(fetch).mockClear();
+
+    const sync1 = pokeDB.sync();
+    const sync2 = pokeDB.sync();
+
+    await Promise.all([sync1, sync2]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits progress events during sync', async () => {
+    // We cannot easily spy on window if it's undefined, let's inject it into global context
+    const originalWindow = global.window;
+    const dispatchEventMock = vi.fn();
+
+    // @ts-ignore
+    global.window = { dispatchEvent: dispatchEventMock };
+
+    await pokeDB.sync();
+
+    const events = dispatchEventMock.mock.calls.map((call) => call[0] as CustomEvent);
+    const progressEvents = events.filter((e) => e.type === 'pokedata-sync-progress');
+
+    expect(progressEvents).toHaveLength(3);
+    expect(progressEvents[0].detail).toEqual({ current: 1, total: 3, stage: 'Pokemon' });
+    expect(progressEvents[1].detail).toEqual({ current: 2, total: 3, stage: 'Encounters' });
+    expect(progressEvents[2].detail).toEqual({ current: 3, total: 3, stage: 'Locations' });
+
+    global.window = originalWindow;
+  });
+
   it('syncs data correctly', async () => {
     const mockData = {
       hash: 'new-hash',

--- a/src/db/__tests__/PokeDB.test.ts
+++ b/src/db/__tests__/PokeDB.test.ts
@@ -44,7 +44,6 @@ describe('PokeDB', () => {
     await tx.done;
   });
 
-
   it('skips fetch if IndexedDB has the same build hash', async () => {
     const db = await getDB();
     const tx = db.transaction(DB_CONFIG.STORES.METADATA, 'readwrite');
@@ -62,7 +61,7 @@ describe('PokeDB', () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: false,
       status: 500,
-      statusText: 'Internal Server Error'
+      statusText: 'Internal Server Error',
     } as Response);
 
     await expect(pokeDB.sync()).rejects.toThrow('Failed to fetch pokedata.json: 500 Internal Server Error');
@@ -70,7 +69,7 @@ describe('PokeDB', () => {
     // Verify it was reset by calling again with a successful fetch
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ hash: 'test-hash-2', poke: [], enc: [], loc: [] })
+      json: async () => ({ hash: 'test-hash-2', poke: [], enc: [], loc: [] }),
     } as Response);
 
     await pokeDB.sync();
@@ -87,7 +86,7 @@ describe('PokeDB', () => {
 
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ hash: 'old-hash', poke: [], enc: [], loc: [] })
+      json: async () => ({ hash: 'old-hash', poke: [], enc: [], loc: [] }),
     } as Response);
 
     const transactionSpy = vi.spyOn(db, 'transaction');
@@ -96,7 +95,12 @@ describe('PokeDB', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
 
-    const allStoreNames = [DB_CONFIG.STORES.POKEMON, DB_CONFIG.STORES.ENCOUNTERS, DB_CONFIG.STORES.LOCATIONS, DB_CONFIG.STORES.METADATA];
+    const allStoreNames = [
+      DB_CONFIG.STORES.POKEMON,
+      DB_CONFIG.STORES.ENCOUNTERS,
+      DB_CONFIG.STORES.LOCATIONS,
+      DB_CONFIG.STORES.METADATA,
+    ];
     expect(transactionSpy).not.toHaveBeenCalledWith(allStoreNames, 'readwrite');
 
     transactionSpy.mockRestore();
@@ -118,7 +122,7 @@ describe('PokeDB', () => {
     const originalWindow = global.window;
     const dispatchEventMock = vi.fn();
 
-    // @ts-ignore
+    // @ts-expect-error
     global.window = { dispatchEvent: dispatchEventMock };
 
     await pokeDB.sync();
@@ -127,9 +131,9 @@ describe('PokeDB', () => {
     const progressEvents = events.filter((e) => e.type === 'pokedata-sync-progress');
 
     expect(progressEvents).toHaveLength(3);
-    expect(progressEvents[0].detail).toEqual({ current: 1, total: 3, stage: 'Pokemon' });
-    expect(progressEvents[1].detail).toEqual({ current: 2, total: 3, stage: 'Encounters' });
-    expect(progressEvents[2].detail).toEqual({ current: 3, total: 3, stage: 'Locations' });
+    expect(progressEvents[0]?.detail).toEqual({ current: 1, total: 3, stage: 'Pokemon' });
+    expect(progressEvents[1]?.detail).toEqual({ current: 2, total: 3, stage: 'Encounters' });
+    expect(progressEvents[2]?.detail).toEqual({ current: 3, total: 3, stage: 'Locations' });
 
     global.window = originalWindow;
   });


### PR DESCRIPTION
🎯 **What:** The `syncData` function in `src/db/PokeDB.ts` was missing adequate tests, specifically due to its heavy reliance on external fetch requests and IndexedDB caching logic, making testing overly complex. This PR addresses that testing gap.

📊 **Coverage:** The following scenarios are now thoroughly tested and safely isolated:
- Early return without external fetches when the cached build hash matches.
- Failure states simulating 500 server errors, verifying that the sync promise correctly resets to allow retrying.
- The fallback logic preventing unnecessary database transactions if the fetched external hash equals the stored IndexedDB hash.
- Verification that concurrent immediate calls to `syncData` are correctly deduplicated, resulting in only one network `fetch`.
- Emitting the correct global `CustomEvent` (`pokedata-sync-progress`) during the 3 stages (Pokemon, Encounters, Locations) of syncing data.

✨ **Result:** Test coverage for `src/db/PokeDB.ts` is substantially increased and its complicated async/deduplication logic is now confidently tested and verified against bugs or future regressions. The overall test suite for `src/db/__tests__/PokeDB.test.ts` was expanded from 4 to 9 resilient tests without any network side effects.

---
*PR created automatically by Jules for task [5662759033037207399](https://jules.google.com/task/5662759033037207399) started by @szubster*