### PR TITLE
Implement Impossible Loop in Orchestrator

### DIFF
--- a/.foundry/tasks/task-017-031-implement-impossible-loop.md
+++ b/.foundry/tasks/task-017-031-implement-impossible-loop.md
@@ -18,6 +18,6 @@ parent: .foundry/stories/story-011-017-impossible-loop.md
 Update `foundry-orchestrator.ts` to implement the "Impossible Loop". The orchestrator must detect nodes that are in `FAILED` status and have a `rejection_reason`.
 
 ## Acceptance Criteria
-- [ ] The orchestrator detects nodes that are `FAILED` and contain a `rejection_reason` in their frontmatter.
-- [ ] Upon detecting such a node, the orchestrator "wakes up" the parent node (transitions it to `ACTIVE`) if one exists.
-- [ ] If no parent exists, the orchestrator flags the node for the `tpm` to create a feedback `IDEA` for the PM/CEO.
+- [x] The orchestrator detects nodes that are `FAILED` and contain a `rejection_reason` in their frontmatter.
+- [x] Upon detecting such a node, the orchestrator "wakes up" the parent node (transitions it to `ACTIVE`) if one exists.
+- [x] If no parent exists, the orchestrator flags the node for the `tpm` to create a feedback `IDEA` for the PM/CEO.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -512,4 +512,58 @@ jules_session_id: null
     const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-active.md'), 'utf-8');
     expect(result).toContain('status: ACTIVE');
   });
+
+  test('Impossible Loop: wakes up parent if impossible child is FAILED with rejection_reason', () => {
+    createNode('.foundry/stories/story-001.md', `
+id: story-001
+type: STORY
+title: "Story"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-impossible.md', `
+id: task-impossible
+type: TASK
+title: "Impossible Task"
+status: FAILED
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+parent: ".foundry/stories/story-001.md"
+rejection_reason: "Feature not supported"
+jules_session_id: null
+`);
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-001.md'), 'utf-8');
+    expect(result).toContain('status: ACTIVE');
+  });
+
+  test('Impossible Loop: flags node for tpm if no parent exists', () => {
+    createNode('.foundry/tasks/task-impossible-no-parent.md', `
+id: task-impossible-no-parent
+type: TASK
+title: "Impossible Task No Parent"
+status: FAILED
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+rejection_reason: "Feature not supported"
+jules_session_id: null
+`);
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-impossible-no-parent.md'), 'utf-8');
+    expect(result).toContain('status: BLOCKED');
+    expect(result).toContain('owner_persona: tpm');
+  });
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -285,6 +285,53 @@ function promoteNodeStatus(node: ParsedNode, currentStatus: Status, targetStatus
   info(`${dryTag}Promoted ${currentStatus} → ${targetStatus}: ${node.repoPath}`);
 }
 
+function promoteNodeToTpm(node: ParsedNode): void {
+  const dateStr = todayISO();
+  const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
+
+  const fmBlockMatch = node.rawContent.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*/m);
+  if (!fmBlockMatch) {
+    warn(`${dryTag}Cannot locate frontmatter delimiters for mutation in: ${node.repoPath}`);
+    return;
+  }
+
+  const originalFmBlock = fmBlockMatch[0];
+  let mutatedFmBlock = originalFmBlock;
+
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(status:\s*)["']?[^"'\r\n]+["']?([ \t\r]*)$/m,
+    `$1BLOCKED$2`,
+  );
+
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(owner_persona:\s*)["']?[^"'\r\n]+["']?([ \t\r]*)$/m,
+    `$1tpm$2`,
+  );
+
+  mutatedFmBlock = mutatedFmBlock.replace(
+    /^(updated_at:\s*)["']?\d{4}-\d{2}-\d{2}["']?([ \t\r]*)$/m,
+    `$1"${dateStr}"$2`,
+  );
+
+  const newContent = node.rawContent.replace(originalFmBlock, mutatedFmBlock);
+
+  if (!DRY_RUN) {
+    try {
+      fs.writeFileSync(node.filePath, newContent, 'utf-8');
+    } catch (e) {
+      warn(`Failed to write file: ${node.repoPath} — ${String(e)}`);
+      return;
+    }
+  }
+
+  node.frontmatter.status = 'BLOCKED';
+  node.frontmatter.owner_persona = 'tpm';
+  node.frontmatter.updated_at = dateStr;
+  node.rawContent = newContent;
+
+  info(`${dryTag}Flagged node for TPM: ${node.repoPath}`);
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 function main(): void {
@@ -435,6 +482,23 @@ function main(): void {
     if (shouldSuspend) {
       info(`Suspending ACTIVE node: ${node.repoPath}`);
       promoteNodeStatus(node, 'ACTIVE', 'PENDING');
+    }
+  }
+
+  // ── Phase 3.6: IMPOSSIBLE LOOP ─────────────────────────────────────────────
+  info('Phase 3.6: Checking for Impossible Loop conditions...');
+  for (const node of nodes) {
+    if (node.frontmatter.status === 'FAILED' && node.frontmatter.rejection_reason) {
+      if (node.frontmatter.parent) {
+        const parentNode = nodeMap.get(node.frontmatter.parent);
+        if (parentNode && parentNode.frontmatter.status !== 'ACTIVE') {
+          info(`Impossible Loop: waking up parent ${parentNode.repoPath}`);
+          promoteNodeStatus(parentNode, parentNode.frontmatter.status, 'ACTIVE');
+        }
+      } else if (node.frontmatter.owner_persona !== 'tpm') {
+        info(`Impossible Loop: flagging node without parent for TPM: ${node.repoPath}`);
+        promoteNodeToTpm(node);
+      }
     }
   }
 


### PR DESCRIPTION
## What
Updated the `.github/scripts/foundry-orchestrator.ts` to add a new Phase 3.6 for the Impossible Loop. It detects nodes in `FAILED` status with a `rejection_reason` and transitions their parent to `ACTIVE`, or flags the node to the `tpm` persona with `BLOCKED` status if no parent exists.

## Why
To handle failure recovery and escalate impossible tasks correctly per The Foundry specs.

Closes #task-017-031-implement-impossible-loop

---
*PR created automatically by Jules for task [1689474346637975995](https://jules.google.com/task/1689474346637975995) started by @szubster*