### PR TITLE
🧪 Sentinel: Add tests for getExclusivesChecker

### DIFF
--- a/src/engine/exclusives/__tests__/index.test.ts
+++ b/src/engine/exclusives/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getUnobtainableReason as gen1UnobtainableReason } from '../gen1Exclusives';
+import { getExclusivesChecker } from '../index';
+
+describe('exclusives/index', () => {
+  describe('getExclusivesChecker', () => {
+    it('should return gen1UnobtainableReason for generation 1', () => {
+      const checker = getExclusivesChecker(1);
+      expect(checker).toBe(gen1UnobtainableReason);
+    });
+
+    it('should return null for unsupported generations', () => {
+      expect(getExclusivesChecker(2)).toBeNull();
+      expect(getExclusivesChecker(9)).toBeNull();
+      expect(getExclusivesChecker(-1)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `getExclusivesChecker` factory function in `src/engine/exclusives/index.ts`.

📊 **Coverage:** The scenarios now tested include:
1. "Happy path": Verify that `getExclusivesChecker(1)` returns the `gen1GetUnobtainableReason` function.
2. "Fallback path": Verify that calling `getExclusivesChecker` with unsupported generations (e.g. 2, 9, -1) returns `null`.

✨ **Result:** Test coverage for `src/engine/exclusives/index.ts` is improved, ensuring the correct unobtainable checker is returned based on the requested generation.

---
*PR created automatically by Jules for task [5871674650805453572](https://jules.google.com/task/5871674650805453572) started by @szubster*