### PR TITLE
Story: Fix disabled oxlint rules across the codebase

### DIFF
--- a/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
+++ b/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
@@ -29,3 +29,11 @@ All disabled oxlint rules should be enabled back. The tech lead should create a 
 ## Instructions for Tech Lead
 1. Create a series of TASK nodes, one for each disabled rule.
 2. Ensure each task focuses strictly on enabling that rule in `.oxlintrc.json` and fixing all corresponding violations across the codebase.
+
+## Generated Tasks
+- [.foundry/tasks/task-015-033-oxlint-require-mock-type-parameters.md](../tasks/task-015-033-oxlint-require-mock-type-parameters.md)
+- [.foundry/tasks/task-015-034-oxlint-expect-expect.md](../tasks/task-015-034-oxlint-expect-expect.md)
+- [.foundry/tasks/task-015-035-oxlint-jest-no-standalone-expect.md](../tasks/task-015-035-oxlint-jest-no-standalone-expect.md)
+- [.foundry/tasks/task-015-036-oxlint-jest-expect-expect.md](../tasks/task-015-036-oxlint-jest-expect-expect.md)
+- [.foundry/tasks/task-015-037-oxlint-jest-no-disabled-tests.md](../tasks/task-015-037-oxlint-jest-no-disabled-tests.md)
+- [.foundry/tasks/task-015-038-oxlint-jest-no-conditional-expect.md](../tasks/task-015-038-oxlint-jest-no-conditional-expect.md)

--- a/.foundry/tasks/task-015-033-oxlint-require-mock-type-parameters.md
+++ b/.foundry/tasks/task-015-033-oxlint-require-mock-type-parameters.md
@@ -1,0 +1,22 @@
+---
+id: "task-015-033-oxlint-require-mock-type-parameters"
+type: "TASK"
+title: "Enable oxlint vitest/require-mock-type-parameters"
+status: "PENDING"
+owner_persona: "coder"
+created_at: "2026-04-25"
+updated_at: "2026-04-25"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/stories/story-010-015-enforce-strict-oxlint-rules.md"
+---
+
+# Enable oxlint vitest/require-mock-type-parameters
+
+## Context
+As part of story `story-010-015-enforce-strict-oxlint-rules`, we are re-enabling strict oxlint rules that were temporarily disabled. This task focuses on `vitest/require-mock-type-parameters`.
+
+## Instructions
+1. In `.oxlintrc.json`, change `"vitest/require-mock-type-parameters": "off"` to `"vitest/require-mock-type-parameters": "error"`.
+2. Run `pnpm exec oxlint .` to identify violations.
+3. Fix all violations by providing type parameters to `vi.fn()` calls, e.g., `vi.fn<() => void>()`.

--- a/.foundry/tasks/task-015-034-oxlint-expect-expect.md
+++ b/.foundry/tasks/task-015-034-oxlint-expect-expect.md
@@ -1,0 +1,22 @@
+---
+id: "task-015-034-oxlint-expect-expect"
+type: "TASK"
+title: "Enable oxlint vitest/expect-expect"
+status: "PENDING"
+owner_persona: "coder"
+created_at: "2026-04-25"
+updated_at: "2026-04-25"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/stories/story-010-015-enforce-strict-oxlint-rules.md"
+---
+
+# Enable oxlint vitest/expect-expect
+
+## Context
+As part of story `story-010-015-enforce-strict-oxlint-rules`, we are re-enabling strict oxlint rules that were temporarily disabled. This task focuses on `vitest/expect-expect`.
+
+## Instructions
+1. In `.oxlintrc.json`, change `"vitest/expect-expect": "off"` (if present) to `"vitest/expect-expect": "error"`.
+2. Run `pnpm exec oxlint .` to identify violations.
+3. Fix all violations by ensuring every test block contains at least one assertion.

--- a/.foundry/tasks/task-015-035-oxlint-jest-no-standalone-expect.md
+++ b/.foundry/tasks/task-015-035-oxlint-jest-no-standalone-expect.md
@@ -1,0 +1,22 @@
+---
+id: "task-015-035-oxlint-jest-no-standalone-expect"
+type: "TASK"
+title: "Enable oxlint jest/no-standalone-expect"
+status: "PENDING"
+owner_persona: "coder"
+created_at: "2026-04-25"
+updated_at: "2026-04-25"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/stories/story-010-015-enforce-strict-oxlint-rules.md"
+---
+
+# Enable oxlint jest/no-standalone-expect
+
+## Context
+As part of story `story-010-015-enforce-strict-oxlint-rules`, we are re-enabling strict oxlint rules that were temporarily disabled. This task focuses on `jest/no-standalone-expect`.
+
+## Instructions
+1. In `.oxlintrc.json`, change `"jest/no-standalone-expect": "off"` to `"jest/no-standalone-expect": "error"`.
+2. Run `pnpm exec oxlint .` to identify violations.
+3. Fix all violations by wrapping floating `expect()` calls in `test` or `it` blocks.

--- a/.foundry/tasks/task-015-036-oxlint-jest-expect-expect.md
+++ b/.foundry/tasks/task-015-036-oxlint-jest-expect-expect.md
@@ -1,0 +1,22 @@
+---
+id: "task-015-036-oxlint-jest-expect-expect"
+type: "TASK"
+title: "Enable oxlint jest/expect-expect"
+status: "PENDING"
+owner_persona: "coder"
+created_at: "2026-04-25"
+updated_at: "2026-04-25"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/stories/story-010-015-enforce-strict-oxlint-rules.md"
+---
+
+# Enable oxlint jest/expect-expect
+
+## Context
+As part of story `story-010-015-enforce-strict-oxlint-rules`, we are re-enabling strict oxlint rules that were temporarily disabled. This task focuses on `jest/expect-expect`.
+
+## Instructions
+1. In `.oxlintrc.json`, change `"jest/expect-expect": "off"` to `"jest/expect-expect": "error"`.
+2. Run `pnpm exec oxlint .` to identify violations.
+3. Fix all violations by adding assertions to empty tests.

--- a/.foundry/tasks/task-015-037-oxlint-jest-no-disabled-tests.md
+++ b/.foundry/tasks/task-015-037-oxlint-jest-no-disabled-tests.md
@@ -1,0 +1,22 @@
+---
+id: "task-015-037-oxlint-jest-no-disabled-tests"
+type: "TASK"
+title: "Enable oxlint jest/no-disabled-tests"
+status: "PENDING"
+owner_persona: "coder"
+created_at: "2026-04-25"
+updated_at: "2026-04-25"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/stories/story-010-015-enforce-strict-oxlint-rules.md"
+---
+
+# Enable oxlint jest/no-disabled-tests
+
+## Context
+As part of story `story-010-015-enforce-strict-oxlint-rules`, we are re-enabling strict oxlint rules that were temporarily disabled. This task focuses on `jest/no-disabled-tests`.
+
+## Instructions
+1. In `.oxlintrc.json`, change `"jest/no-disabled-tests": "off"` to `"jest/no-disabled-tests": "error"`.
+2. Run `pnpm exec oxlint .` to identify violations.
+3. Fix all violations by removing `.skip` or `.todo` from tests.

--- a/.foundry/tasks/task-015-038-oxlint-jest-no-conditional-expect.md
+++ b/.foundry/tasks/task-015-038-oxlint-jest-no-conditional-expect.md
@@ -1,0 +1,22 @@
+---
+id: "task-015-038-oxlint-jest-no-conditional-expect"
+type: "TASK"
+title: "Enable oxlint jest/no-conditional-expect"
+status: "PENDING"
+owner_persona: "coder"
+created_at: "2026-04-25"
+updated_at: "2026-04-25"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/stories/story-010-015-enforce-strict-oxlint-rules.md"
+---
+
+# Enable oxlint jest/no-conditional-expect
+
+## Context
+As part of story `story-010-015-enforce-strict-oxlint-rules`, we are re-enabling strict oxlint rules that were temporarily disabled. This task focuses on `jest/no-conditional-expect`.
+
+## Instructions
+1. In `.oxlintrc.json`, change `"jest/no-conditional-expect": "off"` to `"jest/no-conditional-expect": "error"`.
+2. Run `pnpm exec oxlint .` to identify violations.
+3. Fix all violations by refactoring tests to avoid conditional `expect()` calls.


### PR DESCRIPTION
🎯 What
This PR addresses story-010-015-enforce-strict-oxlint-rules by generating individual technical task nodes to re-enable previously disabled strict oxlint rules. 

The generated tasks are:
- task-015-033-oxlint-require-mock-type-parameters
- task-015-034-oxlint-expect-expect
- task-015-035-oxlint-jest-no-standalone-expect
- task-015-036-oxlint-jest-expect-expect
- task-015-037-oxlint-jest-no-disabled-tests
- task-015-038-oxlint-jest-no-conditional-expect

💡 Why
During the initial rollout of the strict .oxlintrc.json configuration, several rules were temporarily disabled. This story prepares the Foundry orchestration DAG to fix those violations independently.

✨ Result
All necessary TASK nodes are created, properly formatted, and linked within the parent story node.

---
*PR created automatically by Jules for task [9424620988169779516](https://jules.google.com/task/9424620988169779516) started by @szubster*