### PR TITLE
🎨 Palette: Add focus-visible to BottomNav interactive elements

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -45,7 +45,7 @@ export function BottomNav() {
         <Link
           to="/"
           className={cn(
-            'group relative z-10 flex flex-col items-center gap-1.5 py-2 transition-all duration-300 focus-visible:outline-none',
+            'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isDex ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
           )}
         >
@@ -62,7 +62,7 @@ export function BottomNav() {
         <Link
           to="/storage"
           className={cn(
-            'group relative z-10 flex flex-col items-center gap-1.5 py-2 transition-all duration-300 focus-visible:outline-none',
+            'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isStorage ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
           )}
         >
@@ -79,7 +79,7 @@ export function BottomNav() {
         <Link
           to="/assistant"
           className={cn(
-            'group relative z-10 flex flex-col items-center gap-1.5 py-2 transition-all duration-300 focus-visible:outline-none',
+            'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isAssistant ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
           )}
         >
@@ -97,7 +97,7 @@ export function BottomNav() {
           type="button"
           onClick={() => setIsSettingsOpen(true)}
           aria-label="Open settings menu"
-          className="group relative z-10 flex flex-col items-center gap-1.5 py-2 text-zinc-600 transition-all duration-300 focus-visible:outline-none"
+          className="group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 text-zinc-600 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
           <div className="transition-transform active:scale-90">
             <Settings2 size={20} strokeWidth={2} />


### PR DESCRIPTION
Added `focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 rounded-sm` to all `Link` and `button` interactive elements within `src/components/BottomNav.tsx`. This ensures the UI follows keyboard accessibility guidelines for visible focus states as documented in `.jules/palette.md`.

What: Added standard focus-visible styles to BottomNav links and buttons.
Why: Previously, interactive elements in the BottomNav explicitly had `focus-visible:outline-none` but lacked alternative focus states. This made keyboard navigation invisible for users tabbing through the layout.
Accessibility Notes: Used existing design system focus ring utility classes. Rounded borders were applied (`rounded-sm`) to match the typical bounding box of these items.

---
*PR created automatically by Jules for task [6515783806179451012](https://jules.google.com/task/6515783806179451012) started by @szubster*