### PR TITLE
feat: generated epics for human-in-the-loop PRD

### DIFF
--- a/.foundry/epics/epic-010-hitl-schema-extensions.md
+++ b/.foundry/epics/epic-010-hitl-schema-extensions.md
@@ -1,0 +1,23 @@
+---
+id: "epic-010-hitl-schema-extensions"
+type: "EPIC"
+title: "Schema Extensions for Human-in-the-Loop"
+status: "PENDING"
+owner_persona: "story_owner"
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/prds/prd-004-human-in-the-loop.md"
+tags:
+  - "human-in-the-loop"
+---
+
+# Epic 010: Schema Extensions for Human-in-the-Loop
+
+## Prerequisites
+- Knowledge of the Foundry Master Schema (`.foundry/docs/schema.md`).
+
+## Acceptance Criteria
+- [ ] Add `human` to the `owner_persona` enum in the Master Schema.
+- [ ] Add `pr_number` to the global frontmatter schema as `integer | null` (optional, defaults to `null`).

--- a/.foundry/epics/epic-011-hitl-orchestrator-bypass.md
+++ b/.foundry/epics/epic-011-hitl-orchestrator-bypass.md
@@ -1,0 +1,29 @@
+---
+id: "epic-011-hitl-orchestrator-bypass"
+type: "EPIC"
+title: "Orchestrator Bypass for Human-in-the-Loop"
+status: "PENDING"
+owner_persona: "story_owner"
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on:
+  - .foundry/epics/epic-010-hitl-schema-extensions.md
+jules_session_id: null
+parent: ".foundry/prds/prd-004-human-in-the-loop.md"
+tags:
+  - "human-in-the-loop"
+---
+
+# Epic 011: Orchestrator Bypass for Human-in-the-Loop
+
+## Prerequisites
+- Completion of Schema Extensions for Human-in-the-Loop (`.foundry/epics/epic-010-hitl-schema-extensions.md`).
+- Understanding of the `foundry-orchestrator.ts` logic.
+
+## Acceptance Criteria
+- [ ] Update `foundry-orchestrator.ts` to identify nodes with `owner_persona: human`.
+- [ ] Ensure the orchestrator marks `human` nodes as `ACTIVE` but does *not* attempt to spawn a Jules session (bypasses GitHub Actions dispatch).
+- [ ] Allow humans to manually pick up `READY` tasks.
+- [ ] Support manual transition to `COMPLETED` by a human if they committed directly to `main`.
+- [ ] Ensure orchestrator validation enforces that a `qa` node follows human tasks to maintain system-wide standards.
+- [ ] Add unit tests in `foundry-orchestrator.test.ts` to verify the bypass logic and validation.

--- a/.foundry/epics/epic-012-hitl-heartbeat-monitoring.md
+++ b/.foundry/epics/epic-012-hitl-heartbeat-monitoring.md
@@ -1,0 +1,28 @@
+---
+id: "epic-012-hitl-heartbeat-monitoring"
+type: "EPIC"
+title: "Heartbeat Monitoring for Human-in-the-Loop"
+status: "PENDING"
+owner_persona: "story_owner"
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on:
+  - .foundry/epics/epic-011-hitl-orchestrator-bypass.md
+jules_session_id: null
+parent: ".foundry/prds/prd-004-human-in-the-loop.md"
+tags:
+  - "human-in-the-loop"
+---
+
+# Epic 012: Heartbeat Monitoring for Human-in-the-Loop
+
+## Prerequisites
+- Completion of Orchestrator Bypass for Human-in-the-Loop (`.foundry/epics/epic-011-hitl-orchestrator-bypass.md`).
+- Understanding of the `foundry-heartbeat.ts` logic.
+
+## Acceptance Criteria
+- [ ] Update `foundry-heartbeat.ts` to poll the GitHub API for PR status if a node is `ACTIVE` and has a `pr_number`.
+- [ ] Automatically transition the node to `COMPLETED` if the associated PR is merged.
+- [ ] Automatically transition the node to `READY` if the associated PR is closed without being merged (allowing it to be reclaimed).
+- [ ] Ensure human tasks (those with `owner_persona: human`) do not expire or fail based on heartbeat loops, remaining `ACTIVE` until manually completed or the PR is merged.
+- [ ] Add unit tests in `foundry-heartbeat.test.ts` to verify PR polling, completion states, and skipped timeouts.

--- a/.foundry/prds/prd-004-human-in-the-loop.md
+++ b/.foundry/prds/prd-004-human-in-the-loop.md
@@ -61,3 +61,8 @@ The `foundry-orchestrator.ts` and `foundry-heartbeat.ts` must be updated:
 
 ## Next Steps
 - **Epic Planner**: Break down this PRD into Epics mapping out the schema additions, orchestrator script modifications, and required testing.
+
+## Generated Epics
+- [.foundry/epics/epic-010-hitl-schema-extensions.md](../epics/epic-010-hitl-schema-extensions.md)
+- [.foundry/epics/epic-011-hitl-orchestrator-bypass.md](../epics/epic-011-hitl-orchestrator-bypass.md)
+- [.foundry/epics/epic-012-hitl-heartbeat-monitoring.md](../epics/epic-012-hitl-heartbeat-monitoring.md)


### PR DESCRIPTION
This PR completes the breakdown of `prd-004-human-in-the-loop` into actionable epics, successfully fulfilling the responsibilities of the Epic Planner persona.

Three epics were created mapping out dependencies and defining explicit acceptance criteria (including tests and qa nodes for verification):
- `.foundry/epics/epic-010-hitl-schema-extensions.md`
- `.foundry/epics/epic-011-hitl-orchestrator-bypass.md`
- `.foundry/epics/epic-012-hitl-heartbeat-monitoring.md`

The original PRD node was carefully updated to append links to these new epics without altering its YAML frontmatter, complying strictly with DAG formatting rules.

---
*PR created automatically by Jules for task [13927079115328894118](https://jules.google.com/task/13927079115328894118) started by @szubster*