### PR TITLE
🧠 Trainer: Fix friendship evolution logic

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -6,3 +6,6 @@
 **Action:** Always check the `detail.held` property for Trade evolutions and verify the player has it in their `saveData.inventory`.
 
 - Learned: Gen 1 saves track completed in-game NPC trades using a bitfield at `0x29e6` (with `eventFlagsOffset - 16` logic in `saveParser`), exposing `npcTradeFlags` in the parsed state. It's crucial to mask this against the specific `tradeIndex` found in static data to prevent suggesting trades the user has already completed.
+## 2024-05-19 - Assistant Happiness Evolution Suggestion
+**Learning:** The happiness evolution check was not using `friendship` value to suggest the pre-evolution pokemon that has the highest friendship value to easily reach `min_h`.
+**Action:** Use `friendship` instead of `level` to sort the pre-evolution pokemon if `min_h` exists, and show current friendship to max limit on the UI string.

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -349,18 +349,27 @@ export function generateSuggestions(
     const ownedInstances = instancesBySpecies.get(parentId) || [];
     if (ownedInstances.length === 0) return;
 
-    const bestInstance = ownedInstances.reduce((prev, current) => (prev.level > current.level ? prev : current));
-    const isYellowStarterPikachu =
-      displayVersion === 'yellow' && parentId === 25 && bestInstance.otName === saveData.trainerName;
-    if (isYellowStarterPikachu) return;
-
     const details = p.det;
     const detail = details?.[0];
     if (!detail) return;
 
+    const min_h = detail.mh;
+
+    const bestInstance = ownedInstances.reduce((prev, current) => {
+      if (min_h) {
+        const prevFriendship = prev.friendship ?? 0;
+        const currFriendship = current.friendship ?? 0;
+        return prevFriendship > currFriendship ? prev : current;
+      }
+      return prev.level > current.level ? prev : current;
+    });
+
+    const isYellowStarterPikachu =
+      displayVersion === 'yellow' && parentId === 25 && bestInstance.otName === saveData.trainerName;
+    if (isYellowStarterPikachu) return;
+
     const tr = detail.tr;
     const min_l = detail.ml;
-    const min_h = detail.mh;
     const item = detail.item;
     const held = detail.held;
     const tod = detail.time === 1 ? 'day' : detail.time === 2 ? 'night' : undefined;
@@ -382,13 +391,17 @@ export function generateSuggestions(
         });
       } else if (min_h) {
         const todMsg = tod ? ` during the ${tod}` : '';
+        const friendship = bestInstance.friendship ?? 0;
+        const isReady = friendship >= min_h;
         suggestions.push({
           id: `evo-happy-${targetId}`,
           category: 'Evolve',
-          title: `Happiness Evolution: #${targetId}`,
-          description: `Level up your pre-evolution with high happiness to evolve${todMsg}!`,
+          title: isReady ? `Ready to Evolve: #${targetId}!` : `Happiness Evolution: #${targetId}`,
+          description: isReady
+            ? `Your pre-evolution is happy enough to evolve${todMsg}! Level it up once.`
+            : `Level up your pre-evolution with high happiness to evolve${todMsg}! (Current: ${friendship}/${min_h})`,
           pokemonId: targetId,
-          priority: 80,
+          priority: isReady ? 90 : 80,
         });
       }
     } else if (tr === EVO_TRIGGER.USE_ITEM && item) {


### PR DESCRIPTION
This changes the assistant engine to consider a pokemon's `friendship` stat, instead of just `level`, when attempting to suggest a happiness evolution. 

When a pokemon meets the minimum happiness required for evolution (`min_h`), it will properly indicate "Ready to Evolve" with a bumped priority, similarly to the level-up and item evolutions. Otherwise, it will show the current progress towards the required happiness stat.

---
*PR created automatically by Jules for task [11185275454226586592](https://jules.google.com/task/11185275454226586592) started by @szubster*