### PR TITLE
⚡ Bolt: Use cached pokemonList in AssistantPanel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2024-05-24 - Prevent N+1 queries in LocationSuggestions
 **Learning:** IDB queries using `pokeDB.getInverseIndex` inside `.map` over filtered elements can trigger N+1 synchronous database overhead in React useEffects on every keystroke, causing severe UI blocking despite `await`.
 **Action:** When working with objects returned by `pokeDB.getLocations()`, access the pre-computed `pids` array directly (`l.pids?.length`) rather than firing off individual IndexedDB queries for `pokeDB.getInverseIndex(l.id)`. This removes Promises entirely from the render iteration.
+## 2024-05-19 - ⚡ Bolt: Use cached pokemonList in AssistantPanel
+
+**Learning:** When data is prefetched and cached at the root route level via `queryClient.ensureQueryData` (e.g., `pokemonListQueryOptions`), child components like `AssistantPanel` shouldn't re-fetch it independently via `useQuery` or `pokeDB` calls. This causes redundant IndexedDB access, duplicative cache memory allocation, and blocks the main thread with unnecessary array mapping.
+**Action:** Replace `useQuery` with `useSuspenseQuery` utilizing the exact same pre-defined `queryOptions` object from `pokemonQueries.ts`. `useSuspenseQuery` safely eliminates the need for manual `undefined` checks since the data presence is guaranteed by the route loader.

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -1,9 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Bug, Egg, Flag, Info, Loader2, Sparkles, Target, Zap } from 'lucide-react';
 import React from 'react';
-import { pokeDB } from '../db/PokeDB';
 import type { SaveData } from '../engine/saveParser/index';
 import { type Suggestion, type SuggestionCategory, useAssistant } from '../hooks/useAssistant';
+import { pokemonListQueryOptions } from '../utils/pokemonQueries';
 import { AssistantDebugView } from './assistant/AssistantDebugView';
 import { AssistantSuggestionCard } from './assistant/AssistantSuggestionCard';
 
@@ -60,28 +60,22 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
   const { suggestions, debug, isLoading, areaNames } = useAssistant(saveData, isLivingDex, manualVersion);
   const [showDebug, setShowDebug] = React.useState(false);
 
-  const { data: pokemonList } = useQuery<{ id: number; name: string }[]>({
-    queryKey: ['pokemonList'],
-    queryFn: () => pokeDB.getAllPokemon().then((res) => res.map((p) => ({ id: p.id, name: p.n }))),
-    staleTime: Infinity,
-  });
+  // ⚡ Bolt: Removed redundant IDB query, use cached data from root route loader
+  const { data: pokemonList } = useSuspenseQuery(pokemonListQueryOptions);
 
   const pokemonNameRecord = React.useMemo(() => {
     const record: Record<number, string> = {};
-    if (pokemonList) {
-      for (const p of pokemonList) {
-        record[p.id] = p.name;
-      }
+    for (const p of pokemonList) {
+      record[p.id] = p.name;
     }
     return record;
   }, [pokemonList]);
 
   const getPokemonName = React.useCallback(
     (id: number) => {
-      if (!pokemonList) return `#${id}`;
       return pokemonNameRecord[id] ?? `#${id}`;
     },
-    [pokemonList, pokemonNameRecord],
+    [pokemonNameRecord],
   );
 
   return (


### PR DESCRIPTION
**What**: Replaced a duplicate `useQuery` call in `AssistantPanel.tsx` that was querying `pokeDB.getAllPokemon()` with `useSuspenseQuery(pokemonListQueryOptions)`. 

**Why**: `pokemonListQueryOptions` is already prefetched and cached globally at the root route (`__root.tsx`). By using it directly in the assistant panel with `useSuspenseQuery`, we eliminate a redundant IndexedDB query, prevent duplicate array allocations in memory, and remove unnecessary loading checks within the component (since `useSuspenseQuery` guarantees the data is available).

**Expected Impact**: Faster initial rendering of the Assistant Panel when switching routes, reduced memory usage, and no duplicated IndexedDB reads.

**How to Verify**: Run `pnpm test` and `pnpm test:e2e` to ensure the Assistant Panel functions normally and that suggestions are still correctly mapped to their respective Pokémon names.

---
*PR created automatically by Jules for task [12030202660673583802](https://jules.google.com/task/12030202660673583802) started by @szubster*