### PR TITLE
🔒 Fix CWE-209: Sanitize error logging to prevent information leakage

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,5 +1,5 @@
 ## Sanitize error logging to prevent CWE-209 information leakage
-**Pattern:** Directly passing the error object (e.g., `catch(console.error)`) can leak sensitive stack traces and internal state. Use `err instanceof Error ? err.message : String(err)` to sanitize log output and mitigate CWE-209.
+**Pattern:** Directly passing the error object (e.g., `catch(console.error)`) or even conditionally logging `err.message` or `String(err)` can leak sensitive stack traces, paths, and internal state. Explicitly replace raw error messages with static generic strings in generic `console.error` handlers (e.g., `console.error('System: sync failed')`) to prevent leaking sensitive state and fully mitigate CWE-209.
 
 ## Transitive Dependency Audits
 **Pattern:** To resolve vulnerabilities inside deep or transitive dependencies found via `pnpm audit` (like `serialize-javascript` vulnerabilities), add a `pnpm.overrides` section to `package.json` with the safe version constraint, and then run `pnpm install` to enforce the resolution throughout the workspace.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -20,8 +20,8 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           if (chunkFailedMessage) {
             window.location.reload();
           }
-        } catch (err) {
-          console.error(err instanceof Error ? err.message : String(err));
+        } catch {
+          console.error('System: chunk load error handler failed');
         }
       }
     };

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -176,7 +176,7 @@ const syncData = async () => {
       await mStore.put({ key: 'hash', value: data.hash });
       await tx.done;
     } catch (err) {
-      console.error('PokeDB: Sync failed', err instanceof Error ? err.message : String(err));
+      console.error('System: sync failed');
       // Reset promise so we can retry later if needed
       syncPromise = null;
       throw err;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,7 @@ import { routeTree } from './routeTree.gen';
 import './index.css';
 
 // Initialize and sync PokeData
-pokeDB.sync().catch((err) => console.error(err instanceof Error ? err.message : String(err)));
+pokeDB.sync().catch(() => console.error('System: sync failed'));
 
 const router = createRouter({
   routeTree,

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -174,7 +174,7 @@ describe('Zustand Store', () => {
       useStore.getState().loadSaveFromStorage();
 
       // Verify that it caught the error, logged it, and removed the corrupted item
-      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file from localStorage:', expect.any(String));
+      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file');
       expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
     });
 
@@ -189,10 +189,7 @@ describe('Zustand Store', () => {
 
       useStore.getState().loadSaveFromStorage();
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        'Failed to load saved file from localStorage:',
-        'Invalid Base64 string',
-      );
+      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file');
       expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
     });
   });

--- a/src/store.ts
+++ b/src/store.ts
@@ -127,11 +127,8 @@ export const useStore = create<AppStore>()(
             const { manualVersion } = get();
             const data = parseSaveFile(bytes.buffer, manualVersion || undefined);
             set({ saveData: data });
-          } catch (err) {
-            console.error(
-              'Failed to load saved file from localStorage:',
-              err instanceof Error ? err.message : String(err),
-            );
+          } catch {
+            console.error('Failed to load saved file');
             localStorage.removeItem('last_save_file');
           }
         }


### PR DESCRIPTION
🎯 What
This PR updates `console.error` usages within generic `catch` blocks throughout the application (`AppLayout.tsx`, `PokeDB.ts`, `store.ts`, `main.tsx`) to log static, non-revealing strings instead of `err.message` or `String(err)`. 

⚠️ Risk
Although previously sanitized using `.message`, logging any properties from raw error objects can unintentionally leak sensitive data like internal system paths, configuration secrets, or full stack traces into browser consoles.

🛡️ Solution
We fully mitigated CWE-209 (Information Exposure Through an Error Message) by strictly replacing error contents with hardcoded generic strings like `'System: sync failed'`. Unused catch parameters were also removed (`catch {` syntax) to cleanly appease linter rules, and associated unit tests in `store.test.ts` were updated to reflect the new generic outputs.

---
*PR created automatically by Jules for task [3570097515876249122](https://jules.google.com/task/3570097515876249122) started by @szubster*