### PR TITLE
Update TPM Prompt for Archiving Logic

### DIFF
--- a/.foundry/tasks/task-013-024-update-tpm-prompt.md
+++ b/.foundry/tasks/task-013-024-update-tpm-prompt.md
@@ -23,8 +23,8 @@ Update the `.github/agents/tpm.md` persona prompt to instruct the TPM agent on h
 As part of the scheduling improvements, we need to instruct the TPM agent to identify and archive at least one test `COMPLETED` node when present. The agent must be instructed to be conservative: even if marked `COMPLETED`, if it determines it might still be relevant or needed, it should retain it. It's better to leave more nodes unarchived than to aggressively remove nodes that might still have value.
 
 ## Acceptance Criteria
-- [ ] Update `.github/agents/tpm.md` to instruct the TPM to archive at least one `COMPLETED` test node.
-- [ ] Instruct the TPM to be conservative and prioritize retention over aggressive removal of nodes that might still be needed.
+- [x] Update `.github/agents/tpm.md` to instruct the TPM to archive at least one `COMPLETED` test node.
+- [x] Instruct the TPM to be conservative and prioritize retention over aggressive removal of nodes that might still be needed.
 
 ## Technical Contract
 - Modify `.github/agents/tpm.md` using the replace tool.

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -4,7 +4,7 @@ You are the TPM (Technical Program Manager) agent for The Foundry.
 
 ## Core Duties
 - You run **hourly**.
-- **Archive COMPLETED nodes:** Move nodes that have reached the COMPLETED state into the appropriate archive locations.
+- **Archive COMPLETED nodes:** Move nodes that have reached the COMPLETED state into the appropriate archive locations. Identify and archive at least one `COMPLETED` test node when present. Be conservative when archiving: prioritize retention over aggressive removal. Even if a node is marked `COMPLETED`, if you determine it might still be relevant or needed, retain it. It's better to leave more nodes unarchived than to aggressively remove nodes that might still have value.
 - **Resolve Minor Deadlocks:** Detect and resolve minor graph deadlocks in the DAG orchestrator.
 - **Manage Journals:** Archive stale journal content across the `.foundry/journals/` directory to keep the workspace clean.
 


### PR DESCRIPTION
This PR implements the requirements for Task 013-024, updating the TPM agent's persona prompt.

The `.github/agents/tpm.md` file was modified to explicitly state the new rules for conservative archiving:
- Identify and archive at least one `COMPLETED` test node when present.
- Be conservative when archiving: prioritize retention over aggressive removal. Even if a node is marked `COMPLETED`, if it might still be relevant or needed, retain it.

The YAML frontmatter was left untouched per the strict task node constraints.
Manual self-verification (as per the Intelligent Verification Protocol) confirmed the correct text was added. Testing could not be completed automatically due to environmental `node_modules` installation restrictions (`ENETUNREACH`), but the modifications are solely markdown text updates.

---
*PR created automatically by Jules for task [940115287298606683](https://jules.google.com/task/940115287298606683) started by @szubster*