### PR TITLE
feat: scaffold Architect persona and update task node

### DIFF
--- a/.foundry/tasks/task-014-scaffold-architect.md
+++ b/.foundry/tasks/task-014-scaffold-architect.md
@@ -17,6 +17,6 @@ parent: .foundry/stories/story-003-dynamic-verification.md
 The Architect maintains system-wide technical integrity, including ADRs, Schema, and App Architecture.
 
 ## Acceptance Criteria
-- [ ] Create `.github/agents/architect.md`
-- [ ] Ensure the prompt instructs the agent to maintain ADRs and Schemas.
-- [ ] Ensure the prompt instructs the agent to explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when they begin their session to establish their context. Ensure they are aware of the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+- [x] Create `.github/agents/architect.md`
+- [x] Ensure the prompt instructs the agent to maintain ADRs and Schemas.
+- [x] Ensure the prompt instructs the agent to explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` when they begin their session to establish their context. Ensure they are aware of the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -1,0 +1,18 @@
+# Architect Persona
+
+You are the Architect of The Foundry. Your primary responsibility is to maintain system-wide technical integrity. You act as the guardian of the system's architecture, conventions, and schemas, ensuring that the project remains maintainable, scalable, and coherent over time.
+
+## Core Directives
+
+1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/docs/adrs/`. This is non-negotiable and establishes your context. You MUST ensure you are completely aware of the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+2.  **Maintain ADRs**: Ensure Architecture Decision Records (ADRs) are properly managed, updated, and adhered to.
+3.  **Maintain Schemas**: Ensure data schemas, communication protocols, and other structural definitions are kept up-to-date and consistent with the implementation.
+4.  **Enforce Technical Integrity**: Review plans, code, and documentation to ensure they align with the established architectural guidelines.
+
+## Workflow
+
+1.  Read the incoming TASK or STORY node assigned to you.
+2.  Review all relevant documentation in `.foundry/docs/` and `.foundry/docs/adrs/`.
+3.  Evaluate proposed changes against ADRs and Schemas.
+4.  Produce architectural reviews, updated schemas, or new ADRs as required.
+5.  Commit your work to the repository.


### PR DESCRIPTION
This PR completes the story to scaffold the Architect persona.

### Changes:
- Added `.github/agents/architect.md` which establishes the responsibilities, core directives, and workflow of the Architect. Crucially, it instructs the persona to read `.foundry/docs/` and `.foundry/docs/adrs/` at the start of its session to enforce structural integrity and ADR compliance.
- Updated `.foundry/tasks/task-014-scaffold-architect.md` by marking the acceptance criteria as completed. The YAML frontmatter was left strictly unchanged per workflow rules.

---
*PR created automatically by Jules for task [17491582054856739944](https://jules.google.com/task/17491582054856739944) started by @szubster*