### PR TITLE
feat(lint): enable oxlint import and promise plugins

### DIFF
--- a/.foundry/tasks/task-016-040-oxlint-import-promise-plugins.md
+++ b/.foundry/tasks/task-016-040-oxlint-import-promise-plugins.md
@@ -17,6 +17,6 @@ parent: ".foundry/stories/story-010-016-enable-expensive-oxlint-checks.md"
 To perform multi-file checks and catch issues related to ESM imports and promise usage, we need to enable the `--import-plugin` and `--promise-plugin` flags in `oxlint`.
 
 ## Instructions
-1. Update `package.json` linting scripts to run `oxlint` with `--import-plugin` and `--promise-plugin` flags.
-2. Resolve any new lint errors reported across the codebase due to the new checks.
-3. Ensure CI still passes with these expensive checks.
+- [x] Update `package.json` linting scripts to run `oxlint` with `--import-plugin` and `--promise-plugin` flags.
+- [x] Resolve any new lint errors reported across the codebase due to the new checks.
+- [x] Ensure CI still passes with these expensive checks.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:analyze": "ANALYZE=true vite build",
     "preview": "vite preview",
     "clean": "rm -rf dist",
-    "lint": "pnpm type-check && pnpm check:biome && pnpm exec oxlint . && pnpm knip",
+    "lint": "pnpm type-check && pnpm check:biome && pnpm exec oxlint --import-plugin --promise-plugin . && pnpm knip",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",


### PR DESCRIPTION
# What
Added `--import-plugin` and `--promise-plugin` to the `oxlint` run in the `lint` script within `package.json`.

# Why
To catch issues related to ESM imports and promise usage across the codebase during the CI and local linting processes, satisfying the requirements of task node `task-016-040-oxlint-import-promise-plugins`.

# Testing
- Ran `pnpm exec oxlint --import-plugin --promise-plugin .` locally and found 0 errors and 0 warnings.
- Ran the full test suite (`pnpm test` and `pnpm test:e2e`) locally to ensure the expensive checks do not break CI.

---
*PR created automatically by Jules for task [7059844760852214380](https://jules.google.com/task/7059844760852214380) started by @szubster*