### PR TITLE
Agile Coach: Improve persona prompts and propose link checker

### DIFF
--- a/.foundry/ideas/idea-007-automated-link-checker.md
+++ b/.foundry/ideas/idea-007-automated-link-checker.md
@@ -1,0 +1,22 @@
+---
+id: idea-007-automated-link-checker
+type: IDEA
+title: "Automated Link Checker Pre-commit Hook"
+status: PENDING
+owner_persona: product_manager
+created_at: "2026-04-24"
+updated_at: "2026-04-24"
+depends_on: []
+jules_session_id: null
+parent: null
+tags: ["infras", "verification"]
+notes: "Generated proactively by Agile Coach to reduce DAG orchestrator deadlocks caused by hallucinatory links."
+---
+
+# Automated Link Checker Pre-commit Hook
+
+## Concept
+Agents frequently hallucinate dead links when generating child nodes, which can cause DAG orchestrator deadlocks when those non-existent files are referenced in `depends_on` or as `parent`. We should implement an automated pre-commit hook that validates all local markdown file references (both in YAML frontmatter and inline markdown links) to ensure they point to existing files on disk.
+
+## Value Proposition
+This will significantly reduce the number of orchestrator failures, reduce the burden on the TPM agent to resolve minor graph deadlocks, and improve overall repository hygiene.

--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -21,3 +21,7 @@ You are the Agile Coach of The Foundry. You run on a daily or weekly schedule as
 5.  Modify the necessary `.github/agents/*.md` persona files or other configurations to incorporate the learnings and improvements.
 6.  Autonomously generate new `IDEA` or `TASK` nodes to represent larger architectural or process improvements derived from observed friction.
 7.  Submit a PR with your proposed improvements and any newly generated nodes, clearly detailing the "why" based on your analysis or creative insight.
+
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -16,3 +16,7 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 3.  Evaluate proposed changes against ADRs and Schemas.
 4.  Produce architectural reviews, updated schemas, or new ADRs as required.
 5.  Commit your work to the repository.
+
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -9,3 +9,7 @@ When you begin your session, you **must explicitly read** all documents under th
 - `.foundry/docs/adrs/`
 
 Ensure you are fully aware of and adhere to the rules outlined in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -13,3 +13,13 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 ## Output
 
 Produce clean, well-structured markdown files for each Epic, ensuring they align perfectly with the overarching PRD and system architecture.
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
+
+**NODE GENERATION RULES:**
+- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
+- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 2`).
+- Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
+- Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -5,3 +5,14 @@ You are the Product Manager. Your primary responsibility is transforming IDEA ->
 When you begin your session, you must explicitly read all documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/` to establish your context!
 
 You must strictly adhere to the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
+
+**NODE GENERATION RULES:**
+- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
+- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 2`).
+- Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
+- Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -21,3 +21,7 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/001-the-f
 2. **Review**: Ensure implemented code follows architectural constraints (especially ADR 001).
 3. **Approval/Rejection**: If the implementation is valid, approve it. If not, detail what is missing or incorrect according to the contract and architecture.
 4. **Specify Results**: Explicitly specify the results of your validation work. Depending on the scope and need for further analysis, this output can include new tests, documentation updates, or the creation of new tasks, stories, PRDs, or ideas.
+
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -10,3 +10,14 @@ As the Story Owner, your role is to monitor active epics and write STORY nodes d
 
 You must be thoroughly aware of and strictly adhere to the rules outlined in:
 `.foundry/docs/adrs/001-the-foundry-architecture.md`
+
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
+
+**NODE GENERATION RULES:**
+- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
+- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 2`).
+- Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
+- Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -17,3 +17,14 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 2.  Review all relevant documentation in `.foundry/docs/` and `.foundry/docs/adrs/`.
 3.  Draft one or more TASK nodes that implement the story, deciding via the Intelligent Verification Protocol whether a separate QA TASK is required.
 4.  Commit the new TASK nodes to the repository.
+
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
+
+**NODE GENERATION RULES:**
+- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
+- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 2`).
+- Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
+- Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -16,3 +16,12 @@ When you begin your session, you **must explicitly read** all documents under th
 
 Ensure you are completely aware of the rules defined in:
 - `.foundry/docs/adrs/001-the-foundry-architecture.md`
+
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
+
+**ARCHIVING RULES:**
+- Do not archive a parent node (e.g., an EPIC) if any of its child nodes (e.g., STORY, TASK) are still active or pending.
+- When archiving completed nodes to `.foundry/archive/`, you MUST update all active files that reference them via the 'parent' field, 'depends_on' list, or inline markdown links to use the new archived path to prevent DAG orchestrator deadlocks.


### PR DESCRIPTION
This PR contains proactive improvements to The Foundry generated by the Agile Coach persona. It systematically updates the various persona prompts within `.github/agents/*.md` to address friction and common failure modes:

1. **Context Truncation:** Instructs all agents reading contextual documents to use `read_file` individually rather than `cat` or bash loops.
2. **Node Generation Rules:** Explicitly outlines the rules for correctly setting `owner_persona`, determining node sequence numbers, appending references without editing YAML frontmatter, and avoiding circular dependencies in `depends_on`.
3. **Archiving Rules:** Instructs the TPM to prevent archiving parent nodes with active child nodes, and explicitly update related references to avoid DAG orchestrator deadlocks.

Additionally, a new `IDEA` node (`idea-007-automated-link-checker.md`) has been generated proposing a pre-commit hook to validate markdown links to completely prevent issues related to agent hallucinations.

---
*PR created automatically by Jules for task [2572546820076653937](https://jules.google.com/task/2572546820076653937) started by @szubster*