### PR TITLE
🔧 Task: Enable oxlint jest/no-conditional-expect

### DIFF
--- a/.foundry/tasks/task-015-038-oxlint-jest-no-conditional-expect.md
+++ b/.foundry/tasks/task-015-038-oxlint-jest-no-conditional-expect.md
@@ -17,6 +17,6 @@ parent: ".foundry/stories/story-010-015-enforce-strict-oxlint-rules.md"
 As part of story `story-010-015-enforce-strict-oxlint-rules`, we are re-enabling strict oxlint rules that were temporarily disabled. This task focuses on `jest/no-conditional-expect`.
 
 ## Instructions
-1. In `.oxlintrc.json`, change `"jest/no-conditional-expect": "off"` to `"jest/no-conditional-expect": "error"`.
-2. Run `pnpm exec oxlint .` to identify violations.
-3. Fix all violations by refactoring tests to avoid conditional `expect()` calls.
+- [x] 1. In `.oxlintrc.json`, change `"jest/no-conditional-expect": "off"` to `"jest/no-conditional-expect": "error"`.
+- [x] 2. Run `pnpm exec oxlint .` to identify violations.
+- [x] 3. Fix all violations by refactoring tests to avoid conditional `expect()` calls.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,7 +17,7 @@
     "jest/no-standalone-expect": "off",
     "jest/expect-expect": "off",
     "jest/no-disabled-tests": "off",
-    "jest/no-conditional-expect": "off",
+    "jest/no-conditional-expect": "error",
     "react-hooks/exhaustive-deps": "off"
   },
   "env": {

--- a/src/engine/saveParser/index.test.ts
+++ b/src/engine/saveParser/index.test.ts
@@ -226,7 +226,8 @@ describe('saveParser - Error Handling and Fallbacks', () => {
     } as unknown as typeof DataView;
 
     try {
-      expect(() => parseSaveFile(buffer.buffer)).toThrow('The save file is corrupted or incomplete.');
+      const fn = () => parseSaveFile(buffer.buffer);
+      expect(fn).toThrow('The save file is corrupted or incomplete.');
     } finally {
       global.DataView = originalDataView;
     }


### PR DESCRIPTION
🎯 What
Enabled the strict oxlint rule `jest/no-conditional-expect` and fixed existing violations.

💡 Why
As part of story `story-010-015-enforce-strict-oxlint-rules`, we are re-enabling strict oxlint rules that were temporarily disabled. This PR resolves the task `task-015-038-oxlint-jest-no-conditional-expect`.

---
*PR created automatically by Jules for task [5653916609207142458](https://jules.google.com/task/5653916609207142458) started by @szubster*