### PR TITLE
📜 Scribe: Document MapGraph traversal logic

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -9,4 +9,14 @@
     - **High priority (~90-95):** Ready evolutions (has item/level).
     - **Scaling priority (~110 down to ~14):** Nearby encounters, scaling dynamically via graph traversal distance.
     - **Moderate priority (~65-85):** In-game NPC trades (higher if the player already owns the requested Pokémon).
-    - **Lowest priority (~10):** Version exclusives (unobtainable without external hardware/trading).## 2024-05-20 - Gen 1 Save Parsing Offsets\n\n**What:** Added JSDoc for `detectGen1GameVersion`, `isGen1Save`, and `parseGen1`.\n**Why:** The memory offsets used in parsing Gen 1 saves are non-obvious. Specifically, Gen 1 lacks a version byte, requiring heuristic analysis of party and Pokedex to guess the version, and Japanese or Yellow versions often shift these offsets by +1 or more bytes compared to Red/Blue. Adding this context is crucial for future maintainers debugging parsing failures.
+    - **Lowest priority (~10):** Version exclusives (unobtainable without external hardware/trading).
+
+## 2024-05-20 - Gen 1 Save Parsing Offsets
+
+**What:** Added JSDoc for `detectGen1GameVersion`, `isGen1Save`, and `parseGen1`.
+**Why:** The memory offsets used in parsing Gen 1 saves are non-obvious. Specifically, Gen 1 lacks a version byte, requiring heuristic analysis of party and Pokedex to guess the version, and Japanese or Yellow versions often shift these offsets by +1 or more bytes compared to Red/Blue. Adding this context is crucial for future maintainers debugging parsing failures.
+
+## 2024-05-25 - Map Graph Traversal and Precomputed Distances
+
+**What:** Added JSDoc to `getDistanceToMap` and `getOutdoorMapId` in `src/engine/mapGraph/gen1Graph.ts`.
+**Why:** The distance calculation relies on a precomputed lookup table (the `dist` property) generated at build-time via the Floyd-Warshall algorithm, rather than performing real-time pathfinding (like BFS or Dijkstra). This architectural decision enables O(1) distance lookups, which is critical for performance since the suggestion engine evaluates hundreds of potential encounters simultaneously. Furthermore, because distance matrices only connect major outdoor hubs, indoor maps must dynamically resolve to their parent hub via the `prnt` property before calculations can occur. This documentation preserves the "why" behind the `dist` and `prnt` properties to prevent future maintainers from unnecessarily refactoring to real-time pathfinding.

--- a/src/engine/mapGraph/gen1Graph.ts
+++ b/src/engine/mapGraph/gen1Graph.ts
@@ -1,9 +1,21 @@
 import type { UnifiedLocation } from '../../db/schema';
 
 /**
- * Find the distance between the starting map and a target area (aid).
- * Uses the provided list of locations as the graph.
- * Returns { distance, name } where distance is hops in the graph and name is target name.
+ * Calculates the shortest path distance (in graph edges/hops) between the player's
+ * current location and a target area.
+ *
+ * @param allLocations - The unified list of all map locations, pre-populated with Floyd-Warshall distances (`dist`).
+ * @param startMapId - The internal Map ID where the player is currently standing.
+ * @param targetAid - The location Area ID (aid) where the target Pokémon can be found.
+ * @returns An object containing the `distance` (number of hops) and the `name` of the target area, or `null` if unreachable.
+ *
+ * @remarks
+ * **Architecture Note:**
+ * This function does NOT perform real-time pathfinding (e.g., BFS or Dijkstra).
+ * Instead, it relies on the `dist` property of the `UnifiedLocation` objects, which contains
+ * a precomputed lookup table generated at build-time using the Floyd-Warshall algorithm.
+ * This ensures O(1) distance lookups during runtime, which is critical since the suggestion
+ * engine evaluates hundreds of potential encounters simultaneously.
  */
 export function getDistanceToMap(
   allLocations: UnifiedLocation[],
@@ -42,7 +54,18 @@ export function getDistanceToMap(
 }
 
 /**
- * Resolves a potentially indoor map ID to its nearest outdoor equivalent.
+ * Resolves an indoor map to its connected outdoor parent map.
+ *
+ * @param allLocations - The unified list of all map locations.
+ * @param mapId - The Map ID to resolve.
+ * @returns The parent outdoor Map ID, or the original ID if it is already an outdoor map.
+ *
+ * @remarks
+ * **Why this is needed:**
+ * The map graph distance matrix (`dist`) is only computed between major outdoor hubs and routes.
+ * Indoor maps (houses, caves, buildings) are structurally represented as children of these hubs via
+ * the `prnt` property. To calculate the distance to a target from inside a building, we must first
+ * "step outside" by resolving the current location to its parent map.
  */
 export function getOutdoorMapId(allLocations: UnifiedLocation[], mapId: number): number {
   const loc = allLocations.find((l) => l.id === mapId);


### PR DESCRIPTION
**What**
Added comprehensive JSDoc to `getDistanceToMap` and `getOutdoorMapId` in `src/engine/mapGraph/gen1Graph.ts`, and logged the corresponding architectural decisions in `.jules/scribe.md`.

**Why this module needed docs**
The `mapGraph` distance logic relies on pre-computed distances via the Floyd-Warshall algorithm instead of real-time pathfinding (BFS/Dijkstra). Furthermore, it relies on indoor maps resolving to their outdoor parents. Both of these architectural concepts are crucial to understand when making modifications to prevent regressions in performance or logic, necessitating permanent "why" documentation.

**Summary of additions**
- Documented O(1) distance lookups via the `dist` property in `getDistanceToMap`.
- Documented indoor map resolution via the `prnt` property in `getOutdoorMapId`.
- Added the 2024-05-25 entry in `.jules/scribe.md` to permanently capture these decisions.

---
*PR created automatically by Jules for task [6855025864396596405](https://jules.google.com/task/6855025864396596405) started by @szubster*