### PR TITLE
Epic Planner: Breakdown Late Binding Orchestrator PRD

### DIFF
--- a/.foundry/epics/epic-010-persona-permissions.md
+++ b/.foundry/epics/epic-010-persona-permissions.md
@@ -1,0 +1,31 @@
+---
+id: epic-010-persona-permissions
+type: EPIC
+title: "Persona Permissions Matrix for Late Binding"
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/prds/prd-002-late-binding-orchestrator.md"
+tags:
+  - foundry-v2
+  - architecture
+  - orchestration
+---
+
+# Persona Permissions Matrix for Late Binding
+
+## Details
+Implement the system permissions necessary for different personas to dynamically create downstream nodes mid-execution. This enables "zoom in" or "pivot" actions without requiring a full upfront plan.
+
+## Prerequisites
+- Review `.foundry/docs/adrs/001-the-foundry-architecture.md` for current system architecture.
+
+## High-level Acceptance Criteria
+- [ ] `architect` persona can create `TASK`, `ADR`, and `IDEA` nodes.
+- [ ] `tech_lead` persona can create `TASK` and `ADR` nodes to break down a Story.
+- [ ] `story_owner` persona can create `STORY` and `EPIC` nodes to expand requirements.
+- [ ] `product_manager` persona can create `IDEA`, `PRD`, and `EPIC` nodes for roadmap evolution.
+- [ ] System strictly enforces these permissions to prevent unauthorized node creation.

--- a/.foundry/epics/epic-011-wait-and-wake-protocol.md
+++ b/.foundry/epics/epic-011-wait-and-wake-protocol.md
@@ -1,0 +1,31 @@
+---
+id: epic-011-wait-and-wake-protocol
+type: EPIC
+title: "Wait & Wake Protocol and Impossible Loop"
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on:
+  - .foundry/epics/epic-010-persona-permissions.md
+jules_session_id: null
+parent: ".foundry/prds/prd-002-late-binding-orchestrator.md"
+tags:
+  - foundry-v2
+  - architecture
+  - orchestration
+---
+
+# Wait & Wake Protocol and Impossible Loop
+
+## Details
+Implement the orchestration logic required to support the "Wait & Wake" protocol and the "Impossible" failure loop. This allows agents to suspend their sessions when blocked by dynamically spawned nodes and provides a standardized way to signal failure upstream.
+
+## Prerequisites
+- Completion of `epic-010-persona-permissions`.
+
+## High-level Acceptance Criteria
+- [ ] When an agent spawns downstream nodes and adds them to `depends_on`, its session is suspended and the node status transitions to `PENDING`.
+- [ ] The Orchestrator correctly transitions the parent node back to `READY` and re-dispatches the agent once all newly spawned downstream tasks are `COMPLETED`.
+- [ ] If a node is fundamentally impossible, the agent transitions the node to `FAILED` with a `rejection_reason` in the frontmatter.
+- [ ] The Orchestrator detects `FAILED` nodes and either "wakes up" the parent node or flags it for the `tpm` to create a feedback `IDEA` for the PM/CEO.

--- a/.foundry/epics/epic-012-gastown-orchestrator.md
+++ b/.foundry/epics/epic-012-gastown-orchestrator.md
@@ -1,0 +1,32 @@
+---
+id: epic-012-gastown-orchestrator
+type: EPIC
+title: "Gastown Cloudflare Worker Migration Evaluation"
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on:
+  - .foundry/epics/epic-011-wait-and-wake-protocol.md
+jules_session_id: null
+parent: ".foundry/prds/prd-002-late-binding-orchestrator.md"
+tags:
+  - foundry-v2
+  - architecture
+  - orchestration
+---
+
+# Gastown Cloudflare Worker Migration Evaluation
+
+## Details
+Assess the viability and benefits of extracting the `foundry-orchestrator.ts` logic into a Cloudflare Worker ("Gastown") to improve reliability, atomic state tracking, and security boundaries.
+
+## Prerequisites
+- Completion of `epic-011-wait-and-wake-protocol`.
+- Review `.foundry/docs/knowledge_base/foundry/orchestrator/cloudflare_workers_evaluation.md`.
+
+## High-level Acceptance Criteria
+- [ ] Evaluate Cloudflare D1 (SQL) or KV for persisting node states.
+- [ ] Design a sync mechanism (polling GitHub or receiving Webhooks) to keep the markdown file state synced with the internal database.
+- [ ] Ensure the "Unreachable State Constraint" is maintained (Jules cannot access the Orchestrator DB).
+- [ ] Document the findings and propose a final architecture decision on whether to proceed with the migration.

--- a/.foundry/prds/prd-002-late-binding-orchestrator.md
+++ b/.foundry/prds/prd-002-late-binding-orchestrator.md
@@ -66,4 +66,9 @@ When an agent is blocked by new technical realities:
 - **Error Recovery:** Reduction in manual PM intervention for deadlocked or impossible tasks due to the Resurrection Loop.
 
 ## 4. Next Steps
-- [ ] **Epic Planner:** Break down this PRD into Epics mapping out the persona permission implementations, the Wait & Wake protocol orchestration logic, and the Cloudflare Worker Gastown migration.
+- [x] **Epic Planner:** Break down this PRD into Epics mapping out the persona permission implementations, the Wait & Wake protocol orchestration logic, and the Cloudflare Worker Gastown migration.
+
+### Generated Epics
+- [.foundry/epics/epic-010-persona-permissions.md](../epics/epic-010-persona-permissions.md)
+- [.foundry/epics/epic-011-wait-and-wake-protocol.md](../epics/epic-011-wait-and-wake-protocol.md)
+- [.foundry/epics/epic-012-gastown-orchestrator.md](../epics/epic-012-gastown-orchestrator.md)


### PR DESCRIPTION
This PR translates PRD 002 (Late Binding Epics & Recursive Orchestration) into three logical Epics:

- `epic-010-persona-permissions.md`: Defines permissions for dynamic node creation by various personas.
- `epic-011-wait-and-wake-protocol.md`: Implements the orchestrator logic for pausing active agents when they spawn downstream dependencies.
- `epic-012-gastown-orchestrator.md`: Evaluates extracting the Orchestrator to a Cloudflare Worker for better state persistence and isolation.

The parent PRD was updated with references to these generated Epics, and all frontmatter rules were strictly adhered to (no YAML modified in parent PRD).

---
*PR created automatically by Jules for task [13099275005964952586](https://jules.google.com/task/13099275005964952586) started by @szubster*