### PR TITLE
⚡ Bolt: Debounce LocationSuggestions IndexedDB queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,7 @@
 **What:** Converted the `localPids` and `missingIds` arrays into Sets (or parallel Sets) to allow for $O(1)$ lookups instead of $O(n)$ `.includes()` calls inside deeply nested loops.
 **Why:** During suggestion generation, `Array.prototype.includes` was being called frequently within loops iterating over `queryTargets`, `STATIC_NPC_TRADE_DATA`, and local encounters. Using a `Set` mitigates the O(n²) overhead for a noticeable performance win on large datasets or queries.
 **Measured Improvement:** In testing over 1,000 iterations using mock datasets, the `Set` based approach was nearly 10x faster (170ms vs 3.5ms for standalone lookup loop and ~20% faster overall function execution) when checking against large inputs.
+## 2026-04-21 - ⚡ Bolt: Debounce LocationSuggestions IndexedDB queries
+**What:** Debounced IndexedDB query inside LocationSuggestions component by adding a 250ms `setTimeout` to delay `pokeDB.getLocations()` fetch based on user typing.
+**Why:** Typing into the search bar rapidly changes `searchTerm`, which triggered the `useEffect` and fired continuous `pokeDB.getLocations()` requests without a debounce, causing main thread to block and resulting in UI freezes.
+**Expected Impact:** Improved responsiveness during rapid keystrokes as the redundant IDB queries are skipped before 250ms have elapsed.

--- a/src/components/LocationSuggestions.tsx
+++ b/src/components/LocationSuggestions.tsx
@@ -20,7 +20,8 @@ export function LocationSuggestions() {
       return;
     }
 
-    const fetchSuggestions = async () => {
+    // ⚡ Bolt: Debounce IndexedDB queries to prevent main thread blocking on rapid keystrokes
+    const timeoutId = setTimeout(async () => {
       const locations = await pokeDB.getLocations();
 
       // ⚡ Bolt: Hoisted string allocation outside the loop and removed N+1 IDB queries
@@ -32,9 +33,9 @@ export function LocationSuggestions() {
 
       setSuggestions(filteredWithCounts);
       setIsOpen(filteredWithCounts.length > 0);
-    };
+    }, 250);
 
-    fetchSuggestions();
+    return () => clearTimeout(timeoutId);
   }, [searchTerm, selectedLocationId]);
 
   if (!isOpen && !selectedLocationId) return null;


### PR DESCRIPTION
## What
Debounced IndexedDB queries within the `LocationSuggestions` component using a 250ms `setTimeout` triggered on user keystrokes in the search bar.

## Why
Typing rapidly into the search box triggered synchronous IndexedDB queries inside the `useEffect` on every keystroke because it lacked debouncing. This flooded the main thread causing potential UI freezing. By wrapping it in a setTimeout, we bypass unnecessary repetitive requests to IDB.

## Expected Impact
A faster and smoother typing experience without blocking the main thread when rendering UI updates.

## How to Verify
Start typing into the location suggestion box rapidly and see fewer requests for fetching locations from `pokeDB.getLocations` compared to typing each letter rapidly previously. Run `pnpm test` and `pnpm test:e2e` and observe all tests pass successfully.

---
*PR created automatically by Jules for task [5500381742490724216](https://jules.google.com/task/5500381742490724216) started by @szubster*