### PR TITLE
feat(orchestrator): implement human task bypass

### DIFF
--- a/.foundry/tasks/task-022-orchestrator-human-bypass.md
+++ b/.foundry/tasks/task-022-orchestrator-human-bypass.md
@@ -46,9 +46,9 @@ The Foundry orchestrator dispatches `READY` tasks to Jules agents. However, task
 - Test 2: Ensure an already `READY` node with `owner_persona: human` is caught and promoted to `ACTIVE`, keeping it out of the JSON output.
 
 ## 3. Acceptance Criteria
-- [ ] `promoteNodeToReady` is refactored to `promoteNodeStatus(node, currentStatus, targetStatus)`.
-- [ ] Phase 5 iterates through eligible nodes and promotes `human` nodes to `ACTIVE` instead of `READY`.
-- [ ] An additional check catches any existing `READY` `human` nodes and upgrades them to `ACTIVE`.
-- [ ] Human nodes do not appear in the JSON output array from the orchestrator.
-- [ ] Unit tests are added to verify the human bypass behavior in `foundry-orchestrator.test.ts`.
-- [ ] `pnpm lint`, `pnpm test`, and `pnpm test:e2e` pass successfully.
+- [x] `promoteNodeToReady` is refactored to `promoteNodeStatus(node, currentStatus, targetStatus)`.
+- [x] Phase 5 iterates through eligible nodes and promotes `human` nodes to `ACTIVE` instead of `READY`.
+- [x] An additional check catches any existing `READY` `human` nodes and upgrades them to `ACTIVE`.
+- [x] Human nodes do not appear in the JSON output array from the orchestrator.
+- [x] Unit tests are added to verify the human bypass behavior in `foundry-orchestrator.test.ts`.
+- [x] `pnpm lint`, `pnpm test`, and `pnpm test:e2e` pass successfully.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -292,4 +292,59 @@ jules_session_id: null
     expect(story2Content).toContain('status: PENDING');
   });
 
+  test('Human Task Bypass: PENDING human task promotes directly to ACTIVE', () => {
+    createNode('.foundry/tasks/task-001.md', `
+id: task-001
+type: TASK
+title: "Human Task 1"
+status: PENDING
+owner_persona: human
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    main();
+
+    // Verify it promoted directly to ACTIVE
+    const taskContent = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-001.md'), 'utf-8');
+    expect(taskContent).toContain('status: ACTIVE');
+
+    // Verify it was NOT included in the JSON matrix output (Phase 6 only collects READY)
+    expect(logSpy).toHaveBeenCalled();
+    const lastCall = logSpy.mock.calls[logSpy.mock.calls.length - 1][0];
+    const output = JSON.parse(lastCall);
+    expect(output).toHaveLength(0);
+  });
+
+  test('Human Task Bypass: existing READY human task upgrades to ACTIVE', () => {
+    // Already READY, but owned by human
+    createNode('.foundry/tasks/task-002.md', `
+id: task-002
+type: TASK
+title: "Human Task 2"
+status: READY
+owner_persona: human
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    main();
+
+    // Verify Phase 5.1 upgraded it
+    const taskContent = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-002.md'), 'utf-8');
+    expect(taskContent).toContain('status: ACTIVE');
+
+    // Verify it was NOT included in the JSON matrix output
+    expect(logSpy).toHaveBeenCalled();
+    const lastCall = logSpy.mock.calls[logSpy.mock.calls.length - 1][0];
+    const output = JSON.parse(lastCall);
+    expect(output).toHaveLength(0);
+  });
+
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -129,7 +129,7 @@ function discoverNodeFiles(dir: string): string[] {
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(current, { withFileTypes: true });
-    } catch (e) {
+  } catch (_e) {
       warn(`Cannot read directory: ${current}`);
       return;
     }
@@ -163,7 +163,7 @@ function parseNodeFile(filePath: string, repoRoot: string): ParsedNode | null {
   let rawContent: string;
   try {
     rawContent = fs.readFileSync(filePath, 'utf-8');
-  } catch (e) {
+  } catch (_e) {
     warn(`Cannot read file: ${repoPath}`);
     return null;
   }
@@ -172,7 +172,7 @@ function parseNodeFile(filePath: string, repoRoot: string): ParsedNode | null {
   let parsed: ReturnType<typeof matter>;
   try {
     parsed = matter(rawContent);
-  } catch (e) {
+  } catch (_e) {
     warn(`Malformed YAML frontmatter in: ${repoPath} — skipping`);
     return null;
   }
@@ -222,7 +222,7 @@ function parseNodeFile(filePath: string, repoRoot: string): ParsedNode | null {
 // ─── Phase 5: PROMOTE ────────────────────────────────────────────────────────
 
 /**
- * Mutates the on-disk markdown file to change `status: PENDING` → `status: READY`
+ * Mutates the on-disk markdown file to change `status: currentStatus` → `status: targetStatus`
  * and update `updated_at` to today's date.
  *
  * Strategy: surgical string replacement inside the raw frontmatter block only.
@@ -231,7 +231,7 @@ function parseNodeFile(filePath: string, repoRoot: string): ParsedNode | null {
  *
  * In --dry-run mode, logs the intended change but does NOT write to disk.
  */
-function promoteNodeToReady(node: ParsedNode): void {
+function promoteNodeStatus(node: ParsedNode, currentStatus: Status, targetStatus: Status): void {
   const dateStr = todayISO();
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
@@ -246,16 +246,16 @@ function promoteNodeToReady(node: ParsedNode): void {
   const originalFmBlock = fmBlockMatch[0];
   let mutatedFmBlock = originalFmBlock;
 
-  // ① Replace `status: PENDING` (handles optional single/double quotes and trailing whitespace/CR).
+  // ① Replace status (handles optional single/double quotes and trailing whitespace/CR).
   //    The 'm' flag makes ^ and $ match line boundaries within the block.
   mutatedFmBlock = mutatedFmBlock.replace(
-    /^(status:\s*)["']?PENDING["']?([ \t\r]*)$/m,
-    `$1READY$2`,
+    new RegExp(`^(status:\\s*)["']?${currentStatus}["']?([ \\t\\r]*)$`, 'm'),
+    `$1${targetStatus}$2`,
   );
 
-  // Sanity check — if PENDING wasn't found, something is wrong.
+  // Sanity check
   if (mutatedFmBlock === originalFmBlock) {
-    warn(`${dryTag}Could not find 'status: PENDING' line to replace in: ${node.repoPath}`);
+    warn(`${dryTag}Could not find 'status: ${currentStatus}' line to replace in: ${node.repoPath}`);
     return;
   }
 
@@ -277,11 +277,11 @@ function promoteNodeToReady(node: ParsedNode): void {
   }
 
   // Update in-memory state so downstream phases see the correct status.
-  node.frontmatter.status = 'READY';
+  node.frontmatter.status = targetStatus;
   node.frontmatter.updated_at = dateStr;
   node.rawContent = newContent;
 
-  info(`${dryTag}Promoted PENDING → READY: ${node.repoPath}`);
+  info(`${dryTag}Promoted ${currentStatus} → ${targetStatus}: ${node.repoPath}`);
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
@@ -471,7 +471,19 @@ function main(): void {
   // ── Phase 5: PROMOTE ───────────────────────────────────────────────────────
   info('Phase 5: Promoting eligible nodes...');
   for (const node of eligible) {
-    promoteNodeToReady(node);
+    if (node.frontmatter.owner_persona === 'human') {
+      promoteNodeStatus(node, 'PENDING', 'ACTIVE');
+    } else {
+      promoteNodeStatus(node, 'PENDING', 'READY');
+    }
+  }
+
+  // ── Phase 5.1: HANDLE EXISTING READY HUMAN TASKS ───────────────────────────
+  info('Phase 5.1: Upgrading existing READY human tasks to ACTIVE...');
+  for (const node of nodes) {
+    if (node.frontmatter.status === 'READY' && node.frontmatter.owner_persona === 'human') {
+      promoteNodeStatus(node, 'READY', 'ACTIVE');
+    }
   }
 
   // ── Phase 6: COLLECT ───────────────────────────────────────────────────────
@@ -505,4 +517,4 @@ if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith
   main();
 }
 
-export { discoverNodeFiles, parseNodeFile, promoteNodeToReady, main };
+export { discoverNodeFiles, parseNodeFile, promoteNodeStatus, main };


### PR DESCRIPTION
This PR fulfills Task 022, modifying the Foundry orchestrator script to automatically bypass human tasks.

### What
1. **Refactored status promotion logic**: Changed the static `promoteNodeToReady` replacement logic into a dynamic `promoteNodeStatus` utility, allowing replacing a generic `currentStatus` string with a generic `targetStatus` string.
2. **Phase 5 Human Bypass**: The orchestrator now explicitly checks if an eligible node's `owner_persona` is `human`. If so, it promotes it from `PENDING` to `ACTIVE`. Otherwise, it goes from `PENDING` to `READY` as normal.
3. **Phase 5.1 Sweep**: Added a sweep to check for any existing nodes with `status: READY` and `owner_persona: human` and upgrade them to `ACTIVE` to resolve any manual edits or pre-existing state.
4. **Unit Tests**: Added 2 new tests to `foundry-orchestrator.test.ts` covering both the direct bypass and the existing-ready sweep scenario. Tests assert the status changes correctly and the tasks do not appear in the resulting JSON output.

### Verification
- `pnpm lint` passing.
- `pnpm test` (including new orchestrator unit tests) passing.
- `pnpm test:e2e` passing.
- Orchestrator dry run (`node --experimental-strip-types`) executed correctly against the repository.

---
*PR created automatically by Jules for task [13992972196049399213](https://jules.google.com/task/13992972196049399213) started by @szubster*