### PR TITLE
📜 Scribe: Added JSDoc for Gen 1 save parsing functions

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -9,4 +9,4 @@
     - **High priority (~90-95):** Ready evolutions (has item/level).
     - **Scaling priority (~110 down to ~14):** Nearby encounters, scaling dynamically via graph traversal distance.
     - **Moderate priority (~65-85):** In-game NPC trades (higher if the player already owns the requested Pokémon).
-    - **Lowest priority (~10):** Version exclusives (unobtainable without external hardware/trading).
+    - **Lowest priority (~10):** Version exclusives (unobtainable without external hardware/trading).## 2024-05-20 - Gen 1 Save Parsing Offsets\n\n**What:** Added JSDoc for `detectGen1GameVersion`, `isGen1Save`, and `parseGen1`.\n**Why:** The memory offsets used in parsing Gen 1 saves are non-obvious. Specifically, Gen 1 lacks a version byte, requiring heuristic analysis of party and Pokedex to guess the version, and Japanese or Yellow versions often shift these offsets by +1 or more bytes compared to Red/Blue. Adding this context is crucial for future maintainers debugging parsing failures.

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -158,16 +158,20 @@ export const INTERNAL_ID_TO_DEX: Record<number, number> = {
 
 /**
  * Attempts to heuristically determine the specific Generation 1 game version (Red, Blue, or Yellow).
+ *
+ * Gen 1 saves do not contain a dedicated byte that explicitly identifies the game version.
+ * Instead, this function infers the version by analyzing the player's Pokédex (owned/seen exclusives),
+ * in-game trade OT names (which differ between versions), and Yellow-specific markers (like Pikachu's happiness).
  * It first checks for high-confidence Yellow markers (Pikachu friendship/status bytes).
  * If those are inconclusive, it falls back to a scoring system based on version-exclusive
  * Pokémon found in the player's Pokédex and party.
  *
- * @param u8 - The raw save file array.
+ * @param view - The raw save file DataView.
  * @param owned - A set of Pokémon Pokédex IDs the player has caught.
  * @param seen - A set of Pokémon Pokédex IDs the player has seen.
  * @param trainerName - The player's Original Trainer (OT) name.
  * @param partyDetails - A quick parsing of the player's party to verify if Pikachu is a native starter.
- * @returns 'red', 'blue', 'yellow', or 'unknown' if it cannot confidently decide.
+ * @returns 'red', 'blue', 'yellow', or 'unknown' if the heuristic scores are too close to confidently decide.
  */
 export function detectGen1GameVersion(
   view: DataView,
@@ -243,11 +247,13 @@ export function detectGen1GameVersion(
 }
 
 /**
- * Performs a structural check to verify if the save file is a valid Generation 1 save.
- * It checks the party count (must be <= 6), ensures the party list is correctly terminated with 0xFF,
- * and validates that the internal IDs in the party are within the expected range.
+ * Performs a structural check to verify if the binary data is a valid Generation 1 save.
  *
- * @param view - The raw save file view.
+ * Unlike Gen 2 which has robust checksums, Gen 1 validation relies heavily on structural sanity checks.
+ * It verifies that the party count is logical (<= 6), ensures the party list is correctly terminated with 0xFF,
+ * and validates that the internal IDs in the party are not blank or terminator bytes.
+ *
+ * @param view - The raw save file DataView.
  * @returns True if the structure looks like a valid Gen 1 save.
  */
 export function isGen1Save(view: DataView): boolean {
@@ -263,13 +269,18 @@ export function isGen1Save(view: DataView): boolean {
 
 /**
  * Extracts all relevant game data (party, PC boxes, inventory, Pokédex, etc.) from a Gen 1 save.
- * Yellow version shifted many memory offsets by +1 byte compared to Red/Blue. This parser probes both
- * potential Pokédex offsets (0x25A3 for R/B, 0x25A4 for Yellow) and uses padding bit correctness to
- * dynamically detect the offset shift before extracting the rest of the save data.
  *
- * @param view - The raw save file view.
- * @param forcedVersion - An optional version override provided by the user.
- * @returns The structured SaveData object.
+ * Gen 1 save file structures differ slightly based on version and region. Notably, Yellow version
+ * shifted many memory offsets by +1 byte compared to Red/Blue. Japanese versions also have different
+ * string encodings and lengths which affect offset calculations.
+ *
+ * This parser probes both potential Pokédex offsets (0x25A3 for R/B, 0x25A4 for Yellow) and uses
+ * padding bit correctness to dynamically detect the offset shift before extracting the rest of the
+ * save data. It relies on `detectGen1GameVersion` internally to infer the exact version if not forced.
+ *
+ * @param view - The raw save file DataView.
+ * @param forcedVersion - An optional game version override, used to bypass heuristics if the user manually specifies it.
+ * @returns The fully parsed and structured SaveData object.
  */
 export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData {
   const trainerName = decodeGen12String(view, 0x2598);


### PR DESCRIPTION
**What:**
Added detailed JSDoc documentation to `detectGen1GameVersion`, `isGen1Save`, and `parseGen1` within `src/engine/saveParser/parsers/gen1.ts`.

**Why this module needed docs:**
The `parseGen1` module implements critical, yet obscure domain logic. Gen 1 save files lack native version identifiers and strong checksums, necessitating complex heuristic version detection and reliance on padding/structural checks. Additionally, versions like Yellow shift memory offsets dynamically. The codebase lacked comments explaining *why* these non-intuitive workarounds existed.

**Summary of additions:**
* Documented heuristic version detection strategies (Pokedex checks, OT names).
* Documented structural sanity checks used instead of checksums for file validation.
* Documented the dynamic memory offset probing required for Yellow/Japanese versions.

---
*PR created automatically by Jules for task [5428320841129423949](https://jules.google.com/task/5428320841129423949) started by @szubster*