### PR TITLE
⚡ Bolt: Prevent N+1 queries in LocationSuggestions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-05-15 - Optimize getPokemons in PokeDB
 **Learning:** Fetching data via IndexedDB in a loop can cause N+1 query and multiple transaction overhead if `db.get` is used individually, as each creates a separate transaction.
 **Action:** Use a single `readonly` transaction with `tx.objectStore(STORE).get(id)` and `Promise.all` to batch read operations significantly, avoiding transaction overhead while preventing fetching the entire database via `getAll`.
+## 2024-05-24 - Prevent N+1 queries in LocationSuggestions
+**Learning:** IDB queries using `pokeDB.getInverseIndex` inside `.map` over filtered elements can trigger N+1 synchronous database overhead in React useEffects on every keystroke, causing severe UI blocking despite `await`.
+**Action:** When working with objects returned by `pokeDB.getLocations()`, access the pre-computed `pids` array directly (`l.pids?.length`) rather than firing off individual IndexedDB queries for `pokeDB.getInverseIndex(l.id)`. This removes Promises entirely from the render iteration.

--- a/src/components/LocationSuggestions.tsx
+++ b/src/components/LocationSuggestions.tsx
@@ -22,17 +22,16 @@ export function LocationSuggestions() {
 
     const fetchSuggestions = async () => {
       const locations = await pokeDB.getLocations();
-      const filtered = locations.filter((l) => l.n.toLowerCase().includes(searchTerm.toLowerCase())).slice(0, 5);
 
-      const withCounts = await Promise.all(
-        filtered.map(async (l) => {
-          const index = await pokeDB.getInverseIndex(l.id);
-          return { ...l, count: index?.length || 0 };
-        }),
-      );
+      // ⚡ Bolt: Hoisted string allocation outside the loop and removed N+1 IDB queries
+      const term = searchTerm.toLowerCase();
+      const filteredWithCounts = locations
+        .filter((l) => l.n.toLowerCase().includes(term))
+        .slice(0, 5)
+        .map((l) => ({ ...l, count: l.pids?.length || 0 }));
 
-      setSuggestions(withCounts);
-      setIsOpen(withCounts.length > 0);
+      setSuggestions(filteredWithCounts);
+      setIsOpen(filteredWithCounts.length > 0);
     };
 
     fetchSuggestions();


### PR DESCRIPTION
**What:** Optimized `fetchSuggestions` in `LocationSuggestions.tsx` to prevent N+1 queries to IndexedDB.
**Why:** The `LocationSuggestions` component fired an asynchronous IndexedDB query `pokeDB.getInverseIndex(l.id)` for each of the top 5 filtered location results to count the Pokémon present. Because `getLocations()` already returns `UnifiedLocation` objects containing the `pids` array (Pokémon IDs), these queries were fully redundant. Also hoisted `searchTerm.toLowerCase()` outside the `.filter` loop to stop string reallocation.
**Expected Impact:** Eliminates 5 unnecessary IndexedDB database transactions and Promise allocations on every keystroke in the location search bar, immediately reducing main thread sync blocking time.
**How to Verify:** The test suite (`pnpm test`) passes and E2E tests (`pnpm test:e2e`) guarantee suggestions still function properly in the search input.

---
*PR created automatically by Jules for task [6929097480238192439](https://jules.google.com/task/6929097480238192439) started by @szubster*