### PR TITLE
🛡️ Nurse: Remove unnecessary as cast in gen2 save parser

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -14,3 +14,6 @@ The compiler ensures that DataLoader batch functions return valid values or Erro
 ## 2026-04-19 - Nurse: Remove redundant cast in gen2 save parser
 **Learning:** When a variable matches the return type exactly or correctly infers it, redundant `as Type` casts should be removed as they circumvent type narrowing and can hide true typing misalignments in future refactors.
 **Action:** Replaced unsafe cast with strict explicit variable typing.
+## 2026-04-21 - Nurse: Explicitly typing variables removes need for type casting
+**Learning:** Sometimes the compiler loses track of a type after a reassignment if the variable wasn't explicitly typed. By explicitly typing `let variableName: TypeName`, we eliminate the need for downstream `as TypeName` assertions, making the code safer and more readable.
+**Action:** Replaced unsafe cast in `gen2.ts` by explicitly typing the `gameVersion` variable instead.

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -301,7 +301,7 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
     if ((kBadges & (1 << i)) !== 0) badges++;
   }
 
-  let gameVersion = isCrystal ? 'crystal' : detectGen2GameVersion(owned, seen);
+  let gameVersion: GameVersion = isCrystal ? 'crystal' : detectGen2GameVersion(owned, seen);
   if (gameVersion === 'unknown' && !isCrystal) {
     gameVersion = 'gold';
   }
@@ -333,7 +333,7 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
     pc,
     partyDetails,
     pcDetails,
-    gameVersion: gameVersion as GameVersion,
+    gameVersion,
     badges,
     johtoBadges: jBadges,
     kantoBadges: kBadges,


### PR DESCRIPTION
**What was unsafe:**
The `gameVersion` variable in the Generation 2 save parser was implicitly typed, causing it to lose strict type narrowing after variable assignment. This necessitated an unsafe `as GameVersion` cast when building the final `SaveData` object, hiding potential mismatch bugs from the compiler.

**How it was fixed:**
Explicitly typed the `gameVersion` variable as `GameVersion` upon declaration (`let gameVersion: GameVersion = ...`).

**What the compiler now catches:**
The compiler now natively validates that the resulting string is correctly typed to `GameVersion` across all logic branches without requiring a bypass assertion, preventing regressions if the type ever changes.

---
*PR created automatically by Jules for task [11476205964956837836](https://jules.google.com/task/11476205964956837836) started by @szubster*