### PR TITLE
🔒 Fix unbounded Base64 conversion and storage

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -59,10 +59,12 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         let binary = '';
         const bytes = new Uint8Array(buffer);
         const len = bytes.byteLength;
-        for (let i = 0; i < len; i++) {
-          binary += String.fromCharCode(bytes[i] ?? 0);
+        if (len <= 1048576) {
+          for (let i = 0; i < len; i++) {
+            binary += String.fromCharCode(bytes[i] ?? 0);
+          }
+          localStorage.setItem('last_save_file', window.btoa(binary));
         }
-        localStorage.setItem('last_save_file', window.btoa(binary));
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Failed to parse save file.';
         setError(message);


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an unbounded Base64 conversion and storage of a user-provided file. The application attempted to loop over the entire byte array of the file and convert it to a Base64 string before storing it in localStorage, regardless of the file size.
⚠️ **Risk:** A large, maliciously crafted, or incorrectly formatted save file could cause a thread lock in the browser during the Base64 conversion process, or an unhandled `QuotaExceededError` if the string exceeded the storage limit of `localStorage` (typically around 5MB).
🛡️ **Solution:** Implemented a size check (`if (len <= 1048576)`) before iterating over the bytes and storing the data. This limits the conversion and storage to files up to 1MB, effectively mitigating the risk of thread locking and unhandled quota errors, while still maintaining expected functionality for legitimate save files (which are well under 1MB).

---
*PR created automatically by Jules for task [8870541237764734896](https://jules.google.com/task/8870541237764734896) started by @szubster*