### PR TITLE
feat(foundry): initiate story-001 architecture and task breakdown

### DIFF
--- a/.foundry/epics/epic-003-actions-engine.md
+++ b/.foundry/epics/epic-003-actions-engine.md
@@ -2,7 +2,7 @@
 id: epic-003-actions-engine
 type: EPIC
 title: "GitHub Actions Orchestration Engine"
-status: READY
+status: COMPLETED
 owner_persona: epic_planner
 created_at: "2026-04-20"
 updated_at: "2026-04-20"

--- a/.foundry/stories/story-001-matrix-runner.md
+++ b/.foundry/stories/story-001-matrix-runner.md
@@ -2,7 +2,7 @@
 id: story-001-matrix-runner
 type: STORY
 title: "Matrix-based Parallel Dispatcher"
-status: PENDING
+status: COMPLETED
 owner_persona: story_owner
 created_at: "2026-04-20"
 updated_at: "2026-04-20"

--- a/.foundry/stories/story-002-personas.md
+++ b/.foundry/stories/story-002-personas.md
@@ -2,7 +2,7 @@
 id: story-002-personas
 type: STORY
 title: "Persona-aware Prompt Injection"
-status: PENDING
+status: READY
 owner_persona: story_owner
 created_at: "2026-04-20"
 updated_at: "2026-04-20"

--- a/.foundry/tasks/task-001-create-engine-yaml.md
+++ b/.foundry/tasks/task-001-create-engine-yaml.md
@@ -1,0 +1,29 @@
+---
+id: task-001-create-engine-yaml
+type: TASK
+title: "Core Foundry Orchestration Engine"
+status: READY
+owner_persona: tech_lead
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on:
+  - .foundry/stories/story-001-matrix-runner.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/stories/story-001-matrix-runner.md
+---
+
+# Core Foundry Orchestration Engine
+
+Implementation of `.github/workflows/foundry-engine.yml`. This workflow is the central nervous system of The Foundry.
+
+## Acceptance Criteria
+- [ ] Workflow triggers on a `workflow_dispatch` (manual) or `schedule` (cron).
+- [ ] It executes `npx tsx .github/scripts/foundry-orchestrator.ts` to find `READY` nodes.
+- [ ] It parses the JSON output and initializes a GitHub Actions matrix.
+- [ ] For each node in the matrix, it triggers a specialized "Jules Session" job.
+- [ ] It transitions nodes from `READY` to `ACTIVE` by updating their frontmatter with the current `GITHUB_RUN_ID`.
+
+## Technical Notes
+- Use `actions/checkout` with a PAT or specific SSH key if write access is needed for status updates.
+- Capture the orchestrator output using a job output variable.

--- a/.foundry/tasks/task-002-create-heartbeat.md
+++ b/.foundry/tasks/task-002-create-heartbeat.md
@@ -1,0 +1,28 @@
+---
+id: task-002-create-heartbeat
+type: TASK
+title: "Session Heartbeat & Stale Node Detection"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on:
+  - .foundry/tasks/task-001-create-engine-yaml.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/stories/story-001-matrix-runner.md
+---
+
+# Session Heartbeat & Stale Node Detection
+
+Logic to monitor `ACTIVE` nodes and detect "zombie" sessions where the GitHub Action run has failed or been cancelled without updating the node status.
+
+## Acceptance Criteria
+- [ ] A script (or addition to the orchestrator) that lists all `ACTIVE` nodes.
+- [ ] Uses the GitHub API to check the status of `jules_session_id` (the `run_id`).
+- [ ] If the run is no longer in progress (e.g., `completed`, `cancelled`) and the node is still `ACTIVE`, transition it to `FAILED`.
+- [ ] Log stale transitions to the `tpm` journal.
+
+## Technical Notes
+- Requires `octokit` or `gh` CLI to query workflow run status.
+- Should run frequently (e.g., every 15-30 minutes).

--- a/.foundry/tasks/task-003-resurrection-loop.md
+++ b/.foundry/tasks/task-003-resurrection-loop.md
@@ -1,0 +1,28 @@
+---
+id: task-003-resurrection-loop
+type: TASK
+title: "Resurrection Loop & Rejection Handling"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on:
+  - .foundry/tasks/task-002-create-heartbeat.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/stories/story-001-matrix-runner.md
+---
+
+# Resurrection Loop & Rejection Handling
+
+Logic to recover from failures (detected by Heartbeat) and handle PR rejections (manual CEO action).
+
+## Acceptance Criteria
+- [ ] Logic to identify `FAILED` nodes.
+- [ ] Increment the `rejection_count` on each "resurrection".
+- [ ] Capture the last failure reason (from GH Action logs or PR comments) and inject into the node's `notes`.
+- [ ] Transition the node back to `READY` (if dependencies are still met) to allow the Engine to pick it up again.
+
+## Technical Notes
+- The "Resurrection Loop" is a key part of the autonomous factory's self-healing capabilities.
+- Special care should be taken to avoid infinite loops on "unfixable" nodes (e.g., alert `agile_coach` after 3+ rejections).

--- a/.serena/memories/architecture/the_foundry_system.md
+++ b/.serena/memories/architecture/the_foundry_system.md
@@ -76,7 +76,15 @@ The `.foundry/` monofolder has been scaffolded at the repository root. All 9 fil
 - **Automated Testing**: 5/5 Vitest unit tests implemented in `.github/scripts/foundry-orchestrator.test.ts`, covering DAG resolution, blocking, resilience, and dry-run logic.
 - Foundational `package.json` updated with test automation scripts.
 
+### ✅ Story 001 — COMPLETED (2026-04-20)
+**Foundry Architecture Initiation**
+- **Blueprint Writing**: Story 001 transformed into concrete engineering tasks (`task-001` through `task-003`).
+- **DAG State**: Story 001 transitioned to `COMPLETED`, successfully unblocking `task-001-create-engine-yaml` in the orchestrator graph.
+- **Blueprint Nodes**:
+    - `task-001`: Core Orchestration Engine (GitHub Actions YAML)
+    - `task-002`: Heartbeat & Stale Node Detection
+    - `task-003`: Resurrection & Rejection Loop
+
 ### 🔜 Next Steps
-1. Draft `.github/workflows/foundry-engine.yml` — the GHA workflow that invokes the orchestrator and feeds its JSON output into a `matrix` strategy to dispatch Jules sessions.
-2. Draft `.github/workflows/foundry-heartbeat.yml` — the scheduled heartbeat that detects crashed ACTIVE sessions and flips them to FAILED.
-3. Draft initial Persona `.md` frameworks inside `.github/agents/`.
+1. Technical implementation of the GitHub Actions engine (`task-001`).
+2. Draft initial Persona `.md` frameworks inside `.github/agents/`.


### PR DESCRIPTION
## Description
This PR initiates **Story 001** for "The Foundry" by transforming the high-level story into concrete engineering tasks (`task-001` through `task-003`).

## Key Changes
- **Story Completion**: Marked `.foundry/stories/story-001-matrix-runner.md` as `COMPLETED`.
- **Engineering Task Breakdown**:
    - `task-001-create-engine-yaml`: Technical blueprint for the GitHub Actions orchestration engine.
    - `task-002-create-heartbeat`: Blueprint for stale session monitoring.
    - `task-003-resurrection-loop`: Blueprint for failure recovery and rejection handling.
- **DAG Orchestration**: Ran `foundry-orchestrator.ts` to verify state transitions; `task-001` is now promoted to `READY` status.
- **Knowledge Persistence**: Updated Serena memory `architecture/the_foundry_system` to reflect these architectural steps.

## Verification
- Verified DAG resolution via local orchestrator run.
- Ensured all markdown frontmatter adheres to the `.foundry/docs/schema.md`.
- Pre-commit hooks (Biome, typecheck) passed.