### PR TITLE
🧹 cleanup: remove dead code and dev comments in gen2 tests

### DIFF
--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -30,9 +30,7 @@ describe('gen2 parsers', () => {
       const buffer = new ArrayBuffer(32768);
       const view = new DataView(buffer);
       view.setUint8(0x288a, 1); // GS
-      view.setUint8(0x288b + 1, 0xff); // Terminator (correct one)
-      // wait, the test was testing invalid terminator, so let's set it to 0
-      view.setUint8(0x288b + 1, 0x00);
+      view.setUint8(0x288b + 1, 0x00); // Invalid terminator
       expect(isGen2Save(view, false)).toBe(false);
     });
 
@@ -141,7 +139,6 @@ describe('gen2 parsers', () => {
       view.setUint8(0x288b + 7, 1);
 
       // detectGen2GameVersion will return 'unknown'.
-      // Wait, in parseGen2, if (gameVersion === 'unknown' && !isCrystal) gameVersion = 'gold'.
       const data = parseGen2(view, false);
       expect(data.gameVersion).toBe('gold');
     });


### PR DESCRIPTION
### 🎯 What
Removed redundant `setUint8` call and "wait" style developer comments in `src/engine/saveParser/parsers/gen2.test.ts`.

### 💡 Why
These comments represented thought processes during development and were not necessary for the long-term maintainability of the tests. Removing them and the redundant code reduces noise and improves readability.

### ✅ Verification
- Manually verified the file content after modification.
- Attempted to run tests with `pnpm vitest`, but the environment lacked pre-installed dependencies and network access for installation.
- Received a positive code review confirming the logic preservation and safety of the changes.

### ✨ Result
Cleaner and more maintainable test code for the Gen 2 save parser.

---
*PR created automatically by Jules for task [16645025593296240620](https://jules.google.com/task/16645025593296240620) started by @szubster*