### PR TITLE
🎨 Palette: Add missing focus-visible states in Assistant panel

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,7 @@
 ## 2026-04-26 - Focus Visible Styles for Evolution Links
 **Learning:** Inline buttons functioning as text links within complex components like `PokemonEvolutions` can easily miss standard focus indicators, hiding keyboard navigation state.
 **Action:** Always ensure inline text buttons acting as navigation links include standard focus utilities (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 rounded-sm`) so they are clearly perceivable when navigating via keyboard.
+
+## 2024-04-28 - Focus Visible Styles for Assistant Links
+**Learning:** Interactive `<Link>` components embedded within complex list layouts (like AssistantSuggestionCard) can easily lack explicit focus visibility if global styles do not cascade properly.
+**Action:** Always verify that every interactive routing element explicitly defines standard focus utilities (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] ...`).

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -92,7 +92,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
             <button
               type="button"
               onClick={() => setShowDebug(!showDebug)}
-              className={`rounded-xl border p-2 transition-all ${showDebug ? 'border-amber-500/50 bg-amber-500/20 text-amber-400' : 'border-zinc-700 bg-zinc-800 text-zinc-500 hover:text-zinc-300'}`}
+              className={`rounded-xl border p-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${showDebug ? 'border-amber-500/50 bg-amber-500/20 text-amber-400' : 'border-zinc-700 bg-zinc-800 text-zinc-500 hover:text-zinc-300'}`}
               title="Toggle Debug Mode"
               aria-label="Toggle Debug Mode"
             >

--- a/src/components/assistant/AssistantSuggestionCard.tsx
+++ b/src/components/assistant/AssistantSuggestionCard.tsx
@@ -159,7 +159,7 @@ export function AssistantSuggestionCard({
                             to="/pokemon/$pokemonId"
                             params={{ pokemonId: pid.toString() }}
                             search={{ from: '/assistant' }}
-                            className="relative flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-zinc-800/80 p-2 shadow-md transition-all hover:scale-110 hover:border-emerald-500/50 hover:bg-zinc-700"
+                            className="relative flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-zinc-800/80 p-2 shadow-md transition-all hover:scale-110 hover:border-emerald-500/50 hover:bg-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
                             title={getPokemonName(pid)}
                             aria-label={`View details for ${getPokemonName(pid)}`}
                             onClick={(e) => e.stopPropagation()}
@@ -198,7 +198,7 @@ export function AssistantSuggestionCard({
                     to="/pokemon/$pokemonId"
                     params={{ pokemonId: pid.toString() }}
                     search={{ from: '/assistant' }}
-                    className="group/sprite relative h-10 w-10 rounded-lg border border-white/5 bg-black/40 p-1 transition-all hover:scale-110 hover:border-white/40 hover:bg-black/60"
+                    className="group/sprite relative h-10 w-10 rounded-lg border border-white/5 bg-black/40 p-1 transition-all hover:scale-110 hover:border-white/40 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
                     title={getPokemonName(pid)}
                     aria-label={`View details for ${getPokemonName(pid)}`}
                     onClick={(e) => e.stopPropagation()}
@@ -242,7 +242,7 @@ export function AssistantSuggestionCard({
           to="/pokemon/$pokemonId"
           params={{ pokemonId: s.pokemonId.toString() }}
           search={{ from: '/assistant' }}
-          className="block h-full w-full"
+          className="block h-full w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
           {CardContent}
         </Link>


### PR DESCRIPTION
**🎯 What**
Added missing `focus-visible` styles to interactive elements in the Assistant Panel and Assistant Suggestion Cards.

**🤔 Why**
The "Toggle Debug Mode" button and the `<Link>` elements for Pokemon sprites within the assistant cards were missing focus indicators, making it impossible to see the focus state when navigating via keyboard.

**🛠️ How**
Added the standard tailwind utility classes `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` to the missing elements.

---
*PR created automatically by Jules for task [15019703500525753434](https://jules.google.com/task/15019703500525753434) started by @szubster*