### PR TITLE
Refactor state store sync

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -3,3 +3,7 @@
 Successfully implemented the Scheduled Agent Registry by creating the GitHub Actions workflows for TPM and Agile Coach personas.
 
 Verified empty state prompt inclusion in scheduled-agent workflow by extracting the jq construction step and confirming the format locally. Also checked the task as completed.
+## Refactor State Store Sync
+- Removed localStorage logic from state actions.
+- Eliminated Base64 encoding/decoding.
+- Verified changes by running the full test suite successfully.

--- a/.foundry/tasks/task-026-044-refactor-state-store-sync.md
+++ b/.foundry/tasks/task-026-044-refactor-state-store-sync.md
@@ -20,6 +20,6 @@ This Task implements the technical steps required to remove `localStorage` synci
 The `coder` must self-verify the changes and document the verification in their task journal.
 
 ## Acceptance Criteria
-- [ ] `localStorage` save file logic is removed from state actions in `src/store.ts`.
-- [ ] Base64 encoding/decoding and regex validation logic are eliminated in `src/store.ts`.
-- [ ] Verification steps are documented in the task journal.
+- [x] `localStorage` save file logic is removed from state actions in `src/store.ts`.
+- [x] Base64 encoding/decoding and regex validation logic are eliminated in `src/store.ts`.
+- [x] Verification steps are documented in the task journal.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -51,14 +51,6 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         } else {
           setManualVersion(null);
         }
-
-        let binary = '';
-        const bytes = new Uint8Array(buffer);
-        const len = bytes.byteLength;
-        for (let i = 0; i < len; i++) {
-          binary += String.fromCharCode(bytes[i] ?? 0);
-        }
-        localStorage.setItem('last_save_file', window.btoa(binary));
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Failed to parse save file.';
         setError(message);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -67,7 +67,6 @@ export function SettingsModal() {
           />
           <ClearStorageButton
             onClear={() => {
-              localStorage.removeItem('last_save_file');
               setSaveData(null);
               setManualVersion(null);
               setIsSettingsOpen(false);

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,10 +1,9 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { createRootRouteWithContext, Outlet } from '@tanstack/react-router';
-import React, { Suspense, useEffect } from 'react';
+import React, { Suspense } from 'react';
 import { AppLayout } from '../components/AppLayout';
 import { SyncProgress } from '../components/SyncProgress';
 import { pokeDB } from '../db/PokeDB';
-import { useStore } from '../store';
 import { pokemonListQueryOptions } from '../utils/pokemonQueries';
 
 const TanStackRouterDevtools =
@@ -41,13 +40,6 @@ export const Route = createRootRouteWithContext<RootContext>()({
 });
 
 function RootComponent() {
-  const loadSaveFromStorage = useStore((s) => s.loadSaveFromStorage);
-
-  // Load saved data from localStorage on mount
-  useEffect(() => {
-    loadSaveFromStorage();
-  }, [loadSaveFromStorage]);
-
   return (
     <AppLayout>
       <Outlet />

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { parseSaveFile } from './engine/saveParser/index';
+import type { parseSaveFile } from './engine/saveParser/index';
 import { useStore } from './store';
 
 vi.mock('./engine/saveParser/index', () => ({
@@ -139,58 +139,6 @@ describe('Zustand Store', () => {
 
       useStore.getState().setError(null);
       expect(useStore.getState().error).toBeNull();
-    });
-
-    it('should load a valid base64 save from storage successfully', () => {
-      const mockSaveData = { trainerName: 'ASH', generation: 1, gameVersion: 'red' };
-      vi.mocked(parseSaveFile).mockReturnValue(mockSaveData as unknown as ReturnType<typeof parseSaveFile>);
-
-      // valid base64 for "hello"
-      vi.stubGlobal('localStorage', {
-        getItem: vi.fn<() => string>().mockReturnValue('aGVsbG8='),
-        removeItem: vi.fn<() => void>(),
-      });
-      vi.stubGlobal('window', {
-        atob: vi.fn<() => string>().mockReturnValue('hello'),
-      });
-
-      useStore.getState().loadSaveFromStorage();
-
-      expect(parseSaveFile).toHaveBeenCalled();
-      expect(useStore.getState().saveData).toEqual(mockSaveData);
-    });
-
-    it('should handle corrupted save file from localStorage', () => {
-      // Mock localStorage to return an invalid base64 string
-      const mockGetItem = vi.fn<() => string>().mockReturnValue('invalid-base64-!');
-      const mockRemoveItem = vi.fn<() => void>();
-      vi.stubGlobal('localStorage', {
-        getItem: mockGetItem,
-        removeItem: mockRemoveItem,
-      });
-
-      const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      useStore.getState().loadSaveFromStorage();
-
-      // Verify that it caught the error, logged it, and removed the corrupted item
-      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file');
-      expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
-    });
-
-    it('should specifically catch invalid base64 regex failures', () => {
-      const mockRemoveItem = vi.fn<() => void>();
-      vi.stubGlobal('localStorage', {
-        getItem: vi.fn<() => string>().mockReturnValue('!!!'),
-        removeItem: mockRemoveItem,
-      });
-
-      const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      useStore.getState().loadSaveFromStorage();
-
-      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file');
-      expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
     });
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { GameVersion as GameVersionType, SaveData } from './engine/saveParser/index';
-import { parseSaveFile } from './engine/saveParser/index';
 
 // ─── Types ───────────────────────────────────────────────────────────
 export type GameVersion = GameVersionType;
@@ -72,14 +71,6 @@ interface AppStore {
 
   // Derived helpers
   filtersSet: () => Set<FilterType>;
-
-  // Actions
-  /**
-   * Rehydrates `saveData` from a base64 encoded `last_save_file` in localStorage.
-   * Invariant: If the data is corrupted or parsing fails, the cached file is immediately
-   * deleted to prevent infinite crash loops on subsequent reloads.
-   */
-  loadSaveFromStorage: () => void;
 }
 
 // ─── Store ───────────────────────────────────────────────────────────
@@ -123,31 +114,6 @@ export const useStore = create<AppStore>()(
 
       // Derived
       filtersSet: () => new Set(get().filters),
-
-      // Actions
-      loadSaveFromStorage: () => {
-        const savedFile = localStorage.getItem('last_save_file');
-        if (savedFile) {
-          try {
-            const base64Regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
-            if (!base64Regex.test(savedFile)) {
-              throw new Error('Invalid Base64 string');
-            }
-            const binaryString = window.atob(savedFile);
-            const len = binaryString.length;
-            const bytes = new Uint8Array(len);
-            for (let i = 0; i < len; i++) {
-              bytes[i] = binaryString.charCodeAt(i);
-            }
-            const { manualVersion } = get();
-            const data = parseSaveFile(bytes.buffer, manualVersion || undefined);
-            set({ saveData: data });
-          } catch {
-            console.error('Failed to load saved file');
-            localStorage.removeItem('last_save_file');
-          }
-        }
-      },
     }),
     {
       name: 'dexhelper-settings',

--- a/tests/e2e/assistant.spec.ts
+++ b/tests/e2e/assistant.spec.ts
@@ -31,7 +31,10 @@ test.describe('Assistant Page', () => {
   test('should show local catch suggestions if applicable', async ({ page }) => {
     // This would require a save at a specific location, but we can verify the UI structure even with just nearby.
     await initializeWithSave(page);
-    await page.goto('assistant');
+
+    const assistantLink = page.getByRole('link', { name: /Assistant/i });
+    await expect(assistantLink).toBeVisible();
+    await assistantLink.click();
 
     await expect(page.getByText(/Wild Encounters/i)).toBeVisible({ timeout: 15000 });
 

--- a/tests/e2e/save_management.spec.ts
+++ b/tests/e2e/save_management.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { argosScreenshot } from '../../src/utils/argos';
-import { clearStorage, waitForSync } from './test-utils';
+import { clearStorage } from './test-utils';
 
 test.describe('Save Management', () => {
   test('should upload a save file and persist it on reload', async ({ page }) => {
@@ -34,18 +34,8 @@ test.describe('Save Management', () => {
         .first(),
     ).toBeVisible();
 
-    // 5. Persistence: Reload page
-    await page.reload();
-    await waitForSync(page);
-
-    // 6. Verify it's still hydrated (persisted in localStorage)
-    await expect(page.locator('[data-pokemon-id="25"]')).toBeVisible();
-    await expect(
-      page
-        .locator('header')
-        .getByText(/TRAINER/i)
-        .first(),
-    ).toBeVisible();
+    // 5. Persistence: The store no longer persists save data to avoid blowing up quota
+    // We can't verify rehydration from localstorage anymore. We verified it uploads.
 
     await argosScreenshot(page, 'save-persisted-yellow');
   });

--- a/tests/e2e/test-utils.ts
+++ b/tests/e2e/test-utils.ts
@@ -14,22 +14,14 @@ export async function initializeWithSave(page: Page, savePath: string = 'tests/f
   // 2. Wait for initial synchronization to complete if any is happening
   await waitForSync(page);
 
-  // 3. Check if we're already initialized (from storageState)
-  // We use a shorter timeout here as we expect the state to be ready if it exists.
-  const isInitialized = await page
-    .getByText(/TRAINER/i)
-    .first()
-    .isVisible({ timeout: 2000 });
+  // 3. Since we removed localStorage state store sync, we always need to re-initialize
+  // Wait for the file input to be available in AppLayout
+  const fileInput = page.locator('input[type="file"]');
+  await expect(fileInput).toBeVisible({ timeout: 10000 });
+  await fileInput.setInputFiles(savePath);
 
-  if (!isInitialized) {
-    // Wait for the file input to be available in AppLayout
-    const fileInput = page.locator('input[type="file"]');
-    await expect(fileInput).toBeVisible({ timeout: 10000 });
-    await fileInput.setInputFiles(savePath);
-
-    // ⚡ Bolt: Wait for synchronization triggered by save upload
-    await waitForSync(page);
-  }
+  // ⚡ Bolt: Wait for synchronization triggered by save upload
+  await waitForSync(page);
 
   // 4. Final verification: Trainer info and Pokedex should be visible
   await expect(page.getByText(/TRAINER/i).first()).toBeVisible({ timeout: 20000 });
@@ -39,6 +31,7 @@ export async function initializeWithSave(page: Page, savePath: string = 'tests/f
 /**
  * Wait for the IndexedDB synchronization process to finish.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function waitForSync(page: Page) {
   // The overlay might not appear immediately (especially on fast machines)
   // or it might already be gone. We check for it but don't fail if it's not found.

--- a/tests/e2e/version_selection.spec.ts
+++ b/tests/e2e/version_selection.spec.ts
@@ -26,7 +26,7 @@ test.describe('Version Selection', () => {
     await argosScreenshot(page, 'version-selected-yellow');
   });
 
-  test('should persist version selection across reloads', async ({ page }) => {
+  test('should persist manual version selection', async ({ page }) => {
     await initializeWithSave(page);
 
     // Select Blue
@@ -34,10 +34,7 @@ test.describe('Version Selection', () => {
     await page.getByRole('button', { name: 'Blue', exact: true }).click();
     await expect(page.getByText(/BLUE/i).first()).toBeVisible();
 
-    // Reload
-    await page.reload();
-
-    // Should still be BLUE (persisted in localStorage)
-    await expect(page.getByText(/BLUE/i).first()).toBeVisible();
+    // We do not reload, as the underlying save data doesn't persist,
+    // so it would revert to uninitialized state. We verified the manualVersion overrides the save data.
   });
 });


### PR DESCRIPTION
Refactor state store sync

- Removed `loadSaveFromStorage` from `AppStore` interface and `useStore` implementation in `src/store.ts`.
- Removed base64 encoding/decoding and localStorage save logic from `src/components/AppLayout.tsx`.
- Removed saving data rehydration code from `src/routes/__root.tsx`.
- Removed invalid localStorage tests from `src/store.test.ts`.
- Updated test-utils and end-to-end tests to work with un-persisted memory.
- Documented findings in `.foundry/journals/coder.md`

---
*PR created automatically by Jules for task [18350089916052435824](https://jules.google.com/task/18350089916052435824) started by @szubster*