### PR TITLE
🧠 Trainer: filter out claimed NPC trades

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -4,3 +4,5 @@
 ## 2024-04-22 - Assistant Trade Evolution Held Item Support
 **Learning:** The Trade evolution logic (`EVO_TRIGGER.TRADE`) was missing support for checking if a required `held` item was in the player's inventory, which is crucial for Gen 2 evolutions like Onix to Steelix.
 **Action:** Always check the `detail.held` property for Trade evolutions and verify the player has it in their `saveData.inventory`.
+
+- Learned: Gen 1 saves track completed in-game NPC trades using a bitfield at `0x29e6` (with `eventFlagsOffset - 16` logic in `saveParser`), exposing `npcTradeFlags` in the parsed state. It's crucial to mask this against the specific `tradeIndex` found in static data to prevent suggesting trades the user has already completed.

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -219,4 +219,35 @@ describe('generateSuggestions', () => {
     const giftSuggestion = suggestions.find((s) => s.id === 'gift-131');
     expect(giftSuggestion).toBeUndefined();
   });
+
+  it('should not generate "Trade" suggestions when tradeIndex flag is set', () => {
+    const mockSaveData: SaveData = {
+      generation: 1,
+      gameVersion: 'red',
+      owned: new Set([1, 2, 3]), // Missing 122 (Mr. Mime), requires trade index 1
+      seen: new Set(),
+      party: [],
+      inventory: [],
+      currentMapId: 0,
+      npcTradeFlags: 1 << 1, // Set tradeIndex 1
+      partyDetails: [],
+      pcDetails: [],
+      trainerName: 'ASH',
+    } as unknown as SaveData;
+
+    const mockApiData: AssistantApiData = {
+      localAid: 1,
+      localEncounters: [],
+      missingEncounters: {},
+      pokemonMetadata: {},
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+
+    const tradeSuggestion = suggestions.find((s) => s.id === 'npc-trade-122');
+    expect(tradeSuggestion).toBeUndefined();
+  });
 });

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -285,6 +285,11 @@ export function generateSuggestions(
     if (trade.versions && !trade.versions.includes(displayVersion)) continue;
     if (!missingIds.has(trade.receivedId)) continue;
 
+    if (trade.tradeIndex !== undefined && saveData.npcTradeFlags !== undefined) {
+      const isClaimed = (saveData.npcTradeFlags & (1 << trade.tradeIndex)) !== 0;
+      if (isClaimed) continue;
+    }
+
     const hasOffered = ownedSet.has(trade.offeredId);
     suggestions.push({
       id: `npc-trade-${trade.receivedId}`,


### PR DESCRIPTION
What: Filter out claimed NPC trades from assistant suggestions.
Why: Assistant shouldn't recommend trades that the player has already performed.
Impact: Improves suggestion accuracy.
Test coverage: Added unit test in generateSuggestions.test.ts.

---
*PR created automatically by Jules for task [12924243928523931585](https://jules.google.com/task/12924243928523931585) started by @szubster*