### PR TITLE
🧹 Remove unnecessary comment in gen2 tests

### DIFF
--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -138,7 +138,6 @@ describe('gen2 parsers', () => {
       view.setUint8(0x288b, 1);
       view.setUint8(0x288b + 7, 1);
 
-      // detectGen2GameVersion will return 'unknown'.
       const data = parseGen2(view, false);
       expect(data.gameVersion).toBe('gold');
     });


### PR DESCRIPTION
🎯 What: Removed an unnecessary and misleading comment in `src/engine/saveParser/parsers/gen2.test.ts`.
💡 Why: The comment was cluttering the test file and didn't accurately reflect the code's behavior.
✅ Verification: Ran `pnpm lint` and `pnpm test` successfully. No regressions were introduced.
✨ Result: Improved readability and maintainability of the gen2 save parser tests.

---
*PR created automatically by Jules for task [10289194282692630016](https://jules.google.com/task/10289194282692630016) started by @szubster*