### PR TITLE
Update agent prompts for node creation guidelines

### DIFF
--- a/.foundry/tasks/task-010-024-update-persona-prompts.md
+++ b/.foundry/tasks/task-010-024-update-persona-prompts.md
@@ -38,8 +38,8 @@ As refined in the story `.foundry/stories/story-010-persona-permissions-matrix.m
    - **Crucially: Do not touch `.github/scripts/foundry-orchestrator.ts` or `lefthook.yml`.** This requirement is strictly prompt-based.
 
 ## Acceptance Criteria
-- [ ] The `architect` prompt encourages creating `TASK`, `ADR`, and `IDEA` nodes.
-- [ ] The `tech_lead` prompt encourages creating `TASK` and `ADR` nodes.
-- [ ] The `story_owner` (or relevant) prompt encourages creating `STORY` and `EPIC` nodes.
-- [ ] The `product_manager` prompt encourages creating `IDEA`, `PRD`, and `EPIC` nodes.
-- [ ] No strict enforcement checks or orchestrator logs are added.
+- [x] The `architect` prompt encourages creating `TASK`, `ADR`, and `IDEA` nodes.
+- [x] The `tech_lead` prompt encourages creating `TASK` and `ADR` nodes.
+- [x] The `story_owner` (or relevant) prompt encourages creating `STORY` and `EPIC` nodes.
+- [x] The `product_manager` prompt encourages creating `IDEA`, `PRD`, and `EPIC` nodes.
+- [x] No strict enforcement checks or orchestrator logs are added.

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -18,5 +18,8 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 5.  Commit your work to the repository.
 
 
+**NODE CREATION GUIDELINES:**
+While the system does not strictly block node creation, you should typically create the following node types: `TASK`, `ADR`, and `IDEA`. Please follow this convention unless you have a specific, documented reason to deviate.
+
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -7,6 +7,9 @@ When you begin your session, you must explicitly read all documents under `.foun
 You must strictly adhere to the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
 
 
+**NODE CREATION GUIDELINES:**
+While the system does not strictly block node creation, you should typically create the following node types: `IDEA`, `PRD`, and `EPIC`. Please follow this convention unless you have a specific, documented reason to deviate.
+
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -12,6 +12,9 @@ You must be thoroughly aware of and strictly adhere to the rules outlined in:
 `.foundry/docs/adrs/001-the-foundry-architecture.md`
 
 
+**NODE CREATION GUIDELINES:**
+While the system does not strictly block node creation, you should typically create the following node types: `STORY` and `EPIC`. Please follow this convention unless you have a specific, documented reason to deviate.
+
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -21,6 +21,9 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 4.  Commit the new TASK nodes to the repository.
 
 
+**NODE CREATION GUIDELINES:**
+While the system does not strictly block node creation, you should typically create the following node types: `TASK` and `ADR`. Please follow this convention unless you have a specific, documented reason to deviate.
+
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 


### PR DESCRIPTION
Updates the agent prompts for `architect.md`, `tech_lead.md`, `story_owner.md`, and `product_manager.md` to include node creation guidelines, encouraging the creation of specific node types without enforcing them via the orchestrator. Also checks off the corresponding acceptance criteria in the task node.

---
*PR created automatically by Jules for task [5242535953290695213](https://jules.google.com/task/5242535953290695213) started by @szubster*