### PR TITLE
Story Owner: Generated story for human orchestrator bypass

### DIFF
--- a/.foundry/epics/epic-011-human-orchestrator.md
+++ b/.foundry/epics/epic-011-human-orchestrator.md
@@ -35,3 +35,6 @@ Currently, any task that reaches `READY` status is collected by the orchestrator
 ## 5. Implementation Notes
 - Human nodes will still be tracked in the broader DAG resolution loop, they just take a different path at the exact moment of dispatch.
 - Ensure backwards compatibility with all other agent personas.
+
+## Generated Stories
+- `.foundry/stories/story-010-orchestrator-human-bypass.md`

--- a/.foundry/stories/story-010-orchestrator-human-bypass.md
+++ b/.foundry/stories/story-010-orchestrator-human-bypass.md
@@ -1,0 +1,26 @@
+---
+id: story-010-orchestrator-human-bypass
+type: STORY
+title: "Implement Human Task Bypass in Orchestrator"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/epics/epic-011-human-orchestrator.md"
+tags:
+  - "human-in-the-loop"
+  - "orchestrator"
+---
+
+# Story 010: Implement Human Task Bypass in Orchestrator
+
+## 1. Goal
+Implement logic in the orchestrator to intercept `human` tasks that are moving from `READY` to `ACTIVE` to avoid dispatching a Jules session.
+
+## 2. Acceptance Criteria
+- [ ] In `.github/scripts/foundry-orchestrator.ts`, detect when `owner_persona` is `human` for nodes that are in `READY` status.
+- [ ] Automatically mutate the node's status to `ACTIVE` on disk.
+- [ ] Explicitly omit these `human` nodes from the `readyNodes` JSON output array so GitHub Actions does not spawn a matrix runner for them.
+- [ ] Add a unit test in `.github/scripts/foundry-orchestrator.test.ts` to verify this behavior.


### PR DESCRIPTION
Generated `.foundry/stories/story-010-orchestrator-human-bypass.md` dynamically from `.foundry/epics/epic-011-human-orchestrator.md` and appended it to the Epic's markdown body.

- The new STORY explicitly instructs the subsequent `tech_lead` on what code logic and tests to implement in the orchestrator.
- The YAML frontmatter of the parent Epic was strictly left untouched.
- Checked `depends_on` array is empty to prevent circular dependency logic bugs in the orchestration engine.

---
*PR created automatically by Jules for task [5961213059938943122](https://jules.google.com/task/5961213059938943122) started by @szubster*