### PR TITLE
feat: implement ID validation pre-commit hook

### DIFF
--- a/.foundry/tasks/task-022-039-implement-id-validation-hook.md
+++ b/.foundry/tasks/task-022-039-implement-id-validation-hook.md
@@ -17,11 +17,11 @@ parent: .foundry/stories/story-006-022-implement-id-validation-hook.md
 As specified in `story-006-022`, we need to implement a pre-commit hook that validates the `.foundry/**/*.md` file IDs according to the Parent-Linked schema. This ensures our autonomous multi-agent system doesn't generate corrupted nodes or ID collisions.
 
 ## Acceptance Criteria
-- [ ] Create a Node.js script at `scripts/validate-foundry-ids.ts`.
-- [ ] The script must read all `.md` files in `.foundry/` except those in `docs/` and `journals/`.
-- [ ] Parse the YAML frontmatter of each file and extract the `id`.
-- [ ] Validate that the `id` field matches the schema:
+- [x] Create a Node.js script at `scripts/validate-foundry-ids.ts`.
+- [x] The script must read all `.md` files in `.foundry/` except those in `docs/` and `journals/`.
+- [x] Parse the YAML frontmatter of each file and extract the `id`.
+- [x] Validate that the `id` field matches the schema:
   - For `IDEA` nodes: `^idea-\d{3}-[a-z0-9-]+$`
   - For all other nodes: `^(prd|epic|story|task)-\d{3}-\d{3}-[a-z0-9-]+$` (Note: non-IDEA parentless nodes use `000` for the parent NNN segment).
-- [ ] Verify that every extracted `id` is globally unique within the parsed files (throw an error if a duplicate is found).
-- [ ] Add a `validate-foundry-ids` command to `lefthook.yml` under `pre-commit` to run this script. Ensure it runs unconditionally on pre-commit.
+- [x] Verify that every extracted `id` is globally unique within the parsed files (throw an error if a duplicate is found).
+- [x] Add a `validate-foundry-ids` command to `lefthook.yml` under `pre-commit` to run this script. Ensure it runs unconditionally on pre-commit.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,8 @@
 pre-commit:
   parallel: true
   commands:
+    validate-foundry-ids:
+      run: node --experimental-strip-types scripts/validate-foundry-ids.ts
     link-checker:
       run: node --experimental-strip-types scripts/check-links.ts {staged_files}
     biome-check:

--- a/scripts/validate-foundry-ids.ts
+++ b/scripts/validate-foundry-ids.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function getFiles(dir: string, fileList: string[] = []): string[] {
+  const files = fs.readdirSync(dir);
+  for (const file of files) {
+    const stat = fs.statSync(path.join(dir, file));
+    if (stat.isDirectory()) {
+      getFiles(path.join(dir, file), fileList);
+    } else {
+      fileList.push(path.join(dir, file));
+    }
+  }
+  return fileList;
+}
+
+function validateIds() {
+  const foundryDir = path.resolve('.foundry');
+  if (!fs.existsSync(foundryDir)) {
+    console.error('No .foundry directory found.');
+    process.exit(0);
+  }
+
+  const allFiles = getFiles(foundryDir);
+  const targetFiles = allFiles.filter(file => {
+    if (!file.endsWith('.md')) return false;
+    const relativePath = path.relative(foundryDir, file);
+    const normalizedRelative = relativePath.split(path.sep).join('/');
+    if (normalizedRelative.startsWith('docs/')) return false;
+    if (normalizedRelative.startsWith('journals/')) return false;
+    return true;
+  });
+
+  const ids = new Set<string>();
+  let hasError = false;
+
+  const ideaRegex = /^idea-\d{3}-[a-z0-9-]+$/;
+  const otherRegex = /^(prd|epic|story|task)-\d{3}-\d{3}-[a-z0-9-]+$/;
+
+  for (const file of targetFiles) {
+    const content = fs.readFileSync(file, 'utf-8');
+    const idMatch = content.match(/^id:\s*"?([^"\n]+)"?/m);
+
+    if (idMatch && idMatch[1]) {
+      const id = idMatch[1].trim();
+
+      if (ids.has(id)) {
+        console.error(`Error: Duplicate ID found: ${id} in file ${file}`);
+        hasError = true;
+      }
+      ids.add(id);
+
+      if (id.startsWith('idea-')) {
+        if (!ideaRegex.test(id)) {
+          console.error(`Error: Invalid ID format for IDEA node: ${id} in file ${file}`);
+          hasError = true;
+        }
+      } else {
+        if (!otherRegex.test(id)) {
+          console.error(`Error: Invalid ID format for node: ${id} in file ${file}`);
+          hasError = true;
+        }
+      }
+    } else {
+      console.error(`Error: No ID found in frontmatter of file ${file}`);
+      hasError = true;
+    }
+  }
+
+  if (hasError) {
+    process.exit(1);
+  } else {
+    console.log('All Foundry IDs are valid.');
+  }
+}
+
+validateIds();


### PR DESCRIPTION
Implements `task-022-039-implement-id-validation-hook`.

This PR introduces a new script `scripts/validate-foundry-ids.ts` that enforces the Foundry ID schema across all node files (except `docs` and `journals`). It reads the `id` field from the YAML frontmatter, verifies the string format matches the Parent-Linked schema (including special casing for `IDEA` nodes), and checks for duplicate IDs across the entire dataset.

The script is wired up via `lefthook.yml` to run unconditionally during pre-commit. Acceptance criteria for the task node have been marked as completed.

---
*PR created automatically by Jules for task [7691326975112194223](https://jules.google.com/task/7691326975112194223) started by @szubster*