### PR TITLE
🗃️ Archivist: Cleanup stale memories and consolidate journals

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,7 +1,0 @@
-## 2024-04-13 - Added aria-label to icon-only buttons
-**Learning:** For accessibility, ensure all icon-only interactive elements (like buttons) include an `aria-label` attribute, as relying solely on the `title` attribute is insufficient for screen readers. In Dexhelper, several key interactive elements like the Assistant Panel debug toggle, Pokedex Cards, and Storage Grid cards lacked proper screen reader announcements despite having visual cues or titles.
-**Action:** Always add `aria-label` attributes to icon-only buttons and interactive card elements that act as links or triggers, ensuring the label clearly describes the action or destination (e.g., `aria-label={"View details for " + pokemon.name}`).
-
-## 2026-04-16 - Consistent Keyboard Navigation Focus Styles
-**Learning:** Some custom UI elements, like mapped list buttons or dynamically rendered list items (e.g., in LocationSuggestions), can easily omit standard focus indicators when custom styling is heavily applied, making keyboard navigation difficult or invisible.
-**Action:** Always ensure dynamic, mapped, or custom buttons explicitly include focus visible utilities (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950`) to match the application's global focus style.

--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -1,0 +1,10 @@
+## 2026-04-18 - Archivist Run Learnings
+
+**Learning:** Case sensitivity issues (e.g., `.Jules` vs `.jules`) can cause duplication of agent journals, making it harder to track critical learnings.
+**Action:** Ensure that all tools and scripts consistently use lowercase for `.jules` directories.
+
+**Learning:** Agent journals tend to duplicate learning for recurring accessible patterns over time (e.g., `aria-label` missing on icon buttons, `role="switch"` missing on custom toggles, etc.).
+**Action:** Periodically review and consolidate journal entries into a single comprehensive entry per topic to avoid repetition.
+
+**Learning:** Transient PR status notes (e.g., `pr-119-blockers.md` or `pr_209_cleanup_done.md`) often get left behind in `.serena/memories/status` and become stale once the PRs are merged and the migration is complete.
+**Action:** Ensure that status files are deleted or marked as resolved/archived as part of the final PR merge process or clean them up systematically during archivist runs.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,30 +1,27 @@
-## 2025-04-06 - Accessible Custom Toggles
-**Learning:** Custom UI components designed to look like interactive switches lack inherent meaning for screen readers. Using just `<button>` with visual styles leaves assistive tech users unable to determine the current state (on/off) or the element's interactive nature as a toggle.
-**Action:** Always verify that components visually functioning as switches use `role="switch"`, dynamically update `aria-checked`, provide a descriptive `aria-label`, and include distinct `:focus-visible` styles for clear keyboard navigation.
+## 2024-04-11 - Focus Visible Styles for Retro Buttons
+**Learning:** Some custom UI elements, like mapped list buttons or dynamically rendered list items (e.g., in LocationSuggestions), can easily omit standard focus indicators when custom styling is heavily applied, making keyboard navigation difficult or invisible.
+**Action:** Always ensure dynamic, mapped, or custom interactive elements explicitly include focus visible utilities (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950`) to match the application's global focus style.
 
-## 2025-04-06 - Accessible Custom Radio Groups
-**Learning:** Segmented controls built with generic `<button>` elements do not convey mutual exclusivity or selected state to screen readers, acting merely as independent buttons without context.
-**Action:** When implementing custom radio groups (segmented controls), wrap the buttons in a container with `role="radiogroup"` and a descriptive `aria-label`. Ensure individual buttons use `role="radio"` and `aria-checked={boolean}`, along with clear `:focus-visible` styles for keyboard navigation.
+## 2024-04-12 - Custom Segmented Control ARIA Roles
+**Learning:** When creating custom segmented controls with mutually exclusive options, using `role="switch"` is incorrect as switches imply an on/off state. `role="group"` is also too generic. A segmented control is conceptually a set of radio buttons.
+**Action:** Use `role="radiogroup"` for the container and `role="radio"` for the individual buttons, along with `aria-checked={boolean}` and proper `aria-label`s on the container, to ensure screen readers correctly interpret the mutually exclusive selection pattern.
 
-## 2026-04-03 - Missing ARIA Labels on Icon-Only Buttons
-**Learning:** Discovered that several icon-only buttons throughout the app (search clear, modal closes, settings) lacked `aria-label` attributes. This is a common pattern in modern UI development where icons are visually obvious but completely invisible to screen readers, creating significant accessibility barriers.
-**Action:** Always verify that buttons containing only icons (like from `lucide-react`) have descriptive `aria-label` attributes to ensure screen reader compatibility.
-## 2026-04-05 - Switch Role and ARIA Attributes
-**Learning:** When implementing custom toggle buttons using basic HTML elements (like `<button>` or `<div>`), they must have `role="switch"`, `aria-checked={boolean}`, and a descriptive `aria-label` to be properly understood by screen readers as toggles rather than generic buttons.
-**Action:** Always verify that custom switch/toggle components include the correct ARIA attributes for state and labeling.
-## 2026-04-07 - Inline Confirmation for Destructive Actions
-**Learning:** Destructive actions inside easily dismissible modals are prone to accidental clicks. Adding an inline confirmation step prevents data loss without forcing the user out of their current context.
-**Action:** Always implement a two-step inline confirmation (e.g., 'Delete' -> 'Cancel' / 'Confirm') for data-clearing actions within dialogs.
+## 2024-04-13 - Added aria-label to icon-only buttons
+**Learning:** For accessibility, ensure all icon-only interactive elements (like buttons) include an `aria-label` attribute, as relying solely on the `title` attribute is insufficient for screen readers. In Dexhelper, several key interactive elements like the Assistant Panel debug toggle, Pokedex Cards, and Storage Grid cards lacked proper screen reader announcements despite having visual cues or titles.
+**Action:** Always add `aria-label` attributes to icon-only buttons and interactive card elements that act as links or triggers, ensuring the label clearly describes the action or destination (e.g., `aria-label={"View details for " + pokemon.name}`).
 
 ## 2024-05-18 - [File Upload Input Accessibility]
 **Learning:** Using `className="hidden"` on `<input type="file">` elements within a `<label>` hides them completely from the accessibility tree, making it impossible for screen reader users to understand or interact with the file input properly, and preventing keyboard focus.
 **Action:** Instead of `className="hidden"`, use Tailwind's `className="sr-only"` combined with `tabIndex={-1}`. `sr-only` keeps the element accessible to screen readers but visually hidden. `tabIndex={-1}` ensures the input itself doesn't receive redundant keyboard focus (since its wrapping `<label>` is naturally focusable or can be made focusable, often using `focus-within:ring-*` to show visual feedback when the hidden input receives internal focus).
-## 2024-04-11 - Focus Visible Styles for Retro Buttons
-**Learning:** The custom retro-button class and other interactive elements in this design system do not have default keyboard focus indicators. Tabbing through the interface without them makes the app inaccessible to keyboard users.
-**Action:** Always add `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` to interactive elements to ensure a consistent, themed focus state.
-## 2024-04-12 - Custom Segmented Control ARIA Roles
-**Learning:** When creating custom segmented controls with mutually exclusive options, using `role="switch"` is incorrect as switches imply an on/off state. `role="group"` is also too generic. A segmented control is conceptually a set of radio buttons.
-**Action:** Use `role="radiogroup"` for the container and `role="radio"` for the individual buttons, along with `aria-checked={boolean}` and proper `aria-label`s on the container, to ensure screen readers correctly interpret the mutually exclusive selection pattern.
+
+## 2025-04-06 - Accessible Custom Toggles
+**Learning:** Custom UI components designed to look like interactive switches lack inherent meaning for screen readers. Using just `<button>` with visual styles leaves assistive tech users unable to determine the current state (on/off) or the element's interactive nature as a toggle.
+**Action:** Always verify that components visually functioning as switches use `role="switch"`, dynamically update `aria-checked`, provide a descriptive `aria-label`, and include distinct `:focus-visible` styles for clear keyboard navigation.
+
+## 2026-04-07 - Inline Confirmation for Destructive Actions
+**Learning:** Destructive actions inside easily dismissible modals are prone to accidental clicks. Adding an inline confirmation step prevents data loss without forcing the user out of their current context.
+**Action:** Always implement a two-step inline confirmation (e.g., 'Delete' -> 'Cancel' / 'Confirm') for data-clearing actions within dialogs.
+
 ## 2026-04-09 - Accessible Search Inputs
 **Learning:** Standard text inputs used for searching often lack intuitive keyboard navigation and immediate visual feedback when clearing text. Without focus returning to the input after clearing, users must manually re-focus the input to start a new search, disrupting the workflow.
 **Action:** Always add keyboard shortcuts (like `Escape`) to clear search inputs. When a clear button is used, ensure it has visible focus styles and that its `onClick` handler programmatically returns focus back to the search input.

--- a/.serena/memories/development/pr_209_cleanup_done.md
+++ b/.serena/memories/development/pr_209_cleanup_done.md
@@ -1,8 +1,0 @@
-# PR 209 Cleanup Done
-
-Cleaned up PR 209 by:
-- Removing verbose console logs from `PokeDB`, `PokedexGrid`, and E2E test utils.
-- Refactoring `DexDataLoader.getPokemonDetails` to return explicit types.
-- Removing `any` casts in `PokemonDetails.tsx`.
-- Refactoring `scripts/generate-pokedata.ts` to use typed interfaces for PokeAPI data.
-- Verified with type-check, vitest, and playwright tests.

--- a/.serena/memories/dexhelper/lean-data-migration-complete.md
+++ b/.serena/memories/dexhelper/lean-data-migration-complete.md
@@ -1,7 +1,0 @@
-The project has been migrated to a leaner data model and the legacy technical stack has been purged. 
-
-- **Data Model**: Pokemon types were removed from the static generation script, schema, and UI components, reducing `pokedata.json` size significantly. 
-- **Tech Stack Purge**: Removed `pokenode-ts`, `jsdom`, and `tsx`.
-- **Testing Evolution**: Unit tests now run in a native Node environment (no `jsdom`) for maximum performance, with standard DOM guards in `PokeDB.ts`.
-- **Tooling Fixes**: Lefthook configuration has been stabilized using `all_files: true` to prevent Biome/TS pathing leaks. 
-All changes were verified with `pnpm type-check` and successfully pass.

--- a/.serena/memories/status/pr-119-blockers.md
+++ b/.serena/memories/status/pr-119-blockers.md
@@ -1,5 +1,0 @@
-PR 119 Finalization Issues Identified:
-- Type-check failures in PokemonDetails.tsx, PokemonLocations.tsx, and tests due to missing 'strategy' argument in generateSuggestions.
-- Runtime bloat from GEN1_MAP_TO_SLUG in assistantData.ts.
-- Redundant runtime slug generation for distance logic.
-- Untracked tests (tests/e2e/assistant.spec.ts) incomplete.


### PR DESCRIPTION
## What
- Merged the legacy `.Jules/` directory into `.jules/` to resolve case-sensitivity issues and duplication.
- Deduplicated `.jules/palette.md` to remove repetitive accessibility learnings (e.g., `aria-label`, `role="switch"`, focus-visible styles) and consolidate them into clear, distinct entries.
- Removed genuinely stale status notes and migration memories from `.serena/memories/` (specifically `dexhelper/lean-data-migration-complete.md`, `development/pr_209_cleanup_done.md`, and `status/pr-119-blockers.md`).
- Left `purging-stats-and-types-completed.md` intact, as DVs are still actively parsed and `Hidden Power` remains in the source code config, so it is not fully stale yet.
- Logged new learnings in `.jules/archivist.md` about the importance of consistent case usage for directories and cleaning up transient PR status files to prevent knowledge rot.

## How it was verified
- Used `grep` and file reading to verify if the files were truly stale by cross-referencing against active source code (`src/`).
- Verified deduplication by manually rewriting and checking `.jules/palette.md`.
- Ran `pnpm lint` and `pnpm test` to ensure no active CI workflows were broken by the clean up.

---
*PR created automatically by Jules for task [11285275930127553734](https://jules.google.com/task/11285275930127553734) started by @szubster*