### PR TITLE
🎨 Palette: Add role and aria-label to filter buttons group

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2024-04-22 - Focus Styles on Complex App Layouts
 **Learning:** Standard HTML elements functioning as buttons or links in custom, complex UI components (like `AppLayout` Desktop Navigation or headers) sometimes omit standard focus indicators when customized heavily. This breaks keyboard navigation.
 **Action:** All interactive elements (e.g., links, buttons) across the main layout must explicitly define focus styles using the standard utility class string: `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` to ensure consistent accessibility.
+
+## 2026-04-23 - Role Group for Checkbox-like Filters
+**Learning:** Collections of buttons that act like a set of checkboxes (where multiple can be active simultaneously, indicated by `aria-pressed`) need a container role to group them semantically for screen readers.
+**Action:** When creating a row or container of toggle buttons (like multi-select filters), wrap them in a container with `role="group"` and an `aria-label` describing the filter's purpose (e.g., "Filter Pokémon").

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -67,7 +67,8 @@ export function SearchAndFilters() {
         </div>
 
         {/* Filter Buttons designed as Retro Console Switches */}
-        <div className="no-scrollbar flex gap-2 overflow-x-auto px-1 pb-2">
+        {/* biome-ignore lint/a11y/useSemanticElements: semantic element breaks overflow styles */}
+        <div className="no-scrollbar flex gap-2 overflow-x-auto px-1 pb-2" role="group" aria-label="Filter Pokémon">
           <button
             type="button"
             onClick={() => setFilters([])}


### PR DESCRIPTION
## What
Added `role="group"` and `aria-label="Filter Pokémon"` to the container `div` wrapping the toggle filters (All, Secured, Missing, Dex Only) in `src/components/SearchAndFilters.tsx`.
Added a biome ignore comment since the linter complains about `role` on a non-interactive element but the semantic change breaks layout overflow styles.

## Why
When creating a set of toggle buttons that function like checkboxes (multiple can be active, indicated by `aria-pressed`), wrapping them in a `group` role semantically groups them for screen reader users, making the filter controls much more accessible and understandable as a unified set.

## Accessibility Notes
This change resolves an issue where screen reader users navigating to the filter buttons lacked the context that these buttons belonged to a single filter group.

---
*PR created automatically by Jules for task [467227325116686530](https://jules.google.com/task/467227325116686530) started by @szubster*