### PR TITLE
🧠 Trainer: Add relative physical stats (rps) logic for Tyrogue evolution suggestions

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -11,3 +11,6 @@
 
 - **Algorithm Limitation**: The `suggestionEngine` previously only checked the *first* evolution detail (`p.det?.[0]`) when evaluating evolution paths. This failed to handle Pokémon with multiple valid evolution details for the same target species (e.g., when a species has multiple valid evolution stones or items).
 - **Solution**: The engine now iterates through the entire `p.det` array. For each evolution detail found, it independently evaluates the trigger (e.g., level up, item usage) and generates a corresponding suggestion. To ensure suggestions remain distinct, item IDs are now appended to the suggestion's `id` string (e.g., `evo-item-${targetId}-${item}`).
+## 2024-04-29 - Tyrogue Relative Physical Stats Evolution
+**Learning:** Tyrogue evolves at level 20 into Hitmonlee, Hitmonchan, or Hitmontop depending on its Relative Physical Stats (`rps`). The `rps` is calculated as Atk > Def (1), Atk < Def (-1), or Atk = Def (0). We do not have access to PC boxed Pokémon's exact stats, but adding general instructions about these requirements significantly improves assistant suggestion quality.
+**Action:** Extract `detail.rps` when iterating over `p.det` during evolution suggestion generation. Map `rps` values to human-readable strings (e.g., `, Atk > Def`) and append them to the specific level requirement string.

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -364,11 +364,16 @@ export function generateSuggestions(
       const item = detail.item;
       const held = detail.held;
       const tod = detail.time === 1 ? 'day' : detail.time === 2 ? 'night' : undefined;
+      const rps = detail.rps;
 
       if (tr === EVO_TRIGGER.LEVEL_UP) {
         if (min_l) {
           const isReady = bestInstance.level >= min_l;
-          const specificReq = `(needs Lv. ${min_l})`;
+          let rpsReq = '';
+          if (rps === 1) rpsReq = ', Atk > Def';
+          else if (rps === -1) rpsReq = ', Atk < Def';
+          else if (rps === 0) rpsReq = ', Atk = Def';
+          const specificReq = `(needs Lv. ${min_l}${rpsReq})`;
 
           suggestions.push({
             id: `evo-lvl-${targetId}`,


### PR DESCRIPTION
## What
This PR updates the assistant's evolution suggestion engine to handle `rps` (relative physical stats) triggers, which are specifically required for Tyrogue's evolution into Hitmonlee, Hitmonchan, and Hitmontop.

## Why
Previously, the assistant would only mention the level requirement (Lv. 20) for Tyrogue. This was incomplete, leaving the user guessing why their Tyrogue evolved into a specific Hitmon. Rather than calculating full Gen 2 stats (which is complex for Box Pokémon due to missing raw stat storage and requiring Stat Exp recalculation), this adds a targeted hint based on the database's `rps` field mapping (Atk > Def, Atk < Def, Atk = Def).

## Impact on recommendation quality
The assistant now provides precise hints for Tyrogue evolutions, telling the player exactly *how* the stats need to align for each branch.

## Test coverage
* Ran `pnpm lint` without warnings/errors.
* Unit tests `pnpm test` (including strategy and coverage tests) pass.
* E2E tests `pnpm test:e2e` pass across Desktop and Mobile views with 37 tests.

---
*PR created automatically by Jules for task [1518238574207951333](https://jules.google.com/task/1518238574207951333) started by @szubster*