### PR TITLE
🧭 Strategist: prompt improvement - Ensure Strategist uses journals instead of PR history

### DIFF
--- a/.jules/schedules/strategist.md
+++ b/.jules/schedules/strategist.md
@@ -4,14 +4,14 @@ Review the current Jules agent roster, the quality of existing prompts, and the 
 
 ## Context
 
-The current agent roster lives in `.jules/schedules/`. Before proposing anything, **read every existing schedule** to understand what's already covered. Also review recent PRs from all agents to assess whether their prompts are producing good results.
+The current agent roster lives in `.jules/schedules/`. Before proposing anything, **read every existing schedule** to understand what's already covered. Also review agent journals (e.g., `.jules/bolt.md`, `.jules/canvas.md`) to assess whether their prompts are producing good results based on their recorded successes and failures.
 
 ## Focus Areas
 
 - **Uncovered concerns** — areas of the codebase with no agent watching them (e.g., new features, new architectural layers, growing complexity)
-- **Emerging pain points** — patterns of issues appearing in PRs, test failures, or code reviews that a dedicated agent could catch early
+- **Emerging pain points** — patterns of issues appearing in agent journals, test failures, or code reviews that a dedicated agent could catch early
 - **Retired agents** — existing schedules whose focus area no longer exists or has been fully addressed
-- **Prompt quality** — existing prompts that are too vague, too broad, producing low-value PRs, or missing important constraints. Review agent PR history to identify prompts that consistently lead to rejected or unhelpful PRs
+- **Prompt quality** — existing prompts that are too vague, too broad, producing low-value PRs, or missing important constraints. Review agent journals to identify prompts that consistently lead to rejected or unhelpful PRs
 - **Self-improvement** — this prompt itself may need updating as the roster evolves. If you identify a way to make Strategist more effective, propose it
 
 ## Boundaries
@@ -20,8 +20,8 @@ The current agent roster lives in `.jules/schedules/`. Before proposing anything
 - Read your journal before starting — it's your only memory
 - Include a journal entry for the current change in every PR you open
 - Read all files in `.jules/schedules/` before proposing anything
-- Review recent PRs from agents (search by their title prefixes: `⚡ Bolt:`, `🎨 Palette:`, etc.) to assess prompt effectiveness
-- Study the current codebase structure, recent PRs, and open issues for context
+- Review agent journals (`.jules/*.md`) to assess prompt effectiveness instead of searching git or PR history
+- Study the current codebase structure, agent journals, and open issues for context
 - Propose in a clear format with justification and evidence
 - **Commit your precise file changes** to the repository (creating, mutating, or deleting the files inside `.jules/schedules/`). 
 
@@ -42,14 +42,14 @@ You have no memory between sessions. Your only persistence is what's committed t
 ### Normal flow (most sessions):
 
 1. **Reflect** — read `.jules/strategist.md` (your journal). Understand your history and proposal preferences.
-2. **Assess & Implement** — review recent agent PRs and existing schedules. Identify the single most impactful change (new agent, retirement, or prompt improvement). Open a PR that includes:
+2. **Assess & Implement** — review agent journals and existing schedules. Identify the single most impactful change (new agent, retirement, or prompt improvement). Open a PR that includes:
    - A new journal entry in `.jules/strategist.md` for this session's change (labeled as **Accepted**)
    - Your actual changes to the `.jules/schedules/` files
    - Title the PR: `🧭 Strategist: [proposal type] - [description]`
    - PR body detailing:
      - **Proposal**: What is changing and what objective it achieves.
      - **Justification**: Why existing agents can't cover this or why the old prompt failed.
-     - **Evidence**: Links to previous PRs showing the problem patterns.
+     - **Evidence**: Examples from agent journals showing the problem patterns.
 3. **Wait** — the maintainer reviews your PR. Two outcomes are possible:
    - **Merge** — session auto-closes. You succeeded. The journal updates you included are now persisted.
    - **Rejection comment** — the maintainer comments asking to abandon. Continue to step 4.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -55,3 +55,8 @@
 **Outcome:** Merged
 **Why:** System memory requires the Canvas persona to adhere to a "tactical hardware/snooping" aesthetic, but the prompt didn't mention it.
 **Pattern:** Codify system memory constraints into agent prompts so they are respected.
+## 2026-06-04 - [Accepted] - Prompt improvement - Ensure Strategist uses journals instead of PR history
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The maintainer explicitly instructed that agents must not use `git log` or past commits for memory, and instead rely on journals. The Strategist prompt was still instructing itself to review agent PR history instead of agent journals.
+**Pattern:** Update prompts to ensure they align with the system constraint that cross-session memory is exclusively stored in `.jules/*.md` journal files, not git history.


### PR DESCRIPTION
- **Proposal**: Update `strategist.md` to instruct the agent to review agent journals instead of searching git or PR history.
- **Justification**: Maintainer feedback explicitly states that agents must not use `git log` or past commits for memory, and instead rely solely on journals.
- **Evidence**: The Strategist prompt was still instructing itself to review agent PR history instead of agent journals.

---
*PR created automatically by Jules for task [11820969158349743642](https://jules.google.com/task/11820969158349743642) started by @szubster*