### PR TITLE
🛡️ Nurse: Fix unsafe cast in DexDataLoader encounters batch function

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -1,3 +1,13 @@
 ## $(date +%Y-%m-%d) - Typed `CATEGORY_STYLES` with `SuggestionCategory`
 **Learning:** `Object.entries()` returns keys as `string`, which requires an explicit `as Type` cast when the original object uses a strict union or enum for its keys. Furthermore, when using `.reduce` to build an object with strict string literal keys, use `Partial<Record<TargetKey, ValueType>>` for the initial accumulator so it can start as an empty object (`{}`) without failing type-checks, as opposed to forcing it with `as Record<TargetKey, ValueType>`.
 **Action:** Use `Partial` instead of raw `Record` types when starting with empty objects in `.reduce()` functions if not all keys are guaranteed to be populated at start. Remember to cast keys yielded by `Object.entries()` if they need to map back to strict unions, or use `.reduce` instead with typed iterables.
+## 2025-02-15 - Unsafe casts in DataLoader
+
+**What was unsafe:**
+`as Promise<LocationAreaEncounters>` cast in the `DataLoader` batch function hid the `undefined` return type from `pokeDB.getEncounters`. This caused `DataLoader` to return `undefined` instead of `LocationAreaEncounters` or rejecting the promise for missing values.
+
+**How it was fixed:**
+Removed the cast, awaited the result, and mapped `undefined` results to an `Error` object as required by `DataLoader` for missing items.
+
+**What the compiler now catches:**
+The compiler ensures that DataLoader batch functions return valid values or Errors, preventing unexpected `undefined` results downstream.

--- a/src/db/DexDataLoader.ts
+++ b/src/db/DexDataLoader.ts
@@ -15,7 +15,8 @@ export const dexDataLoader = {
 
   encounters: new DataLoader<number, LocationAreaEncounters>(
     async (ids) => {
-      return Promise.all(ids.map((id) => pokeDB.getEncounters(id) as Promise<LocationAreaEncounters>));
+      const encounters = await Promise.all(ids.map((id) => pokeDB.getEncounters(id)));
+      return encounters.map((enc, index) => enc ?? new Error(`Encounters not found for ${ids[index]}`));
     },
     { cache: true },
   ),


### PR DESCRIPTION
### What was unsafe
The `as Promise<LocationAreaEncounters>` cast in the `DataLoader` batch function hid the `undefined` return type from `pokeDB.getEncounters()`. When an encounter was not found, this caused `DataLoader` to resolve with `undefined` instead of rejecting the specific key's promise, which violates the `DataLoader` contract and can lead to unexpected `Cannot read properties of undefined` runtime crashes.

### How it was fixed
Removed the unsafe `as` cast. The array of promises is now properly awaited, and any `undefined` results are mapped to `Error` objects, which `DataLoader` recognizes as a failure for that specific key.

### What the compiler now catches
The compiler now natively ensures that the `DataLoader` batch function returns an array of explicitly defined types (`LocationAreaEncounters | Error`). It prevents accidental regressions that could introduce `undefined` elements into the batch result array, improving overall type safety and error propagation.

---
*PR created automatically by Jules for task [11337787904293152585](https://jules.google.com/task/11337787904293152585) started by @szubster*