### PR TITLE
🎨 Palette: Add empty state for Pokedex search/filters

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,6 @@
 ## 2026-04-09 - Accessible Search Inputs
 **Learning:** Standard text inputs used for searching often lack intuitive keyboard navigation and immediate visual feedback when clearing text. Without focus returning to the input after clearing, users must manually re-focus the input to start a new search, disrupting the workflow.
 **Action:** Always add keyboard shortcuts (like `Escape`) to clear search inputs. When a clear button is used, ensure it has visible focus styles and that its `onClick` handler programmatically returns focus back to the search input.
+## 2026-04-10 - Empty States for Search and Filters
+**Learning:** Data grids and lists that can be heavily filtered or searched often lack empty states. When a user applies a combination of filters that yields no results, presenting an empty UI implies a bug or broken data load.
+**Action:** Always implement a distinct empty state for filtered lists. Use appropriate icons, clear messaging ("No results found"), and actionable advice (e.g., "Try adjusting your filters") to maintain context and guide the user.

--- a/src/components/PokedexGrid.tsx
+++ b/src/components/PokedexGrid.tsx
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { SearchX } from 'lucide-react';
 import React, { useMemo } from 'react';
 import { pokeDB } from '../db/PokeDB';
 import { useStore } from '../store';
@@ -82,6 +83,18 @@ export function PokedexGrid({ pokemonList }: { pokemonList: { id: number; name: 
     }
     return set;
   }, [saveData]);
+
+  if (finalPokemon.length === 0) {
+    return (
+      <div className="fade-in mx-1 mt-4 flex animate-in flex-col items-center justify-center rounded-[2rem] border border-zinc-800/50 bg-zinc-900/50 p-12 text-center duration-500">
+        <SearchX className="mb-4 text-zinc-600" size={48} />
+        <h3 className="font-bold text-lg text-zinc-400 uppercase tracking-wide">No Pokémon Found</h3>
+        <p className="mt-2 max-w-sm font-medium text-sm text-zinc-600">
+          Try adjusting your search terms or clearing your filters to see more results.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="fade-in grid animate-in grid-cols-2 gap-5 px-1 pb-10 duration-500 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">


### PR DESCRIPTION
**🎨 Palette: Add empty state for Pokedex search/filters**

### 💡 What
Implemented a distinct empty state UI for the `PokedexGrid` component when search terms or filter combinations yield zero results.

### 🎯 Why
Previously, applying filters that resulted in no matching Pokémon would simply render an empty container, leaving the user without any visual feedback about whether the application was loading, broken, or simply returning zero results. Providing explicit visual feedback in these scenarios is a key micro-UX standard.

### 📸 Before/After
**Before:** Filtering for a non-existent Pokémon (e.g. "MissingNo") resulted in a completely blank grid area below the search bar.
**After:** The grid displays a styled fallback container with the `SearchX` icon, a bold "No Pokémon Found" heading, and helpful copy instructing the user to adjust their search terms or clear filters. 

### ♿ Accessibility
The empty state acts as a clear visual indicator. By displaying clear, descriptive text, users of assistive technologies and standard visual navigation alike are informed of the system's status. Tested thoroughly to ensure keyboard focus patterns remain unaffected.

---
*PR created automatically by Jules for task [8329118643671659966](https://jules.google.com/task/8329118643671659966) started by @szubster*