### PR TITLE
Update acceptance criteria for story-010-017-fix-jest-rules

### DIFF
--- a/.foundry/stories/story-010-017-fix-jest-rules.md
+++ b/.foundry/stories/story-010-017-fix-jest-rules.md
@@ -23,7 +23,7 @@ Even though we use vitest, oxlint uses the jest plugin to lint test files. We tu
 
 ## Acceptance Criteria
 - [x] Tasks are created to fix and enable these rules.
-- [ ] `pnpm exec oxlint .` passes with these rules enabled.
+- [x] `pnpm exec oxlint .` passes with these rules enabled.
 
 ## Generated Tasks
 - [.foundry/tasks/task-017-041-fix-jest-standalone-expect.md](../tasks/task-017-041-fix-jest-standalone-expect.md)

--- a/.jules/coder.md
+++ b/.jules/coder.md
@@ -7,3 +7,7 @@
   - `jest/no-standalone-expect` is correctly handled by providing `additionalTestBlockFunctions` in `.oxlintrc.json`.
   - Full test suite passed (node, browser, and e2e tests).
 - **What**: Verified and fully confirmed the `jest/no-disabled-tests` rule as `error` in `.oxlintrc.json`. No code changes were necessary as the change was previously implemented. Validated with `pnpm exec oxlint .` and full `pnpm test` suite which completed successfully.
+## Story 010-017: Fix jest rules reported by oxlint
+- Verified that the generated tasks `task-017-041-fix-jest-standalone-expect` and `task-017-042-fix-jest-disabled-tests` exist and are COMPLETED.
+- Verified that `pnpm exec oxlint .` passes with the rules enabled.
+- Checked off the acceptance criteria in the story node.


### PR DESCRIPTION
Verified that the tasks `task-017-041-fix-jest-standalone-expect` and `task-017-042-fix-jest-disabled-tests` were correctly implemented, and that `pnpm exec oxlint .` successfully passes with the rules enabled. Checked off the acceptance criteria in the story node `story-010-017-fix-jest-rules.md`.

---
*PR created automatically by Jules for task [4407967394995973287](https://jules.google.com/task/4407967394995973287) started by @szubster*