### PR TITLE
Update Playwright IDB Injection

### DIFF
--- a/.foundry/tasks/task-033-053-update-playwright-idb-injection.md
+++ b/.foundry/tasks/task-033-053-update-playwright-idb-injection.md
@@ -24,6 +24,6 @@ Update `tests/e2e/test-utils.ts` to include logic for injecting save files into 
 - Maintain backward compatibility for `localStorage` until the migration is fully completed.
 
 ## Acceptance Criteria
-- [ ] `tests/e2e/test-utils.ts` is updated.
-- [ ] A sample test is converted to use IndexedDB injection.
-- [ ] All tests pass.
+- [x] `tests/e2e/test-utils.ts` is updated.
+- [x] A sample test is converted to use IndexedDB injection.
+- [x] All tests pass.

--- a/.jules/coder.md
+++ b/.jules/coder.md
@@ -19,3 +19,5 @@ Verified creation and updating by examining file outputs and running tests with 
 ## task-029-050-implement-async-hydration
 
 Created `.foundry/tasks/task-029-050-implement-async-hydration.md` to establish the technical specifications for implementing asynchronous startup hydration. I updated the parent story to reference this newly created task and successfully passed the CI/CD pipeline tests.
+## task-033-053-update-playwright-idb-injection
+Updated `tests/e2e/test-utils.ts` to properly inject save data into `SaveDB` via Playwright's `evaluate` while maintaining `localStorage` backwards compatibility. Converted `tests/e2e/pokemon-details.spec.ts` as a sample.

--- a/tests/e2e/pokemon-details.spec.ts
+++ b/tests/e2e/pokemon-details.spec.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { initializeWithSave } from './test-utils';
@@ -5,7 +6,9 @@ import { initializeWithSave } from './test-utils';
 test.describe('Pokemon Details Modal', () => {
   test('should display detailed information for a Pokemon', async ({ page }) => {
     // 1. Initialize with a Gen 1 save (Yellow)
-    await initializeWithSave(page, path.join(process.cwd(), 'tests/fixtures/yellow.sav'));
+    const savePath = path.join(process.cwd(), 'tests/fixtures/yellow.sav');
+    const saveData = fs.readFileSync(savePath);
+    await initializeWithSave(page, new Uint8Array(saveData));
 
     // 2. Click on a Pokemon (e.g., Pikachu - ID 25)
     await page.getByLabel('View details for Pikachu').click();
@@ -29,7 +32,9 @@ test.describe('Pokemon Details Modal', () => {
   });
 
   test('should show correct locations for the version', async ({ page }) => {
-    await initializeWithSave(page, path.join(process.cwd(), 'tests/fixtures/yellow.sav'));
+    const savePath = path.join(process.cwd(), 'tests/fixtures/yellow.sav');
+    const saveData = fs.readFileSync(savePath);
+    await initializeWithSave(page, new Uint8Array(saveData));
 
     // 1. Search for Pidgey to be efficient
     await page.getByTestId('search-input').fill('Pidgey');

--- a/tests/e2e/test-utils.ts
+++ b/tests/e2e/test-utils.ts
@@ -1,67 +1,82 @@
+import fs from 'node:fs';
 import { expect, type Page } from '@playwright/test';
 
-/**
- * Initializes the Dexhelper app with a save file.
- * Defaults to Yellow version if no path is provided.
- */
-export async function initializeWithSave(page: Page, savePath: string = 'tests/fixtures/yellow.sav') {
+export async function initializeWithSave(
+  page: Page,
+  savePathOrData: string | Uint8Array = 'tests/fixtures/yellow.sav',
+) {
   await page.goto('.');
 
-  // 1. Wait for the app to be "interactive" - either showing synced state or the upload button
-  // We wait for the root layout to at least mount correctly.
   await expect(page.locator('header')).toBeVisible({ timeout: 15000 });
-
-  // 2. Wait for initial synchronization to complete if any is happening
   await waitForSync(page);
 
-  // 3. Check if we're already initialized (from storageState)
-  // We use a shorter timeout here as we expect the state to be ready if it exists.
   const isInitialized = await page
     .getByText(/TRAINER/i)
     .first()
     .isVisible({ timeout: 2000 });
 
   if (!isInitialized) {
-    // Wait for the file input to be available in AppLayout
-    const fileInput = page.locator('input[type="file"]');
-    await expect(fileInput).toBeVisible({ timeout: 10000 });
-    await fileInput.setInputFiles(savePath);
+    let fileBuffer: Buffer;
+    if (typeof savePathOrData === 'string') {
+      fileBuffer = fs.readFileSync(savePathOrData);
+    } else {
+      fileBuffer = Buffer.from(savePathOrData);
+    }
+    const saveArray = Array.from(fileBuffer);
+    const base64String = fileBuffer.toString('base64');
 
-    // ⚡ Bolt: Wait for synchronization triggered by save upload
+    await page.evaluate(
+      async ({ saveArray, base64String }) => {
+        // 1. LocalStorage injection (backward compatibility)
+        localStorage.setItem('last_save_file', base64String);
+
+        // 2. IndexedDB injection
+        const SAVE_DB_NAME = 'SaveDB';
+        const STORE_NAME = 'saves';
+
+        const db = await new Promise<IDBDatabase>((resolve, reject) => {
+          const request = indexedDB.open(SAVE_DB_NAME, 1);
+          request.onupgradeneeded = (event) => {
+            const db = (event.target as IDBOpenDBRequest).result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+              db.createObjectStore(STORE_NAME);
+            }
+          };
+          request.onsuccess = (event) => resolve((event.target as IDBOpenDBRequest).result);
+          request.onerror = (event) => reject((event.target as IDBOpenDBRequest).error);
+        });
+
+        await new Promise<void>((resolve, reject) => {
+          const tx = db.transaction(STORE_NAME, 'readwrite');
+          const store = tx.objectStore(STORE_NAME);
+          const request = store.put(new Uint8Array(saveArray), 'last_save_file');
+          request.onsuccess = () => resolve();
+          request.onerror = () => reject(request.error);
+        });
+        db.close();
+      },
+      { saveArray, base64String },
+    );
+
+    await page.reload();
     await waitForSync(page);
   }
 
-  // 4. Final verification: Trainer info and Pokedex should be visible
   await expect(page.getByText(/TRAINER/i).first()).toBeVisible({ timeout: 20000 });
   await expect(page.getByTestId('pokedex-card').first()).toBeVisible({ timeout: 30000 });
 }
 
-/**
- * Wait for the IndexedDB synchronization process to finish.
- */
 export async function waitForSync(page: Page) {
-  // The overlay might not appear immediately (especially on fast machines)
-  // or it might already be gone. We check for it but don't fail if it's not found.
   const overlay = page.getByTestId('sync-progress-overlay');
-
   try {
-    // If the overlay appears within 3s, wait for it to be hidden.
-    // If it takes longer than 3s, we assume it's not coming or already finished.
     const isVisible = await overlay.isVisible({ timeout: 3000 });
     if (isVisible) {
       await expect(overlay).toBeHidden({ timeout: 60000 });
     }
-  } catch {
-    // Timeout waiting for visibility is fine - it means sync was fast or unnecessary.
-  }
-
-  // Final wait for IndexedDB to be ready
+  } catch {}
   await page.waitForTimeout(1000);
 }
 
-/**
- * Clears LocalStorage and all IndexedDB databases.
- */
 export async function clearStorage(page: Page) {
   await page.goto('.');
   await page.evaluate(async () => {


### PR DESCRIPTION
Updated tests/e2e/test-utils.ts to properly inject save data into SaveDB via Playwright's evaluate while maintaining localStorage backwards compatibility. Converted tests/e2e/pokemon-details.spec.ts as a sample.

---
*PR created automatically by Jules for task [18282285785810934783](https://jules.google.com/task/18282285785810934783) started by @szubster*