### PR TITLE
🖼️ Canvas: Pokedex Search/Filter Dashboard Layout

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -9,3 +9,9 @@
 **Outcome:** Rejected → journaled
 **Why:** Maintainer pointed out that clicking on boxes instead of scrolling is more problematic, especially on mobile devices.
 **Pattern:** Avoid replacing vertical scrolling with click-to-navigate tab/sidebar layouts when the number of items is high (like 14+ boxes), as it can degrade the mobile experience.
+
+## 2026-04-20 - [Accepted] - 🖼️ Canvas: Condensed Pokedex Grid Layout
+**What:** Redesigned the PokedexCard component to use a condensed layout, moving the sprite to fill the card bounds and making information float on top of it.
+**Outcome:** Accepted → journaled
+**Why:** The PR was merged, confirming that a more dense layout with imagery focused design works well for the Pokedex grid.
+**Pattern:** Strive for visual density and maximizing artwork visibility while keeping important data distinct through gradient overlays.

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -30,12 +30,12 @@ export function SearchAndFilters() {
   };
 
   return (
-    <div className="mb-6 space-y-5 px-4">
-      <div className="flex flex-col gap-4 lg:flex-row">
-        {/* Modern Search Bar with Retro Flair */}
+    <div className="mb-6 px-2 sm:px-4">
+      <div className="glass-card flex flex-col gap-4 rounded-3xl border border-white/10 bg-zinc-900/50 p-4 shadow-2xl backdrop-blur-xl lg:flex-row lg:items-center">
+        {/* Unified Search Input Section */}
         <div className="group relative flex-1">
-          <div className="absolute top-1/2 left-4 flex -translate-y-1/2 items-center justify-center rounded-lg bg-[var(--theme-primary)]/10 p-1.5 text-[var(--theme-primary)] transition-all duration-300 group-focus-within:bg-[var(--theme-primary)] group-focus-within:text-white">
-            <Search size={14} className="transition-transform group-focus-within:scale-110" />
+          <div className="absolute top-1/2 left-4 flex -translate-y-1/2 items-center justify-center rounded-lg bg-[var(--theme-primary)]/20 p-2 text-[var(--theme-primary)] transition-all duration-300 group-focus-within:bg-[var(--theme-primary)] group-focus-within:text-white">
+            <Search size={16} className="transition-transform group-focus-within:scale-110" />
           </div>
           <input
             ref={inputRef}
@@ -46,62 +46,68 @@ export function SearchAndFilters() {
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             onKeyDown={handleKeyDown}
-            className="glass-card w-full rounded-2xl border-white/5 bg-zinc-900/40 py-4 pr-12 pl-14 font-black font-mono text-white text-xs uppercase tracking-widest shadow-[inset_0_2px_10px_rgba(0,0,0,0.5)] outline-none transition-all placeholder:text-zinc-600 focus:border-[var(--theme-primary)]/50 focus:bg-zinc-900/60"
+            className="w-full rounded-2xl border-2 border-white/5 bg-black/40 py-4 pr-12 pl-16 font-black font-mono text-sm text-white uppercase tracking-widest outline-none transition-all placeholder:text-zinc-600 focus:border-[var(--theme-primary)] focus:bg-black/60 focus:shadow-[0_0_20px_rgba(var(--theme-primary-rgb),0.2)]"
           />
           {searchTerm && (
             <button
               type="button"
               onClick={handleClearSearch}
               aria-label="Clear search"
-              className="absolute top-1/2 right-4 -translate-y-1/2 rounded-xl p-2 text-zinc-500 transition-all hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+              className="absolute top-1/2 right-4 -translate-y-1/2 rounded-xl p-2 text-zinc-500 transition-all hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
-              <X size={14} />
+              <X size={16} />
             </button>
           )}
-          {/* LCD Effect on Input */}
-          <div className="pointer-events-none absolute inset-x-4 top-0 h-[1px] bg-white/5" />
 
           {/* Location Suggestions Dropdown */}
           <LocationSuggestions />
         </div>
 
-        {/* Filter Buttons designed as Retro Console Switches */}
-        <div className="no-scrollbar flex gap-2 overflow-x-auto px-1 pb-2">
-          <button
-            type="button"
-            onClick={() => setFilters([])}
-            aria-pressed={filtersSet.size === 0}
-            className={cn(
-              'retro-button relative flex shrink-0 items-center gap-3 overflow-hidden rounded-2xl border-2 px-5 py-3 font-black text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
-              filtersSet.size === 0
-                ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)] text-white shadow-[0_10px_20px_rgba(var(--theme-primary-rgb),0.3)]'
-                : 'border-white/5 bg-zinc-900 text-zinc-500 hover:bg-zinc-800 hover:text-white',
-            )}
-          >
-            <span className="relative z-10">All</span>
-            {filtersSet.size === 0 && <div className="lcd-flicker pointer-events-none absolute inset-0 bg-white/10" />}
-          </button>
+        {/* Separator on Desktop */}
+        <div className="hidden h-12 w-[2px] bg-white/10 lg:block" />
 
-          {(['secured', 'missing', 'dex-only'] as FilterType[]).map((f) => (
+        {/* Status Filters Section */}
+        <div className="flex flex-col gap-2 lg:min-w-[400px]">
+          <span className="pl-1 font-black text-[9px] text-zinc-500 uppercase tracking-widest">Filter by Status</span>
+          <div className="no-scrollbar flex gap-2 overflow-x-auto">
             <button
               type="button"
-              key={f}
-              onClick={() => toggleFilter(f)}
-              aria-pressed={filtersSet.has(f)}
-              data-testid={`filter-${f}`}
+              onClick={() => setFilters([])}
+              aria-pressed={filtersSet.size === 0}
               className={cn(
-                'retro-button relative flex shrink-0 items-center gap-3 overflow-hidden rounded-2xl border-2 px-5 py-3 font-black text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
-                filtersSet.has(f)
-                  ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)] text-white shadow-[0_10px_20px_rgba(var(--theme-primary-rgb),0.3)]'
-                  : 'border-white/5 bg-zinc-900 text-zinc-500 hover:bg-zinc-800 hover:text-white',
+                'retro-button relative flex flex-1 shrink-0 items-center justify-center gap-2 overflow-hidden rounded-xl border-2 px-4 py-2 font-black text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+                filtersSet.size === 0
+                  ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)] text-white shadow-[0_5px_15px_rgba(var(--theme-primary-rgb),0.3)]'
+                  : 'border-transparent bg-white/5 text-zinc-400 hover:bg-white/10 hover:text-white',
               )}
             >
-              <span className="relative z-10">
-                {f === 'secured' ? 'Secured' : f === 'missing' ? 'Missing' : 'Dex Only'}
-              </span>
-              {filtersSet.has(f) && <div className="lcd-flicker pointer-events-none absolute inset-0 bg-white/10" />}
+              <span className="relative z-10">All</span>
+              {filtersSet.size === 0 && (
+                <div className="lcd-flicker pointer-events-none absolute inset-0 bg-white/10" />
+              )}
             </button>
-          ))}
+
+            {(['secured', 'missing', 'dex-only'] as FilterType[]).map((f) => (
+              <button
+                type="button"
+                key={f}
+                onClick={() => toggleFilter(f)}
+                aria-pressed={filtersSet.has(f)}
+                data-testid={`filter-${f}`}
+                className={cn(
+                  'retro-button relative flex flex-1 shrink-0 items-center justify-center gap-2 overflow-hidden rounded-xl border-2 px-4 py-2 font-black text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+                  filtersSet.has(f)
+                    ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)] text-white shadow-[0_5px_15px_rgba(var(--theme-primary-rgb),0.3)]'
+                    : 'border-transparent bg-white/5 text-zinc-400 hover:bg-white/10 hover:text-white',
+                )}
+              >
+                <span className="relative z-10">
+                  {f === 'secured' ? 'Secured' : f === 'missing' ? 'Missing' : 'Dex Only'}
+                </span>
+                {filtersSet.has(f) && <div className="lcd-flicker pointer-events-none absolute inset-0 bg-white/10" />}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What
Redesigned `SearchAndFilters.tsx` to display as a unified "Dashboard Control Panel". The search input and filter buttons are now wrapped in a cohesive glass-card container rather than being distinct stacked elements.

## Outcome
Proposed design change.

## Before/After
*Screenshot generated via Playwright frontend verification.*

## Journal Updates
Included the accepted PR outcome for "Canvas: Condensed Pokedex Grid Layout" to `.jules/canvas.md`.

---
*PR created automatically by Jules for task [12769625436949777702](https://jules.google.com/task/12769625436949777702) started by @szubster*