### PR TITLE
Create blueprint task for ID Schema decision

### DIFF
--- a/.foundry/stories/story-004-id-schema-decision.md
+++ b/.foundry/stories/story-004-id-schema-decision.md
@@ -32,3 +32,6 @@ Collaborate with the Architect/Tech Lead to finalize the new collision-free ID s
 - A new or updated ADR confirms the chosen ID pattern.
 - `.foundry/docs/schema.md` accurately describes the new ID format.
 - All technical contracts specify exactly how the IDs should be generated going forward.
+
+## Generated Tasks
+- .foundry/tasks/task-021-document-id-schema.md

--- a/.foundry/tasks/task-021-document-id-schema.md
+++ b/.foundry/tasks/task-021-document-id-schema.md
@@ -1,0 +1,24 @@
+---
+id: task-021-document-id-schema
+type: TASK
+title: "Finalize ID Schema and Update Documentation"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on:
+  - .foundry/stories/story-004-id-schema-decision.md
+jules_session_id: null
+parent: .foundry/stories/story-004-id-schema-decision.md
+---
+
+# Finalize ID Schema and Update Documentation
+
+## Context
+The system requires a collision-free ID schema pattern across distributed nodes. The Architect/Tech Lead needs an exact pattern documented and enforced going forward.
+
+## Acceptance Criteria
+- [ ] Create a new Architectural Decision Record (ADR) file, e.g., `.foundry/docs/adrs/002-collision-free-id-schema.md`.
+- [ ] In the ADR, select and document a specific pattern (e.g., adding a random short hex or suffix hash to prevent naming collisions for concurrent autonomous agents).
+- [ ] Update `.foundry/docs/schema.md` with the newly decided ID pattern. Update any examples (such as the node template) to correctly show the new structure.
+- [ ] **Verification**: The Coder is responsible for self-verifying that the documentation is clean, formatting is correct, and tests/linting pass. (No separate QA task is required).

--- a/.foundry/tasks/task-021-document-id-schema.md
+++ b/.foundry/tasks/task-021-document-id-schema.md
@@ -19,6 +19,6 @@ The system requires a collision-free ID schema pattern across distributed nodes.
 
 ## Acceptance Criteria
 - [ ] Create a new Architectural Decision Record (ADR) file, e.g., `.foundry/docs/adrs/002-collision-free-id-schema.md`.
-- [ ] In the ADR, select and document a specific pattern (e.g., adding a random short hex or suffix hash to prevent naming collisions for concurrent autonomous agents).
+- [ ] In the ADR, select and document a specific pattern. The solution should be creative, focusing on discoverability and ease of use. It should ensure high entropy to prevent naming collisions for concurrent autonomous agents, and also consider how to handle items that do not have a parent.
 - [ ] Update `.foundry/docs/schema.md` with the newly decided ID pattern. Update any examples (such as the node template) to correctly show the new structure.
 - [ ] **Verification**: The Coder is responsible for self-verifying that the documentation is clean, formatting is correct, and tests/linting pass. (No separate QA task is required).


### PR DESCRIPTION
Created `.foundry/tasks/task-021-document-id-schema.md` assigning it to the `coder` persona, requiring an ADR creation and an update to `schema.md`. Also appended a reference to this generated task in the parent story (`.foundry/stories/story-004-id-schema-decision.md`).

---
*PR created automatically by Jules for task [15838567258000250548](https://jules.google.com/task/15838567258000250548) started by @szubster*