### PR TITLE
🧪 Sentinel: add test case for invalid base64 storage string

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,5 @@ If you encounter `Error: Failed to load custom Reporter from text` when running 
 # Sentinel Learnings
 - Added tests to cover `RangeError` and other error paths in `decodeGen12String` by mocking `DataView.prototype.getUint8` to verify error bubbling.
 - Used `vi.spyOn` from vitest to explicitly mock native method throws.
+- Improved `src/store.test.ts` robustness by moving mock and global restoration to `afterEach` hooks, ensuring clean state even after test failures.
+- Covered untested error path in `loadSaveFromStorage` by simulating invalid base64 regex failures.

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { parseSaveFile } from './engine/saveParser/index';
 import { useStore } from './store';
 
@@ -20,6 +20,11 @@ describe('Zustand Store', () => {
       isSettingsOpen: false,
       isVersionModalOpen: false,
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('UI state', () => {
@@ -153,8 +158,6 @@ describe('Zustand Store', () => {
 
       expect(parseSaveFile).toHaveBeenCalled();
       expect(useStore.getState().saveData).toEqual(mockSaveData);
-
-      vi.unstubAllGlobals();
     });
 
     it('should handle corrupted save file from localStorage', () => {
@@ -173,14 +176,34 @@ describe('Zustand Store', () => {
       // Verify that it caught the error, logged it, and removed the corrupted item
       expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file from localStorage:', expect.any(String));
       expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
+    });
 
-      vi.restoreAllMocks();
-      vi.unstubAllGlobals();
+    it('should specifically catch invalid base64 regex failures', () => {
+      const mockRemoveItem = vi.fn();
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn().mockReturnValue('!!!'),
+        removeItem: mockRemoveItem,
+      });
+
+      const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      useStore.getState().loadSaveFromStorage();
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        'Failed to load saved file from localStorage:',
+        'Invalid Base64 string',
+      );
+      expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
     });
   });
 });
 
 describe('Persist Hydration Error Handling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   it('should handle corrupted persist storage gracefully when getItem throws', async () => {
     // We must reset modules to force Zustand to re-evaluate and re-hydrate
     vi.resetModules();
@@ -206,9 +229,6 @@ describe('Persist Hydration Error Handling', () => {
     expect(freshStore.getState().manualVersion).toBeNull();
 
     // Zustand persist logs a warning internally when getItem throws
-
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it('should handle corrupted persist storage gracefully when JSON is invalid', async () => {
@@ -232,8 +252,5 @@ describe('Persist Hydration Error Handling', () => {
     // The store should not crash, but initialize with defaults
     expect(freshStore.getState().filters).toEqual([]);
     expect(freshStore.getState().isLivingDex).toBe(false);
-
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested error path in the store's `loadSaveFromStorage` function specifically when the Base64 regex validation fails.
📊 **Coverage:** Added a new test case that mocks `localStorage` with an invalid string ('!!!') and asserts that `console.error` logs the specific 'Invalid Base64 string' error and that the item is removed from storage. Also improved the entire test file's reliability by moving cleanup logic to `afterEach` hooks.
✨ **Result:** Increased coverage of the core state management module and improved test suite robustness against mock/global pollution.

---
*PR created automatically by Jules for task [6809488457741369666](https://jules.google.com/task/6809488457741369666) started by @szubster*