### PR TITLE
🔧 Infras: Implement Link Checker Pre-commit Hook Script

### DIFF
--- a/.foundry/tasks/task-015-028-implement-link-checker.md
+++ b/.foundry/tasks/task-015-028-implement-link-checker.md
@@ -30,8 +30,8 @@ Implement an automated git pre-commit hook script that validates all local markd
 This task addresses the requirements outlined in `.foundry/stories/story-006-015-implement-link-checker.md`. Ensure that the implementation respects the project's strict TS and linting rules if writing a Node.js script.
 
 ## Acceptance Criteria
-- [ ] A script is written to perform the required link validation.
-- [ ] `lefthook.yml` is updated to run the script during `pre-commit`.
-- [ ] Staged markdown files are properly parsed for frontmatter fields `depends_on` and `parent` and their existence validated.
-- [ ] Staged markdown files are parsed for inline links, and the targets are validated.
-- [ ] Commits are rejected if a broken link is detected.
+- [x] A script is written to perform the required link validation.
+- [x] `lefthook.yml` is updated to run the script during `pre-commit`.
+- [x] Staged markdown files are properly parsed for frontmatter fields `depends_on` and `parent` and their existence validated.
+- [x] Staged markdown files are parsed for inline links, and the targets are validated.
+- [x] Commits are rejected if a broken link is detected.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,8 @@
 pre-commit:
   parallel: true
   commands:
+    link-checker:
+      run: node --experimental-strip-types scripts/check-links.ts {staged_files}
     biome-check:
       run: pnpm exec biome check --write --error-on-warnings --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
       stage_fixed: true

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function extractFrontmatterPaths(fm: string): string[] {
+  const paths: string[] = [];
+  const lines = fm.split('\n');
+  let inDependsOn = false;
+
+  for (const line of lines) {
+    if (line.startsWith('depends_on:')) {
+      const remainder = line.slice('depends_on:'.length).trim();
+      if (remainder.startsWith('[')) {
+        const arrStr = remainder.slice(1, remainder.indexOf(']'));
+        const items = arrStr.split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
+        paths.push(...items);
+        inDependsOn = false;
+      } else {
+        inDependsOn = true;
+      }
+      continue;
+    }
+
+    if (inDependsOn) {
+      if (line.match(/^\s*-/)) {
+        const pathStr = line.replace(/^\s*-/, '').trim().replace(/^["']|["']$/g, '');
+        if (pathStr) {
+          paths.push(pathStr);
+        }
+        continue;
+      } else if (line.match(/^[a-zA-Z0-9_-]+:/)) {
+        inDependsOn = false;
+      }
+    }
+
+    if (line.startsWith('parent:')) {
+      inDependsOn = false;
+      const parentVal = line.slice('parent:'.length).trim().replace(/^["']|["']$/g, '');
+      if (parentVal && parentVal !== 'null') {
+        paths.push(parentVal);
+      }
+    }
+  }
+  return paths;
+}
+
+function extractInlineLinks(content: string): string[] {
+  const links: string[] = [];
+  // Ignore links in inline code blocks or regular code blocks. For a simple parser, we'll just parse lines and skip lines that are code blocks or links that contain backticks around them roughly.
+  // Actually, standard markdown links in backticks will not be matched if we don't look inside them, but `[text](./path)` inside a backtick will be matched by a simple regex. Let's do a simple approach.
+
+  // Strip out code blocks
+  content = content.replace(/```[\s\S]*?```/g, '');
+  // Strip out inline code
+  content = content.replace(/`[^`]*`/g, '');
+
+  const regex = /\[[^\]]*\]\(\s*([^)]+)\s*\)/g;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    let link = match[1]?.trim();
+    if (!link) continue;
+    if (link.startsWith('http://') || link.startsWith('https://') || link.startsWith('mailto:') || link.startsWith('#')) {
+      continue;
+    }
+    link = link.split('#')[0] || '';
+    if (link) {
+      links.push(link);
+    }
+  }
+  return links;
+}
+
+function checkLinks() {
+  const files = process.argv.slice(2);
+  let hasErrors = false;
+
+  for (const file of files) {
+    if (!file.endsWith('.md')) {
+      continue;
+    }
+
+    try {
+      const content = fs.readFileSync(file, 'utf8');
+      const hasFrontmatter = content.startsWith('---');
+      let frontmatter = '';
+      let body = content;
+
+      if (hasFrontmatter) {
+        const fmEndIndex = content.indexOf('---', 3);
+        if (fmEndIndex !== -1) {
+          frontmatter = content.slice(3, fmEndIndex);
+          body = content.slice(fmEndIndex + 3);
+        }
+      }
+
+      if (file.startsWith('.foundry/') && frontmatter) {
+        const fmPaths = extractFrontmatterPaths(frontmatter);
+        for (const fmPath of fmPaths) {
+          const absolutePath = path.resolve(process.cwd(), fmPath);
+          if (!fs.existsSync(absolutePath)) {
+            console.error(`❌ Broken link in ${file}: Frontmatter path '${fmPath}' does not exist.`);
+            hasErrors = true;
+          }
+        }
+      }
+
+      const inlineLinks = extractInlineLinks(body);
+      for (const link of inlineLinks) {
+        const absolutePath = path.resolve(path.dirname(file), link);
+        if (!fs.existsSync(absolutePath)) {
+          console.error(`❌ Broken link in ${file}: Inline link '${link}' does not exist.`);
+          hasErrors = true;
+        }
+      }
+
+    } catch (e) {
+      console.error(`Error processing file ${file}:`, e);
+      hasErrors = true;
+    }
+  }
+
+  if (hasErrors) {
+    process.exit(1);
+  }
+}
+
+checkLinks();


### PR DESCRIPTION
🎯 What
Implemented an automated git pre-commit hook script (`scripts/check-links.ts`) that parses staged markdown files and validates repo-relative paths in YAML frontmatter (`depends_on`, `parent`) and inline markdown links to ensure they point to existing local files.

💡 Why
To prevent DAG orchestrator deadlocks caused by invalid file paths within Foundry node definitions.

Impact on DX/CI
Ensures structural integrity of `.foundry` files automatically before they are committed, preventing CI breaks due to typos or dead links.

Setup notes
The script parses markdown robustly but simply, stripping code blocks and filtering external/anchor links. The project utilizes native Node functionality (`node --experimental-strip-types`) to execute the TypeScript script efficiently within Lefthook without additional transpilation steps.

✅ Verification
- `pnpm lint`, `pnpm test`, and `pnpm test:e2e` have been run successfully.
- Manually verified the script on the target task node file.

---
*PR created automatically by Jules for task [4471598574628144123](https://jules.google.com/task/4471598574628144123) started by @szubster*