### PR TITLE
🎨 Palette: Add missing focus-visible styles to AppLayout interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,7 @@
 
 ## 2026-05-15 - Tooltips for Icon-Only Interactive Elements
 **Learning:** Icon-only buttons (e.g. close buttons, clear input buttons) can be visually ambiguous. Always provide a `title` attribute for sighted users (especially on desktop where they can hover) alongside `aria-label` for screen readers. This makes the interface more intuitive and accessible without cluttering the visual design.
+
+## 2024-04-22 - Focus Styles on Complex App Layouts
+**Learning:** Standard HTML elements functioning as buttons or links in custom, complex UI components (like `AppLayout` Desktop Navigation or headers) sometimes omit standard focus indicators when customized heavily. This breaks keyboard navigation.
+**Action:** All interactive elements (e.g., links, buttons) across the main layout must explicitly define focus styles using the standard utility class string: `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` to ensure consistent accessibility.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -90,7 +90,10 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
       <div className="mx-auto flex min-h-screen max-w-[1600px] flex-col">
         <header className="sticky top-2 z-40 flex flex-col items-center justify-between gap-6 border-white/5 border-b bg-zinc-950/80 px-4 py-6 backdrop-blur-xl sm:px-8 sm:py-10 lg:flex-row">
           <div className="flex w-full items-center justify-between gap-12 lg:w-auto">
-            <Link to="/">
+            <Link
+              to="/"
+              className="rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+            >
               <div className="group slide-in-from-left-4 fade-in flex animate-in flex-col pt-2 duration-500">
                 <div className="flex items-end gap-2">
                   <span className="font-black text-4xl text-white tracking-tighter transition-colors group-hover:text-[var(--theme-primary)]">
@@ -118,7 +121,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                       'bg-[var(--theme-primary)] text-white shadow-[0_0_20px_rgba(var(--theme-primary-rgb),0.3)]',
                   }}
                   inactiveProps={{ className: 'text-zinc-500 hover:text-white hover:bg-white/5' }}
-                  className="flex items-center gap-2 rounded-xl px-6 py-2.5 font-black text-[11px] uppercase tracking-widest transition-all"
+                  className="flex items-center gap-2 rounded-xl px-6 py-2.5 font-black text-[11px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
                 >
                   <LayoutGrid size={16} />
                   Pokedex
@@ -130,7 +133,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                       'bg-[var(--theme-primary)] text-white shadow-[0_0_20px_rgba(var(--theme-primary-rgb),0.3)]',
                   }}
                   inactiveProps={{ className: 'text-zinc-500 hover:text-white hover:bg-white/5' }}
-                  className="flex items-center gap-2 rounded-xl px-6 py-2.5 font-black text-[11px] uppercase tracking-widest transition-all"
+                  className="flex items-center gap-2 rounded-xl px-6 py-2.5 font-black text-[11px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
                 >
                   <LayoutGrid size={16} />
                   Storage
@@ -142,7 +145,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                       'bg-[var(--theme-primary)] text-white shadow-[0_0_20px_rgba(var(--theme-primary-rgb),0.3)]',
                   }}
                   inactiveProps={{ className: 'text-zinc-500 hover:text-white hover:bg-white/5' }}
-                  className="flex items-center gap-2 rounded-xl px-6 py-2.5 font-black text-[11px] uppercase tracking-widest transition-all"
+                  className="flex items-center gap-2 rounded-xl px-6 py-2.5 font-black text-[11px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
                 >
                   <Sparkles size={16} />
                   Assistant
@@ -202,7 +205,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                 data-testid="version-selector"
                 onClick={() => setIsVersionModalOpen(true)}
                 className={cn(
-                  'group zoom-in-95 fade-in relative animate-in overflow-hidden rounded-2xl border px-5 py-2.5 font-black text-[11px] uppercase tracking-widest transition-all duration-500',
+                  'group zoom-in-95 fade-in relative animate-in overflow-hidden rounded-2xl border px-5 py-2.5 font-black text-[11px] uppercase tracking-widest transition-all duration-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
                   effectiveVersion === 'unknown'
                     ? 'border-amber-500/20 bg-amber-500/10 text-amber-500'
                     : 'border-[var(--theme-primary)]/20 bg-[var(--theme-primary)]/10 text-[var(--theme-primary)] hover:bg-[var(--theme-primary)] hover:text-white',
@@ -222,7 +225,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                   type="button"
                   onClick={() => setIsSettingsOpen(true)}
                   aria-label="System Settings"
-                  className="retro-button flex items-center justify-center rounded-2xl border border-white/5 bg-white/5 p-3 text-zinc-400 transition-all hover:bg-white/10 hover:text-white"
+                  className="retro-button flex items-center justify-center rounded-2xl border border-white/5 bg-white/5 p-3 text-zinc-400 transition-all hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
                   title="System Settings"
                 >
                   <Settings2 size={20} />


### PR DESCRIPTION
### What
Added standard `focus-visible` utility classes to interactive elements in the `AppLayout` component that were previously missing them, breaking keyboard navigation visibility. Specifically updated:
1. The main 'DEX HELPER' logo link.
2. The Desktop Navigation links (Pokedex, Storage, Assistant).
3. The Game Version selector button.
4. The System Settings button.

### Why
To improve keyboard navigation and accessibility. Sighted users relying on keyboard navigation (e.g. tabbing) could not tell which top-level application layout element currently had focus because the custom styling overrode browser defaults without explicitly providing a replacement `focus-visible` state.

### Before/After
*(Visual changes verified via automated Playwright screenshots showing the `var(--theme-primary)` ring when elements receive focus via Tab).*

### Accessibility notes
Standardized using `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` to match the rest of the application.

---
*PR created automatically by Jules for task [2509922990380401680](https://jules.google.com/task/2509922990380401680) started by @szubster*