### PR TITLE
🧹 Sweeper: Clean up unused exports and types

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -1,3 +1,7 @@
 ## 2026-04-19 - Cleaned up unused constants in gen1 assistantData
 **Learning:** Found `GEN1_ITEMS` and `OBEDIENCE_CAPS` in `src/engine/data/gen1/assistantData.ts` which were not imported or used anywhere else in the application. `knip` tool or targeted `grep` commands are useful for finding such dead code.
 **Action:** Always verify potential unused exports by doing a global repository search to ensure they aren't dynamically referenced or used in tests before removing them.
+
+## 2026-04-22 - Cleaned up unused exports and dead code with knip
+**Learning:** `knip` is highly effective at identifying unused types and functions, but manual verification is crucial. Removing types and function exports works well, but one must be very careful when `knip` marks entire files (like `src/test-setup.ts`) as unused, as they may be required by configuration files or test runners implicitly. Similarly, `knip` might complain about "unused" `devDependencies` like `fake-indexeddb` when they are actually implicitly used.
+**Action:** Always verify test and lint commands after any `knip`-driven cleanup to avoid silently breaking the build or test environment. Use `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to verify.

--- a/scripts/data/gen1/mapping.ts
+++ b/scripts/data/gen1/mapping.ts
@@ -3,7 +3,7 @@
  * Moved out of src/ to keep client bundle lean.
  */
 
-export interface MapNode {
+interface MapNode {
   id: number;
   aid: number;
   name: string;

--- a/scripts/data/gen2/mapping.ts
+++ b/scripts/data/gen2/mapping.ts
@@ -3,7 +3,7 @@
  * Maps mapGroup -> mapId -> PokeAPI Area ID (aid).
  */
 
-export interface Gen2MapNode {
+interface Gen2MapNode {
   name: string;
   aid: number;
   connections?: number[];
@@ -80,5 +80,4 @@ export const GEN2_MAP_TO_AID: Record<number, Record<number, Gen2MapNode>> = {
   },
 };
 
-export const encodeGen2Id = (group: number, id: number) => (group << 8) | id;
 export const decodeGen2Id = (encoded: number) => ({ group: encoded >> 8, id: encoded & 0xff });

--- a/src/components/PokedexCard.tsx
+++ b/src/components/PokedexCard.tsx
@@ -5,7 +5,7 @@ import type { SaveData } from '../engine/saveParser';
 import { cn } from '../utils/cn';
 import { getGenerationConfig } from '../utils/generationConfig';
 
-export interface PokedexCardProps {
+interface PokedexCardProps {
   pokemon: { id: number; name: string };
   idx: number;
   saveData: SaveData | null;

--- a/src/components/settings/SettingsControls.tsx
+++ b/src/components/settings/SettingsControls.tsx
@@ -3,7 +3,7 @@ import type { GameVersion, PokeballType } from '../../store';
 import type { GenerationConfig } from '../../utils/generationConfig';
 import { getGenerationConfig } from '../../utils/generationConfig';
 
-export interface SettingsControlsProps {
+interface SettingsControlsProps {
   effectiveVersion: string;
   setManualVersion: (v: GameVersion | null) => void;
   isLivingDex: boolean;

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -69,7 +69,7 @@ export const getDB = () => {
   return dbPromise;
 };
 
-export const syncData = async () => {
+const syncData = async () => {
   if (syncPromise) {
     return syncPromise;
   }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -93,8 +93,6 @@ export interface UnifiedLocation {
 }
 
 export type GenericLocation = UnifiedLocation;
-export type SpecificArea = UnifiedLocation;
-export type InverseLocationIndex = UnifiedLocation;
 
 export interface CompactEvolutionDetail {
   tr?: number | undefined; // trigger (EVO_TRIGGER)
@@ -123,8 +121,6 @@ export interface PokemonMetadata {
   efrm: number[]; // Parent, Grandparent, etc.
   det: CompactEvolutionDetail[]; // Evolutionary requirements to reach THIS pokemon from parent
 }
-
-export type PokemonCompact = PokemonMetadata;
 
 export interface PokeDataExport {
   poke: PokemonMetadata[];

--- a/src/engine/assistant/index.ts
+++ b/src/engine/assistant/index.ts
@@ -1,8 +1,0 @@
-// Engine public API
-export { getStrategy } from './strategies/index';
-export type {
-  AssistantStrategy,
-  EncounterDetail,
-  RejectedSuggestion,
-  Suggestion,
-} from './strategies/types';

--- a/src/engine/data/gen1/assistantData.ts
+++ b/src/engine/data/gen1/assistantData.ts
@@ -93,7 +93,7 @@ export const STATIC_GIFT_DATA: Record<
  * `receivedOtName` — the OT name the game assigns to the received pokémon (used to detect if claimed)
  * `gen`          — generation the trade belongs to
  */
-export interface NpcTradeEntry {
+interface NpcTradeEntry {
   receivedId: number;
   offeredId: number;
   location: string;

--- a/src/engine/exclusives/gen1Exclusives.ts
+++ b/src/engine/exclusives/gen1Exclusives.ts
@@ -1,11 +1,3 @@
-// One-time static choices (if you miss the pre-evolution without breeding, you're locked out)
-export const ONE_TIME_CHOICES = {
-  starters: [1, 4, 7], // Bulbasaur, Charmander, Squirtle families
-  fossils: [138, 140], // Omanyte, Kabuto
-  hitmons: [106, 107], // Hitmonlee, Hitmonchan
-  eevee: [133],
-};
-
 const GEN1_VERSION_EXCLUSIVES: Record<string, number[]> = {
   red: [
     27,

--- a/src/engine/exclusives/index.ts
+++ b/src/engine/exclusives/index.ts
@@ -1,8 +1,6 @@
 import { getUnobtainableReason as gen1UnobtainableReason } from './gen1Exclusives';
 
-export { getUnobtainableReason, ONE_TIME_CHOICES } from './gen1Exclusives';
-
-export type UnobtainableChecker = (
+type UnobtainableChecker = (
   pokemonId: number,
   gameVersion: string,
   ownedCount: number,

--- a/src/engine/mapGraph/index.ts
+++ b/src/engine/mapGraph/index.ts
@@ -2,10 +2,6 @@ import type { UnifiedLocation } from '../../db/schema';
 import { getDistanceToMap, getOutdoorMapId } from './gen1Graph';
 import type { MapDistanceResult, MapGraph } from './types';
 
-// Re-export for backward compat
-export { getDistanceToMap, getOutdoorMapId as resolveOutdoorMapId } from './gen1Graph';
-export type { MapDistanceResult, MapGraph, MapNode } from './types';
-
 const gen1MapGraph: MapGraph = {
   getDistanceToMap: (
     locations: UnifiedLocation[],

--- a/src/engine/mapGraph/types.ts
+++ b/src/engine/mapGraph/types.ts
@@ -1,12 +1,5 @@
 import type { UnifiedLocation } from '../../db/schema';
 
-export interface MapNode {
-  id: number;
-  slug: string;
-  name: string;
-  conn: number[];
-}
-
 export interface MapDistanceResult {
   distance: number;
   name: string;

--- a/src/engine/saveParser/index.ts
+++ b/src/engine/saveParser/index.ts
@@ -1,11 +1,10 @@
-import type { GameVersion, Generation, PokemonInstance, SaveData } from './parsers/common';
-import { INTERNAL_ID_TO_DEX, isGen1Save, parseGen1 } from './parsers/gen1';
+import type { GameVersion, PokemonInstance, SaveData } from './parsers/common';
+import { isGen1Save, parseGen1 } from './parsers/gen1';
 import { isGen2Save, parseGen2 } from './parsers/gen2';
 
 export { decodeGen12String } from './parsers/common';
 
-export type { GameVersion, Generation, PokemonInstance, SaveData };
-export { INTERNAL_ID_TO_DEX };
+export type { GameVersion, PokemonInstance, SaveData };
 
 /**
  * Main entry point for decoding a raw Pokémon save file buffer.

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -2,7 +2,7 @@ import gen1MapLocations from '../../data/gen1/mapLocations.json';
 import type { GameVersion, PokemonInstance, SaveData } from './common';
 import { checkShiny, decodeGen12String, parseDVs } from './common';
 
-export const INTERNAL_ID_TO_DEX: Record<number, number> = {
+const INTERNAL_ID_TO_DEX: Record<number, number> = {
   1: 112,
   2: 115,
   3: 32,

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -47,7 +47,7 @@ export function parseCaughtData(view: DataView, offset: number) {
  * @param slot - The 1-indexed slot the Pokémon occupies in its storage container.
  * @returns A fully constructed PokemonInstance object, or undefined if the species ID is invalid.
  */
-export function parseGen2PokemonInstance(
+function parseGen2PokemonInstance(
   view: DataView,
   offset: number,
   isCrystal: boolean,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -25,7 +25,7 @@ const ReactQueryDevtools =
         })),
       );
 
-export interface RootContext {
+interface RootContext {
   queryClient: QueryClient;
 }
 

--- a/src/utils/pokemonQueries.ts
+++ b/src/utils/pokemonQueries.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from '@tanstack/react-query';
 import { getDB } from '../db/PokeDB';
 
-export interface PokemonListItem {
+interface PokemonListItem {
   id: number;
   name: string;
 }


### PR DESCRIPTION
🎯 What
This PR cleans up several unused exports, types, and dead code identified by `knip`.
- Removed `export` from functions and types only used locally (e.g., `syncData`, `parseGen2PokemonInstance`, `PokedexCardProps`).
- Removed `ONE_TIME_CHOICES` from `gen1Exclusives.ts` which was demonstrably dead code.
- Deleted `src/engine/assistant/index.ts` which was an unused barrel file.

💡 Why
To improve codebase health by reducing clutter and minimizing the public API surface area of modules.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no functionality or types were broken.

✨ Result
A cleaner, more concise codebase with accurate module exports.

---
*PR created automatically by Jules for task [17851687157095629116](https://jules.google.com/task/17851687157095629116) started by @szubster*