### PR TITLE
🎨 Palette: Fix ghost focus on hidden file inputs

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -238,6 +238,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                   <RefreshCw size={20} />
                   <input
                     type="file"
+                    tabIndex={-1}
                     aria-label="Import New Save"
                     accept=".sav"
                     className="sr-only"
@@ -252,6 +253,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
               Initialize Pokedex
               <input
                 type="file"
+                tabIndex={-1}
                 aria-label="Initialize Pokedex"
                 accept=".sav"
                 className="sr-only"


### PR DESCRIPTION
**What:**
Added `tabIndex={-1}` to `sr-only` file inputs inside `<label>` elements in `AppLayout.tsx`.

**Why:**
To prevent 'ghost focus' during keyboard navigation. The visually hidden file input elements were retaining their default tab order, allowing users to tab to invisible elements, creating a confusing keyboard navigation experience. The wrapping `<label>` already correctly handles focus and programmatic activation of the file dialog.

**Accessibility Notes:**
This change specifically targets keyboard navigation UX. Using `tabIndex={-1}` on visually hidden elements removes them from the sequential tab order while keeping them semantically available to the `label` trigger.

---
*PR created automatically by Jules for task [2894514119091286858](https://jules.google.com/task/2894514119091286858) started by @szubster*