### PR TITLE
Update Schema for rejection_reason

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -73,6 +73,7 @@ pr_number: null         # Optional. PR number for human-in-the-loop tasks, or nu
 parent: null            # Required if node is derived from another node (e.g. PRD from IDEA, EPIC from PRD). Repo-relative path to the logical parent node. Blocks the parent from completion if this node is incomplete.
 tags: []                # Optional. Free-form string labels for filtering and context injection.
 rejection_count: 0      # Optional. Incremented by the Resurrection Loop on each CEO veto. Omit for IDEA nodes.
+rejection_reason: ""    # Optional. Used when transitioning a node to FAILED because it is fundamentally impossible to complete.
 notes: ""               # Optional. Free-form Markdown remarks.
 ---
 ```
@@ -94,6 +95,7 @@ notes: ""               # Optional. Free-form Markdown remarks.
 | `parent` | `string \| null` | optional | Repo-relative path to logical parent (e.g., a story's parent epic). Used for context hydration when spawning Jules — concatenates reading graphs upward. Does **not** affect DAG blocking. |
 | `tags` | `string[]` | optional | Labels for filtering and selective context injection (e.g. `["gen2", "save-engine"]`). |
 | `rejection_count` | `integer` | optional | Tracks CEO vetoes. Incremented by the Resurrection Loop. The `agile_coach` monitors high values as signals of chronic failure areas. Omit for `IDEA` and `PRD` nodes. |
+| `rejection_reason` | `string` | optional | Used when transitioning a node to `FAILED` because it is fundamentally impossible to complete. |
 | `notes` | `string` | optional | Free-form Markdown for human remarks, caveats, or inline research. |
 
 ---
@@ -206,6 +208,7 @@ pr_number: null
 parent: null
 tags: []
 rejection_count: 0
+rejection_reason: ""
 notes: ""
 ---
 

--- a/.foundry/tasks/task-017-030-update-schema-rejection-reason.md
+++ b/.foundry/tasks/task-017-030-update-schema-rejection-reason.md
@@ -17,5 +17,5 @@ parent: .foundry/stories/story-011-017-impossible-loop.md
 Update `.foundry/docs/schema.md` to document the new `rejection_reason` property. This property is used when a node is transitioned to `FAILED` because it is fundamentally impossible to complete.
 
 ## Acceptance Criteria
-- [ ] The `rejection_reason` property is added to the YAML Frontmatter Schema in `.foundry/docs/schema.md`.
-- [ ] The property is documented as an optional string.
+- [x] The `rejection_reason` property is added to the YAML Frontmatter Schema in `.foundry/docs/schema.md`.
+- [x] The property is documented as an optional string.


### PR DESCRIPTION
🎯 What
- Added `rejection_reason` to the YAML Frontmatter Schema in `.foundry/docs/schema.md`
- Documented `rejection_reason` in the Field Reference table as an optional string
- Added `rejection_reason` to the New Node Template

💡 Why
- To provide a mechanism to document why a node was transitioned to `FAILED` because it was fundamentally impossible to complete, as specified in the task `.foundry/tasks/task-017-030-update-schema-rejection-reason.md`.

✅ Verification
- Verified `.foundry/docs/schema.md` has been successfully updated with the correct `rejection_reason` properties
- Checked `.foundry/tasks/task-017-030-update-schema-rejection-reason.md` acceptance criteria checkboxes
- Ran the test suite to ensure no regressions

✨ Result
- The Foundry schema now officially supports the `rejection_reason` property for `FAILED` impossible tasks.

---
*PR created automatically by Jules for task [14896202037716630630](https://jules.google.com/task/14896202037716630630) started by @szubster*