### PR TITLE
Draft tasks for expensive oxlint checks

### DIFF
--- a/.foundry/stories/story-010-016-enable-expensive-oxlint-checks.md
+++ b/.foundry/stories/story-010-016-enable-expensive-oxlint-checks.md
@@ -22,8 +22,8 @@ Oxlint has additional options for multi-file checks and rules that require types
 - Update `package.json` lint scripts to include these flags.
 
 ## Acceptance Criteria
-- [ ] Tasks are created for enabling type-aware checks.
-- [ ] Tasks are created for enabling import/promise plugins.
+- [x] Tasks are created for enabling type-aware checks.
+- [x] Tasks are created for enabling import/promise plugins.
 - [ ] `package.json` lint commands run these expensive checks.
 
 ## Generated Tasks


### PR DESCRIPTION
This PR drafts the tasks for enabling the expensive oxlint checks as requested by the Product Story.

- Checked off the `Tasks are created for enabling type-aware checks.` criteria.
- Checked off the `Tasks are created for enabling import/promise plugins.` criteria.
- Verified that the `task-016-039-oxlint-type-aware.md` and `task-016-040-oxlint-import-promise-plugins.md` files are properly formatted and placed in the `.foundry/tasks/` directory.

---
*PR created automatically by Jules for task [169757625085582630](https://jules.google.com/task/169757625085582630) started by @szubster*