### PR TITLE
Update story 028 acceptance criteria for jest rules verification

### DIFF
--- a/.foundry/stories/story-010-028-verify-jest-tests.md
+++ b/.foundry/stories/story-010-028-verify-jest-tests.md
@@ -22,7 +22,7 @@ Even though we resolved the jest rules, we still have FAILED statuses in previou
 
 ## Acceptance Criteria
 - [x] Tasks are created for verifying the jest rules resolution.
-- [ ] `pnpm exec oxlint .` passes with these rules completely enabled.
+- [x] `pnpm exec oxlint .` passes with these rules completely enabled.
 
 ## Generated Tasks
 - [.foundry/tasks/task-028-046-verify-jest-rules-resolution.md](../../.foundry/tasks/task-028-046-verify-jest-rules-resolution.md)


### PR DESCRIPTION
Checked off the final acceptance criteria for story-010-028-verify-jest-tests as the coder has successfully completed the task and verified that oxlint passes.

---
*PR created automatically by Jules for task [2080959487400432244](https://jules.google.com/task/2080959487400432244) started by @szubster*