### PR TITLE
🔒 Shield: Migrate save file storage to IndexedDB

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -6,3 +6,6 @@
 
 ## IndexedDB Save Storage
 **Pattern:** The `window.atob` Base64 decoder is insecure. Instead of doing base64 serialization with handwritten code, or installing base-64 dependencies, the save file storage logic should be migrated completely to `IndexedDB` which natively supports ArrayBuffers and avoids this issue altogether.
+
+## IndexedDB Migration Correctness
+**Pattern:** When migrating localStorage usage to IndexedDB (`saveDB`), remember to update all test implementations and type boundaries. If using `saveDB` methods like `.getSave()`, they return promises and must be `await`ed. Ensure any `ArrayBufferLike` conversion logic accurately casts using `as ArrayBuffer` if TypeScript strictness complains about `SharedArrayBuffer` incompatibilities.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router';
 import { AlertTriangle, LayoutGrid, RefreshCw, Settings2, Sparkles, Upload, Zap } from 'lucide-react';
 import type React from 'react';
 import { useEffect } from 'react';
+import { saveDB } from '../db/SaveDB';
 import { parseSaveFile } from '../engine/saveParser/index';
 import { useStore } from '../store';
 import { cn } from '../utils/cn';
@@ -56,13 +57,8 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           setManualVersion(null);
         }
 
-        let binary = '';
         const bytes = new Uint8Array(buffer);
-        const len = bytes.byteLength;
-        for (let i = 0; i < len; i++) {
-          binary += String.fromCharCode(bytes[i] ?? 0);
-        }
-        localStorage.setItem('last_save_file', window.btoa(binary));
+        void saveDB.putSave('last_save_file', bytes);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Failed to parse save file.';
         setError(message);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,4 +1,5 @@
 import { X } from 'lucide-react';
+import { saveDB } from '../db/SaveDB';
 import { useStore } from '../store';
 import { getGenerationConfig, POKEBALL_LABELS } from '../utils/generationConfig';
 import { ClearStorageButton } from './settings/ClearStorageButton';
@@ -66,8 +67,8 @@ export function SettingsModal() {
             genConfig={genConfig}
           />
           <ClearStorageButton
-            onClear={() => {
-              localStorage.removeItem('last_save_file');
+            onClear={async () => {
+              await saveDB.deleteSave('last_save_file');
               setSaveData(null);
               setManualVersion(null);
               setIsSettingsOpen(false);

--- a/src/db/SaveDB.ts
+++ b/src/db/SaveDB.ts
@@ -4,7 +4,7 @@ const SAVE_DB_NAME = 'SaveDB';
 const SAVE_DB_VERSION = 1;
 const STORE_NAME = 'saves';
 
-export interface SaveDBSchema extends DBSchema {
+interface SaveDBSchema extends DBSchema {
   [STORE_NAME]: {
     key: string;
     value: Uint8Array;

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { saveDB } from './db/SaveDB';
 import { parseSaveFile } from './engine/saveParser/index';
 import { useStore } from './store';
 
 vi.mock('./engine/saveParser/index', () => ({
   parseSaveFile: vi.fn(),
+}));
+
+vi.mock('./db/SaveDB', () => ({
+  saveDB: {
+    getSave: vi.fn(),
+    putSave: vi.fn(),
+    deleteSave: vi.fn(),
+  },
 }));
 
 describe('Zustand Store', () => {
@@ -141,56 +150,32 @@ describe('Zustand Store', () => {
       expect(useStore.getState().error).toBeNull();
     });
 
-    it('should load a valid base64 save from storage successfully', () => {
+    it('should load a valid save from storage successfully', async () => {
       const mockSaveData = { trainerName: 'ASH', generation: 1, gameVersion: 'red' };
       vi.mocked(parseSaveFile).mockReturnValue(mockSaveData as unknown as ReturnType<typeof parseSaveFile>);
+      const mockBytes = new Uint8Array([1, 2, 3]);
+      vi.mocked(saveDB.getSave).mockResolvedValue(mockBytes);
 
-      // valid base64 for "hello"
-      vi.stubGlobal('localStorage', {
-        getItem: vi.fn().mockReturnValue('aGVsbG8='),
-        removeItem: vi.fn(),
-      });
-      vi.stubGlobal('window', {
-        atob: vi.fn().mockReturnValue('hello'),
-      });
+      await useStore.getState().loadSaveFromStorage();
 
-      useStore.getState().loadSaveFromStorage();
-
+      expect(saveDB.getSave).toHaveBeenCalledWith('last_save_file');
       expect(parseSaveFile).toHaveBeenCalled();
       expect(useStore.getState().saveData).toEqual(mockSaveData);
     });
 
-    it('should handle corrupted save file from localStorage', () => {
-      // Mock localStorage to return an invalid base64 string
-      const mockGetItem = vi.fn().mockReturnValue('invalid-base64-!');
-      const mockRemoveItem = vi.fn();
-      vi.stubGlobal('localStorage', {
-        getItem: mockGetItem,
-        removeItem: mockRemoveItem,
+    it('should handle corrupted save file from storage', async () => {
+      const mockBytes = new Uint8Array([1, 2, 3]);
+      vi.mocked(saveDB.getSave).mockResolvedValue(mockBytes);
+      vi.mocked(parseSaveFile).mockImplementation(() => {
+        throw new Error('Parse error');
       });
 
       const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-      useStore.getState().loadSaveFromStorage();
-
-      // Verify that it caught the error, logged it, and removed the corrupted item
-      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file');
-      expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
-    });
-
-    it('should specifically catch invalid base64 regex failures', () => {
-      const mockRemoveItem = vi.fn();
-      vi.stubGlobal('localStorage', {
-        getItem: vi.fn().mockReturnValue('!!!'),
-        removeItem: mockRemoveItem,
-      });
-
-      const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      useStore.getState().loadSaveFromStorage();
+      await useStore.getState().loadSaveFromStorage();
 
       expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file');
-      expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
+      expect(saveDB.deleteSave).toHaveBeenCalledWith('last_save_file');
     });
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { saveDB } from './db/SaveDB';
 import type { GameVersion as GameVersionType, SaveData } from './engine/saveParser/index';
 import { parseSaveFile } from './engine/saveParser/index';
 
@@ -75,11 +76,11 @@ interface AppStore {
 
   // Actions
   /**
-   * Rehydrates `saveData` from a base64 encoded `last_save_file` in localStorage.
+   * Rehydrates `saveData` from `last_save_file` in IndexedDB.
    * Invariant: If the data is corrupted or parsing fails, the cached file is immediately
    * deleted to prevent infinite crash loops on subsequent reloads.
    */
-  loadSaveFromStorage: () => void;
+  loadSaveFromStorage: () => Promise<void>;
 }
 
 // ─── Store ───────────────────────────────────────────────────────────
@@ -125,26 +126,16 @@ export const useStore = create<AppStore>()(
       filtersSet: () => new Set(get().filters),
 
       // Actions
-      loadSaveFromStorage: () => {
-        const savedFile = localStorage.getItem('last_save_file');
-        if (savedFile) {
+      loadSaveFromStorage: async () => {
+        const bytes = await saveDB.getSave('last_save_file');
+        if (bytes) {
           try {
-            const base64Regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
-            if (!base64Regex.test(savedFile)) {
-              throw new Error('Invalid Base64 string');
-            }
-            const binaryString = window.atob(savedFile);
-            const len = binaryString.length;
-            const bytes = new Uint8Array(len);
-            for (let i = 0; i < len; i++) {
-              bytes[i] = binaryString.charCodeAt(i);
-            }
             const { manualVersion } = get();
-            const data = parseSaveFile(bytes.buffer, manualVersion || undefined);
+            const data = parseSaveFile(bytes.buffer as ArrayBuffer, manualVersion || undefined);
             set({ saveData: data });
           } catch {
             console.error('Failed to load saved file');
-            localStorage.removeItem('last_save_file');
+            await saveDB.deleteSave('last_save_file');
           }
         }
       },


### PR DESCRIPTION
🎯 What: Migrated save file storage from Base64 encoded string in `localStorage` to `Uint8Array` in `IndexedDB`.
⚠️ Risk: Base64 encoding using `window.atob`/`window.btoa` can be vulnerable and base64 usage takes up significant `localStorage` quota memory.
🛡️ Solution: Relying on IndexedDB via `saveDB` eliminates Base64 usage and mitigates the risk, while also avoiding potential `localStorage` quota limitations.

---
*PR created automatically by Jules for task [12709191367210894754](https://jules.google.com/task/12709191367210894754) started by @szubster*