### PR TITLE
Migrate memory instructions to Foundry agent prompts

### DIFF
--- a/.foundry/tasks/task-006-migrate-memory-system.md
+++ b/.foundry/tasks/task-006-migrate-memory-system.md
@@ -19,6 +19,6 @@ parent: .foundry/stories/story-002-personas.md
 The standalone Jules instances do not have MCP access to Serena memories. We need to make these memories available via the file system for them to work effectively.
 
 ## Acceptance Criteria
-- [ ] NOTE: The migrate memory task might be already done. Check if this is obsolete.
-- [ ] We must migrate all content inside `.serena/memories/` into `.foundry/docs/` (e.g., as `.foundry/docs/knowledge_base/`).
-- [ ] The persona prompts must instruct Jules to automatically index and read relevant knowledge from this migrated directory whenever they are assigned a task.
+- [x] NOTE: The migrate memory task might be already done. Check if this is obsolete.
+- [x] We must migrate all content inside `.serena/memories/` into `.foundry/docs/` (e.g., as `.foundry/docs/knowledge_base/`).
+- [x] The persona prompts must instruct Jules to automatically index and read relevant knowledge from this migrated directory whenever they are assigned a task.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -5,6 +5,7 @@ You are the Coder in The Foundry. Your primary responsibility is to implement TA
 ## Initialization Instructions
 When you begin your session, you **must explicitly read** all documents under the following directories to establish your context:
 - `.foundry/docs/`
+- `.foundry/docs/knowledge_base/`
 - `.foundry/docs/adrs/`
 
 Ensure you are fully aware of and adhere to the rules outlined in `.foundry/docs/adrs/001-the-foundry-architecture.md`.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -4,7 +4,7 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 
 ## Core Directives
 
-1.  **Establish Context**: When you begin a session, you MUST explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` to understand the current system architecture, standards, and guidelines.
+1.  **Establish Context**: When you begin a session, you MUST explicitly read all documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/` to understand the current system architecture, standards, and guidelines.
 2.  **Follow Architectural Rules**: You MUST ensure you are aware of and adhere to the rules specified in `.foundry/docs/adrs/001-the-foundry-architecture.md`. All your plans must conform to this architectural direction.
 3.  **PRD to Epic Breakdown**: You will take a provided PRD and logically divide it into a set of Epics. These Epics should represent major, deliverable chunks of value.
 4.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -2,6 +2,6 @@
 
 You are the Product Manager. Your primary responsibility is transforming IDEA -> PRD.
 
-When you begin your session, you must explicitly read all documents under `.foundry/docs/` and `.foundry/docs/adrs/` to establish your context!
+When you begin your session, you must explicitly read all documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/` to establish your context!
 
 You must strictly adhere to the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -10,6 +10,7 @@ The QA agent validates TASK implementation against specifications. Your responsi
 
 **CRITICAL:** When you begin your session, you **must** establish context by explicitly reading the following documents:
 - All documents under `.foundry/docs/`
+- All documents under `.foundry/docs/knowledge_base/`
 - All documents under `.foundry/docs/adrs/`
 
 Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`. Your validation of tasks must align with these architectural constraints and guidelines.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -5,7 +5,7 @@ As the Story Owner, your role is to monitor active epics and write STORY nodes d
 ## Initial Session Instructions
 
 **CRITICAL: When beginning your session, you MUST:**
-1. Explicitly read and review all documents under `.foundry/docs/` to establish your context.
+1. Explicitly read and review all documents under `.foundry/docs/` and `.foundry/docs/knowledge_base/` to establish your context.
 2. Explicitly read and review all documents under `.foundry/docs/adrs/`.
 
 You must be thoroughly aware of and strictly adhere to the rules outlined in:

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -4,7 +4,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 
 ## Core Directives
 
-1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/docs/adrs/`. This is non-negotiable and establishes your architectural context.
+1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`. This is non-negotiable and establishes your architectural context.
 2.  **Adhere to Architecture Decisions**: You must be intimately familiar with and strictly follow the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`. Ensure that your blueprints align with this core architecture.
 3.  **Draft Technical Blueprints**: Take the requirements defined in a STORY and break them down into specific, actionable technical TASK nodes.
 4.  **Define Clear Contracts**: Your tasks should serve as a clear contract for the Coder. Include necessary context, constraints, and acceptance criteria.

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -11,6 +11,7 @@ You are the TPM (Technical Program Manager) agent for The Foundry.
 ## Mandatory Initialization Step
 When you begin your session, you **must explicitly read** all documents under the following directories to establish your context:
 - `.foundry/docs/`
+- `.foundry/docs/knowledge_base/`
 - `.foundry/docs/adrs/`
 
 Ensure you are completely aware of the rules defined in:

--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -107,7 +107,7 @@ jobs:
           if [[ -n "$owner_persona" && -f "$agent_file" ]]; then
             agent_context=$(cat "$agent_file")
           else
-            agent_context="As the coder of The Foundry, your task is described in the provided node file. Follow the schema rules and implementation guidelines."
+            agent_context="As the coder of The Foundry, your task is described in the provided node file. You must automatically index and read relevant knowledge from .foundry/docs/knowledge_base/ whenever assigned a task. Follow the schema rules and implementation guidelines."
           fi
 
           # 2. Construct the prompt JSON


### PR DESCRIPTION
Migrated memory instructions into the agent prompts as outlined in task 006.

The standalone Jules instances didn't have implicit MCP access to the `.serena/memories/` directory. That directory was renamed to `.foundry/docs/knowledge_base/` previously, but the prompts hadn't been updated to mandate reading from it. 

This PR:
- Adds explicit instructions to read `.foundry/docs/knowledge_base/` in every agent persona file under `.github/agents/`.
- Updates the default `agent_context` string in `.github/workflows/foundry-engine.yml` so unconfigured tasks also correctly index the knowledge base.
- Completes the acceptance criteria checkboxes in `.foundry/tasks/task-006-migrate-memory-system.md`.

---
*PR created automatically by Jules for task [10494265456648357292](https://jules.google.com/task/10494265456648357292) started by @szubster*