### PR TITLE
test(qa): validate lifecycle integration tests

### DIFF
--- a/.foundry/tasks/task-032-049-qa-lifecycle-tests.md
+++ b/.foundry/tasks/task-032-049-qa-lifecycle-tests.md
@@ -25,5 +25,5 @@ Verify the implementation of the lifecycle integration tests to ensure they accu
 - Log verification results and critical learnings in the QA journal at `.jules/qa.md`.
 
 ## Acceptance Criteria
-- [ ] Tests simulate a full IDEA -> PRD -> EPIC -> STORY -> TASK lifecycle using atomic files.
-- [ ] Implementation passes all verification criteria.
+- [x] Tests simulate a full IDEA -> PRD -> EPIC -> STORY -> TASK lifecycle using atomic files.
+- [x] Implementation passes all verification criteria.

--- a/.jules/qa.md
+++ b/.jules/qa.md
@@ -2,3 +2,9 @@
 ## Task task-025-045-qa-dag-atomic-test.md
 - Verified that foundry-orchestrator.test.ts accurately covers atomic, single-owner files depending on each other.
 - Verified that DAG resolves correctly without deadlocks.
+
+## Task: task-032-049-qa-lifecycle-tests
+
+- Read and validated all foundry docs, schema and ADRs.
+- Tested `foundry-orchestrator.test.ts`, tests pass fully, verifying that the integration tests correctly set up the simulated `.foundry` state, and cover the end-to-end IDEA -> PRD -> EPIC -> STORY -> TASK lifecycle using atomic node interactions.
+- Tested all other tests, test suites complete successfully.


### PR DESCRIPTION
Verified the implementation of the lifecycle integration tests, ensuring they accurately simulate the full orchestrator node pipeline (IDEA -> PRD -> EPIC -> STORY -> TASK) using atomic node interactions. Logged the successful verification in `.jules/qa.md`.

---
*PR created automatically by Jules for task [15189331194239100979](https://jules.google.com/task/15189331194239100979) started by @szubster*