### PR TITLE
Generate Story Node for Human Heartbeat Script

### DIFF
--- a/.foundry/epics/epic-012-human-heartbeat.md
+++ b/.foundry/epics/epic-012-human-heartbeat.md
@@ -37,3 +37,6 @@ The heartbeat script currently ensures that `ACTIVE` tasks have a living `jules_
 ## 5. Implementation Notes
 - The heartbeat should use standard GitHub Action environment variables (`GITHUB_TOKEN`, `GITHUB_REPOSITORY`) to make its API calls.
 - Direct-to-main commits (no `pr_number`) simply remain `ACTIVE` until manually moved to `COMPLETED` by a human. The heartbeat ignores them.
+
+## Generated Stories
+- [.foundry/stories/story-011-human-heartbeat-script.md](.foundry/stories/story-011-human-heartbeat-script.md)

--- a/.foundry/stories/story-011-human-heartbeat-script.md
+++ b/.foundry/stories/story-011-human-heartbeat-script.md
@@ -1,0 +1,27 @@
+---
+id: story-011-human-heartbeat-script
+type: STORY
+title: "Update heartbeat script to support human tasks"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/epics/epic-012-human-heartbeat.md"
+tags:
+  - "human-in-the-loop"
+  - "heartbeat"
+---
+
+# Story 011: Update heartbeat script to support human tasks
+
+## Background
+Currently, the heartbeat script (`.github/scripts/foundry-heartbeat.ts`) will mark any task without a valid `jules_session_id` as FAILED. For tasks assigned to `owner_persona: human`, there won't be a jules_session_id. We need to modify the script to not mark these tasks as FAILED, and instead query the GitHub API to check the PR status if a PR number is associated with the task.
+
+## Acceptance Criteria
+- [ ] Ensure the script ignores missing `jules_session_id` when `owner_persona: human`.
+- [ ] If an `ACTIVE` human task has a `pr_number`, query the GitHub API.
+- [ ] If PR is merged, transition task to `COMPLETED`.
+- [ ] If PR is closed but unmerged, transition task to `READY`.
+- [ ] Add unit tests mocking the GitHub API.


### PR DESCRIPTION
As the Story Owner persona, dynamically generated a new STORY node to detail the technical work needed for updating the heartbeat script to handle human-in-the-loop tasks, and linked it back to the parent EPIC.

---
*PR created automatically by Jules for task [4881910207713104368](https://jules.google.com/task/4881910207713104368) started by @szubster*