### PR TITLE
🗃️ Archivist: Remove stale pokenode-ts reference from onboarding docs

### DIFF
--- a/.foundry/docs/knowledge_base/onboarding/project_overview.md
+++ b/.foundry/docs/knowledge_base/onboarding/project_overview.md
@@ -8,7 +8,7 @@
 - **Styling**: Tailwind CSS 4, Vanilla CSS, Lucide React (Icons), clsx & tailwind-merge.
 - **State Management**: Zustand.
 - **Routing**: TanStack React Router.
-- **Data Fetching**: TanStack React Query & `pokenode-ts`.
+- **Data Fetching**: TanStack React Query.
 - **Testing**:
   - **Unit Tests**: Vitest.
   - **E2E Tests (Primary)**: Playwright (E2E-first strategy).

--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -24,3 +24,8 @@
 
 **Learning:** Keeping the single most impactful cleanup as the core focus is critical to respect boundaries.
 **Action:** Found that `jules_agents_dispatch.md` had an outdated list of agents. Updated it to properly reflect the 13 agents deployed, instead of 11.
+
+## 2026-04-26 - Archivist Run Learnings
+
+**Learning:** When refactoring drops a dependency (like `pokenode-ts`), references to it often persist in onboarding documents, creating an inaccurate view of the tech stack.
+**Action:** Routinely search onboarding and project overview documents for deprecated dependencies after a major migration.


### PR DESCRIPTION
**What was stale/wrong**:
The `.foundry/docs/knowledge_base/onboarding/project_overview.md` file listed `pokenode-ts` under "Data Fetching". However, `pokenode-ts` is no longer a project dependency (it was removed in an earlier refactor towards offline modernization), making this reference inaccurate.

**How it was verified**:
- Verified `package.json` does not contain `pokenode-ts`.
- Verified `src/` does not import or use `pokenode-ts`.
- Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no agent workflows or code relies on it.

**What was removed/updated**:
- Removed the `& pokenode-ts` text from the Data Fetching bullet point in `.foundry/docs/knowledge_base/onboarding/project_overview.md`.
- Appended a journal entry in `.jules/archivist.md` noting to check onboarding documents for removed dependencies after major refactors.

---
*PR created automatically by Jules for task [9822141611650811148](https://jules.google.com/task/9822141611650811148) started by @szubster*