### PR TITLE
🧪 Sentinel: Add test coverage for Zustand Store Actions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,14 +1,14 @@
-## 2026-04-19 - saveParser fallback coverage
-**What:** Improved test coverage for the save parser engine, specifically covering fallback paths and structural validations when checksums are invalid.
-**Coverage Before/After:** Increased `src/engine/saveParser/index.ts` coverage significantly from ~62% to ~89%.
-**Why this target matters:** The save parser is a core engine module and critical for parsing user files correctly. By validating fallbacks when checksums fail (a common real-world scenario), we ensure more resilient data parsing.
-**Learning:** When writing tests to verify error handling, avoid using try/catch blocks with empty catches, as they silently swallow unexpected errors and result in false positive passes. Use `expect(() => ...).toThrow(...)` instead.
+## Tricky mocking patterns
 
-## 2026-04-19 - Unit tests for common save parsers
-**What:** Tested `byte`, `decodeGen12String`, `parseDVs`, and `checkShiny` in `common.ts`
-**Coverage Before/After:** Gained test coverage for these basic data decoding utility functions
-**Why this target matters:** These pure utility functions are the foundation of all generation 1 and 2 save parsers. By verifying their decoding stability, we ensure all other features downstream correctly interpret fundamental save data types.
+- When writing Vitest tests that interact with IndexedDB (like the suggestion engine or PokeDB), include `/** @vitest-environment jsdom */` at the top of the file and `import 'fake-indexeddb/auto';` to provide the required browser-like environment and prevent 'indexedDB is not defined' errors.
+- Mocking functions imported from index files (like `parseSaveFile` from `./engine/saveParser/index`) requires defining the mock at the top level and using `vi.mocked()` to cast types locally:
+  ```ts
+  vi.mock('./engine/saveParser/index', () => ({
+    parseSaveFile: vi.fn(),
+  }));
+  // later...
+  vi.mocked(parseSaveFile).mockReturnValue(mockSaveData as unknown as ReturnType<typeof parseSaveFile>);
+  ```
 
-## 2026-04-19 - Using vitest specific matchers and utilities
-**What:** Switched test cases in `common.test.ts` from classic `for` loops and repetition to `test.each`.
-**Why:** Vitest features like `test.each` improve test reporting, readability, and traceablity for data-driven checks (like iterating variants). By utilizing them, tests become more robust and generate cleaner UI feedback.
+## Parsing vitest coverage json
+When running vitest with `--reporter=json > cov.json`, the output often includes prefix lines from the test runner (like `> dexhelper@0.0.0 test`). If parsing via Node script, strip the leading text: `content.substring(content.indexOf('{'))`.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,5 +1,19 @@
-## Tricky mocking patterns
+## 2026-04-19 - saveParser fallback coverage
+**What:** Improved test coverage for the save parser engine, specifically covering fallback paths and structural validations when checksums are invalid.
+**Coverage Before/After:** Increased `src/engine/saveParser/index.ts` coverage significantly from ~62% to ~89%.
+**Why this target matters:** The save parser is a core engine module and critical for parsing user files correctly. By validating fallbacks when checksums fail (a common real-world scenario), we ensure more resilient data parsing.
+**Learning:** When writing tests to verify error handling, avoid using try/catch blocks with empty catches, as they silently swallow unexpected errors and result in false positive passes. Use `expect(() => ...).toThrow(...)` instead.
 
+## 2026-04-19 - Unit tests for common save parsers
+**What:** Tested `byte`, `decodeGen12String`, `parseDVs`, and `checkShiny` in `common.ts`
+**Coverage Before/After:** Gained test coverage for these basic data decoding utility functions
+**Why this target matters:** These pure utility functions are the foundation of all generation 1 and 2 save parsers. By verifying their decoding stability, we ensure all other features downstream correctly interpret fundamental save data types.
+
+## 2026-04-19 - Using vitest specific matchers and utilities
+**What:** Switched test cases in `common.test.ts` from classic `for` loops and repetition to `test.each`.
+**Why:** Vitest features like `test.each` improve test reporting, readability, and traceablity for data-driven checks (like iterating variants). By utilizing them, tests become more robust and generate cleaner UI feedback.
+
+## Tricky mocking patterns
 - When writing Vitest tests that interact with IndexedDB (like the suggestion engine or PokeDB), include `/** @vitest-environment jsdom */` at the top of the file and `import 'fake-indexeddb/auto';` to provide the required browser-like environment and prevent 'indexedDB is not defined' errors.
 - Mocking functions imported from index files (like `parseSaveFile` from `./engine/saveParser/index`) requires defining the mock at the top level and using `vi.mocked()` to cast types locally:
   ```ts

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseSaveFile } from './engine/saveParser/index';
 import { useStore } from './store';
+
+vi.mock('./engine/saveParser/index', () => ({
+  parseSaveFile: vi.fn(),
+}));
 
 describe('Zustand Store', () => {
   beforeEach(() => {
@@ -18,6 +23,11 @@ describe('Zustand Store', () => {
   });
 
   describe('UI state', () => {
+    it('should set selected location id', () => {
+      useStore.getState().setSelectedLocationId(10);
+      expect(useStore.getState().selectedLocationId).toBe(10);
+    });
+
     it('should toggle search term', () => {
       useStore.getState().setSearchTerm('pikachu');
       expect(useStore.getState().searchTerm).toBe('pikachu');
@@ -124,6 +134,27 @@ describe('Zustand Store', () => {
 
       useStore.getState().setError(null);
       expect(useStore.getState().error).toBeNull();
+    });
+
+    it('should load a valid base64 save from storage successfully', () => {
+      const mockSaveData = { trainerName: 'ASH', generation: 1, gameVersion: 'red' };
+      vi.mocked(parseSaveFile).mockReturnValue(mockSaveData as unknown as ReturnType<typeof parseSaveFile>);
+
+      // valid base64 for "hello"
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn().mockReturnValue('aGVsbG8='),
+        removeItem: vi.fn(),
+      });
+      vi.stubGlobal('window', {
+        atob: vi.fn().mockReturnValue('hello'),
+      });
+
+      useStore.getState().loadSaveFromStorage();
+
+      expect(parseSaveFile).toHaveBeenCalled();
+      expect(useStore.getState().saveData).toEqual(mockSaveData);
+
+      vi.unstubAllGlobals();
     });
 
     it('should handle corrupted save file from localStorage', () => {


### PR DESCRIPTION
🧪 Sentinel: Add test coverage for Zustand Store Actions

**What**
- Added tests for `setSelectedLocationId`.
- Added tests for a valid Base64 save payload inside `loadSaveFromStorage` (with `localStorage` and `window.atob` stubbing).
- Stubbed `./engine/saveParser/index` via Vitest `vi.mock` to ensure unit test isolation for the store state transitions.

**Coverage Before/After**
- **Before:** ~72.22% Statement Coverage for `src/store.ts`
- **After:** 100% Statement Coverage for `src/store.ts` (36/36)

**Why this target matters**
The `src/store.ts` module manages the entirety of the application's persisted state, transient UI state, and the critical parsing integration point (`loadSaveFromStorage`) triggered when a user returns to the app. Ensuring this integration point acts correctly under a valid Base64 payload prevents silent hydration bugs.

---
*PR created automatically by Jules for task [1396026486897055568](https://jules.google.com/task/1396026486897055568) started by @szubster*