### PR TITLE
📜 Scribe: Zustand store state and invariants

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -22,14 +22,21 @@ export type PokeballType =
 // ─── Store Interface ─────────────────────────────────────────────────
 interface AppStore {
   // Save data
+  /**
+   * The heavy, transient parsed save state.
+   * This is intentionally excluded from localStorage persistence (via `partialize`)
+   * to prevent bloating the storage quota and stale state bugs.
+   */
   saveData: SaveData | null;
   error: string | null;
   setSaveData: (data: SaveData | null) => void;
   setError: (v: string | null) => void;
 
   // Persisted settings
+  /** Active UI filters explicitly persisted to localStorage via partialize. */
   filters: FilterType[];
   manualVersion: GameVersion | null;
+  /** Whether the user is tracking a living dex (persisted via partialize). */
   isLivingDex: boolean;
   globalPokeball: PokeballType;
   toggleFilter: (f: FilterType) => void;
@@ -52,6 +59,11 @@ interface AppStore {
   filtersSet: () => Set<FilterType>;
 
   // Actions
+  /**
+   * Rehydrates `saveData` from a base64 encoded `last_save_file` in localStorage.
+   * Invariant: If the data is corrupted or parsing fails, the cached file is immediately
+   * deleted to prevent infinite crash loops on subsequent reloads.
+   */
   loadSaveFromStorage: () => void;
 }
 


### PR DESCRIPTION
What: Documented `src/store.ts` state shape, actions, and invariants.
Why this module needed docs: It manages global application state. The separation between persisted lightweight settings and non-persisted heavy save data/transient UI needed documentation to prevent developers from accidentally bloating local storage or breaking rehydration.
Summary of additions: Added JSDoc for `AppStore` interface detailing `partialize` persistence invariants and the `loadSaveFromStorage` action's crash prevention logic.

---
*PR created automatically by Jules for task [17735201903990732485](https://jules.google.com/task/17735201903990732485) started by @szubster*