### PR TITLE
🧹 Clean up unused assistantData exports

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -1,0 +1,3 @@
+## 2026-04-19 - Cleaned up unused constants in gen1 assistantData
+**Learning:** Found `GEN1_ITEMS` and `OBEDIENCE_CAPS` in `src/engine/data/gen1/assistantData.ts` which were not imported or used anywhere else in the application. `knip` tool or targeted `grep` commands are useful for finding such dead code.
+**Action:** Always verify potential unused exports by doing a global repository search to ensure they aren't dynamically referenced or used in tests before removing them.

--- a/src/engine/data/gen1/assistantData.ts
+++ b/src/engine/data/gen1/assistantData.ts
@@ -2,22 +2,6 @@
 
 // This file maps internal game IDs to standard names or PokeAPI slugs
 
-export const GEN1_ITEMS = {
-  MOON_STONE: 0x0a,
-  FIRE_STONE: 0x20,
-  THUNDER_STONE: 0x21,
-  WATER_STONE: 0x22,
-  LEAF_STONE: 0x2f,
-};
-
-export const OBEDIENCE_CAPS = [
-  { badges: 0, level: 10 },
-  { badges: 2, level: 30 },
-  { badges: 4, level: 50 },
-  { badges: 6, level: 70 },
-  { badges: 8, level: 100 },
-];
-
 export const STATIC_GIFT_DATA: Record<
   number,
   { name: string; location: string; reason: string; gen?: number; eventFlag?: number }


### PR DESCRIPTION
🎯 What: Removed `GEN1_ITEMS` and `OBEDIENCE_CAPS` from `src/engine/data/gen1/assistantData.ts` since they are completely unused in the codebase.
💡 Why: Cleaning up dead code improves maintainability and reduces clutter in the codebase.
✅ Verification: Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no functionality is broken. Tests passed successfully.
✨ Result: The codebase is cleaner and no longer contains these unused exports.

---
*PR created automatically by Jules for task [426343473040614646](https://jules.google.com/task/426343473040614646) started by @szubster*