### PR TITLE
🧭 Strategist: Prompt improvement - Ensure Strategist properly discovers and logs unrecorded past outcomes

### DIFF
--- a/.jules/schedules/strategist.md
+++ b/.jules/schedules/strategist.md
@@ -18,7 +18,7 @@ The current agent roster lives in `.jules/schedules/`. Before proposing anything
 
 **Always:**
 - Read your journal and PR history before starting — it's your only memory
-- Search for unrecorded PR outcomes via `git log --all --grep="Strategist:"` (if `gh` is unavailable) and verify integration against `main`. Log newly discovered past outcomes in `.jules/strategist.md`
+- Include a journal entry for the current change in every PR you open
 - Read all files in `.jules/schedules/` before proposing anything
 - Review recent PRs from agents (search by their title prefixes: `⚡ Bolt:`, `🎨 Palette:`, etc.) to assess prompt effectiveness
 - Study the current codebase structure, recent PRs, and open issues for context
@@ -43,7 +43,7 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 1. **Reflect** — read `.jules/strategist.md` (your journal). Understand your history and proposal preferences.
 2. **Assess & Implement** — review recent agent PRs and existing schedules. Identify the single most impactful change (new agent, retirement, or prompt improvement). Open a PR that includes:
-   - Updates to `.jules/strategist.md` ONLY for newly discovered past outcomes (merged/closed PRs) using `[Accepted/Rejected]` states. Never log your current proposal yet.
+   - A new journal entry in `.jules/strategist.md` for this session's change (labeled as **Accepted**)
    - Your actual changes to the `.jules/schedules/` files
    - Title the PR: `🧭 Strategist: [proposal type] - [description]`
    - PR body detailing:
@@ -51,11 +51,11 @@ You have no memory between sessions. Your only persistence is what's committed t
      - **Justification**: Why existing agents can't cover this or why the old prompt failed.
      - **Evidence**: Links to previous PRs showing the problem patterns.
 3. **Wait** — the maintainer reviews your PR. Two outcomes are possible:
-   - **Merge** — session auto-closes. You succeeded. The outcome will be recorded in a future run.
+   - **Merge** — session auto-closes. You succeeded. The journal updates you included are now persisted.
    - **Rejection comment** — the maintainer comments asking to abandon. Continue to step 4.
-4. **Convert to journal-only** — revert all schedule changes on the branch. Add a journal entry for this session with status **Rejected** and document why (read the maintainer's comment). Push to the same PR. Update title to `🧭 Strategist: journal — learned from [topic]`. The maintainer merges the journal-only result.
+4. **Convert to journal-only** — revert all schedule changes on the branch. Update the journal entry for this session: change status to **Rejected** and document why (read the maintainer's comment). Push to the same PR. Update title to `🧭 Strategist: journal — learned from [topic]`. The maintainer merges the journal-only result.
 
-**Why this matters:** since you have no cross-session memory, successful PRs are discovered in future runs. But if a proposal is rejected, converting the PR to journal-only ensures the learning from that failure still ships.
+**Why this matters:** since you have no cross-session memory, every journal entry must be committed _inside_ the PR. If a proposal is accepted, the journal updates ship with it. If rejected, converting the PR to journal-only ensures the learning still ships.
 
 ## Journal
 

--- a/.jules/schedules/strategist.md
+++ b/.jules/schedules/strategist.md
@@ -18,7 +18,7 @@ The current agent roster lives in `.jules/schedules/`. Before proposing anything
 
 **Always:**
 - Read your journal and PR history before starting — it's your only memory
-- Include a journal entry for the current change in every PR you open
+- Search for unrecorded PR outcomes via `git log --all --grep="Strategist:"` (if `gh` is unavailable) and verify integration against `main`. Log newly discovered past outcomes in `.jules/strategist.md`
 - Read all files in `.jules/schedules/` before proposing anything
 - Review recent PRs from agents (search by their title prefixes: `⚡ Bolt:`, `🎨 Palette:`, etc.) to assess prompt effectiveness
 - Study the current codebase structure, recent PRs, and open issues for context
@@ -43,7 +43,7 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 1. **Reflect** — read `.jules/strategist.md` (your journal). Understand your history and proposal preferences.
 2. **Assess & Implement** — review recent agent PRs and existing schedules. Identify the single most impactful change (new agent, retirement, or prompt improvement). Open a PR that includes:
-   - A new journal entry in `.jules/strategist.md` for this session's change (labeled as **Accepted**)
+   - Updates to `.jules/strategist.md` ONLY for newly discovered past outcomes (merged/closed PRs) using `[Accepted/Rejected]` states. Never log your current proposal yet.
    - Your actual changes to the `.jules/schedules/` files
    - Title the PR: `🧭 Strategist: [proposal type] - [description]`
    - PR body detailing:
@@ -51,11 +51,11 @@ You have no memory between sessions. Your only persistence is what's committed t
      - **Justification**: Why existing agents can't cover this or why the old prompt failed.
      - **Evidence**: Links to previous PRs showing the problem patterns.
 3. **Wait** — the maintainer reviews your PR. Two outcomes are possible:
-   - **Merge** — session auto-closes. You succeeded. The journal updates you included are now persisted.
+   - **Merge** — session auto-closes. You succeeded. The outcome will be recorded in a future run.
    - **Rejection comment** — the maintainer comments asking to abandon. Continue to step 4.
-4. **Convert to journal-only** — revert all schedule changes on the branch. Update the journal entry for this session: change status to **Rejected** and document why (read the maintainer's comment). Push to the same PR. Update title to `🧭 Strategist: journal — learned from [topic]`. The maintainer merges the journal-only result.
+4. **Convert to journal-only** — revert all schedule changes on the branch. Add a journal entry for this session with status **Rejected** and document why (read the maintainer's comment). Push to the same PR. Update title to `🧭 Strategist: journal — learned from [topic]`. The maintainer merges the journal-only result.
 
-**Why this matters:** since you have no cross-session memory, every journal entry must be committed _inside_ the PR. If a proposal is accepted, the journal updates ship with it. If rejected, converting the PR to journal-only ensures the learning still ships.
+**Why this matters:** since you have no cross-session memory, successful PRs are discovered in future runs. But if a proposal is rejected, converting the PR to journal-only ensures the learning from that failure still ships.
 
 ## Journal
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -15,8 +15,8 @@
 **Outcome:** Accepted
 **Why:** Proposal submitted to maintainer and maintainer merged the changes.
 **Pattern:** Proposing an improvement based on specific missing test strategies found in the ecosystem.
-## 2025-04-22 - [Accepted] - Prompt improvement - Ensure Strategist properly discovers and logs unrecorded past outcomes
+## 2025-04-22 - [Rejected] - Prompt improvement - Ensure Strategist properly discovers and logs unrecorded past outcomes
 **Type:** Prompt improvement
-**Outcome:** Accepted
-**Why:** Proposal aligns instructions with system guidelines specifying to "discover past outcomes via `git log` instead of preemptively logging current proposals".
-**Pattern:** Following the system guideline: "When searching for unrecorded PR outcomes via `git log`, note that a PR's commit hash might not exist in `main` if it was squashed or fast-forwarded. Verify integration by checking if the code changes actually exist in the `main` branch's files".
+**Outcome:** Rejected → journaled
+**Why:** The maintainer rejected the proposal to use `git log` to retroactively discover outcomes, stating explicitly: "They should not look at past commits to figure out their memory, as journal always has them. Every PR either has code changes + journal (optionally, if useful), or journal only with rejection statement and reason for future learning."
+**Pattern:** Do not propose tracking memory through past commits instead of the explicit journal mechanism defined in the "Wait and Convert" flow.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -15,3 +15,8 @@
 **Outcome:** Accepted
 **Why:** Proposal submitted to maintainer and maintainer merged the changes.
 **Pattern:** Proposing an improvement based on specific missing test strategies found in the ecosystem.
+## 2025-04-22 - [Accepted] - Prompt improvement - Ensure Strategist properly discovers and logs unrecorded past outcomes
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** Proposal aligns instructions with system guidelines specifying to "discover past outcomes via `git log` instead of preemptively logging current proposals".
+**Pattern:** Following the system guideline: "When searching for unrecorded PR outcomes via `git log`, note that a PR's commit hash might not exist in `main` if it was squashed or fast-forwarded. Verify integration by checking if the code changes actually exist in the `main` branch's files".


### PR DESCRIPTION
**Proposal**: Updating the Strategist schedule instructions to align with explicit system constraints on memory tracking. The new prompt explicitly instructs the agent to discover and log *past* outcomes (via `git log`) instead of inappropriately attempting to persist the *current* proposal inside its `.jules/strategist.md` file during the same session it proposes it.

**Justification**: The previous prompt had two conflicting behaviors. One instructed the agent that it had no cross-session memory and instructed it to wait for PR closure and then "convert to journal only" if rejected. The other part of the prompt instructed the agent to log its current proposal as "Accepted" in `.jules/strategist.md` *before* the PR was even opened. The original design ignored how Git commits work, resulting in incorrect instructions that broke the agent's ability to actually log outcomes correctly. By instructing the agent to dynamically sync its journal at the start of the session by reading from Git history, this patch ensures accurate and reliable memory persistence without needing fragile workflow branches.

**Evidence**: System memory explicitly states: "Log only newly discovered past outcomes (merged/closed PRs) in `.jules/strategist.md` using `[Accepted/Rejected]` states (never log `[Pending]` for current proposals)". This prompt update enforces that exact pattern.

---
*PR created automatically by Jules for task [1145956789693105428](https://jules.google.com/task/1145956789693105428) started by @szubster*