### PR TITLE
🛡️ Nurse: remove unsafe cast in PokemonDetails.tsx

### DIFF
--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -123,7 +123,7 @@ export function PokemonDetails({
 
   const getLocationsForVersion = React.useCallback(
     (version: string) => {
-      const versionId = (POKE_VERSION_MAP as Record<string, number>)[version] || 0;
+      const versionId = POKE_VERSION_MAP[version] || 0;
       const versionEncounters = encounters.filter((e) => e.v === versionId);
 
       return versionEncounters.flatMap((enc) => {


### PR DESCRIPTION
Changing the type of POKE_VERSION_MAP from `Record<string, number>` to `Record<string, number | undefined>` explicitly models that an unmapped string key might return `undefined`. This allows us to remove unsafe casts like `(POKE_VERSION_MAP as Record<string, number>)` and forces callers to handle the `undefined` case, improving type safety without changing runtime fallback behavior.

---
*PR created automatically by Jules for task [18058642840356949042](https://jules.google.com/task/18058642840356949042) started by @szubster*