### PR TITLE
QA Verify Orchestrator Validation for Parent-Linked ID Schema

### DIFF
--- a/.foundry/tasks/task-005-026-qa-orchestrator-validation.md
+++ b/.foundry/tasks/task-005-026-qa-orchestrator-validation.md
@@ -25,6 +25,6 @@ This task verifies the work completed in `task-005-025-update-orchestrator-valid
 4. **Dry-Run Validation:** Optionally perform a dry run of the orchestrator (`ts-node .github/scripts/foundry-orchestrator.ts --dry-run`) on the current `.foundry/` directory to ensure no new warnings or errors are surfaced for valid IDs.
 
 ## Acceptance Criteria
-- [ ] Code modifications align with ADR 002.
-- [ ] Test coverage includes the new ID schema.
-- [ ] All tests pass successfully and the orchestrator does not emit invalid validation warnings for correctly formatted IDs.
+- [x] Code modifications align with ADR 002.
+- [x] Test coverage includes the new ID schema.
+- [x] All tests pass successfully and the orchestrator does not emit invalid validation warnings for correctly formatted IDs.


### PR DESCRIPTION
Checked off acceptance criteria in `.foundry/tasks/task-005-026-qa-orchestrator-validation.md`. Verified that `foundry-orchestrator.ts` correctly handles the `<type>-<parent_NNN>-<NNN>-<slug>` format natively, the new unit test handles dependency logic properly, and `pnpm test` runs successfully without ID warnings.

---
*PR created automatically by Jules for task [3393320214333743467](https://jules.google.com/task/3393320214333743467) started by @szubster*