### PR TITLE
🔒 [security fix] Sanitize error logging to prevent information disclosure

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,5 +1,5 @@
 ## Sanitize error logging to prevent CWE-209 information leakage
-**Pattern:** Directly passing the error object (e.g., `catch(console.error)`) can leak sensitive stack traces and internal state. Use `err instanceof Error ? err.message : String(err)` to sanitize log output and mitigate CWE-209.
+**Pattern:** Directly passing the error object or its message (e.g., `err instanceof Error ? err.message : String(err)`) to `console.error` can leak sensitive internal state or path information. Use generic, non-revealing error messages to mitigate CWE-209.
 
 ## Transitive Dependency Audits
 **Pattern:** To resolve vulnerabilities inside deep or transitive dependencies found via `pnpm audit` (like `serialize-javascript` vulnerabilities), add a `pnpm.overrides` section to `package.json` with the safe version constraint, and then run `pnpm install` to enforce the resolution throughout the workspace.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -21,7 +21,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             window.location.reload();
           }
         } catch (err) {
-          console.error(err instanceof Error ? err.message : String(err));
+          console.error('System: Chunk load failed');
         }
       }
     };

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -176,7 +176,7 @@ const syncData = async () => {
       await mStore.put({ key: 'hash', value: data.hash });
       await tx.done;
     } catch (err) {
-      console.error('PokeDB: Sync failed', err instanceof Error ? err.message : String(err));
+      console.error('PokeDB: Sync failed');
       // Reset promise so we can retry later if needed
       syncPromise = null;
       throw err;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,7 @@ import { routeTree } from './routeTree.gen';
 import './index.css';
 
 // Initialize and sync PokeData
-pokeDB.sync().catch((err) => console.error(err instanceof Error ? err.message : String(err)));
+pokeDB.sync().catch(() => console.error('System: Initial sync failed'));
 
 const router = createRouter({
   routeTree,

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -171,7 +171,7 @@ describe('Zustand Store', () => {
       useStore.getState().loadSaveFromStorage();
 
       // Verify that it caught the error, logged it, and removed the corrupted item
-      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file from localStorage:', expect.any(String));
+      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file from localStorage');
       expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
 
       vi.restoreAllMocks();

--- a/src/store.ts
+++ b/src/store.ts
@@ -128,10 +128,7 @@ export const useStore = create<AppStore>()(
             const data = parseSaveFile(bytes.buffer, manualVersion || undefined);
             set({ saveData: data });
           } catch (err) {
-            console.error(
-              'Failed to load saved file from localStorage:',
-              err instanceof Error ? err.message : String(err),
-            );
+            console.error('Failed to load saved file from localStorage');
             localStorage.removeItem('last_save_file');
           }
         }


### PR DESCRIPTION
This PR addresses a security vulnerability related to information disclosure via `console.error` logging.

### 🎯 What
- Replaced detailed error messages (`err.message`) in `catch` blocks with generic strings in:
  - `src/store.ts`
  - `src/components/AppLayout.tsx`
  - `src/db/PokeDB.ts`
  - `src/main.tsx`
- Updated the test suite in `src/store.test.ts` to reflect these changes.
- Updated `.jules/shield.md` to document the correct pattern for sanitizing error logs.

### ⚠️ Risk
Directly logging error objects or messages (e.g., `err instanceof Error ? err.message : String(err)`) can leak sensitive internal state, stack traces, or path information, which contributes to information disclosure (CWE-209).

### 🛡️ Solution
Used generic, non-revealing error messages that inform the developer of the high-level failure without exposing sensitive details.

### Verification
- Changes manually verified for correctness.
- Test assertion updated and verified via `grep`.
- Full test suite run attempt was made, but environment limitations (missing `node_modules` and network timeout) prevented execution. Code review confirmed the logic is sound and safe.

---
*PR created automatically by Jules for task [2026964105510776836](https://jules.google.com/task/2026964105510776836) started by @szubster*