### PR TITLE
🎨 Palette: Add missing focus-visible to grid buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,7 @@
 ## 2026-04-10 - Empty States for Search and Filters
 **Learning:** Data grids and lists that can be heavily filtered or searched often lack empty states. When a user applies a combination of filters that yields no results, presenting an empty UI implies a bug or broken data load.
 **Action:** Always implement a distinct empty state for filtered lists. Use appropriate icons, clear messaging ("No results found"), and actionable advice (e.g., "Try adjusting your filters") to maintain context and guide the user.
+
+## 2026-04-10 - Palette: Add missing focus-visible to grid buttons
+**Learning:** The application had missing `focus-visible` styles on core grid interactive elements (`PokedexCard` and `StorageGrid` main buttons), which breaks keyboard navigation visibility.
+**Action:** Always include the standard `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` classes when adding or updating interactive list/grid items.

--- a/src/components/PokedexCard.tsx
+++ b/src/components/PokedexCard.tsx
@@ -53,7 +53,7 @@ export const PokedexCard = React.memo(function PokedexCard({
       data-pokemon-id={pokemon.id}
       onClick={() => navigate({ to: `/pokemon/${pokemon.id}`, search: { from: '/' } })}
       className={cn(
-        'group relative w-full cursor-pointer rounded-3xl border-2 p-4 text-left transition-all duration-500 hover:scale-[1.02] active:scale-[0.98]',
+        'group relative w-full cursor-pointer rounded-3xl border-2 p-4 text-left transition-all duration-500 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98]',
         hasInStorage
           ? 'border-emerald-500/30 bg-zinc-900 hover:border-emerald-500/50 hover:shadow-[0_0_30px_rgba(16,185,129,0.15)]'
           : 'border-white/5 bg-zinc-900 hover:border-white/10 hover:shadow-[0_0_30px_rgba(255,255,255,0.05)]',

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -88,7 +88,7 @@ export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: 
                       // biome-ignore lint/suspicious/noArrayIndexKey: Array index is stable and required for duplicates
                       key={`${location}-${p.speciesId}-${idx}`}
                       onClick={() => navigate({ to: `/pokemon/${pokemon.id}`, search: { from: '/storage' } })}
-                      className={`relative flex w-full cursor-pointer flex-col items-center rounded-2xl p-5 text-left transition-all duration-200 hover:-translate-y-1 active:scale-95 ${cardStyle}`}
+                      className={`relative flex w-full cursor-pointer flex-col items-center rounded-2xl p-5 text-left transition-all duration-200 hover:-translate-y-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-95 ${cardStyle}`}
                     >
                       <div className="absolute top-3 left-3 font-bold font-mono text-[10px] text-zinc-600">
                         LV.{p.level}


### PR DESCRIPTION
💡 What
Added the standard `focus-visible` utility classes to the main interactive `<button>` elements in `PokedexCard` and `StorageGrid`.

🎯 Why
These heavily custom-styled buttons lacked visual focus indicators, making it impossible for keyboard users to track their position when navigating through the main data grids.

📸 Before/After
Before: Tabbing through the grid provided no visual feedback.
After: Focused cards now display a crisp theme-colored ring (using existing `--theme-primary` variables).

♿ Accessibility
Addresses a WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) failure on core application navigation paths.

---
*PR created automatically by Jules for task [13614374165085870653](https://jules.google.com/task/13614374165085870653) started by @szubster*