### PR TITLE
feat(foundry): dynamic agent context injection

### DIFF
--- a/.foundry/tasks/task-005-modify-action-runner.md
+++ b/.foundry/tasks/task-005-modify-action-runner.md
@@ -18,6 +18,6 @@ parent: .foundry/stories/story-002-personas.md
 We need to modify the GitHub action runner to inject the agent configuration depending on the persona.
 
 ## Acceptance Criteria
-- [ ] Update `.github/workflows/foundry-engine.yml`'s "Invoke Jules Agent" step.
-- [ ] It should dynamically read the `.github/agents/${owner_persona}.md` file according to the node's `owner_persona`.
-- [ ] If the file exists, inject its context into the JSON prompt sent to Jules. If not, fallback to a default prompt.
+- [x] Update `.github/workflows/foundry-engine.yml`'s "Invoke Jules Agent" step.
+- [x] It should dynamically read the `.github/agents/${owner_persona}.md` file according to the node's `owner_persona`.
+- [x] If the file exists, inject its context into the JSON prompt sent to Jules. If not, fallback to a default prompt.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -1,0 +1,1 @@
+You are a tech lead.

--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -101,15 +101,25 @@ jobs:
           # 1. Capture task content for the prompt
           task_content=$(cat "${{ matrix.node.repo_path }}")
           
+          owner_persona="${{ matrix.node.owner_persona }}"
+          agent_file=".github/agents/${owner_persona}.md"
+
+          if [[ -n "$owner_persona" && -f "$agent_file" ]]; then
+            agent_context=$(cat "$agent_file")
+          else
+            agent_context="As the coder of The Foundry, your task is described in the provided node file. Follow the schema rules and implementation guidelines."
+          fi
+
           # 2. Construct the prompt JSON
           # source: sources/github/<owner>/<repo>
           prompt_json=$(jq -n \
             --arg task "$task_content" \
+            --arg agent_context "$agent_context" \
             --arg title "${{ matrix.node.title }}" \
             --arg repo "${{ github.repository }}" \
             --arg schema_url "https://github.com/${{ github.repository }}/blob/main/.foundry/docs/schema.md" \
             '{
-              "prompt": "As the coder of The Foundry, your task is described in the provided node file. Follow the schema rules and implementation guidelines.\n\n### CRITICAL RULE\nDO NOT modify the YAML frontmatter of the task node. Only update the markdown body (e.g., acceptance criteria checkboxes).\n\n### TASK NODE\n\($task)\n\n### SCHEMA\n\($schema_url)",
+              "prompt": "\($agent_context)\n\n### CRITICAL RULE\nDO NOT modify the YAML frontmatter of the task node. Only update the markdown body (e.g., acceptance criteria checkboxes).\n\n### TASK NODE\n\($task)\n\n### SCHEMA\n\($schema_url)",
               "sourceContext": {
                 "source": "sources/github/\($repo)",
                 "githubRepoContext": {


### PR DESCRIPTION
Updates `.github/workflows/foundry-engine.yml`'s "Invoke Jules Agent" step to dynamically read `.github/agents/${owner_persona}.md` and inject its context into the JSON prompt.

Acceptance Criteria:
- [x] Update `.github/workflows/foundry-engine.yml`'s "Invoke Jules Agent" step.
- [x] It should dynamically read the `.github/agents/${owner_persona}.md` file according to the node's `owner_persona`.
- [x] If the file exists, inject its context into the JSON prompt sent to Jules. If not, fallback to a default prompt.

---
*PR created automatically by Jules for task [4277112534067136284](https://jules.google.com/task/4277112534067136284) started by @szubster*