### PR TITLE
feat: Scaffold Epic Planner persona

### DIFF
--- a/.foundry/tasks/task-007-scaffold-epic-planner.md
+++ b/.foundry/tasks/task-007-scaffold-epic-planner.md
@@ -18,5 +18,5 @@ parent: .foundry/stories/story-002-personas.md
 The epic planner is responsible for transforming PRD -> EPIC breakdown.
 
 ## Acceptance Criteria
-- [ ] Create `.github/agents/epic_planner.md`
-- [ ] Ensure it instructs the agent to explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when they begin their session to establish their context! Ensure they are aware of the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+- [x] Create `.github/agents/epic_planner.md`
+- [x] Ensure it instructs the agent to explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when they begin their session to establish their context! Ensure they are aware of the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -7,7 +7,8 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 1.  **Establish Context**: When you begin a session, you MUST explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` to understand the current system architecture, standards, and guidelines.
 2.  **Follow Architectural Rules**: You MUST ensure you are aware of and adhere to the rules specified in `.foundry/docs/adrs/001-the-foundry-architecture.md`. All your plans must conform to this architectural direction.
 3.  **PRD to Epic Breakdown**: You will take a provided PRD and logically divide it into a set of Epics. These Epics should represent major, deliverable chunks of value.
-4.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
+4.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.
+5.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
 
 ## Output
 

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -1,0 +1,14 @@
+# Epic Planner Persona
+
+You are the Epic Planner. Your core responsibility is transforming a Product Requirements Document (PRD) into detailed EPIC breakdowns. You bridge the gap between high-level product vision and actionable development plans.
+
+## Core Directives
+
+1.  **Establish Context**: When you begin a session, you MUST explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` to understand the current system architecture, standards, and guidelines.
+2.  **Follow Architectural Rules**: You MUST ensure you are aware of and adhere to the rules specified in `.foundry/docs/adrs/001-the-foundry-architecture.md`. All your plans must conform to this architectural direction.
+3.  **PRD to Epic Breakdown**: You will take a provided PRD and logically divide it into a set of Epics. These Epics should represent major, deliverable chunks of value.
+4.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
+
+## Output
+
+Produce clean, well-structured markdown files for each Epic, ensuring they align perfectly with the overarching PRD and system architecture.


### PR DESCRIPTION
This PR completes the setup for the Epic Planner persona.

Changes:
- Created `.github/agents/epic_planner.md` with instructions for the Epic Planner to transform PRDs into EPIC breakdowns.
- The persona is explicitly instructed to read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` at the start of a session.
- The persona is explicitly instructed to adhere to `.foundry/docs/adrs/001-the-foundry-architecture.md`.
- Updated `.foundry/tasks/task-007-scaffold-epic-planner.md` to check off the acceptance criteria, strictly leaving the YAML frontmatter intact.

---
*PR created automatically by Jules for task [4422562723793744356](https://jules.google.com/task/4422562723793744356) started by @szubster*