### PR TITLE
🧠 Trainer: Add support for held items in trade evolutions

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -1,3 +1,7 @@
 ## 2024-03-31 - Assistant Evolution Item Suggestion
 **Learning:** The item evolution check was verifying if an evolution stone existed in `saveData.inventory`, but was not checking its `quantity`. This could cause false "Ready to Evolve" suggestions if the save parser left 0-quantity items in the inventory array.
 **Action:** Always check `quantity > 0` when verifying player items in `saveData.inventory`.
+## 2024-04-22 - Assistant Trade Evolution Held Item Support\n**Learning:** The Trade evolution logic () was missing support for checking if a required `held` item was in the player's inventory, which is crucial for Gen 2 evolutions like Onix to Steelix. \n**Action:** Always check the `detail.held` property for Trade evolutions and verify the player has it in their `saveData.inventory`.
+## 2024-04-22 - Assistant Trade Evolution Held Item Support
+**Learning:** The Trade evolution logic (`EVO_TRIGGER.TRADE`) was missing support for checking if a required `held` item was in the player's inventory, which is crucial for Gen 2 evolutions like Onix to Steelix.
+**Action:** Always check the `detail.held` property for Trade evolutions and verify the player has it in their `saveData.inventory`.

--- a/src/engine/assistant/__tests__/test-coverage.test.ts
+++ b/src/engine/assistant/__tests__/test-coverage.test.ts
@@ -10,7 +10,7 @@ test('coverage for suggestionEngine new lines', () => {
     gameVersion: 'crystal',
     // Mock owned up to 251 except the ones we want to suggest (targets must be missing)
     owned: new Set(
-      [...Array(251).keys()].map((i) => i + 1).filter((i) => ![196, 197, 106, 107, 237, 136, 68].includes(i)),
+      [...Array(251).keys()].map((i) => i + 1).filter((i) => ![196, 197, 106, 107, 237, 136, 68, 208].includes(i)),
     ),
     seen: new Set(),
     party: [],
@@ -21,6 +21,7 @@ test('coverage for suggestionEngine new lines', () => {
       { speciesId: 133, level: 20, otName: 'PLAYER' } as PokemonInstance,
       { speciesId: 236, level: 20, otName: 'PLAYER' } as PokemonInstance,
       { speciesId: 67, level: 30, otName: 'PLAYER' } as PokemonInstance,
+      { speciesId: 95, level: 30, otName: 'PLAYER' } as PokemonInstance,
     ],
     pcDetails: [],
     trainerName: 'PLAYER',
@@ -30,6 +31,7 @@ test('coverage for suggestionEngine new lines', () => {
   mockSaveData.owned.add(133);
   mockSaveData.owned.add(236);
   mockSaveData.owned.add(67);
+  mockSaveData.owned.add(95);
 
   const mockApiData: AssistantApiData = {
     localEncounters: [],
@@ -85,6 +87,13 @@ test('coverage for suggestionEngine new lines', () => {
         det: [{ tr: 2 }], // Trade (EVO_TRIGGER.TRADE = 2)
         eto: [],
       }, // Machamp (Trade)
+      208: {
+        id: 208,
+        n: 'Steelix',
+        efrm: [95],
+        det: [{ tr: 2, held: 0x8f }], // Trade with Metal Coat
+        eto: [],
+      }, // Steelix
     },
     areaNames: {},
     allLocations: [],
@@ -118,6 +127,23 @@ test('coverage for suggestionEngine new lines', () => {
   const machamp = suggestions.find((s) => s.pokemonId === 68);
   expect(machamp).toBeDefined();
   expect(machamp?.title).toContain('Trade Evolution');
+
+  const steelix = suggestions.find((s) => s.pokemonId === 208);
+  expect(steelix).toBeDefined();
+  expect(steelix?.title).toContain('Item Needed for Trade');
+
+  // Verify ready trade evolve
+  mockSaveData.inventory.push({ id: 0x8f, quantity: 1 });
+  const { suggestions: readySuggestions } = generateSuggestions(
+    mockSaveData,
+    false,
+    'crystal',
+    mockApiData,
+    gen1Strategy,
+  );
+  const readySteelix = readySuggestions.find((s) => s.pokemonId === 208);
+  expect(readySteelix).toBeDefined();
+  expect(readySteelix?.title).toContain('Ready to Trade Evolve');
 });
 
 test('coverage for suggestionEngine edge cases', () => {

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -317,6 +317,7 @@ export function generateSuggestions(
     const min_l = detail.ml;
     const min_h = detail.mh;
     const item = detail.item;
+    const held = detail.held;
     const tod = detail.time === 1 ? 'day' : detail.time === 2 ? 'night' : undefined;
 
     if (tr === EVO_TRIGGER.LEVEL_UP) {
@@ -356,14 +357,28 @@ export function generateSuggestions(
         priority: hasStone ? 95 : 40,
       });
     } else if (tr === EVO_TRIGGER.TRADE) {
-      suggestions.push({
-        id: `evo-trade-${targetId}`,
-        category: 'Evolve',
-        title: `Trade Evolution: #${targetId}`,
-        description: `Trade your pre-evolution to evolve it!`,
-        pokemonId: targetId,
-        priority: 85,
-      });
+      if (held) {
+        const hasHeldItem = saveData.inventory.some((i) => i.id === held && i.quantity > 0);
+        suggestions.push({
+          id: `evo-trade-held-${targetId}`,
+          category: 'Evolve',
+          title: hasHeldItem ? `Ready to Trade Evolve: #${targetId}!` : `Item Needed for Trade: #${targetId}`,
+          description: hasHeldItem
+            ? `Have your pre-evolution hold the item and trade it to evolve!`
+            : `Find the right item, have your pre-evolution hold it, and trade to evolve.`,
+          pokemonId: targetId,
+          priority: hasHeldItem ? 90 : 45,
+        });
+      } else {
+        suggestions.push({
+          id: `evo-trade-${targetId}`,
+          category: 'Evolve',
+          title: `Trade Evolution: #${targetId}`,
+          description: `Trade your pre-evolution to evolve it!`,
+          pokemonId: targetId,
+          priority: 85,
+        });
+      }
     }
   });
 


### PR DESCRIPTION
🧠 Trainer: Add support for held items in trade evolutions

### What
Added logic to the `suggestionEngine.ts` to check if a trade evolution requires a `held` item, and if so, verifies whether the player possesses that item in their inventory. This is particularly important for Generation 2 trade evolutions (e.g., Onix -> Steelix using a Metal Coat, Scyther -> Scizor using a Metal Coat, etc.).

### Why
Previously, the `EVO_TRIGGER.TRADE` branch in the suggestion engine did not check the `held` property on the evolution details. This meant it would simply suggest "Trade your pre-evolution to evolve it!" without informing the player they needed a specific item, leading to confusing or unhelpful recommendations for certain Gen 2 species.

### Impact on recommendation quality
Suggestions are now significantly more accurate for Gen 2. Players will see:
*   `Ready to Trade Evolve: #[id]!` if they have both the pre-evolution and the required held item.
*   `Item Needed for Trade: #[id]` if they have the pre-evolution but are missing the required held item.

### Test coverage
Updated `test-coverage.test.ts` to include a test case for Steelix (requires trading Onix with a Metal Coat), covering both the state where the item is missing and the state where the item is present in the player's inventory. Tests ran successfully.

---
*PR created automatically by Jules for task [17648720597720415875](https://jules.google.com/task/17648720597720415875) started by @szubster*