### PR TITLE
QA Validation: Link Checker Pre-commit Hook Script

### DIFF
--- a/.foundry/tasks/task-015-029-qa-link-checker.md
+++ b/.foundry/tasks/task-015-029-qa-link-checker.md
@@ -31,8 +31,8 @@ Verify that the automated git pre-commit hook script implemented by the `coder` 
 This QA task ensures the requirements outlined in `.foundry/stories/story-006-015-implement-link-checker.md` and implemented in `.foundry/tasks/task-015-028-implement-link-checker.md` are met.
 
 ## Acceptance Criteria
-- [ ] Validated that broken `depends_on` links prevent commits.
-- [ ] Validated that broken `parent` links prevent commits.
-- [ ] Validated that broken inline markdown links prevent commits.
-- [ ] Validated that perfectly valid files can be committed successfully.
-- [ ] Verified that the hook runs correctly via `lefthook`.
+- [x] Validated that broken `depends_on` links prevent commits.
+- [x] Validated that broken `parent` links prevent commits.
+- [x] Validated that broken inline markdown links prevent commits.
+- [x] Validated that perfectly valid files can be committed successfully.
+- [x] Verified that the hook runs correctly via `lefthook`.


### PR DESCRIPTION
# QA Validation: Link Checker Pre-commit Hook Script

**What:**
Validated the automated git pre-commit hook script implemented by the `coder` to ensure it correctly validates all local markdown file references and correctly rejects commits containing dead links.

**Validation Steps Completed:**
- Simulated an invalid reference in the `depends_on` array of a `.foundry/**/*.md` file, attempted to commit, and verified that the commit is aborted by `lefthook` with a clear error message.
- Simulated an invalid reference in the `parent` field of a `.foundry/**/*.md` file, attempted to commit, and verified the commit is similarly rejected.
- Introduced an invalid inline markdown link into a staged markdown file, attempted to commit, and verified it is rejected.
- Introduced only valid links in `depends_on`, `parent`, and inline markdown, attempted to commit, and verified the commit succeeds.
- Confirmed the hook only runs on modified/staged markdown files via `lefthook.yml`.

---
*PR created automatically by Jules for task [14182164790383977373](https://jules.google.com/task/14182164790383977373) started by @szubster*