### PR TITLE
Empty PR: Target PRD already existed

### DIFF
--- a/.foundry/journals/agile_coach_anomaly_prd_007_005.md
+++ b/.foundry/journals/agile_coach_anomaly_prd_007_005.md
@@ -1,0 +1,7 @@
+# Anomaly Report: Target PRD Already Existed
+
+Date: 2026-04-26
+Persona: Product Manager
+
+During the transformation of `idea-007-migrate-saves-to-indexeddb` to a PRD, the target artifact `.foundry/prds/prd-007-005-migrate-saves-to-indexeddb.md` already unexpectedly existed prior to the session.
+No changes were made to the PRD file. This is an empty PR to allow the automatic progression of the node state as per the EMPTY PR POLICY.


### PR DESCRIPTION
During the session to transform `idea-007` to a PRD, it was discovered that the target artifact `.foundry/prds/prd-007-005-migrate-saves-to-indexeddb.md` unexpectedly existed prior to the start.
Following the EMPTY PR POLICY and anomaly guidelines, I left the PRD file unchanged and created an anomaly report in `.foundry/journals/agile_coach_anomaly_prd_007_005.md` for the Agile Coach to review.

---
*PR created automatically by Jules for task [9015883676113542673](https://jules.google.com/task/9015883676113542673) started by @szubster*