### PR TITLE
test: add test for orchestrator PR merge transition

### DIFF
--- a/.foundry/tasks/task-024-041-update-status-on-merge.md
+++ b/.foundry/tasks/task-024-041-update-status-on-merge.md
@@ -21,6 +21,6 @@ As defined in Story 008-024, the orchestrator/heartbeat must correctly identify 
 While looking at `.github/scripts/foundry-heartbeat.ts` and its test, there is already an implementation for checking if a PR is merged (`pr.merged` and fetching from GitHub API if undefined) and it invokes `transitionNodeToCompleted`. Your task is to verify if there is any bug in the implementation preventing nodes from being transitioned to `COMPLETED` upon PR merge. Review `foundry-heartbeat.ts` and `foundry-heartbeat.test.ts`. If there are any bugs, fix them. If the implementation is already fully working, verify the tests cover this feature, run the tests to confirm, and check off the acceptance criteria.
 
 ## Acceptance Criteria
-- [ ] The GitHub Action workflow or orchestrator script correctly identifies when a PR is merged.
-- [ ] The node associated with the merged PR is transitioned to `COMPLETED` status.
-- [ ] Tests verify that the node status updates correctly upon PR merge.
+- [x] The GitHub Action workflow or orchestrator script correctly identifies when a PR is merged.
+- [x] The node associated with the merged PR is transitioned to `COMPLETED` status.
+- [x] Tests verify that the node status updates correctly upon PR merge.

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -189,6 +189,49 @@ describe('Foundry Heartbeat', () => {
     expect(fs.writeFileSync).not.toHaveBeenCalledWith(expect.any(String), expect.stringContaining('status: "FAILED"'), expect.any(String));
   });
 
+  it('should transition a node to COMPLETED if PR from Jules session link is merged', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: 'session-pr-link'
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: "session-pr-link"\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    globalFetch.mockImplementation((url) => {
+      if (url.includes('jules.googleapis.com')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            state: 'COMPLETED',
+            outputs: [{ pullRequest: { url: 'https://github.com/szubster/dexhelper/pull/402' } }]
+          })
+        });
+      }
+      if (url.includes('pulls/402')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ number: 402, state: 'closed', merged: true })
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+    });
+
+    await main();
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(writeCall[1]).toContain('status: "COMPLETED"');
+  });
+
   it('should find PR from fallback list and NOT transition to FAILED', async () => {
     const mockNode = {
       filePath: '/mock/repo/.foundry/tasks/task-1.md',


### PR DESCRIPTION
Adds test coverage to `.github/scripts/foundry-heartbeat.test.ts` to assert that nodes transition to `COMPLETED` when their associated Pull Request from a Jules session is merged. Updates the corresponding `task-024-041-update-status-on-merge.md` to check off acceptance criteria. No source changes were necessary as the actual implementation correctly transitions merged PRs by querying the detail API when `isMerged` is undefined in list queries.

---
*PR created automatically by Jules for task [8222136041464651265](https://jules.google.com/task/8222136041464651265) started by @szubster*