### PR TITLE
🧪 Testing: add test for fetch fallback on initial hash

### DIFF
--- a/src/db/__tests__/PokeDB.test.ts
+++ b/src/db/__tests__/PokeDB.test.ts
@@ -78,6 +78,30 @@ describe('PokeDB', () => {
     errorSpy.mockRestore();
   });
 
+  it('fetches and propagates error if global hash is initial', async () => {
+    vi.mocked(fetch).mockClear();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const db = await getDB();
+    const tx = db.transaction(DB_CONFIG.STORES.METADATA, 'readwrite');
+    await tx.objectStore(DB_CONFIG.STORES.METADATA).put({ key: 'hash', value: 'initial' });
+    await tx.done;
+
+    vi.stubGlobal('__POKEDATA_HASH__', 'initial');
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as Response);
+
+    await expect(pokeDB.sync()).rejects.toThrow('Failed to fetch pokedata.json: 404 Not Found');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    vi.stubGlobal('__POKEDATA_HASH__', 'test-hash'); // Restore to previous stubbed value
+    errorSpy.mockRestore();
+  });
+
   it('skips parsing and updates metadata if fetched data hash matches existing DB hash', async () => {
     const db = await getDB();
     const tx = db.transaction(DB_CONFIG.STORES.METADATA, 'readwrite');


### PR DESCRIPTION
## 🧪 Testing: add test for fetch fallback on initial hash

**🎯 What:**
Added a missing test case in `PokeDB.test.ts` to verify that when the global `__POKEDATA_HASH__` is set to `'initial'`, the database `sync()` function correctly falls back to fetching the data JSON, and accurately propagates any fetch errors if the network request fails.

**📊 Coverage:**
Specifically covers the edge case in `src/db/PokeDB.ts` where we evaluate `existingHash?.value === __POKEDATA_HASH__ && __POKEDATA_HASH__ !== 'initial'` and forces the system through the fetch pathway, improving coverage for local development scenarios and error handling pathways.

**✨ Result:**
Increased confidence when working with the database synchronization functionality, ensuring error propagation is not swallowed when operating in an environment without a pre-computed build hash.

**✅ Verification:**
- Tests pass (`pnpm test`)
- E2E tests pass (`pnpm test:e2e`)
- Type-checking, formatting, and linting pass (`pnpm lint`)

---
*PR created automatically by Jules for task [16188955981596212613](https://jules.google.com/task/16188955981596212613) started by @szubster*