### PR TITLE
✨ Epic Planner: Break down PRD-004 (Human-in-the-Loop) into Epics

### DIFF
--- a/.foundry/epics/epic-010-human-schema.md
+++ b/.foundry/epics/epic-010-human-schema.md
@@ -1,0 +1,35 @@
+---
+id: epic-010-human-schema
+type: EPIC
+title: "Update Foundry Schema for Human Persona"
+status: READY
+owner_persona: story_owner
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/prds/prd-004-human-in-the-loop.md"
+tags:
+  - "human-in-the-loop"
+  - "schema"
+---
+
+# Epic 010: Update Foundry Schema for Human Persona
+
+## 1. Goal
+Extend the Foundry Master Schema to formally support human ownership of tasks, bypassing the standard Jules autonomous execution loop.
+
+## 2. Background
+According to `PRD-004`, there are tasks that require human intervention (e.g. subjective UX design, testing on real hardware). We need to represent these tasks within the DAG to maintain a single source of truth for repository progress. This requires adding a new `owner_persona` and a way to optionally link tasks to human-opened Pull Requests.
+
+## 3. Scope
+This Epic is solely responsible for defining the structural rules and constraints within `.foundry/docs/schema.md`. No orchestrator logic will be modified in this Epic.
+
+## 4. Acceptance Criteria
+- [ ] The `owner_persona` enum in `.foundry/docs/schema.md` includes `human`.
+- [ ] A new optional global frontmatter field `pr_number` is defined. It should be described as an integer or null, defaulting to null.
+- [ ] The schema explicitly notes that tasks owned by `human` bypass Jules dispatch and heartbeat failure timeouts.
+
+## 5. Implementation Notes
+- Modify `.foundry/docs/schema.md`.
+- Ensure changes are communicated clearly so the orchestrator developers (in subsequent Epics) have a strict contract to follow.

--- a/.foundry/epics/epic-011-human-orchestrator.md
+++ b/.foundry/epics/epic-011-human-orchestrator.md
@@ -1,0 +1,37 @@
+---
+id: epic-011-human-orchestrator
+type: EPIC
+title: "Bypass Jules Dispatch for Human Tasks in Orchestrator"
+status: READY
+owner_persona: story_owner
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on:
+  - ".foundry/epics/epic-010-human-schema.md"
+jules_session_id: null
+parent: ".foundry/prds/prd-004-human-in-the-loop.md"
+tags:
+  - "human-in-the-loop"
+  - "orchestrator"
+---
+
+# Epic 011: Bypass Jules Dispatch for Human Tasks in Orchestrator
+
+## 1. Goal
+Modify the `.github/scripts/foundry-orchestrator.ts` script so it transitions `READY` human tasks to `ACTIVE` without attempting to dispatch a Jules session.
+
+## 2. Background
+Currently, any task that reaches `READY` status is collected by the orchestrator and dispatched to a Jules agent via GitHub Actions matrix. For tasks assigned to `owner_persona: human`, we need to intercept this process. We want the orchestrator to mark the task as `ACTIVE` (so the rest of the DAG knows it's unblocked and being worked on) but avoid invoking the Jules API.
+
+## 3. Scope
+- Updates to `foundry-orchestrator.ts` logic.
+- Associated unit tests in `foundry-orchestrator.test.ts`.
+
+## 4. Acceptance Criteria
+- [ ] The orchestrator detects `owner_persona: human` for nodes moving from `READY` to `ACTIVE`.
+- [ ] Nodes with `human` persona transition to `ACTIVE` but are explicitly omitted from the GitHub Actions dispatch JSON output.
+- [ ] Unit tests cover the human bypass scenario.
+
+## 5. Implementation Notes
+- Human nodes will still be tracked in the broader DAG resolution loop, they just take a different path at the exact moment of dispatch.
+- Ensure backwards compatibility with all other agent personas.

--- a/.foundry/epics/epic-012-human-heartbeat.md
+++ b/.foundry/epics/epic-012-human-heartbeat.md
@@ -1,0 +1,39 @@
+---
+id: epic-012-human-heartbeat
+type: EPIC
+title: "Modify Heartbeat Script for Human Tasks"
+status: READY
+owner_persona: story_owner
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on:
+  - ".foundry/epics/epic-010-human-schema.md"
+jules_session_id: null
+parent: ".foundry/prds/prd-004-human-in-the-loop.md"
+tags:
+  - "human-in-the-loop"
+  - "heartbeat"
+---
+
+# Epic 012: Modify Heartbeat Script for Human Tasks
+
+## 1. Goal
+Update `.github/scripts/foundry-heartbeat.ts` so that it monitors GitHub PR statuses for human tasks instead of enforcing timeout failures based on `jules_session_id`.
+
+## 2. Background
+The heartbeat script currently ensures that `ACTIVE` tasks have a living `jules_session_id`. If a task is abandoned or the agent crashes, the heartbeat transitions the task to `FAILED`. For `human` tasks, there is no timeout. Instead, if a `pr_number` is provided, the heartbeat should check if the PR has been merged or closed without merging.
+
+## 3. Scope
+- Updates to `foundry-heartbeat.ts` logic.
+- Associated unit tests in `foundry-heartbeat.test.ts`.
+
+## 4. Acceptance Criteria
+- [ ] Heartbeat ignores missing `jules_session_id` for nodes with `owner_persona: human`.
+- [ ] If an `ACTIVE` human task has a `pr_number`, the heartbeat queries the GitHub API for the PR's status.
+- [ ] If the PR is merged, the task transitions to `COMPLETED`.
+- [ ] If the PR is closed but unmerged, the task transitions to `READY` to allow reclamation.
+- [ ] Unit tests cover all these scenarios, mocking the GitHub API.
+
+## 5. Implementation Notes
+- The heartbeat should use standard GitHub Action environment variables (`GITHUB_TOKEN`, `GITHUB_REPOSITORY`) to make its API calls.
+- Direct-to-main commits (no `pr_number`) simply remain `ACTIVE` until manually moved to `COMPLETED` by a human. The heartbeat ignores them.

--- a/.foundry/prds/prd-004-human-in-the-loop.md
+++ b/.foundry/prds/prd-004-human-in-the-loop.md
@@ -61,3 +61,8 @@ The `foundry-orchestrator.ts` and `foundry-heartbeat.ts` must be updated:
 
 ## Next Steps
 - **Epic Planner**: Break down this PRD into Epics mapping out the schema additions, orchestrator script modifications, and required testing.
+
+## Generated Epics
+- .foundry/epics/epic-010-human-schema.md
+- .foundry/epics/epic-011-human-orchestrator.md
+- .foundry/epics/epic-012-human-heartbeat.md


### PR DESCRIPTION
Created three new EPIC markdown nodes (010, 011, 012) to address PRD-004: Human-in-the-Loop Handoff. 
These Epics cover updating the schema, modifying the orchestrator to bypass dispatch for human tasks, and modifying the heartbeat script to check PR statuses.
Updated PRD-004 to track the newly generated epics.

---
*PR created automatically by Jules for task [15209786094862017553](https://jules.google.com/task/15209786094862017553) started by @szubster*