### PR TITLE
feat(foundry): Generate story 012 for human persona schema update

### DIFF
--- a/.foundry/epics/epic-010-human-schema.md
+++ b/.foundry/epics/epic-010-human-schema.md
@@ -33,3 +33,6 @@ This Epic is solely responsible for defining the structural rules and constraint
 ## 5. Implementation Notes
 - Modify `.foundry/docs/schema.md`.
 - Ensure changes are communicated clearly so the orchestrator developers (in subsequent Epics) have a strict contract to follow.
+
+## Generated Stories
+- [.foundry/stories/story-010-012-schema-human-persona.md](.foundry/stories/story-010-012-schema-human-persona.md)

--- a/.foundry/stories/story-010-012-schema-human-persona.md
+++ b/.foundry/stories/story-010-012-schema-human-persona.md
@@ -1,0 +1,29 @@
+---
+id: story-010-012-schema-human-persona
+type: STORY
+title: "Update Foundry Schema for Human Persona"
+status: "PENDING"
+owner_persona: tech_lead
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/epics/epic-010-human-schema.md"
+tags:
+  - "human-in-the-loop"
+  - "schema"
+---
+
+# Story 012: Update Foundry Schema for Human Persona
+
+## 1. Goal
+Extend the Foundry Master Schema to formally support human ownership of tasks, bypassing the standard Jules autonomous execution loop.
+
+## 2. Acceptance Criteria
+- [ ] Update the `owner_persona` enum in `.foundry/docs/schema.md` to include `human`.
+- [ ] Define a new optional global frontmatter field `pr_number` in `.foundry/docs/schema.md`. It should be described as an integer or null, defaulting to null.
+- [ ] Add explicit notes in the schema that tasks owned by `human` bypass Jules dispatch and heartbeat failure timeouts.
+
+## 3. Implementation Notes
+- Modify `.foundry/docs/schema.md`.
+- Ensure changes are communicated clearly so the orchestrator developers have a strict contract to follow.


### PR DESCRIPTION
This PR introduces a new STORY node, generated by the `story_owner` persona, to handle the implementation phase of adding a `human` persona to the Foundry Master Schema.

Key changes:
- Created `.foundry/stories/story-010-012-schema-human-persona.md` linking to its parent Epic `epic-010-human-schema`.
- Assigned the story to `owner_persona: tech_lead`.
- Appended the story path under `## Generated Stories` in `.foundry/epics/epic-010-human-schema.md`.
- Carefully preserved the YAML frontmatter and un-checked Acceptance Criteria status on the parent epic per `story_owner` rules.

---
*PR created automatically by Jules for task [15969432490887437472](https://jules.google.com/task/15969432490887437472) started by @szubster*