### PR TITLE
QA: Wait & Wake logic in Orchestrator (Task 016-031)

### DIFF
--- a/.foundry/tasks/task-016-031-qa-wait-wake.md
+++ b/.foundry/tasks/task-016-031-qa-wait-wake.md
@@ -19,6 +19,6 @@ parent: ".foundry/stories/story-011-016-wait-wake-implementation.md"
 Verify the Wait & Wake orchestration logic implemented in `.github/scripts/foundry-orchestrator.ts`. Write test suites in `.github/scripts/foundry-orchestrator.test.ts` to cover the `ACTIVE` -> `PENDING` state transition.
 
 ## Acceptance Criteria
-- [ ] Add a test that verifies an `ACTIVE` node transitions to `PENDING` when a new incomplete dependency is added to its `depends_on` array.
-- [ ] Add a test that verifies a `PENDING` parent node transitions to `READY` when its new dependency is `COMPLETED` (the Wake condition).
-- [ ] All tests pass successfully.
+- [x] Add a test that verifies an `ACTIVE` node transitions to `PENDING` when a new incomplete dependency is added to its `depends_on` array.
+- [x] Add a test that verifies a `PENDING` parent node transitions to `READY` when its new dependency is `COMPLETED` (the Wake condition).
+- [x] All tests pass successfully.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -513,6 +513,62 @@ jules_session_id: null
     expect(result).toContain('status: ACTIVE');
   });
 
+
+  test('Wait and Wake: Wakes PENDING node to READY if new dependency is COMPLETED', () => {
+    createNode('.foundry/tasks/task-complete.md', `id: task-complete
+type: TASK
+title: "Complete Task"
+status: COMPLETED
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null`);
+
+    createNode('.foundry/tasks/task-pending.md', `id: task-pending
+type: TASK
+title: "Pending Task"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: [".foundry/tasks/task-complete.md"]
+jules_session_id: null`);
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-pending.md'), 'utf-8');
+    expect(result).toContain('status: READY');
+  });
+
+
+  test('Wait and Wake: ACTIVE node transitions to PENDING when new incomplete dependency is added', () => {
+    createNode('.foundry/tasks/task-incomplete.md', `id: task-incomplete
+type: TASK
+title: "Incomplete Task"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null`);
+
+    createNode('.foundry/tasks/task-active.md', `id: task-active
+type: TASK
+title: "Active Task"
+status: ACTIVE
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: [".foundry/tasks/task-incomplete.md"]
+jules_session_id: "session-123"`);
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-active.md'), 'utf-8');
+    expect(result).toContain('status: PENDING');
+  });
+
   test('Impossible Loop: wakes up parent if impossible child is FAILED with rejection_reason', () => {
     createNode('.foundry/stories/story-001.md', `
 id: story-001


### PR DESCRIPTION
**What**
- Added a test verifying that an `ACTIVE` node transitions to `PENDING` when a new incomplete dependency is added to its `depends_on` array.
- Added a test verifying that a `PENDING` parent node transitions to `READY` when its new dependency is `COMPLETED`.
- Checked off completion on `task-016-031-qa-wait-wake.md`.

**Why**
- To properly assert the Foundry Orchestrator handles the "Wait & Wake" cycle for DAG jobs that become temporarily blocked by newly spawned dependencies (the human-in-the-loop expansion / delayed evaluation mechanic).

**Verification**
- Executed local tests with `pnpm test .github/scripts/foundry-orchestrator.test.ts`, all orchestrator suites pass successfully.
- Ran project full test suite to guarantee zero side effects.

---
*PR created automatically by Jules for task [6506187454819549743](https://jules.google.com/task/6506187454819549743) started by @szubster*