### PR TITLE
Fix and enable jest/no-disabled-tests

### DIFF
--- a/.foundry/tasks/task-017-042-fix-jest-disabled-tests.md
+++ b/.foundry/tasks/task-017-042-fix-jest-disabled-tests.md
@@ -23,3 +23,9 @@ The rule `jest/no-disabled-tests` was disabled to unblock CI. We need to fix the
 
 ## Verification
 Since this is a straightforward linting fix, please self-verify the changes by confirming `pnpm exec oxlint .` passes and all updated tests pass without regressions (`pnpm test`). Document the verification steps and results in your task journal.
+
+### Self Verification
+- Checked that `"jest/no-disabled-tests": "error"` is set in `.oxlintrc.json`.
+- `pnpm exec oxlint .` completed with no errors.
+- All tests passed via `pnpm test`.
+- [x] Acceptance criteria verified.

--- a/.jules/coder.md
+++ b/.jules/coder.md
@@ -6,3 +6,4 @@
   - The false positive with `jest/no-disabled-tests` in `src/engine/saveParser/parsers/saveFixtures.test.ts` where `baseTest.extend` is used is properly bypassed with an inline `// oxlint-disable-next-line jest/no-disabled-tests` directive.
   - `jest/no-standalone-expect` is correctly handled by providing `additionalTestBlockFunctions` in `.oxlintrc.json`.
   - Full test suite passed (node, browser, and e2e tests).
+- **What**: Verified and fully confirmed the `jest/no-disabled-tests` rule as `error` in `.oxlintrc.json`. No code changes were necessary as the change was previously implemented. Validated with `pnpm exec oxlint .` and full `pnpm test` suite which completed successfully.


### PR DESCRIPTION
- Confirmed that `"jest/no-disabled-tests": "error"` is already set correctly in `.oxlintrc.json`.
- Confirmed that `pnpm exec oxlint .` runs without errors or warnings.
- Ran the full test suite (`pnpm lint`, `pnpm test -- --project=node`, `pnpm test -- --project=browser`, and `pnpm test:e2e`) which all passed.
- Checked off task acceptance criteria in the markdown body of `.foundry/tasks/task-017-042-fix-jest-disabled-tests.md`.
- Documented findings in `.jules/coder.md`.

---
*PR created automatically by Jules for task [1386735746982041749](https://jules.google.com/task/1386735746982041749) started by @szubster*