### PR TITLE
Refactor State Store Sync

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -9,3 +9,9 @@ Verified empty state prompt inclusion in scheduled-agent workflow by extracting 
 - To avoid oxlint throwing false positives on `expect` calls inside Vitest's custom test functions, added `additionalTestBlockFunctions` to the rule configuration:
   `"jest/no-standalone-expect": ["error", { "additionalTestBlockFunctions": ["customTest", "customTest.for", "customTest.each"] }]`
 - Verified `pnpm exec oxlint .` and `pnpm test` passed.
+
+
+## Refactor State Store Sync
+- Replaced `localStorage` Base64 logic with `saveDB` fetching raw `Uint8Array`.
+- Refactored tests to use async and mocked `saveDB`.
+- Verification steps: `pnpm test` and `pnpm lint` passed.

--- a/.foundry/tasks/task-026-044-refactor-state-store-sync.md
+++ b/.foundry/tasks/task-026-044-refactor-state-store-sync.md
@@ -20,6 +20,6 @@ This Task implements the technical steps required to remove `localStorage` synci
 The `coder` must self-verify the changes and document the verification in their task journal.
 
 ## Acceptance Criteria
-- [ ] `localStorage` save file logic is removed from state actions in `src/store.ts`.
-- [ ] Base64 encoding/decoding and regex validation logic are eliminated in `src/store.ts`.
-- [ ] Verification steps are documented in the task journal.
+- [x] `localStorage` save file logic is removed from state actions in `src/store.ts`.
+- [x] Base64 encoding/decoding and regex validation logic are eliminated in `src/store.ts`.
+- [x] Verification steps are documented in the task journal.

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -45,7 +45,7 @@ function RootComponent() {
 
   // Load saved data from localStorage on mount
   useEffect(() => {
-    loadSaveFromStorage();
+    void loadSaveFromStorage();
   }, [loadSaveFromStorage]);
 
   return (

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { saveDB } from './db/SaveDB';
 import { parseSaveFile } from './engine/saveParser/index';
 import { useStore } from './store';
+
+vi.mock('./db/SaveDB', () => ({
+  saveDB: {
+    getSave: vi.fn<() => Promise<Uint8Array | undefined>>(),
+    deleteSave: vi.fn<() => Promise<void>>(),
+  },
+}));
 
 vi.mock('./engine/saveParser/index', () => ({
   parseSaveFile: vi.fn<() => ReturnType<typeof parseSaveFile>>(),
@@ -141,56 +149,35 @@ describe('Zustand Store', () => {
       expect(useStore.getState().error).toBeNull();
     });
 
-    it('should load a valid base64 save from storage successfully', () => {
+    it('should load a valid raw save from storage successfully', async () => {
       const mockSaveData = { trainerName: 'ASH', generation: 1, gameVersion: 'red' };
       vi.mocked(parseSaveFile).mockReturnValue(mockSaveData as unknown as ReturnType<typeof parseSaveFile>);
 
-      // valid base64 for "hello"
-      vi.stubGlobal('localStorage', {
-        getItem: vi.fn<() => string>().mockReturnValue('aGVsbG8='),
-        removeItem: vi.fn<() => void>(),
-      });
-      vi.stubGlobal('window', {
-        atob: vi.fn<() => string>().mockReturnValue('hello'),
-      });
+      const mockBytes = new Uint8Array([104, 101, 108, 108, 111]); // "hello"
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(saveDB.getSave).mockResolvedValue(mockBytes);
 
-      useStore.getState().loadSaveFromStorage();
+      await useStore.getState().loadSaveFromStorage();
 
-      expect(parseSaveFile).toHaveBeenCalled();
+      expect(parseSaveFile).toHaveBeenCalledWith(mockBytes.buffer, undefined);
       expect(useStore.getState().saveData).toEqual(mockSaveData);
     });
 
-    it('should handle corrupted save file from localStorage', () => {
-      // Mock localStorage to return an invalid base64 string
-      const mockGetItem = vi.fn<() => string>().mockReturnValue('invalid-base64-!');
-      const mockRemoveItem = vi.fn<() => void>();
-      vi.stubGlobal('localStorage', {
-        getItem: mockGetItem,
-        removeItem: mockRemoveItem,
+    it('should handle corrupted save file from storage', async () => {
+      const mockBytes = new Uint8Array([104, 101, 108, 108, 111]); // valid bytes, but trigger parse error
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(saveDB.getSave).mockResolvedValue(mockBytes);
+      vi.mocked(parseSaveFile).mockImplementation(() => {
+        throw new Error('parse error');
       });
 
       const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-      useStore.getState().loadSaveFromStorage();
+      await useStore.getState().loadSaveFromStorage();
 
-      // Verify that it caught the error, logged it, and removed the corrupted item
-      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file');
-      expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
-    });
-
-    it('should specifically catch invalid base64 regex failures', () => {
-      const mockRemoveItem = vi.fn<() => void>();
-      vi.stubGlobal('localStorage', {
-        getItem: vi.fn<() => string>().mockReturnValue('!!!'),
-        removeItem: mockRemoveItem,
-      });
-
-      const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      useStore.getState().loadSaveFromStorage();
-
-      expect(mockConsoleError).toHaveBeenCalledWith('Failed to load saved file');
-      expect(mockRemoveItem).toHaveBeenCalledWith('last_save_file');
+      expect(mockConsoleError).toHaveBeenCalledWith('System: sync failed');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(saveDB.deleteSave).toHaveBeenCalledWith('last_save_file');
     });
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { saveDB } from './db/SaveDB';
 import type { GameVersion as GameVersionType, SaveData } from './engine/saveParser/index';
 import { parseSaveFile } from './engine/saveParser/index';
 
@@ -24,7 +25,7 @@ interface AppStore {
   // Save data
   /**
    * The heavy, transient parsed save state.
-   * This is intentionally excluded from localStorage persistence (via `partialize`)
+   * This is intentionally excluded from save data persistence
    * to prevent bloating the storage quota and stale state bugs.
    */
   saveData: SaveData | null;
@@ -75,11 +76,11 @@ interface AppStore {
 
   // Actions
   /**
-   * Rehydrates `saveData` from a base64 encoded `last_save_file` in localStorage.
+   * Rehydrates `saveData` from IndexedDB via saveDB.
    * Invariant: If the data is corrupted or parsing fails, the cached file is immediately
    * deleted to prevent infinite crash loops on subsequent reloads.
    */
-  loadSaveFromStorage: () => void;
+  loadSaveFromStorage: () => Promise<void>;
 }
 
 // ─── Store ───────────────────────────────────────────────────────────
@@ -125,26 +126,16 @@ export const useStore = create<AppStore>()(
       filtersSet: () => new Set(get().filters),
 
       // Actions
-      loadSaveFromStorage: () => {
-        const savedFile = localStorage.getItem('last_save_file');
-        if (savedFile) {
+      loadSaveFromStorage: async () => {
+        const bytes = await saveDB.getSave('last_save_file');
+        if (bytes) {
           try {
-            const base64Regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
-            if (!base64Regex.test(savedFile)) {
-              throw new Error('Invalid Base64 string');
-            }
-            const binaryString = window.atob(savedFile);
-            const len = binaryString.length;
-            const bytes = new Uint8Array(len);
-            for (let i = 0; i < len; i++) {
-              bytes[i] = binaryString.charCodeAt(i);
-            }
             const { manualVersion } = get();
-            const data = parseSaveFile(bytes.buffer, manualVersion || undefined);
+            const data = parseSaveFile(bytes.buffer as ArrayBuffer, manualVersion || undefined);
             set({ saveData: data });
           } catch {
-            console.error('Failed to load saved file');
-            localStorage.removeItem('last_save_file');
+            console.error('System: sync failed');
+            await saveDB.deleteSave('last_save_file');
           }
         }
       },


### PR DESCRIPTION
Refactored the application's state storage strategy to use IndexedDB (`saveDB`) instead of `localStorage` with Base64 encoding. This eliminates the string manipulation overhead and better utilizes local storage quotas. Updated all related store unit tests to utilize `async/await` and handle mocking `saveDB`. The `coder` task node and journal have been updated to reflect verification.

---
*PR created automatically by Jules for task [16449301439635440933](https://jules.google.com/task/16449301439635440933) started by @szubster*