### PR TITLE
Story Owner: Generate STORY for Atomic Handoff Schema Update

### DIFF
--- a/.foundry/epics/epic-007-atomic-handoff-schema.md
+++ b/.foundry/epics/epic-007-atomic-handoff-schema.md
@@ -26,3 +26,6 @@ This Epic covers the required updates to the `.foundry/docs/schema.md` and relat
 - [ ] `schema.md` is updated to explicitly define the single-owner invariant per node.
 - [ ] Examples in documentation reflect the new atomic file structure.
 - [ ] Any references to "composite nodes" are removed or marked deprecated.
+
+## Generated Stories
+- `.foundry/stories/story-007-update-schema-atomic-handoff.md`

--- a/.foundry/stories/story-007-update-schema-atomic-handoff.md
+++ b/.foundry/stories/story-007-update-schema-atomic-handoff.md
@@ -1,0 +1,31 @@
+---
+id: "story-007-update-schema-atomic-handoff"
+type: "STORY"
+title: "Update Schema for Atomic Handoffs"
+status: "PENDING"
+owner_persona: "tech_lead"
+created_at: "2026-04-22"
+updated_at: "2026-04-22"
+depends_on:
+  - ".foundry/epics/epic-007-atomic-handoff-schema.md"
+jules_session_id: null
+parent: ".foundry/epics/epic-007-atomic-handoff-schema.md"
+tags: ["schema", "atomic-handoffs"]
+rejection_count: 0
+notes: ""
+---
+
+# Update Schema for Atomic Handoffs
+
+## Goal
+Update `.foundry/docs/schema.md` and related documentation to formally support the "Atomic Handoffs" paradigm.
+
+## Requirements
+- `schema.md` must be updated to explicitly define the single-owner invariant per node.
+- Examples in documentation must reflect the new atomic file structure.
+- Any references to "composite nodes" must be removed or marked deprecated.
+
+## Definition of Done
+- `schema.md` is updated.
+- `schema.md` examples reflect the atomic file structure.
+- References to composite nodes are removed or marked deprecated.


### PR DESCRIPTION
Created a new `STORY` node `story-007-update-schema-atomic-handoff.md` mapped to `epic-007-atomic-handoff-schema.md` to instruct the `tech_lead` to formally define the Atomic Handoffs invariants in `schema.md` and deprecate composite nodes. This unblocks the next step for this Epic. Updated the Epic markdown with the generated story to keep the lineage clear according to the schema rules.

---
*PR created automatically by Jules for task [9753837594150167752](https://jules.google.com/task/9753837594150167752) started by @szubster*