### PR TITLE
🧬 Oak: story-010-015-enforce-strict-oxlint-rules frontmatter fix

### DIFF
--- a/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
+++ b/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
@@ -8,7 +8,8 @@ created_at: "2026-04-24"
 updated_at: "2026-04-24"
 depends_on:
   - ".foundry/tasks/task-014-027-configure-oxlint-json.md"
-parent: ".foundry/epics/epic-002-005-static-analysis.md"
+parent: ".foundry/epics/epic-010-oxlint-config.md"
+jules_session_id: null
 ---
 
 # Fix disabled oxlint rules across the codebase

--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -9,3 +9,9 @@
 
 ## Data Integrity - Evolution Chains
 *   **ROM parsing quirks / Data Pipeline Gotchas:** Some Gen 2 Pokémon evolutions (like Tyrogue -> Hitmonlee/Hitmonchan/Hitmontop) depend on the Pokémon's stats (Attack > Defense, Attack < Defense, or Attack == Defense). PokeAPI models this via `relative_physical_stats` in the `evolution_details`. Ensure the schema (`CompactEvolutionDetail`) and data generation script (`scripts/generate-pokedata.ts`) correctly map `relative_physical_stats` (to `rps`) so the application logic can accurately evaluate these conditional evolutions.
+
+## 2026-04-24 - 🧬 Oak: [story-010-015-enforce-strict-oxlint-rules frontmatter fix]
+**What was wrong:** The STORY node \`.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md\` was missing the required \`jules_session_id\` field in its frontmatter, and it also had an incorrect \`parent\` path (\`.foundry/epics/epic-002-005-static-analysis.md\` which does not exist). Both issues caused the orchestrator to skip or block the node.
+**Canonical source used:** The Foundry Master Schema (\`.foundry/docs/schema.md\`) for required fields, and the \`.foundry/epics/\` directory to find the correct parent (\`epic-010-oxlint-config.md\`).
+**Impact on users:** The STORY was not being resolved by the DAG orchestrator, preventing downstream TASKS from being scheduled.
+**Learning:** Manual creation of Foundry nodes is prone to human error; automation or strict linting of node files should be considered. Also, always verify that parent paths exist in the repo.


### PR DESCRIPTION
🎯 What: Added missing 'jules_session_id' field and corrected 'parent' path in .foundry/stories/story-010-015-enforce-strict-oxlint-rules.md.

💡 Why: The 'jules_session_id' field is required by the Foundry orchestrator as per the system schema. An incorrect 'parent' path also caused DAG resolution issues. These errors prevented the node from being promoted to READY.

🧬 Oak: [data correction]
- What was wrong: Missing 'jules_session_id' and incorrect 'parent' path in STORY node.
- Canonical source used: .foundry/docs/schema.md and file system inspection.
- Impact on users: STORY was stuck in PENDING and couldn't be promoted to READY/ACTIVE, blocking engineering progress on oxlint rule enforcement.

Fixes #560

---
*PR created automatically by Jules for task [17716555912101332500](https://jules.google.com/task/17716555912101332500) started by @szubster*