### PR TITLE
Epic Planner: Agent Scheduling Breakdown

### DIFF
--- a/.foundry/epics/epic-004-generic-agent-scheduling.md
+++ b/.foundry/epics/epic-004-generic-agent-scheduling.md
@@ -1,0 +1,33 @@
+---
+id: "epic-004-generic-agent-scheduling"
+type: "EPIC"
+title: "Generic Agent Scheduling"
+status: "PENDING"
+owner_persona: "story_owner"
+created_at: "2026-04-21"
+updated_at: "2026-04-21"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/prds/prd-001-agent-scheduling.md"
+tags: ["infrastructure"]
+rejection_count: 0
+notes: ""
+---
+
+# Generic Agent Scheduling
+
+## Objective
+Implement a generic, robust mechanism for scheduling autonomous agents within the Foundry architecture.
+
+## Details
+This epic covers the creation of a generic GitHub Actions workflow or a cron-based solution that can be used to trigger scheduled agents.
+The implementation must handle empty results gracefully without failing or spamming logs (e.g., when an agent's query returns no actionable work).
+The scheduling mechanism should be configurable to easily accommodate adding new scheduled agents, and it must support standard cron expressions.
+Scheduled agents should execute using standard Jules prompt hydration logic.
+
+## Prerequisites
+- None.
+
+## Acceptance Criteria
+- [ ] A generic scheduling implementation is defined and documented.
+- [ ] Tests confirm that the scheduled run exits successfully when there is no work to do.

--- a/.foundry/epics/epic-005-tpm-agent-scheduling.md
+++ b/.foundry/epics/epic-005-tpm-agent-scheduling.md
@@ -1,0 +1,34 @@
+---
+id: "epic-005-tpm-agent-scheduling"
+type: "EPIC"
+title: "TPM Agent Scheduling"
+status: "PENDING"
+owner_persona: "story_owner"
+created_at: "2026-04-21"
+updated_at: "2026-04-21"
+depends_on:
+  - ".foundry/epics/epic-004-generic-agent-scheduling.md"
+jules_session_id: null
+parent: ".foundry/prds/prd-001-agent-scheduling.md"
+tags: ["infrastructure"]
+rejection_count: 0
+notes: ""
+---
+
+# TPM Agent Scheduling
+
+## Objective
+Implement scheduling for the Technical Program Manager (TPM) persona.
+
+## Details
+This epic covers the integration of the TPM agent (`.github/agents/tpm.md`) with the new generic scheduling mechanism.
+The TPM agent must be configured to run on an hourly schedule. It should be capable of scanning the `.foundry/` monofolder for `COMPLETED` nodes.
+When found, the TPM agent will move them to an archive structure or clean them up according to established TPM rules.
+This will serve as the first implementation of the scheduled agents system.
+
+## Prerequisites
+- Generic scheduling mechanism (Epic `epic-004-generic-agent-scheduling`) must be implemented.
+
+## Acceptance Criteria
+- [ ] The TPM agent is scheduled to run hourly.
+- [ ] The TPM agent successfully archives at least one test `COMPLETED` node when present.

--- a/.foundry/prds/prd-001-agent-scheduling.md
+++ b/.foundry/prds/prd-001-agent-scheduling.md
@@ -48,6 +48,9 @@ Currently, the Foundry orchestrates tasks dynamically based on dependencies (DAG
 - The TPM must be able to scan the `.foundry/` monofolder for `COMPLETED` nodes.
 - If found, it should move them to an archive structure or clean them up according to TPM rules.
 
+## Implementation Progress
+- [x] Transformed into EPIC breakdowns (`epic-004-generic-agent-scheduling.md`, `epic-005-tpm-agent-scheduling.md`).
+
 ## 5. Acceptance Criteria
 - [ ] A generic scheduling implementation is defined and documented.
 - [ ] The TPM agent is scheduled to run hourly.


### PR DESCRIPTION
This submission implements the Epic Planner persona's task for the "Agent Scheduling" PRD. It:
1. Creates `epic-004-generic-agent-scheduling.md` to define the overarching scheduling mechanism requirements.
2. Creates `epic-005-tpm-agent-scheduling.md` to define the specific TPM implementation requirements, ensuring it maps a dependency onto `epic-004`.
3. Ensures both Epics contain the required formatting, including Prerequisites and Acceptance Criteria properly distributed from the PRD.
4. Updates `prd-001-agent-scheduling.md` to include an "Implementation Progress" checkbox for the new epics, without modifying the existing YAML frontmatter.

---
*PR created automatically by Jules for task [469811331638361368](https://jules.google.com/task/469811331638361368) started by @szubster*