### PR TITLE
🎨 Palette: Add focus-visible states to evolution navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,6 @@
 ## 2026-04-24 - Focus Visible on Modal and Custom Action Buttons
 **Learning:** Several custom action buttons in modals (like the Close buttons in `SettingsModal` and `PokemonDetails`, Confirmation buttons in `ClearStorageButton`, and choice selectors in `VersionModal`) were missing standard `focus-visible` styles, leading to poor keyboard navigation visibility.
 **Action:** Always ensure that every custom button, regardless of its context (modals, overlays, inline prompts), includes the standard focus indicator utility classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` or a context-appropriate color variant like `ring-red-500` for destructive actions).
+## 2026-04-26 - Focus Visible Styles for Evolution Links
+**Learning:** Inline buttons functioning as text links within complex components like `PokemonEvolutions` can easily miss standard focus indicators, hiding keyboard navigation state.
+**Action:** Always ensure inline text buttons acting as navigation links include standard focus utilities (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 rounded-sm`) so they are clearly perceivable when navigating via keyboard.

--- a/src/components/pokemon/details/PokemonEvolutions.tsx
+++ b/src/components/pokemon/details/PokemonEvolutions.tsx
@@ -63,7 +63,7 @@ function ProcurementStrategy({
             <button
               type="button"
               onClick={() => onNavigate(evoReq.fromId, evoReq.fromName)}
-              className="text-red-400 underline decoration-red-500/30 underline-offset-4 transition-colors hover:text-white"
+              className="rounded-sm text-red-400 underline decoration-red-500/30 underline-offset-4 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
               Evolving {evoReq.fromName.toUpperCase()}
             </button>
@@ -118,7 +118,7 @@ function EvolutionFrom({
         <button
           type="button"
           onClick={() => onNavigate(evoReq.fromId, evoReq.fromName)}
-          className="text-white underline decoration-purple-500/30 underline-offset-4 transition-colors hover:text-purple-400"
+          className="rounded-sm text-white underline decoration-purple-500/30 underline-offset-4 transition-colors hover:text-purple-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
           {evoReq.fromName.toUpperCase()}
         </button>
@@ -159,7 +159,7 @@ function EvolutionTo({
             <button
               type="button"
               onClick={() => onNavigate(evo.id, evo.name)}
-              className="text-white underline decoration-blue-500/30 underline-offset-4 transition-colors hover:text-blue-400"
+              className="rounded-sm text-white underline decoration-blue-500/30 underline-offset-4 transition-colors hover:text-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
               {evo.name.toUpperCase()}
             </button>
@@ -196,7 +196,7 @@ function BreedingProtocol({
                 const id = breedingInfo.parentIds[i];
                 if (id) onNavigate(id, name);
               }}
-              className="text-white underline decoration-pink-500/30 underline-offset-4 transition-colors hover:text-pink-400"
+              className="rounded-sm text-white underline decoration-pink-500/30 underline-offset-4 transition-colors hover:text-pink-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
               {name.toUpperCase()}
             </button>


### PR DESCRIPTION
### 🎯 What
Added `focus-visible` states to the inline navigation buttons inside `PokemonEvolutions.tsx`.

### 💡 Why
These buttons acts as links to navigate between related Pokemon in the `PokemonDetails` view. However, they were missing proper focus rings, making keyboard navigation difficult.

### 📸 Before/After
Before: Keyboard navigation via Tab would focus these elements without any visual indicator.
After: Keyboard navigation properly displays the standard `[var(--theme-primary)]` colored focus ring.

### ♿ Accessibility notes
Improves keyboard navigation visibility by ensuring interactive elements have a clear focus state using standard design system focus utilities.

---
*PR created automatically by Jules for task [2680002142626843844](https://jules.google.com/task/2680002142626843844) started by @szubster*