### PR TITLE
🧭 Strategist: Prompt improvement - Prevent Oak from modifying Foundry DAG nodes

### DIFF
--- a/.jules/schedules/oak.md
+++ b/.jules/schedules/oak.md
@@ -34,6 +34,7 @@ All Pokémon data is pre-generated at build time and committed to the repo. The 
 - Change the data format or schema without justification
 - Modify assistant logic or UI — only data correctness
 - Fabricate Pokémon data from memory — always verify against a canonical source
+- Modify Foundry DAG nodes (`.foundry/`) or fix orchestrator metadata — "Data Integrity" refers ONLY to Pokémon game data, not project management files
 
 ## Process
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -1,3 +1,9 @@
+## 2026-06-01 - [Accepted] - Prompt improvement - Prevent Oak from modifying Foundry DAG nodes
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** Agent PR history showed Oak repeatedly fixing `jules_session_id` and parent links in `.foundry/` DAG nodes instead of doing its actual domain tasks. Oak interpreted "Data Integrity" as applying to DAG files.
+**Pattern:** When an agent's domain name (like "Data Integrity") is broad, it must explicitly exclude meta-files (like `.foundry/`) to prevent it from getting distracted by orchestrator warnings.
+
 ## 2025-04-19 - [Accepted] - New agent: Sweeper (Code Health & Tech Debt)
 **Type:** New agent
 **Outcome:** Accepted


### PR DESCRIPTION
**Proposal**: Update `oak.md` prompt to explicitly forbid modifying `.foundry/` DAG nodes.
**Justification**: The Oak agent is designed to maintain Pokémon data integrity. However, it gets distracted by orchestrator metadata warnings and erroneously attempts to fix DAG node issues (like `jules_session_id` or parent links) because it misinterprets "Data" as applying to project management files.
**Evidence**: Recent PRs show this pattern:
- `dc07071 🧪 Oak: fix missing jules_session_id in DAG nodes`
- `73aeede 🧪 Oak: [data correction] - Fix DAG resolution warnings`
- `344a692 🧪 Oak: fix missing jules_session_id and broken parent in story-010-015`
- `5bcff4b 🧪 Oak: fix missing jules_session_id and incorrect parent in foundry story`
- `8027605 🧪 Oak: add missing jules_session_id to story-010-015`
- `a6c15ed 🧬 Oak: story-010-015-enforce-strict-oxlint-rules frontmatter fix`

---
*PR created automatically by Jules for task [4244771762116273518](https://jules.google.com/task/4244771762116273518) started by @szubster*