### PR TITLE
🛡️ Nurse: fix missing jules_session_id and broken parent link in DAG node

### DIFF
--- a/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
+++ b/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
@@ -8,7 +8,8 @@ created_at: "2026-04-24"
 updated_at: "2026-04-24"
 depends_on:
   - ".foundry/tasks/task-014-027-configure-oxlint-json.md"
-parent: ".foundry/epics/epic-002-005-static-analysis.md"
+jules_session_id: null
+parent: ".foundry/epics/epic-010-oxlint-config.md"
 ---
 
 # Fix disabled oxlint rules across the codebase

--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -22,3 +22,10 @@ The compiler ensures that DataLoader batch functions return valid values or Erro
 ## 2025-04-23
 
 - **Type narrow arrays in `.reduce` calls directly:** Rather than explicitly typing function parameters and applying an `as` cast on the starting object (`{} as Record<...>`), it is safer and cleaner to provide the generic parameter directly to the reduce function `.reduce<Record<...>>((acc, val) => ... , {})`. This eliminates an unnecessary `as` cast and allows TypeScript to properly catch incorrect shape returns without bypassing type safety.
+# Nurse Learnings
+
+## 2026-04-25 - Fix missing jules_session_id and broken parent link in DAG node
+
+- **What was unsafe**: A DAG node (`.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md`) was missing the mandatory `jules_session_id` field and had an incorrect `parent` reference. This caused the Foundry orchestrator to skip the node and fail to resolve the DAG.
+- **How it was fixed**: Added `jules_session_id: null` and corrected the `parent` field to point to an existing epic (`.foundry/epics/epic-010-oxlint-config.md`).
+- **What the compiler now catches**: The orchestrator's schema validation now properly validates the node, and the dependency resolver can correctly trace the hierarchy.


### PR DESCRIPTION
What was unsafe: The `.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md` node was missing the mandatory `jules_session_id` field and had an incorrect parent epic reference (`epic-002-005-static-analysis.md` instead of `epic-010-oxlint-config.md`). This caused the node to be skipped or blocked by the Foundry orchestrator, stalling the DAG.
How it was fixed: Added `jules_session_id: null` to the frontmatter and updated the `parent` field to point to the correct epic file.
What the compiler now catches: The orchestrator's schema validation and dependency resolution now correctly identify this file as a valid, unblocked DAG node.

Fixes #570

---
*PR created automatically by Jules for task [874381557477132443](https://jules.google.com/task/874381557477132443) started by @szubster*