### PR TITLE
🎨 Palette: Add focus-visible to modal buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,7 @@
 ## 2026-04-23 - Role Group for Checkbox-like Filters
 **Learning:** Collections of buttons that act like a set of checkboxes (where multiple can be active simultaneously, indicated by `aria-pressed`) need a container role to group them semantically for screen readers.
 **Action:** When creating a row or container of toggle buttons (like multi-select filters), wrap them in a container with `role="group"` and an `aria-label` describing the filter's purpose (e.g., "Filter Pokémon").
+
+## 2026-04-24 - Focus Visible on Modal and Custom Action Buttons
+**Learning:** Several custom action buttons in modals (like the Close buttons in `SettingsModal` and `PokemonDetails`, Confirmation buttons in `ClearStorageButton`, and choice selectors in `VersionModal`) were missing standard `focus-visible` styles, leading to poor keyboard navigation visibility.
+**Action:** Always ensure that every custom button, regardless of its context (modals, overlays, inline prompts), includes the standard focus indicator utility classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` or a context-appropriate color variant like `ring-red-500` for destructive actions).

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -260,7 +260,7 @@ export function PokemonDetails({
               onClick={onClose}
               aria-label="Close details"
               title="Close details"
-              className="group absolute top-6 right-6 rounded-none border border-white/20 bg-black/40 p-3 transition-all hover:border-[var(--theme-primary)] hover:bg-[var(--theme-primary)]/20 active:scale-95 sm:relative sm:top-auto sm:right-auto"
+              className="group absolute top-6 right-6 rounded-none border border-white/20 bg-black/40 p-3 transition-all hover:border-[var(--theme-primary)] hover:bg-[var(--theme-primary)]/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-95 sm:relative sm:top-auto sm:right-auto"
             >
               <X size={20} className="text-zinc-400 transition-colors group-hover:text-[var(--theme-primary)]" />
             </button>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -47,7 +47,7 @@ export function SettingsModal() {
             onClick={() => setIsSettingsOpen(false)}
             aria-label="Close settings"
             title="Close settings"
-            className="rounded-full bg-zinc-800 p-3 text-zinc-400 transition-colors hover:bg-zinc-700"
+            className="rounded-full bg-zinc-800 p-3 text-zinc-400 transition-colors hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
           >
             <X size={20} />
           </button>

--- a/src/components/VersionModal.tsx
+++ b/src/components/VersionModal.tsx
@@ -37,7 +37,7 @@ export function VersionModal() {
                 setManualVersion(v.id as GameVersion);
                 setIsVersionModalOpen(false);
               }}
-              className="group relative overflow-hidden rounded-3xl border border-zinc-800 bg-zinc-950 p-6 text-center transition-all hover:border-red-500/50"
+              className="group relative overflow-hidden rounded-3xl border border-zinc-800 bg-zinc-950 p-6 text-center transition-all hover:border-red-500/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
               <div className="relative z-10 flex flex-col items-center gap-3">
                 <div className={`h-3 w-3 rounded-full shadow-lg ${v.dotColor}`} />

--- a/src/components/settings/ClearStorageButton.tsx
+++ b/src/components/settings/ClearStorageButton.tsx
@@ -10,14 +10,14 @@ export function ClearStorageButton({ onClear }: { onClear: () => void }) {
         <button
           type="button"
           onClick={() => setIsConfirming(false)}
-          className="flex-1 rounded-2xl border border-zinc-700 bg-zinc-800 p-5 font-bold text-[10px] text-zinc-300 uppercase tracking-widest transition-all hover:bg-zinc-700"
+          className="flex-1 rounded-2xl border border-zinc-700 bg-zinc-800 p-5 font-bold text-[10px] text-zinc-300 uppercase tracking-widest transition-all hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
           Cancel
         </button>
         <button
           type="button"
           onClick={onClear}
-          className="group flex flex-1 items-center justify-center gap-2 rounded-2xl border border-red-500 bg-red-600 p-5 font-bold text-[10px] text-white uppercase tracking-widest transition-all hover:bg-red-500"
+          className="group flex flex-1 items-center justify-center gap-2 rounded-2xl border border-red-500 bg-red-600 p-5 font-bold text-[10px] text-white uppercase tracking-widest transition-all hover:bg-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
           <Trash2 size={14} className="transition-transform group-hover:rotate-12" />
           Confirm Delete
@@ -30,7 +30,7 @@ export function ClearStorageButton({ onClear }: { onClear: () => void }) {
     <button
       type="button"
       onClick={() => setIsConfirming(true)}
-      className="group fade-in zoom-in-95 flex w-full animate-in items-center justify-center gap-3 rounded-2xl border border-red-600/20 bg-red-600/10 p-5 font-bold text-[10px] text-red-500 uppercase tracking-widest transition-all duration-200 hover:bg-red-600/20"
+      className="group fade-in zoom-in-95 flex w-full animate-in items-center justify-center gap-3 rounded-2xl border border-red-600/20 bg-red-600/10 p-5 font-bold text-[10px] text-red-500 uppercase tracking-widest transition-all duration-200 hover:bg-red-600/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
     >
       <Trash2 size={16} className="transition-transform group-hover:rotate-12" />
       Clear Stored Save


### PR DESCRIPTION
🎨 Palette: Add focus-visible to modal buttons

**What**
Added standard `focus-visible` utility classes to several interactive elements inside modals that were previously missing keyboard navigation focus indicators.

**Why**
Custom buttons and controls need explicit focus styles to remain accessible to users navigating via keyboard. Missing focus states make it impossible to tell which element is currently active.

**Affected Components:**
- `src/components/SettingsModal.tsx`
- `src/components/PokemonDetails.tsx`
- `src/components/settings/ClearStorageButton.tsx`
- `src/components/VersionModal.tsx`

**Accessibility Notes:**
Added standard application-wide focus styles (`focus-visible:ring-[var(--theme-primary)]` or `focus-visible:ring-red-500` for destructive actions) to ensure clear, consistent visual feedback for keyboard users.

---
*PR created automatically by Jules for task [4496485134419246906](https://jules.google.com/task/4496485134419246906) started by @szubster*