### PR TITLE
Deprecate Composite Nodes in Schema

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -184,6 +184,7 @@ These are the hard rules the orchestrator, heartbeat, and resurrection loop rely
 10. **The `id` field must be globally unique across all `.foundry/` directories.** Duplicate IDs are undefined behaviour in the orchestrator.
 11. **`owner_persona` must be exactly one persona.** The system enforces a single-owner invariant per node for atomic handoffs; arrays or multiple personas are invalid.
 12. **`human` persona bypasses Jules dispatch and heartbeat timeouts.** The orchestrator will not dispatch Jules for nodes owned by `human`, and the heartbeat will not fail them.
+13. **Composite Nodes are an anti-pattern.** Do not create "Composite Nodes". They bundle multiple lifecycle states or responsibilities that conflict with the strict Directed Acyclic Graph orchestrator. This leads to circular dependencies or unresolved `depends_on` chains, causing DAG deadlocks.
 
 ---
 

--- a/.foundry/tasks/task-009-028-deprecate-composite-nodes.md
+++ b/.foundry/tasks/task-009-028-deprecate-composite-nodes.md
@@ -25,5 +25,5 @@ As defined in Story 009, we need to explicitly deprecate the concept of "composi
 3. The `coder` can self-verify this change since it is a simple documentation update.
 
 ## Acceptance Criteria
-- [ ] "Composite node" terminology is explicitly flagged as an anti-pattern in `.foundry/docs/schema.md`.
-- [ ] Context is added explaining why composite nodes cause deadlocks.
+- [x] "Composite node" terminology is explicitly flagged as an anti-pattern in `.foundry/docs/schema.md`.
+- [x] Context is added explaining why composite nodes cause deadlocks.


### PR DESCRIPTION
Deprecate Composite Nodes in Schema

- Added rule 13 to `.foundry/docs/schema.md` explicitly deprecating "Composite Nodes" as an anti-pattern.
- Explained that they cause DAG deadlocks due to circular dependencies and unresolved `depends_on` chains.
- Checked off acceptance criteria in `task-009-028-deprecate-composite-nodes.md` without modifying YAML frontmatter.

---
*PR created automatically by Jules for task [14911875075999718464](https://jules.google.com/task/14911875075999718464) started by @szubster*