### PR TITLE
📜 Scribe: Documented AssistantStrategy interface

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -39,3 +39,8 @@ Documenting these mechanical quirks is essential for future maintainability of t
 
 **What:** Documented `src/store.ts` Zustand properties and actions.
 **Why:** The `AppStore` interface mixes persisted user settings (via localStorage `partialize`, like `isLivingDex` and `filters`) with heavy transient data (like the entire parsed `saveData`) and lightweight UI view state (like `isSettingsOpen`). Documenting which properties belong to which lifecycle prevents future developers from accidentally persisting the massive `saveData` object into localStorage, which would bloat the storage quota and cause stale state bugs on reload.
+
+## 2025-05-20 - AssistantStrategy documentation
+
+**What:** Added JSDoc for `AssistantStrategy` interface in `src/engine/assistant/strategies/types.ts`.
+**Why:** The `AssistantStrategy` interface is the core contract for adding new generations to the suggestion engine, so it should be well-documented.

--- a/src/engine/assistant/strategies/types.ts
+++ b/src/engine/assistant/strategies/types.ts
@@ -33,15 +33,81 @@ export interface RejectedSuggestion {
   code: 'VERSION_EXCLUSIVE' | 'GIFT_CLAIMED' | 'EVO_ALREADY_OWNED' | 'HOF_LOCKED' | 'CHOICE_TAKEN' | 'MISSING_DATA';
 }
 
+/**
+ * Defines the generation-specific logic and rules for the Assistant recommendation engine.
+ * Each generation (Gen 1, Gen 2, etc.) must implement this strategy to handle mechanical differences
+ * such as map layouts, obtainability rules, and specific generation features.
+ */
 export interface AssistantStrategy {
+  /**
+   * The generation number (e.g. 1 for Gen 1).
+   */
   generation: number;
+
+  /**
+   * Resolves the current map ID to the Area ID (AID) used by the database.
+   *
+   * @param saveData - The parsed save data containing the player's current map ID.
+   * @param allLocations - The unified list of all map locations.
+   * @returns The Area ID corresponding to the player's location, or null if unknown.
+   *
+   * @example
+   * const aid = strategy.resolveMapAid(saveData, allLocations);
+   */
   resolveMapAid(saveData: SaveData, allLocations: UnifiedLocation[]): number | null;
+
+  /**
+   * Calculates the shortest path distance (in graph edges/hops) between two locations.
+   *
+   * @param currentMapId - The internal Map ID where the player is currently standing.
+   * @param targetAid - The location Area ID (AID) where the target Pokémon can be found.
+   * @param allLocations - The unified list of all map locations.
+   * @returns An object containing the distance and the name of the target area, or null if unreachable.
+   *
+   * @example
+   * const distInfo = strategy.getMapDistance(saveData.currentMapId, encounter.aid, allLocations);
+   */
   getMapDistance(
     currentMapId: number,
     targetAid: number,
     allLocations: UnifiedLocation[],
   ): { distance: number; name: string } | null;
+
+  /**
+   * Checks if a Pokémon is unobtainable in the given version and returns the reason.
+   *
+   * @param pokemonId - The Pokedex ID of the target Pokemon.
+   * @param version - The current game version (e.g. 'red', 'gold').
+   * @param ownedCount - The total number of Pokemon caught.
+   * @param ownedSet - The set of Pokemon IDs the player currently owns.
+   * @returns A string explaining why the Pokemon is unobtainable, or null if it is obtainable.
+   *
+   * @example
+   * const reason = strategy.getUnobtainableReason(26, 'yellow', ownedSet.size, ownedSet);
+   */
   getUnobtainableReason(pokemonId: number, version: string, ownedCount: number, ownedSet: Set<number>): string | null;
+
+  /**
+   * Generates generation-specific suggestions (e.g., Box full warning).
+   *
+   * @param saveData - The parsed save data.
+   * @param missingIds - An array of Pokemon IDs the player is missing.
+   * @returns An array of special suggestions.
+   *
+   * @example
+   * const specialSuggestions = strategy.getSpecialSuggestions(saveData, Array.from(missingIds));
+   */
   getSpecialSuggestions(saveData: SaveData, missingIds: number[]): Suggestion[];
+
+  /**
+   * Checks if a Pokémon is obtainable internally without trading (e.g. via breeding).
+   *
+   * @param baseId - The Pokedex ID of the base Pokemon.
+   * @param version - The current game version.
+   * @returns True if obtainable, false otherwise.
+   *
+   * @example
+   * const canBreed = strategy.isInternallyObtainable(1, 'gold');
+   */
   isInternallyObtainable(baseId: number, version: string): boolean;
 }


### PR DESCRIPTION
Added comprehensive JSDoc comments to the `AssistantStrategy` interface in `src/engine/assistant/strategies/types.ts`. This interface is a critical contract for the suggestion engine, and documenting its methods with `@param`, `@returns`, and `@example` tags significantly improves maintainability and clarity for future generations.

Also added an entry to `.jules/scribe.md`.

---
*PR created automatically by Jules for task [18232630448100720979](https://jules.google.com/task/18232630448100720979) started by @szubster*