### PR TITLE
🧪 Sentinel: Add tests for Assistant suggestion strategy routing

### DIFF
--- a/src/engine/assistant/strategies/index.test.ts
+++ b/src/engine/assistant/strategies/index.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { gen1Strategy } from './gen1Strategy';
+import { getStrategy } from './index';
+
+describe('getStrategy', () => {
+  it('returns gen1Strategy for generation 1', () => {
+    expect(getStrategy(1)).toBe(gen1Strategy);
+  });
+
+  it('returns gen1Strategy as fallback for unsupported generation (e.g. 2)', () => {
+    expect(getStrategy(2)).toBe(gen1Strategy);
+  });
+
+  it('returns gen1Strategy as fallback for unknown generation (e.g. 99)', () => {
+    expect(getStrategy(99)).toBe(gen1Strategy);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `getStrategy` function in `src/engine/assistant/strategies/index.ts` was missing test coverage.
📊 **Coverage:** The new test file (`src/engine/assistant/strategies/index.test.ts`) tests generation 1 returning `gen1Strategy` and other unknown/unsupported generations falling back to `gen1Strategy` as expected.
✨ **Result:** Enhanced unit test suite coverage providing confidence when adding support for future generations.

---
*PR created automatically by Jules for task [4516279408968871432](https://jules.google.com/task/4516279408968871432) started by @szubster*