### PR TITLE
feat(foundry): break down collision-free id schema epic into stories

### DIFF
--- a/.foundry/epics/epic-004-distributed-id-schema.md
+++ b/.foundry/epics/epic-004-distributed-id-schema.md
@@ -31,3 +31,8 @@ None. This epic can be implemented independently and serves as the foundation fo
 - [ ] An Architectural Decision Record (ADR) or schema document update confirms the chosen ID pattern.
 - [ ] `.foundry/docs/schema.md` accurately reflects the new ID format.
 - [ ] Boilerplate templates and generation scripts output the new ID format automatically.
+
+## Stories
+- [ ] .foundry/stories/story-004-id-pattern-adr.md
+- [ ] .foundry/stories/story-005-id-schema-doc-update.md
+- [ ] .foundry/stories/story-006-update-node-templates.md

--- a/.foundry/stories/story-004-id-pattern-adr.md
+++ b/.foundry/stories/story-004-id-pattern-adr.md
@@ -1,0 +1,23 @@
+---
+id: story-004-id-pattern-adr
+type: STORY
+title: "Determine and Document Collision-Free ID Pattern ADR"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-21"
+updated_at: "2026-04-21"
+depends_on: []
+jules_session_id: null
+parent: .foundry/epics/epic-004-distributed-id-schema.md
+tags: ["schema", "distributed-ids", "adr"]
+rejection_count: 0
+notes: ""
+---
+
+# Story: Determine and Document Collision-Free ID Pattern ADR
+
+## Description
+Collaborate and write an Architectural Decision Record (ADR) that establishes the new collision-free ID pattern (e.g., UUID-Based, Content-Hash Suffix, or Parent-Child Hierarchy) replacing the problematic sequential numbering.
+
+## Acceptance Criteria
+- [ ] An ADR document is created and outlines the chosen ID pattern.

--- a/.foundry/stories/story-005-id-schema-doc-update.md
+++ b/.foundry/stories/story-005-id-schema-doc-update.md
@@ -1,0 +1,24 @@
+---
+id: story-005-id-schema-doc-update
+type: STORY
+title: "Update Schema Documentation for New ID Format"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-21"
+updated_at: "2026-04-21"
+depends_on:
+  - .foundry/stories/story-004-id-pattern-adr.md
+jules_session_id: null
+parent: .foundry/epics/epic-004-distributed-id-schema.md
+tags: ["schema", "distributed-ids", "docs"]
+rejection_count: 0
+notes: ""
+---
+
+# Story: Update Schema Documentation for New ID Format
+
+## Description
+Update `.foundry/docs/schema.md` to accurately reflect the newly approved ID format as determined in the ADR.
+
+## Acceptance Criteria
+- [ ] `.foundry/docs/schema.md` is updated with the new collision-free ID format.

--- a/.foundry/stories/story-006-update-node-templates.md
+++ b/.foundry/stories/story-006-update-node-templates.md
@@ -1,0 +1,25 @@
+---
+id: story-006-update-node-templates
+type: STORY
+title: "Update Node Templates and Scripts for New ID Schema"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-21"
+updated_at: "2026-04-21"
+depends_on:
+  - .foundry/stories/story-005-id-schema-doc-update.md
+jules_session_id: null
+parent: .foundry/epics/epic-004-distributed-id-schema.md
+tags: ["schema", "distributed-ids", "templates"]
+rejection_count: 0
+notes: ""
+---
+
+# Story: Update Node Templates and Scripts for New ID Schema
+
+## Description
+Update the orchestrator, boilerplate templates, and generation scripts to output nodes using the new ID schema.
+
+## Acceptance Criteria
+- [ ] Boilerplate templates output the new ID format.
+- [ ] Generation scripts use the new ID format automatically.


### PR DESCRIPTION
This PR breaks down the `epic-004-distributed-id-schema` epic into actionable STORY nodes. It creates three new stories for the tech lead to handle ADR formulation, schema documentation updates, and node template updates. The epic's markdown body has been updated to list the new stories, while preserving its YAML frontmatter as required by the system invariants.

---
*PR created automatically by Jules for task [12936307500402479339](https://jules.google.com/task/12936307500402479339) started by @szubster*