### PR TITLE
feat: draft task for single owner validation in orchestrator

### DIFF
--- a/.foundry/stories/story-008-023-validate-single-owner.md
+++ b/.foundry/stories/story-008-023-validate-single-owner.md
@@ -20,3 +20,5 @@ To enforce Atomic Handoffs, the orchestrator script must explicitly reject or er
 - [ ] The orchestrator script explicitly checks the `owner_persona` field of each node.
 - [ ] If `owner_persona` is an array or contains multiple personas, the orchestrator logs an error and skips or rejects the node.
 - [ ] Tests are added to verify this validation logic.
+
+- [x] Task created for implementation: `.foundry/tasks/task-023-041-implement-single-owner-validation.md`

--- a/.foundry/tasks/task-023-041-implement-single-owner-validation.md
+++ b/.foundry/tasks/task-023-041-implement-single-owner-validation.md
@@ -1,0 +1,29 @@
+---
+id: "task-023-041-implement-single-owner-validation"
+type: "TASK"
+title: "Implement single owner validation in orchestrator"
+status: PENDING
+owner_persona: "coder"
+created_at: "2026-04-26"
+updated_at: "2026-04-26"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/stories/story-008-023-validate-single-owner.md"
+---
+
+# Implement single owner validation in orchestrator
+
+## Context
+To enforce Atomic Handoffs, the orchestrator script must explicitly reject or error on files defining multiple `owner_persona`s.
+
+## Constraints & Directives
+- Modify `.github/scripts/foundry-orchestrator.ts` to validate the `owner_persona` field in the node's frontmatter.
+- If `owner_persona` is an array or contains multiple personas (e.g., separated by commas), log an error and skip/reject the node.
+- Write tests in `.github/scripts/foundry-orchestrator.test.ts` to verify the new validation logic.
+- Self-verify the changes (no separate QA task required).
+
+## Acceptance Criteria
+- [ ] `.github/scripts/foundry-orchestrator.ts` validates `owner_persona`.
+- [ ] Nodes with multiple owners log an error and are skipped.
+- [ ] Tests verify the single owner validation logic.
+- [ ] Self-verification completed successfully.


### PR DESCRIPTION
Created a technical blueprint (`task-023-041-implement-single-owner-validation`) to enforce Atomic Handoffs by validating the `owner_persona` field in the Foundry orchestrator. Updated the parent story node (`story-008-023-validate-single-owner`) to reference the newly created task without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [11237409449898581042](https://jules.google.com/task/11237409449898581042) started by @szubster*