### PR TITLE
📜 Scribe: Documented saveParser module

### DIFF
--- a/src/engine/saveParser/index.ts
+++ b/src/engine/saveParser/index.ts
@@ -7,6 +7,16 @@ export { decodeGen12String } from './parsers/common';
 export type { GameVersion, Generation, PokemonInstance, SaveData };
 export { INTERNAL_ID_TO_DEX };
 
+/**
+ * Main entry point for decoding a raw Pokémon save file buffer.
+ * It identifies whether the file belongs to Generation 1 (R/B/Y) or Generation 2 (G/S/C)
+ * by verifying checksums and internal structures.
+ *
+ * @param buffer - The raw binary data of the .sav file.
+ * @param forcedVersion - An optional version override provided by the user to force specific parsing logic (e.g., forcing Yellow or Crystal).
+ * @returns The structured SaveData object representing the player's progress and Pokémon.
+ * @throws An Error if the file size is invalid or if neither Gen 1 nor Gen 2 structures could be matched.
+ */
 export function parseSaveFile(buffer: ArrayBuffer, forcedVersion?: GameVersion): SaveData {
   const u8 = new Uint8Array(buffer);
 
@@ -15,6 +25,9 @@ export function parseSaveFile(buffer: ArrayBuffer, forcedVersion?: GameVersion):
   }
 
   // Gen 1 Checksum
+  // Gen 1 calculates its checksum by iterating over the main save data block (0x2598 to 0x3522),
+  // subtracting each byte's value from an initial value of 255 (0xFF).
+  // The result is stored at 0x3523.
   let gen1Sum = 255;
   for (let i = 0x2598; i <= 0x3522; i++) {
     gen1Sum -= u8[i] ?? 0;
@@ -22,6 +35,8 @@ export function parseSaveFile(buffer: ArrayBuffer, forcedVersion?: GameVersion):
   const isGen1ChecksumValid = (gen1Sum & 0xff) === (u8[0x3523] ?? 0);
 
   // Gen 2 Checksum
+  // Gen 2 calculates its checksum by summing up the bytes in the main save data block (0x2009 to 0x2D0C).
+  // The expected total is stored as a 16-bit little-endian integer at 0x2D0D.
   let gen2Sum = 0;
   for (let i = 0x2009; i <= 0x2d0c; i++) {
     gen2Sum += u8[i] ?? 0;

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -156,6 +156,19 @@ export const INTERNAL_ID_TO_DEX: Record<number, number> = {
   190: 71,
 };
 
+/**
+ * Attempts to heuristically determine the specific Generation 1 game version (Red, Blue, or Yellow).
+ * It first checks for high-confidence Yellow markers (Pikachu friendship/status bytes).
+ * If those are inconclusive, it falls back to a scoring system based on version-exclusive
+ * Pokémon found in the player's Pokédex and party.
+ *
+ * @param u8 - The raw save file array.
+ * @param owned - A set of Pokémon Pokédex IDs the player has caught.
+ * @param seen - A set of Pokémon Pokédex IDs the player has seen.
+ * @param trainerName - The player's Original Trainer (OT) name.
+ * @param partyDetails - A quick parsing of the player's party to verify if Pikachu is a native starter.
+ * @returns 'red', 'blue', 'yellow', or 'unknown' if it cannot confidently decide.
+ */
 export function detectGen1GameVersion(
   u8: Uint8Array,
   owned: Set<number>,
@@ -232,6 +245,14 @@ export function detectGen1GameVersion(
   return 'unknown';
 }
 
+/**
+ * Performs a structural check to verify if the save file is a valid Generation 1 save.
+ * It checks the party count (must be <= 6), ensures the party list is correctly terminated with 0xFF,
+ * and validates that the internal IDs in the party are within the expected range.
+ *
+ * @param u8 - The raw save file array.
+ * @returns True if the structure looks like a valid Gen 1 save.
+ */
 export function isGen1Save(u8: Uint8Array): boolean {
   const partyCount = byte(u8, 0x2f2c) ?? 0;
   if (partyCount > 6) return false;
@@ -243,6 +264,16 @@ export function isGen1Save(u8: Uint8Array): boolean {
   return true;
 }
 
+/**
+ * Extracts all relevant game data (party, PC boxes, inventory, Pokédex, etc.) from a Gen 1 save.
+ * Yellow version shifted many memory offsets by +1 byte compared to Red/Blue. This parser probes both
+ * potential Pokédex offsets (0x25A3 for R/B, 0x25A4 for Yellow) and uses padding bit correctness to
+ * dynamically detect the offset shift before extracting the rest of the save data.
+ *
+ * @param u8 - The raw save file array.
+ * @param forcedVersion - An optional version override provided by the user.
+ * @returns The structured SaveData object.
+ */
 export function parseGen1(u8: Uint8Array, forcedVersion?: GameVersion): SaveData {
   const trainerName = decodeGen12String(u8, 0x2598);
 

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -3,6 +3,15 @@ import gen2MapLocations from '../../data/gen2/mapLocations.json';
 import type { GameVersion, PokemonInstance, SaveData } from './common';
 import { byte, checkShiny, decodeGen12String, parseDVs } from './common';
 
+/**
+ * Extracts the caught data (time of day, level, and location) from a Generation 2 Pokémon structure.
+ * Caught data is only populated in Crystal version; Gold and Silver leave these bytes as 0.
+ * Time and level are packed into a single byte via bitwise operations.
+ *
+ * @param u8 - The raw save file array.
+ * @param offset - The memory offset of the specific Pokémon structure.
+ * @returns An object containing the time, level, location ID, and location name, or undefined if missing.
+ */
 export function parseCaughtData(u8: Uint8Array, offset: number) {
   const caughtByte1 = byte(u8, offset + 29);
   const caughtByte2 = byte(u8, offset + 30);
@@ -28,6 +37,16 @@ export function parseCaughtData(u8: Uint8Array, offset: number) {
   return { time, level: caughtLevel, location, locationName };
 }
 
+/**
+ * Extracts details for a single Pokémon from a Generation 2 save block.
+ *
+ * @param u8 - The raw save file array.
+ * @param offset - The memory offset for the start of the Pokémon's 32-byte data block.
+ * @param isCrystal - Whether the save file is from Pokémon Crystal (determines if caught data exists).
+ * @param storageLocation - A string indicating where the Pokémon is stored (e.g., 'Party', 'Box 1').
+ * @param slot - The 1-indexed slot the Pokémon occupies in its storage container.
+ * @returns A fully constructed PokemonInstance object, or undefined if the species ID is invalid.
+ */
 export function parseGen2PokemonInstance(
   u8: Uint8Array,
   offset: number,
@@ -65,6 +84,15 @@ export function parseGen2PokemonInstance(
   };
 }
 
+/**
+ * Attempts to heuristically determine whether a Generation 2 save is Gold or Silver.
+ * This is done by checking the player's Pokédex (owned and seen) against known
+ * version-exclusive Pokémon.
+ *
+ * @param owned - A set of Pokémon Pokédex IDs the player has caught.
+ * @param seen - A set of Pokémon Pokédex IDs the player has seen.
+ * @returns 'gold', 'silver', or 'unknown'.
+ */
 export function detectGen2GameVersion(owned: Set<number>, seen: Set<number>): GameVersion {
   const goldExclusives = [56, 57, 58, 59, 167, 168, 190, 207, 249];
   const silverExclusives = [37, 38, 52, 53, 165, 166, 216, 217, 227, 250];
@@ -87,6 +115,15 @@ export function detectGen2GameVersion(owned: Set<number>, seen: Set<number>): Ga
   return 'unknown';
 }
 
+/**
+ * Performs a structural check to verify if the save file is a valid Generation 2 save.
+ * It dynamically checks the party offset based on the `crystal` flag, ensuring the party count
+ * is valid (<= 6), correctly terminated with 0xFF, and contains valid internal Pokémon IDs.
+ *
+ * @param u8 - The raw save file array.
+ * @param crystal - Whether to test offsets specific to Pokémon Crystal.
+ * @returns True if the structure looks like a valid Gen 2 save for the specified game type.
+ */
 export function isGen2Save(u8: Uint8Array, crystal: boolean): boolean {
   const countOffset = crystal ? 0x2865 : 0x288a;
   const speciesOffset = crystal ? 0x2866 : 0x288b;
@@ -100,6 +137,16 @@ export function isGen2Save(u8: Uint8Array, crystal: boolean): boolean {
   return true;
 }
 
+/**
+ * Extracts all relevant game data (party, PC boxes, inventory, Pokédex, etc.) from a Gen 2 save.
+ * Memory offsets differ significantly between Gold/Silver and Crystal. This function detects Crystal
+ * by checking party sizes at the different offset locations, and dynamically selects the correct
+ * memory map before extraction.
+ *
+ * @param u8 - The raw save file array.
+ * @param forceCrystal - An optional flag to force the parser to use Crystal memory offsets.
+ * @returns The structured SaveData object.
+ */
 export function parseGen2(u8: Uint8Array, forceCrystal = false): SaveData {
   let isCrystal = forceCrystal;
   if (!isCrystal) {


### PR DESCRIPTION
### What
Added JSDoc to the exported functions in `src/engine/saveParser/index.ts`, `parsers/gen1.ts`, and `parsers/gen2.ts`. Added inline comments explaining the Gen 1 and Gen 2 checksum algorithms.

### Why this module needed docs
The `saveParser` module handles complex domain logic involving binary offsets, heuristics for version detection (e.g., Gold vs Silver exclusives, Yellow memory shifts), and structural validation. The magic numbers and bitwise operations used for extraction were completely undocumented, making the module difficult to read and maintain for developers unfamiliar with the exact structure of `.sav` files.

### Summary of additions
- Documented `parseSaveFile` and the checksum algorithms in `index.ts`.
- Documented `detectGen1GameVersion`, `isGen1Save`, and `parseGen1` in `gen1.ts`, specifically noting the Yellow offset shifts.
- Documented `detectGen2GameVersion`, `isGen2Save`, `parseGen2`, `parseCaughtData`, and `parseGen2PokemonInstance` in `gen2.ts`, clarifying Crystal vs G/S offset differences and bitwise time/level extraction.

---
*PR created automatically by Jules for task [6490108494338395779](https://jules.google.com/task/6490108494338395779) started by @szubster*