### PR TITLE
Tech Lead: Draft blueprint tasks for ID schema templates update

### DIFF
--- a/.foundry/stories/story-005-id-schema-templates.md
+++ b/.foundry/stories/story-005-id-schema-templates.md
@@ -29,3 +29,8 @@ Implement the new collision-free ID schema across the orchestrator and all node 
 ## Definition of Done
 - Boilerplate templates and generation scripts output the new ID format automatically.
 - The orchestrator continues to function correctly with the newly formatted IDs.
+
+## Generated Tasks
+- `.foundry/tasks/task-005-024-update-id-templates.md`
+- `.foundry/tasks/task-005-025-update-orchestrator-validation.md`
+- `.foundry/tasks/task-005-026-qa-orchestrator-validation.md`

--- a/.foundry/tasks/task-005-024-update-id-templates.md
+++ b/.foundry/tasks/task-005-024-update-id-templates.md
@@ -1,0 +1,36 @@
+---
+id: task-005-024-update-id-templates
+type: TASK
+title: "Update Generation Templates to Parent-Linked ID Schema"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on: []
+jules_session_id: null
+parent: .foundry/stories/story-005-id-schema-templates.md
+---
+
+# Task: Update Generation Templates to Parent-Linked ID Schema
+
+## Context
+As per ADR 002, The Foundry system has transitioned to a Parent-Linked Distributed ID Schema for nodes. The new format is `<type>-<parent_NNN>-<NNN>-<slug>`, replacing the older `<type>-<NNN>-<slug>` format.
+
+## Contract
+Update all boilerplate templates and generation instructions to strictly adhere to the new schema.
+
+## Requirements
+1. **Schema Document (`.foundry/docs/schema.md`)**
+   - Update the "New Node Template" section (Section 8) to explicitly reflect the new format `<type>-<parent_NNN>-<NNN>-<slug>`.
+   - Ensure the field reference description for `id` under Section 3.1 accurately details this convention.
+
+2. **Persona Prompts (`.github/agents/*.md`)**
+   - Review agent prompts that generate nodes (e.g., `agile_coach.md`, `epic_planner.md`, `product_manager.md`, `story_owner.md`, `tech_lead.md`).
+   - If they include explicit ID schema examples, ensure they are updated. (If they don't, no action needed, but ensure they point to `schema.md`).
+
+3. **Orchestrator Templates (If applicable)**
+   - Check if any `.ts` scripts contain hardcoded markdown templates (e.g., in `foundry-orchestrator.ts` or `foundry-heartbeat.ts`) and update them if they do.
+
+## Acceptance Criteria
+- [ ] `.foundry/docs/schema.md` properly documents the parent-linked ID format in both definitions and templates.
+- [ ] Any script or agent prompt that dynamically or statically references the ID schema format reflects the `<type>-<parent_NNN>-<NNN>-<slug>` structure.

--- a/.foundry/tasks/task-005-025-update-orchestrator-validation.md
+++ b/.foundry/tasks/task-005-025-update-orchestrator-validation.md
@@ -1,0 +1,36 @@
+---
+id: task-005-025-update-orchestrator-validation
+type: TASK
+title: "Update Orchestrator Validation for Parent-Linked ID Schema"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on: []
+jules_session_id: null
+parent: .foundry/stories/story-005-id-schema-templates.md
+---
+
+# Task: Update Orchestrator Validation for Parent-Linked ID Schema
+
+## Context
+ADR 002 introduces a new Parent-Linked Distributed ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>`. The previous format was `<type>-<NNN>-<slug>`.
+The `foundry-orchestrator.ts` parses these nodes and might perform strict sequential numbering checks or ID validations.
+
+## Contract
+Modify the orchestrator validation logic to support the new ID format. The orchestrator must not fail validation or dependency resolution due to the new schema.
+
+## Requirements
+1. **Orchestrator Validation (`.github/scripts/foundry-orchestrator.ts`)**
+   - Review ID parsing and validation logic.
+   - If there are regular expressions or substring checks assuming the old format, update them to support both the old and new format (since older nodes will not be backfilled).
+   - Ensure the new format parses successfully and doesn't trigger warnings.
+
+2. **Test Updates (`.github/scripts/foundry-orchestrator.test.ts`)**
+   - Add new test cases using the new ID schema (`<type>-<parent_NNN>-<NNN>-<slug>`) to ensure it parses and resolves dependencies correctly.
+   - Ensure existing tests with the old ID schema continue to pass.
+
+## Acceptance Criteria
+- [ ] `foundry-orchestrator.ts` gracefully handles nodes utilizing the `<type>-<parent_NNN>-<NNN>-<slug>` format without validation warnings.
+- [ ] Backward compatibility is maintained for older `<type>-<NNN>-<slug>` node IDs.
+- [ ] Unit tests are added/updated to verify orchestrator behavior against the new schema.

--- a/.foundry/tasks/task-005-026-qa-orchestrator-validation.md
+++ b/.foundry/tasks/task-005-026-qa-orchestrator-validation.md
@@ -1,0 +1,30 @@
+---
+id: task-005-026-qa-orchestrator-validation
+type: TASK
+title: "QA Verification: Orchestrator Validation for Parent-Linked ID Schema"
+status: PENDING
+owner_persona: qa
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on:
+  - .foundry/tasks/task-005-025-update-orchestrator-validation.md
+jules_session_id: null
+parent: .foundry/stories/story-005-id-schema-templates.md
+---
+
+# QA Task: Verify Orchestrator Validation for Parent-Linked ID Schema
+
+## Context
+The Foundry Orchestrator (`.github/scripts/foundry-orchestrator.ts`) is a critical component. Modifying its validation logic for the new Parent-Linked ID schema (`<type>-<parent_NNN>-<NNN>-<slug>`) carries systemic risk.
+This task verifies the work completed in `task-005-025-update-orchestrator-validation.md`.
+
+## Verification Steps
+1. **Review Code Changes:** Ensure the changes in `foundry-orchestrator.ts` correctly accommodate both the new and old ID schemas without breaking backward compatibility.
+2. **Run Tests:** Run the test suite (`pnpm test` in the root or `.github/scripts/` depending on workspace setup) to ensure all orchestrator tests pass.
+3. **Verify Coverage:** Confirm that new test cases were added to specifically cover nodes using the new `<type>-<parent_NNN>-<NNN>-<slug>` format.
+4. **Dry-Run Validation:** Optionally perform a dry run of the orchestrator (`ts-node .github/scripts/foundry-orchestrator.ts --dry-run`) on the current `.foundry/` directory to ensure no new warnings or errors are surfaced for valid IDs.
+
+## Acceptance Criteria
+- [ ] Code modifications align with ADR 002.
+- [ ] Test coverage includes the new ID schema.
+- [ ] All tests pass successfully and the orchestrator does not emit invalid validation warnings for correctly formatted IDs.


### PR DESCRIPTION
This PR implements the Tech Lead tasks for updating templates and generation scripts to the new Parent-Linked ID Schema (`<type>-<parent_NNN>-<NNN>-<slug>`), following ADR 002.

**Changes:**
- Generated `task-005-024-update-id-templates.md` for updating documentation and script templates.
- Generated `task-005-025-update-orchestrator-validation.md` to update the orchestrator to accept the new format alongside backward compatibility.
- Generated `task-005-026-qa-orchestrator-validation.md` for QA verification on the critical orchestrator validation updates per the Intelligent Verification Protocol.
- Updated `story-005-id-schema-templates.md` to include links to the generated tasks, leaving the frontmatter untouched.

---
*PR created automatically by Jules for task [9741922439502902273](https://jules.google.com/task/9741922439502902273) started by @szubster*