### PR TITLE
🧠 Trainer: Add Static Gift Recommendations (Progression-Aware)

### DIFF
--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -109,4 +109,114 @@ describe('generateSuggestions', () => {
     // Best distance is 1. Math.max(10, 110 - 1 * 12) = 110 - 12 = 98
     expect(nearbySuggestion?.priority).toBe(98);
   });
+
+  it('should generate "Gift" suggestions when event flag is not set and badges are sufficient', () => {
+    const eventFlags = new Uint8Array(300);
+    // Do not set 0x190 (Lapras gift flag)
+
+    const mockSaveData: SaveData = {
+      generation: 1,
+      gameVersion: 'red',
+      owned: new Set([1, 2, 3]), // Missing 131 (Lapras)
+      seen: new Set(),
+      party: [],
+      inventory: [],
+      currentMapId: 0,
+      badges: 4, // Enough badges for Lapras
+      eventFlags,
+      partyDetails: [],
+      pcDetails: [],
+      trainerName: 'ASH',
+    } as unknown as SaveData;
+
+    const mockApiData: AssistantApiData = {
+      localAid: 1,
+      localEncounters: [],
+      missingEncounters: {},
+      pokemonMetadata: {},
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+
+    const giftSuggestion = suggestions.find((s) => s.id === 'gift-131');
+    expect(giftSuggestion).toBeDefined();
+    expect(giftSuggestion?.title).toBe('Claim Gift: #131');
+    expect(giftSuggestion?.category).toBe('Gift');
+  });
+
+  it('should not generate "Gift" suggestions when badges are insufficient', () => {
+    const eventFlags = new Uint8Array(300);
+
+    const mockSaveData: SaveData = {
+      generation: 1,
+      gameVersion: 'red',
+      owned: new Set([1, 2, 3]), // Missing 131 (Lapras)
+      seen: new Set(),
+      party: [],
+      inventory: [],
+      currentMapId: 0,
+      badges: 3, // Not enough for Lapras (requires 4)
+      eventFlags,
+      partyDetails: [],
+      pcDetails: [],
+      trainerName: 'ASH',
+    } as unknown as SaveData;
+
+    const mockApiData: AssistantApiData = {
+      localAid: 1,
+      localEncounters: [],
+      missingEncounters: {},
+      pokemonMetadata: {},
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+
+    const giftSuggestion = suggestions.find((s) => s.id === 'gift-131');
+    expect(giftSuggestion).toBeUndefined();
+  });
+
+  it('should not generate "Gift" suggestions when event flag is set', () => {
+    const eventFlags = new Uint8Array(300);
+    // Set 0x190 (Lapras gift flag)
+    const byteIndex = 0x190 >> 3;
+    const bitIndex = 0x190 & 7;
+    // @ts-expect-error
+    eventFlags[byteIndex] |= 1 << bitIndex;
+
+    const mockSaveData: SaveData = {
+      generation: 1,
+      gameVersion: 'red',
+      owned: new Set([1, 2, 3]), // Missing 131 (Lapras)
+      seen: new Set(),
+      party: [],
+      inventory: [],
+      currentMapId: 0,
+      badges: 8, // Enough badges
+      eventFlags,
+      partyDetails: [],
+      pcDetails: [],
+      trainerName: 'ASH',
+    } as unknown as SaveData;
+
+    const mockApiData: AssistantApiData = {
+      localAid: 1,
+      localEncounters: [],
+      missingEncounters: {},
+      pokemonMetadata: {},
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+
+    const giftSuggestion = suggestions.find((s) => s.id === 'gift-131');
+    expect(giftSuggestion).toBeUndefined();
+  });
 });

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -81,6 +81,15 @@ export async function fetchAssistantApiData(saveData: SaveData, queryTargets: nu
   };
 }
 
+function checkFlag(flags: Uint8Array | undefined, flagId: number | undefined) {
+  if (!flags || flagId === undefined) return false;
+  const byteIndex = flagId >> 3;
+  const bitIndex = flagId & 7;
+  const byte = flags[byteIndex];
+  if (byte === undefined) return false;
+  return (byte & (1 << bitIndex)) !== 0;
+}
+
 const METHOD_NAMES: Record<number, string> = {
   [ENCOUNTER_METHOD.WALK]: 'walk',
   [ENCOUNTER_METHOD.SURF]: 'surf',
@@ -286,7 +295,30 @@ export function generateSuggestions(
     });
   }
 
-  // D. Evolutions
+  // D. Static Gifts
+  // Suggests available static encounters and gifts that haven't been claimed yet.
+  for (const [idStr, gift] of Object.entries(STATIC_GIFT_DATA)) {
+    const giftId = parseInt(idStr, 10);
+    if (gift.gen && gift.gen !== saveData.generation) continue;
+    if (!missingIds.has(giftId)) continue;
+
+    const requiredBadges = gift.requiredBadges || 0;
+    if (saveData.badges < requiredBadges) continue;
+
+    const hasClaimed = checkFlag(saveData.eventFlags, gift.eventFlag);
+    if (hasClaimed) continue;
+
+    suggestions.push({
+      id: `gift-${giftId}`,
+      category: 'Gift',
+      title: `Claim Gift: #${giftId}`,
+      description: `Get ${gift.name} at ${gift.location} (${gift.reason}).`,
+      pokemonId: giftId,
+      priority: 85,
+    });
+  }
+
+  // E. Evolutions
   // Evaluates the player's current boxes and party to find pre-evolutions.
   // Priority boosts significantly if the evolution criteria are actively met (e.g. required level reached, evolution stone in inventory).
   const instancesBySpecies = new Map<number, PokemonInstance[]>();

--- a/src/engine/data/gen1/assistantData.ts
+++ b/src/engine/data/gen1/assistantData.ts
@@ -4,7 +4,7 @@
 
 export const STATIC_GIFT_DATA: Record<
   number,
-  { name: string; location: string; reason: string; gen?: number; eventFlag?: number }
+  { name: string; location: string; reason: string; gen?: number; eventFlag?: number; requiredBadges?: number }
 > = {
   // Gen 1
   1: {
@@ -13,6 +13,7 @@ export const STATIC_GIFT_DATA: Record<
     reason: 'Gift from NPC (Yellow only)',
     gen: 1,
     eventFlag: 0x2a1,
+    requiredBadges: 1, // Need to reach Cerulean City (Brock)
   },
   4: {
     name: 'Charmander',
@@ -20,6 +21,7 @@ export const STATIC_GIFT_DATA: Record<
     reason: 'Gift from NPC (Yellow only)',
     gen: 1,
     eventFlag: 0x217,
+    requiredBadges: 1, // Need to reach Cerulean City (Brock)
   },
   7: {
     name: 'Squirtle',
@@ -27,6 +29,7 @@ export const STATIC_GIFT_DATA: Record<
     reason: 'Gift from Officer Jenny (Yellow only)',
     gen: 1,
     eventFlag: 0x221,
+    requiredBadges: 2, // Need Thunderbadge (Surge) actually not strictly required for city but makes sense
   },
   131: {
     name: 'Lapras',
@@ -34,6 +37,7 @@ export const STATIC_GIFT_DATA: Record<
     reason: 'Gift from NPC during Silph Co. invasion',
     gen: 1,
     eventFlag: 0x190,
+    requiredBadges: 4, // Needs to reach Saffron / Silph Co (usually requires 4 badges)
   },
   133: {
     name: 'Eevee',
@@ -41,6 +45,7 @@ export const STATIC_GIFT_DATA: Record<
     reason: 'Gift from the back entrance',
     gen: 1,
     eventFlag: 0x2fd,
+    requiredBadges: 2, // Reach Celadon City (usually 2+ badges)
   },
   106: {
     name: 'Hitmonlee',
@@ -48,6 +53,7 @@ export const STATIC_GIFT_DATA: Record<
     reason: 'Reward',
     gen: 1,
     eventFlag: 0x23b,
+    requiredBadges: 4, // Reach Saffron City
   },
   107: {
     name: 'Hitmonchan',
@@ -55,15 +61,16 @@ export const STATIC_GIFT_DATA: Record<
     reason: 'Reward',
     gen: 1,
     eventFlag: 0x23b,
+    requiredBadges: 4, // Reach Saffron City
   }, // Shared flag for Dojo? Yes, you pick one.
-  138: { name: 'Omanyte', location: 'Cinnabar Lab', reason: 'Fossil', gen: 1, eventFlag: 0x232 }, // Dome Fossil? No, shared flag for choosing fossil?
-  140: { name: 'Kabuto', location: 'Cinnabar Lab', reason: 'Fossil', gen: 1, eventFlag: 0x232 },
-  142: { name: 'Aerodactyl', location: 'Cinnabar Lab', reason: 'Fossil', gen: 1, eventFlag: 0x234 },
-  143: { name: 'Snorlax', location: 'Route 12 / 16', reason: 'Static', gen: 1, eventFlag: 0x23f }, // One of the Snorlaxes
-  144: { name: 'Articuno', location: 'Seafoam', reason: 'Static', gen: 1, eventFlag: 0x228 },
-  145: { name: 'Zapdos', location: 'Power Plant', reason: 'Static', gen: 1, eventFlag: 0x227 },
-  146: { name: 'Moltres', location: 'Victory Road', reason: 'Static', gen: 1, eventFlag: 0x230 },
-  150: { name: 'Mewtwo', location: 'Cerulean Cave', reason: 'Static', gen: 1, eventFlag: 0x231 },
+  138: { name: 'Omanyte', location: 'Cinnabar Lab', reason: 'Fossil', gen: 1, eventFlag: 0x232, requiredBadges: 6 }, // Reach Cinnabar (usually 6 badges)
+  140: { name: 'Kabuto', location: 'Cinnabar Lab', reason: 'Fossil', gen: 1, eventFlag: 0x232, requiredBadges: 6 },
+  142: { name: 'Aerodactyl', location: 'Cinnabar Lab', reason: 'Fossil', gen: 1, eventFlag: 0x234, requiredBadges: 6 },
+  143: { name: 'Snorlax', location: 'Route 12 / 16', reason: 'Static', gen: 1, eventFlag: 0x23f, requiredBadges: 3 }, // Need Poke Flute (Lavender Town, so 3+ badges usually)
+  144: { name: 'Articuno', location: 'Seafoam', reason: 'Static', gen: 1, eventFlag: 0x228, requiredBadges: 5 }, // Need Surf/Strength (5+ badges)
+  145: { name: 'Zapdos', location: 'Power Plant', reason: 'Static', gen: 1, eventFlag: 0x227, requiredBadges: 3 }, // Need Surf (from Safari Zone/Koga so usually 4, but let's say 3+)
+  146: { name: 'Moltres', location: 'Victory Road', reason: 'Static', gen: 1, eventFlag: 0x230, requiredBadges: 8 }, // Need all 8 badges to reach Victory Road
+  150: { name: 'Mewtwo', location: 'Cerulean Cave', reason: 'Static', gen: 1, eventFlag: 0x231, requiredBadges: 8 }, // Need to beat E4
 
   // Gen 2 (Placeholder: event flags for Gen 2 are at different offsets and not yet mapped)
   152: { name: 'Chikorita', location: 'New Bark Town', reason: 'Starter', gen: 2 },


### PR DESCRIPTION
Adds a new section to `generateSuggestions` to recommend `STATIC_GIFT_DATA` items (like Eevee, Lapras, Hitmonchan, fossils) if they are missing from the player's Pokedex.

Gifts are suggested with a priority of 85, placing them alongside readily actionable NPC trades.

The suggestions are progression-aware:
1. They filter out items if the `eventFlag` in `saveData` has already been flipped (indicating the item was claimed).
2. They verify `saveData.badges` against newly added `requiredBadges` thresholds on `STATIC_GIFT_DATA` items to prevent suggesting late-game gifts (like Cinnabar fossils) to new players.

---
*PR created automatically by Jules for task [18349866077886680392](https://jules.google.com/task/18349866077886680392) started by @szubster*