### PR TITLE
chore: fix and enable jest/no-standalone-expect rule

### DIFF
--- a/.foundry/tasks/task-017-041-fix-jest-standalone-expect.md
+++ b/.foundry/tasks/task-017-041-fix-jest-standalone-expect.md
@@ -17,6 +17,6 @@ parent: ".foundry/stories/story-010-017-fix-jest-rules.md"
 The rule `jest/no-standalone-expect` was disabled to unblock CI. We need to fix the violations in the codebase and re-enable it.
 
 ## Instructions
-1. Change `"jest/no-standalone-expect": "off"` to `"error"` in `.oxlintrc.json`.
-2. Fix all violations by wrapping standalone `expect` calls in `test` or `it` blocks (e.g. in `saveFixtures.test.ts`).
-3. Ensure `pnpm exec oxlint .` passes.
+- [x] 1. Change `"jest/no-standalone-expect": "off"` to `"error"` in `.oxlintrc.json`.
+- [x] 2. Fix all violations by wrapping standalone `expect` calls in `test` or `it` blocks (e.g. in `saveFixtures.test.ts`).
+- [x] 3. Ensure `pnpm exec oxlint .` passes.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -16,7 +16,12 @@
     "react-hooks/exhaustive-deps": "off",
     "vitest/expect-expect": "error",
     "jest/no-disabled-tests": "off",
-    "jest/no-standalone-expect": "off"
+    "jest/no-standalone-expect": [
+      "error",
+      {
+        "additionalTestBlockFunctions": ["customTest"]
+      }
+    ]
   },
   "env": {
     "builtin": true

--- a/src/engine/saveParser/parsers/saveFixtures.test.ts
+++ b/src/engine/saveParser/parsers/saveFixtures.test.ts
@@ -77,11 +77,8 @@ describe('Real Save Fixtures Verification', () => {
     },
   ];
 
-  // Using the advanced 'test.for' to map our suite, removing all duplication
-  // and securely injecting the `loadSaveData` contextual fixture.
-  customTest.for(saveCases)(
-    'should parse generic bounds for $file',
-    ({ file, gen, expectedVersion, expectedTrainer, expectedId, expectedPartyLength }, { loadSaveData }) => {
+  for (const { file, gen, expectedVersion, expectedTrainer, expectedId, expectedPartyLength } of saveCases) {
+    customTest(`should parse generic bounds for ${file}`, ({ loadSaveData }) => {
       const data = loadSaveData(file, gen);
 
       expect(data.generation).toBe(gen);
@@ -92,6 +89,6 @@ describe('Real Save Fixtures Verification', () => {
 
       // Verify PC box counts don't error and are numbers
       expect(typeof data.pc.length).toBe('number');
-    },
-  );
+    });
+  }
 });


### PR DESCRIPTION
I have successfully resolved the task to enable and fix the `jest/no-standalone-expect` linter rule.

**What was done:**
- Updated `.oxlintrc.json` to change the rule configuration from `"off"` to `"error"`.
- Added the `additionalTestBlockFunctions` option to the rule's config in `.oxlintrc.json` so that the custom test wrapper (`customTest`) used in tests is properly recognized as a valid boundary.
- Refactored `saveFixtures.test.ts` to replace the `customTest.for` parameterized test syntax with a standard `for...of` loop invoking `customTest` directly, properly encapsulating all `expect` assertions within valid test blocks.
- Checked off the acceptance criteria checkboxes in `.foundry/tasks/task-017-041-fix-jest-standalone-expect.md` without modifying its YAML frontmatter.

**Verification:**
- Ran `pnpm exec oxlint .` which now successfully passes with zero warnings/errors.
- Ran `pnpm test` successfully (all 236 assertions pass).
- Ran `pnpm test:e2e` to ensure no wider regressions.

---
*PR created automatically by Jules for task [3799978853957289057](https://jules.google.com/task/3799978853957289057) started by @szubster*