### PR TITLE
🧪 Oak: fix gen1 red and blue version exclusives logic

### DIFF
--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -3,3 +3,6 @@
 **Canonical source used:** PokeAPI encounters (`https://pokeapi.co/api/v2/pokemon/${id}/encounters`).
 **Impact on users:** Users playing Yellow version will now correctly see that they can catch Sandshrew, Sandslash, and Pinsir, and will correctly be told they need to trade for Electabuzz.
 **Learning:** PokeAPI encounter endpoints are the absolute source of truth for base-form version availability, especially for complex cases like Yellow version where availability diverges significantly from Red/Blue.
+
+## Data Integrity - Gen 1 Exclusives
+*   **ROM parsing quirks / Data Pipeline Gotchas:** The version exclusivity arrays in `src/engine/exclusives/gen1Exclusives.ts` operate as *exclusion* lists, not inclusion lists. The array for `red` must contain the IDs of Pokémon that are **missing** or **unobtainable** in Red (which are the Blue exclusives), and vice versa. This is counter-intuitive initially, but required because `getUnobtainableReason` checks if a Pokémon ID `.includes` in the version's list to determine if it should be locked. Always verify whether a data array in the engine is intended to represent "available" or "unavailable" entities before modifying it.

--- a/data/db/metadata.json
+++ b/data/db/metadata.json
@@ -1,4 +1,4 @@
 {
   "sourceSha": "",
-  "generatedAt": "2026-04-18T07:44:24.183Z"
+  "generatedAt": "2026-04-20T04:39:37.741Z"
 }

--- a/src/engine/exclusives/__tests__/gen1Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen1Exclusives.test.ts
@@ -197,5 +197,33 @@ describe('gen1Exclusives', () => {
         expect(reason).toBeNull();
       });
     });
+
+    describe('Red and Blue Version Exclusives', () => {
+      it('should lock Sandshrew (27) in Red', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(27, 'red', 0, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('not available in Red');
+      });
+
+      it('should not lock Ekans (23) in Red', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(23, 'red', 0, ownedSet);
+        expect(reason).toBeNull();
+      });
+
+      it('should lock Ekans (23) in Blue', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(23, 'blue', 0, ownedSet);
+        expect(typeof reason).toBe('string');
+        expect(reason).toContain('not available in Blue');
+      });
+
+      it('should not lock Sandshrew (27) in Blue', () => {
+        const ownedSet = new Set<number>();
+        const reason = getUnobtainableReason(27, 'blue', 0, ownedSet);
+        expect(reason).toBeNull();
+      });
+    });
   });
 });

--- a/src/engine/exclusives/gen1Exclusives.ts
+++ b/src/engine/exclusives/gen1Exclusives.ts
@@ -8,19 +8,6 @@ export const ONE_TIME_CHOICES = {
 
 const GEN1_VERSION_EXCLUSIVES: Record<string, number[]> = {
   red: [
-    23,
-    24, // Ekans, Arbok
-    43,
-    44,
-    45, // Oddish, Gloom, Vileplume
-    56,
-    57, // Mankey, Primeape
-    58,
-    59, // Growlithe, Arcanine
-    123, // Scyther
-    125, // Electabuzz
-  ],
-  blue: [
     27,
     28, // Sandshrew, Sandslash
     37,
@@ -32,6 +19,19 @@ const GEN1_VERSION_EXCLUSIVES: Record<string, number[]> = {
     71, // Bellsprout, Weepinbell, Victreebel
     126, // Magmar
     127, // Pinsir
+  ],
+  blue: [
+    23,
+    24, // Ekans, Arbok
+    43,
+    44,
+    45, // Oddish, Gloom, Vileplume
+    56,
+    57, // Mankey, Primeape
+    58,
+    59, // Growlithe, Arcanine
+    123, // Scyther
+    125, // Electabuzz
   ],
   yellow: [
     13,


### PR DESCRIPTION
## What was wrong
The version exclusivity arrays for Red and Blue in `src/engine/exclusives/gen1Exclusives.ts` were populated with the Pokémon *available* in those versions instead of the Pokémon *missing* from them. Since `getUnobtainableReason` uses these arrays as exclusion lists, it was incorrectly locking Red exclusives in Red and Blue exclusives in Blue.

## Canonical source used
Game logic requirements for Pokémon version exclusives (Red vs. Blue) were correctly mapped but placed in the wrong keys.

## Impact on users
Users will now correctly see suggestions for Pokémon available in their chosen version, and see the proper "Must be traded" reason for Pokémon exclusive to the opposite version.

## Tests
Added specific tests in `src/engine/exclusives/__tests__/gen1Exclusives.test.ts` to lock in this behavior.

---
*PR created automatically by Jules for task [7490390331178158380](https://jules.google.com/task/7490390331178158380) started by @szubster*