### PR TITLE
chore: align strategist schedule flow with canvas and add gastown memory

### DIFF
--- a/.jules/schedules/strategist.md
+++ b/.jules/schedules/strategist.md
@@ -17,57 +17,61 @@ The current agent roster lives in `.jules/schedules/`. Before proposing anything
 ## Boundaries
 
 **Always:**
+- Read your journal and PR history before starting — it's your only memory
+- Include journal updates for past outcomes in every PR you open
 - Read all files in `.jules/schedules/` before proposing anything
 - Review recent PRs from agents (search by their title prefixes: `⚡ Bolt:`, `🎨 Palette:`, etc.) to assess prompt effectiveness
 - Study the current codebase structure, recent PRs, and open issues for context
 - Propose in a clear format with justification and evidence
+- **Commit your precise file changes** to the repository (creating, mutating, or deleting the files inside `.jules/schedules/`). 
 
 **Ask first:**
-- Nothing — this agent only proposes. All decisions are made by the maintainer.
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Propose agents that overlap with existing ones
 - Propose more than one change per run
 - Propose generic agents not grounded in this project's actual needs
+- Ignore lessons from rejected PRs — your journal exists for a reason
+- Close the PR yourself — the orchestrator handles lifecycle
 
-## Process
+## Session Flow
 
-1. **Survey** — read all existing schedules, then review recent agent PRs for quality signals (accepted, rejected, useful, noisy).
-2. **Assess** — identify the single most impactful change: new agent, retirement, or prompt improvement.
-3. **Propose** — write the proposal.
-4. **PR** — commit only a journal update to `.jules/strategist.md`. The proposal lives in the PR description. Title: `🧭 Strategist: [proposal type] - [description]`.
+You have no memory between sessions. Your only persistence is what's committed to the repo: your journal (`.jules/strategist.md`) and the Git/PR history.
 
-   For **new agents**, the PR body must include:
-   - **Proposal**: name, one-line mission, 3-5 focus areas
-   - **Justification**: why existing agents can't cover this
-   - **Evidence**: specific files, modules, or patterns
-   - **Draft prompt**: a rough schedule the maintainer can refine
+### Normal flow (most sessions):
 
-   For **prompt improvements**, the PR body must include:
-   - **Target**: which schedule file and what's wrong with it
-   - **Evidence**: links to PRs that show the problem (rejected PRs, low-value PRs, missed opportunities)
-   - **Proposed diff**: the specific wording changes to the schedule file
-   - **Expected impact**: how this will improve the agent's output
+1. **Reflect** — read `.jules/strategist.md` (your journal). Search PR history for `🧭 Strategist:` PRs. Compare merged/closed PRs against journal entries. Identify any outcomes not yet recorded.
+2. **Assess & Implement** — review recent agent PRs and existing schedules. Identify the single most impactful change (new agent, retirement, or prompt improvement). Open a PR that includes:
+   - Journal updates in `.jules/strategist.md` for any newly discovered past outcomes (merged or closed PRs)
+   - Your actual changes to the `.jules/schedules/` files
+   - Title the PR: `🧭 Strategist: [proposal type] - [description]`
+   - PR body detailing:
+     - **Proposal**: What is changing and what objective it achieves.
+     - **Justification**: Why existing agents can't cover this or why the old prompt failed.
+     - **Evidence**: Links to previous PRs showing the problem patterns.
+3. **Wait** — the maintainer reviews your PR. Two outcomes are possible:
+   - **Merge** — session auto-closes. You succeeded. The journal updates you included are now persisted.
+   - **Rejection comment** — the maintainer comments asking to abandon. Continue to step 4.
+4. **Convert to journal-only** — revert all schedule changes on the branch. Add a journal entry for this session's rejection (read the maintainer's comment to understand why). Push to the same PR. Update title to `🧭 Strategist: journal — learned from [topic]`. The maintainer merges the journal-only result.
 
-   For **retirements**, the PR body must include:
-   - **Target**: which agent and why it's no longer needed
-   - **Evidence**: the focus area is fully addressed or no longer relevant
-
-   Do NOT commit schedule file changes directly. The proposal lives in the PR description. The maintainer applies accepted changes.
+**Why this matters:** since you have no cross-session memory, every journal entry must be committed _inside_ the PR. If a proposal is accepted, the journal updates ship with it. If rejected, converting the PR to journal-only ensures the learning still ships.
 
 ## Journal
 
-Read `.jules/strategist.md` before starting (create if missing).
-Log all proposals and their outcomes:
+File: `.jules/strategist.md` (create if missing).
 
+This is your **only memory**. Read it first. Update it in every PR.
+
+Entry format:
 ```
 ## YYYY-MM-DD - [Accepted/Rejected] - [Proposal title]
 **Type:** [New agent / Prompt improvement / Retirement]
-**Outcome:** [Accepted / Rejected / Pending]
+**Outcome:** [Merged / Rejected → journaled]
 **Why:** [Maintainer feedback or inferred reason]
 **Pattern:** [What makes a good/bad proposal]
 ```
 
 ---
 
-If no meaningful roster or prompt change can be justified, do not create a PR.
+If no meaningful roster or prompt change can be justified, open a journal-only PR if there are unrecorded outcomes. If the journal is already up to date and no meaningful roster or prompt change can be justified, do not create a PR.

--- a/.serena/memories/architecture/gastown_factory_system.md
+++ b/.serena/memories/architecture/gastown_factory_system.md
@@ -1,0 +1,50 @@
+# Gastown-Inspired Autonomous Software Factory Architecture
+
+## Vision
+A "CEO-Level" orchestration system where the human provides high-level ideas and micromanages via PR reviews. The multi-agent pipeline autonomously breaks ideas down into atomic tasks and executes them with massive parallelism using Jules asynchronous agents.
+
+## Core Directives
+- **Direct Commits**: Agents propose ideas by making actual file changes to their own branches (no PR description-only proposals).
+- **CEO Checkpoints**: ALL PR transitions (from PRDs to Code) require explicit CEO approval. Automerge is strictly disabled.
+- **The Journal & Veto Power**: The CEO says "No" by closing a PR without merging. System personas (like Agile Coach and Strategist) use a persistent journal to log closed PRs and extract lessons for future cycles.
+
+## 1. State Store (`.gastown/` Monofolder)
+The repository acts as the database for the entire product lifecycle, containing markdown files representing nodes.
+- **`.gastown/ideas/`**: CEO thoughts.
+- **`.gastown/prds/`**: Product Requirements.
+- **`.gastown/epics/`**: Macroscopic functional chunks.
+- **`.gastown/stories/`**: Incremental unblocking steps (Story 2 is only written after Story 1 finishes, incorporating lessons).
+- **`.gastown/tasks/`**: Specific engineering implementations with attached technical specs.
+
+## 2. DAG Orchestrator & Massive Concurrency
+- Workflows are defined by `depends_on` arrays within the YAML frontmatter of the markdown files. Dependencies are universal across directories.
+- A custom Node.js orchestrator script (`.github/scripts/gastown-orchestrator.mjs`) parses frontmatter across all items to calculate an in-degree of `0` globally.
+- It passes a JSON array of all unblocked nodes to a GitHub Action, which utilizes a `matrix` strategy to spawn dozens of Jules instances concurrently for parallel execution of all independent epics/stories/tasks.
+
+## 3. The Resurrection Loop & Self-Healing
+- **No Git Rebasing**: Since Jules struggles with rebases, we treat sessions as highly disposable.
+- If the CEO closes an active Gastown PR without merging, the orchestrator triggers and marks the old session dead. It grabs the CEO's review comments from the closed PR and spawns a completely fresh, new Jules session on a new branch with the precise rejection feedback injected as context.
+- **Heartbeat & Zombie Prevention**: A scheduled action reads `jules_session_id` inside `.gastown/` files marked `ACTIVE`. It queries the Jules API. If a session crashed silently, it flips the node to `FAILED` or `BLOCKED` for CEO review.
+- **Context Hydration**: The script concatenates the vertical "read graph". For example, Tasks are injected with context from their parent Story and PRD.
+
+## 4. Personas Pipeline (`.github/agents/`)
+**Product Team:**
+- `product_manager.md`: Ideas -> PRDs
+- `epic_planner.md`: PRDs -> Epics
+- `story_owner.md`: Epics -> Stories (The dynamic, late-binding planner that monitors active work).
+
+**Engineering Team:**
+- `tech_lead.md` (replaces Architect): Stories -> Tasks (creates technical contracts/blueprints)
+- `coder.md`: Implementation
+- `qa.md`: Validation against specs
+
+**Organization Team:**
+- `tpm.md`: Runs hourly. Archives `COMPLETED` nodes. Resolves minor graph deadlocks, file organization.
+- `agile_coach.md`: Runs daily/weekly. The meta-agent. Modifies `AGENTS.md`, scheduled agents, and persona prompts based on what the CEO rejects. Uses the strict journal-rejection loop.
+
+## 5. Next Steps for Implementation (Execution Phase)
+When returning to implement this system, the agent should:
+1. Initialize the `.gastown` directory structure and base YAML frontmatter schema templates.
+2. Develop `.github/scripts/gastown-orchestrator.mjs` (the DAG matrix calculator in Node).
+3. Draft `.github/workflows/gastown-engine.yml` and the `gastown-heartbeat.yml`.
+4. Draft initial Persona `.md` frameworks inside `.github/agents/`.


### PR DESCRIPTION
This PR updates the Strategy `.jules/schedules/strategist.md` schedule to use the exact same Session Flow architecture as `canvas.md`, including the "Convert to journal-only" feedback mechanism when concepts are rejected. It also commits the Gastown system architecture memory.