### PR TITLE
🧹 [Sweeper: removed dead code from schema.ts]

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -16,15 +16,6 @@ export const DB_CONFIG = {
   },
 } as const;
 
-export const POKE_VERSION = {
-  RED: 1,
-  BLUE: 2,
-  YELLOW: 3,
-  GOLD: 4,
-  SILVER: 5,
-  CRYSTAL: 6,
-} as const;
-
 export const POKE_VERSION_MAP: Record<string, number> = {
   red: 1,
   blue: 2,
@@ -33,10 +24,6 @@ export const POKE_VERSION_MAP: Record<string, number> = {
   silver: 5,
   crystal: 6,
 };
-
-export const REVERSE_VERSION_MAP: Record<number, string> = Object.fromEntries(
-  Object.entries(POKE_VERSION_MAP).map(([k, v]) => [v, k]),
-);
 
 export const ENCOUNTER_METHOD = {
   WALK: 1,
@@ -76,19 +63,6 @@ export const EVO_TRIGGER_MAP: Record<string, number> = {
   trade: 2,
   'use-item': 3,
   shed: 4,
-};
-
-export const ITEM_MAP: Record<number, string> = {
-  81: 'Moon Stone',
-  82: 'Fire Stone',
-  83: 'Thunder Stone',
-  84: 'Water Stone',
-  85: 'Leaf Stone',
-  191: 'Sun Stone',
-  198: "King's Rock",
-  210: 'Metal Coat',
-  211: 'Dragon Scale',
-  212: 'Up-Grade',
 };
 
 export interface CompactEncounterDetail {


### PR DESCRIPTION
🎯 What
Removed fully unused constants (`POKE_VERSION`, `REVERSE_VERSION_MAP`, and `ITEM_MAP`) from `src/db/schema.ts`.

💡 Why
`knip` static analysis identified these constants as dead code, taking up unnecessary space in the core schema definitions. Removing them reduces technical debt and cognitive load without changing any runtime functionality.

✅ Verification
- Used `knip` static analysis to confirm they are unreferenced.
- `pnpm type-check` verified the types.
- `pnpm lint` and `pnpm test` (unit and E2E) passed successfully.

✨ Result
A cleaner `src/db/schema.ts` file, free of unused numeric dictionaries.

---
*PR created automatically by Jules for task [4086467673666246452](https://jules.google.com/task/4086467673666246452) started by @szubster*