### PR TITLE
🧪 Scribe: Test SettingsControls component

### DIFF
--- a/src/components/settings/__tests__/SettingsControls.test.tsx
+++ b/src/components/settings/__tests__/SettingsControls.test.tsx
@@ -1,7 +1,7 @@
+import { userEvent } from '@vitest/browser/context';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { SettingsControls } from '../SettingsControls';
-import { userEvent } from '@vitest/browser/context';
 
 describe('SettingsControls', () => {
   it('renders correctly and handles interactions', async () => {
@@ -9,20 +9,20 @@ describe('SettingsControls', () => {
     const setIsLivingDex = vi.fn();
     const setGlobalPokeball = vi.fn();
 
-    const { getByText, getByRole, getByLabelText } = render(
+    const { getByText, getByRole, getByLabelText } = await render(
       <SettingsControls
         effectiveVersion="scarlet-violet"
         setManualVersion={setManualVersion}
         isLivingDex={false}
         setIsLivingDex={setIsLivingDex}
-        globalPokeball="pokeball"
+        globalPokeball="poke"
         setGlobalPokeball={setGlobalPokeball}
         filteredPokeballs={[
-          { value: 'pokeball', label: 'Poké Ball' },
-          { value: 'greatball', label: 'Great Ball' },
+          { value: 'poke', label: 'Poké Ball' },
+          { value: 'great', label: 'Great Ball' },
         ]}
         genConfig={null}
-      />
+      />,
     );
 
     // Verify labels
@@ -42,7 +42,7 @@ describe('SettingsControls', () => {
 
     // Verify changing ball style
     const ballSelect = getByLabelText('Select Ball Style');
-    await userEvent.selectOptions(ballSelect, 'greatball');
-    expect(setGlobalPokeball).toHaveBeenCalledWith('greatball');
+    await userEvent.selectOptions(ballSelect, 'great');
+    expect(setGlobalPokeball).toHaveBeenCalledWith('great');
   });
 });

--- a/src/components/settings/__tests__/SettingsControls.test.tsx
+++ b/src/components/settings/__tests__/SettingsControls.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { SettingsControls } from '../SettingsControls';
+import { userEvent } from '@vitest/browser/context';
+
+describe('SettingsControls', () => {
+  it('renders correctly and handles interactions', async () => {
+    const setManualVersion = vi.fn();
+    const setIsLivingDex = vi.fn();
+    const setGlobalPokeball = vi.fn();
+
+    const { getByText, getByRole, getByLabelText } = render(
+      <SettingsControls
+        effectiveVersion="scarlet-violet"
+        setManualVersion={setManualVersion}
+        isLivingDex={false}
+        setIsLivingDex={setIsLivingDex}
+        globalPokeball="pokeball"
+        setGlobalPokeball={setGlobalPokeball}
+        filteredPokeballs={[
+          { value: 'pokeball', label: 'Poké Ball' },
+          { value: 'greatball', label: 'Great Ball' },
+        ]}
+        genConfig={null}
+      />
+    );
+
+    // Verify labels
+    await expect.element(getByText('Version')).toBeInTheDocument();
+    await expect.element(getByText('Living Dex')).toBeInTheDocument();
+    await expect.element(getByText('Ball Style')).toBeInTheDocument();
+
+    // Verify toggling living dex
+    const livingDexToggle = getByRole('switch', { name: 'Toggle Living Dex Mode' });
+    await userEvent.click(livingDexToggle);
+    expect(setIsLivingDex).toHaveBeenCalledWith(true);
+
+    // Verify changing version
+    const versionSelect = getByLabelText('Select Game Version');
+    await userEvent.selectOptions(versionSelect, 'unknown'); // "Auto" option
+    expect(setManualVersion).toHaveBeenCalledWith('unknown');
+
+    // Verify changing ball style
+    const ballSelect = getByLabelText('Select Ball Style');
+    await userEvent.selectOptions(ballSelect, 'greatball');
+    expect(setGlobalPokeball).toHaveBeenCalledWith('greatball');
+  });
+});


### PR DESCRIPTION
🎯 **What:**
Added browser tests for the `SettingsControls` UI component to ensure it properly renders and wires callbacks correctly.

📊 **Coverage:**
- Component labels are correctly rendered.
- Interacting with the "Living Dex" switch fires `setIsLivingDex` with `true`.
- Selecting the "Auto" option in the game version dropdown fires `setManualVersion` with `"unknown"`.
- Selecting a global Poké Ball style fires `setGlobalPokeball` with the newly chosen option.

✨ **Result:**
The test suite now has reliable tests for `SettingsControls` which simulate real user interactions via `vitest-browser-react` and `@vitest/browser/context`.

---
*PR created automatically by Jules for task [11719742388811199076](https://jules.google.com/task/11719742388811199076) started by @szubster*