### PR TITLE
Implement Scheduled Agent Registry

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -1,0 +1,3 @@
+# 2026-04-23 - Task 018
+
+Successfully implemented the Scheduled Agent Registry by creating the GitHub Actions workflows for TPM and Agile Coach personas.

--- a/.foundry/tasks/task-018-implement-scheduled-agent-registry.md
+++ b/.foundry/tasks/task-018-implement-scheduled-agent-registry.md
@@ -31,8 +31,8 @@ Create individual GitHub Actions workflow files for scheduled agents that invoke
    - Call the `foundry-scheduled-agent.yml` workflow and pass `persona: "agile_coach"`.
 
 ## Acceptance Criteria
-- [ ] `.github/workflows/schedule-tpm.yml` exists and has an hourly cron schedule.
-- [ ] `.github/workflows/schedule-agile-coach.yml` exists and has a daily cron schedule.
-- [ ] Both workflows correctly invoke `foundry-scheduled-agent.yml` with the correct inputs.
+- [x] `.github/workflows/schedule-tpm.yml` exists and has an hourly cron schedule.
+- [x] `.github/workflows/schedule-agile-coach.yml` exists and has a daily cron schedule.
+- [x] Both workflows correctly invoke `foundry-scheduled-agent.yml` with the correct inputs.
 
 *Verification*: This is a low-risk, declarative infrastructure task. The `coder` must verify the YAML syntax is correct and document completion in their journal. No separate QA task is required (Intelligent Verification Protocol: Self-verify).

--- a/.github/workflows/schedule-agile-coach.yml
+++ b/.github/workflows/schedule-agile-coach.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   run_agile_coach:
     uses: ./.github/workflows/foundry-scheduled-agent.yml

--- a/.github/workflows/schedule-agile-coach.yml
+++ b/.github/workflows/schedule-agile-coach.yml
@@ -1,0 +1,11 @@
+name: "🕰️ Schedule: Agile Coach"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+jobs:
+  run_agile_coach:
+    uses: ./.github/workflows/foundry-scheduled-agent.yml
+    with:
+      persona: "agile_coach"
+    secrets: inherit

--- a/.github/workflows/schedule-tpm.yml
+++ b/.github/workflows/schedule-tpm.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "0 * * * *"
   workflow_dispatch:
+permissions:
+  contents: read
+  packages: read
 jobs:
   run_tpm:
     uses: ./.github/workflows/foundry-scheduled-agent.yml

--- a/.github/workflows/schedule-tpm.yml
+++ b/.github/workflows/schedule-tpm.yml
@@ -1,0 +1,11 @@
+name: "🕰️ Schedule: TPM"
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+jobs:
+  run_tpm:
+    uses: ./.github/workflows/foundry-scheduled-agent.yml
+    with:
+      persona: "tpm"
+    secrets: inherit


### PR DESCRIPTION
Created `.github/workflows/schedule-tpm.yml` with an hourly schedule and `.github/workflows/schedule-agile-coach.yml` with a daily schedule. Both files call `foundry-scheduled-agent.yml` with their respective persona inputs. Completed task checks in `.foundry/tasks/task-018-implement-scheduled-agent-registry.md` and added an entry to `.foundry/journals/coder.md`.

---
*PR created automatically by Jules for task [12059888989811248189](https://jules.google.com/task/12059888989811248189) started by @szubster*