### PR TITLE
fix(foundry): add missing jules_session_id to Story 003

### DIFF
--- a/.foundry/stories/story-003-dynamic-verification.md
+++ b/.foundry/stories/story-003-dynamic-verification.md
@@ -9,6 +9,7 @@ updated_at: "2026-04-21"
 depends_on:
   - .foundry/docs/adrs/001-the-foundry-architecture.md
   - .foundry/stories/story-002-personas.md
+jules_session_id: null
 ---
 
 # Intelligent Verification & Evolution


### PR DESCRIPTION
Adds the missing `jules_session_id` field to `story-003-dynamic-verification.md` to satisfy the orchestrator's schema requirements and ensure the node is processed correctly.