### PR TITLE
Update Generation Templates to Parent-Linked ID Schema

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -80,7 +80,7 @@ notes: ""               # Optional. Free-form Markdown remarks.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `id` | `string` | ✅ | Globally unique. Convention: `<type>-<parent_NNN>-<NNN>-<slug>`. Used by humans and search; the DAG uses file paths. |
+| `id` | `string` | ✅ | Globally unique. Convention: `<type>-<parent_NNN>-<NNN>-<slug>` (IDEA nodes omit parent NNN). Used by humans and search; the DAG uses file paths. |
 | `type` | `enum` | ✅ | `IDEA \| PRD \| EPIC \| STORY \| TASK` |
 | `title` | `string` | ✅ | Short, human-readable description. |
 | `status` | `enum` | ✅ | Current lifecycle state. See §4. |
@@ -188,7 +188,7 @@ Copy-paste this block to start any new node. Fill in all required fields before 
 
 ```yaml
 ---
-id: <type>-<parent_NNN>-<NNN>-<slug>
+id: <type>-<parent_NNN>-<NNN>-<slug> # e.g. task-001-002-implement-feature
 type: 
 title: ""
 status: PENDING

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -20,6 +20,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 **NODE GENERATION RULES:**
 - Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
-- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 2`).
+- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
+- When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -13,6 +13,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 **NODE GENERATION RULES:**
 - Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
-- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 2`).
+- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
+- When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -18,6 +18,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 **NODE GENERATION RULES:**
 - Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
-- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 2`).
+- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
+- When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -27,6 +27,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 **NODE GENERATION RULES:**
 - Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
-- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 2`).
+- Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
+- When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.


### PR DESCRIPTION
This PR updates `.foundry/docs/schema.md` and the ID sequence logic inside the `.github/agents/*.md` prompts (`product_manager.md`, `epic_planner.md`, `story_owner.md`, `tech_lead.md`) to strictly follow the Parent-Linked ID Schema (`<type>-<parent_NNN>-<NNN>-<slug>`).

It adjusts the ID field description in the schema and adds explicit references in the node generation rules section of the agent prompts, also pointing to the updated sorting schema (`sort -n -t '-' -k 3`).

---
*PR created automatically by Jules for task [7820065613631510653](https://jules.google.com/task/7820065613631510653) started by @szubster*