### PR TITLE
📜 Scribe: Documented useAssistant hook logic and API

### DIFF
--- a/src/hooks/useAssistant.ts
+++ b/src/hooks/useAssistant.ts
@@ -6,9 +6,25 @@ import { getGenerationConfig } from '../utils/generationConfig';
 
 export * from '../engine/assistant/strategies/types';
 
+/**
+ * A React hook that orchestrates the Pokémon suggestion engine.
+ * It identifies missing Pokémon, fetches necessary encounter data from IndexedDB,
+ * and generates prioritized recommendations.
+ *
+ * @param saveData - The parsed save data of the current game.
+ * @param isLivingDex - If true, evaluates "owned" based on physical storage (PC/Party) instead of Pokédex flags.
+ * @param manualVersion - An optional version override if heuristics detected the wrong game.
+ * @returns An object containing the generated suggestions, loading state, and area name mappings.
+ *
+ * @example
+ * const { suggestions, isLoading } = useAssistant(saveData, false, 'red');
+ */
 export function useAssistant(saveData: SaveData | null, isLivingDex: boolean, manualVersion?: string | null) {
   const maxDex = saveData ? getGenerationConfig(saveData.generation).maxDex : 0;
   const missingIds: number[] = [];
+
+  // If building a Living Dex, the internal Pokédex 'owned' flag isn't sufficient.
+  // We must verify the player physically possesses the Pokémon in their Party or PC.
   const ownedSet = saveData
     ? isLivingDex
       ? new Set([...saveData.party, ...saveData.pc])
@@ -18,11 +34,15 @@ export function useAssistant(saveData: SaveData | null, isLivingDex: boolean, ma
   if (saveData) {
     for (let i = 1; i <= maxDex; i++) {
       if (!ownedSet.has(i)) {
+        // Mewtwo (150) is physically inaccessible in Gen 1 until the Elite Four is defeated.
         if (saveData.generation === 1 && i === 150 && (saveData.hallOfFameCount || 0) === 0) continue;
         missingIds.push(i);
       }
     }
   }
+
+  // Limit the synchronous engine to evaluating the first 30 missing Pokémon at a time.
+  // This prevents massive batched queries to IndexedDB and keeps the UI responsive.
   const queryTargetsSlice = missingIds.slice(0, 30);
 
   const { data: apiData, isLoading: isLoadingEncounters } = useQuery({


### PR DESCRIPTION
**What:**
Added JSDoc and inline comments to `src/hooks/useAssistant.ts`.

**Why this module needed docs:**
The `useAssistant` hook coordinates the suggestion engine logic, yet some of its specific decisions (like why `ownedSet` changes logic with `isLivingDex`, why Mewtwo is hardcoded, and why `queryTargetsSlice` truncates to 30 elements) are non-obvious to future maintainers. Documenting the reasoning ensures performance and logic invariants are not broken during refactoring.

**Summary of additions:**
- Added a JSDoc block to `useAssistant` with `@param`, `@returns`, and `@example` tags.
- Added inline comment explaining `ownedSet` logic for Living Dex vs standard Pokédex.
- Added inline comment explaining the Gen 1 Mewtwo Elite Four lockout.
- Added inline comment explaining why the query payload is sliced to 30 elements for performance.

---
*PR created automatically by Jules for task [13916418890587728461](https://jules.google.com/task/13916418890587728461) started by @szubster*