### PR TITLE
🕵️‍♂️ Sentinel: Fix and enable jest/no-standalone-expect

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -3,3 +3,9 @@
 Successfully implemented the Scheduled Agent Registry by creating the GitHub Actions workflows for TPM and Agile Coach personas.
 
 Verified empty state prompt inclusion in scheduled-agent workflow by extracting the jq construction step and confirming the format locally. Also checked the task as completed.
+
+### Task: task-017-041-fix-jest-standalone-expect
+- Re-enabled `jest/no-standalone-expect` in `.oxlintrc.json`.
+- To avoid oxlint throwing false positives on `expect` calls inside Vitest's custom test functions, added `additionalTestBlockFunctions` to the rule configuration:
+  `"jest/no-standalone-expect": ["error", { "additionalTestBlockFunctions": ["customTest", "customTest.for", "customTest.each"] }]`
+- Verified `pnpm exec oxlint .` and `pnpm test` passed.

--- a/.foundry/tasks/task-017-041-fix-jest-standalone-expect.md
+++ b/.foundry/tasks/task-017-041-fix-jest-standalone-expect.md
@@ -23,3 +23,8 @@ The rule `jest/no-standalone-expect` was disabled to unblock CI. We need to fix 
 
 ## Verification
 Since this is a straightforward linting fix, please self-verify the changes by confirming `pnpm exec oxlint .` passes and all updated tests pass without regressions (`pnpm test`). Document the verification steps and results in your task journal.
+
+- [x] Changed `jest/no-standalone-expect` from "off" to "error" in `.oxlintrc.json`.
+- [x] Configured `additionalTestBlockFunctions` to recognize `customTest` variations in Vitest.
+- [x] Verified `pnpm exec oxlint .` passes.
+- [x] Verified `pnpm test` passes.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -16,7 +16,16 @@
     "react-hooks/exhaustive-deps": "off",
     "vitest/expect-expect": "error",
     "jest/no-disabled-tests": "off",
-    "jest/no-standalone-expect": "off"
+    "jest/no-standalone-expect": [
+      "error",
+      {
+        "additionalTestBlockFunctions": [
+          "customTest",
+          "customTest.for",
+          "customTest.each"
+        ]
+      }
+    ]
   },
   "env": {
     "builtin": true


### PR DESCRIPTION
🎯 What
- Re-enabled `jest/no-standalone-expect` rule in `.oxlintrc.json`.
- Configured the rule with `additionalTestBlockFunctions` to support Vitest's `test.extend` functions (`customTest`, `customTest.for`, `customTest.each`) so it avoids false positives.
- Updated task and coder journal to mark task as complete and document the fix.

💡 Why
The `jest/no-standalone-expect` rule was previously disabled to unblock CI. Since there were no actual violations outside of Vitest's `test.extend` custom test wrappers, configuring the rule accurately allowed us to re-enable it and prevent future standalone expects.

✅ Verification
- Ensured all tests continue to pass via `pnpm test`.
- Ensured the full e2e suite passes via `pnpm run test:e2e`.
- Ensured no linting errors were reported using `pnpm lint` and specifically `pnpm exec oxlint .`.

✨ Result
Oxlint properly checks and enforces standalone expectations correctly, without throwing false positives on legitimate `test.extend` custom test declarations.

---
*PR created automatically by Jules for task [7986716776718238507](https://jules.google.com/task/7986716776718238507) started by @szubster*