### PR TITLE
🧪 Sentinel: Wait & Wake test suite in Orchestrator

### DIFF
--- a/.foundry/tasks/task-016-031-qa-wait-wake.md
+++ b/.foundry/tasks/task-016-031-qa-wait-wake.md
@@ -19,6 +19,9 @@ parent: ".foundry/stories/story-011-016-wait-wake-implementation.md"
 Verify the Wait & Wake orchestration logic implemented in `.github/scripts/foundry-orchestrator.ts`. Write test suites in `.github/scripts/foundry-orchestrator.test.ts` to cover the `ACTIVE` -> `PENDING` state transition.
 
 ## Acceptance Criteria
-- [ ] Add a test that verifies an `ACTIVE` node transitions to `PENDING` when a new incomplete dependency is added to its `depends_on` array.
-- [ ] Add a test that verifies a `PENDING` parent node transitions to `READY` when its new dependency is `COMPLETED` (the Wake condition).
-- [ ] All tests pass successfully.
+- [x] Add a test that verifies an `ACTIVE` node transitions to `PENDING` when a new incomplete dependency is added to its `depends_on` array.
+- [x] Add a test that verifies a `PENDING` parent node transitions to `READY` when its new dependency is `COMPLETED` (the Wake condition).
+- [x] All tests pass successfully.
+
+## QA Result
+The Wait & Wake logic in `foundry-orchestrator.ts` is correctly implemented and covered by tests. Both Wait condition and Wake condition are validated. Approved.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -512,4 +512,35 @@ jules_session_id: null
     const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-active.md'), 'utf-8');
     expect(result).toContain('status: ACTIVE');
   });
+
+  test('Wait and Wake: Wakes PENDING parent node to READY when its dependency is COMPLETED', () => {
+    createNode('.foundry/tasks/task-complete.md', `
+id: task-complete
+type: TASK
+title: "Complete Task"
+status: COMPLETED
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-parent.md', `
+id: task-parent
+type: TASK
+title: "Parent Task"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: [".foundry/tasks/task-complete.md"]
+jules_session_id: null
+`);
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-parent.md'), 'utf-8');
+    expect(result).toContain('status: READY');
+  });
 });

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -53,3 +53,9 @@ If you encounter `Error: Failed to load custom Reporter from text` when running 
 - When testing RangeError throwing inside DataView, avoid overriding `global.DataView` without `try...finally` as it breaks downstream tests if `expect().toThrow()` fails.
 - Be careful when replacing `as any` casting: use `as unknown as typeof DataView` to avoid Biome's `lint/suspicious/noExplicitAny`.
 - `noUncheckedIndexedAccess: true` requires indexing arrays using fallback (e.g., `buffer[i] ?? 0`) or checking for bounds to prevent TypeScript compilation errors (`TS2532`).
+
+## 2026-04-26 - Wait & Wake orchestration logic test
+**What:** Added test case for the Wake condition of the Wait & Wake orchestration protocol.
+**Coverage Before/After:** Increased coverage by ensuring the `PENDING` -> `READY` node transition functions as designed when dependencies are completed.
+**Why this target matters:** The DAG relies on strict state boundaries to ensure deterministic execution order and prevent deadlocks.
+**Learning:** The `foundry-orchestrator.ts` script iterates across different node structures mapping relationships, requiring mock markdown node files directly written to the sandbox fs to act as test fixtures.


### PR DESCRIPTION
🎯 What
Added a missing Wait & Wake test case for Wake condition.
     
📊 Coverage
Added the test `Wait and Wake: Wakes PENDING parent node to READY when its dependency is COMPLETED` to `.github/scripts/foundry-orchestrator.test.ts` to cover the `PENDING` -> `READY` state transition when the wait dependencies are fulfilled.

✨ Result
All tests pass. QA is fully satisfied with the wait & wake protocol orchestrator implementation.

---
*PR created automatically by Jules for task [8718557929428105910](https://jules.google.com/task/8718557929428105910) started by @szubster*