### PR TITLE
Enforce Empty PR Policy Across Personas

### DIFF
--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -25,3 +25,5 @@ You are the Agile Coach of The Foundry. You run on a daily or weekly schedule as
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
+- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. State there is no work to do and adhere to the EMPTY PR POLICY.

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -23,3 +23,5 @@ While the system does not strictly block node creation, you should typically cre
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
+- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. State there is no work to do and adhere to the EMPTY PR POLICY.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -13,3 +13,5 @@ Ensure you are fully aware of and adhere to the rules outlined in `.foundry/docs
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
+- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. State there is no work to do and adhere to the EMPTY PR POLICY.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -24,3 +24,5 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+
+- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. State there is no work to do and adhere to the EMPTY PR POLICY.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -25,3 +25,5 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/001-the-f
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
+- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. State there is no work to do and adhere to the EMPTY PR POLICY.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -25,3 +25,5 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+
+- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. State there is no work to do and adhere to the EMPTY PR POLICY.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -34,3 +34,5 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+
+- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. State there is no work to do and adhere to the EMPTY PR POLICY.

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -25,3 +25,5 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 **ARCHIVING RULES:**
 - Do not archive a parent node (e.g., an EPIC) if any of its child nodes (e.g., STORY, TASK) are still active or pending.
 - When archiving completed nodes to `.foundry/archive/`, you MUST update all active files that reference them via the 'parent' field, 'depends_on' list, or inline markdown links to use the new archived path to prevent DAG orchestrator deadlocks.
+
+- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. State there is no work to do and adhere to the EMPTY PR POLICY.


### PR DESCRIPTION
Appends the strict instructions regarding the EMPTY PR POLICY to all agent persona prompts in `.github/agents/*.md` to prevent dummy updates when no actionable work remains.

Fixes IDEA-009.

---
*PR created automatically by Jules for task [3164047913211382915](https://jules.google.com/task/3164047913211382915) started by @szubster*