### PR TITLE
Check off acceptance criteria for task-022-040-qa-id-validation-hook

### DIFF
--- a/.foundry/tasks/task-022-040-qa-id-validation-hook.md
+++ b/.foundry/tasks/task-022-040-qa-id-validation-hook.md
@@ -18,7 +18,7 @@ parent: .foundry/stories/story-006-022-implement-id-validation-hook.md
 The coder has implemented a pre-commit hook to validate the global uniqueness and format of Foundry IDs. We need to verify that this script works as expected and correctly halts commits on failure.
 
 ## Acceptance Criteria
-- [ ] Temporarily create a dummy node with an invalid ID format (e.g., `task-abc-123.md` or missing sequence numbers) and verify the script fails.
-- [ ] Temporarily duplicate an existing ID in a different node file and verify the global uniqueness check fails.
-- [ ] Verify that running `pnpm lefthook run pre-commit` executes the new check and fails correctly.
-- [ ] Remove any temporary dummy nodes/changes before completing the task.
+- [x] Temporarily create a dummy node with an invalid ID format (e.g., `task-abc-123.md` or missing sequence numbers) and verify the script fails.
+- [x] Temporarily duplicate an existing ID in a different node file and verify the global uniqueness check fails.
+- [x] Verify that running `pnpm lefthook run pre-commit` executes the new check and fails correctly.
+- [x] Remove any temporary dummy nodes/changes before completing the task.


### PR DESCRIPTION
Checked off the completed Acceptance Criteria for `task-022-040-qa-id-validation-hook.md` after verifying the pre-commit script properly halts commits containing bad IDs or duplicates.

---
*PR created automatically by Jules for task [760231929485073371](https://jules.google.com/task/760231929485073371) started by @szubster*