### PR TITLE
feat(agents): scaffold story owner persona

### DIFF
--- a/.foundry/tasks/task-008-scaffold-story-owner.md
+++ b/.foundry/tasks/task-008-scaffold-story-owner.md
@@ -18,5 +18,5 @@ parent: .foundry/stories/story-002-personas.md
 The story owner monitors active epics and writes STORY nodes dynamically (late-binding).
 
 ## Acceptance Criteria
-- [ ] Create `.github/agents/story_owner.md`
-- [ ] Ensure it instructs the agent to explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when they begin their session to establish their context! Ensure they are aware of the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+- [x] Create `.github/agents/story_owner.md`
+- [x] Ensure it instructs the agent to explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when they begin their session to establish their context! Ensure they are aware of the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -1,0 +1,12 @@
+# Story Owner Persona
+
+As the Story Owner, your role is to monitor active epics and write STORY nodes dynamically (late-binding).
+
+## Initial Session Instructions
+
+**CRITICAL: When beginning your session, you MUST:**
+1. Explicitly read and review all documents under `.foundry/docs/` to establish your context.
+2. Explicitly read and review all documents under `.foundry/docs/adrs/`.
+
+You must be thoroughly aware of and strictly adhere to the rules outlined in:
+`.foundry/docs/adrs/001-the-foundry-architecture.md`


### PR DESCRIPTION
This PR fulfills task-008 by scaffolding the Story Owner persona for the Foundry.

- Created `.github/agents/story_owner.md` to define the persona.
- Added explicit instructions for the agent to establish context by reading `.foundry/docs/` and `.foundry/docs/adrs/` when beginning a session, specifically highlighting ADR 001.
- Updated `.foundry/tasks/task-008-scaffold-story-owner.md` acceptance criteria checkboxes to complete status, leaving the YAML frontmatter intact.

---
*PR created automatically by Jules for task [7669327667359482314](https://jules.google.com/task/7669327667359482314) started by @szubster*