### PR TITLE
🧬 Oak: [Tyrogue Evolution Conditions]

### DIFF
--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -6,3 +6,6 @@
 
 ## Data Integrity - Gen 1 Exclusives
 *   **ROM parsing quirks / Data Pipeline Gotchas:** The version exclusivity arrays in `src/engine/exclusives/gen1Exclusives.ts` operate as *exclusion* lists, not inclusion lists. The array for `red` must contain the IDs of Pokémon that are **missing** or **unobtainable** in Red (which are the Blue exclusives), and vice versa. This is counter-intuitive initially, but required because `getUnobtainableReason` checks if a Pokémon ID `.includes` in the version's list to determine if it should be locked. Always verify whether a data array in the engine is intended to represent "available" or "unavailable" entities before modifying it.
+
+## Data Integrity - Evolution Chains
+*   **ROM parsing quirks / Data Pipeline Gotchas:** Some Gen 2 Pokémon evolutions (like Tyrogue -> Hitmonlee/Hitmonchan/Hitmontop) depend on the Pokémon's stats (Attack > Defense, Attack < Defense, or Attack == Defense). PokeAPI models this via `relative_physical_stats` in the `evolution_details`. Ensure the schema (`CompactEvolutionDetail`) and data generation script (`scripts/generate-pokedata.ts`) correctly map `relative_physical_stats` (to `rps`) so the application logic can accurately evaluate these conditional evolutions.

--- a/data/db/metadata.json
+++ b/data/db/metadata.json
@@ -1,4 +1,4 @@
 {
   "sourceSha": "",
-  "generatedAt": "2026-04-23T20:25:49.046Z"
+  "generatedAt": "2026-04-24T09:49:26.248Z"
 }

--- a/data/db/pokemon.jsonl
+++ b/data/db/pokemon.jsonl
@@ -103,8 +103,8 @@
 {"id":103,"n":"Exeggutor","cr":45,"efrm":[102],"det":[{"tr":3,"item":47},{"tr":3,"item":47}]}
 {"id":104,"n":"Cubone","cr":190,"eto":[{"id":105,"det":[{"ml":28},{"ml":28,"time":2}],"ef":104}]}
 {"id":105,"n":"Marowak","cr":75,"efrm":[104],"det":[{"ml":28},{"ml":28,"time":2}]}
-{"id":106,"n":"Hitmonlee","cr":45,"gr":0,"efrm":[236],"det":[{"ml":20}]}
-{"id":107,"n":"Hitmonchan","cr":45,"gr":0,"efrm":[236],"det":[{"ml":20}]}
+{"id":106,"n":"Hitmonlee","cr":45,"gr":0,"efrm":[236],"det":[{"ml":20,"rps":1}]}
+{"id":107,"n":"Hitmonchan","cr":45,"gr":0,"efrm":[236],"det":[{"ml":20,"rps":-1}]}
 {"id":108,"n":"Lickitung","cr":45,"eto":[{"id":463,"det":[{}],"ef":108}]}
 {"id":109,"n":"Koffing","cr":190,"eto":[{"id":110,"det":[{"ml":35},{"ml":35}],"ef":109}]}
 {"id":110,"n":"Weezing","cr":60,"efrm":[109],"det":[{"ml":35},{"ml":35}]}
@@ -233,8 +233,8 @@
 {"id":233,"n":"Porygon2","cr":45,"gr":-1,"eto":[{"id":474,"det":[{"tr":2,"held":301}],"ef":233}],"efrm":[137],"det":[{"tr":2,"held":229}]}
 {"id":234,"n":"Stantler","cr":45,"eto":[{"id":899,"det":[{"tr":0}],"ef":234}]}
 {"id":235,"n":"Smeargle","cr":45}
-{"id":236,"n":"Tyrogue","cr":75,"gr":0,"baby":true,"eto":[{"id":106,"det":[{"ml":20}],"ef":236},{"id":107,"det":[{"ml":20}],"ef":236},{"id":237,"det":[{"ml":20}],"ef":236}]}
-{"id":237,"n":"Hitmontop","cr":45,"gr":0,"efrm":[236],"det":[{"ml":20}]}
+{"id":236,"n":"Tyrogue","cr":75,"gr":0,"baby":true,"eto":[{"id":106,"det":[{"ml":20,"rps":1}],"ef":236},{"id":107,"det":[{"ml":20,"rps":-1}],"ef":236},{"id":237,"det":[{"ml":20,"rps":0}],"ef":236}]}
+{"id":237,"n":"Hitmontop","cr":45,"gr":0,"efrm":[236],"det":[{"ml":20,"rps":0}]}
 {"id":238,"n":"Smoochum","cr":45,"gr":8,"baby":true,"eto":[{"id":124,"det":[{"ml":30}],"ef":238}]}
 {"id":239,"n":"Elekid","cr":45,"gr":2,"baby":true,"eto":[{"id":125,"eto":[{"id":466,"det":[{"tr":2,"held":299}],"ef":125}],"det":[{"ml":30}],"ef":239}]}
 {"id":240,"n":"Magby","cr":45,"gr":2,"baby":true,"eto":[{"id":126,"eto":[{"id":467,"det":[{"tr":2,"held":300}],"ef":126}],"det":[{"ml":30}],"ef":240}]}

--- a/scripts/generate-pokedata.ts
+++ b/scripts/generate-pokedata.ts
@@ -56,6 +56,7 @@ interface PokeApiEvolutionDetail {
   item?: { url: string };
   held_item?: { url: string };
   time_of_day?: string;
+  relative_physical_stats?: number;
 }
 
 interface PokeApiChainLink {
@@ -380,6 +381,7 @@ for (const cid of uniqueChainIds) {
           : undefined,
         held: ed.held_item ? parseInt(ed.held_item.url.split('/').filter(Boolean).pop() || '0', 10) : undefined,
         time: ed.time_of_day === 'day' ? 1 : ed.time_of_day === 'night' ? 2 : undefined,
+        rps: ed.relative_physical_stats ?? undefined,
       })),
       ef,
     };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -110,6 +110,7 @@ export interface CompactEvolutionDetail {
   item?: number | undefined; // item id
   held?: number | undefined; // held item id
   time?: number | undefined; // 1: day, 2: night
+  rps?: number | undefined; // relative_physical_stats (1: Atk > Def, -1: Atk < Def, 0: Atk == Def)
 }
 
 export interface CompactChainLink {


### PR DESCRIPTION
**What was wrong:** The Tyrogue evolution chain (into Hitmonlee, Hitmonchan, and Hitmontop) relies on the `relative_physical_stats` condition in PokeAPI (determining if Attack > Defense, Attack < Defense, or Attack == Defense). This crucial evolution trigger data was being omitted from the generated database.
**Canonical source used:** PokeAPI evolution chains (`relative_physical_stats`).
**Impact on users:** The application can now accurately represent complex, stat-based evolution conditions like Tyrogue's in the generated datasets and subsequent features that rely on accurate Pokemon evolution trees.

---
*PR created automatically by Jules for task [10857949256475300262](https://jules.google.com/task/10857949256475300262) started by @szubster*