### PR TITLE
🧬 Oak: [data correction] Fix Yellow version exclusives

### DIFF
--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -1,0 +1,5 @@
+## 2024-05-18 - 🧬 Oak: [Gen 1 Yellow Exclusives correction]
+**What was wrong:** Sandshrew, Sandslash, and Pinsir were incorrectly listed as unobtainable (exclusives) in Yellow version, while Electabuzz was missing from the unobtainable list.
+**Canonical source used:** PokeAPI encounters (`https://pokeapi.co/api/v2/pokemon/${id}/encounters`).
+**Impact on users:** Users playing Yellow version will now correctly see that they can catch Sandshrew, Sandslash, and Pinsir, and will correctly be told they need to trade for Electabuzz.
+**Learning:** PokeAPI encounter endpoints are the absolute source of truth for base-form version availability, especially for complex cases like Yellow version where availability diverges significantly from Red/Blue.

--- a/src/engine/exclusives/__tests__/gen1Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen1Exclusives.test.ts
@@ -117,6 +117,23 @@ describe('gen1Exclusives', () => {
       });
     });
 
+    describe('Yellow Version Exclusives', () => {
+      it('should lock Electabuzz (125) in Yellow', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(125, 'yellow', 0, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('not available in Yellow');
+      });
+
+      it('should not lock Sandshrew (27) or Pinsir (127) in Yellow', () => {
+        const ownedSet = new Set<number>();
+        const reasonSandshrew = getUnobtainableReason(27, 'yellow', 0, ownedSet);
+        const reasonPinsir = getUnobtainableReason(127, 'yellow', 0, ownedSet);
+        expect(reasonSandshrew).toBeNull();
+        expect(reasonPinsir).toBeNull();
+      });
+    });
+
     describe('Fossils (Mutually Exclusive)', () => {
       it('should lock Omanyte (138) if Kabuto (140) is owned', () => {
         const ownedSet = new Set([140]); // Own Kabuto

--- a/src/engine/exclusives/gen1Exclusives.ts
+++ b/src/engine/exclusives/gen1Exclusives.ts
@@ -39,15 +39,13 @@ const GEN1_VERSION_EXCLUSIVES: Record<string, number[]> = {
     15, // Weedle, Kakuna, Beedrill
     23,
     24, // Ekans, Arbok
-    27,
-    28, // Sandshrew, Sandslash
     52,
     53, // Meowth, Persian
     109,
     110, // Koffing, Weezing
     124, // Jynx
+    125, // Electabuzz
     126, // Magmar
-    127, // Pinsir
   ],
 };
 


### PR DESCRIPTION
**What was wrong:**
Sandshrew, Sandslash, and Pinsir were incorrectly listed as unobtainable (exclusives) in Yellow version, while Electabuzz was missing from the unobtainable list.

**Canonical source used:**
PokeAPI encounters (`https://pokeapi.co/api/v2/pokemon/${id}/encounters`).

**Impact on users:**
Users playing Yellow version will now correctly see that they can catch Sandshrew, Sandslash, and Pinsir, and will correctly be told they need to trade for Electabuzz.

---
*PR created automatically by Jules for task [15710811034697635606](https://jules.google.com/task/15710811034697635606) started by @szubster*