### PR TITLE
🧪 Sentinel: PokeDB recursive inflateChain test coverage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,3 +33,6 @@ When running vitest with `--reporter=json > cov.json`, the output often includes
 
 ### Vitest Coverage Issues
 If you encounter `Error: Failed to load custom Reporter from text` when running `npx vitest run --coverage`, it's likely a mismatch or issue with the coverage reporter setup. Use `--reporter=default` as a workaround (e.g. `npx vitest run --coverage --reporter=default`).
+## Learnings
+* Make sure `pnpm` resolves correct version compatibility warning, `vitest coverage` reporter configuration error (like loading `text` report module causing Startup Error, use `--reporter=default` instead).
+* `vi.mocked(fetch).mockResolvedValue` requires mocking properties appropriately for Deep Types (like `json: async () => mockData` to simulate Response Object resolving body mapping)

--- a/src/db/__tests__/PokeDB.test.ts
+++ b/src/db/__tests__/PokeDB.test.ts
@@ -209,6 +209,51 @@ describe('PokeDB', () => {
     expect(manyResult[0]).toBeInstanceOf(Error);
   });
 
+  it('inflates recursive evo chains correctly', async () => {
+    const mockData = {
+      hash: 'evo-chain-hash',
+      poke: [
+        {
+          id: 1,
+          n: 'P1',
+          cr: 10,
+          gr: 1,
+          baby: false,
+          efrm: [],
+          det: [],
+          eto: [
+            {
+              id: 2,
+              det: [{ tr: 1 }],
+              eto: [
+                {
+                  id: 3,
+                  det: [{ tr: 2 }],
+                  eto: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      enc: [],
+      loc: [],
+    };
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    } as Response);
+
+    await pokeDB.sync();
+
+    const p1 = await pokeDB.getPokemon(1);
+    expect(p1?.eto?.[0]?.id).toBe(2);
+    expect(p1?.eto?.[0]?.det?.[0]?.tr).toBe(1);
+    expect(p1?.eto?.[0]?.eto?.[0]?.id).toBe(3);
+    expect(p1?.eto?.[0]?.eto?.[0]?.det?.[0]?.tr).toBe(2);
+  });
+
   it('resolves area names correctly', async () => {
     const mockData = {
       hash: 'area-hash',


### PR DESCRIPTION
🧪 Sentinel: PokeDB recursive inflateChain test coverage

### What
Added a dedicated unit test in `src/db/__tests__/PokeDB.test.ts` to assert that recursive evolution structures (`eto` fields) and their associated details (`det`) are properly inflated to the defaults via the internal `inflateChain` function. 

### Coverage Before/After
- PokeDB Statements: 95.62% -> 97.08%
- PokeDB Branches: 85.71% -> 87.01%

### Why this target matters
The recursive `inflateChain` mechanism initializes missing properties during PokeDB synchronization. An untested branch traversing arbitrarily nested JSON `eto` arrays opens the door to silent transformation failures and runtime bugs that won't show up until rendering deep evolution chains in the UI.

I verified the test passes locally and all E2E tests have succeeded.

---
*PR created automatically by Jules for task [15348016308400818586](https://jules.google.com/task/15348016308400818586) started by @szubster*