### PR TITLE
feat(foundry): implement DAG orchestrator script

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -16,7 +16,7 @@ The workflow is a directed acyclic graph (DAG):
 IDEA → PRD → EPIC → STORY → TASK
 ```
 
-A custom orchestrator (`.github/scripts/foundry-orchestrator.mjs`) parses the `depends_on` field across all files to find nodes with an **in-degree of zero** (all dependencies satisfied). These unblocked nodes are dispatched in parallel to Jules agent sessions via a GitHub Actions matrix. All PR transitions require explicit **CEO approval** — automerge is disabled.
+A custom orchestrator (`.github/scripts/foundry-orchestrator.ts`) parses the `depends_on` field across all files to find nodes with an **in-degree of zero** (all dependencies satisfied). These unblocked nodes are dispatched in parallel to Jules agent sessions via a GitHub Actions matrix. All PR transitions require explicit **CEO approval** — automerge is disabled.
 
 ---
 

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -1,0 +1,400 @@
+/**
+ * foundry-orchestrator.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The Foundry DAG Orchestrator — Epic 2 / Story 2.1
+ *
+ * Execution phases:
+ *   1. DISCOVER  — walk .foundry/**\/*.md, skipping journals/ and docs/
+ *   2. PARSE     — extract YAML frontmatter via gray-matter; skip malformed nodes
+ *   3. MAP       — build a repo-relative-path → ParsedNode lookup
+ *   4. RESOLVE   — find PENDING nodes whose depends_on are all COMPLETED (or [])
+ *   5. PROMOTE   — mutate those files: PENDING → READY, bump updated_at
+ *   6. COLLECT   — gather all READY nodes (promoted + previously ready)
+ *   7. OUTPUT    — console.log(JSON.stringify(readyNodes))  ← only stdout line
+ *   8. EXIT      — 0 on success; 1 if unresolvable deps found in --strict mode
+ *
+ * Usage:
+ *   node --strip-types foundry-orchestrator.ts [--dry-run] [--strict]
+ *
+ * Flags:
+ *   --dry-run   Log what would be promoted; do NOT write any files.
+ *   --strict    Exit 1 if any depends_on path is unresolvable.
+ *
+ * Authority: .foundry/docs/schema.md
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createRequire } from 'node:module';
+
+// gray-matter is CJS; import via require() for clean ESM interop.
+const require = createRequire(import.meta.url);
+const matter = require('gray-matter') as typeof import('gray-matter');
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+const VALID_STATUSES = [
+  'PENDING',
+  'READY',
+  'ACTIVE',
+  'IN_REVIEW',
+  'COMPLETED',
+  'FAILED',
+  'BLOCKED',
+  'CANCELLED',
+] as const;
+
+type Status = (typeof VALID_STATUSES)[number];
+
+const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK'] as const;
+type NodeType = (typeof VALID_TYPES)[number];
+
+/** Mirrors the YAML frontmatter schema defined in .foundry/docs/schema.md §3 */
+interface FoundryFrontmatter {
+  id: string;
+  type: NodeType;
+  title: string;
+  status: Status;
+  owner_persona: string;
+  created_at: string;
+  updated_at: string;
+  depends_on: string[];
+  jules_session_id: string | null;
+  pr_number: number | null;
+  parent?: string | null;
+  tags?: string[];
+  rejection_count?: number;
+  notes?: string;
+}
+
+interface ParsedNode {
+  /** Absolute path on disk */
+  filePath: string;
+  /** Repo-relative path, e.g. ".foundry/stories/story-001-scaffold.md" */
+  repoPath: string;
+  frontmatter: FoundryFrontmatter;
+  /** Full raw file content — needed for surgical in-place mutation */
+  rawContent: string;
+}
+
+// ─── Required fields (schema §3.1) ───────────────────────────────────────────
+
+const REQUIRED_FIELDS: ReadonlyArray<keyof FoundryFrontmatter> = [
+  'id',
+  'type',
+  'title',
+  'status',
+  'owner_persona',
+  'created_at',
+  'updated_at',
+  'depends_on',
+  'jules_session_id',
+  'pr_number',
+];
+
+// ─── CLI flags ────────────────────────────────────────────────────────────────
+
+const DRY_RUN: boolean = process.argv.includes('--dry-run');
+const STRICT: boolean = process.argv.includes('--strict');
+
+// ─── Logging (all diagnostic output → stderr; only the matrix JSON → stdout) ─
+
+function warn(msg: string): void {
+  process.stderr.write(`[orchestrator] WARN  ${msg}\n`);
+}
+
+function info(msg: string): void {
+  process.stderr.write(`[orchestrator] INFO  ${msg}\n`);
+}
+
+// ─── Utilities ────────────────────────────────────────────────────────────────
+
+/** Returns today's date in ISO-8601 YYYY-MM-DD format (local time). */
+function todayISO(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+// ─── Phase 1: DISCOVER ───────────────────────────────────────────────────────
+
+/**
+ * Recursively walks `dir` and returns absolute paths to all .md files,
+ * excluding anything under `journals/` or `docs/` subdirectories.
+ */
+function discoverNodeFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  function walk(current: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch (e) {
+      warn(`Cannot read directory: ${current}`);
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        // Skip the journals/ and docs/ subtrees entirely.
+        if (entry.name === 'journals' || entry.name === 'docs') continue;
+        walk(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  walk(dir);
+  return results;
+}
+
+// ─── Phase 2: PARSE ──────────────────────────────────────────────────────────
+
+/**
+ * Parses a single markdown file and returns a ParsedNode, or null if the file
+ * is malformed or missing required fields. Warnings are emitted for all errors.
+ */
+function parseNodeFile(filePath: string, repoRoot: string): ParsedNode | null {
+  const repoPath = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+
+  let rawContent: string;
+  try {
+    rawContent = fs.readFileSync(filePath, 'utf-8');
+  } catch (e) {
+    warn(`Cannot read file: ${repoPath}`);
+    return null;
+  }
+
+  // gray-matter throws on malformed YAML — catch gracefully.
+  let parsed: ReturnType<typeof matter>;
+  try {
+    parsed = matter(rawContent);
+  } catch (e) {
+    warn(`Malformed YAML frontmatter in: ${repoPath} — skipping`);
+    return null;
+  }
+
+  // Files without a frontmatter block have an empty data object.
+  if (!parsed.matter || parsed.matter.trim() === '') {
+    warn(`No YAML frontmatter found in: ${repoPath} — skipping`);
+    return null;
+  }
+
+  const fm = parsed.data as Partial<FoundryFrontmatter>;
+
+  // Validate required fields.
+  for (const field of REQUIRED_FIELDS) {
+    if (fm[field] === undefined) {
+      warn(`Missing required field '${field}' in: ${repoPath} — skipping`);
+      return null;
+    }
+  }
+
+  // Validate status enum.
+  if (!VALID_STATUSES.includes(fm.status as Status)) {
+    warn(`Invalid status '${String(fm.status)}' in: ${repoPath} — skipping`);
+    return null;
+  }
+
+  // Validate type enum.
+  if (!VALID_TYPES.includes(fm.type as NodeType)) {
+    warn(`Invalid type '${String(fm.type)}' in: ${repoPath} — skipping`);
+    return null;
+  }
+
+  // Ensure depends_on is an array (gray-matter may parse a missing key as undefined).
+  if (!Array.isArray(fm.depends_on)) {
+    warn(`'depends_on' is not an array in: ${repoPath} — skipping`);
+    return null;
+  }
+
+  return {
+    filePath,
+    repoPath,
+    frontmatter: fm as FoundryFrontmatter,
+    rawContent,
+  };
+}
+
+// ─── Phase 5: PROMOTE ────────────────────────────────────────────────────────
+
+/**
+ * Mutates the on-disk markdown file to change `status: PENDING` → `status: READY`
+ * and update `updated_at` to today's date.
+ *
+ * Strategy: surgical string replacement inside the raw frontmatter block only.
+ * We do NOT re-serialize the full YAML (which would reorder keys and cause diff noise).
+ * The two regexes target only the relevant lines, preserving everything else verbatim.
+ *
+ * In --dry-run mode, logs the intended change but does NOT write to disk.
+ */
+function promoteNodeToReady(node: ParsedNode): void {
+  const dateStr = todayISO();
+  const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
+
+  // Locate the frontmatter block: --- ... --- at the start of the file.
+  // The block can use LF or CRLF; we handle both.
+  const fmBlockMatch = node.rawContent.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*/m);
+  if (!fmBlockMatch) {
+    warn(`${dryTag}Cannot locate frontmatter delimiters for mutation in: ${node.repoPath}`);
+    return;
+  }
+
+  const originalFmBlock = fmBlockMatch[0];
+  let mutatedFmBlock = originalFmBlock;
+
+  // ① Replace `status: PENDING` (unquoted, per schema template).
+  //    The 'm' flag makes ^ and $ match line boundaries within the block.
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(status:\s*)PENDING([ \t]*)$/m,
+    `$1READY$2`,
+  );
+
+  // Sanity check — if PENDING wasn't found, something is wrong.
+  if (mutatedFmBlock === originalFmBlock) {
+    warn(`${dryTag}Could not find 'status: PENDING' line to replace in: ${node.repoPath}`);
+    return;
+  }
+
+  // ② Replace `updated_at` — handles both quoted and unquoted date values.
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(updated_at:\s*)["']?\d{4}-\d{2}-\d{2}["']?([ \t]*)$/m,
+    `$1"${dateStr}"$2`,
+  );
+
+  const newContent = node.rawContent.replace(originalFmBlock, mutatedFmBlock);
+
+  if (!DRY_RUN) {
+    try {
+      fs.writeFileSync(node.filePath, newContent, 'utf-8');
+    } catch (e) {
+      warn(`Failed to write file: ${node.repoPath} — ${String(e)}`);
+      return;
+    }
+  }
+
+  // Update in-memory state so downstream phases see the correct status.
+  node.frontmatter.status = 'READY';
+  node.frontmatter.updated_at = dateStr;
+  node.rawContent = newContent;
+
+  info(`${dryTag}Promoted PENDING → READY: ${node.repoPath}`);
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+function main(): void {
+  if (DRY_RUN) {
+    info('🔍 Dry-run mode active — no files will be modified.');
+  }
+  if (STRICT) {
+    info('⚠️  Strict mode active — unresolvable deps will cause exit(1).');
+  }
+
+  const repoRoot = process.cwd();
+  const foundryDir = path.join(repoRoot, '.foundry');
+
+  if (!fs.existsSync(foundryDir)) {
+    warn(`'.foundry/' directory not found at repo root: ${repoRoot}`);
+    console.log(JSON.stringify([]));
+    process.exit(0);
+  }
+
+  // ── Phase 1: DISCOVER ──────────────────────────────────────────────────────
+  info('Phase 1: Discovering node files...');
+  const filePaths = discoverNodeFiles(foundryDir);
+  info(`Found ${filePaths.length} candidate .md file(s).`);
+
+  // ── Phase 2: PARSE ─────────────────────────────────────────────────────────
+  info('Phase 2: Parsing frontmatter...');
+  const nodes: ParsedNode[] = [];
+  for (const fp of filePaths) {
+    const node = parseNodeFile(fp, repoRoot);
+    if (node !== null) nodes.push(node);
+  }
+  info(`Successfully parsed ${nodes.length} valid node(s) (skipped ${filePaths.length - nodes.length}).`);
+
+  // ── Phase 3: BUILD MAP ─────────────────────────────────────────────────────
+  info('Phase 3: Building dependency resolution map...');
+  const nodeMap = new Map<string, ParsedNode>();
+  for (const node of nodes) {
+    nodeMap.set(node.repoPath, node);
+  }
+
+  // ── Phase 4: RESOLVE ───────────────────────────────────────────────────────
+  info('Phase 4: Resolving DAG — finding eligible PENDING nodes...');
+  let hasUnresolvableDeps = false;
+  const eligible: ParsedNode[] = [];
+
+  for (const node of nodes) {
+    if (node.frontmatter.status !== 'PENDING') continue;
+
+    const deps = node.frontmatter.depends_on;
+
+    // Case A: Empty depends_on → in-degree zero → immediately eligible.
+    if (deps.length === 0) {
+      eligible.push(node);
+      continue;
+    }
+
+    // Case B: All deps must exist in the graph AND be COMPLETED.
+    let blocked = false;
+    for (const depPath of deps) {
+      const dep = nodeMap.get(depPath);
+      if (!dep) {
+        warn(`Unresolvable dependency '${depPath}' referenced by: ${node.repoPath}`);
+        hasUnresolvableDeps = true;
+        blocked = true;
+        break;
+      }
+      if (dep.frontmatter.status !== 'COMPLETED') {
+        // Not an error — just not yet unblocked.
+        blocked = true;
+        break;
+      }
+    }
+
+    if (!blocked) {
+      eligible.push(node);
+    }
+  }
+
+  info(`${eligible.length} node(s) eligible for promotion to READY.`);
+
+  // ── Phase 5: PROMOTE ───────────────────────────────────────────────────────
+  info('Phase 5: Promoting eligible nodes...');
+  for (const node of eligible) {
+    promoteNodeToReady(node);
+  }
+
+  // ── Phase 6: COLLECT ───────────────────────────────────────────────────────
+  info('Phase 6: Collecting all READY nodes for matrix output...');
+  // Include both freshly-promoted nodes AND any that were already READY before
+  // this run (idempotent: re-running the orchestrator is always safe).
+  const readyFrontmatters = nodes
+    .filter((n) => n.frontmatter.status === 'READY')
+    .map((n) => n.frontmatter);
+
+  info(`Total READY nodes: ${readyFrontmatters.length}`);
+
+  // ── Phase 7: OUTPUT ────────────────────────────────────────────────────────
+  // This is the ONLY line written to stdout. The GitHub Actions matrix step
+  // captures this exact output via: matrix=$(node ... | tail -1)
+  console.log(JSON.stringify(readyFrontmatters));
+
+  // ── Phase 8: EXIT ──────────────────────────────────────────────────────────
+  if (hasUnresolvableDeps && STRICT) {
+    warn('Exiting with code 1: unresolvable dependency paths detected (--strict mode).');
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "foundry-scripts",
+  "version": "1.0.0",
+  "description": "Foundry DAG orchestration scripts — run with Node 24 native TypeScript support.",
+  "type": "module",
+  "scripts": {
+    "orchestrate": "node --strip-types foundry-orchestrator.ts",
+    "orchestrate:dry": "node --strip-types foundry-orchestrator.ts --dry-run",
+    "orchestrate:strict": "node --strip-types foundry-orchestrator.ts --strict"
+  },
+  "dependencies": {
+    "gray-matter": "^4.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/.github/scripts/pnpm-lock.yaml
+++ b/.github/scripts/pnpm-lock.yaml
@@ -1,0 +1,107 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+
+packages:
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  esprima@4.0.1: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
+  is-extendable@0.1.1: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  kind-of@6.0.3: {}
+
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
+  sprintf-js@1.0.3: {}
+
+  strip-bom-string@1.0.0: {}
+
+  undici-types@6.21.0: {}

--- a/.serena/memories/architecture/the_foundry_system.md
+++ b/.serena/memories/architecture/the_foundry_system.md
@@ -23,7 +23,7 @@ To prevent massive context bloat while keeping tasks context-aware, global syste
 
 ## 2. DAG Orchestrator & Massive Concurrency
 - Workflows are defined by `depends_on` arrays within the YAML frontmatter of the markdown files. Dependencies are universal across directories.
-- A custom Node.js orchestrator script (`.github/scripts/foundry-orchestrator.mjs`) parses frontmatter across all items to calculate an in-degree of `0` globally.
+- A custom Node.js orchestrator script (`.github/scripts/foundry-orchestrator.ts`) parses frontmatter across all items to calculate an in-degree of `0` globally.
 - It passes a JSON array of all unblocked nodes to a GitHub Action, which utilizes a `matrix` strategy to spawn dozens of Jules instances concurrently for parallel execution of all independent epics/stories/tasks.
 
 ## 3. The Resurrection Loop & Self-Healing
@@ -69,7 +69,19 @@ The `.foundry/` monofolder has been scaffolded at the repository root. All 9 fil
 - `status: READY` is orchestrator-authored only — never set manually by a persona
 - Journals are unstructured free-form Markdown; each persona decides its own structure/layout; `tpm` is responsible for archiving them
 
-### 🔜 Next Steps (Epic 1 remaining stories)
-1. Develop `.github/scripts/foundry-orchestrator.mjs` (the DAG matrix calculator in Node).
-2. Draft `.github/workflows/foundry-engine.yml` and the `foundry-heartbeat.yml`.
+### ✅ Epic 2, Story 2.1 — COMPLETED (2026-04-20)
+`.github/scripts/foundry-orchestrator.ts` implemented and verified (8/8 integration tests pass).
+
+**Key implementation details:**
+- **Runtime**: Node 24 native TypeScript via `node --strip-types` — no build step needed
+- **Parser**: `gray-matter` (ships its own types) installed in isolated `.github/scripts/package.json` (using **pnpm**)
+- **Discovery**: Recursive `readdirSync` walk; `journals/` and `docs/` subtrees are skipped at the directory level (not filtered post-walk)
+- **Mutation strategy**: Surgical regex replacement inside the raw frontmatter block — does NOT re-serialize YAML, preserving key order and avoiding diff noise
+- **Flags**: `--dry-run` (log only, no writes) and `--strict` (exit 1 on unresolvable dep paths)
+- **Stdout contract**: Exactly one line — a JSON array of READY node frontmatter objects (for GitHub Actions matrix consumption)
+- **Idempotent**: Re-running is always safe; pre-existing READY nodes are included in output without being re-written
+
+### 🔜 Next Steps
+1. Draft `.github/workflows/foundry-engine.yml` — the GHA workflow that invokes the orchestrator and feeds its JSON output into a `matrix` strategy to dispatch Jules sessions.
+2. Draft `.github/workflows/foundry-heartbeat.yml` — the scheduled heartbeat that detects crashed ACTIVE sessions and flips them to FAILED.
 3. Draft initial Persona `.md` frameworks inside `.github/agents/`.


### PR DESCRIPTION
Implement the DAG Orchestrator script for The Foundry (Epic 2, Story 2.1).

### Key Changes
- Created `.github/scripts/foundry-orchestrator.ts`:
  - Discovers all `.foundry/*.md` nodes (skipping journals/docs).
  - Parses YAML frontmatter via `gray-matter`.
  - Resolves dependencies and promotes `PENDING` nodes to `READY` if dependencies are `COMPLETED`.
  - Mutates files in-place using surgical regex replacements to preserve key order.
  - Outputs a JSON array of `READY` nodes for GitHub Actions matrix consumption.
- Setup `.github/scripts/package.json` with `pnpm` and Node 24 support (`--strip-types`).
- Updated `.foundry/docs/schema.md` to reference the `.ts` extension.
- Updated project memories.

### Verification
- 8/8 integration tests passed (verifying all DAG logic edge cases).
- Smoke tested against the current repository state.