### PR TITLE
🔐 Implement single owner validation in orchestrator

### DIFF
--- a/.foundry/tasks/task-023-041-implement-single-owner-validation.md
+++ b/.foundry/tasks/task-023-041-implement-single-owner-validation.md
@@ -23,7 +23,7 @@ To enforce Atomic Handoffs, the orchestrator script must explicitly reject or er
 - Self-verify the changes (no separate QA task required).
 
 ## Acceptance Criteria
-- [ ] `.github/scripts/foundry-orchestrator.ts` validates `owner_persona`.
-- [ ] Nodes with multiple owners log an error and are skipped.
-- [ ] Tests verify the single owner validation logic.
-- [ ] Self-verification completed successfully.
+- [x] `.github/scripts/foundry-orchestrator.ts` validates `owner_persona`.
+- [x] Nodes with multiple owners log an error and are skipped.
+- [x] Tests verify the single owner validation logic.
+- [x] Self-verification completed successfully.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -120,6 +120,46 @@ pr_number: null
     expect(JSON.parse(lastCall)).toHaveLength(0);
   });
 
+  test('Validation: skips nodes with multiple owners (comma separated)', () => {
+    createNode('.foundry/tasks/task-multi-owner.md', `id: task-multi-owner
+type: TASK
+title: "Task with multiple owners"
+status: PENDING
+owner_persona: "coder, qa"
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null`);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    main();
+
+    expect(logSpy).toHaveBeenCalled();
+    const lastCall = logSpy.mock.calls[logSpy.mock.calls.length - 1][0];
+    expect(JSON.parse(lastCall)).toHaveLength(0);
+  });
+
+  test('Validation: skips nodes with array owners', () => {
+    createNode('.foundry/tasks/task-array-owner.md', `id: task-array-owner
+type: TASK
+title: "Task with array owners"
+status: PENDING
+owner_persona:
+  - coder
+  - qa
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null`);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    main();
+
+    expect(logSpy).toHaveBeenCalled();
+    const lastCall = logSpy.mock.calls[logSpy.mock.calls.length - 1][0];
+    expect(JSON.parse(lastCall)).toHaveLength(0);
+  });
+
   test('Resilience: skips malformed YAML gracefully', () => {
     const filePath = path.join(tmpDir, '.foundry/epics/bad-node.md');
     fs.writeFileSync(filePath, `---\nid: bad\nstatus: PENDING\n---`, 'utf-8'); // Missing required fields

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -212,6 +212,12 @@ function parseNodeFile(filePath: string, repoRoot: string): ParsedNode | null {
     return null;
   }
 
+  // Validate owner_persona is a single string (not array, no commas).
+  if (typeof fm.owner_persona !== 'string' || fm.owner_persona.includes(',')) {
+    warn(`Multiple owner_personas detected in: ${repoPath} — skipping`);
+    return null;
+  }
+
   return {
     filePath,
     repoPath,


### PR DESCRIPTION
Add validation to orchestrator script to enforce single owner for atomic handoffs. If `owner_persona` contains multiple personas (e.g. separated by comma or array), it skips the node. Added test cases to verify.

---
*PR created automatically by Jules for task [6747783012420628316](https://jules.google.com/task/6747783012420628316) started by @szubster*