### PR TITLE
Draft task node to verify jest rules fix resolution

### DIFF
--- a/.foundry/stories/story-010-028-verify-jest-tests.md
+++ b/.foundry/stories/story-010-028-verify-jest-tests.md
@@ -21,7 +21,8 @@ Even though we resolved the jest rules, we still have FAILED statuses in previou
 - Verify these are fully fixed and oxlint passes with them as `error`.
 
 ## Acceptance Criteria
-- [ ] Tasks are created for verifying the jest rules resolution.
+- [x] Tasks are created for verifying the jest rules resolution.
 - [ ] `pnpm exec oxlint .` passes with these rules completely enabled.
 
 ## Generated Tasks
+- [.foundry/tasks/task-028-046-verify-jest-rules-resolution.md](../../.foundry/tasks/task-028-046-verify-jest-rules-resolution.md)

--- a/.foundry/tasks/task-028-046-verify-jest-rules-resolution.md
+++ b/.foundry/tasks/task-028-046-verify-jest-rules-resolution.md
@@ -1,0 +1,29 @@
+---
+id: "task-028-046-verify-jest-rules-resolution"
+type: "TASK"
+title: "Verify jest rules fix resolution"
+status: "PENDING"
+owner_persona: "coder"
+created_at: "2026-04-26"
+updated_at: "2026-04-26"
+depends_on: []
+jules_session_id: null
+parent: ".foundry/stories/story-010-028-verify-jest-tests.md"
+---
+
+# Verify jest rules fix resolution
+
+## Context
+Even though we resolved the jest rules, we still have FAILED statuses in previous tests that might need further evaluation or the new rules should be ensured passing correctly across all test suites without issues. We need an extra verification step.
+
+## Requirements
+- Identify why tests failed previously for `jest/no-standalone-expect` and `jest/no-disabled-tests`.
+- Verify these are fully fixed and oxlint passes with them as `error`.
+- Ensure rules are properly configured in `.oxlintrc.json` and any false positives are handled (e.g., using `// oxlint-disable jest/no-disabled-tests` for `baseTest.extend`).
+- Self-verify the changes and document the verification in the task journal.
+
+## Acceptance Criteria
+- [ ] `pnpm exec oxlint .` passes with these rules completely enabled.
+- [ ] False positives for `jest/no-disabled-tests` (e.g., in `baseTest.extend`) are suppressed.
+- [ ] False positives for `jest/no-standalone-expect` (e.g., custom test functions) are correctly configured in `.oxlintrc.json`.
+- [ ] Journal updated with verification details.


### PR DESCRIPTION
Drafted a new task `task-028-046-verify-jest-rules-resolution.md` based on the story `story-010-028-verify-jest-tests.md`. The task instructs the coder to enable rules in `.oxlintrc.json`, handle false positives, and self-verify the changes per the Intelligent Verification Protocol. Checked off the acceptance criteria in the parent story and appended the link to the generated task.

---
*PR created automatically by Jules for task [16650464130701141934](https://jules.google.com/task/16650464130701141934) started by @szubster*