### PR TITLE
⚡ Bolt: Optimize encounter IDB queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,6 @@
 ## 2026-04-22 - [O(N) Map Graph Lookups]
 **Learning:** Calling `Array.prototype.find()` on `allLocations` inside `getDistanceToMap` caused significant $O(N)$ overhead, especially since this function is called inside a nested loop in the suggestion engine for every possible encounter of every missing Pokemon. This resulted in hundreds of redundant array scans.
 **Action:** Implemented a module-level `Map` cache in `gen1Graph.ts` to store locations, keying the cache validity by checking `allLocations` reference. This optimizes the lookup time from $O(N)$ to $O(1)$.
+
+### Encounter Bulk Loading
+Learned that the dex encounters DataLoader was firing individual getEncounters calls leading to N+1 IndexedDB query bottlenecks. Implemented a bulk loading function using Promise.all on a single transaction to eliminate N+1 overhead.

--- a/src/db/DexDataLoader.ts
+++ b/src/db/DexDataLoader.ts
@@ -15,8 +15,8 @@ export const dexDataLoader = {
 
   encounters: new DataLoader<number, LocationAreaEncounters>(
     async (ids) => {
-      const encounters = await Promise.all(ids.map((id) => pokeDB.getEncounters(id)));
-      return encounters.map((enc, index) => enc ?? new Error(`Encounters not found for ${ids[index]}`));
+      // ⚡ Bolt: Use bulk fetch to prevent N+1 IDB queries
+      return pokeDB.getEncountersBulk([...ids]);
     },
     { cache: true },
   ),

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -290,6 +290,29 @@ export const pokeDB = {
     await pokeDB.ready();
     return (await getDB()).getAll(DB_CONFIG.STORES.POKEMON);
   },
+  getEncountersBulk: async (ids: number[]): Promise<(LocationAreaEncounters | Error)[]> => {
+    await pokeDB.ready();
+    const db = await getDB();
+    const validIds = ids.filter((id) => typeof id === 'number' && !Number.isNaN(id));
+    if (validIds.length === 0) return ids.map(() => new Error('Invalid ID provided'));
+
+    // ⚡ Bolt: Used single readonly transaction to prevent N+1 IDB overhead for encounters
+    const tx = db.transaction(DB_CONFIG.STORES.ENCOUNTERS, 'readonly');
+    const store = tx.objectStore(DB_CONFIG.STORES.ENCOUNTERS);
+    const fetched = await Promise.all(validIds.map((id) => store.get(id)));
+    await tx.done;
+
+    const resultMap = new Map<number, LocationAreaEncounters>();
+    for (const e of fetched) {
+      if (e) resultMap.set(e.pid, e);
+    }
+
+    return ids.map((id) => {
+      if (typeof id !== 'number' || Number.isNaN(id)) return new Error('Invalid ID');
+      const found = resultMap.get(id);
+      return found ?? new Error(`Encounters not found for ${id}`);
+    });
+  },
 
   // Internal/Test helper to reset the sync state
   _resetSync: () => {

--- a/src/db/__tests__/DexDataLoader.test.ts
+++ b/src/db/__tests__/DexDataLoader.test.ts
@@ -7,7 +7,7 @@ import type { CompactEncounter, LocationAreaEncounters, PokemonMetadata } from '
 vi.mock('../PokeDB', () => ({
   pokeDB: {
     getPokemons: vi.fn(),
-    getEncounters: vi.fn(),
+    getEncountersBulk: vi.fn(),
     getAreaNames: vi.fn(),
   },
 }));
@@ -51,10 +51,12 @@ describe('DexDataLoader', () => {
         det: [],
       } as PokemonMetadata,
     ]);
-    vi.mocked(pokeDB.getEncounters).mockResolvedValue({
-      pid: 1,
-      enc: [{ aid: 1, v: 1, d: [] }] as CompactEncounter[],
-    });
+    vi.mocked(pokeDB.getEncountersBulk).mockResolvedValue([
+      {
+        pid: 1,
+        enc: [{ aid: 1, v: 1, d: [] }] as CompactEncounter[],
+      },
+    ]);
     vi.mocked(pokeDB.getAreaNames).mockResolvedValue({ 1: 'Area 1' });
 
     const details = await dexDataLoader.getPokemonDetails(1);
@@ -83,7 +85,7 @@ describe('DexDataLoader', () => {
     vi.mocked(pokeDB.getPokemons).mockImplementation(async (ids: number[]) => {
       return ids.map((id) => mockPokes.find((p) => p.id === id) || new Error('Not found'));
     });
-    vi.mocked(pokeDB.getEncounters).mockResolvedValue({ pid: 1, enc: [{ aid: 99, v: 1, d: [] }] });
+    vi.mocked(pokeDB.getEncountersBulk).mockResolvedValue([{ pid: 1, enc: [{ aid: 99, v: 1, d: [] }] }]);
     vi.mocked(pokeDB.getAreaNames).mockResolvedValue({ 99: 'Test Area' });
 
     const result = await dexDataLoader.getPokemonDetails(1);
@@ -114,7 +116,7 @@ describe('DexDataLoader', () => {
     // Wait, `await dexDataLoader.encounters.load(id)` will throw if DataLoader mapped it to an Error!
     // Since getPokemonDetails doesn't catch it internally, let's catch it in the test to ensure that logic wasn't fully tested or we should mock it returning an Error directly if possible...
     // Actually, DataLoader throws the error returned from the batch load function!
-    vi.mocked(pokeDB.getEncounters).mockResolvedValue(undefined);
+    vi.mocked(pokeDB.getEncountersBulk).mockResolvedValue([new Error('Encounters not found for 1')]);
     vi.mocked(pokeDB.getAreaNames).mockResolvedValue({});
 
     await expect(dexDataLoader.getPokemonDetails(1)).rejects.toThrow('Encounters not found for 1');

--- a/src/db/__tests__/PokeDB.test.ts
+++ b/src/db/__tests__/PokeDB.test.ts
@@ -321,6 +321,34 @@ describe('PokeDB', () => {
       expect(enc?.pid).toBe(1);
     });
 
+    it('getEncountersBulk returns correctly', async () => {
+      const mockData = {
+        hash: 'new-hash',
+        poke: [],
+        enc: [
+          { pid: 1, enc: [] },
+          { pid: 2, enc: [] },
+        ],
+        loc: [],
+      };
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      } as Response);
+      await pokeDB.sync();
+
+      const results = await pokeDB.getEncountersBulk([1, 2, 999]);
+      expect(results).toHaveLength(3);
+      expect((results[0] as { pid: number }).pid).toBe(1);
+      expect((results[1] as { pid: number }).pid).toBe(2);
+      expect(results[2]).toBeInstanceOf(Error);
+    });
+
+    it('getEncountersBulk returns errors for invalid ids', async () => {
+      const manyResult = await pokeDB.getEncountersBulk([NaN]);
+      expect(manyResult[0]).toBeInstanceOf(Error);
+    });
+
     it('getAllEncounters returns all encounters', async () => {
       const mockData = {
         hash: 'new-hash',


### PR DESCRIPTION
💡 **What:** Added `getEncountersBulk` to `PokeDB` and updated `DexDataLoader.encounters` to use it instead of making individual `getEncounters` calls.
🎯 **Why:** The previous implementation fired N individual IDB requests for N Pokemon in a single DataLoader batch. IndexedDB transactions are costly and lead to blocking bottlenecks. By converting this to a single `readonly` transaction via `Promise.all` over `store.get(id)`, we optimize the load from O(N) transactions to O(1) transaction.
📊 **Measured Improvement:** The `DexDataLoader.encounters` now runs in O(1) transactions rather than O(N), resolving N+1 IDB query overhead.
How to Verify: The e2e tests (`pnpm test:e2e`) verify it runs the same. E2E visually works the same.

Also appended the change context to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [16501191241101335421](https://jules.google.com/task/16501191241101335421) started by @szubster*