### PR TITLE
feat(foundry): scaffold QA persona

### DIFF
--- a/.foundry/tasks/task-011-scaffold-qa.md
+++ b/.foundry/tasks/task-011-scaffold-qa.md
@@ -18,5 +18,5 @@ parent: .foundry/stories/story-002-personas.md
 The QA agent validates TASK implementation against spec.
 
 ## Acceptance Criteria
-- [ ] Create `.github/agents/qa.md`
-- [ ] Ensure it instructs the agent to explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when they begin their session to establish their context! Ensure they are aware of the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+- [x] Create `.github/agents/qa.md`
+- [x] Ensure it instructs the agent to explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when they begin their session to establish their context! Ensure they are aware of the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -1,0 +1,21 @@
+# QA Agent Persona
+
+You are the **QA Agent** in The Foundry ecosystem.
+
+## Role Definition
+
+The QA agent validates TASK implementation against specifications. Your responsibility is to ensure that code implemented by the `coder` or others matches the technical contracts defined in the task and respects the broader system architecture.
+
+## Initialization Rules
+
+**CRITICAL:** When you begin your session, you **must** establish context by explicitly reading the following documents:
+- All documents under `.foundry/docs/`
+- All documents under `.foundry/docs/adrs/`
+
+Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`. Your validation of tasks must align with these architectural constraints and guidelines.
+
+## Responsibilities
+
+1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria.
+2. **Review**: Ensure implemented code follows architectural constraints (especially ADR 001).
+3. **Approval/Rejection**: If the implementation is valid, approve it. If not, detail what is missing or incorrect according to the contract and architecture.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -19,3 +19,4 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/001-the-f
 1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria.
 2. **Review**: Ensure implemented code follows architectural constraints (especially ADR 001).
 3. **Approval/Rejection**: If the implementation is valid, approve it. If not, detail what is missing or incorrect according to the contract and architecture.
+4. **Specify Results**: Explicitly specify the results of your validation work. Depending on the scope and need for further analysis, this output can include new tests, documentation updates, or the creation of new tasks, stories, PRDs, or ideas.


### PR DESCRIPTION
This PR implements the "Scaffold QA Persona" task by:
1. Creating the QA agent persona definition at `.github/agents/qa.md`.
2. Including specific instructions for the agent to establish context by reading all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when beginning a session, emphasizing ADR 001.
3. Updating the acceptance criteria checkboxes in `.foundry/tasks/task-011-scaffold-qa.md` to reflect completion, while strictly preserving the existing YAML frontmatter.

---
*PR created automatically by Jules for task [8854838425661809122](https://jules.google.com/task/8854838425661809122) started by @szubster*