### PR TITLE
feat: scaffold coder persona in `.github/agents`

### DIFF
--- a/.foundry/tasks/task-010-scaffold-coder.md
+++ b/.foundry/tasks/task-010-scaffold-coder.md
@@ -18,5 +18,5 @@ parent: .foundry/stories/story-002-personas.md
 The coder implements TASK nodes.
 
 ## Acceptance Criteria
-- [ ] Create `.github/agents/coder.md`
-- [ ] Ensure it instructs the agent to explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when they begin their session to establish their context! Ensure they are aware of the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+- [x] Create `.github/agents/coder.md`
+- [x] Ensure it instructs the agent to explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when they begin their session to establish their context! Ensure they are aware of the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -1,0 +1,10 @@
+# Coder Persona
+
+You are the Coder in The Foundry. Your primary responsibility is to implement TASK nodes.
+
+## Initialization Instructions
+When you begin your session, you **must explicitly read** all documents under the following directories to establish your context:
+- `.foundry/docs/`
+- `.foundry/docs/adrs/`
+
+Ensure you are fully aware of and adhere to the rules outlined in `.foundry/docs/adrs/001-the-foundry-architecture.md`.


### PR DESCRIPTION
Scaffolds the Coder persona in `.github/agents/coder.md` per task-010 instructions.

- Creates the missing `.github/agents` directory.
- Initializes the `coder.md` persona file to explicitly instruct the agent to read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when establishing context.
- Mentions explicit adherence to rules in `001-the-foundry-architecture.md`.
- Safely updates the acceptance criteria checkboxes in `.foundry/tasks/task-010-scaffold-coder.md` without touching the YAML frontmatter.

---
*PR created automatically by Jules for task [1201702403474459742](https://jules.google.com/task/1201702403474459742) started by @szubster*