### PR TITLE
🗃️ Archivist: cleanup duplicated trainer entries, stale jsdom learning, and consolidate palette a11y

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,8 +7,8 @@
 **Action:** Use `role="radiogroup"` for the container and `role="radio"` for the individual buttons, along with `aria-checked={boolean}` and proper `aria-label`s on the container, to ensure screen readers correctly interpret the mutually exclusive selection pattern.
 
 ## 2024-04-13 - Added aria-label to icon-only buttons
-**Learning:** For accessibility, ensure all icon-only interactive elements (like buttons) include an `aria-label` attribute, as relying solely on the `title` attribute is insufficient for screen readers. In Dexhelper, several key interactive elements like the Assistant Panel debug toggle, Pokedex Cards, and Storage Grid cards lacked proper screen reader announcements despite having visual cues or titles.
-**Action:** Always add `aria-label` attributes to icon-only buttons and interactive card elements that act as links or triggers, ensuring the label clearly describes the action or destination (e.g., `aria-label={"View details for " + pokemon.name}`).
+**Learning:** For accessibility, ensure all icon-only interactive elements (like buttons) include an `aria-label` attribute, as relying solely on the `title` attribute is insufficient for screen readers. Icon-only buttons (e.g. close buttons, clear input buttons) can also be visually ambiguous. In Dexhelper, several key interactive elements like the Assistant Panel debug toggle, Pokedex Cards, and Storage Grid cards lacked proper screen reader announcements despite having visual cues or titles.
+**Action:** Always provide a `title` attribute for sighted users (especially on desktop where they can hover) alongside `aria-label` for screen readers to icon-only buttons and interactive card elements that act as links or triggers, ensuring the label clearly describes the action or destination (e.g., `aria-label={"View details for " + pokemon.name}`). This makes the interface more intuitive and accessible without cluttering the visual design.
 
 ## 2024-05-18 - [File Upload Input Accessibility]
 **Learning:** Using `className="hidden"` on `<input type="file">` elements within a `<label>` hides them completely from the accessibility tree, making it impossible for screen reader users to understand or interact with the file input properly, and preventing keyboard focus.
@@ -39,9 +39,6 @@
 ## 2026-04-20 - Interactive Elements Focus Styles
 **Learning:** Standard HTML elements functioning as buttons or links in custom UI components (like `BottomNav`) sometimes omit standard focus indicators when customized heavily.
 **Action:** All interactive elements (e.g., links, buttons) must explicitly define focus styles using the standard utility class string: `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950`. This ensures consistent keyboard navigation visibility across the app.
-
-## 2026-05-15 - Tooltips for Icon-Only Interactive Elements
-**Learning:** Icon-only buttons (e.g. close buttons, clear input buttons) can be visually ambiguous. Always provide a `title` attribute for sighted users (especially on desktop where they can hover) alongside `aria-label` for screen readers. This makes the interface more intuitive and accessible without cluttering the visual design.
 
 ## 2024-04-22 - Focus Styles on Complex App Layouts
 **Learning:** Standard HTML elements functioning as buttons or links in custom, complex UI components (like `AppLayout` Desktop Navigation or headers) sometimes omit standard focus indicators when customized heavily. This breaks keyboard navigation.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,7 +14,7 @@
 **Why:** Vitest features like `test.each` improve test reporting, readability, and traceablity for data-driven checks (like iterating variants). By utilizing them, tests become more robust and generate cleaner UI feedback.
 
 ## Tricky mocking patterns
-- When writing Vitest tests that interact with IndexedDB (like the suggestion engine or PokeDB), include `/** @vitest-environment jsdom */` at the top of the file and `import 'fake-indexeddb/auto';` to provide the required browser-like environment and prevent 'indexedDB is not defined' errors.
+- When writing Vitest tests that interact with IndexedDB (like the suggestion engine or PokeDB), `fakeIndexedDB` is polyfilled globally for the node environment via `src/node-setup.ts`, so you do NOT need to use `/** @vitest-environment jsdom */` or import `fake-indexeddb/auto` manually in individual test files.
 - Mocking functions imported from index files (like `parseSaveFile` from `./engine/saveParser/index`) requires defining the mock at the top level and using `vi.mocked()` to cast types locally:
   ```ts
   vi.mock('./engine/saveParser/index', () => ({

--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -1,7 +1,6 @@
 ## 2024-03-31 - Assistant Evolution Item Suggestion
 **Learning:** The item evolution check was verifying if an evolution stone existed in `saveData.inventory`, but was not checking its `quantity`. This could cause false "Ready to Evolve" suggestions if the save parser left 0-quantity items in the inventory array.
 **Action:** Always check `quantity > 0` when verifying player items in `saveData.inventory`.
-## 2024-04-22 - Assistant Trade Evolution Held Item Support\n**Learning:** The Trade evolution logic () was missing support for checking if a required `held` item was in the player's inventory, which is crucial for Gen 2 evolutions like Onix to Steelix. \n**Action:** Always check the `detail.held` property for Trade evolutions and verify the player has it in their `saveData.inventory`.
 ## 2024-04-22 - Assistant Trade Evolution Held Item Support
 **Learning:** The Trade evolution logic (`EVO_TRIGGER.TRADE`) was missing support for checking if a required `held` item was in the player's inventory, which is crucial for Gen 2 evolutions like Onix to Steelix.
 **Action:** Always check the `detail.held` property for Trade evolutions and verify the player has it in their `saveData.inventory`.


### PR DESCRIPTION
- **What was stale/wrong**:
  - The `jsdom` configuration entry in `.jules/sentinel.md` was stale. It incorrectly recommended using `/** @vitest-environment jsdom */` and importing `fake-indexeddb/auto` in every test file, which conflicts with the project's current global node polyfill setup in `src/node-setup.ts`.
  - There was a corrupted and duplicated learning entry in `.jules/trainer.md` regarding Trade evolution and held items that contained unparsed `\n` characters.
  - There were duplicated learning entries in `.jules/palette.md` regarding adding `aria-label` and `title` to icon-only buttons (from `2024-04-13` and `2026-05-15`).

- **How it was verified**:
  - Ran `pnpm test` and `pnpm test:e2e` to verify no test files were impacted or broken by the documentation change and that `fake-indexeddb` is indeed properly polyfilled globally.
  - Confirmed the modifications applied cleanly.

- **What was removed/updated**:
  - Updated `.jules/sentinel.md` to explain the modern approach of relying on `src/node-setup.ts` to polyfill `fakeIndexedDB` globally for node environment testing.
  - Removed the duplicated and poorly-formatted Trade evolution entry in `.jules/trainer.md`.
  - Consolidated the `aria-label` and icon-only button tooltips learnings in `.jules/palette.md` into a single comprehensive entry to prevent knowledge rot.

---
*PR created automatically by Jules for task [9213282902714960626](https://jules.google.com/task/9213282902714960626) started by @szubster*