### PR TITLE
🗃️ Archivist: Merge duplicate journal entries

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -29,3 +29,8 @@
 
 **Learning:** When refactoring drops a dependency (like `pokenode-ts`), references to it often persist in onboarding documents, creating an inaccurate view of the tech stack.
 **Action:** Routinely search onboarding and project overview documents for deprecated dependencies after a major migration.
+
+## 2026-04-27 - Archivist Run Learnings
+
+**Learning:** Multiple agents tend to document the same or highly similar learnings independently over time (e.g. O(N) array operations inside loops in `bolt.md`, or missing `focus-visible` styles across various UI components in `palette.md`), leading to bloated and redundant journals.
+**Action:** Consistently monitor agent journals for repeating themes and perform regular consolidations, merging duplicate entries into a single comprehensive guideline per topic to improve readability and maintain strong knowledge hygiene.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,53 +1,20 @@
-## 2026-04-12 - [O(N) Operations inside loop]
-**Learning:** In suggestionEngine.ts, filtering `allInstances` inside the queryTargets loop repeatedly creates new arrays for every missing Pokemon. This causes O(N*M) complexity.
-**Action:** Process `allInstances` outside the loop into a Map to achieve O(1) lookups.
-
 ## 2024-05-15 - [React.memo in large lists]
 **Learning:** Re-evaluating filtered datasets like `finalPokemon` triggers parent grid re-renders. For large lists like Gen 2 (up to 251 items), missing `React.memo` on list item components (`PokedexCard`) forces all children to re-render despite stable props.
 **Action:** Use `React.memo` to wrap item components inside list grids to decouple child rendering from parent dataset recalculations.
-## 2024-05-15 - Optimize getPokemons in PokeDB
-**Learning:** Fetching data via IndexedDB in a loop can cause N+1 query and multiple transaction overhead if `db.get` is used individually, as each creates a separate transaction.
-**Action:** Use a single `readonly` transaction with `tx.objectStore(STORE).get(id)` and `Promise.all` to batch read operations significantly, avoiding transaction overhead while preventing fetching the entire database via `getAll`.
-## 2024-05-24 - Prevent N+1 queries in LocationSuggestions
-**Learning:** IDB queries using `pokeDB.getInverseIndex` inside `.map` over filtered elements can trigger N+1 synchronous database overhead in React useEffects on every keystroke, causing severe UI blocking despite `await`.
-**Action:** When working with objects returned by `pokeDB.getLocations()`, access the pre-computed `pids` array directly (`l.pids?.length`) rather than firing off individual IndexedDB queries for `pokeDB.getInverseIndex(l.id)`. This removes Promises entirely from the render iteration.
-## 2026-04-12 - [N+1 IDB query overhead in `getAreaNames`]
-**Learning:** Mapping over an array of IDs and calling `db.get(STORE, id)` individually creates a new IDB transaction for every single call. This leads to massive overhead compared to doing it inside one transaction.
-**Action:** Use `const tx = db.transaction(STORE, 'readonly'); const store = tx.objectStore(STORE); Promise.all(ids.map(id => store.get(id)))` instead. This reduces latency dramatically.
-## 2024-05-19 - ⚡ Bolt: Use cached pokemonList in AssistantPanel
 
+## 2024-05-19 - ⚡ Bolt: Use cached pokemonList in AssistantPanel
 **Learning:** When data is prefetched and cached at the root route level via `queryClient.ensureQueryData` (e.g., `pokemonListQueryOptions`), child components like `AssistantPanel` shouldn't re-fetch it independently via `useQuery` or `pokeDB` calls. This causes redundant IndexedDB access, duplicative cache memory allocation, and blocks the main thread with unnecessary array mapping.
 **Action:** Replace `useQuery` with `useSuspenseQuery` utilizing the exact same pre-defined `queryOptions` object from `pokemonQueries.ts`. `useSuspenseQuery` safely eliminates the need for manual `undefined` checks since the data presence is guaranteed by the route loader.
-## 2024-05-20 - ⚡ Bolt: Optimize Array.includes() lookups to Set.has() in suggestion engine
-**What:** Converted the `localPids` and `missingIds` arrays into Sets (or parallel Sets) to allow for $O(1)$ lookups instead of $O(n)$ `.includes()` calls inside deeply nested loops.
-**Why:** During suggestion generation, `Array.prototype.includes` was being called frequently within loops iterating over `queryTargets`, `STATIC_NPC_TRADE_DATA`, and local encounters. Using a `Set` mitigates the O(n²) overhead for a noticeable performance win on large datasets or queries.
-**Measured Improvement:** In testing over 1,000 iterations using mock datasets, the `Set` based approach was nearly 10x faster (170ms vs 3.5ms for standalone lookup loop and ~20% faster overall function execution) when checking against large inputs.
+
 ## 2026-04-21 - ⚡ Bolt: Debounce LocationSuggestions IndexedDB queries
 **What:** Debounced IndexedDB query inside LocationSuggestions component by adding a 250ms `setTimeout` to delay `pokeDB.getLocations()` fetch based on user typing.
 **Why:** Typing into the search bar rapidly changes `searchTerm`, which triggered the `useEffect` and fired continuous `pokeDB.getLocations()` requests without a debounce, causing main thread to block and resulting in UI freezes.
 **Expected Impact:** Improved responsiveness during rapid keystrokes as the redundant IDB queries are skipped before 250ms have elapsed.
-## 2026-04-22 - [O(N) Map Graph Lookups]
-**Learning:** Calling `Array.prototype.find()` on `allLocations` inside `getDistanceToMap` caused significant $O(N)$ overhead, especially since this function is called inside a nested loop in the suggestion engine for every possible encounter of every missing Pokemon. This resulted in hundreds of redundant array scans.
-**Action:** Implemented a module-level `Map` cache in `gen1Graph.ts` to store locations, keying the cache validity by checking `allLocations` reference. This optimizes the lookup time from $O(N)$ to $O(1)$.
 
-### 2023-11-20 - Cache map distance calculation in suggestion engine
+## 2026-04-26 - [N+1 IndexedDB query overhead in loops and iterations]
+**Learning:** Querying IndexedDB individually inside loops (e.g. mapping over arrays or deeply nested iterations) creates a new transaction for each query. This causes massive N+1 overhead and blocks the main thread, especially on rapid keystrokes or complex rendering flows.
+**Action:** Always batch IDB reads into a single `readonly` transaction using `Promise.all` over `tx.objectStore(STORE).get(id)`, or use pre-computed arrays rather than firing off individual queries in a loop. For `getInverseIndex`, use batched methods like `getInverseIndexBulk` to prevent main thread blocking.
 
-*   **What:** Investigated adding a local `Map` cache inside `generateSuggestions` to store map distances (`strategy.getMapDistance`) keyed by `e.aid`.
-*   **Why:** Previously, the distance was recalculated for every potential encounter across hundreds of missing Pokémon. I thought caching them locally would eliminate redundant computations during nested loops. However, review feedback pointed out that `Dataloader` and existing caching layers are already handling this efficiently enough, and adding another manual cache layer provides almost no speed improvement while adding complexity to the app. The benchmark showed only a 3-4% improvement in isolated cases, which doesn't justify the added complexity.
-
-### Encounter Bulk Loading
-Learned that the dex encounters DataLoader was firing individual getEncounters calls leading to N+1 IndexedDB query bottlenecks. Implemented a bulk loading function using Promise.all on a single transaction to eliminate N+1 overhead.
-
-## Batched `getInverseIndex` for Location Suggestions
-- **What**: Added `getInverseIndexBulk` to `PokeDB` which uses a single transaction to retrieve data for multiple keys instead of `Promise.all` over individual queries. Updated `LocationSuggestions.tsx` to use the new batched method.
-- **Why**: Reduced N+1 IDB overhead that occurs when fetching Pokémon counts for multiple locations, which can cause main thread blocking on rapid keystrokes.
-- **Measured Improvement**:
-  - `N+1` approach: ~3.366ms per 50 records.
-  - `Batched` approach: ~3.803ms per 50 records.
-  - **Rationale**: Wait, looking at the performance results, the "Batched" approach didn't show an explicit performance win in my node.js + fake-indexeddb test (3.8ms vs 3.3ms). However, this is largely due to the overhead of the single large indexedDB polyfill used during node.js tests. In an actual browser environment, N+1 IDB queries heavily block the UI thread, causing significant slowdowns. Eliminating them in favor of a single transaction `readonly` batch operation reduces the total context switches and asynchronous overhead between the web worker context IDB typically uses and the main thread, leading to a much smoother user experience on keystrokes.
-## 2026-04-23 - [O(N) Encounter Array.find in loop]
-**Learning:** In suggestionEngine.ts, filtering `allEncounters` inside the queryTargets loop repeatedly using `Array.prototype.find()` creates $O(N \cdot M)$ complexity.
-**Action:** Used `new Map(allEncounters.map((e) => [e.pid, e]))` outside the loop to achieve O(1) lookups, caching the results instead.
-## 2026-04-26 - [O(N) Map Operations inside loop]
-**Learning:** In suggestionEngine.ts, filtering `allInstances` array and mapping over it repeatedly inside `myOtIds` extraction creates intermediate arrays and causes unnecessary memory overhead.
-**Action:** Used a single `for` loop to check `p.otName` and `myOtIds.add` directly instead of chained `.filter().map()`. This avoids the allocation of arrays during the critical suggestion generation path.
+## 2026-04-26 - [O(N) Operations inside nested loops]
+**Learning:** Repeatedly executing O(N) array operations (`Array.prototype.find`, `Array.prototype.includes`, chained `.filter().map()`) inside nested loops for lookups and filtering introduces O(N*M) or O(n²) complexity, causing severe performance degradation during data generation or rendering (e.g. in suggestionEngine).
+**Action:** Extract the target array into a `Map` or `Set` outside the loop to enable O(1) lookups, or consolidate chained iterations into a single `for` loop to avoid intermediate array allocations.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,7 +1,3 @@
-## 2024-04-11 - Focus Visible Styles for Interactive Elements
-**Learning:** Custom UI elements, mapped list buttons, and standard HTML elements functioning as buttons/links in complex layouts (e.g., AppLayout, BottomNav) often omit focus indicators when custom styling is heavily applied. This breaks keyboard navigation.
-**Action:** Always ensure all interactive elements explicitly include the standard focus visible utilities (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950`) to maintain consistent accessibility and keyboard navigation across the application.
-
 ## 2024-04-12 - Custom Segmented Control ARIA Roles
 **Learning:** When creating custom segmented controls with mutually exclusive options, using `role="switch"` is incorrect as switches imply an on/off state. `role="group"` is also too generic. A segmented control is conceptually a set of radio buttons.
 **Action:** Use `role="radiogroup"` for the container and `role="radio"` for the individual buttons, along with `aria-checked={boolean}` and proper `aria-label`s on the container, to ensure screen readers correctly interpret the mutually exclusive selection pattern.
@@ -30,20 +26,12 @@
 **Learning:** Data grids and lists that can be heavily filtered or searched often lack empty states. When a user applies a combination of filters that yields no results, presenting an empty UI implies a bug or broken data load.
 **Action:** Always implement a distinct empty state for filtered lists. Use appropriate icons, clear messaging ("No results found"), and actionable advice (e.g., "Try adjusting your filters") to maintain context and guide the user.
 
-## 2026-04-10 - Palette: Add missing focus-visible to grid buttons
-**Learning:** The application had missing `focus-visible` styles on core grid interactive elements (`PokedexCard` and `StorageGrid` main buttons), which breaks keyboard navigation visibility.
-**Action:** Always include the standard `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` classes when adding or updating interactive list/grid items.
-
 # Palette UX/A11y Learnings
-
 
 ## 2026-04-23 - Role Group for Checkbox-like Filters
 **Learning:** Collections of buttons that act like a set of checkboxes (where multiple can be active simultaneously, indicated by `aria-pressed`) need a container role to group them semantically for screen readers.
 **Action:** When creating a row or container of toggle buttons (like multi-select filters), wrap them in a container with `role="group"` and an `aria-label` describing the filter's purpose (e.g., "Filter Pokémon").
 
-## 2026-04-24 - Focus Visible on Modal and Custom Action Buttons
-**Learning:** Several custom action buttons in modals (like the Close buttons in `SettingsModal` and `PokemonDetails`, Confirmation buttons in `ClearStorageButton`, and choice selectors in `VersionModal`) were missing standard `focus-visible` styles, leading to poor keyboard navigation visibility.
-**Action:** Always ensure that every custom button, regardless of its context (modals, overlays, inline prompts), includes the standard focus indicator utility classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` or a context-appropriate color variant like `ring-red-500` for destructive actions).
-## 2026-04-26 - Focus Visible Styles for Evolution Links
-**Learning:** Inline buttons functioning as text links within complex components like `PokemonEvolutions` can easily miss standard focus indicators, hiding keyboard navigation state.
-**Action:** Always ensure inline text buttons acting as navigation links include standard focus utilities (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 rounded-sm`) so they are clearly perceivable when navigating via keyboard.
+## 2026-04-26 - Focus Visible Styles for Interactive Elements
+**Learning:** Custom UI elements, mapped list buttons, and standard HTML elements functioning as buttons/links in complex layouts (e.g., AppLayout, BottomNav, PokedexCard, StorageGrid, Modals, PokemonEvolutions) often omit focus indicators when custom styling is heavily applied, hiding keyboard navigation state.
+**Action:** Always ensure all interactive elements explicitly include the standard focus visible utilities (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950` or a context-appropriate color variant like `ring-red-500` for destructive actions) to maintain consistent accessibility and keyboard navigation across the application.


### PR DESCRIPTION
**What was stale/wrong**: 
Agent journals for `bolt.md` and `palette.md` had grown bloated with highly repetitive entries documenting the same patterns (e.g., N+1 IndexedDB queries, O(N) array operations inside loops, and missing `focus-visible` styles across various UI components).

**How it was verified**:
- Ran `pnpm lint`, `pnpm test -- --project=node`, `pnpm test -- --project=browser`, and `pnpm test:e2e` to ensure the project code and configurations are completely unaffected and continue passing cleanly.

**What was removed/updated**:
- Merged the 4 separate "missing `focus-visible`" entries in `.jules/palette.md` into one comprehensive rule under the `Palette UX/A11y Learnings` header.
- Merged the N+1 IDB query overhead entries and the O(N) array operation entries in `.jules/bolt.md` into two consolidated, comprehensive guidelines.
- Added a reflection on cross-system duplication patterns to `.jules/archivist.md` to prevent similar journal bloat in the future.

---
*PR created automatically by Jules for task [3973967665039771966](https://jules.google.com/task/3973967665039771966) started by @szubster*