### PR TITLE
feat(foundry): generate ID schema decision stories from epic-004

### DIFF
--- a/.foundry/epics/epic-004-distributed-id-schema.md
+++ b/.foundry/epics/epic-004-distributed-id-schema.md
@@ -31,3 +31,7 @@ None. This epic can be implemented independently and serves as the foundation fo
 - [ ] An Architectural Decision Record (ADR) or schema document update confirms the chosen ID pattern.
 - [ ] `.foundry/docs/schema.md` accurately reflects the new ID format.
 - [ ] Boilerplate templates and generation scripts output the new ID format automatically.
+
+## Generated Stories
+- `.foundry/stories/story-004-id-schema-decision.md`: Decision and documentation update for the new collision-free ID pattern.
+- `.foundry/stories/story-005-id-schema-templates.md`: Updates to templates and node generation scripts to automatically output the new ID format.

--- a/.foundry/stories/story-004-id-schema-decision.md
+++ b/.foundry/stories/story-004-id-schema-decision.md
@@ -1,0 +1,34 @@
+---
+id: story-004-id-schema-decision
+type: STORY
+title: "Decide ID Schema and Update Documentation"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on:
+  - .foundry/epics/epic-004-distributed-id-schema.md
+jules_session_id: null
+parent: .foundry/epics/epic-004-distributed-id-schema.md
+---
+
+# Story: Decide ID Schema and Update Documentation
+
+## Goal
+Collaborate with the Architect/Tech Lead to finalize the new collision-free ID schema pattern and document it across the system.
+
+## Requirements
+
+1. **Decision Record**
+   - Choose a pattern for the ID schema (e.g., UUID-Based, Content-Hash Suffix, or Parent-Child Hierarchy).
+   - This must guarantee high entropy to prevent collisions when created autonomously across parallel branches.
+   - Write or update an Architectural Decision Record (ADR) capturing this choice.
+
+2. **Schema Documentation Update**
+   - Update `.foundry/docs/schema.md` to accurately reflect the new ID format.
+   - Ensure the new node template and `id` field references are updated in the schema documentation.
+
+## Definition of Done
+- A new or updated ADR confirms the chosen ID pattern.
+- `.foundry/docs/schema.md` accurately describes the new ID format.
+- All technical contracts specify exactly how the IDs should be generated going forward.

--- a/.foundry/stories/story-005-id-schema-templates.md
+++ b/.foundry/stories/story-005-id-schema-templates.md
@@ -1,0 +1,31 @@
+---
+id: story-005-id-schema-templates
+type: STORY
+title: "Update Templates and Generation Scripts"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on:
+  - .foundry/stories/story-004-id-schema-decision.md
+jules_session_id: null
+parent: .foundry/epics/epic-004-distributed-id-schema.md
+---
+
+# Story: Update Templates and Generation Scripts
+
+## Goal
+Implement the new collision-free ID schema across the orchestrator and all node generation tools.
+
+## Requirements
+
+1. **Template Updates**
+   - Update any boilerplate node templates or generation scripts (used by personas like `story_owner`, `epic_planner`, `agile_coach` or the orchestrator) to automatically output the new ID format.
+   - This ensures that any new nodes created in the system follow the new schema correctly from day one.
+
+2. **Orchestrator Validation**
+   - Update the orchestrator validation logic or schema definitions if needed to parse and accept the new ID format properly, avoiding strict sequential numbering checks.
+
+## Definition of Done
+- Boilerplate templates and generation scripts output the new ID format automatically.
+- The orchestrator continues to function correctly with the newly formatted IDs.


### PR DESCRIPTION
Generates `story-004-id-schema-decision` and `story-005-id-schema-templates` from `epic-004-distributed-id-schema`, appending references to the new stories to the epic's markdown body. The frontmatter remains untouched as required.

---
*PR created automatically by Jules for task [16616195905422125590](https://jules.google.com/task/16616195905422125590) started by @szubster*