### PR TITLE
🛡️ Nurse: [type improvement] Enable oxlint vitest/require-mock-type-parameters

### DIFF
--- a/.foundry/tasks/task-015-033-oxlint-require-mock-type-parameters.md
+++ b/.foundry/tasks/task-015-033-oxlint-require-mock-type-parameters.md
@@ -17,6 +17,6 @@ parent: ".foundry/stories/story-010-015-enforce-strict-oxlint-rules.md"
 As part of story `story-010-015-enforce-strict-oxlint-rules`, we are re-enabling strict oxlint rules that were temporarily disabled. This task focuses on `vitest/require-mock-type-parameters`.
 
 ## Instructions
-1. In `.oxlintrc.json`, change `"vitest/require-mock-type-parameters": "off"` to `"vitest/require-mock-type-parameters": "error"`.
-2. Run `pnpm exec oxlint .` to identify violations.
-3. Fix all violations by providing type parameters to `vi.fn()` calls, e.g., `vi.fn<() => void>()`.
+- [x] 1. In `.oxlintrc.json`, change `"vitest/require-mock-type-parameters": "off"` to `"vitest/require-mock-type-parameters": "error"`.
+- [x] 2. Run `pnpm exec oxlint .` to identify violations.
+- [x] 3. Fix all violations by providing type parameters to `vi.fn()` calls, e.g., `vi.fn<() => void>()`.

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -7,7 +7,7 @@ import * as orchestrator from './foundry-orchestrator.ts';
 vi.mock('node:fs');
 vi.mock('./foundry-orchestrator.ts');
 
-const globalFetch = vi.fn();
+const globalFetch = vi.fn<typeof fetch>();
 vi.stubGlobal('fetch', globalFetch);
 
 describe('Foundry Heartbeat', () => {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -13,7 +13,7 @@
     "correctness": "error"
   },
   "rules": {
-    "vitest/require-mock-type-parameters": "off",
+    "vitest/require-mock-type-parameters": "error",
     "jest/no-standalone-expect": "off",
     "jest/expect-expect": "off",
     "jest/no-disabled-tests": "off",

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -28,7 +28,7 @@ describe('AppLayout chunk error handling', () => {
     originalLocation = window.location;
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: { ...originalLocation, reload: vi.fn() },
+      value: { ...originalLocation, reload: vi.fn<() => void>() },
     });
   });
 

--- a/src/db/__tests__/DexDataLoader.test.ts
+++ b/src/db/__tests__/DexDataLoader.test.ts
@@ -6,9 +6,9 @@ import type { CompactEncounter, LocationAreaEncounters, PokemonMetadata } from '
 // Mock pokeDB
 vi.mock('../PokeDB', () => ({
   pokeDB: {
-    getPokemons: vi.fn(),
-    getEncountersBulk: vi.fn(),
-    getAreaNames: vi.fn(),
+    getPokemons: vi.fn<() => Promise<PokemonMetadata[]>>(),
+    getEncountersBulk: vi.fn<() => Promise<LocationAreaEncounters[]>>(),
+    getAreaNames: vi.fn<() => Promise<Record<number, string>>>(),
   },
 }));
 

--- a/src/db/__tests__/PokeDB.test.ts
+++ b/src/db/__tests__/PokeDB.test.ts
@@ -7,7 +7,7 @@ import { DB_CONFIG } from '../schema';
 vi.stubGlobal('__POKEDATA_HASH__', 'test-hash');
 vi.stubGlobal(
   'fetch',
-  vi.fn().mockResolvedValue({
+  vi.fn<() => Promise<Response>>().mockResolvedValue({
     ok: true,
     json: async () => ({
       hash: 'test-hash',
@@ -144,7 +144,7 @@ describe('PokeDB', () => {
   it('emits progress events during sync', async () => {
     // We cannot easily spy on window if it's undefined, let's inject it into global context
     const originalWindow = global.window;
-    const dispatchEventMock = vi.fn();
+    const dispatchEventMock = vi.fn<(event: CustomEvent) => boolean>();
 
     // @ts-expect-error
     global.window = { dispatchEvent: dispatchEventMock };

--- a/src/node-setup.ts
+++ b/src/node-setup.ts
@@ -28,14 +28,17 @@ globalThis.IDBVersionChangeEvent = IDBVersionChangeEvent;
 // Mock other browser APIs if needed
 Object.defineProperty(globalThis, 'matchMedia', {
   writable: true,
-  value: vi.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(), // deprecated
-    removeListener: vi.fn(), // deprecated
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
+  value: vi.fn<(query: string) => MediaQueryList>().mockImplementation(
+    (query) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn<() => void>(), // deprecated
+        removeListener: vi.fn<() => void>(), // deprecated
+        addEventListener: vi.fn<() => void>(),
+        removeEventListener: vi.fn<() => void>(),
+        dispatchEvent: vi.fn<() => void>(),
+      }) as unknown as MediaQueryList,
+  ),
 });

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -3,7 +3,7 @@ import { parseSaveFile } from './engine/saveParser/index';
 import { useStore } from './store';
 
 vi.mock('./engine/saveParser/index', () => ({
-  parseSaveFile: vi.fn(),
+  parseSaveFile: vi.fn<() => ReturnType<typeof parseSaveFile>>(),
 }));
 
 describe('Zustand Store', () => {
@@ -147,11 +147,11 @@ describe('Zustand Store', () => {
 
       // valid base64 for "hello"
       vi.stubGlobal('localStorage', {
-        getItem: vi.fn().mockReturnValue('aGVsbG8='),
-        removeItem: vi.fn(),
+        getItem: vi.fn<() => string>().mockReturnValue('aGVsbG8='),
+        removeItem: vi.fn<() => void>(),
       });
       vi.stubGlobal('window', {
-        atob: vi.fn().mockReturnValue('hello'),
+        atob: vi.fn<() => string>().mockReturnValue('hello'),
       });
 
       useStore.getState().loadSaveFromStorage();
@@ -162,8 +162,8 @@ describe('Zustand Store', () => {
 
     it('should handle corrupted save file from localStorage', () => {
       // Mock localStorage to return an invalid base64 string
-      const mockGetItem = vi.fn().mockReturnValue('invalid-base64-!');
-      const mockRemoveItem = vi.fn();
+      const mockGetItem = vi.fn<() => string>().mockReturnValue('invalid-base64-!');
+      const mockRemoveItem = vi.fn<() => void>();
       vi.stubGlobal('localStorage', {
         getItem: mockGetItem,
         removeItem: mockRemoveItem,
@@ -179,9 +179,9 @@ describe('Zustand Store', () => {
     });
 
     it('should specifically catch invalid base64 regex failures', () => {
-      const mockRemoveItem = vi.fn();
+      const mockRemoveItem = vi.fn<() => void>();
       vi.stubGlobal('localStorage', {
-        getItem: vi.fn().mockReturnValue('!!!'),
+        getItem: vi.fn<() => string>().mockReturnValue('!!!'),
         removeItem: mockRemoveItem,
       });
 
@@ -205,7 +205,7 @@ describe('Persist Hydration Error Handling', () => {
     // We must reset modules to force Zustand to re-evaluate and re-hydrate
     vi.resetModules();
 
-    const mockGetItem = vi.fn().mockImplementation((key) => {
+    const mockGetItem = vi.fn<(key: string) => string | null>().mockImplementation((key) => {
       if (key === 'dexhelper-settings') {
         throw new Error('Simulated storage error');
       }
@@ -214,8 +214,8 @@ describe('Persist Hydration Error Handling', () => {
 
     vi.stubGlobal('localStorage', {
       getItem: mockGetItem,
-      setItem: vi.fn(),
-      removeItem: vi.fn(),
+      setItem: vi.fn<() => void>(),
+      removeItem: vi.fn<() => void>(),
     });
 
     // Dynamically import to trigger store creation and hydration
@@ -231,7 +231,7 @@ describe('Persist Hydration Error Handling', () => {
   it('should handle corrupted persist storage gracefully when JSON is invalid', async () => {
     vi.resetModules();
 
-    const mockGetItem = vi.fn().mockImplementation((key) => {
+    const mockGetItem = vi.fn<(key: string) => string | null>().mockImplementation((key) => {
       if (key === 'dexhelper-settings') {
         return '{ invalid json';
       }
@@ -240,8 +240,8 @@ describe('Persist Hydration Error Handling', () => {
 
     vi.stubGlobal('localStorage', {
       getItem: mockGetItem,
-      setItem: vi.fn(),
-      removeItem: vi.fn(),
+      setItem: vi.fn<() => void>(),
+      removeItem: vi.fn<() => void>(),
     });
 
     const { useStore: freshStore } = await import('./store');

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -4,14 +4,17 @@ import { vi } from 'vitest';
 // Mock other browser APIs if needed
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: vi.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(), // deprecated
-    removeListener: vi.fn(), // deprecated
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
+  value: vi.fn<(query: string) => MediaQueryList>().mockImplementation(
+    (query) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn<() => void>(), // deprecated
+        removeListener: vi.fn<() => void>(), // deprecated
+        addEventListener: vi.fn<() => void>(),
+        removeEventListener: vi.fn<() => void>(),
+        dispatchEvent: vi.fn<() => void>(),
+      }) as unknown as MediaQueryList,
+  ),
 });


### PR DESCRIPTION
What was unsafe: The codebase used `vi.fn()` mocks without explicit type parameters, missing strict type checking on mocked functions, bypassing TypeScript safety.
How it was fixed: Explicit type signatures like `vi.fn<() => void>()` were added to all mock instances across the test suite, and `"vitest/require-mock-type-parameters": "error"` was enabled in `.oxlintrc.json`.
What the compiler now catches: The compiler and linter will now throw errors if `vi.fn()` lacks generic type arguments, ensuring mocked function signatures strictly match the types they intend to mock.

---
*PR created automatically by Jules for task [7922875017554747416](https://jules.google.com/task/7922875017554747416) started by @szubster*