### PR TITLE
Update acceptance criteria for dual-write save persistence story

### DIFF
--- a/.foundry/stories/story-014-031-dual-write-save-persistence.md
+++ b/.foundry/stories/story-014-031-dual-write-save-persistence.md
@@ -20,9 +20,9 @@ tags: ["persistence", "indexeddb", "localStorage"]
 To ensure a safe transition and prevent data loss, the application should temporarily write new save uploads to BOTH `localStorage` and `IndexedDB`. This allows us to verify the IndexedDB implementation while maintaining the existing fallback.
 
 ## Acceptance Criteria
-- [ ] New save file uploads are persisted to `localStorage` (as base64).
-- [ ] New save file uploads are persisted to `IndexedDB` (as binary).
-- [ ] Both operations happen atomically or with robust error handling.
+- [x] New save file uploads are persisted to `localStorage` (as base64).
+- [x] New save file uploads are persisted to `IndexedDB` (as binary).
+- [x] Both operations happen atomically or with robust error handling.
 
 ## Generated Tasks
 - .foundry/tasks/task-031-051-implement-dual-write-persistence.md


### PR DESCRIPTION
## Description
This PR updates the `.foundry/stories/story-014-031-dual-write-save-persistence.md` story by marking its acceptance criteria as complete (`[x]`).

## Context
As the `tech_lead` persona, my role is to process Product Stories into technical blueprints (Tasks). Upon reviewing `story-014-031-dual-write-save-persistence.md`, I discovered that the required technical tasks (`task-031-051-implement-dual-write-persistence.md` and `task-031-055-qa-dual-write-persistence.md`) have already been generated and marked as `COMPLETED`. 

Following the `EMPTY PR POLICY`, instead of creating dummy tasks or trivial changes to force a git diff, I verified the completion of the acceptance criteria by the tasks and correctly checked them off in the story's Markdown body, leaving the YAML frontmatter intact.

---
*PR created automatically by Jules for task [11188313241697340951](https://jules.google.com/task/11188313241697340951) started by @szubster*