### PR TITLE
Idea 006: Gen 2 Support Expansion

### DIFF
--- a/.foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+++ b/.foundry/docs/knowledge_base/development/gen2_implementation_plan.md
@@ -1,5 +1,9 @@
 # Gen 2 Complete Implementation Plan
 
+> [!NOTE]
+> This implementation plan has been converted to a **Foundry Idea** for autonomous execution.
+> Track progress here: [.foundry/ideas/idea-006-gen2-expansion.md](file:///home/tszuba/projects/dexhelper/.foundry/ideas/idea-006-gen2-expansion.md)
+
 ## Overview
 While the current app has basic support for parsing Gen 2 (Gold/Silver/Crystal) save files, it lacks the generation-specific logic for map traversal, assistance suggestions, mechanics, and accurate data handling. This document details the missing features and provides a phase-by-phase implementation plan.
 

--- a/.foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+++ b/.foundry/docs/knowledge_base/development/gen2_implementation_plan.md
@@ -2,7 +2,7 @@
 
 > [!NOTE]
 > This implementation plan has been converted to a **Foundry Idea** for autonomous execution.
-> Track progress here: [.foundry/ideas/idea-006-gen2-expansion.md](file:///home/tszuba/projects/dexhelper/.foundry/ideas/idea-006-gen2-expansion.md)
+> Track progress here: [.foundry/ideas/idea-006-gen2-expansion.md](.foundry/ideas/idea-006-gen2-expansion.md)
 
 ## Overview
 While the current app has basic support for parsing Gen 2 (Gold/Silver/Crystal) save files, it lacks the generation-specific logic for map traversal, assistance suggestions, mechanics, and accurate data handling. This document details the missing features and provides a phase-by-phase implementation plan.

--- a/.foundry/docs/knowledge_base/foundry/ideas/gen2-expansion.md
+++ b/.foundry/docs/knowledge_base/foundry/ideas/gen2-expansion.md
@@ -10,5 +10,5 @@ Formalizes the Gen 2 support expansion into the Foundry autonomous workflow.
   3. Johto/Kanto Map Graph.
   4. Strategy & Suggestion Engine.
 
-Linked Implementation Plan: [.foundry/docs/knowledge_base/development/gen2_implementation_plan.md](file:///home/tszuba/projects/dexhelper/.foundry/docs/knowledge_base/development/gen2_implementation_plan.md)
-Foundry Idea: [.foundry/ideas/idea-006-gen2-expansion.md](file:///home/tszuba/projects/dexhelper/.foundry/ideas/idea-006-gen2-expansion.md)
+Linked Implementation Plan: [.foundry/docs/knowledge_base/development/gen2_implementation_plan.md](.foundry/docs/knowledge_base/development/gen2_implementation_plan.md)
+Foundry Idea: [.foundry/ideas/idea-006-gen2-expansion.md](.foundry/ideas/idea-006-gen2-expansion.md)

--- a/.foundry/docs/knowledge_base/foundry/ideas/gen2-expansion.md
+++ b/.foundry/docs/knowledge_base/foundry/ideas/gen2-expansion.md
@@ -1,0 +1,14 @@
+# Idea 006: Gen 2 Support Expansion
+
+Formalizes the Gen 2 support expansion into the Foundry autonomous workflow.
+
+- **Status**: ACTIVE (as of PR #362)
+- **Goal**: Full fidelity for Johto/Kanto lifecycle features.
+- **Phases**:
+  1. Save Parser Expansion.
+  2. Exclusives & Static Data.
+  3. Johto/Kanto Map Graph.
+  4. Strategy & Suggestion Engine.
+
+Linked Implementation Plan: [.foundry/docs/knowledge_base/development/gen2_implementation_plan.md](file:///home/tszuba/projects/dexhelper/.foundry/docs/knowledge_base/development/gen2_implementation_plan.md)
+Foundry Idea: [.foundry/ideas/idea-006-gen2-expansion.md](file:///home/tszuba/projects/dexhelper/.foundry/ideas/idea-006-gen2-expansion.md)

--- a/.foundry/ideas/idea-006-gen2-expansion.md
+++ b/.foundry/ideas/idea-006-gen2-expansion.md
@@ -1,0 +1,48 @@
+---
+id: idea-006-gen2-expansion
+type: IDEA
+title: "Gen 2 Support Expansion: Johto/Kanto Lifecycle"
+status: ACTIVE
+owner_persona: product_manager
+created_at: "2026-04-21"
+updated_at: "2026-04-21"
+depends_on:
+  - .foundry/ideas/idea-001-the-foundry.md
+  - .foundry/ideas/idea-003-atomic-handoff-foundation.md
+---
+
+# Gen 2 Support Expansion: Johto/Kanto Lifecycle
+
+## Problem Statement
+
+While the current application has basic support for parsing Gen 2 (Gold/Silver/Crystal) save files, it lacks the generation-specific logic for map traversal, assistance suggestions, mechanics (breeding, held items, RTC), and accurate cross-region routing between Johto and Kanto. This gaps prevents the Assistant from providing the same level of fidelity for Gen 2 as it does for Gen 1.
+
+## Proposed Strategy
+
+Convert the existing [Gen 2 Implementation Plan](file:///home/tszuba/projects/dexhelper/.foundry/docs/knowledge_base/development/gen2_implementation_plan.md) into a Foundry-orchestrated workflow. The strategy is broken down into four core phases:
+
+### 1. Save Parser Expansion (Engine Data Layer)
+Expand `src/engine/saveParser/parsers/gen2.ts` to include missing Gen 2 structs:
+- **Detailed Inventory**: Extract Key Items, special Rods, TMs/HMs (Headbutt, Rock Smash), Apricorns, and Evolution Items.
+- **Roamer Tracking**: Extract the map locations of roaming legendaries (Raikou, Entei, Suicune) from RAM.
+- **Progress Metadata**: Extract Hall of Fame counts and regional badge progression.
+
+### 2. Exclusives & Static Data Setup
+Establish the static knowledge base for Gen 2:
+- **Version Exclusives**: Define availability differences across Gold, Silver, and Crystal.
+- **Assistant Data**: Catalog static gift data (Togepi Egg, Eevee from Bill, Shuckle in Cianwood, Dratini, Tyrogue) and NPC trade data.
+
+### 3. Johto/Kanto Map Graph Routing
+Develop a unified routing engine for the dual-region layout:
+- **Map Graph**: Create a comprehensive graph for Johto and Kanto.
+- **Cross-Region Distance**: Implement algorithms for transition points like Magnet Train, S.S. Aqua, and Route 27.
+
+### 4. Strategy & Suggestion Engine Adaptations
+Inject Gen 2 logic into the Assistant's core:
+- **Time-Based Suggestions**: Filter encounters based on Morning/Day/Night cycles.
+- **Breeding Suggestions**: Detect compatible parents and suggest breeding for missing baby Pokémon.
+- **Interaction Logic**: Handle Headbutt/Rock Smash encounters and stat-based evolutions (Tyrogue).
+
+## Next Steps
+- [ ] **Product Manager**: Draft the Gen 2 Expansion PRD, formalizing the scope for Phase 1 and 2.
+- [ ] **Architect**: Review the Map Graph design to ensure it scales for dual-region routing.

--- a/.foundry/ideas/idea-006-gen2-expansion.md
+++ b/.foundry/ideas/idea-006-gen2-expansion.md
@@ -19,7 +19,7 @@ While the current application has basic support for parsing Gen 2 (Gold/Silver/C
 
 ## Proposed Strategy
 
-Convert the existing [Gen 2 Implementation Plan](file:///home/tszuba/projects/dexhelper/.foundry/docs/knowledge_base/development/gen2_implementation_plan.md) into a Foundry-orchestrated workflow. The strategy is broken down into four core phases:
+Convert the existing [Gen 2 Implementation Plan](.foundry/docs/knowledge_base/development/gen2_implementation_plan.md) into a Foundry-orchestrated workflow. The strategy is broken down into four core phases:
 
 ### 1. Save Parser Expansion (Engine Data Layer)
 Expand `src/engine/saveParser/parsers/gen2.ts` to include missing Gen 2 structs:


### PR DESCRIPTION
## Summary
This PR formalizes the **Gen 2 Support Expansion** by converting the existing `gen2_implementation_plan.md` into a Foundry `IDEA` node.

## Changes
- **Idea 006**: Created `.foundry/ideas/idea-006-gen2-expansion.md` to track the 4-phase implementation of Johto/Kanto lifecycle features.
- **Documentation**: Updated `.foundry/docs/knowledge_base/development/gen2_implementation_plan.md` to link back to the new idea.

## Impact
Once merged, the Foundry orchestrator will be able to pick up this idea and sequence the creation of PRDs and tasks for Gen 2 features, ensuring systematic progress towards full Gen 2 fidelity.

## Dependencies
- Depends on Idea 001 (Foundry Foundation)
- Depends on Idea 003 (Atomic Handoffs) for the V2 lifecycle logic.