### PR TITLE
🧭 Strategist: Prompt improvement - Remove Git/PR history as memory source

### DIFF
--- a/.jules/schedules/canvas.md
+++ b/.jules/schedules/canvas.md
@@ -4,7 +4,7 @@ Propose and implement ONE ambitious UI/UX change that meaningfully improves a co
 
 ## Session Flow
 
-You have no memory between sessions. Your only persistence is what's committed to the repo: your journal (`.jules/canvas.md`) and the Git/PR history.
+You have no memory between sessions. Your only persistence is what's committed to the repo: your journal (`.jules/canvas.md`).
 
 ### Normal flow (most sessions):
 
@@ -31,7 +31,7 @@ You have no memory between sessions. Your only persistence is what's committed t
 ## Boundaries
 
 **Always:**
-- Read your journal and PR history before starting — it's your only memory
+- Read your journal before starting — it's your only memory
 - Include a journal entry for the current change in every PR you open
 - Run `pnpm lint` and `pnpm test` before pushing
 - Include before/after screenshots in the PR description

--- a/.jules/schedules/strategist.md
+++ b/.jules/schedules/strategist.md
@@ -17,7 +17,7 @@ The current agent roster lives in `.jules/schedules/`. Before proposing anything
 ## Boundaries
 
 **Always:**
-- Read your journal and PR history before starting — it's your only memory
+- Read your journal before starting — it's your only memory
 - Include a journal entry for the current change in every PR you open
 - Read all files in `.jules/schedules/` before proposing anything
 - Review recent PRs from agents (search by their title prefixes: `⚡ Bolt:`, `🎨 Palette:`, etc.) to assess prompt effectiveness
@@ -37,7 +37,7 @@ The current agent roster lives in `.jules/schedules/`. Before proposing anything
 
 ## Session Flow
 
-You have no memory between sessions. Your only persistence is what's committed to the repo: your journal (`.jules/strategist.md`) and the Git/PR history.
+You have no memory between sessions. Your only persistence is what's committed to the repo: your journal (`.jules/strategist.md`).
 
 ### Normal flow (most sessions):
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -20,3 +20,9 @@
 **Outcome:** Rejected → journaled
 **Why:** The maintainer rejected the proposal to use `git log` to retroactively discover outcomes, stating explicitly: "They should not look at past commits to figure out their memory, as journal always has them. Every PR either has code changes + journal (optionally, if useful), or journal only with rejection statement and reason for future learning."
 **Pattern:** Do not propose tracking memory through past commits instead of the explicit journal mechanism defined in the "Wait and Convert" flow.
+
+## 2025-04-23 - [Accepted] - Prompt improvement - Remove Git/PR history as memory source
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** Maintainer clarified that agents should not look at past commits to figure out their memory, as the journal always has them.
+**Pattern:** Do not instruct agents to read PR history for cross-session memory.


### PR DESCRIPTION
**Proposal:** Update the `strategist.md` and `canvas.md` schedule prompts to stop instructing agents to read "Git/PR history" as their memory, and record this learning in the Strategist's journal.
**Justification:** The maintainer explicitly rejected a previous proposal to use Git history for memory, clarifying: "They should not look at past commits to figure out their memory, as journal always has them." Relying on Git history contradicts the explicit "Wait and Convert" flow designed to persist learnings in a journal file.
**Evidence:** The `.jules/strategist.md` journal's entry dated 2025-04-22 explicitly documents this rejection and the rule not to use past commits for memory.

---
*PR created automatically by Jules for task [14084615336387880222](https://jules.google.com/task/14084615336387880222) started by @szubster*