### PR TITLE
🔐 Prevent raw error logging in UI components (CWE-209)

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -6,3 +6,4 @@
 
 ## IndexedDB Save Storage
 **Pattern:** The `window.atob` Base64 decoder is insecure. Instead of doing base64 serialization with handwritten code, or installing base-64 dependencies, the save file storage logic should be migrated completely to `IndexedDB` which natively supports ArrayBuffers and avoids this issue altogether.
+\n**Pattern:** Directly passing the error object (e.g., `catch(console.error)`) or even conditionally logging `err.message` or `String(err)` can leak sensitive stack traces, paths, and internal state. Explicitly replace raw error messages with static generic strings in generic `console.error` handlers (e.g., `console.error('System: sync failed')`) to prevent leaking sensitive state and fully mitigate CWE-209.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -54,7 +54,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           setManualVersion(null);
         }
 
-        saveDB.putSave('last_save_file', new Uint8Array(buffer)).catch(console.error);
+        saveDB.putSave('last_save_file', new Uint8Array(buffer)).catch(() => console.error('System: sync failed'));
 
         let binary = '';
         const bytes = new Uint8Array(buffer);

--- a/src/components/SyncProgress.tsx
+++ b/src/components/SyncProgress.tsx
@@ -21,7 +21,7 @@ export function SyncProgress() {
           setShouldRender(true);
         }
       })
-      .catch(console.error);
+      .catch(() => console.error('System: sync failed'));
 
     const handleProgress = (event: Event) => {
       const customEvent = event as CustomEvent<{ current: number; total: number; stage: string }>;


### PR DESCRIPTION
🎯 What: Replace raw `console.error` calls with generic static error messages in `AppLayout` and `SyncProgress`.
⚠️ Risk: CWE-209 - Sensitive information leakage. Raw error objects might contain sensitive state, paths, or stack traces.
🛡️ Solution: Explicitly map caught errors to a generic static string (`'System: sync failed'`), ensuring no sensitive data is leaked through the client console.

---
*PR created automatically by Jules for task [15576163770504910754](https://jules.google.com/task/15576163770504910754) started by @szubster*