### PR TITLE
QA: verify idb wrapper

### DIFF
--- a/.foundry/tasks/task-021-031-qa-idb-wrapper.md
+++ b/.foundry/tasks/task-021-031-qa-idb-wrapper.md
@@ -19,6 +19,6 @@ tags: ["indexeddb", "infrastructure", "persistence", "qa"]
 Verify the IndexedDB wrapper implemented in `.foundry/tasks/task-021-030-implement-idb-wrapper.md`.
 
 ## Acceptance Criteria
-- [ ] Verify `idb` wrapper supports binary read/write/delete.
-- [ ] Verify graceful fallback handling when IndexedDB is inaccessible (e.g. `QuotaExceededError` or private mode).
-- [ ] Verify generic error logging (e.g., "System: sync failed") to prevent internal error leakage (CWE-209 mitigation).
+- [x] Verify `idb` wrapper supports binary read/write/delete.
+- [x] Verify graceful fallback handling when IndexedDB is inaccessible (e.g. `QuotaExceededError` or private mode).
+- [x] Verify generic error logging (e.g., "System: sync failed") to prevent internal error leakage (CWE-209 mitigation).


### PR DESCRIPTION
🎯 What: Validated the acceptance criteria defined in task-021-031-qa-idb-wrapper.
💡 Why: To ensure proper fallback mechanisms and generic error logging via sandbox tests. IndexedDB operations correctly fall back to an in-memory Map and log generic errors upon exceptions.

---
*PR created automatically by Jules for task [7536372889529311458](https://jules.google.com/task/7536372889529311458) started by @szubster*