### PR TITLE
feat(foundry): create story-006-015 for automated link checker pre-commit hook

### DIFF
--- a/.foundry/prds/prd-007-006-automated-link-checker.md
+++ b/.foundry/prds/prd-007-006-automated-link-checker.md
@@ -20,3 +20,6 @@ Agents frequently hallucinate dead links when generating child nodes, which can 
 
 ## Value Proposition
 This will significantly reduce the number of orchestrator failures, reduce the burden on the TPM agent to resolve minor graph deadlocks, and improve overall repository hygiene.
+
+## Generated Stories
+- [x] `.foundry/stories/story-006-015-implement-link-checker.md`

--- a/.foundry/stories/story-006-015-implement-link-checker.md
+++ b/.foundry/stories/story-006-015-implement-link-checker.md
@@ -1,0 +1,26 @@
+---
+id: story-006-015-implement-link-checker
+type: STORY
+title: "Implement Link Checker Pre-commit Hook"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-24"
+updated_at: "2026-04-24"
+depends_on: []
+jules_session_id: null
+parent: .foundry/prds/prd-007-006-automated-link-checker.md
+tags: ["infras", "verification"]
+rejection_count: 0
+notes: ""
+---
+
+# Story: Implement Automated Link Checker Pre-commit Hook
+
+## Objective
+Implement an automated git pre-commit hook that validates all local markdown file references (both in YAML frontmatter and inline markdown links) to ensure they point to existing files on disk, preventing DAG orchestrator deadlocks.
+
+## Acceptance Criteria
+- [ ] A pre-commit script is created to parse markdown files and validate all relative file paths.
+- [ ] The script checks `depends_on` and `parent` fields in the YAML frontmatter.
+- [ ] The script checks inline markdown links within the files.
+- [ ] The pre-commit hook is integrated and successfully rejects commits containing dead links.


### PR DESCRIPTION
This PR adds the story node for implementing the automated link checker pre-commit hook based on the parent PRD. The story outlines the acceptance criteria for a git pre-commit script to validate markdown file references.

- Added `.foundry/stories/story-006-015-implement-link-checker.md` with `owner_persona: tech_lead`.
- Updated parent PRD `.foundry/prds/prd-007-006-automated-link-checker.md` body to check off generated story without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [3799897130653957605](https://jules.google.com/task/3799897130653957605) started by @szubster*