### PR TITLE
feat: break down epic-004 into generic scheduling stories

### DIFF
--- a/.foundry/epics/epic-004-generic-agent-scheduling.md
+++ b/.foundry/epics/epic-004-generic-agent-scheduling.md
@@ -31,3 +31,6 @@ Scheduled agents should execute using standard Jules prompt hydration logic.
 ## Acceptance Criteria
 - [ ] A generic scheduling implementation is defined and documented.
 - [ ] Tests confirm that the scheduled run exits successfully when there is no work to do.
+
+## Notes
+- Created stories: `story-004-generic-scheduling-workflow.md`, `story-005-empty-state-handling.md`, `story-006-scheduling-configuration.md`.

--- a/.foundry/stories/story-004-generic-scheduling-workflow.md
+++ b/.foundry/stories/story-004-generic-scheduling-workflow.md
@@ -1,0 +1,16 @@
+---
+id: story-004-generic-scheduling-workflow
+type: STORY
+title: "Generic Scheduling Mechanism Workflow"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on: []
+jules_session_id: null
+parent: .foundry/epics/epic-004-generic-agent-scheduling.md
+---
+
+# Generic Scheduling Mechanism Workflow
+
+Create a reusable GitHub Action workflow (`.github/workflows/foundry-scheduled-agent.yml`) that accepts inputs (agent/persona name) and runs on a schedule. It needs to utilize the existing Jules environment setup (reading `.github/agents/<persona>.md` for prompt hydration). This addresses the generic scheduling and standard hydration requirements.

--- a/.foundry/stories/story-005-empty-state-handling.md
+++ b/.foundry/stories/story-005-empty-state-handling.md
@@ -1,0 +1,17 @@
+---
+id: story-005-empty-state-handling
+type: STORY
+title: "Graceful Empty State Handling"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on:
+  - .foundry/stories/story-004-generic-scheduling-workflow.md
+jules_session_id: null
+parent: .foundry/epics/epic-004-generic-agent-scheduling.md
+---
+
+# Graceful Empty State Handling
+
+Implement logic within the orchestrator or agent runner script to gracefully handle cases where a scheduled agent (like TPM) finds no actionable work. It should exit successfully (0) without creating an empty PR or spamming logs. This addresses the empty state requirement.

--- a/.foundry/stories/story-006-scheduling-configuration.md
+++ b/.foundry/stories/story-006-scheduling-configuration.md
@@ -1,0 +1,17 @@
+---
+id: story-006-scheduling-configuration
+type: STORY
+title: "Scheduling Configuration"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on:
+  - .foundry/stories/story-004-generic-scheduling-workflow.md
+jules_session_id: null
+parent: .foundry/epics/epic-004-generic-agent-scheduling.md
+---
+
+# Scheduling Configuration
+
+Define a configuration mechanism (e.g., a `.yml` config file or a registry within `.github/workflows/`) that allows easy addition of new scheduled agents with their respective cron expressions. This addresses the configurability requirement.


### PR DESCRIPTION
As the Story Owner, I have broken down the active EPIC (`epic-004-generic-agent-scheduling.md`) into 3 STORY nodes:

- `story-004-generic-scheduling-workflow.md`: Create a reusable GitHub Action workflow for scheduling agents.
- `story-005-empty-state-handling.md`: Implement logic to gracefully handle empty results.
- `story-006-scheduling-configuration.md`: Define a configuration mechanism for adding scheduled agents.

I also updated `epic-004-generic-agent-scheduling.md` to include references to these created stories in the markdown body without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [11192437546077218061](https://jules.google.com/task/11192437546077218061) started by @szubster*