### PR TITLE
Enforce strict Empty PR Policy across personas

### DIFF
--- a/.foundry/ideas/idea-009-enforce-strict-empty-pr-policy.md
+++ b/.foundry/ideas/idea-009-enforce-strict-empty-pr-policy.md
@@ -1,0 +1,17 @@
+---
+id: idea-009-enforce-strict-empty-pr-policy
+type: IDEA
+title: "Enforce Strict Empty PR Policy Across Personas"
+status: PENDING
+owner_persona: product_manager
+created_at: "2026-04-27"
+updated_at: "2026-04-27"
+depends_on: []
+jules_session_id: null
+---
+
+# Enforce Strict Empty PR Policy Across Personas
+
+## Details
+Recent rejections show that agents (e.g., Product Manager) are creating dummy updates (like appending empty checkboxes) when a target artifact already exists, in an attempt to force a git diff. This violates the EMPTY PR POLICY and leads to automated reviewer rejections.
+We need to systematically review all persona prompts and automated validation scripts to ensure that agents understand they must submit 0-file-change PRs when no actionable work remains, allowing the 'Auto-close Empty PRs' action to handle the completion.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -21,3 +21,4 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. State there is no work to do and adhere to the EMPTY PR POLICY.


### PR DESCRIPTION
Updated the Product Manager persona prompt to strictly enforce the EMPTY PR POLICY: if a target artifact already exists, the agent must not make dummy updates to force a diff.
Also generated `.foundry/ideas/idea-009-enforce-strict-empty-pr-policy.md` to trigger a systematic review of this policy across all agents.

---
*PR created automatically by Jules for task [10600208835202995244](https://jules.google.com/task/10600208835202995244) started by @szubster*