### PR TITLE
fix(foundry): improve ID validation and relax constraints

### DIFF
--- a/.foundry/ideas/idea-007-migrate-saves-to-indexeddb.md
+++ b/.foundry/ideas/idea-007-migrate-saves-to-indexeddb.md
@@ -1,5 +1,5 @@
 ---
-id: idea-007
+id: idea-007-migrate-saves-to-indexeddb
 type: IDEA
 title: "Migrate Save Data to IndexedDB"
 status: "ACTIVE"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,7 +5,7 @@ pre-commit:
   parallel: true
   commands:
     validate-foundry-ids:
-      run: node --experimental-strip-types scripts/validate-foundry-ids.ts {staged_files}
+      run: git diff --name-only --cached --diff-filter=A -- {staged_files} | xargs -r node --experimental-strip-types scripts/validate-foundry-ids.ts
     link-checker:
       run: node --experimental-strip-types scripts/check-links.ts {staged_files}
     biome-check:

--- a/scripts/validate-foundry-ids.ts
+++ b/scripts/validate-foundry-ids.ts
@@ -48,8 +48,8 @@ function validateIds() {
   const ids = new Set<string>();
   let hasError = false;
 
-  const ideaRegex = /^idea-\d{3}-[a-z0-9-]+$/;
-  const otherRegex = /^(prd|epic|story|task)-\d{3}-\d{3}-[a-z0-9-]+$/;
+  const ideaRegex = /^idea-\d{3}(-[a-z0-9-]+)?$/;
+  const otherRegex = /^(prd|epic|story|task)-\d{3}(-\d{3})?(-[a-z0-9-]+)?$/;
 
   for (const file of targetFiles) {
     const content = fs.readFileSync(file, 'utf-8');


### PR DESCRIPTION
This PR improves the Foundry ID validation workflow to be less disruptive and more flexible.

### Key Changes:
- **Restrict to Added Files**: Updated `lefthook.yml` to only run the ID validation on files that are being newly added to the repository (`git diff --diff-filter=A`). This prevents being blocked by existing files with "legacy" formats.
- **Flexible Regex**: Updated `scripts/validate-foundry-ids.ts` to allow IDs with one or two levels of numbering (e.g., `epic-012` and `story-010-014` are both valid).
- **ID Correction**: Fixed the ID in `.foundry/ideas/idea-007-migrate-saves-to-indexeddb.md` to include its slug.

### Verification:
- Verified that `epic-012-gastown-orchestrator` and `idea-007-migrate-saves-to-indexeddb` are now correctly identified as valid.
- Verified that newly added files with invalid IDs are still caught.
- Verified that modified existing files with invalid IDs are correctly ignored by the pre-commit hook.

Part 2 of the link checker/validator improvements requested by @szubster.