### PR TITLE
🛠️ Infras: Enable Playwright parallelism

### DIFF
--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -18,3 +18,6 @@
 
 ## 2026-04-24 - Enabled TypeScript Incremental Builds
 **Learning:** Enabled `"incremental": true` in the base `tsconfig.json` to significantly improve local `pnpm type-check` performance (reducing run time from ~14s to ~4s on subsequent runs). This provides a massive developer experience improvement for local pre-commit hooks, allowing the system to maintain full project type safety (as originally desired) without the painful delay of a complete rebuild every time. Added `*.tsbuildinfo` to `.gitignore` to prevent cache file pollution.
+
+## 2026-04-26 - Enabled Playwright Parallelism
+**Learning:** Updated `playwright.config.ts` to allow multiple workers (`workers: process.env['CI'] ? 2 : '50%'`) instead of the hardcoded `1` worker. This unblocks Playwright's concurrency capabilities, drastically speeding up E2E test suite execution time both locally and in CI. Additionally, confirmed that caching `.tsbuildinfo` in CI is actively rejected by the user, as the incremental build cache is strictly intended for local development performance.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env['CI'],
   retries: process.env['CI'] ? 2 : 0,
-  workers: 1,
+  workers: process.env['CI'] ? 2 : '50%',
   reporter: [
     ['html', { open: 'never' }],
     ['@argos-ci/playwright/reporter', {


### PR DESCRIPTION
**What**
Updated `playwright.config.ts` to allow multiple workers (defaults to `50%` locally which uses 50% of CPU cores, and `2` in CI).

**Why**
The config was hardcoded to `workers: 1`, which bottlenecked the test runner and forced tests to run sequentially despite `fullyParallel: true`. Allowing concurrent execution significantly reduces E2E test suite execution time for developers and the CI pipeline.

**Impact on DX/CI**
Local E2E test runs will be significantly faster utilizing multiple cores. CI run times for the `playwright` action will also decrease, improving pipeline throughput.

**Setup notes**
No additional setup needed. Playwright will automatically distribute tests across available workers.

---
*PR created automatically by Jules for task [1391216549928367962](https://jules.google.com/task/1391216549928367962) started by @szubster*