### PR TITLE
🧪 Oak: add missing jules_session_id to story-010-015

### DIFF
--- a/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
+++ b/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
@@ -6,6 +6,7 @@ status: "PENDING"
 owner_persona: "story_owner"
 created_at: "2026-04-24"
 updated_at: "2026-04-24"
+jules_session_id: null
 depends_on:
   - ".foundry/tasks/task-014-027-configure-oxlint-json.md"
 parent: ".foundry/epics/epic-002-005-static-analysis.md"

--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -9,3 +9,9 @@
 
 ## Data Integrity - Evolution Chains
 *   **ROM parsing quirks / Data Pipeline Gotchas:** Some Gen 2 Pokémon evolutions (like Tyrogue -> Hitmonlee/Hitmonchan/Hitmontop) depend on the Pokémon's stats (Attack > Defense, Attack < Defense, or Attack == Defense). PokeAPI models this via `relative_physical_stats` in the `evolution_details`. Ensure the schema (`CompactEvolutionDetail`) and data generation script (`scripts/generate-pokedata.ts`) correctly map `relative_physical_stats` (to `rps`) so the application logic can accurately evaluate these conditional evolutions.
+
+## 2026-04-24 - 🧪 Oak: [data correction]
+**What was wrong:** The file \`.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md\` was missing the mandatory \`jules_session_id\` frontmatter field, causing the orchestrator to skip the node during DAG resolution.
+**Canonical source used:** Foundry Orchestrator error logs and project frontmatter requirements.
+**Impact on users:** Restores the story node and its dependencies to the active DAG resolution, ensuring that the work planned for enforcing strict oxlint rules can proceed.
+**Learning:** The \`jules_session_id\` field is a hard requirement for the Foundry DAG orchestrator parser in strict mode. All node files under \`.foundry/\` (PRDs, Epics, Stories, Tasks) must include this field, even if set to \`null\`, to avoid being skipped during discovery.


### PR DESCRIPTION
What was wrong: The file `.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md` was missing the mandatory `jules_session_id` frontmatter field, causing the orchestrator to skip the node.
Canonical source used: Foundry Orchestrator error logs and project frontmatter requirements.
Impact on users: Restores the story node and its dependencies to the active DAG resolution.

Fixes #567

---
*PR created automatically by Jules for task [18287678643633850070](https://jules.google.com/task/18287678643633850070) started by @szubster*