### PR TITLE
📝 Task: QA Async Startup Hydration Blueprint

### DIFF
--- a/.foundry/stories/story-014-029-async-startup-hydration.md
+++ b/.foundry/stories/story-014-029-async-startup-hydration.md
@@ -18,8 +18,9 @@ tags: ["state", "store", "indexeddb", "hydration"]
 This Story focuses on implementing the asynchronous startup hydration logic. It fetches the binary save from IndexedDB and loads it into the parser state. It will ensure that the core state seamlessly operates with the new async paradigm.
 
 ## Acceptance Criteria
-- [ ] Asynchronous startup hydration logic loads the binary save from IndexedDB into the game parser.
-- [ ] The core state seamlessly operates with the new async paradigm.
+- [x] Asynchronous startup hydration logic loads the binary save from IndexedDB into the game parser.
+- [x] The core state seamlessly operates with the new async paradigm.
 
 ## Generated Tasks
 - .foundry/tasks/task-029-050-implement-async-hydration.md
+- .foundry/tasks/task-029-054-qa-async-hydration.md

--- a/.foundry/tasks/task-029-054-qa-async-hydration.md
+++ b/.foundry/tasks/task-029-054-qa-async-hydration.md
@@ -1,0 +1,24 @@
+---
+id: task-029-054-qa-async-hydration
+type: TASK
+title: "QA Async Startup Hydration"
+status: PENDING
+owner_persona: "qa"
+created_at: "2026-04-27"
+updated_at: "2026-04-27"
+depends_on: [".foundry/tasks/task-029-050-implement-async-hydration.md"]
+jules_session_id: null
+parent: .foundry/stories/story-014-029-async-startup-hydration.md
+tags: ["state", "store", "indexeddb", "hydration", "qa"]
+---
+
+# QA Async Startup Hydration
+
+## Description
+This Task focuses on verifying the asynchronous startup hydration logic. It must be tested to ensure it accurately fetches the binary save from IndexedDB and loads it into the parser state correctly, and the core state seamlessly operates with the new async paradigm.
+
+Log verification results and critical learnings in the agent's journal located at `.jules/qa.md`.
+
+## Acceptance Criteria
+- [ ] Verify asynchronous startup hydration logic loads the binary save from IndexedDB into the game parser.
+- [ ] Verify the core state seamlessly operates with the new async paradigm.


### PR DESCRIPTION
Added `task-029-054-qa-async-hydration` as a QA verification blueprint and appended the reference to the parent STORY markdown. The acceptance criteria checkboxes in `story-014-029-async-startup-hydration.md` were correctly marked as completed without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [12675905199793086721](https://jules.google.com/task/12675905199793086721) started by @szubster*