### PR TITLE
🛡️ Nurse: tighten typing and remove cast for gameVersion in Gen 2 parser

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -11,3 +11,6 @@ Removed the cast, awaited the result, and mapped `undefined` results to an `Erro
 
 **What the compiler now catches:**
 The compiler ensures that DataLoader batch functions return valid values or Errors, preventing unexpected `undefined` results downstream.
+## 2026-04-19 - Nurse: Remove redundant cast in gen2 save parser
+**Learning:** When a variable matches the return type exactly or correctly infers it, redundant `as Type` casts should be removed as they circumvent type narrowing and can hide true typing misalignments in future refactors.
+**Action:** Replaced unsafe cast with strict explicit variable typing.

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -242,7 +242,7 @@ export function parseGen2(u8: Uint8Array, forceCrystal = false): SaveData {
     if ((byte(u8, kantoBadgesOffset) & (1 << i)) !== 0) badges++;
   }
 
-  let gameVersion = isCrystal ? 'crystal' : detectGen2GameVersion(owned, seen);
+  let gameVersion: GameVersion = isCrystal ? 'crystal' : detectGen2GameVersion(owned, seen);
   if (gameVersion === 'unknown' && !isCrystal) {
     gameVersion = 'gold';
   }
@@ -277,7 +277,7 @@ export function parseGen2(u8: Uint8Array, forceCrystal = false): SaveData {
     pc,
     partyDetails,
     pcDetails,
-    gameVersion: gameVersion as GameVersion,
+    gameVersion,
     badges,
     johtoBadges: johtoBadgesValue,
     kantoBadges: kantoBadgesValue,


### PR DESCRIPTION
### What was unsafe
The `parseGen2` function was previously returning the `gameVersion` property using an explicit `as GameVersion` cast. Meanwhile, the `gameVersion` variable was inferred as `string` due to how the inference worked between its declaration and the detection function. 

### How it was fixed
- Explicitly typed the local variable `gameVersion` as `GameVersion`: `let gameVersion: GameVersion = ...`
- Removed the redundant `as GameVersion` cast inside the returned `SaveData` object, relying on the variable's strict type.

### What the compiler now catches
The TypeScript compiler now ensures that the returned `gameVersion` strictly satisfies the `GameVersion` type via variable flow rather than circumventing safety with a raw cast. If the output of `detectGen2GameVersion` or `isCrystal` logic changes in the future, the compiler will natively catch misalignments at the variable assignment rather than at the end of the parser execution.

---
*PR created automatically by Jules for task [16272865263470077531](https://jules.google.com/task/16272865263470077531) started by @szubster*