### PR TITLE
🛡️ Nurse: Fix typecast in AssistantSuggestionCard

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -18,3 +18,7 @@ The compiler ensures that DataLoader batch functions return valid values or Erro
 **Learning:** Sometimes the compiler loses track of a type after a reassignment if the variable wasn't explicitly typed. By explicitly typing `let variableName: TypeName`, we eliminate the need for downstream `as TypeName` assertions, making the code safer and more readable.
 **Action:** Replaced unsafe cast in `gen2.ts` by explicitly typing the `gameVersion` variable instead.
 - Replaced unsafe `{} as Partial<Record<...>>` with `reduce<Partial<Record<...>>>({}, ...)` to ensure the accumulator is strictly type-checked and properly tracks optional keys instead of forcing an unsafe cast in `AssistantPanel.tsx`.
+
+## 2025-04-23
+
+- **Type narrow arrays in `.reduce` calls directly:** Rather than explicitly typing function parameters and applying an `as` cast on the starting object (`{} as Record<...>`), it is safer and cleaner to provide the generic parameter directly to the reduce function `.reduce<Record<...>>((acc, val) => ... , {})`. This eliminates an unnecessary `as` cast and allows TypeScript to properly catch incorrect shape returns without bypassing type safety.

--- a/src/components/assistant/AssistantSuggestionCard.tsx
+++ b/src/components/assistant/AssistantSuggestionCard.tsx
@@ -99,19 +99,16 @@ export function AssistantSuggestionCard({
           <div className={`relative z-20 mt-0 flex flex-col gap-4`}>
             {s.category === 'Catch' ? (
               Object.entries(
-                (s.pokemonIds || []).reduce(
-                  (acc: Record<string, { pid: number; enc: EncounterDetail }[]>, pid: number) => {
-                    const encs = s.encounterInfo?.[pid];
-                    if (!encs) return acc;
-                    const mainEnc = [...encs].sort((a, b) => b.chance - a.chance)[0];
-                    if (!mainEnc) return acc;
-                    const method = mainEnc.method;
-                    if (!acc[method]) acc[method] = [];
-                    acc[method]?.push({ pid, enc: mainEnc });
-                    return acc;
-                  },
-                  {} as Record<string, { pid: number; enc: EncounterDetail }[]>,
-                ),
+                (s.pokemonIds || []).reduce<Record<string, { pid: number; enc: EncounterDetail }[]>>((acc, pid) => {
+                  const encs = s.encounterInfo?.[pid];
+                  if (!encs) return acc;
+                  const mainEnc = [...encs].sort((a, b) => b.chance - a.chance)[0];
+                  if (!mainEnc) return acc;
+                  const method = mainEnc.method;
+                  if (!acc[method]) acc[method] = [];
+                  acc[method]?.push({ pid, enc: mainEnc });
+                  return acc;
+                }, {}),
               ).map(([method, pokes]: [string, { pid: number; enc: EncounterDetail }[]]) => {
                 const isRod = method.includes('rod');
                 const isSurf = method === 'surf';


### PR DESCRIPTION
### What was unsafe
In `src/components/assistant/AssistantSuggestionCard.tsx`, the accumulator in a `.reduce()` function was typed using an explicit `as` cast on the initial value: `{} as Record<string, { pid: number; enc: EncounterDetail }[]>`. This bypassed strict type checking on the initial value and allowed any type to be returned, relying on developer discipline rather than the compiler.

### How it was fixed
Removed the `as` cast and replaced it with a direct generic type parameter on the `.reduce` method itself: `.reduce<Record<string, { pid: number; enc: EncounterDetail }[]>>((acc, pid) => { ... }, {})`.

### What the compiler now catches
The TypeScript compiler will now natively enforce that the return value inside the `reduce` callback correctly matches the expected `Record` shape, without artificially widening the type through an `as` assertion.

---
*PR created automatically by Jules for task [9862707242648948329](https://jules.google.com/task/9862707242648948329) started by @szubster*