### PR TITLE
⚡ Bolt: Optimize map graph lookups from O(N) to O(1)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -26,3 +26,6 @@
 **What:** Debounced IndexedDB query inside LocationSuggestions component by adding a 250ms `setTimeout` to delay `pokeDB.getLocations()` fetch based on user typing.
 **Why:** Typing into the search bar rapidly changes `searchTerm`, which triggered the `useEffect` and fired continuous `pokeDB.getLocations()` requests without a debounce, causing main thread to block and resulting in UI freezes.
 **Expected Impact:** Improved responsiveness during rapid keystrokes as the redundant IDB queries are skipped before 250ms have elapsed.
+## 2026-04-22 - [O(N) Map Graph Lookups]
+**Learning:** Calling `Array.prototype.find()` on `allLocations` inside `getDistanceToMap` caused significant $O(N)$ overhead, especially since this function is called inside a nested loop in the suggestion engine for every possible encounter of every missing Pokemon. This resulted in hundreds of redundant array scans.
+**Action:** Implemented a module-level `Map` cache in `gen1Graph.ts` to store locations, keying the cache validity by checking `allLocations` reference. This optimizes the lookup time from $O(N)$ to $O(1)$.

--- a/src/engine/mapGraph/gen1Graph.ts
+++ b/src/engine/mapGraph/gen1Graph.ts
@@ -17,25 +17,40 @@ import type { UnifiedLocation } from '../../db/schema';
  * This ensures O(1) distance lookups during runtime, which is critical since the suggestion
  * engine evaluates hundreds of potential encounters simultaneously.
  */
+// ⚡ Bolt: Cache locations map to prevent O(N) Array.find calls on every lookup
+const locationCache = new Map<number, UnifiedLocation>();
+let lastLocationsRef: UnifiedLocation[] | null = null;
+
+function getLocation(allLocations: UnifiedLocation[], id: number): UnifiedLocation | undefined {
+  if (lastLocationsRef !== allLocations) {
+    locationCache.clear();
+    for (const loc of allLocations) {
+      locationCache.set(loc.id, loc);
+    }
+    lastLocationsRef = allLocations;
+  }
+  return locationCache.get(id);
+}
+
 export function getDistanceToMap(
   allLocations: UnifiedLocation[],
   startMapId: number,
   targetAid: number,
 ): { distance: number; name: string } | null {
   // 1. Resolve target location (where the Pokémon is found)
-  const targetLoc = allLocations.find((l) => l.id === targetAid);
+  const targetLoc = getLocation(allLocations, targetAid);
   if (!targetLoc) return null;
 
   const targetDisplayName = targetLoc.n;
 
   // 2. Resolve start location (where the player is)
   const outdoorStartMapId = getOutdoorMapId(allLocations, startMapId);
-  let startLoc = allLocations.find((l) => l.id === outdoorStartMapId);
+  let startLoc = getLocation(allLocations, outdoorStartMapId);
 
   // Fallback if unknown
   if (!startLoc) {
     // Saffron City (Map ID 10 in Kanto)
-    startLoc = allLocations.find((l) => l.id === 10);
+    startLoc = getLocation(allLocations, 10);
   }
 
   if (!startLoc) return null;
@@ -68,7 +83,7 @@ export function getDistanceToMap(
  * "step outside" by resolving the current location to its parent map.
  */
 export function getOutdoorMapId(allLocations: UnifiedLocation[], mapId: number): number {
-  const loc = allLocations.find((l) => l.id === mapId);
+  const loc = getLocation(allLocations, mapId);
   if (loc?.prnt !== undefined) {
     return loc.prnt;
   }


### PR DESCRIPTION
### 💡 What
Implemented a `Map` cache inside `src/engine/mapGraph/gen1Graph.ts` to replace `Array.prototype.find()` calls when resolving locations inside `getDistanceToMap` and `getOutdoorMapId`.

### 🎯 Why
`getDistanceToMap` is invoked iteratively inside `suggestionEngine.ts` for every encounter of every missing Pokemon, leading to hundreds of redundant $O(N)$ operations. Converting this to a $O(1)$ Map lookup prevents unnecessary main thread overhead during suggestion generation.

### 📊 Measured Improvement
Reduced the lookup complexity of individual locations during map graph traversals from $O(N)$ to $O(1)$. Given $L$ total locations, $T$ targets, and $E$ encounters per target, complexity dropped from $O(T \times E \times L)$ to $O(L + (T \times E))$.

### How to Verify
1. Run `pnpm test` and `pnpm test:e2e` to verify all tests still pass and map calculations stay correct.
2. Observe fast suggestion load times in the assistant view.

---
*PR created automatically by Jules for task [9833977970812368858](https://jules.google.com/task/9833977970812368858) started by @szubster*