### PR TITLE
fix(foundry): revert jules_session_id for Story 002

### DIFF
--- a/.foundry/stories/story-002-personas.md
+++ b/.foundry/stories/story-002-personas.md
@@ -9,7 +9,7 @@ created_at: "2026-04-20"
 updated_at: "2026-04-21"
 depends_on:
   - .foundry/epics/epic-003-actions-engine.md
-jules_session_id: "4782834001287011115"
+jules_session_id: "2745393184170604066"
 ---
 
 # Persona-aware Prompt Injection


### PR DESCRIPTION
Reverts the `jules_session_id` for Story 002 back to `2745393184170604066` while keeping the status as `ACTIVE`. This addresses an accidental transition merge.