### PR TITLE
🧪 Oak: fix missing jules_session_id and broken parent in story-010-015

### DIFF
--- a/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
+++ b/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
@@ -6,9 +6,10 @@ status: "PENDING"
 owner_persona: "story_owner"
 created_at: "2026-04-24"
 updated_at: "2026-04-24"
+jules_session_id: null
 depends_on:
   - ".foundry/tasks/task-014-027-configure-oxlint-json.md"
-parent: ".foundry/epics/epic-002-005-static-analysis.md"
+parent: ".foundry/epics/epic-010-oxlint-config.md"
 ---
 
 # Fix disabled oxlint rules across the codebase


### PR DESCRIPTION
- 🎯 What: Added missing `jules_session_id: null` field and corrected the `parent` path to `.foundry/epics/epic-010-oxlint-config.md` in `.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md`.
- 💡 Why: The Foundry DAG orchestrator requires the session ID field and valid parent paths; their absence/incorrectness was causing the node to be skipped or blocked.
- Canonical source used: Foundry DAG orchestrator logs and filesystem inspection.
- Impact on users: Restores DAG resolution for this story and its dependents.

Fixes #576

---
*PR created automatically by Jules for task [7241904551373240754](https://jules.google.com/task/7241904551373240754) started by @szubster*