### PR TITLE
📜 Scribe: Documented Zustand store properties and actions

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -34,3 +34,8 @@
 - `parseDVs`: DVs are stored as 4-bit nibbles across two bytes. Crucially, the HP DV is not explicitly stored; it is calculated dynamically by extracting the least significant bit (LSB) from the Attack, Defense, Speed, and Special DVs.
 - `checkShiny`: In Gen 2, Shininess is determined entirely by stat DVs (making it retroactive and permanent across trades to Gen 1). A Pokémon is Shiny if Defense, Speed, and Special are exactly 10, and Attack is 2, 3, 6, 7, 10, 11, 14, or 15.
 Documenting these mechanical quirks is essential for future maintainability of the parsing engine.
+
+## 2025-05-15 - Zustand Store State Separation
+
+**What:** Documented `src/store.ts` Zustand properties and actions.
+**Why:** The `AppStore` interface mixes persisted user settings (via localStorage `partialize`, like `isLivingDex` and `filters`) with heavy transient data (like the entire parsed `saveData`) and lightweight UI view state (like `isSettingsOpen`). Documenting which properties belong to which lifecycle prevents future developers from accidentally persisting the massive `saveData` object into localStorage, which would bloat the storage quota and cause stale state bugs on reload.

--- a/src/store.ts
+++ b/src/store.ts
@@ -35,24 +35,39 @@ interface AppStore {
   // Persisted settings
   /** Active UI filters explicitly persisted to localStorage via partialize. */
   filters: FilterType[];
+  /** Manual override for the game version, bypassing auto-detection heuristics. */
   manualVersion: GameVersion | null;
   /** Whether the user is tracking a living dex (persisted via partialize). */
   isLivingDex: boolean;
+  /** Global visual preference for which Pokéball to use in the UI. */
   globalPokeball: PokeballType;
+  /** Toggles a specific UI filter type in the `filters` array. */
   toggleFilter: (f: FilterType) => void;
+  /** Overwrites the entire array of active UI filters. */
   setFilters: (f: FilterType[]) => void;
+  /** Sets the manual game version override. */
   setManualVersion: (v: GameVersion | null) => void;
+  /** Sets the living dex tracking preference. */
   setIsLivingDex: (v: boolean) => void;
+  /** Sets the global visual Pokéball preference. */
   setGlobalPokeball: (v: PokeballType) => void;
 
   // Transient UI state (not persisted)
+  /** Current search query for filtering Pokémon lists. */
   searchTerm: string;
+  /** Currently selected map location for viewing details. */
   selectedLocationId: number | null;
+  /** Toggles the global settings modal. */
   isSettingsOpen: boolean;
+  /** Toggles the manual version selection modal. */
   isVersionModalOpen: boolean;
+  /** Updates the active search query. */
   setSearchTerm: (v: string) => void;
+  /** Updates the currently selected map location ID. */
   setSelectedLocationId: (id: number | null) => void;
+  /** Updates the settings modal visibility. */
   setIsSettingsOpen: (v: boolean) => void;
+  /** Updates the manual version modal visibility. */
   setIsVersionModalOpen: (v: boolean) => void;
 
   // Derived helpers


### PR DESCRIPTION
What: Added detailed JSDoc comments to properties and actions within the `AppStore` interface in `src/store.ts`. Updated `.jules/scribe.md` to document the core architectural pattern of the store.
Why: The Zustand store mixes persisted configuration (e.g., `isLivingDex`, `manualVersion`) with transient UI state (e.g., modal visibility) and heavy, ephemeral save data. Adding documentation clarifies which properties belong to which lifecycle and explicitly notes when a setting bypasses other logic (like `manualVersion`), making it safer for future maintainers to extend.

Summary of additions:
- Documented `isLivingDex`, `globalPokeball`, `manualVersion`, and `filters` as persisted settings.
- Documented their corresponding setter functions.
- Documented transient UI state (search queries, modal toggles, etc.) and their setters.
- Documented critical learnings in `.jules/scribe.md` to avoid accidental persistence of heavy save data.

---
*PR created automatically by Jules for task [16175762087203801387](https://jules.google.com/task/16175762087203801387) started by @szubster*