### PR TITLE
feat(orchestrator): implement DAG resolution tests for atomic files

### DIFF
--- a/.foundry/tasks/task-025-044-implement-dag-atomic-test.md
+++ b/.foundry/tasks/task-025-044-implement-dag-atomic-test.md
@@ -17,6 +17,6 @@ parent: ".foundry/stories/story-008-025-verify-dag-resolution.md"
 As part of the atomic handoff orchestrator epic, we need to verify that our DAG resolution algorithm handles dependencies across atomic, single-persona files gracefully and without deadlocks.
 
 ## Acceptance Criteria
-- [ ] Add test cases to `.github/scripts/foundry-orchestrator.test.ts` to simulate a sequence of atomic files where one depends on another.
-- [ ] Ensure that DAG resolution correctly calculates unblocked nodes based on dependencies without cycles or deadlocks.
-- [ ] The tests must cover the single-persona atomic files successfully.
+- [x] Add test cases to `.github/scripts/foundry-orchestrator.test.ts` to simulate a sequence of atomic files where one depends on another.
+- [x] Ensure that DAG resolution correctly calculates unblocked nodes based on dependencies without cycles or deadlocks.
+- [x] The tests must cover the single-persona atomic files successfully.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -697,4 +697,49 @@ jules_session_id: null
     expect(result).toContain('status: BLOCKED');
     expect(result).toContain('owner_persona: tpm');
   });
+
+  test('Atomic Handoffs: resolves dependencies across single-persona atomic tasks', () => {
+    createNode('.foundry/tasks/task-atomic-1.md', `id: task-atomic-1
+type: TASK
+title: "Tech Lead Task"
+status: COMPLETED
+owner_persona: tech_lead
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-atomic-2.md', `id: task-atomic-2
+type: TASK
+title: "Coder Task"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on:
+  - .foundry/tasks/task-atomic-1.md
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-atomic-3.md', `id: task-atomic-3
+type: TASK
+title: "QA Task"
+status: PENDING
+owner_persona: qa
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on:
+  - .foundry/tasks/task-atomic-2.md
+jules_session_id: null
+`);
+
+    main();
+
+    const coderResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-atomic-2.md'), 'utf-8');
+    expect(coderResult).toContain('status: READY');
+
+    const qaResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-atomic-3.md'), 'utf-8');
+    expect(qaResult).toContain('status: PENDING');
+  });
 });


### PR DESCRIPTION
This PR adds a new test case to `.github/scripts/foundry-orchestrator.test.ts` to verify the functionality of DAG resolution for atomic, single-persona tasks, as part of the Atomic Handoff Orchestrator epic.

### 🎯 What
- Added the `Atomic Handoffs: resolves dependencies across single-persona atomic tasks` test to `foundry-orchestrator.test.ts`.
- Verified that single-persona tasks are correctly unblocked sequentially in the DAG without deadlocks.
- Updated `.foundry/tasks/task-025-044-implement-dag-atomic-test.md` to check off acceptance criteria.

### 💡 Why
- To fulfill the requirements of `task-025-044-implement-dag-atomic-test.md` and ensure our orchestrator can correctly handle task sequences assigned to different personas, such as `tech_lead` -> `coder` -> `qa`.

### ✅ Verification
- Ran the full test suite in `.github/scripts` using `pnpm run test`, and all 38 orchestrator tests passed.
- Ran the project-wide suite including `vitest`, `lint`, and `playwright` successfully.

---
*PR created automatically by Jules for task [8900538756516984675](https://jules.google.com/task/8900538756516984675) started by @szubster*