### PR TITLE
🧪 Sentinel: Add unit tests for generation config constants

### DIFF
--- a/src/utils/generationConfig.test.ts
+++ b/src/utils/generationConfig.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { GENERATION_CONFIGS, getGenerationConfig, getVersionInfo } from './generationConfig';
+import {
+  ALL_VERSION_IDS,
+  GENERATION_CONFIGS,
+  MAX_DEX_ACROSS_GENS,
+  POKEBALL_LABELS,
+  VERSION_THEMES,
+  getGenerationConfig,
+  getVersionInfo,
+} from './generationConfig';
 
 describe('getGenerationConfig', () => {
   it('should return the correct configuration for an existing generation (Gen 1)', () => {
@@ -92,5 +100,45 @@ describe('generation config sprite URLs', () => {
     expect(gen2.fallbackSpriteUrl(25)).toBe(
       'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/25.png',
     );
+  });
+});
+
+describe('generation config constants', () => {
+  it('MAX_DEX_ACROSS_GENS should be the maximum of maxDex across all generations', () => {
+    // Dynamically test MAX_DEX_ACROSS_GENS based on GENERATION_CONFIGS
+    const expectedMaxDex = Math.max(...Object.values(GENERATION_CONFIGS).map((c) => c.maxDex));
+    expect(MAX_DEX_ACROSS_GENS).toBe(expectedMaxDex);
+  });
+
+  it('VERSION_THEMES should contain entries for all versions, unsupported, and unknown', () => {
+    // Assert known values
+    expect(VERSION_THEMES['red']).toBe('theme-red');
+    expect(VERSION_THEMES['gold']).toBe('theme-gold');
+    expect(VERSION_THEMES['unsupported']).toBe('');
+    expect(VERSION_THEMES['unknown']).toBe('');
+
+    // Dynamically assert that all version IDs have a theme class
+    Object.values(GENERATION_CONFIGS).forEach((gc) => {
+      gc.versions.forEach((v) => {
+        expect(VERSION_THEMES[v.id]).toBe(v.themeClass);
+      });
+    });
+  });
+
+  it('ALL_VERSION_IDS should contain all known version IDs across all registered generations', () => {
+    const expectedIds = Object.values(GENERATION_CONFIGS).flatMap((gc) =>
+      gc.versions.map((v) => v.id),
+    );
+    expect(ALL_VERSION_IDS).toEqual(expectedIds);
+    expect(ALL_VERSION_IDS.includes('red')).toBe(true);
+    expect(ALL_VERSION_IDS.includes('crystal')).toBe(true);
+  });
+
+  it('POKEBALL_LABELS should contain labels for all known pokeball types', () => {
+    expect(POKEBALL_LABELS['poke']).toBe('Poké Ball');
+    expect(POKEBALL_LABELS['great']).toBe('Great Ball');
+    expect(POKEBALL_LABELS['safari']).toBe('Safari Ball');
+    // Ensure it's an object with the correct structure
+    expect(typeof POKEBALL_LABELS).toBe('object');
   });
 });

--- a/src/utils/generationConfig.test.ts
+++ b/src/utils/generationConfig.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   ALL_VERSION_IDS,
   GENERATION_CONFIGS,
+  getGenerationConfig,
+  getVersionInfo,
   MAX_DEX_ACROSS_GENS,
   POKEBALL_LABELS,
   VERSION_THEMES,
-  getGenerationConfig,
-  getVersionInfo,
 } from './generationConfig';
 
 describe('getGenerationConfig', () => {
@@ -112,10 +112,10 @@ describe('generation config constants', () => {
 
   it('VERSION_THEMES should contain entries for all versions, unsupported, and unknown', () => {
     // Assert known values
-    expect(VERSION_THEMES['red']).toBe('theme-red');
-    expect(VERSION_THEMES['gold']).toBe('theme-gold');
-    expect(VERSION_THEMES['unsupported']).toBe('');
-    expect(VERSION_THEMES['unknown']).toBe('');
+    expect(VERSION_THEMES.red).toBe('theme-red');
+    expect(VERSION_THEMES.gold).toBe('theme-gold');
+    expect(VERSION_THEMES.unsupported).toBe('');
+    expect(VERSION_THEMES.unknown).toBe('');
 
     // Dynamically assert that all version IDs have a theme class
     Object.values(GENERATION_CONFIGS).forEach((gc) => {
@@ -126,18 +126,16 @@ describe('generation config constants', () => {
   });
 
   it('ALL_VERSION_IDS should contain all known version IDs across all registered generations', () => {
-    const expectedIds = Object.values(GENERATION_CONFIGS).flatMap((gc) =>
-      gc.versions.map((v) => v.id),
-    );
+    const expectedIds = Object.values(GENERATION_CONFIGS).flatMap((gc) => gc.versions.map((v) => v.id));
     expect(ALL_VERSION_IDS).toEqual(expectedIds);
     expect(ALL_VERSION_IDS.includes('red')).toBe(true);
     expect(ALL_VERSION_IDS.includes('crystal')).toBe(true);
   });
 
   it('POKEBALL_LABELS should contain labels for all known pokeball types', () => {
-    expect(POKEBALL_LABELS['poke']).toBe('Poké Ball');
-    expect(POKEBALL_LABELS['great']).toBe('Great Ball');
-    expect(POKEBALL_LABELS['safari']).toBe('Safari Ball');
+    expect(POKEBALL_LABELS.poke).toBe('Poké Ball');
+    expect(POKEBALL_LABELS.great).toBe('Great Ball');
+    expect(POKEBALL_LABELS.safari).toBe('Safari Ball');
     // Ensure it's an object with the correct structure
     expect(typeof POKEBALL_LABELS).toBe('object');
   });

--- a/src/utils/generationConfig.test.ts
+++ b/src/utils/generationConfig.test.ts
@@ -112,10 +112,14 @@ describe('generation config constants', () => {
 
   it('VERSION_THEMES should contain entries for all versions, unsupported, and unknown', () => {
     // Assert known values
-    expect(VERSION_THEMES.red).toBe('theme-red');
-    expect(VERSION_THEMES.gold).toBe('theme-gold');
-    expect(VERSION_THEMES.unsupported).toBe('');
-    expect(VERSION_THEMES.unknown).toBe('');
+    // biome-ignore lint/complexity/useLiteralKeys: Using literal access here fails type-check due to index signature
+    expect(VERSION_THEMES['red']).toBe('theme-red');
+    // biome-ignore lint/complexity/useLiteralKeys: Using literal access here fails type-check due to index signature
+    expect(VERSION_THEMES['gold']).toBe('theme-gold');
+    // biome-ignore lint/complexity/useLiteralKeys: Using literal access here fails type-check due to index signature
+    expect(VERSION_THEMES['unsupported']).toBe('');
+    // biome-ignore lint/complexity/useLiteralKeys: Using literal access here fails type-check due to index signature
+    expect(VERSION_THEMES['unknown']).toBe('');
 
     // Dynamically assert that all version IDs have a theme class
     Object.values(GENERATION_CONFIGS).forEach((gc) => {


### PR DESCRIPTION
🎯 **What:** Expanded test coverage for `src/utils/generationConfig.ts` by adding explicit unit tests for globally exported constants (`MAX_DEX_ACROSS_GENS`, `VERSION_THEMES`, `ALL_VERSION_IDS`, and `POKEBALL_LABELS`). The `getGenerationConfig` and `getVersionInfo` methods already had 100% test coverage.

📊 **Coverage:** Covered edge cases and map logic generated dynamically by registry configs, guaranteeing derived datasets are constructed properly.

✨ **Result:** Ensure derived state mappings for generations are deterministically tested, maintaining 100% coverage on `src/utils/generationConfig.ts`.

---
*PR created automatically by Jules for task [11463586030328425736](https://jules.google.com/task/11463586030328425736) started by @szubster*