### PR TITLE
Implement Wait & Wake orchestration logic

### DIFF
--- a/.foundry/tasks/task-016-030-implement-wait-wake.md
+++ b/.foundry/tasks/task-016-030-implement-wait-wake.md
@@ -18,7 +18,7 @@ parent: ".foundry/stories/story-011-016-wait-wake-implementation.md"
 Implement the Wait & Wake orchestration logic in `.github/scripts/foundry-orchestrator.ts`. The orchestrator needs to support suspending the current session by moving an `ACTIVE` node to `PENDING` if it dynamically adds incomplete downstream nodes to its `depends_on` array.
 
 ## Acceptance Criteria
-- [ ] Add a new phase (e.g., Phase 3.5: SUSPEND) to iterate through all `ACTIVE` nodes.
-- [ ] For each `ACTIVE` node, check its `depends_on` array.
-- [ ] If any of the paths in `depends_on` points to a node that is not `COMPLETED`, the `ACTIVE` node must be suspended.
-- [ ] Transition its status from `ACTIVE` to `PENDING` using `promoteNodeStatus(node, 'ACTIVE', 'PENDING')`.
+- [x] Add a new phase (e.g., Phase 3.5: SUSPEND) to iterate through all `ACTIVE` nodes.
+- [x] For each `ACTIVE` node, check its `depends_on` array.
+- [x] If any of the paths in `depends_on` points to a node that is not `COMPLETED`, the `ACTIVE` node must be suspended.
+- [x] Transition its status from `ACTIVE` to `PENDING` using `promoteNodeStatus(node, 'ACTIVE', 'PENDING')`.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -387,4 +387,129 @@ jules_session_id: null
     expect(output[0].status).toBe('READY');
   });
 
+
+  test('Wait and Wake: Suspends ACTIVE node if dependencies are unresolvable', () => {
+    createNode('.foundry/tasks/task-active.md', `
+id: task-active
+type: TASK
+title: "Active Task"
+status: ACTIVE
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: [".foundry/tasks/task-missing.md"]
+jules_session_id: null
+`);
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-active.md'), 'utf-8');
+    expect(result).toContain('status: PENDING');
+  });
+
+  test('Wait and Wake: Suspends ACTIVE node if dependency is incomplete', () => {
+    createNode('.foundry/tasks/task-incomplete.md', `
+id: task-incomplete
+type: TASK
+title: "Incomplete Task"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-active.md', `
+id: task-active
+type: TASK
+title: "Active Task"
+status: ACTIVE
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: [".foundry/tasks/task-incomplete.md"]
+jules_session_id: null
+`);
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-active.md'), 'utf-8');
+    expect(result).toContain('status: PENDING');
+  });
+
+  test('Wait and Wake: Suspends ACTIVE node if dependency is hierarchically incomplete', () => {
+    createNode('.foundry/stories/story-001.md', `
+id: story-001
+type: STORY
+title: "Story"
+status: COMPLETED
+owner_persona: tech_lead
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-child.md', `
+id: task-child
+type: TASK
+title: "Child Task"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+parent: ".foundry/stories/story-001.md"
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-active.md', `
+id: task-active
+type: TASK
+title: "Active Task"
+status: ACTIVE
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: [".foundry/stories/story-001.md"]
+jules_session_id: null
+`);
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-active.md'), 'utf-8');
+    expect(result).toContain('status: PENDING');
+  });
+
+  test('Wait and Wake: Does not suspend ACTIVE node if all dependencies are COMPLETED', () => {
+    createNode('.foundry/tasks/task-complete.md', `
+id: task-complete
+type: TASK
+title: "Complete Task"
+status: COMPLETED
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-active.md', `
+id: task-active
+type: TASK
+title: "Active Task"
+status: ACTIVE
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: [".foundry/tasks/task-complete.md"]
+jules_session_id: null
+`);
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-active.md'), 'utf-8');
+    expect(result).toContain('status: ACTIVE');
+  });
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -335,10 +335,7 @@ function main(): void {
     }
   }
 
-  // ── Phase 4: RESOLVE ───────────────────────────────────────────────────────
-  info('Phase 4: Resolving DAG — finding eligible PENDING nodes...');
   let hasUnresolvableDeps = false;
-  const eligible: ParsedNode[] = [];
 
   // Helper to recursively check if a node is blocked.
   // A node is blocked if:
@@ -402,6 +399,48 @@ function main(): void {
     evalCache.set(nodePath, false);
     return false;
   }
+
+  // ── Phase 3.5: SUSPEND (Wait & Wake) ───────────────────────────────────────
+  info('Phase 3.5: Checking ACTIVE nodes for suspension...');
+  for (const node of nodes) {
+    if (node.frontmatter.status !== 'ACTIVE') continue;
+
+    let shouldSuspend = false;
+    for (const depPath of node.frontmatter.depends_on) {
+      const dep = nodeMap.get(depPath);
+      if (!dep) {
+        if (fs.existsSync(path.join(repoRoot, depPath))) {
+          continue;
+        }
+        warn(`Unresolvable dependency '${depPath}' referenced by ACTIVE node: ${node.repoPath}`);
+        hasUnresolvableDeps = true;
+        shouldSuspend = true;
+        break;
+      }
+
+      // If it is an ancestor, we only care that it is status ACTIVE or COMPLETED.
+      if (!isDescendant(node.repoPath, depPath)) {
+        if (isHierarchicallyIncomplete(depPath)) {
+          shouldSuspend = true;
+          break;
+        }
+      } else {
+        if (dep.frontmatter.status !== 'ACTIVE' && dep.frontmatter.status !== 'COMPLETED') {
+          shouldSuspend = true;
+          break;
+        }
+      }
+    }
+
+    if (shouldSuspend) {
+      info(`Suspending ACTIVE node: ${node.repoPath}`);
+      promoteNodeStatus(node, 'ACTIVE', 'PENDING');
+    }
+  }
+
+  // ── Phase 4: RESOLVE ───────────────────────────────────────────────────────
+  info('Phase 4: Resolving DAG — finding eligible PENDING nodes...');
+  const eligible: ParsedNode[] = [];
 
   for (const node of nodes) {
     if (node.frontmatter.status !== 'PENDING') continue;


### PR DESCRIPTION
🎯 What
- Added Phase 3.5: SUSPEND to the `foundry-orchestrator.ts`.
- Added logic to iterate over all `ACTIVE` nodes and verify their dependencies.
- Automatically transitions `ACTIVE` nodes to `PENDING` if any dependencies are unresolvable or hierarchically incomplete.
- Added unit tests for Wait & Wake logic in `foundry-orchestrator.test.ts`.

💡 Why
- Allows sessions to dynamically add downstream node dependencies and gracefully wait for them to finish before resuming work, improving autonomous pipeline handling.

---
*PR created automatically by Jules for task [4294823295979874503](https://jules.google.com/task/4294823295979874503) started by @szubster*