### PR TITLE
🛡️ Nurse: remove unsafe type cast in AssistantPanel

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -17,3 +17,4 @@ The compiler ensures that DataLoader batch functions return valid values or Erro
 ## 2026-04-21 - Nurse: Explicitly typing variables removes need for type casting
 **Learning:** Sometimes the compiler loses track of a type after a reassignment if the variable wasn't explicitly typed. By explicitly typing `let variableName: TypeName`, we eliminate the need for downstream `as TypeName` assertions, making the code safer and more readable.
 **Action:** Replaced unsafe cast in `gen2.ts` by explicitly typing the `gameVersion` variable instead.
+- Replaced unsafe `{} as Partial<Record<...>>` with `reduce<Partial<Record<...>>>({}, ...)` to ensure the accumulator is strictly type-checked and properly tracks optional keys instead of forcing an unsafe cast in `AssistantPanel.tsx`.

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -120,14 +120,11 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
       ) : (
         <div className="space-y-8">
           {Object.entries(
-            suggestions.reduce(
-              (acc, s) => {
-                if (!acc[s.category]) acc[s.category] = [];
-                acc[s.category]?.push(s);
-                return acc;
-              },
-              {} as Partial<Record<SuggestionCategory, Suggestion[]>>,
-            ),
+            suggestions.reduce<Partial<Record<SuggestionCategory, Suggestion[]>>>((acc, s) => {
+              if (!acc[s.category]) acc[s.category] = [];
+              acc[s.category]?.push(s);
+              return acc;
+            }, {}),
             // Custom sort order for categories
           )
             .sort(([a], [b]) => {


### PR DESCRIPTION
**What was unsafe:**
In `src/components/AssistantPanel.tsx`, the initial empty accumulator object `{}` for a `reduce()` operation was forcefully type-asserted as `Partial<Record<SuggestionCategory, Suggestion[]>>`. This bypasses strict type-checking and could hide potential assignment errors if the key-value structures were changed, as `as` masks TypeScript's ability to evaluate the type incrementally.

**How it was fixed:**
I removed the unsafe `as Partial<Record<...>>` assertion and instead supplied `Partial<Record<SuggestionCategory, Suggestion[]>>` as a generic parameter directly to the `reduce` function call. The initial accumulator is now safely just `{}`.

**What the compiler now catches:**
The compiler will now enforce that the accumulator matches the provided generic signature natively, rather than relying on an unsafe runtime assumption. Any future logic assigning a non-matching property to the `reduce` accumulator will correctly be flagged by TypeScript.

---
*PR created automatically by Jules for task [3578168960945874886](https://jules.google.com/task/3578168960945874886) started by @szubster*