### PR TITLE
🧪 [testing] add missing edge case bounds for decodeGen12String

### DIFF
--- a/src/engine/saveParser/parsers/common.test.ts
+++ b/src/engine/saveParser/parsers/common.test.ts
@@ -82,6 +82,38 @@ describe('common parsers', () => {
       expect(decodeGen12String(view, 0)).toBe('AB');
     });
 
+    test('handles negative offset gracefully (RangeError)', () => {
+      const buffer = new ArrayBuffer(2);
+      const view = new DataView(buffer);
+      view.setUint8(0, 0x80);
+      view.setUint8(1, 0x81);
+      expect(decodeGen12String(view, -1)).toBe('');
+    });
+
+    test('handles offset beyond buffer length gracefully (RangeError)', () => {
+      const buffer = new ArrayBuffer(2);
+      const view = new DataView(buffer);
+      view.setUint8(0, 0x80);
+      view.setUint8(1, 0x81);
+      expect(decodeGen12String(view, 5)).toBe('');
+    });
+
+    test('handles zero maxLength', () => {
+      const buffer = new ArrayBuffer(2);
+      const view = new DataView(buffer);
+      view.setUint8(0, 0x80);
+      view.setUint8(1, 0x81);
+      expect(decodeGen12String(view, 0, 0)).toBe('');
+    });
+
+    test('handles negative maxLength', () => {
+      const buffer = new ArrayBuffer(2);
+      const view = new DataView(buffer);
+      view.setUint8(0, 0x80);
+      view.setUint8(1, 0x81);
+      expect(decodeGen12String(view, 0, -1)).toBe('');
+    });
+
     test('rethrows non-RangeError exceptions', () => {
       const buffer = new ArrayBuffer(4);
       const view = new DataView(buffer);


### PR DESCRIPTION
🎯 **What:** Added tests for bounds handling (`offset < 0`, `offset > length`, `maxLength <= 0`) in `decodeGen12String`.
📊 **Coverage:** The edge cases handling parameters leading to `RangeError` within `DataView.getUint8` bounds are now properly covered by assertions verifying they exit cleanly and return `''`.
✨ **Result:** Better confidence in the stability of `decodeGen12String` against malformed inputs and corrupt parameters.

---
*PR created automatically by Jules for task [5014435947829672293](https://jules.google.com/task/5014435947829672293) started by @szubster*