### PR TITLE
QA task-031-055: Verify dual-write save persistence

### DIFF
--- a/.foundry/tasks/task-031-055-qa-dual-write-persistence.md
+++ b/.foundry/tasks/task-031-055-qa-dual-write-persistence.md
@@ -21,6 +21,6 @@ This Task focuses on verifying the dual-write save persistence logic. It must be
 Log verification results and critical learnings in the agent's journal located at `.jules/qa.md`.
 
 ## Acceptance Criteria
-- [ ] Verify that new save file uploads are successfully stored in `localStorage` as base64 strings.
-- [ ] Verify that new save file uploads are successfully stored in `IndexedDB` as binary data (`Uint8Array`).
-- [ ] Verify that the application handles errors gracefully (e.g. if writing to one storage backend fails, it is logged correctly).
+- [x] Verify that new save file uploads are successfully stored in `localStorage` as base64 strings.
+- [x] Verify that new save file uploads are successfully stored in `IndexedDB` as binary data (`Uint8Array`).
+- [x] Verify that the application handles errors gracefully (e.g. if writing to one storage backend fails, it is logged correctly).

--- a/.jules/qa.md
+++ b/.jules/qa.md
@@ -8,3 +8,9 @@
 - Read and validated all foundry docs, schema and ADRs.
 - Tested `foundry-orchestrator.test.ts`, tests pass fully, verifying that the integration tests correctly set up the simulated `.foundry` state, and cover the end-to-end IDEA -> PRD -> EPIC -> STORY -> TASK lifecycle using atomic node interactions.
 - Tested all other tests, test suites complete successfully.
+
+## Task: task-031-055-qa-dual-write-persistence.md
+
+- Validated dual-write logic in `AppLayout.tsx`: uploading a new save successfully writes to `IndexedDB` (`saveDB.putSave`) and `localStorage` as base64.
+- Verified `SaveDB.ts` falls back gracefully to in-memory maps if storage limits or IDB failure occurs, fulfilling the error handling criteria.
+- E2E tests for save management succeed without regressions.


### PR DESCRIPTION
QA task-031-055: Verify dual-write save persistence

- Verified AppLayout.tsx writes to both IndexedDB and localStorage
- Verified SaveDB.ts correctly handles IDB/storage failures by using in-memory Map
- Appended findings to .jules/qa.md
- Marked Acceptance Criteria as complete in task-031-055-qa-dual-write-persistence.md

---
*PR created automatically by Jules for task [14865387917538555423](https://jules.google.com/task/14865387917538555423) started by @szubster*