### PR TITLE
🗃️ Archivist: Merged duplicate journals and removed stale BundleMon memory

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,13 +45,6 @@ Learned that the dex encounters DataLoader was firing individual getEncounters c
   - `N+1` approach: ~3.366ms per 50 records.
   - `Batched` approach: ~3.803ms per 50 records.
   - **Rationale**: Wait, looking at the performance results, the "Batched" approach didn't show an explicit performance win in my node.js + fake-indexeddb test (3.8ms vs 3.3ms). However, this is largely due to the overhead of the single large indexedDB polyfill used during node.js tests. In an actual browser environment, N+1 IDB queries heavily block the UI thread, causing significant slowdowns. Eliminating them in favor of a single transaction `readonly` batch operation reduces the total context switches and asynchronous overhead between the web worker context IDB typically uses and the main thread, leading to a much smoother user experience on keystrokes.
-
-- **What**: Added `getInverseIndexBulk` to `PokeDB` which uses a single transaction to retrieve data for multiple keys instead of `Promise.all` over individual queries. Updated `LocationSuggestions.tsx` to use the new batched method.
-- **Why**: Reduced N+1 IDB overhead that occurs when fetching Pokémon counts for multiple locations, which can cause main thread blocking on rapid keystrokes.
-- **Measured Improvement**:
-  - `N+1` approach: ~3.366ms per 50 records.
-  - `Batched` approach: ~3.803ms per 50 records.
-  - **Rationale**: Wait, looking at the performance results, the "Batched" approach didn't show an explicit performance win in my node.js + fake-indexeddb test (3.8ms vs 3.3ms). However, this is largely due to the overhead of the single large indexedDB polyfill used during node.js tests. In an actual browser environment, N+1 IDB queries heavily block the UI thread, causing significant slowdowns. Eliminating them in favor of a single transaction `readonly` batch operation reduces the total context switches and asynchronous overhead between the web worker context IDB typically uses and the main thread, leading to a much smoother user experience on keystrokes.
 ## 2026-04-23 - [O(N) Encounter Array.find in loop]
 **Learning:** In suggestionEngine.ts, filtering `allEncounters` inside the queryTargets loop repeatedly using `Array.prototype.find()` creates $O(N \cdot M)$ complexity.
 **Action:** Used `new Map(allEncounters.map((e) => [e.pid, e]))` outside the loop to achieve O(1) lookups, caching the results instead.

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -1,6 +1,3 @@
-## 2026-04-19 - Removed BundleMon
-**Learning:** Replaced BundleMon with `@codecov/vite-plugin` for bundle analysis since bundle size monitoring is already handled alongside test coverage. BundleMon is redundant and creates overlapping concerns.
-
 ## 2026-04-19 - Restored BundleMon
 **Learning:** User prefers to keep BundleMon alongside `@codecov/vite-plugin`. BundleMon is explicitly maintained despite overlapping with `@codecov/vite-plugin` per user request.
 

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,6 +1,6 @@
-## 2024-04-11 - Focus Visible Styles for Retro Buttons
-**Learning:** Some custom UI elements, like mapped list buttons or dynamically rendered list items (e.g., in LocationSuggestions), can easily omit standard focus indicators when custom styling is heavily applied, making keyboard navigation difficult or invisible.
-**Action:** Always ensure dynamic, mapped, or custom interactive elements explicitly include focus visible utilities (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950`) to match the application's global focus style.
+## 2024-04-11 - Focus Visible Styles for Interactive Elements
+**Learning:** Custom UI elements, mapped list buttons, and standard HTML elements functioning as buttons/links in complex layouts (e.g., AppLayout, BottomNav) often omit focus indicators when custom styling is heavily applied. This breaks keyboard navigation.
+**Action:** Always ensure all interactive elements explicitly include the standard focus visible utilities (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950`) to maintain consistent accessibility and keyboard navigation across the application.
 
 ## 2024-04-12 - Custom Segmented Control ARIA Roles
 **Learning:** When creating custom segmented controls with mutually exclusive options, using `role="switch"` is incorrect as switches imply an on/off state. `role="group"` is also too generic. A segmented control is conceptually a set of radio buttons.
@@ -36,13 +36,6 @@
 
 # Palette UX/A11y Learnings
 
-## 2026-04-20 - Interactive Elements Focus Styles
-**Learning:** Standard HTML elements functioning as buttons or links in custom UI components (like `BottomNav`) sometimes omit standard focus indicators when customized heavily.
-**Action:** All interactive elements (e.g., links, buttons) must explicitly define focus styles using the standard utility class string: `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950`. This ensures consistent keyboard navigation visibility across the app.
-
-## 2024-04-22 - Focus Styles on Complex App Layouts
-**Learning:** Standard HTML elements functioning as buttons or links in custom, complex UI components (like `AppLayout` Desktop Navigation or headers) sometimes omit standard focus indicators when customized heavily. This breaks keyboard navigation.
-**Action:** All interactive elements (e.g., links, buttons) across the main layout must explicitly define focus styles using the standard utility class string: `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` to ensure consistent accessibility.
 
 ## 2026-04-23 - Role Group for Checkbox-like Filters
 **Learning:** Collections of buttons that act like a set of checkboxes (where multiple can be active simultaneously, indicated by `aria-pressed`) need a container role to group them semantically for screen readers.


### PR DESCRIPTION
- Removed duplicated `Batched getInverseIndex` entry in `.jules/bolt.md`
- Removed stale `Removed BundleMon` entry in `.jules/infras.md` to resolve contradiction
- Consolidated three separate focus styles learnings into a single, unified interactive elements focus style entry in `.jules/palette.md`

---
*PR created automatically by Jules for task [12040982272536430730](https://jules.google.com/task/12040982272536430730) started by @szubster*