### PR TITLE
🔧 Infras: Resolve Foundry DAG resolution warnings

### DIFF
--- a/.foundry/epics/epic-007-atomic-handoff-schema.md
+++ b/.foundry/epics/epic-007-atomic-handoff-schema.md
@@ -1,6 +1,7 @@
 ---
 id: "epic-007-atomic-handoff-schema"
 type: "EPIC"
+title: "Epic: Atomic Handoff Schema & Documentation"
 status: "PENDING"
 owner_persona: "story_owner"
 created_at: "2026-04-22"

--- a/.foundry/epics/epic-008-atomic-handoff-orchestrator.md
+++ b/.foundry/epics/epic-008-atomic-handoff-orchestrator.md
@@ -1,6 +1,7 @@
 ---
 id: "epic-008-atomic-handoff-orchestrator"
 type: "EPIC"
+title: "Epic: Orchestrator Script Refactor for Atomic Handoffs"
 status: "PENDING"
 owner_persona: "story_owner"
 created_at: "2026-04-22"

--- a/.foundry/epics/epic-009-atomic-handoff-testing.md
+++ b/.foundry/epics/epic-009-atomic-handoff-testing.md
@@ -1,6 +1,7 @@
 ---
 id: "epic-009-atomic-handoff-testing"
 type: "EPIC"
+title: "Epic: Atomic Handoff Testing Expansion"
 status: "PENDING"
 owner_persona: "story_owner"
 created_at: "2026-04-22"

--- a/.foundry/ideas/idea-006-gen2-expansion.md
+++ b/.foundry/ideas/idea-006-gen2-expansion.md
@@ -6,6 +6,7 @@ status: ACTIVE
 owner_persona: product_manager
 created_at: "2026-04-21"
 updated_at: "2026-04-21"
+jules_session_id: null
 depends_on:
   - .foundry/ideas/idea-001-the-foundry.md
   - .foundry/ideas/idea-003-atomic-handoff-foundation.md

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -348,13 +348,26 @@ function main(): void {
 
   function isBlocked(nodePath: string, visited = new Set<string>()): boolean {
     if (evalCache.has(nodePath)) return evalCache.get(nodePath)!;
+
+    const node = nodeMap.get(nodePath);
+
+    // If node is already COMPLETED, it cannot block anything.
+    if (node?.frontmatter.status === 'COMPLETED') {
+      evalCache.set(nodePath, false);
+      return false;
+    }
+
+    if (!node && fs.existsSync(path.join(repoRoot, nodePath))) {
+      evalCache.set(nodePath, false);
+      return false;
+    }
+
     if (visited.has(nodePath)) {
       warn(`Circular dependency detected at ${nodePath}`);
       return true;
     }
     visited.add(nodePath);
 
-    const node = nodeMap.get(nodePath);
     if (!node) {
       hasUnresolvableDeps = true;
       evalCache.set(nodePath, true);
@@ -365,6 +378,9 @@ function main(): void {
     for (const depPath of node.frontmatter.depends_on) {
       const dep = nodeMap.get(depPath);
       if (!dep) {
+        if (fs.existsSync(path.join(repoRoot, depPath))) {
+          continue;
+        }
         warn(`Unresolvable dependency '${depPath}' referenced by: ${nodePath}`);
         hasUnresolvableDeps = true;
         evalCache.set(nodePath, true);
@@ -429,7 +445,12 @@ function main(): void {
       // Parent blocked by its own dependencies?
       for (const depPath of parentNode.frontmatter.depends_on) {
         const dep = nodeMap.get(depPath);
-        if (!dep || dep.frontmatter.status !== 'COMPLETED' || isBlocked(depPath)) {
+        if (!dep) {
+          if (fs.existsSync(path.join(repoRoot, depPath))) continue;
+          blocked = true;
+          break;
+        }
+        if (dep.frontmatter.status !== 'COMPLETED' || isBlocked(depPath)) {
             blocked = true;
             break;
         }
@@ -445,6 +466,9 @@ function main(): void {
     for (const depPath of deps) {
       const dep = nodeMap.get(depPath);
       if (!dep) {
+        if (fs.existsSync(path.join(repoRoot, depPath))) {
+          continue;
+        }
         warn(`Unresolvable dependency '${depPath}' referenced by: ${node.repoPath}`);
         hasUnresolvableDeps = true;
         blocked = true;

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -346,76 +346,6 @@ function main(): void {
   // 3. ANY of its recursive children are blocked.
   const evalCache = new Map<string, boolean>();
 
-  function isBlocked(nodePath: string, visited = new Set<string>()): boolean {
-    if (evalCache.has(nodePath)) return evalCache.get(nodePath)!;
-
-    const node = nodeMap.get(nodePath);
-
-    // If node is already COMPLETED, it cannot block anything.
-    if (node?.frontmatter.status === 'COMPLETED') {
-      evalCache.set(nodePath, false);
-      return false;
-    }
-
-    if (!node && fs.existsSync(path.join(repoRoot, nodePath))) {
-      evalCache.set(nodePath, false);
-      return false;
-    }
-
-    if (visited.has(nodePath)) {
-      warn(`Circular dependency detected at ${nodePath}`);
-      return true;
-    }
-    visited.add(nodePath);
-
-    if (!node) {
-      hasUnresolvableDeps = true;
-      evalCache.set(nodePath, true);
-      return true;
-    }
-
-    // Unresolved dependencies
-    for (const depPath of node.frontmatter.depends_on) {
-      const dep = nodeMap.get(depPath);
-      if (!dep) {
-        if (fs.existsSync(path.join(repoRoot, depPath))) {
-          continue;
-        }
-        warn(`Unresolvable dependency '${depPath}' referenced by: ${nodePath}`);
-        hasUnresolvableDeps = true;
-        evalCache.set(nodePath, true);
-        return true;
-      }
-
-      if (dep.frontmatter.status !== 'COMPLETED') {
-        evalCache.set(nodePath, true);
-        return true;
-      }
-
-      if (isBlocked(depPath, visited)) {
-        evalCache.set(nodePath, true);
-        return true;
-      }
-    }
-
-    // Hierarchical blocking: ALL children must be COMPLETED
-    const children = parentToChildren.get(nodePath) || [];
-    for (const child of children) {
-      if (child.frontmatter.status !== 'COMPLETED') {
-        evalCache.set(nodePath, true);
-        return true;
-      }
-      if (isBlocked(child.repoPath, visited)) {
-        evalCache.set(nodePath, true);
-        return true;
-      }
-    }
-
-    visited.delete(nodePath);
-    evalCache.set(nodePath, false);
-    return false;
-  }
-
   // Helper to safely check if 'child' is a deep descendant of 'ancestor'
   function isDescendant(childPath: string, ancestorPath: string): boolean {
     let curr = nodeMap.get(childPath)?.frontmatter.parent;
@@ -423,6 +353,52 @@ function main(): void {
       if (curr === ancestorPath) return true;
       curr = nodeMap.get(curr)?.frontmatter.parent;
     }
+    return false;
+  }
+
+  /**
+   * Helper to recursively check if a node (parent or dependency) is "incomplete"
+   * and thus blocks downstream work.
+   *
+   * A node is hierarchically incomplete if:
+   * 1. Its status is NOT 'COMPLETED'.
+   * 2. ANY of its recursive children (sub-tasks/stories) are incomplete.
+   *
+   * Note: This function only traverses the parent -> child tree. It does NOT
+   * follow 'depends_on' links to avoid circular deadlock between parents and children.
+   */
+  function isHierarchicallyIncomplete(nodePath: string): boolean {
+    if (evalCache.has(nodePath)) return evalCache.get(nodePath)!;
+
+    const node = nodeMap.get(nodePath);
+
+    // 1. Non-node files on disk (e.g. ADRs) are considered complete/static.
+    if (!node) {
+      if (fs.existsSync(path.join(repoRoot, nodePath))) {
+        evalCache.set(nodePath, false);
+        return false;
+      }
+      hasUnresolvableDeps = true;
+      evalCache.set(nodePath, true);
+      return true;
+    }
+
+    // 2. If node is not COMPLETED, it is definitely incomplete.
+    if (node.frontmatter.status !== 'COMPLETED') {
+      evalCache.set(nodePath, true);
+      return true;
+    }
+
+    // 3. If node is COMPLETED, it is still incomplete if its children (recursive) are not done.
+    const children = parentToChildren.get(nodePath) || [];
+    for (const child of children) {
+      if (isHierarchicallyIncomplete(child.repoPath)) {
+        evalCache.set(nodePath, true);
+        return true;
+      }
+    }
+
+    evalCache.set(nodePath, false);
     return false;
   }
 
@@ -440,22 +416,18 @@ function main(): void {
     let currParent = node.frontmatter.parent;
     while (currParent) {
       const parentNode = nodeMap.get(currParent);
-      if (!parentNode) break;
-
-      // Parent blocked by its own dependencies?
-      for (const depPath of parentNode.frontmatter.depends_on) {
-        const dep = nodeMap.get(depPath);
-        if (!dep) {
-          if (fs.existsSync(path.join(repoRoot, depPath))) continue;
-          blocked = true;
-          break;
-        }
-        if (dep.frontmatter.status !== 'COMPLETED' || isBlocked(depPath)) {
-            blocked = true;
-            break;
-        }
+      if (!parentNode) {
+        warn(`Parent '${currParent}' not found for: ${node.repoPath}`);
+        blocked = true;
+        break;
       }
-      if (blocked) break;
+
+      // A node is blocked if its parent is not COMPLETED
+      if (parentNode.frontmatter.status !== 'COMPLETED') {
+        blocked = true;
+        break;
+      }
+
       currParent = parentNode.frontmatter.parent;
     }
 
@@ -475,36 +447,18 @@ function main(): void {
         break;
       }
 
-      if (dep.frontmatter.status !== 'COMPLETED') {
-        blocked = true;
-        break;
-      }
-
-      // Is the dependency itself structurally blocked?
-      // For the dependency's children, skip checking children if the CURRENT node is a descendant of that dependency.
-      // E.g. Epic depends on Idea. Idea has no children. Not blocked.
-      // Story depends on Epic. Epic has Story as child. Story is descendant of Epic -> Skip child check for Epic.
-
-      // We do a custom check for the dependency so we can exclude checking the current node's path in the children.
-      let depStructurallyBlocked = false;
-      for(const innerDepPath of dep.frontmatter.depends_on) {
-         if(isBlocked(innerDepPath)) {
-            depStructurallyBlocked = true;
-            break;
-         }
-      }
-
-      if(depStructurallyBlocked) {
-         blocked = true;
-         break;
-      }
-
+      // If it's an external dependency (not an ancestor), it must be hierarchically complete.
+      // If it is an ancestor, we only care that it is status COMPLETED.
       if (!isDescendant(node.repoPath, depPath)) {
-          // It's an external dependency. We must ensure the dependency and ALL its children are completed.
-          if(isBlocked(depPath)) {
-              blocked = true;
-              break;
-          }
+        if (isHierarchicallyIncomplete(depPath)) {
+          blocked = true;
+          break;
+        }
+      } else {
+        if (dep.frontmatter.status !== 'COMPLETED') {
+          blocked = true;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
### What
Resolved missing frontmatter fields in several Foundry node files and improved the orchestrator's dependency resolution logic to handle non-node files and circularities involving completed nodes.

### Why
The Foundry orchestrator was emitting warnings and exiting with error code 1 in strict mode due to:
1. Nodes missing required schema fields (`title`, `jules_session_id`).
2. Dependencies on static documentation files (ADRs) that are not parsed as orchestrator nodes.
3. False-positive circular dependency detections in hierarchical completion flows.

### Impact on DX/CI
Unblocks the Foundry V2 lifecycle, enabling automated node promotion to READY and parallel execution of task agents.

### Setup notes
Ensure dependencies are installed for the orchestrator subproject:
`pnpm install --dir .github/scripts/`

Fixes #400

---
*PR created automatically by Jules for task [9654928555785424160](https://jules.google.com/task/9654928555785424160) started by @szubster*