### PR TITLE
fix(foundry): allow repo root links in link checker

### DIFF
--- a/.foundry/docs/knowledge_base/architecture/link_checker_behavior.md
+++ b/.foundry/docs/knowledge_base/architecture/link_checker_behavior.md
@@ -1,0 +1,13 @@
+# Link Checker Behavior
+
+The link checker (`scripts/check-links.ts`) is used to validate links in markdown files, particularly within the `.foundry` directory.
+
+## Resolution Logic
+
+- **Frontmatter Paths**: Always resolved relative to the repository root.
+- **Inline Links**: Resolved relative to the file containing the link. If not found, they are also checked relative to the repository root. This allows for flexible link styles, including repo-root-relative links like `.foundry/stories/...`.
+
+## Usage
+
+The link checker is integrated into the pre-commit hook via `lefthook.yml`. It can be run manually as:
+`node --experimental-strip-types scripts/check-links.ts [files...]`

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -105,8 +105,10 @@ function checkLinks() {
 
       const inlineLinks = extractInlineLinks(body);
       for (const link of inlineLinks) {
-        const absolutePath = path.resolve(path.dirname(file), link);
-        if (!fs.existsSync(absolutePath)) {
+        const relativePath = path.resolve(path.dirname(file), link);
+        const rootPath = path.resolve(process.cwd(), link);
+
+        if (!fs.existsSync(relativePath) && !fs.existsSync(rootPath)) {
           console.error(`❌ Broken link in ${file}: Inline link '${link}' does not exist.`);
           hasErrors = true;
         }


### PR DESCRIPTION
This PR updates the link checker to support repository-root-relative links. 

### Problem
Valid links starting with folders at the root (like `.foundry/`) were being marked as broken when referenced from subdirectories because the link checker only resolved links relative to the current file.

### Solution
Modified `scripts/check-links.ts` to attempt resolution from both the file's local directory and the repository root.

### Verification
- Verified with a reproduction case (root-relative link in a subdirectory).
- Verified on existing `.foundry` files which previously failed or would have failed.
- All pre-commit hooks passed.