### PR TITLE
chore: mark task failed due to missing SaveDB integration

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -9,3 +9,10 @@ Verified empty state prompt inclusion in scheduled-agent workflow by extracting 
 - To avoid oxlint throwing false positives on `expect` calls inside Vitest's custom test functions, added `additionalTestBlockFunctions` to the rule configuration:
   `"jest/no-standalone-expect": ["error", { "additionalTestBlockFunctions": ["customTest", "customTest.for", "customTest.each"] }]`
 - Verified `pnpm exec oxlint .` and `pnpm test` passed.
+
+## task-026-044-refactor-state-store-sync (FAILED)
+- Removed `loadSaveFromStorage` logic from `src/store.ts` to stop using `localStorage` for syncing save files.
+- Removed base64 encoding/decoding logic in `src/store.ts` and `src/components/AppLayout.tsx`.
+- Removed `last_save_file` caching.
+- However, e2e tests failed because `SaveDB.ts` is not wired up to replace `localStorage`, so save files were not persisted properly.
+- Task marked as blocked/failed in the task markdown body.

--- a/.foundry/tasks/task-026-044-refactor-state-store-sync.md
+++ b/.foundry/tasks/task-026-044-refactor-state-store-sync.md
@@ -23,3 +23,9 @@ The `coder` must self-verify the changes and document the verification in their 
 - [ ] `localStorage` save file logic is removed from state actions in `src/store.ts`.
 - [ ] Base64 encoding/decoding and regex validation logic are eliminated in `src/store.ts`.
 - [ ] Verification steps are documented in the task journal.
+
+---
+
+## Technical Block / Failure
+> **Date:** 2026-04-26
+> **Blocker:** Tests in `tests/e2e` fail after removing base64 caching because IndexedDB `PokeDB` doesn't fully persist the raw `.sav` file natively outside of the explicit sync process. I need guidance on how to fix E2E persistence, since `SaveDB.ts` exists but is not wired up yet.


### PR DESCRIPTION
Marked the task `task-026-044-refactor-state-store-sync` as blocked / failed in the journal because `src/db/SaveDB.ts` is not currently integrated to replace the removed localStorage save persistence, which causes the E2E tests to fail on reload. As the coder, I am not modifying the YAML frontmatter and instead marking the task body and journal as blocked, per Foundry invariants.

---
*PR created automatically by Jules for task [861503796942054873](https://jules.google.com/task/861503796942054873) started by @szubster*