### PR TITLE
fix: fully recursive block status in foundry orchestrator

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -67,7 +67,7 @@ created_at: ""          # Required. ISO-8601 date (YYYY-MM-DD). Set once, never 
 updated_at: ""          # Required. ISO-8601 date. Updated by any persona that edits the node.
 depends_on: []          # Required. Array of repo-relative file paths. Empty [] = unblocked.
 jules_session_id: null  # Required. Active Jules session ID string, or null when idle.
-parent: null            # Optional. Repo-relative path to the logical parent node. Used for context hydration only — does NOT block the DAG.
+parent: null            # Required if node is derived from another node (e.g. PRD from IDEA, EPIC from PRD). Repo-relative path to the logical parent node. Blocks the parent from completion if this node is incomplete.
 tags: []                # Optional. Free-form string labels for filtering and context injection.
 rejection_count: 0      # Optional. Incremented by the Resurrection Loop on each CEO veto. Omit for IDEA nodes.
 notes: ""               # Optional. Free-form Markdown remarks.

--- a/.foundry/epics/epic-003-actions-engine.md
+++ b/.foundry/epics/epic-003-actions-engine.md
@@ -6,6 +6,7 @@ status: COMPLETED
 owner_persona: epic_planner
 created_at: "2026-04-20"
 updated_at: "2026-04-20"
+parent: ".foundry/ideas/idea-001-the-foundry.md"
 depends_on:
   - .foundry/ideas/idea-001-the-foundry.md
 jules_session_id: null

--- a/.foundry/ideas/idea-002-collision-free-ids.md
+++ b/.foundry/ideas/idea-002-collision-free-ids.md
@@ -6,6 +6,7 @@ status: "COMPLETED"
 owner_persona: product_manager
 created_at: "2026-04-21"
 updated_at: "2026-04-21"
+parent: ".foundry/ideas/idea-001-the-foundry.md"
 depends_on:
   - .foundry/ideas/idea-001-the-foundry.md
 jules_session_id: null

--- a/.foundry/ideas/idea-004-human-in-the-loop.md
+++ b/.foundry/ideas/idea-004-human-in-the-loop.md
@@ -6,6 +6,7 @@ status: "COMPLETED"
 owner_persona: product_manager
 created_at: "2026-04-21"
 updated_at: "2026-04-21"
+parent: ".foundry/ideas/idea-003-atomic-handoff-foundation.md"
 depends_on: [".foundry/ideas/idea-003-atomic-handoff-foundation.md"]
 jules_session_id: null
 ---

--- a/.foundry/ideas/idea-005-late-binding-orchestrator.md
+++ b/.foundry/ideas/idea-005-late-binding-orchestrator.md
@@ -6,6 +6,7 @@ status: "COMPLETED"
 owner_persona: product_manager
 created_at: "2026-04-21"
 updated_at: "2026-04-21"
+parent: ".foundry/ideas/idea-003-atomic-handoff-foundation.md"
 depends_on: [".foundry/ideas/idea-003-atomic-handoff-foundation.md"]
 jules_session_id: null
 tags: ["foundry-v2", "architecture", "orchestration"]

--- a/.foundry/prds/prd-001-v2-lifecycle.md
+++ b/.foundry/prds/prd-001-v2-lifecycle.md
@@ -9,7 +9,7 @@ updated_at: "2026-04-21"
 depends_on:
   - .foundry/ideas/idea-003-atomic-handoff-foundation.md
 jules_session_id: null
-parent: null
+parent: ".foundry/ideas/idea-003-atomic-handoff-foundation.md"
 tags:
   - "v2-architecture"
   - "lifecycle"

--- a/.foundry/prds/prd-002-late-binding-orchestrator.md
+++ b/.foundry/prds/prd-002-late-binding-orchestrator.md
@@ -9,7 +9,7 @@ updated_at: "2026-04-21"
 depends_on:
   - .foundry/ideas/idea-005-late-binding-orchestrator.md
 jules_session_id: null
-parent: null
+parent: ".foundry/ideas/idea-005-late-binding-orchestrator.md"
 tags:
   - "foundry-v2"
   - "architecture"

--- a/.foundry/prds/prd-004-human-in-the-loop.md
+++ b/.foundry/prds/prd-004-human-in-the-loop.md
@@ -9,7 +9,7 @@ updated_at: "2026-04-21"
 depends_on:
   - .foundry/ideas/idea-004-human-in-the-loop.md
 jules_session_id: null
-parent: null
+parent: ".foundry/ideas/idea-004-human-in-the-loop.md"
 tags:
   - "human-in-the-loop"
 ---

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -15,6 +15,8 @@ describe('foundry-orchestrator', () => {
     fs.mkdirSync(foundryDir);
     fs.mkdirSync(path.join(foundryDir, 'ideas'));
     fs.mkdirSync(path.join(foundryDir, 'epics'));
+    fs.mkdirSync(path.join(foundryDir, 'stories'));
+    fs.mkdirSync(path.join(foundryDir, 'tasks'));
 
     // Mock process context
     vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
@@ -46,7 +48,7 @@ updated_at: "2026-04-20"
 depends_on: []
 jules_session_id: null
 pr_number: null
-    `);
+`);
 
     createNode('.foundry/epics/epic-001.md', `
 id: epic-001
@@ -60,7 +62,7 @@ depends_on:
   - .foundry/ideas/idea-001.md
 jules_session_id: null
 pr_number: null
-    `);
+`);
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     main();
@@ -90,7 +92,7 @@ updated_at: "2026-04-20"
 depends_on: []
 jules_session_id: "sess-123"
 pr_number: null
-    `);
+`);
 
     createNode('.foundry/epics/epic-001.md', `
 id: epic-001
@@ -104,7 +106,7 @@ depends_on:
   - .foundry/ideas/idea-001.md
 jules_session_id: null
 pr_number: null
-    `);
+`);
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     main();
@@ -143,7 +145,7 @@ updated_at: "2026-04-20"
 depends_on: []
 jules_session_id: null
 pr_number: null
-    `);
+`);
 
     main();
 
@@ -163,7 +165,7 @@ updated_at: "2026-04-20"
 depends_on:
   - .foundry/missing/ghost.md
 jules_session_id: null
-    `);
+`);
 
     main();
 
@@ -183,7 +185,7 @@ created_at: "2026-04-20"
 updated_at: "2026-04-20"
 depends_on: []
 jules_session_id: null
-    `);
+`);
 
     // Task 1: Child of Story 1, PENDING
     createNode('.foundry/tasks/task-001.md', `
@@ -198,7 +200,7 @@ depends_on:
   - .foundry/stories/story-001.md
 parent: .foundry/stories/story-001.md
 jules_session_id: null
-    `);
+`);
 
     // Story 2: Depends on Story 1, PENDING (External dependent)
     createNode('.foundry/stories/story-002.md', `
@@ -212,7 +214,7 @@ updated_at: "2026-04-20"
 depends_on:
   - .foundry/stories/story-001.md
 jules_session_id: null
-    `);
+`);
 
     main();
 
@@ -224,4 +226,70 @@ jules_session_id: null
     const story2Content = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-002.md'), 'utf-8');
     expect(story2Content).toContain('status: PENDING');
   });
+
+  test('Deep Hierarchical Completion: blocks external dependent if dependency has deep incomplete children', () => {
+    // Story 1: COMPLETED
+    createNode('.foundry/stories/story-001.md', `
+id: story-001
+type: STORY
+title: "Story 1"
+status: COMPLETED
+owner_persona: story_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    // Task 1: Child of Story 1, COMPLETED
+    createNode('.foundry/tasks/task-001.md', `
+id: task-001
+type: TASK
+title: "Task 1"
+status: COMPLETED
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on:
+  - .foundry/stories/story-001.md
+parent: .foundry/stories/story-001.md
+jules_session_id: null
+`);
+
+    // Subtask 1: Child of Task 1, PENDING
+    createNode('.foundry/tasks/subtask-001.md', `
+id: subtask-001
+type: TASK
+title: "Subtask 1"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on:
+  - .foundry/tasks/task-001.md
+parent: .foundry/tasks/task-001.md
+jules_session_id: null
+`);
+
+    // Story 2: Depends on Story 1, PENDING
+    createNode('.foundry/stories/story-002.md', `
+id: story-002
+type: STORY
+title: "Story 2"
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on:
+  - .foundry/stories/story-001.md
+jules_session_id: null
+`);
+
+    main();
+
+    // Story 2 SHOULD NOT be promoted (it waits for Subtask 1)
+    const story2Content = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-002.md'), 'utf-8');
+    expect(story2Content).toContain('status: PENDING');
+  });
+
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -250,7 +250,7 @@ function promoteNodeToReady(node: ParsedNode): void {
   //    The 'm' flag makes ^ and $ match line boundaries within the block.
   mutatedFmBlock = mutatedFmBlock.replace(
     /^(status:\s*)["']?PENDING["']?([ \t]*)$/m,
-    `$1"READY"$2`,
+    `$1READY$2`,
   );
 
   // Sanity check — if PENDING wasn't found, something is wrong.
@@ -339,21 +339,109 @@ function main(): void {
   let hasUnresolvableDeps = false;
   const eligible: ParsedNode[] = [];
 
+  // Helper to recursively check if a node is blocked.
+  // A node is blocked if:
+  // 1. Its status is not COMPLETED (and it's not the target node we are evaluating).
+  // 2. ANY of its recursive dependencies are blocked.
+  // 3. ANY of its recursive children are blocked.
+  const evalCache = new Map<string, boolean>();
+
+  function isBlocked(nodePath: string, visited = new Set<string>()): boolean {
+    if (evalCache.has(nodePath)) return evalCache.get(nodePath)!;
+    if (visited.has(nodePath)) {
+      warn(`Circular dependency detected at ${nodePath}`);
+      return true;
+    }
+    visited.add(nodePath);
+
+    const node = nodeMap.get(nodePath);
+    if (!node) {
+      hasUnresolvableDeps = true;
+      evalCache.set(nodePath, true);
+      return true;
+    }
+
+    // Unresolved dependencies
+    for (const depPath of node.frontmatter.depends_on) {
+      const dep = nodeMap.get(depPath);
+      if (!dep) {
+        warn(`Unresolvable dependency '${depPath}' referenced by: ${nodePath}`);
+        hasUnresolvableDeps = true;
+        evalCache.set(nodePath, true);
+        return true;
+      }
+
+      if (dep.frontmatter.status !== 'COMPLETED') {
+        evalCache.set(nodePath, true);
+        return true;
+      }
+
+      if (isBlocked(depPath, visited)) {
+        evalCache.set(nodePath, true);
+        return true;
+      }
+    }
+
+    // Hierarchical blocking: ALL children must be COMPLETED
+    const children = parentToChildren.get(nodePath) || [];
+    for (const child of children) {
+      if (child.frontmatter.status !== 'COMPLETED') {
+        evalCache.set(nodePath, true);
+        return true;
+      }
+      if (isBlocked(child.repoPath, visited)) {
+        evalCache.set(nodePath, true);
+        return true;
+      }
+    }
+
+    visited.delete(nodePath);
+    evalCache.set(nodePath, false);
+    return false;
+  }
+
+  // Helper to safely check if 'child' is a deep descendant of 'ancestor'
+  function isDescendant(childPath: string, ancestorPath: string): boolean {
+    let curr = nodeMap.get(childPath)?.frontmatter.parent;
+    while (curr) {
+      if (curr === ancestorPath) return true;
+      curr = nodeMap.get(curr)?.frontmatter.parent;
+    }
+    return false;
+  }
+
   for (const node of nodes) {
     if (node.frontmatter.status !== 'PENDING') continue;
 
-    const deps = node.frontmatter.depends_on;
+    // A PENDING node is blocked if:
+    // 1. It has an unresolvable dependency.
+    // 2. Its parent is blocked (recursive).
+    // 3. Any of its explicit dependencies is blocked (recursive).
 
-    // Case A: Empty depends_on → in-degree zero → immediately eligible.
-    if (deps.length === 0) {
-      eligible.push(node);
-      continue;
+    let blocked = false;
+
+    // Check parent inheritance
+    let currParent = node.frontmatter.parent;
+    while (currParent) {
+      const parentNode = nodeMap.get(currParent);
+      if (!parentNode) break;
+
+      // Parent blocked by its own dependencies?
+      for (const depPath of parentNode.frontmatter.depends_on) {
+        const dep = nodeMap.get(depPath);
+        if (!dep || dep.frontmatter.status !== 'COMPLETED' || isBlocked(depPath)) {
+            blocked = true;
+            break;
+        }
+      }
+      if (blocked) break;
+      currParent = parentNode.frontmatter.parent;
     }
 
-    // Case B: All deps must exist in the graph AND be COMPLETED.
-    // AND: if the node is NOT a child of the dependency, then all children
-    // of that dependency must also be COMPLETED (Hierarchical Completion).
-    let blocked = false;
+    if (blocked) continue;
+
+    const deps = node.frontmatter.depends_on;
+
     for (const depPath of deps) {
       const dep = nodeMap.get(depPath);
       if (!dep) {
@@ -368,16 +456,31 @@ function main(): void {
         break;
       }
 
-      // Hierarchical Completion: Check if dependency's children are also completed.
-      // Skip this check if the current node IS a child of the dependency (it's unblocked by planning).
-      if (node.frontmatter.parent !== depPath) {
-        const children = parentToChildren.get(depPath) || [];
-        const incompleteChild = children.find((c) => c.frontmatter.status !== 'COMPLETED');
-        if (incompleteChild) {
-          // Dependency is "planned" but not "implemented".
-          blocked = true;
-          break;
-        }
+      // Is the dependency itself structurally blocked?
+      // For the dependency's children, skip checking children if the CURRENT node is a descendant of that dependency.
+      // E.g. Epic depends on Idea. Idea has no children. Not blocked.
+      // Story depends on Epic. Epic has Story as child. Story is descendant of Epic -> Skip child check for Epic.
+
+      // We do a custom check for the dependency so we can exclude checking the current node's path in the children.
+      let depStructurallyBlocked = false;
+      for(const innerDepPath of dep.frontmatter.depends_on) {
+         if(isBlocked(innerDepPath)) {
+            depStructurallyBlocked = true;
+            break;
+         }
+      }
+
+      if(depStructurallyBlocked) {
+         blocked = true;
+         break;
+      }
+
+      if (!isDescendant(node.repoPath, depPath)) {
+          // It's an external dependency. We must ensure the dependency and ALL its children are completed.
+          if(isBlocked(depPath)) {
+              blocked = true;
+              break;
+          }
       }
     }
 


### PR DESCRIPTION
What: Updated Phase 4 of `foundry-orchestrator.ts` to fully and recursively verify blocked statuses. Added deeply recursive nested tests to ensure nodes do not erroneously unblock due to their children, or grandchildren, being in pending states.

Why: The current logic was incorrectly resolving deeply nested dependencies.

Verification: Tests passing `pnpm test` and `pnpm test` inside `.github/scripts/`.

---
*PR created automatically by Jules for task [5049630757465845453](https://jules.google.com/task/5049630757465845453) started by @szubster*