### PR TITLE
Draft TASK node for Scheduled Agent Workflow

### DIFF
--- a/.foundry/stories/story-004-generic-scheduling-workflow.md
+++ b/.foundry/stories/story-004-generic-scheduling-workflow.md
@@ -14,3 +14,5 @@ parent: .foundry/epics/epic-004-generic-agent-scheduling.md
 # Generic Scheduling Mechanism Workflow
 
 Create a reusable GitHub Action workflow (`.github/workflows/foundry-scheduled-agent.yml`) that accepts inputs (agent/persona name) and runs on a schedule. It needs to utilize the existing Jules environment setup (reading `.github/agents/<persona>.md` for prompt hydration). This addresses the generic scheduling and standard hydration requirements.
+### Generated Tasks
+- [ ] `.foundry/tasks/task-017-create-scheduled-agent-workflow.md`

--- a/.foundry/tasks/task-017-create-scheduled-agent-workflow.md
+++ b/.foundry/tasks/task-017-create-scheduled-agent-workflow.md
@@ -1,0 +1,42 @@
+---
+id: task-017-create-scheduled-agent-workflow
+type: TASK
+title: "Create Scheduled Agent Workflow"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on: []
+jules_session_id: null
+parent: .foundry/stories/story-004-generic-scheduling-workflow.md
+tags: []
+rejection_count: 0
+notes: ""
+---
+
+# Create Scheduled Agent Workflow
+
+Implement `.github/workflows/foundry-scheduled-agent.yml`, a reusable workflow that provides a generic scheduling mechanism for Foundry agents.
+
+## Technical Blueprint
+
+1. **Workflow Triggers**:
+   - `workflow_call`: To be called by other scheduling workflows. It should accept an input `persona` (string, required).
+   - `workflow_dispatch`: For manual testing, accepting a `persona` input.
+
+2. **Job Definition**:
+   - Create a job (e.g., `execute_scheduled_agent`) running on `ubuntu-latest`.
+   - Checkout the code and set up Node.js.
+
+3. **Prompt Hydration & Execution**:
+   - Construct a `prompt_json` payload similar to how `foundry-engine.yml` does.
+   - Specifically read `.github/agents/${{ inputs.persona }}.md` for the context.
+   - Dispatch to `https://jules.googleapis.com/v1alpha/sessions`.
+
+## Acceptance Criteria
+- [ ] Workflow correctly handles input `persona`.
+- [ ] Workflow successfully hydrates prompt from `.github/agents/<persona>.md`.
+- [ ] Workflow triggers Jules API correctly.
+- [ ] Code strictly follows existing patterns in `.github/workflows/foundry-engine.yml`.
+
+*Self-verification*: Since this task consists of writing a self-contained GitHub Actions workflow similar to existing ones and does not change application logic, the `coder` is authorized to self-verify by triggering the workflow manually via `workflow_dispatch` and confirming it runs.

--- a/.foundry/tasks/task-017-create-scheduled-agent-workflow.md
+++ b/.foundry/tasks/task-017-create-scheduled-agent-workflow.md
@@ -39,4 +39,4 @@ Implement `.github/workflows/foundry-scheduled-agent.yml`, a reusable workflow t
 - [ ] Workflow triggers Jules API correctly.
 - [ ] Code strictly follows existing patterns in `.github/workflows/foundry-engine.yml`.
 
-*Self-verification*: Since this task consists of writing a self-contained GitHub Actions workflow similar to existing ones and does not change application logic, the `coder` is authorized to self-verify by triggering the workflow manually via `workflow_dispatch` and confirming it runs.
+*Verification*: Automated verification might not be possible for this CI workflow. A human will verify manually and create a new task or provide a fix outside of the Foundry mechanism if needed.


### PR DESCRIPTION
Added a `TASK` node representing the work for the coder to create the scheduled agent workflow per the architectural specification. Updated `story-004-generic-scheduling-workflow` to reference this new generated task in its body.

---
*PR created automatically by Jules for task [14124981584148528432](https://jules.google.com/task/14124981584148528432) started by @szubster*