### PR TITLE
🔒 Shield: Sanitize error logging to prevent CWE-209 information leakage

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,0 +1,2 @@
+## Sanitize error logging to prevent CWE-209 information leakage
+**Pattern:** Directly passing the error object (e.g., `catch(console.error)`) can leak sensitive stack traces and internal state. Use `err instanceof Error ? err.message : String(err)` to sanitize log output and mitigate CWE-209.

--- a/scripts/generate-pokedata.ts
+++ b/scripts/generate-pokedata.ts
@@ -448,6 +448,6 @@ writeJsonl(path.join(OUTPUT_DIR, 'locations.jsonl'), Array.from(locationMap.valu
 }
 
 main().catch(err => {
-  console.error('\nGeneration failed:', err);
+  console.error('\nGeneration failed:', err instanceof Error ? err.message : String(err));
   process.exit(1);
 });

--- a/scripts/generateMapLocations.ts
+++ b/scripts/generateMapLocations.ts
@@ -243,4 +243,4 @@ async function run() {
 
 }
 
-run().catch(console.error);
+run().catch((err) => console.error(err instanceof Error ? err.message : String(err)));

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -21,7 +21,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             window.location.reload();
           }
         } catch (err) {
-          console.error(err);
+          console.error(err instanceof Error ? err.message : String(err));
         }
       }
     };

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -174,7 +174,7 @@ export const syncData = async () => {
       await mStore.put({ key: 'hash', value: data.hash });
       await tx.done;
     } catch (err) {
-      console.error('PokeDB: Sync failed', err);
+      console.error('PokeDB: Sync failed', err instanceof Error ? err.message : String(err));
       // Reset promise so we can retry later if needed
       syncPromise = null;
       throw err;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,7 @@ import { routeTree } from './routeTree.gen';
 import './index.css';
 
 // Initialize and sync PokeData
-pokeDB.sync().catch(console.error);
+pokeDB.sync().catch((err) => console.error(err instanceof Error ? err.message : String(err)));
 
 const router = createRouter({
   routeTree,


### PR DESCRIPTION
🎯 What: Updated `console.error` calls across the application and build scripts to log only the error message instead of the raw error object.
⚠️ Risk: Raw error objects can inadvertently leak sensitive stack traces, file paths, or internal system states, violating CWE-209 guidelines.
🛡️ Solution: Applied the `err instanceof Error ? err.message : String(err)` pattern to securely handle and format thrown objects without crashing or leaking sensitive information.

---
*PR created automatically by Jules for task [17034767233687711606](https://jules.google.com/task/17034767233687711606) started by @szubster*