### PR TITLE
🎨 Palette: Add empty state to PokedexGrid

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,7 @@
 ## 2026-04-09 - Accessible Search Inputs
 **Learning:** Standard text inputs used for searching often lack intuitive keyboard navigation and immediate visual feedback when clearing text. Without focus returning to the input after clearing, users must manually re-focus the input to start a new search, disrupting the workflow.
 **Action:** Always add keyboard shortcuts (like `Escape`) to clear search inputs. When a clear button is used, ensure it has visible focus styles and that its `onClick` handler programmatically returns focus back to the search input.
+
+## 2026-04-10 - Empty States in Heavily Filtered Lists
+**Learning:** When grids or lists implement complex or combined filtering logic (such as searching by name + status filters), users can quickly hit zero results. Without a distinct empty state, an empty screen can confuse users, causing them to believe the app broke rather than their search yielding no matches.
+**Action:** Always provide explicit empty states for heavily filterable/searchable lists, including clear messaging ("No results found") and actionable advice on how to recover context ("Try adjusting your search filters").

--- a/src/components/PokedexGrid.tsx
+++ b/src/components/PokedexGrid.tsx
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { Search } from 'lucide-react';
 import React, { useMemo } from 'react';
 import { pokeDB } from '../db/PokeDB';
 import { useStore } from '../store';
@@ -82,6 +83,20 @@ export function PokedexGrid({ pokemonList }: { pokemonList: { id: number; name: 
     }
     return set;
   }, [saveData]);
+
+  if (finalPokemon.length === 0) {
+    return (
+      <div className="fade-in flex min-h-[40vh] flex-col items-center justify-center space-y-4 px-4 text-center animate-in duration-500">
+        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-zinc-900/50 border border-zinc-800/50">
+          <Search size={32} className="text-zinc-600" />
+        </div>
+        <h3 className="font-black font-display text-xl text-white uppercase tracking-tight">No Pokémon Found</h3>
+        <p className="max-w-[280px] font-bold text-xs text-zinc-500 uppercase leading-relaxed tracking-widest">
+          Try adjusting your search term or filters to find what you're looking for.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="fade-in grid animate-in grid-cols-2 gap-5 px-1 pb-10 duration-500 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">

--- a/src/components/PokedexGrid.tsx
+++ b/src/components/PokedexGrid.tsx
@@ -86,11 +86,11 @@ export function PokedexGrid({ pokemonList }: { pokemonList: { id: number; name: 
 
   if (finalPokemon.length === 0) {
     return (
-      <div className="fade-in flex min-h-[40vh] flex-col items-center justify-center space-y-4 px-4 text-center animate-in duration-500">
-        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-zinc-900/50 border border-zinc-800/50">
+      <div className="fade-in flex min-h-[40vh] animate-in flex-col items-center justify-center space-y-4 px-4 text-center duration-500">
+        <div className="flex h-20 w-20 items-center justify-center rounded-full border border-zinc-800/50 bg-zinc-900/50">
           <Search size={32} className="text-zinc-600" />
         </div>
-        <h3 className="font-black font-display text-xl text-white uppercase tracking-tight">No Pokémon Found</h3>
+        <h3 className="font-black font-display text-white text-xl uppercase tracking-tight">No Pokémon Found</h3>
         <p className="max-w-[280px] font-bold text-xs text-zinc-500 uppercase leading-relaxed tracking-widest">
           Try adjusting your search term or filters to find what you're looking for.
         </p>


### PR DESCRIPTION
### 💡 What
Added a distinct empty state to the `PokedexGrid` component that displays when a user's search or filter parameters yield zero results. The state features a descriptive icon, clear messaging ("No Pokémon Found"), and actionable recovery advice.

### 🎯 Why
When users combine various filters and text queries, they can quickly hit an empty result set. An entirely blank grid is confusing and might make the application feel broken. Providing an explicit empty state informs the user that their current filters were applied successfully but simply returned no matches, allowing them to recover their context easily.

### 📸 Before/After
*(See attached screenshot verification from Playwright tests)*

### ♿ Accessibility
The empty state enhances cognitive accessibility by eliminating ambiguity around the application's current state and providing explicit next steps for the user.

---
*PR created automatically by Jules for task [5227416390373452610](https://jules.google.com/task/5227416390373452610) started by @szubster*