### PR TITLE
refactor: implement TacticalCard base component

### DIFF
--- a/.foundry/tasks/task-007-043-tactical-card-refactor.md
+++ b/.foundry/tasks/task-007-043-tactical-card-refactor.md
@@ -31,6 +31,6 @@ Abstract the core `TacticalCard` component from `PokedexCard` and `StorageGrid` 
    - Replace the custom card implementations in `StorageGrid` with `TacticalCard`.
 
 ## Acceptance Criteria
-- [ ] `TacticalCard` component is created and abstracts the shared UI shell.
-- [ ] `PokedexCard` uses `TacticalCard` without visual regressions.
-- [ ] `StorageGrid` uses `TacticalCard` without visual regressions.
+- [x] `TacticalCard` component is created and abstracts the shared UI shell.
+- [x] `PokedexCard` uses `TacticalCard` without visual regressions.
+- [x] `StorageGrid` uses `TacticalCard` without visual regressions.

--- a/src/components/PokedexCard.tsx
+++ b/src/components/PokedexCard.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import type { SaveData } from '../engine/saveParser';
 import { cn } from '../utils/cn';
 import { PokemonSprite } from './pokemon/PokemonSprite';
+import { TacticalCard } from './TacticalCard';
 
 interface PokedexCardProps {
   pokemon: { id: number; name: string };
@@ -43,22 +44,20 @@ export const PokedexCard = React.memo(function PokedexCard({
 
   const isShiny = shinySpeciesIds.has(pokemon.id);
 
+  let variant: 'default' | 'emerald' | 'amber' = 'default';
+  if (hasInStorage) {
+    variant = 'emerald';
+  } else if (saveData?.owned.has(pokemon.id)) {
+    variant = 'amber';
+  }
+
   return (
-    <button
-      type="button"
-      aria-label={`View details for ${pokemon.name}`}
-      data-testid="pokedex-card"
-      data-pokemon-id={pokemon.id}
+    <TacticalCard
+      ariaLabel={`View details for ${pokemon.name}`}
+      testId="pokedex-card"
+      pokemonId={pokemon.id}
       onClick={() => navigate({ to: `/pokemon/${pokemon.id}`, search: { from: '/' } })}
-      className={cn(
-        'group relative w-full cursor-pointer rounded-none border border-dashed p-4 text-left font-mono transition-all duration-500 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98]',
-        hasInStorage
-          ? 'border-emerald-500/50 bg-emerald-950/20 hover:border-emerald-400 hover:bg-emerald-900/30'
-          : 'border-white/20 bg-zinc-900/50 hover:border-white/40 hover:bg-zinc-800/80',
-        saveData?.owned.has(pokemon.id) &&
-          !hasInStorage &&
-          'border-amber-500/50 bg-amber-950/20 hover:border-amber-400 hover:bg-amber-900/30',
-      )}
+      variant={variant}
       style={{ animationDelay: `${(idx % 20) * 0.02}s` }}
     >
       {/* Card Header: Num & Icons */}
@@ -170,12 +169,6 @@ export const PokedexCard = React.memo(function PokedexCard({
       <div className="absolute right-[-10px] bottom-[-10px] p-4 opacity-0 transition-opacity group-hover:opacity-100">
         <ChevronRight size={14} className="text-[var(--theme-primary)]" />
       </div>
-
-      {/* Corner Crosshairs */}
-      <div className="absolute top-0 left-0 h-2 w-2 border-white/40 border-t-2 border-l-2 transition-colors group-hover:border-[var(--theme-primary)]" />
-      <div className="absolute top-0 right-0 h-2 w-2 border-white/40 border-t-2 border-r-2 transition-colors group-hover:border-[var(--theme-primary)]" />
-      <div className="absolute bottom-0 left-0 h-2 w-2 border-white/40 border-b-2 border-l-2 transition-colors group-hover:border-[var(--theme-primary)]" />
-      <div className="absolute right-0 bottom-0 h-2 w-2 border-white/40 border-r-2 border-b-2 transition-colors group-hover:border-[var(--theme-primary)]" />
-    </button>
+    </TacticalCard>
   );
 });

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -5,6 +5,7 @@ import type { PokemonInstance } from '../engine/saveParser/index';
 import { useStore } from '../store';
 import { getGenerationConfig } from '../utils/generationConfig';
 import { PokemonSprite } from './pokemon/PokemonSprite';
+import { TacticalCard } from './TacticalCard';
 
 export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: string }[] }) {
   const saveData = useStore((s) => s.saveData);
@@ -84,23 +85,23 @@ export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: 
                 </div>
               ) : (
                 pokemonInLocation.map(({ p, pokemon }, idx) => {
-                  let cardStyle = 'bg-zinc-900 border border-zinc-800 hover:border-zinc-700 shadow-sm';
+                  let variant: 'storage-default' | 'storage-emerald' | 'storage-amber' | 'storage-red' =
+                    'storage-default';
                   if (p.isShiny) {
-                    cardStyle = 'bg-amber-900/10 border border-amber-500/30 hover:bg-amber-900/20';
+                    variant = 'storage-amber';
                   } else if (location === 'Party') {
-                    cardStyle = 'bg-red-900/10 border border-red-900/30 hover:bg-red-900/20';
+                    variant = 'storage-red';
                   } else {
-                    cardStyle = 'bg-emerald-900/10 border border-emerald-900/30 hover:bg-emerald-900/20';
+                    variant = 'storage-emerald';
                   }
 
                   return (
-                    <button
-                      type="button"
-                      aria-label={`View details for ${pokemon.name} in ${location}`}
+                    <TacticalCard
+                      ariaLabel={`View details for ${pokemon.name} in ${location}`}
                       // biome-ignore lint/suspicious/noArrayIndexKey: Array index is stable and required for duplicates
                       key={`${location}-${p.speciesId}-${idx}`}
                       onClick={() => navigate({ to: `/pokemon/${pokemon.id}`, search: { from: '/storage' } })}
-                      className={`relative flex w-full cursor-pointer flex-col items-center rounded-2xl p-5 text-left transition-all duration-200 hover:-translate-y-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-95 ${cardStyle}`}
+                      variant={variant}
                     >
                       <div className="absolute top-3 left-3 font-bold font-mono text-[10px] text-zinc-600">
                         LV.{p.level}
@@ -125,7 +126,7 @@ export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: 
                       <div className="w-full truncate px-1 text-center font-bold text-[10px] text-zinc-100 uppercase tracking-wider">
                         {pokemon.name}
                       </div>
-                    </button>
+                    </TacticalCard>
                   );
                 })
               )}

--- a/src/components/TacticalCard.tsx
+++ b/src/components/TacticalCard.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { cn } from '../utils/cn';
+
+interface TacticalCardProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+  ariaLabel?: string;
+  testId?: string;
+  pokemonId?: number;
+  className?: string;
+  style?: React.CSSProperties;
+  variant?: 'default' | 'emerald' | 'amber' | 'storage-default' | 'storage-emerald' | 'storage-amber' | 'storage-red';
+}
+
+export const TacticalCard = React.forwardRef<HTMLButtonElement, TacticalCardProps>(
+  ({ children, onClick, ariaLabel, testId, pokemonId, className, style, variant = 'default' }, ref) => {
+    let variantClasses = '';
+
+    switch (variant) {
+      case 'emerald':
+        variantClasses = 'border-emerald-500/50 bg-emerald-950/20 hover:border-emerald-400 hover:bg-emerald-900/30';
+        break;
+      case 'amber':
+        variantClasses = 'border-amber-500/50 bg-amber-950/20 hover:border-amber-400 hover:bg-amber-900/30';
+        break;
+      case 'default':
+        variantClasses = 'border-white/20 bg-zinc-900/50 hover:border-white/40 hover:bg-zinc-800/80';
+        break;
+      case 'storage-amber':
+        variantClasses = 'rounded-2xl bg-amber-900/10 border border-amber-500/30 hover:bg-amber-900/20';
+        break;
+      case 'storage-red':
+        variantClasses = 'rounded-2xl bg-red-900/10 border border-red-900/30 hover:bg-red-900/20';
+        break;
+      case 'storage-emerald':
+        variantClasses = 'rounded-2xl bg-emerald-900/10 border border-emerald-900/30 hover:bg-emerald-900/20';
+        break;
+      case 'storage-default':
+        variantClasses = 'rounded-2xl bg-zinc-900 border border-zinc-800 hover:border-zinc-700 shadow-sm';
+        break;
+    }
+
+    const isStorageVariant = variant.startsWith('storage-');
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-label={ariaLabel}
+        data-testid={testId}
+        data-pokemon-id={pokemonId}
+        onClick={onClick}
+        className={cn(
+          'group relative w-full cursor-pointer text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+          isStorageVariant
+            ? 'flex flex-col items-center p-5 transition-all duration-200 hover:-translate-y-1 active:scale-95'
+            : 'rounded-none border border-dashed p-4 font-mono transition-all duration-500 hover:scale-[1.02] active:scale-[0.98]',
+          variantClasses,
+          className,
+        )}
+        style={style}
+      >
+        {!isStorageVariant && (
+          <>
+            {/* Corner Crosshairs */}
+            <div className="absolute top-0 left-0 h-2 w-2 border-white/40 border-t-2 border-l-2 transition-colors group-hover:border-[var(--theme-primary)]" />
+            <div className="absolute top-0 right-0 h-2 w-2 border-white/40 border-t-2 border-r-2 transition-colors group-hover:border-[var(--theme-primary)]" />
+            <div className="absolute bottom-0 left-0 h-2 w-2 border-white/40 border-b-2 border-l-2 transition-colors group-hover:border-[var(--theme-primary)]" />
+            <div className="absolute right-0 bottom-0 h-2 w-2 border-white/40 border-r-2 border-b-2 transition-colors group-hover:border-[var(--theme-primary)]" />
+          </>
+        )}
+        {children}
+      </button>
+    );
+  },
+);
+
+TacticalCard.displayName = 'TacticalCard';


### PR DESCRIPTION
This PR implements the `TacticalCard` base component as outlined in `task-007-043-tactical-card-refactor`.

Changes:
1. Created `src/components/TacticalCard.tsx` to encapsulate the shared interactive shell, background styling, focus states, and corner accents.
2. Refactored `src/components/PokedexCard.tsx` to utilize `TacticalCard`, cleaning up redundant markup.
3. Refactored `src/components/StorageGrid.tsx` to also utilize `TacticalCard`.
4. Verified that all tests and linting checks pass. Visual regressions avoided by faithfully replicating the original CSS styling through a prop-based variant system.

---
*PR created automatically by Jules for task [8539471943775079108](https://jules.google.com/task/8539471943775079108) started by @szubster*