### PR TITLE
Epic Planner: Late Binding PRD Breakdown

### DIFF
--- a/.foundry/epics/epic-010-late-binding-permissions.md
+++ b/.foundry/epics/epic-010-late-binding-permissions.md
@@ -1,0 +1,29 @@
+---
+id: "epic-010-late-binding-permissions"
+type: "EPIC"
+title: "Epic: Late Binding Persona Permissions Matrix"
+status: "PENDING"
+owner_persona: "story_owner"
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on:
+  - .foundry/prds/prd-002-late-binding-orchestrator.md
+jules_session_id: null
+parent: ".foundry/prds/prd-002-late-binding-orchestrator.md"
+tags: ["v2-architecture", "permissions", "late-binding"]
+---
+
+# Epic: Late Binding Persona Permissions Matrix
+
+## Overview
+This Epic implements the dynamic node creation permissions matrix required for Late Binding Orchestration. It ensures that only authorized personas can spawn specific types of nodes during their sessions, enabling dynamic "zoom in" or "pivot" actions mid-execution while maintaining system integrity.
+
+## Prerequisites
+- Approval of PRD-002: Late Binding Epics & Recursive Orchestration (`.foundry/prds/prd-002-late-binding-orchestrator.md`)
+
+## Acceptance Criteria
+- [ ] `architect` persona is configured and verified to create `TASK`, `ADR`, and `IDEA` nodes.
+- [ ] `tech_lead` persona is configured and verified to create `TASK` and `ADR` nodes.
+- [ ] `story_owner` persona is configured and verified to create `STORY` and `EPIC` nodes.
+- [ ] `product_manager` persona is configured and verified to create `IDEA`, `PRD`, and `EPIC` nodes.
+- [ ] System documentation and schemas are updated to reflect the new dynamic permission boundaries.

--- a/.foundry/epics/epic-011-wait-wake-orchestration.md
+++ b/.foundry/epics/epic-011-wait-wake-orchestration.md
@@ -1,0 +1,30 @@
+---
+id: "epic-011-wait-wake-orchestration"
+type: "EPIC"
+title: "Epic: Wait & Wake Orchestration Protocol"
+status: "PENDING"
+owner_persona: "story_owner"
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on:
+  - .foundry/epics/epic-010-late-binding-permissions.md
+jules_session_id: null
+parent: ".foundry/prds/prd-002-late-binding-orchestrator.md"
+tags: ["v2-architecture", "orchestration", "wait-and-wake"]
+---
+
+# Epic: Wait & Wake Orchestration Protocol
+
+## Overview
+This Epic builds out the core "Wait & Wake" and "Impossible Loop" mechanisms for Late Binding Orchestration. It allows agents blocked by newly discovered technical realities to dynamically spawn downstream tasks, suspend their own execution, and automatically resume once the orchestrator resolves the newly spawned dependencies.
+
+## Prerequisites
+- Implementation of Late Binding Persona Permissions (`.foundry/epics/epic-010-late-binding-permissions.md`)
+- Approval of PRD-002: Late Binding Epics & Recursive Orchestration (`.foundry/prds/prd-002-late-binding-orchestrator.md`)
+
+## Acceptance Criteria
+- [ ] Implement the Wait & Wake protocol: agents can spawn nodes, append them to `depends_on`, and suspend their session back to `PENDING`.
+- [ ] Orchestrator correctly handles the suspended state and re-triggers the parent node to `READY` when all spawned dependencies are `COMPLETED`.
+- [ ] Implement the "Impossible Loop": agents can flag a node as `FAILED` with a `rejection_reason` in frontmatter.
+- [ ] Orchestrator detects `FAILED` states from the Impossible Loop and wakes the parent node or flags it for `tpm` review.
+- [ ] Integration testing across multiple node lifecycles simulating dynamic spawning and wait/wake.

--- a/.foundry/epics/epic-012-gastown-migration-evaluation.md
+++ b/.foundry/epics/epic-012-gastown-migration-evaluation.md
@@ -1,0 +1,29 @@
+---
+id: "epic-012-gastown-migration-evaluation"
+type: "EPIC"
+title: "Epic: Gastown Worker Migration Evaluation"
+status: "PENDING"
+owner_persona: "story_owner"
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on:
+  - .foundry/epics/epic-011-wait-wake-orchestration.md
+jules_session_id: null
+parent: ".foundry/prds/prd-002-late-binding-orchestrator.md"
+tags: ["v2-architecture", "orchestration", "gastown-migration"]
+---
+
+# Epic: Gastown Worker Migration Evaluation
+
+## Overview
+This Epic involves a deep evaluation of migrating the Foundry orchestrator from GitHub Actions to an external Cloudflare Worker service ("Gastown"). The evaluation will determine if the increased state management and reliability benefits outweigh the added system complexity.
+
+## Prerequisites
+- Implementation of Wait & Wake Orchestration Protocol (`.foundry/epics/epic-011-wait-wake-orchestration.md`)
+- Approval of PRD-002: Late Binding Epics & Recursive Orchestration (`.foundry/prds/prd-002-late-binding-orchestrator.md`)
+
+## Acceptance Criteria
+- [ ] Research and document a proof-of-concept for the Gastown Worker utilizing Cloudflare D1 (SQL) or KV to persist node states.
+- [ ] Propose and document a state synchronization mechanism (polling GitHub vs Webhooks) ensuring consistency with the markdown file states.
+- [ ] Define the security boundaries ensuring agents (Jules) cannot access the Orchestrator DB or hallucinate markdown states.
+- [ ] Produce an Architecture Decision Record (ADR) recommending whether to proceed with the Gastown migration or improve GitHub Actions natively.

--- a/.foundry/prds/prd-002-late-binding-orchestrator.md
+++ b/.foundry/prds/prd-002-late-binding-orchestrator.md
@@ -66,4 +66,9 @@ When an agent is blocked by new technical realities:
 - **Error Recovery:** Reduction in manual PM intervention for deadlocked or impossible tasks due to the Resurrection Loop.
 
 ## 4. Next Steps
-- [ ] **Epic Planner:** Break down this PRD into Epics mapping out the persona permission implementations, the Wait & Wake protocol orchestration logic, and the Cloudflare Worker Gastown migration.
+- [x] **Epic Planner:** Break down this PRD into Epics mapping out the persona permission implementations, the Wait & Wake protocol orchestration logic, and the Cloudflare Worker Gastown migration.
+
+## Generated Epics
+- `.foundry/epics/epic-010-late-binding-permissions.md`
+- `.foundry/epics/epic-011-wait-wake-orchestration.md`
+- `.foundry/epics/epic-012-gastown-migration-evaluation.md`


### PR DESCRIPTION
* Created `epic-010-late-binding-permissions.md` mapping out persona permission implementations.
* Created `epic-011-wait-wake-orchestration.md` mapping out the Wait & Wake protocol.
* Created `epic-012-gastown-migration-evaluation.md` for evaluating the Cloudflare Worker Gastown migration.
* Updated `prd-002-late-binding-orchestrator.md` to check off the "Next Steps" Epic Planner task and appended a list of the newly generated Epics without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [1978872399059388713](https://jules.google.com/task/1978872399059388713) started by @szubster*