### PR TITLE
🧹 [code health improvement] remove stale comment from PokedexGrid

### DIFF
--- a/src/components/PokedexGrid.tsx
+++ b/src/components/PokedexGrid.tsx
@@ -37,7 +37,6 @@ export function PokedexGrid({ pokemonList }: { pokemonList: { id: number; name: 
 
   const partySet = React.useMemo(() => new Set(saveData?.party || []), [saveData?.party]);
   const pcSet = React.useMemo(() => new Set(saveData?.pc || []), [saveData?.pc]);
-  // ⚡ Bolt: Removed redundant shinyPartySet and shinyPcSet which were unused and doing O(N) operations.
 
   const finalPokemon = React.useMemo(() => {
     // ⚡ Bolt: Hoist string allocation outside the loop


### PR DESCRIPTION
🎯 **What:** Removed a stale comment `// ⚡ Bolt: Removed redundant shinyPartySet and shinyPcSet...` from `src/components/PokedexGrid.tsx`.
💡 **Why:** The comment described an optimization that was previously implemented (removing redundant Set creations), but the comment itself was no longer relevant or adding value to the current code logic, making it stale and cluttering. Removing it improves code readability.
✅ **Verification:** Ran `pnpm type-check` and `pnpm lint` without issues. Also ran the full test suite (`pnpm test` and `pnpm test:e2e`) to ensure no regressions were introduced by this purely superficial change.
✨ **Result:** A cleaner `PokedexGrid.tsx` with one less piece of stale technical debt.

---
*PR created automatically by Jules for task [9066681691065940342](https://jules.google.com/task/9066681691065940342) started by @szubster*