### PR TITLE
feat(foundry): add tasks for link checker hook implementation

### DIFF
--- a/.foundry/stories/story-006-015-implement-link-checker.md
+++ b/.foundry/stories/story-006-015-implement-link-checker.md
@@ -24,3 +24,7 @@ Implement an automated git pre-commit hook that validates all local markdown fil
 - [ ] The script checks `depends_on` and `parent` fields in the YAML frontmatter.
 - [ ] The script checks inline markdown links within the files.
 - [ ] The pre-commit hook is integrated and successfully rejects commits containing dead links.
+
+## Generated Tasks
+- .foundry/tasks/task-015-028-implement-link-checker.md
+- .foundry/tasks/task-015-029-qa-link-checker.md

--- a/.foundry/tasks/task-015-028-implement-link-checker.md
+++ b/.foundry/tasks/task-015-028-implement-link-checker.md
@@ -1,0 +1,37 @@
+---
+id: task-015-028-implement-link-checker
+type: TASK
+title: "Implement Link Checker Pre-commit Hook Script"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-25"
+updated_at: "2026-04-25"
+depends_on: []
+jules_session_id: null
+parent: .foundry/stories/story-006-015-implement-link-checker.md
+tags: ["infras", "verification"]
+rejection_count: 0
+notes: ""
+---
+
+# Task: Implement Link Checker Pre-commit Hook Script
+
+## Objective
+Implement an automated git pre-commit hook script that validates all local markdown file references (both in YAML frontmatter and inline markdown links) to ensure they point to existing files on disk.
+
+## Requirements
+- Create a script (e.g., Node.js or bash) that parses markdown files staged for commit.
+- The script must read the YAML frontmatter of `.foundry/**/*.md` files and validate that any repo-relative paths specified in the `depends_on` and `parent` fields exist on the filesystem.
+- The script must parse the markdown body and extract inline markdown links (e.g., `[text](./relative/path.md)`) and ensure the resolved file paths exist.
+- Integrate this script into the `lefthook.yml` configuration under the `pre-commit` hook.
+- The hook should prevent the commit if any invalid links are found and log an appropriate error message indicating which file contains the broken link.
+
+## Context
+This task addresses the requirements outlined in `.foundry/stories/story-006-015-implement-link-checker.md`. Ensure that the implementation respects the project's strict TS and linting rules if writing a Node.js script.
+
+## Acceptance Criteria
+- [ ] A script is written to perform the required link validation.
+- [ ] `lefthook.yml` is updated to run the script during `pre-commit`.
+- [ ] Staged markdown files are properly parsed for frontmatter fields `depends_on` and `parent` and their existence validated.
+- [ ] Staged markdown files are parsed for inline links, and the targets are validated.
+- [ ] Commits are rejected if a broken link is detected.

--- a/.foundry/tasks/task-015-029-qa-link-checker.md
+++ b/.foundry/tasks/task-015-029-qa-link-checker.md
@@ -1,0 +1,38 @@
+---
+id: task-015-029-qa-link-checker
+type: TASK
+title: "QA Validation: Link Checker Pre-commit Hook Script"
+status: PENDING
+owner_persona: qa
+created_at: "2026-04-25"
+updated_at: "2026-04-25"
+depends_on:
+  - .foundry/tasks/task-015-028-implement-link-checker.md
+jules_session_id: null
+parent: .foundry/stories/story-006-015-implement-link-checker.md
+tags: ["infras", "verification"]
+rejection_count: 0
+notes: ""
+---
+
+# QA Task: Validate Link Checker Pre-commit Hook
+
+## Objective
+Verify that the automated git pre-commit hook script implemented by the `coder` correctly validates all local markdown file references (both YAML frontmatter and inline markdown links) and correctly rejects commits containing dead links.
+
+## Verification Steps
+- Simulate an invalid reference in the `depends_on` array of a `.foundry/**/*.md` file, attempt to commit, and verify that the commit is aborted by `lefthook` with a clear error message.
+- Simulate an invalid reference in the `parent` field of a `.foundry/**/*.md` file, attempt to commit, and verify the commit is similarly rejected.
+- Introduce an invalid inline markdown link (e.g., `[Test](./invalid-path.md)`) into a staged markdown file, attempt to commit, and verify it is rejected.
+- Introduce only valid links in `depends_on`, `parent`, and inline markdown, attempt to commit, and verify the commit succeeds.
+- Confirm the hook only runs on modified/staged markdown files to avoid performance overhead on irrelevant files.
+
+## Context
+This QA task ensures the requirements outlined in `.foundry/stories/story-006-015-implement-link-checker.md` and implemented in `.foundry/tasks/task-015-028-implement-link-checker.md` are met.
+
+## Acceptance Criteria
+- [ ] Validated that broken `depends_on` links prevent commits.
+- [ ] Validated that broken `parent` links prevent commits.
+- [ ] Validated that broken inline markdown links prevent commits.
+- [ ] Validated that perfectly valid files can be committed successfully.
+- [ ] Verified that the hook runs correctly via `lefthook`.


### PR DESCRIPTION
Drafted task blueprints for implementing and testing the link checker pre-commit hook. 
- Created `task-015-028-implement-link-checker.md` for `coder` implementation.
- Created `task-015-029-qa-link-checker.md` for `qa` validation.
- Appended task references in `story-006-015-implement-link-checker.md`.

---
*PR created automatically by Jules for task [8792271753470318954](https://jules.google.com/task/8792271753470318954) started by @szubster*