### PR TITLE
🔧 Jules: align journaling with current session workflow

### DIFF
--- a/.foundry/docs/knowledge_base/infrastructure/jules_journaling_policy.md
+++ b/.foundry/docs/knowledge_base/infrastructure/jules_journaling_policy.md
@@ -1,0 +1,24 @@
+# Jules Journaling Policy — Current Session Workflow
+
+To maintain continuity without cross-session memory, specific Jules agents (currently **Canvas** and **Strategist**) use a journaling system in `.jules/*.md`.
+
+## Policy
+
+Each individual PR is responsible for its own session's journal entry. **Past history is handled by the past**; agents should NOT attempt to back-fill "unrecorded past outcomes" from PR history.
+
+### Workflow
+
+1. **Initial PR**: Must include a new journal entry for the current change, labeled as **Accepted**.
+2. **On Merge**: The optimistic entry is persisted.
+3. **On Rejection**:
+   - The agent reverts all code changes.
+   - Updates the journal entry to **Rejected**.
+   - Documents the maintainer's feedback ("Why") and lessons learned ("Pattern").
+   - Pushes the journal-only result to the same PR for merging.
+
+### Affected Agents
+
+- **Canvas**: High-stakes UI changes.
+- **Strategist**: Agent roster & prompt quality.
+
+Other agents (Bolt, Palette, etc.) follow a lighter journaling requirement, logging only critical learnings.

--- a/.jules/schedules/canvas.md
+++ b/.jules/schedules/canvas.md
@@ -8,14 +8,14 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 ### Normal flow (most sessions):
 
-1. **Reflect** — read `.jules/canvas.md` (your journal). Search PR history for `🖼️ Canvas:` PRs. Compare merged/closed PRs against journal entries. Identify any outcomes not yet recorded.
+1. **Reflect** — read `.jules/canvas.md` (your journal). Understand your history and design preferences.
 2. **Implement** — open a PR that includes:
-   - Journal updates in `.jules/canvas.md` for any newly discovered past outcomes (merged or closed PRs)
+   - A new journal entry in `.jules/canvas.md` for this session's change (labeled as **Accepted**)
    - Your new design change
 3. **Wait** — the maintainer reviews your PR. Two outcomes are possible:
    - **Merge** — session auto-closes. You succeeded. The journal updates you included are now persisted.
    - **Rejection comment** — the maintainer comments asking to abandon. Continue to step 4.
-4. **Convert to journal-only** — revert all design/code changes on the branch. Add a journal entry for this session's rejection (read the maintainer's comment to understand why). Push to the same PR. Update title to `🖼️ Canvas: journal — learned from [topic]`. The maintainer merges the journal-only result.
+4. **Convert to journal-only** — revert all design/code changes on the branch. Update the journal entry for this session: change status to **Rejected** and document why (read the maintainer's comment). Push to the same PR. Update title to `🖼️ Canvas: journal — learned from [topic]`. The maintainer merges the journal-only result.
 
 **Why this matters:** since you have no cross-session memory, every journal entry must be committed _inside_ the PR. If a design is accepted, the journal updates ship with it. If rejected, converting the PR to journal-only ensures the learning still ships.
 
@@ -32,7 +32,7 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 **Always:**
 - Read your journal and PR history before starting — it's your only memory
-- Include journal updates for past outcomes in every PR you open
+- Include a journal entry for the current change in every PR you open
 - Run `pnpm lint` and `pnpm test` before pushing
 - Include before/after screenshots in the PR description
 - Keep changes to a single component or page — ambitious but scoped
@@ -63,4 +63,4 @@ Entry format:
 
 ---
 
-If no bold UI improvement can be justified, open a journal-only PR if there are unrecorded outcomes. If the journal is already up to date and no design opportunity exists, do not create a PR.
+If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no design opportunity exists, do not create a PR.

--- a/.jules/schedules/strategist.md
+++ b/.jules/schedules/strategist.md
@@ -18,7 +18,7 @@ The current agent roster lives in `.jules/schedules/`. Before proposing anything
 
 **Always:**
 - Read your journal and PR history before starting — it's your only memory
-- Include journal updates for past outcomes in every PR you open
+- Include a journal entry for the current change in every PR you open
 - Read all files in `.jules/schedules/` before proposing anything
 - Review recent PRs from agents (search by their title prefixes: `⚡ Bolt:`, `🎨 Palette:`, etc.) to assess prompt effectiveness
 - Study the current codebase structure, recent PRs, and open issues for context
@@ -41,9 +41,9 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 ### Normal flow (most sessions):
 
-1. **Reflect** — read `.jules/strategist.md` (your journal). Search PR history for `🧭 Strategist:` PRs. Compare merged/closed PRs against journal entries. Identify any outcomes not yet recorded.
+1. **Reflect** — read `.jules/strategist.md` (your journal). Understand your history and proposal preferences.
 2. **Assess & Implement** — review recent agent PRs and existing schedules. Identify the single most impactful change (new agent, retirement, or prompt improvement). Open a PR that includes:
-   - Journal updates in `.jules/strategist.md` for any newly discovered past outcomes (merged or closed PRs)
+   - A new journal entry in `.jules/strategist.md` for this session's change (labeled as **Accepted**)
    - Your actual changes to the `.jules/schedules/` files
    - Title the PR: `🧭 Strategist: [proposal type] - [description]`
    - PR body detailing:
@@ -53,7 +53,7 @@ You have no memory between sessions. Your only persistence is what's committed t
 3. **Wait** — the maintainer reviews your PR. Two outcomes are possible:
    - **Merge** — session auto-closes. You succeeded. The journal updates you included are now persisted.
    - **Rejection comment** — the maintainer comments asking to abandon. Continue to step 4.
-4. **Convert to journal-only** — revert all schedule changes on the branch. Add a journal entry for this session's rejection (read the maintainer's comment to understand why). Push to the same PR. Update title to `🧭 Strategist: journal — learned from [topic]`. The maintainer merges the journal-only result.
+4. **Convert to journal-only** — revert all schedule changes on the branch. Update the journal entry for this session: change status to **Rejected** and document why (read the maintainer's comment). Push to the same PR. Update title to `🧭 Strategist: journal — learned from [topic]`. The maintainer merges the journal-only result.
 
 **Why this matters:** since you have no cross-session memory, every journal entry must be committed _inside_ the PR. If a proposal is accepted, the journal updates ship with it. If rejected, converting the PR to journal-only ensures the learning still ships.
 
@@ -74,4 +74,4 @@ Entry format:
 
 ---
 
-If no meaningful roster or prompt change can be justified, open a journal-only PR if there are unrecorded outcomes. If the journal is already up to date and no meaningful roster or prompt change can be justified, do not create a PR.
+If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no meaningful roster or prompt change can be justified, do not create a PR.


### PR DESCRIPTION
This PR updates the schedule instructions for the **Canvas** and **Strategist** agents to ensure that each PR handles its own journal entry, avoiding the redundant "Search PR history for unrecorded outcomes" ritual.

### Changes
- **Canvas & Strategist Schedules**: Removed the back-filling logic and updated the session flow to focus on the current change.
- **New Memory**: Added `infrastructure/jules_journaling_policy` to codify this behavior for future agents.

### Verification
- Verified problematic phrases (`unrecorded`, `newly discovered past outcomes`) are removed from schedules via `grep`.
- Updated Serena memories to reflect the new policy.