### PR TITLE
🧬 Oak: Fix Gen 1 and Gen 2 version exclusives and missing logic

### DIFF
--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -3,3 +3,13 @@
 **Canonical source used:** PokeAPI encounters (`https://pokeapi.co/api/v2/pokemon/${id}/encounters`).
 **Impact on users:** Users playing Yellow version will now correctly see that they can catch Sandshrew, Sandslash, and Pinsir, and will correctly be told they need to trade for Electabuzz.
 **Learning:** PokeAPI encounter endpoints are the absolute source of truth for base-form version availability, especially for complex cases like Yellow version where availability diverges significantly from Red/Blue.
+
+## 2024-05-19 - Fix Version Exclusives Gen 1/Gen 2
+**What:** Verified and updated the version-exclusive lists for Generation 1 and Generation 2.
+**Canonical source used:** Bulbapedia Version-exclusive Pokémon lists.
+**Impact on users:** The Assistant will accurately report when Pokémon are unobtainable in their current game version and require trading.
+
+**Learnings:**
+1. In `gen1Exclusives` and `gen2Exclusives`, the arrays for each version (e.g. `red`, `gold`) must list the Pokémon that are **MISSING** from that version (i.e. the opposite version's exclusives), not the Pokémon that are present in it, since the logic uses `exclusives.includes(pokemonId)` to return an unobtainable reason.
+2. Gen 2 international version exclusives for Teddiursa/Ursaring and Phanpy/Donphan differ from the Japanese release. Internationally, Teddiursa is Gold exclusive and Phanpy is Silver exclusive.
+3. Added missing Gen 2 one-time checks (starters) and missing Gen 1 Pokémon (starters, fossils, legendaries).

--- a/data/db/metadata.json
+++ b/data/db/metadata.json
@@ -1,4 +1,4 @@
 {
   "sourceSha": "",
-  "generatedAt": "2026-04-18T07:44:24.183Z"
+  "generatedAt": "2026-04-19T08:11:58.677Z"
 }

--- a/src/engine/exclusives/__tests__/gen1Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen1Exclusives.test.ts
@@ -117,6 +117,20 @@ describe('gen1Exclusives', () => {
       });
     });
 
+    describe('Red Version Exclusives', () => {
+      it('should not lock Ekans (23) in Red', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(23, 'red', 0, ownedSet);
+        expect(reason).toBeNull();
+      });
+
+      it('should lock Sandshrew (27) in Red', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(27, 'red', 0, ownedSet);
+        expect(typeof reason).toBe('string');
+      });
+    });
+
     describe('Yellow Version Exclusives', () => {
       it('should lock Electabuzz (125) in Yellow', () => {
         const ownedSet = new Set<number>();

--- a/src/engine/exclusives/__tests__/gen2Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen2Exclusives.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { getUnobtainableReason } from '../gen2Exclusives';
+
+describe('gen2Exclusives', () => {
+  describe('getUnobtainableReason', () => {
+    describe('Johto Starters (Mutually Exclusive)', () => {
+      it('should lock Cyndaquil (155) if Chikorita (152) is owned', () => {
+        const ownedSet = new Set([152]); // Own Chikorita
+        const reason = getUnobtainableReason(155, 'gold', 1, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('different Johto starter');
+      });
+
+      it('should lock Totodile (158) if Quilava (156) is owned', () => {
+        const ownedSet = new Set([156]); // Own Quilava
+        const reason = getUnobtainableReason(158, 'silver', 1, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('different Johto starter');
+      });
+
+      it('should not lock Totodile (158) if neither is owned', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(158, 'gold', 0, ownedSet);
+        expect(reason).toBeNull();
+      });
+
+      it('should not lock Totodile (158) if it is already owned', () => {
+        const ownedSet = new Set([152, 158]); // Owned both through trading
+        const reason = getUnobtainableReason(158, 'crystal', 2, ownedSet);
+        expect(reason).toBeNull();
+      });
+    });
+
+    describe('Version Exclusives', () => {
+      it('should lock Mantine (226) in Silver', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(226, 'silver', 0, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('not available in Silver');
+      });
+
+      it('should not lock Mantine (226) in Gold', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(226, 'gold', 0, ownedSet);
+        expect(reason).toBeNull();
+      });
+
+      it('should lock Delibird (225) in Gold', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(225, 'gold', 0, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('not available in Gold');
+      });
+
+      it('should not lock Delibird (225) in Silver', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(225, 'silver', 0, ownedSet);
+        expect(reason).toBeNull();
+      });
+
+      it('should not lock version exclusives if they are already owned', () => {
+        const ownedSet = new Set([225]);
+        const reason = getUnobtainableReason(225, 'gold', 1, ownedSet);
+        expect(reason).toBeNull();
+      });
+    });
+
+    describe('Missing Gen 1 Pokemon', () => {
+      it('should lock Bulbasaur (1)', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(1, 'crystal', 0, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('Not found in Johto or Kanto in Generation 2');
+      });
+
+      it('should lock Omanyte (138)', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(138, 'gold', 0, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('Not found in Johto or Kanto in Generation 2');
+      });
+
+      it('should lock Mewtwo (150)', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(150, 'silver', 0, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('Not found in Johto or Kanto in Generation 2');
+      });
+
+      it('should not lock missing Gen 1 if already owned', () => {
+        const ownedSet = new Set([150]);
+        const reason = getUnobtainableReason(150, 'silver', 1, ownedSet);
+        expect(reason).toBeNull();
+      });
+    });
+
+    describe('Celebi', () => {
+      it('should lock Celebi (251) in Gold/Silver', () => {
+        const ownedSet = new Set<number>();
+        const reasonGold = getUnobtainableReason(251, 'gold', 0, ownedSet);
+        const reasonSilver = getUnobtainableReason(251, 'silver', 0, ownedSet);
+        expect(typeof reasonGold).toBe('string');
+        expect(typeof reasonSilver).toBe('string');
+        expect(reasonGold).toContain('Virtual Console release of Pokémon Crystal');
+      });
+
+      it('should not lock Celebi in Crystal', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(251, 'crystal', 0, ownedSet);
+        expect(reason).toBeNull();
+      });
+    });
+
+    describe('General Obtainable Pokémon', () => {
+      it('should return null for normally obtainable Pokémon (Pidgey 16)', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(16, 'gold', 0, ownedSet);
+        expect(reason).toBeNull();
+      });
+    });
+  });
+});

--- a/src/engine/exclusives/gen1Exclusives.ts
+++ b/src/engine/exclusives/gen1Exclusives.ts
@@ -7,20 +7,8 @@ export const ONE_TIME_CHOICES = {
 };
 
 const GEN1_VERSION_EXCLUSIVES: Record<string, number[]> = {
+  // Lists of Pokemon MISSING from each version
   red: [
-    23,
-    24, // Ekans, Arbok
-    43,
-    44,
-    45, // Oddish, Gloom, Vileplume
-    56,
-    57, // Mankey, Primeape
-    58,
-    59, // Growlithe, Arcanine
-    123, // Scyther
-    125, // Electabuzz
-  ],
-  blue: [
     27,
     28, // Sandshrew, Sandslash
     37,
@@ -32,6 +20,19 @@ const GEN1_VERSION_EXCLUSIVES: Record<string, number[]> = {
     71, // Bellsprout, Weepinbell, Victreebel
     126, // Magmar
     127, // Pinsir
+  ],
+  blue: [
+    23,
+    24, // Ekans, Arbok
+    43,
+    44,
+    45, // Oddish, Gloom, Vileplume
+    56,
+    57, // Mankey, Primeape
+    58,
+    59, // Growlithe, Arcanine
+    123, // Scyther
+    125, // Electabuzz
   ],
   yellow: [
     13,

--- a/src/engine/exclusives/gen2Exclusives.ts
+++ b/src/engine/exclusives/gen2Exclusives.ts
@@ -1,0 +1,125 @@
+// One-time static choices in Gen 2
+export const ONE_TIME_CHOICES = {
+  starters: [152, 155, 158], // Chikorita, Cyndaquil, Totodile
+  eevee: [133], // Bill gives an Eevee
+  tyrogue: [236], // Dojo gives Tyrogue
+  shuckle: [213], // Mania gives Shuckle
+  spearow: [21], // Kenya the Spearow
+};
+
+const GEN2_VERSION_EXCLUSIVES: Record<string, number[]> = {
+  // Lists of Pokemon MISSING from each version
+  gold: [
+    37,
+    38, // Vulpix, Ninetales
+    52,
+    53, // Meowth, Persian
+    165,
+    166, // Ledyba, Ledian
+    225, // Delibird
+    227, // Skarmory
+    231,
+    232, // Phanpy, Donphan
+  ],
+  silver: [
+    56,
+    57, // Mankey, Primeape
+    58,
+    59, // Growlithe, Arcanine
+    167,
+    168, // Spinarak, Ariados
+    207, // Gligar
+    216,
+    217, // Teddiursa, Ursaring
+    226, // Mantine
+  ],
+  crystal: [
+    13,
+    14,
+    15, // Weedle, Kakuna, Beedrill
+    37,
+    38, // Vulpix, Ninetales
+    56,
+    57, // Mankey, Primeape
+    179,
+    180,
+    181, // Mareep, Flaaffy, Ampharos
+    203, // Girafarig
+    223,
+    224, // Remoraid, Octillery
+  ],
+};
+
+export function getUnobtainableReason(
+  pokemonId: number,
+  gameVersion: string,
+  _ownedCount: number,
+  ownedSet: Set<number>,
+): string | null {
+  // Gen 2 allows breeding, so missing a pre-evolution doesn't lock you out if you have the evolution.
+  // The only truly mutually exclusive choices are the starters.
+  const hasFamily = (base: number, evos: number[]) => {
+    return ownedSet.has(base) || evos.some((e) => ownedSet.has(e));
+  };
+
+  const isStarter = (id: number) => [152, 153, 154, 155, 156, 157, 158, 159, 160].includes(id);
+
+  if (isStarter(pokemonId) && !ownedSet.has(pokemonId)) {
+    const hasChikorita = hasFamily(152, [153, 154]);
+    const hasCyndaquil = hasFamily(155, [156, 157]);
+    const hasTotodile = hasFamily(158, [159, 160]);
+
+    let requestedFamily = '';
+    if ([152, 153, 154].includes(pokemonId)) requestedFamily = 'chikorita';
+    else if ([155, 156, 157].includes(pokemonId)) requestedFamily = 'cyndaquil';
+    else if ([158, 159, 160].includes(pokemonId)) requestedFamily = 'totodile';
+
+    if (requestedFamily === 'chikorita' && !hasChikorita && (hasCyndaquil || hasTotodile)) {
+      return `You chose a different Johto starter. Must trade for this one.`;
+    }
+    if (requestedFamily === 'cyndaquil' && !hasCyndaquil && (hasChikorita || hasTotodile)) {
+      return `You chose a different Johto starter. Must trade for this one.`;
+    }
+    if (requestedFamily === 'totodile' && !hasTotodile && (hasChikorita || hasCyndaquil)) {
+      return `You chose a different Johto starter. Must trade for this one.`;
+    }
+  }
+
+  // Version Exclusives
+  const exclusives = GEN2_VERSION_EXCLUSIVES[gameVersion] || [];
+  if (exclusives.includes(pokemonId) && !ownedSet.has(pokemonId)) {
+    return `This Pokémon is not available in ${gameVersion.charAt(0).toUpperCase() + gameVersion.slice(1)}. Must be traded from another version.`;
+  }
+
+  // Gen 1 starters, fossils, and legendaries are unobtainable in Gen 2 without trading
+  const gen1Missing = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9, // Starters
+    138,
+    139,
+    140,
+    141, // Fossils
+    144,
+    145,
+    146, // Birds
+    150,
+    151, // Mewtwo, Mew
+  ];
+  if (gen1Missing.includes(pokemonId) && !ownedSet.has(pokemonId)) {
+    return `Not found in Johto or Kanto in Generation 2. Must be traded from Generation 1 via Time Capsule.`;
+  }
+
+  // Celebi
+  if (pokemonId === 251 && !ownedSet.has(pokemonId) && gameVersion !== 'crystal') {
+    return `Celebi is only obtainable in the Virtual Console release of Pokémon Crystal.`;
+  }
+
+  return null;
+}

--- a/src/engine/exclusives/gen2Exclusives.ts
+++ b/src/engine/exclusives/gen2Exclusives.ts
@@ -7,6 +7,28 @@ export const ONE_TIME_CHOICES = {
   spearow: [21], // Kenya the Spearow
 };
 
+// Gen 1 starters, fossils, and legendaries are unobtainable in Gen 2 without trading
+const GEN1_MISSING = [
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9, // Starters
+  138,
+  139,
+  140,
+  141, // Fossils
+  144,
+  145,
+  146, // Birds
+  150,
+  151, // Mewtwo, Mew
+];
+
 const GEN2_VERSION_EXCLUSIVES: Record<string, number[]> = {
   // Lists of Pokemon MISSING from each version
   gold: [
@@ -91,28 +113,7 @@ export function getUnobtainableReason(
     return `This Pokémon is not available in ${gameVersion.charAt(0).toUpperCase() + gameVersion.slice(1)}. Must be traded from another version.`;
   }
 
-  // Gen 1 starters, fossils, and legendaries are unobtainable in Gen 2 without trading
-  const gen1Missing = [
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    9, // Starters
-    138,
-    139,
-    140,
-    141, // Fossils
-    144,
-    145,
-    146, // Birds
-    150,
-    151, // Mewtwo, Mew
-  ];
-  if (gen1Missing.includes(pokemonId) && !ownedSet.has(pokemonId)) {
+  if (GEN1_MISSING.includes(pokemonId) && !ownedSet.has(pokemonId)) {
     return `Not found in Johto or Kanto in Generation 2. Must be traded from Generation 1 via Time Capsule.`;
   }
 

--- a/src/engine/exclusives/index.ts
+++ b/src/engine/exclusives/index.ts
@@ -1,4 +1,5 @@
 import { getUnobtainableReason as gen1UnobtainableReason } from './gen1Exclusives';
+import { getUnobtainableReason as gen2UnobtainableReason } from './gen2Exclusives';
 
 export { getUnobtainableReason, ONE_TIME_CHOICES } from './gen1Exclusives';
 
@@ -11,7 +12,7 @@ export type UnobtainableChecker = (
 
 const EXCLUSIVES_CHECKERS: Record<number, UnobtainableChecker> = {
   1: gen1UnobtainableReason,
-  // Future: 2: gen2UnobtainableReason, etc.
+  2: gen2UnobtainableReason,
 };
 
 /** Get the version-exclusives checker for a generation. Returns null if none exists. */

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -66,8 +66,8 @@ export function parseGen2PokemonInstance(
 }
 
 export function detectGen2GameVersion(owned: Set<number>, seen: Set<number>): GameVersion {
-  const goldExclusives = [56, 57, 58, 59, 167, 168, 190, 207, 249];
-  const silverExclusives = [37, 38, 52, 53, 165, 166, 216, 217, 227, 250];
+  const goldExclusives = [56, 57, 58, 59, 167, 168, 207, 216, 217, 226]; // Mankey, Primeape, Growlithe, Arcanine, Spinarak, Ariados, Gligar, Teddiursa, Ursaring, Mantine
+  const silverExclusives = [37, 38, 52, 53, 165, 166, 225, 227, 231, 232]; // Vulpix, Ninetales, Meowth, Persian, Ledyba, Ledian, Delibird, Skarmory, Phanpy, Donphan
 
   let goldScore = 0;
   let silverScore = 0;


### PR DESCRIPTION
## 🧬 Oak: Fix and complete Gen 1 and Gen 2 version-exclusive data

**What was wrong:**
- The Gen 1 version exclusives logic checked if an ID was in the array to say "not available in this version," but the arrays for `red` and `blue` mistakenly contained the Pokémon that *were* available in that version.
- The Gen 2 exclusives logic in the save parser incorrectly treated Aipom, Lugia, and Ho-Oh as version-exclusive.
- International Gen 2 exclusive differences for the Teddiursa and Phanpy lines were incorrect.
- There was no true `getUnobtainableReason` checker for Generation 2 to explain lock-outs for starters or version exclusives.

**Canonical source used:**
- Bulbapedia's Version-exclusive Pokémon lists.
- Core series Pokémon encounter maps.

**Impact on users:**
- Assistant will now correctly inform the user when a Pokémon is unobtainable in their specific version (e.g., Red or Gold) and must be traded, rather than erroneously marking present Pokémon as missing or missing Pokémon as present. 
- Fixes Gen 2 starter mutually exclusive locks and properly flags Gen 1 Pokémon (like Fossils and Legendaries) that require the Time Capsule to obtain in Gen 2.

---
*PR created automatically by Jules for task [1129594293271637002](https://jules.google.com/task/1129594293271637002) started by @szubster*