### PR TITLE
infra: fix foundry session marking with robust regex and upsert logic

### DIFF
--- a/.foundry/docs/knowledge_base/foundry/engine/architecture.md
+++ b/.foundry/docs/knowledge_base/foundry/engine/architecture.md
@@ -24,5 +24,5 @@ The Foundry Engine automates the lifecycle of Foundry nodes (Ideas, Epics, Stori
 ## Best Practices
 
 *   **Idempotency**: The orchestrator is designed to be re-run safely. Any node already in `READY` status is included in the output matrix.
-*   **Audit Trail**: The `jules_session_id` is populated with the GitHub `run_id`, providing a direct link between the node state and the CI execution logs.
+*   **Audit Trail**: The `jules_session_id` is populated with the ID returned by the Jules API, providing a direct link between the node state and the automated agent session. The GitHub `run_id` is typically included in the commit message to provide secondary linkage to CI logs.
 *   **Security**: Workflow is restricted to the `main` branch.

--- a/.foundry/docs/knowledge_base/foundry/engine/architecture.md
+++ b/.foundry/docs/knowledge_base/foundry/engine/architecture.md
@@ -13,7 +13,8 @@ The Foundry Engine automates the lifecycle of Foundry nodes (Ideas, Epics, Stori
 
 2.  **State Transition Script (`.github/scripts/foundry-active.ts`)**:
     *   Transitions a node from `READY` to `ACTIVE`.
-    *   **Strict "Dumb" Diff Verification**: Before saving, it performs a character-by-character comparison (via `gray-matter` parsing) to ensure ONLY the `status`, `jules_session_id`, and `updated_at` fields were modified. This prevents accidental metadata corruption by autonomous processes.
+    *   **Strict "Dumb" Diff Verification**: Before saving, it performs a character-by-character comparison (via `gray-matter` parsing) to ensure ONLY the `status`, `jules_session_id`, and `updated_at` fields were modified.
+    *   **Robust Metadata Handling**: The script uses regex patterns that handle optional quotes (e.g., `status: "READY"`) and implements an `upsertField` logic to gracefully handle missing fields by appending them to the frontmatter. This prevents transition failures due to minor formatting differences and accidental metadata corruption by autonomous processes.
 
 3.  **Foundry Engine Workflow (`.github/workflows/foundry-engine.yml`)**:
     *   **Orchestrate Job**: Runs the orchestrator and sets an output for the matrix.

--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -186,11 +186,11 @@ Copy-paste this block to start any new node. Fill in all required fields before 
 
 ```yaml
 ---
-id: "<type>-<NNN>-<slug>"
-type: ""
+id: <type>-<NNN>-<slug>
+type: 
 title: ""
 status: PENDING
-owner_persona: ""
+owner_persona: 
 created_at: "YYYY-MM-DD"
 updated_at: "YYYY-MM-DD"
 depends_on: []

--- a/.foundry/ideas/idea-003-atomic-handoff-foundation.md
+++ b/.foundry/ideas/idea-003-atomic-handoff-foundation.md
@@ -1,13 +1,13 @@
 ---
-id: "idea-003-atomic-handoff-foundation"
-type: "IDEA"
+id: idea-003-atomic-handoff-foundation
+type: IDEA
 title: "Foundry V2: Atomic Handoffs & Single-Persona Ownership"
-status: "READY"
-owner_persona: "product_manager"
+status: ACTIVE
+owner_persona: product_manager
 created_at: "2026-04-21"
 updated_at: "2026-04-21"
 depends_on: []
-jules_session_id: null
+jules_session_id: "24741413813"
 ---
 
 # Foundry V2: Atomic Handoffs & Single-Persona Ownership

--- a/.foundry/ideas/idea-003-atomic-handoff-foundation.md
+++ b/.foundry/ideas/idea-003-atomic-handoff-foundation.md
@@ -7,7 +7,7 @@ owner_persona: product_manager
 created_at: "2026-04-21"
 updated_at: "2026-04-21"
 depends_on: []
-jules_session_id: "24741413813"
+jules_session_id: "14078626391991235454"
 ---
 
 # Foundry V2: Atomic Handoffs & Single-Persona Ownership

--- a/.github/scripts/foundry-active.test.ts
+++ b/.github/scripts/foundry-active.test.ts
@@ -44,10 +44,25 @@ pr_number: null
     transitionNodeToActive(relPath, 'sessions/123456', tmpDir);
 
     const result = fs.readFileSync(path.join(tmpDir, relPath), 'utf-8');
-    expect(result).toContain('status: ACTIVE');
+    expect(result).toContain('status: "ACTIVE"');
     expect(result).toContain('jules_session_id: "sessions/123456"');
     expect(result).not.toContain('status: READY');
     expect(result).toContain('# Body content');
+  });
+
+  test('Quoted Values: handles READY in quotes correctly', () => {
+    const relPath = createNode('.foundry/tasks/task-quoted.md', `---
+id: task-quoted
+status: "READY"
+jules_session_id: null
+updated_at: "2026-04-20"
+---`);
+
+    transitionNodeToActive(relPath, 'run-quoted', tmpDir);
+
+    const result = fs.readFileSync(path.join(tmpDir, relPath), 'utf-8');
+    expect(result).toContain('status: "ACTIVE"');
+    expect(result).toContain('jules_session_id: "run-quoted"');
   });
 
   test('Validation: fails if node is not READY', () => {

--- a/.github/scripts/foundry-active.ts
+++ b/.github/scripts/foundry-active.ts
@@ -42,13 +42,13 @@ export function transitionNodeToActive(repoPath: string, sessionId: string, repo
   const original = matter(rawContent);
 
   // 1. Pre-validation
-  if (original.data.status !== 'READY') {
-    throw new Error(`Node is not in READY status (current: ${original.data.status}): ${repoPath}`);
+  if (original.data['status'] !== 'READY') {
+    throw new Error(`Node is not in READY status (current: ${original.data['status']}): ${repoPath}`);
   }
 
   const dateStr = todayISO();
-  
-  // 2. Perform surgical mutation via regex to preserve formatting/order
+
+  // 2. Perform surgical mutation to preserve formatting/order
   const fmBlockMatch = rawContent.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*/m);
   if (!fmBlockMatch) {
     throw new Error(`Cannot locate frontmatter delimiters in: ${repoPath}`);
@@ -57,22 +57,36 @@ export function transitionNodeToActive(repoPath: string, sessionId: string, repo
   const originalFmBlock = fmBlockMatch[0];
   let mutatedFmBlock = originalFmBlock;
 
-  // status: READY -> ACTIVE
-  mutatedFmBlock = mutatedFmBlock.replace(
-    /^(status:\s*)READY([ \t]*)$/m,
-    `$1ACTIVE$2`,
+  const upsertField = (fm: string, key: string, value: string, pattern: RegExp): string => {
+    if (pattern.test(fm)) {
+      return fm.replace(pattern, `$1"${value}"$2`);
+    }
+    // Append before the closing ---
+    return fm.replace(/\r?\n---[ \t]*$/, `\n${key}: "${value}"\n---`);
+  };
+
+  // status: READY -> ACTIVE (handles optional quotes and missing field)
+  mutatedFmBlock = upsertField(
+    mutatedFmBlock,
+    'status',
+    'ACTIVE',
+    /^(status:\s*)["']?(?:READY|PENDING|ACTIVE)["']?([ \t]*)$/m
   );
 
-  // jules_session_id: null -> sessionId
-  mutatedFmBlock = mutatedFmBlock.replace(
-    /^(jules_session_id:\s*)(null|["']?.*?["']?)([ \t]*)$/m,
-    `$1"${sessionId}"$3`,
+  // jules_session_id: null -> sessionId (handles optional quotes and missing field)
+  mutatedFmBlock = upsertField(
+    mutatedFmBlock,
+    'jules_session_id',
+    sessionId,
+    /^(jules_session_id:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m
   );
 
-  // updated_at: YYYY-MM-DD -> today
-  mutatedFmBlock = mutatedFmBlock.replace(
-    /^(updated_at:\s*)["']?\d{4}-\d{2}-\d{2}["']?([ \t]*)$/m,
-    `$1"${dateStr}"$2`,
+  // updated_at: YYYY-MM-DD -> today (handles optional quotes and missing field)
+  mutatedFmBlock = upsertField(
+    mutatedFmBlock,
+    'updated_at',
+    dateStr,
+    /^(updated_at:\s*)["']?\d{4}-\d{2}-\d{2}["']?([ \t]*)$/m
   );
 
   const newContent = rawContent.replace(originalFmBlock, mutatedFmBlock);
@@ -85,10 +99,10 @@ export function transitionNodeToActive(repoPath: string, sessionId: string, repo
   const violations: string[] = [];
   for (const key of allKeys) {
     if (allowedChanges.includes(key)) {
-      if (key === 'status' && mutated.data.status !== 'ACTIVE') {
+      if (key === 'status' && mutated.data['status'] !== 'ACTIVE') {
         violations.push(`Failed to update status to ACTIVE in: ${repoPath}`);
       }
-      if (key === 'jules_session_id' && String(mutated.data.jules_session_id) !== sessionId) {
+      if (key === 'jules_session_id' && String(mutated.data['jules_session_id']) !== sessionId) {
         violations.push(`Failed to update jules_session_id to ${sessionId} in: ${repoPath}`);
       }
       continue;

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -16,7 +16,7 @@ describe('Foundry Heartbeat', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env = { ...originalEnv, JULES_API_KEY: 'mock-api-key' };
+    process.env = { ...originalEnv, JULES_API_KEY: 'mock-api-key', GITHUB_TOKEN: 'mock-token' };
     vi.spyOn(process, 'cwd').mockReturnValue(mockRepoRoot);
 
     // Default: fs.existsSync returns true for .foundry
@@ -64,7 +64,7 @@ describe('Foundry Heartbeat', () => {
     expect(fs.writeFileSync).toHaveBeenCalled();
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
     expect(writeCall[0]).toBe(mockNode.filePath);
-    expect(writeCall[1]).toContain('status: FAILED');
+    expect(writeCall[1]).toContain('status: "FAILED"');
     expect(writeCall[1]).toContain('jules_session_id: null');
 
     expect(fs.appendFileSync).toHaveBeenCalled();

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -41,8 +41,8 @@ export async function transitionNodeToFailed(node: any, repoRoot: string): Promi
   const originalFmBlock = fmBlockMatch[0];
   let mutatedFmBlock = originalFmBlock;
 
-  mutatedFmBlock = mutatedFmBlock.replace(/^(status:\s*)ACTIVE([ \t]*)$/m, `$1FAILED$2`);
-  mutatedFmBlock = mutatedFmBlock.replace(/^(jules_session_id:\s*)(["']?.*?["']?)([ \t]*)$/m, `$1null$3`);
+  mutatedFmBlock = mutatedFmBlock.replace(/^(status:\s*)["']?ACTIVE["']?([ \t]*)$/m, `$1"FAILED"$2`);
+  mutatedFmBlock = mutatedFmBlock.replace(/^(jules_session_id:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m, `$1null$2`);
   mutatedFmBlock = mutatedFmBlock.replace(/^(updated_at:\s*)["']?\d{4}-\d{2}-\d{2}["']?([ \t]*)$/m, `$1"${dateStr}"$2`);
 
   const newContent = node.rawContent.replace(originalFmBlock, mutatedFmBlock);
@@ -65,8 +65,8 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
   const originalFmBlock = fmBlockMatch[0];
   let mutatedFmBlock = originalFmBlock;
 
-  mutatedFmBlock = mutatedFmBlock.replace(/^(status:\s*)ACTIVE([ \t]*)$/m, `$1COMPLETED$2`);
-  mutatedFmBlock = mutatedFmBlock.replace(/^(jules_session_id:\s*)(["']?.*?["']?)([ \t]*)$/m, `$1null$3`);
+  mutatedFmBlock = mutatedFmBlock.replace(/^(status:\s*)["']?ACTIVE["']?([ \t]*)$/m, `$1"COMPLETED"$2`);
+  mutatedFmBlock = mutatedFmBlock.replace(/^(jules_session_id:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m, `$1null$2`);
   mutatedFmBlock = mutatedFmBlock.replace(/^(updated_at:\s*)["']?\d{4}-\d{2}-\d{2}["']?([ \t]*)$/m, `$1"${dateStr}"$2`);
 
   const newContent = node.rawContent.replace(originalFmBlock, mutatedFmBlock);
@@ -89,11 +89,11 @@ export async function transitionNodeToReady(node: any, repoRoot: string, reason:
   const originalFmBlock = fmBlockMatch[0];
   let mutatedFmBlock = originalFmBlock;
 
-  mutatedFmBlock = mutatedFmBlock.replace(/^(status:\s*)(FAILED|ACTIVE)([ \it]*)$/m, `$1READY$3`);
-  mutatedFmBlock = mutatedFmBlock.replace(/^(jules_session_id:\s*)(["']?.*?["']?)([ \t]*)$/m, `$1null$3`);
+  mutatedFmBlock = mutatedFmBlock.replace(/^(status:\s*)["']?(?:FAILED|ACTIVE)["']?([ \t]*)$/m, `$1"READY"$2`);
+  mutatedFmBlock = mutatedFmBlock.replace(/^(jules_session_id:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m, `$1null$2`);
 
   if (/^rejection_count:/m.test(mutatedFmBlock)) {
-    mutatedFmBlock = mutatedFmBlock.replace(/^rejection_count:\s*(\d+)/m, (_, count) => `rejection_count: ${parseInt(count, 10) + 1}`);
+    mutatedFmBlock = mutatedFmBlock.replace(/^rejection_count:\s*(\d+)/m, (_: string, count: string) => `rejection_count: ${parseInt(count, 10) + 1}`);
   } else {
     mutatedFmBlock = mutatedFmBlock.replace(/^status: READY/m, `status: READY\nrejection_count: 1`);
   }


### PR DESCRIPTION
## Problem
Foundry nodes with quoted values in frontmatter (e.g., `status: "READY"`) failed to transition to `ACTIVE` because the regex in `foundry-active.ts` was too strict. This caused CI jobs to fail without marking the session in the repository, leading to lost context and "zombie" sessions.

## Solution
1. **Robust Regex**: Updated `foundry-active.ts` and `foundry-heartbeat.ts` regex patterns to handle optional single/double quotes and varied whitespace.
2. **Upsert Logic**: Implemented an `upsertField` helper in `foundry-active.ts` that gracefully handles missing fields by appending them if they don't exist.
3. **Infrastructure Fixes**: Fixed `foundry-heartbeat.test.ts` which was missing `GITHUB_TOKEN` in its mock environment, causing pre-existing test failures.
4. **Improved Validation**: Maintained the "Strict Dumb Check" but made it compatible with quoted YAML values.

## Verification
- Added a new test case `Quoted Values: handles READY in quotes correctly` to `foundry-active.test.ts`.
- Verified that all infrastructure tests (`foundry-active`, `foundry-heartbeat`, `foundry-orchestrator`) pass.
- Manually verified the fix with a reproduction script.
