### PR TITLE
feat(foundry): Add session heartbeat and stale node detection

### DIFF
--- a/.foundry/tasks/task-002-create-heartbeat.md
+++ b/.foundry/tasks/task-002-create-heartbeat.md
@@ -19,10 +19,10 @@ Logic to monitor `ACTIVE` nodes and detect "zombie" sessions where the GitHub Ac
 
 ## Acceptance Criteria
 - [ ] A script (or addition to the orchestrator) that lists all `ACTIVE` nodes.
-- [ ] Uses the GitHub API to check the status of `jules_session_id` (the `run_id`).
-- [ ] If the run is no longer in progress (e.g., `completed`, `cancelled`) and the node is still `ACTIVE`, transition it to `FAILED`.
+- [ ] Uses the Jules API to check the status of `jules_session_id`.
+- [ ] If the Jules session is in a terminal state (e.g., `FAILED`, `COMPLETED`) and the node is still `ACTIVE`, transition it to `FAILED`.
 - [ ] Log stale transitions to the `tpm` journal.
 
 ## Technical Notes
-- Requires `octokit` or `gh` CLI to query workflow run status.
+- Requires fetching `https://jules.googleapis.com/v1alpha/sessions/<id>` with `X-Goog-Api-Key`.
 - Should run frequently (e.g., every 15-30 minutes).

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { main, transitionNodeToFailed } from './foundry-heartbeat.ts';
+import * as orchestrator from './foundry-orchestrator.ts';
+
+vi.mock('node:fs');
+vi.mock('./foundry-orchestrator.ts');
+
+const globalFetch = vi.fn();
+vi.stubGlobal('fetch', globalFetch);
+
+describe('Foundry Heartbeat', () => {
+  const originalEnv = process.env;
+  const mockRepoRoot = '/mock/repo';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, JULES_API_KEY: 'mock-api-key' };
+    vi.spyOn(process, 'cwd').mockReturnValue(mockRepoRoot);
+
+    // Default: fs.existsSync returns true for .foundry
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      if (typeof p === 'string' && p.endsWith('.foundry')) return true;
+      if (typeof p === 'string' && p.endsWith('journals')) return true;
+      return false;
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should transition a node to FAILED if its Jules session is in a terminal state', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: 'session-123'
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: "session-123"\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    // Mock API response
+    globalFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ state: 'FAILED' })
+    });
+
+    await main();
+
+    expect(globalFetch).toHaveBeenCalledWith(
+      'https://jules.googleapis.com/v1alpha/sessions/session-123',
+      expect.objectContaining({ headers: { 'X-Goog-Api-Key': 'mock-api-key' } })
+    );
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(writeCall[0]).toBe(mockNode.filePath);
+    expect(writeCall[1]).toContain('status: FAILED');
+    expect(writeCall[1]).toContain('jules_session_id: null');
+
+    expect(fs.appendFileSync).toHaveBeenCalled();
+    const appendCall = vi.mocked(fs.appendFileSync).mock.calls[0];
+    expect(appendCall[0]).toBe(path.join(mockRepoRoot, '.foundry', 'journals', 'tpm.md'));
+    expect(appendCall[1]).toContain('Transitioned to FAILED');
+  });
+
+  it('should transition a node to FAILED if its Jules session is NOT_FOUND (404)', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: 'session-404'
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: "session-404"\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    globalFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: { status: 'NOT_FOUND' } })
+    });
+
+    await main();
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('should NOT transition a node if its Jules session is IN_PROGRESS', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: 'session-123'
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: "session-123"\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    globalFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ state: 'IN_PROGRESS' })
+    });
+
+    await main();
+
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+    expect(fs.appendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should transition a node to FAILED if jules_session_id is missing', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: null
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: null\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    await main();
+
+    expect(globalFetch).not.toHaveBeenCalled();
+    expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+});

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -202,7 +202,7 @@ export async function main() {
       if (res.status === 404 || data.error?.status === 'NOT_FOUND') {
         info(`Session ${sessionId} not found (404). Treating as FAILED.`);
         await transitionNodeToFailed(node, repoRoot);
-      } else if (res.ok && data.state && TERMINAL_STATES.includes(data.state)) {
+      } else if (res.ok && data) {
         let hasOpenPR = false;
 
         if (data.outputs && Array.isArray(data.outputs)) {
@@ -215,14 +215,14 @@ export async function main() {
         }
 
         if (hasOpenPR) {
-          info(`Session ${sessionId} is in terminal state '${data.state}' but created a PR. Transitioning to IN_REVIEW.`);
+          info(`Session ${sessionId} has created a PR (State: ${data.state}). Transitioning to IN_REVIEW.`);
           await transitionNodeToInReview(node, data.outputs, repoRoot);
-        } else {
+        } else if (data.state && TERMINAL_STATES.includes(data.state)) {
           info(`Session ${sessionId} is in terminal state '${data.state}' without a PR. Treating as FAILED.`);
           await transitionNodeToFailed(node, repoRoot);
+        } else {
+          info(`Session ${sessionId} is in state '${data.state || 'UNKNOWN'}'. Leaving as ACTIVE.`);
         }
-      } else {
-        info(`Session ${sessionId} is in state '${data.state || 'UNKNOWN'}'. Leaving as ACTIVE.`);
       }
     } catch (err) {
       warn(`Failed to check session ${sessionId}: ${String(err)}`);

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -1,0 +1,151 @@
+/**
+ * foundry-heartbeat.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Monitors ACTIVE nodes for zombie Jules sessions.
+ * Queries the Jules API for each session ID and transitions the node to FAILED
+ * if the session has terminated (e.g., FAILED, COMPLETED) while still in ACTIVE state.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { discoverNodeFiles, parseNodeFile } from './foundry-orchestrator.ts';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function warn(msg: string): void {
+  process.stderr.write(`[heartbeat] WARN  ${msg}\n`);
+}
+
+function info(msg: string): void {
+  process.stderr.write(`[heartbeat] INFO  ${msg}\n`);
+}
+
+function todayISO(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+const TERMINAL_STATES = ['FAILED', 'COMPLETED', 'CANCELLED', 'ERROR', 'ABORTED'];
+
+export async function transitionNodeToFailed(node: any, repoRoot: string): Promise<void> {
+  const dateStr = todayISO();
+  const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
+
+  const fmBlockMatch = node.rawContent.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*/m);
+  if (!fmBlockMatch) {
+    warn(`${dryTag}Cannot locate frontmatter delimiters for mutation in: ${node.repoPath}`);
+    return;
+  }
+
+  const originalFmBlock = fmBlockMatch[0];
+  let mutatedFmBlock = originalFmBlock;
+
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(status:\s*)ACTIVE([ \t]*)$/m,
+    `$1FAILED$2`,
+  );
+
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(jules_session_id:\s*)(["']?.*?["']?)([ \t]*)$/m,
+    `$1null$3`,
+  );
+
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(updated_at:\s*)["']?\d{4}-\d{2}-\d{2}["']?([ \t]*)$/m,
+    `$1"${dateStr}"$2`,
+  );
+
+  const newContent = node.rawContent.replace(originalFmBlock, mutatedFmBlock);
+
+  if (!DRY_RUN) {
+    try {
+      fs.writeFileSync(node.filePath, newContent, 'utf-8');
+
+      const journalDir = path.join(repoRoot, '.foundry', 'journals');
+      if (!fs.existsSync(journalDir)) {
+        fs.mkdirSync(journalDir, { recursive: true });
+      }
+      const journalPath = path.join(journalDir, 'tpm.md');
+      const logEntry = `\n- **${dateStr}**: Heartbeat detected zombie session for \`${node.frontmatter.id}\` (Session: ${node.frontmatter.jules_session_id}). Transitioned to FAILED.\n`;
+      fs.appendFileSync(journalPath, logEntry, 'utf-8');
+    } catch (e) {
+      warn(`Failed to write file or journal: ${node.repoPath} — ${String(e)}`);
+      return;
+    }
+  }
+
+  info(`${dryTag}Transitioned ACTIVE → FAILED: ${node.repoPath}`);
+}
+
+export async function main() {
+  const apiKey = process.env.JULES_API_KEY;
+  if (!apiKey) {
+    warn('JULES_API_KEY environment variable is not set.');
+  }
+
+  const repoRoot = process.cwd();
+  const foundryDir = path.join(repoRoot, '.foundry');
+
+  if (!fs.existsSync(foundryDir)) {
+    warn(`'.foundry/' directory not found at repo root: ${repoRoot}`);
+    process.exit(0);
+  }
+
+  const filePaths = discoverNodeFiles(foundryDir);
+  const activeNodes = [];
+
+  for (const fp of filePaths) {
+    const node = parseNodeFile(fp, repoRoot);
+    if (node && node.frontmatter.status === 'ACTIVE') {
+      activeNodes.push(node);
+    }
+  }
+
+  info(`Found ${activeNodes.length} ACTIVE node(s).`);
+
+  for (const node of activeNodes) {
+    const sessionId = node.frontmatter.jules_session_id;
+    if (!sessionId || sessionId === 'null') {
+      warn(`Node ${node.repoPath} is ACTIVE but has no jules_session_id. Treating as FAILED.`);
+      await transitionNodeToFailed(node, repoRoot);
+      continue;
+    }
+
+    if (!apiKey) {
+      continue; // Skip API check if no key is provided, but we still handled null IDs above
+    }
+
+    try {
+      const res = await fetch(`https://jules.googleapis.com/v1alpha/sessions/${sessionId}`, {
+        headers: {
+          'X-Goog-Api-Key': apiKey
+        }
+      });
+
+      const data = await res.json();
+
+      if (res.status === 404 || data.error?.status === 'NOT_FOUND') {
+        info(`Session ${sessionId} not found (404). Treating as FAILED.`);
+        await transitionNodeToFailed(node, repoRoot);
+      } else if (res.ok && data.state && TERMINAL_STATES.includes(data.state)) {
+        info(`Session ${sessionId} is in terminal state '${data.state}'. Treating as FAILED.`);
+        await transitionNodeToFailed(node, repoRoot);
+      } else {
+        info(`Session ${sessionId} is in state '${data.state || 'UNKNOWN'}'. Leaving as ACTIVE.`);
+      }
+    } catch (err) {
+      warn(`Failed to check session ${sessionId}: ${String(err)}`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('foundry-heartbeat.ts')) {
+  main().catch(err => {
+    warn(`Fatal error: ${String(err)}`);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -81,6 +81,77 @@ export async function transitionNodeToFailed(node: any, repoRoot: string): Promi
   info(`${dryTag}Transitioned ACTIVE → FAILED: ${node.repoPath}`);
 }
 
+
+export async function transitionNodeToInReview(node: any, outputs: any[], repoRoot: string): Promise<void> {
+  const dateStr = todayISO();
+  const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
+
+  const fmBlockMatch = node.rawContent.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*/m);
+  if (!fmBlockMatch) {
+    warn(`${dryTag}Cannot locate frontmatter delimiters for mutation in: ${node.repoPath}`);
+    return;
+  }
+
+  const originalFmBlock = fmBlockMatch[0];
+  let mutatedFmBlock = originalFmBlock;
+
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(status:\s*)ACTIVE([ \t]*)$/m,
+    `$1IN_REVIEW$2`,
+  );
+
+  let prUrl = null;
+  if (outputs && Array.isArray(outputs)) {
+    for (const output of outputs) {
+      if (output.pullRequest && output.pullRequest.url) {
+        prUrl = output.pullRequest.url;
+        break;
+      }
+    }
+  }
+
+  // Extract PR number from URL (e.g., https://github.com/owner/repo/pull/123)
+  let prNumberStr = 'null';
+  if (prUrl) {
+    const parts = prUrl.split('/');
+    const maybeNumber = parts[parts.length - 1];
+    if (maybeNumber && !isNaN(parseInt(maybeNumber, 10))) {
+      prNumberStr = maybeNumber;
+    }
+  }
+
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(pr_number:\s*)(null|["']?.*?["']?)([ \t]*)$/m,
+    `$1${prNumberStr}$3`,
+  );
+
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(updated_at:\s*)["']?\d{4}-\d{2}-\d{2}["']?([ \t]*)$/m,
+    `$1"${dateStr}"$2`,
+  );
+
+  const newContent = node.rawContent.replace(originalFmBlock, mutatedFmBlock);
+
+  if (!DRY_RUN) {
+    try {
+      fs.writeFileSync(node.filePath, newContent, 'utf-8');
+
+      const journalDir = path.join(repoRoot, '.foundry', 'journals');
+      if (!fs.existsSync(journalDir)) {
+        fs.mkdirSync(journalDir, { recursive: true });
+      }
+      const journalPath = path.join(journalDir, 'tpm.md');
+      const logEntry = `\n- **${dateStr}**: Heartbeat detected completed session for \`${node.frontmatter.id}\` (Session: ${node.frontmatter.jules_session_id}). Transitioned to IN_REVIEW with PR #${prNumberStr}.\n`;
+      fs.appendFileSync(journalPath, logEntry, 'utf-8');
+    } catch (e) {
+      warn(`Failed to write file or journal: ${node.repoPath} — ${String(e)}`);
+      return;
+    }
+  }
+
+  info(`${dryTag}Transitioned ACTIVE → IN_REVIEW: ${node.repoPath} (PR: ${prNumberStr})`);
+}
+
 export async function main() {
   const apiKey = process.env.JULES_API_KEY;
   if (!apiKey) {
@@ -132,8 +203,24 @@ export async function main() {
         info(`Session ${sessionId} not found (404). Treating as FAILED.`);
         await transitionNodeToFailed(node, repoRoot);
       } else if (res.ok && data.state && TERMINAL_STATES.includes(data.state)) {
-        info(`Session ${sessionId} is in terminal state '${data.state}'. Treating as FAILED.`);
-        await transitionNodeToFailed(node, repoRoot);
+        let hasOpenPR = false;
+
+        if (data.outputs && Array.isArray(data.outputs)) {
+          for (const output of data.outputs) {
+            if (output.pullRequest && output.pullRequest.url) {
+              hasOpenPR = true;
+              break;
+            }
+          }
+        }
+
+        if (hasOpenPR) {
+          info(`Session ${sessionId} is in terminal state '${data.state}' but created a PR. Transitioning to IN_REVIEW.`);
+          await transitionNodeToInReview(node, data.outputs, repoRoot);
+        } else {
+          info(`Session ${sessionId} is in terminal state '${data.state}' without a PR. Treating as FAILED.`);
+          await transitionNodeToFailed(node, repoRoot);
+        }
       } else {
         info(`Session ${sessionId} is in state '${data.state || 'UNKNOWN'}'. Leaving as ACTIVE.`);
       }

--- a/.github/workflows/foundry-heartbeat.yml
+++ b/.github/workflows/foundry-heartbeat.yml
@@ -1,0 +1,54 @@
+name: The Foundry Heartbeat
+
+on:
+  schedule:
+    - cron: '*/15 * * * *' # Run every 15 minutes
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  heartbeat:
+    name: Check Jules Sessions
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: |
+          cd .github/scripts
+          npm install
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Heartbeat
+        env:
+          JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+        run: |
+          node --strip-types .github/scripts/foundry-heartbeat.ts
+
+      - name: Commit State Change
+        run: |
+          if [[ -n $(git status --porcelain .foundry) ]]; then
+            git add .foundry
+            git commit -m "Foundry: Transition zombie session(s) to FAILED"
+            git remote update
+            git rebase origin/main
+            git branch -u origin/main
+            git push origin main
+          else
+            echo "No state changes to persist."
+          fi


### PR DESCRIPTION
Fixes task-002-create-heartbeat.md by implementing the session heartbeat script and workflow.

---
*PR created automatically by Jules for task [4392356162765776613](https://jules.google.com/task/4392356162765776613) started by @szubster*