### PR TITLE
Generate story node for oxlint config

### DIFF
--- a/.foundry/epics/epic-010-oxlint-config.md
+++ b/.foundry/epics/epic-010-oxlint-config.md
@@ -18,6 +18,9 @@ In response to CEO feedback (PR comment 4303644512), we need to schedule work in
 - `oxlint` is installed in the repository (completed in `jules-infras-oxlint`).
 
 ## Acceptance Criteria
-- A `.oxlintrc.json` configuration file is added.
-- Relevant `oxlint` plugins (e.g. jest/vitest, react, jsx-a11y) are enabled and configured to be "tight".
-- A story is generated to execute this epic.
+- [ ] A `.oxlintrc.json` configuration file is added.
+- [ ] Relevant `oxlint` plugins (e.g. jest/vitest, react, jsx-a11y) are enabled and configured to be "tight".
+- [x] A story is generated to execute this epic.
+
+## Generated Stories
+- [.foundry/stories/story-010-014-implement-oxlint-config.md](../stories/story-010-014-implement-oxlint-config.md)

--- a/.foundry/stories/story-010-014-implement-oxlint-config.md
+++ b/.foundry/stories/story-010-014-implement-oxlint-config.md
@@ -1,0 +1,25 @@
+---
+id: "story-010-014-implement-oxlint-config"
+type: "STORY"
+title: "Implement strict oxlint configuration"
+status: "PENDING"
+owner_persona: "tech_lead"
+created_at: "2026-04-23"
+updated_at: "2026-04-23"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/epics/epic-010-oxlint-config.md"
+---
+
+# Implement strict oxlint configuration
+
+## Context
+In response to CEO feedback (PR comment 4303644512), we need to schedule work in the Foundry system to provide a tight `oxlint` config, enable plugins, and make the best use of `oxlint`.
+
+## Requirements
+- Add a `.oxlintrc.json` configuration file.
+- Relevant `oxlint` plugins (e.g., jest/vitest, react, jsx-a11y) must be enabled and configured to be "tight".
+
+## Acceptance Criteria
+- [ ] Blueprint tasks are created to add and configure `.oxlintrc.json`.
+- [ ] Plugins configuration is explicitly addressed in the blueprint tasks.


### PR DESCRIPTION
Created a story node to address the configuration of `oxlint`. The story lays out the necessary requirements and acceptance criteria for the tech lead. Also updated the parent Epic node to reflect the progression by checking off the relevant acceptance criteria in the markdown body without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [4415664169684320614](https://jules.google.com/task/4415664169684320614) started by @szubster*