### PR TITLE
🔒 [security fix] Sanitize error logging and fix CI linting issues

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,5 +1,5 @@
 ## Sanitize error logging to prevent CWE-209 information leakage
-**Pattern:** Directly passing the error object (e.g., `catch(console.error)`) can leak sensitive stack traces and internal state. Use `err instanceof Error ? err.message : String(err)` to sanitize log output and mitigate CWE-209.
+**Pattern:** Directly passing the error object or its message (e.g., `err instanceof Error ? err.message : String(err)`) to `console.error` can leak sensitive internal state or path information. Use generic, non-revealing error messages to mitigate CWE-209.
 
 ## Transitive Dependency Audits
 **Pattern:** To resolve vulnerabilities inside deep or transitive dependencies found via `pnpm audit` (like `serialize-javascript` vulnerabilities), add a `pnpm.overrides` section to `package.json` with the safe version constraint, and then run `pnpm install` to enforce the resolution throughout the workspace.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -20,7 +20,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           if (chunkFailedMessage) {
             window.location.reload();
           }
-        } catch (err) {
+        } catch {
           console.error('System: Chunk load failed');
         }
       }

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -21,7 +21,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             window.location.reload();
           }
         } catch (err) {
-          console.error(err instanceof Error ? err.message : String(err));
+          console.error('System: Chunk load failed');
         }
       }
     };

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -176,7 +176,7 @@ const syncData = async () => {
       await mStore.put({ key: 'hash', value: data.hash });
       await tx.done;
     } catch (err) {
-      console.error('PokeDB: Sync failed', err instanceof Error ? err.message : String(err));
+      console.error('PokeDB: Sync failed');
       // Reset promise so we can retry later if needed
       syncPromise = null;
       throw err;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,7 @@ import { routeTree } from './routeTree.gen';
 import './index.css';
 
 // Initialize and sync PokeData
-pokeDB.sync().catch((err) => console.error(err instanceof Error ? err.message : String(err)));
+pokeDB.sync().catch(() => console.error('System: Initial sync failed'));
 
 const router = createRouter({
   routeTree,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -8,7 +8,7 @@ import { useStore } from '../store';
 import { pokemonListQueryOptions } from '../utils/pokemonQueries';
 
 const TanStackRouterDevtools =
-  import.meta.env.PROD || !!window.navigator.webdriver
+  import.meta.env.PROD || window.navigator.webdriver
     ? () => null // Render nothing in production or automated tests
     : React.lazy(() =>
         import('@tanstack/react-router-devtools').then((res) => ({
@@ -17,7 +17,7 @@ const TanStackRouterDevtools =
       );
 
 const ReactQueryDevtools =
-  import.meta.env.PROD || !!window.navigator.webdriver
+  import.meta.env.PROD || window.navigator.webdriver
     ? () => null
     : React.lazy(() =>
         import('@tanstack/react-query-devtools').then((res) => ({

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -171,7 +171,7 @@ describe('Zustand Store', () => {
       useStore.getState().loadSaveFromStorage();
 
       // Verify that it caught the error, logged it, and removed the corrupted item
-      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file from localStorage:', expect.any(String));
+      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file from localStorage');
       expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
 
       vi.restoreAllMocks();

--- a/src/store.ts
+++ b/src/store.ts
@@ -128,10 +128,7 @@ export const useStore = create<AppStore>()(
             const data = parseSaveFile(bytes.buffer, manualVersion || undefined);
             set({ saveData: data });
           } catch (err) {
-            console.error(
-              'Failed to load saved file from localStorage:',
-              err instanceof Error ? err.message : String(err),
-            );
+            console.error('Failed to load saved file from localStorage');
             localStorage.removeItem('last_save_file');
           }
         }

--- a/src/store.ts
+++ b/src/store.ts
@@ -127,7 +127,7 @@ export const useStore = create<AppStore>()(
             const { manualVersion } = get();
             const data = parseSaveFile(bytes.buffer, manualVersion || undefined);
             set({ saveData: data });
-          } catch (err) {
+          } catch {
             console.error('Failed to load saved file from localStorage');
             localStorage.removeItem('last_save_file');
           }


### PR DESCRIPTION
This PR addresses the security vulnerability related to information disclosure via `console.error` logging and fixes subsequent CI failures.

### 🎯 What
- Sanitized error logs by replacing `err.message` with generic strings in `src/store.ts`, `src/components/AppLayout.tsx`, `src/db/PokeDB.ts`, and `src/main.tsx`.
- Resolved unused variable warnings in `catch` blocks in `src/store.ts` and `src/components/AppLayout.tsx`.
- Removed redundant double-negations in `src/routes/__root.tsx`.
- Updated Biome schema version in `biome.jsonc` to match the CLI version.
- Updated `src/store.test.ts` to reflect the changes in log messages.
- Updated `.jules/shield.md` to document the correct pattern for sanitizing error logs.

### ⚠️ Risk
Previously, logging actual error messages could leak sensitive internal details (CWE-209). CI was failing due to new linting warnings introduced by the fix and pre-existing linting issues.

### 🛡️ Solution
Ensured all logs are generic and non-revealing. Fixed all linting issues to ensure a clean CI pass.

### Verification
- Manually verified all code changes.
- Updated unit tests to match the new behavior.
- Addressed all specific CI failure annotations.

---
*PR created automatically by Jules for task [2026964105510776836](https://jules.google.com/task/2026964105510776836) started by @szubster*