### PR TITLE
docs(foundry): write Gastown Migration ADR

### DIFF
--- a/.foundry/docs/adrs/003-gastown-migration-decision.md
+++ b/.foundry/docs/adrs/003-gastown-migration-decision.md
@@ -1,0 +1,41 @@
+# ADR 003: Gastown Migration Decision
+
+## Status
+Accepted
+
+## Context
+The Foundry currently relies on GitHub Actions as its orchestration engine. While functional, it is prone to slow start times, race conditions, and limited observability. We have evaluated migrating the orchestration logic ("Gastown") to Cloudflare Workers to address these issues.
+
+## Decision
+We will migrate the Foundry orchestrator from GitHub Actions to a Cloudflare Worker using D1 for state persistence.
+
+### Cloudflare Worker Benefits
+- **Reliable sub-minute scheduling**: Cloudflare Workers allow for precise and frequent cron triggers, solving the lag inherent in GitHub Actions scheduling.
+- **Atomic transitions**: Centralizing state transitions in a single Worker environment eliminates race conditions between parallel Actions.
+- **External reachability**: Workers provide a natural HTTP endpoint for webhooks and API interactions.
+
+### D1 vs KV
+We will use Cloudflare D1 (SQLite) instead of Workers KV.
+- D1 provides **strict consistency**, which is critical for maintaining the integrity of the Directed Acyclic Graph (DAG).
+- D1 allows for complex state queries needed to efficiently calculate the graph's `in-degree` and resolve dependencies.
+
+### Architecture
+- **D1 Schema**:
+  - `nodes` table (id, type, status, owner_persona, updated_at, session_id)
+  - `dependencies` table (parent_id, child_id)
+  - `tags` table (node_id, tag_name)
+- **Webhook Sync Mechanism**:
+  1. A commit is pushed to the repository.
+  2. GitHub triggers a webhook to the Cloudflare Worker.
+  3. The Worker identifies changed markdown files.
+  4. The Worker fetches the updated markdown content from GitHub.
+  5. The Worker parses the frontmatter and updates the D1 relational schema accordingly.
+
+### Migration Plan (High-Level)
+1. **Phase 1: Dual-Write Setup.** Implement the Cloudflare Worker and D1 schema. Configure the repo webhook to sync `.foundry/` file changes to D1 passively.
+2. **Phase 2: Validation.** Run a shadow orchestrator on the Worker to compare D1 state and in-degree calculations against the existing GitHub Actions graph.
+3. **Phase 3: Cutover.** Disable the GitHub Actions orchestrator workflow. Enable the Worker to actively dispatch Jules sessions via GitHub API based on D1 state.
+
+## Consequences
+- The orchestrator will no longer run locally inside the repository context; it requires external infrastructure.
+- Requires maintaining the sync mechanism between the GitHub repository file state and the D1 database.

--- a/.foundry/tasks/task-029-047-write-gastown-adr.md
+++ b/.foundry/tasks/task-029-047-write-gastown-adr.md
@@ -32,9 +32,9 @@ Write `.foundry/docs/adrs/003-gastown-migration-decision.md` to document the Gas
 This is a documentation task (low risk). The `coder` is designated to self-verify by checking the ADR format and document the verification in their task journal.
 
 ## Acceptance Criteria
-- [ ] Create `.foundry/docs/adrs/003-gastown-migration-decision.md`.
-- [ ] Document Cloudflare Worker benefits (reliable sub-minute scheduling, atomic transitions, external reachability).
-- [ ] Document the decision to use D1 over KV for strict consistency and complex state queries.
-- [ ] Detail the D1 schema (`nodes`, `dependencies`, `tags`) and webhook sync mechanism (Git push -> Webhook -> Worker -> Diff -> Fetch -> D1).
-- [ ] Include the "go" decision and high-level migration plan.
-- [ ] Document self-verification in `.jules/coder.md`.
+- [x] Create `.foundry/docs/adrs/003-gastown-migration-decision.md`.
+- [x] Document Cloudflare Worker benefits (reliable sub-minute scheduling, atomic transitions, external reachability).
+- [x] Document the decision to use D1 over KV for strict consistency and complex state queries.
+- [x] Detail the D1 schema (`nodes`, `dependencies`, `tags`) and webhook sync mechanism (Git push -> Webhook -> Worker -> Diff -> Fetch -> D1).
+- [x] Include the "go" decision and high-level migration plan.
+- [x] Document self-verification in `.jules/coder.md`.

--- a/.jules/coder.md
+++ b/.jules/coder.md
@@ -7,3 +7,7 @@
   - `jest/no-standalone-expect` is correctly handled by providing `additionalTestBlockFunctions` in `.oxlintrc.json`.
   - Full test suite passed (node, browser, and e2e tests).
 - **What**: Verified and fully confirmed the `jest/no-disabled-tests` rule as `error` in `.oxlintrc.json`. No code changes were necessary as the change was previously implemented. Validated with `pnpm exec oxlint .` and full `pnpm test` suite which completed successfully.
+
+## Verification Log: Task task-029-047-write-gastown-adr
+- Verified creation of `.foundry/docs/adrs/003-gastown-migration-decision.md` containing Cloudflare Workers evaluation, D1 schema, and migration plan.
+- The document conforms to the ADR format.


### PR DESCRIPTION
Completes `task-029-047-write-gastown-adr` by creating the Gastown Migration ADR and logging the self-verification in the coder journal.

## What
- Created `.foundry/docs/adrs/003-gastown-migration-decision.md` evaluating Cloudflare Workers and D1 for orchestration.
- Updated `task-029-047-write-gastown-adr.md` acceptance criteria checkboxes.
- Logged verification in `.jules/coder.md`.

---
*PR created automatically by Jules for task [13340916664433767286](https://jules.google.com/task/13340916664433767286) started by @szubster*