### PR TITLE
🧪 Oak: Fix missing Gen 2 headbutt encounters and evolution duplication

### DIFF
--- a/data/db/pokemon.jsonl
+++ b/data/db/pokemon.jsonl
@@ -78,8 +78,8 @@
 {"id":78,"n":"Rapidash","cr":60,"efrm":[77],"det":[{"ml":40}]}
 {"id":79,"n":"Slowpoke","cr":190,"eto":[{"id":80,"det":[{"ml":37},{"tr":3,"item":1633}],"ef":79},{"id":199,"det":[{"tr":2,"held":198},{"tr":3,"item":1643}],"ef":79}]}
 {"id":80,"n":"Slowbro","cr":75,"efrm":[79],"det":[{"ml":37},{"tr":3,"item":1633}]}
-{"id":81,"n":"Magnemite","cr":190,"gr":-1,"eto":[{"id":82,"eto":[{"id":462,"det":[{},{},{},{},{},{"tr":3,"item":33}],"ef":82}],"det":[{"ml":30}],"ef":81}]}
-{"id":82,"n":"Magneton","cr":60,"gr":-1,"eto":[{"id":462,"det":[{},{},{},{},{},{"tr":3,"item":33}],"ef":82}],"efrm":[81],"det":[{"ml":30}]}
+{"id":81,"n":"Magnemite","cr":190,"gr":-1,"eto":[{"id":82,"eto":[{"id":462,"det":[{},{"tr":3,"item":33}],"ef":82}],"det":[{"ml":30}],"ef":81}]}
+{"id":82,"n":"Magneton","cr":60,"gr":-1,"eto":[{"id":462,"det":[{},{"tr":3,"item":33}],"ef":82}],"efrm":[81],"det":[{"ml":30}]}
 {"id":83,"n":"Farfetch’d","cr":45,"eto":[{"id":865,"det":[{"tr":0}],"ef":83}]}
 {"id":84,"n":"Doduo","cr":190,"eto":[{"id":85,"det":[{"ml":31}],"ef":84}]}
 {"id":85,"n":"Dodrio","cr":45,"efrm":[84],"det":[{"ml":31}]}
@@ -130,7 +130,7 @@
 {"id":130,"n":"Gyarados","cr":45,"efrm":[129],"det":[{"ml":20}]}
 {"id":131,"n":"Lapras","cr":45}
 {"id":132,"n":"Ditto","cr":35,"gr":-1}
-{"id":133,"n":"Eevee","cr":45,"gr":1,"eto":[{"id":134,"det":[{"tr":3,"item":34}],"ef":133},{"id":135,"det":[{"tr":3,"item":33}],"ef":133},{"id":136,"det":[{"tr":3,"item":32}],"ef":133},{"id":196,"det":[{"time":1}],"ef":133},{"id":197,"det":[{"time":2}],"ef":133},{"id":470,"det":[{},{},{},{"tr":3,"item":47}],"ef":133},{"id":471,"det":[{},{},{},{"tr":3,"item":885}],"ef":133},{"id":700,"det":[{},{}],"ef":133}]}
+{"id":133,"n":"Eevee","cr":45,"gr":1,"eto":[{"id":134,"det":[{"tr":3,"item":34}],"ef":133},{"id":135,"det":[{"tr":3,"item":33}],"ef":133},{"id":136,"det":[{"tr":3,"item":32}],"ef":133},{"id":196,"det":[{"time":1}],"ef":133},{"id":197,"det":[{"time":2}],"ef":133},{"id":470,"det":[{},{"tr":3,"item":47}],"ef":133},{"id":471,"det":[{},{"tr":3,"item":885}],"ef":133},{"id":700,"det":[{}],"ef":133}]}
 {"id":134,"n":"Vaporeon","cr":45,"gr":1,"efrm":[133],"det":[{"tr":3,"item":34}]}
 {"id":135,"n":"Jolteon","cr":45,"gr":1,"efrm":[133],"det":[{"tr":3,"item":33}]}
 {"id":136,"n":"Flareon","cr":45,"gr":1,"efrm":[133],"det":[{"tr":3,"item":32}]}
@@ -208,7 +208,7 @@
 {"id":208,"n":"Steelix","cr":25,"efrm":[95],"det":[{"tr":2,"held":210}]}
 {"id":209,"n":"Snubbull","cr":190,"gr":6,"eto":[{"id":210,"det":[{"ml":23}],"ef":209}]}
 {"id":210,"n":"Granbull","cr":75,"gr":6,"efrm":[209],"det":[{"ml":23}]}
-{"id":211,"n":"Qwilfish","cr":45,"eto":[{"id":904,"det":[{"tr":0},{},{"tr":0}],"ef":211}]}
+{"id":211,"n":"Qwilfish","cr":45,"eto":[{"id":904,"det":[{"tr":0},{}],"ef":211}]}
 {"id":212,"n":"Scizor","cr":25,"efrm":[123],"det":[{"tr":2,"held":210}]}
 {"id":213,"n":"Shuckle","cr":190}
 {"id":214,"n":"Heracross","cr":45}

--- a/fix_dupes3.mjs
+++ b/fix_dupes3.mjs
@@ -1,0 +1,51 @@
+import fs from 'fs';
+const data = fs.readFileSync('data/db/pokemon.jsonl', 'utf-8');
+const lines = data.split('\n').filter(Boolean);
+
+const newLines = lines.map(line => {
+    const obj = JSON.parse(line);
+
+    // Dedup det array
+    if (obj.det) {
+        const seen = new Set();
+        obj.det = obj.det.filter(d => {
+            const str = JSON.stringify(d);
+            if (seen.has(str)) return false;
+            seen.add(str);
+            return true;
+        });
+    }
+
+    if (obj.eto) {
+        obj.eto = obj.eto.map(etoObj => {
+            if (etoObj.det) {
+                const seen = new Set();
+                etoObj.det = etoObj.det.filter(d => {
+                    const str = JSON.stringify(d);
+                    if (seen.has(str)) return false;
+                    seen.add(str);
+                    return true;
+                });
+            }
+            if (etoObj.eto) {
+               etoObj.eto = etoObj.eto.map(etoObj2 => {
+                   if (etoObj2.det) {
+                       const seen = new Set();
+                       etoObj2.det = etoObj2.det.filter(d => {
+                           const str = JSON.stringify(d);
+                           if (seen.has(str)) return false;
+                           seen.add(str);
+                           return true;
+                       });
+                   }
+                   return etoObj2;
+               });
+            }
+            return etoObj;
+        });
+    }
+
+    return JSON.stringify(obj);
+});
+
+fs.writeFileSync('data/db/pokemon.jsonl', newLines.join('\n') + '\n');

--- a/fix_pr.mjs
+++ b/fix_pr.mjs
@@ -1,4 +1,0 @@
-// The user asks about `det: [{}]`.
-// Those empty objects appear because the trigger is `level-up` (default `1`, which gets omitted by the `compact` function in the generator script to save space) and there are no other constraints.
-// For example, Eevee evolves into Sylveon or Leafeon. Leafeon's evolution condition was "level up near a Moss Rock". Since "location" is not captured in `PokeApiEvolutionDetail` in our code, it just looks like a normal `level-up`.
-// We can just reply and explain this!

--- a/fix_pr.mjs
+++ b/fix_pr.mjs
@@ -1,0 +1,4 @@
+// The user asks about `det: [{}]`.
+// Those empty objects appear because the trigger is `level-up` (default `1`, which gets omitted by the `compact` function in the generator script to save space) and there are no other constraints.
+// For example, Eevee evolves into Sylveon or Leafeon. Leafeon's evolution condition was "level up near a Moss Rock". Since "location" is not captured in `PokeApiEvolutionDetail` in our code, it just looks like a normal `level-up`.
+// We can just reply and explain this!


### PR DESCRIPTION
### 🎯 What was wrong
1. **Missing Encounters:** Gen 2 headbutt encounters were missing from the generated offline data (`encounters.jsonl`). This happened because PokeAPI uses variant strings (`headbutt-low`, `headbutt-normal`, `headbutt-high`) for these encounters, but our generation script only expected the base string `headbutt`. As a result, these encounters were silently discarded or mapped to the `unknown` (0) method.
2. **Corrupted Evolutions:** Regenerating the data locally exposed a bug where PokeAPI's `evolution_details` array was being parsed blindly. This resulted in duplicate evolution triggers (e.g., Pikachu having two identical Thunder Stone triggers) and, more critically, leaked newer-generation regional forms (e.g., Hisuian Cyndaquil's evolution level of 17) into our Gen 1/2 offline dataset.

### 📚 Canonical source used
- **PokeAPI (`/api/v2/pokemon/{id}/encounters`)**: Identified the `headbutt-*` variants used for Johto tree encounters.
- **PokeAPI (`/api/v2/evolution-chain/{id}`)**: Verified that newer-generation regional evolutions include a `region: { name: "hisui" }` attribute inside their `evolution_details`, whereas standard Gen 1/2 evolutions have `region: null`.

### 🛡️ Impact on users
- **Fixed:** Users will now correctly see `Headbutt` as a valid encounter method for Pokémon like Pineco and Heracross. 
- **Fixed:** The application's evolution data is now strictly accurate to Gen 1 and 2, preventing confusing UI states where Pokémon (like Cyndaquil) might show incorrect evolution levels (like 14 *and* 17). 
- **Data Integrity:** The generation pipeline is now more robust against newer-generation PokeAPI updates.

---
*PR created automatically by Jules for task [10229533312456626935](https://jules.google.com/task/10229533312456626935) started by @szubster*