### PR TITLE
fix: strict type errors in foundry-heartbeat.test.ts

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -12,3 +12,8 @@ Verified empty state prompt inclusion in scheduled-agent workflow by extracting 
 
 ## 2026-04-29
 - **task-016-039-oxlint-type-aware**: Successfully updated package.json to enable oxlint's `--type-aware` and `--type-check` flags. Verified changes by resolving TypeScript errors in `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts`. Also added a tech debt task `task-016-056-fix-heartbeat-test-types` to address the type mismatch in `foundry-heartbeat.test.ts`. Verified the final state via pnpm lint, test, and test:e2e.
+
+## 2026-04-29
+- Fixed type errors in `.github/scripts/foundry-heartbeat.test.ts`.
+- Removed `// @ts-nocheck` directive.
+- Verified by running `pnpm exec oxlint --type-check --type-aware`, `pnpm test`, and `pnpm lint`.

--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -17,3 +17,6 @@ Verified empty state prompt inclusion in scheduled-agent workflow by extracting 
 - Fixed type errors in `.github/scripts/foundry-heartbeat.test.ts`.
 - Removed `// @ts-nocheck` directive.
 - Verified by running `pnpm exec oxlint --type-check --type-aware`, `pnpm test`, and `pnpm lint`.
+
+## 2026-04-29 (Update)
+- CodeQL caught incomplete substring matching of URL string in `.github/scripts/foundry-heartbeat.test.ts`. Fixed it to use `startsWith('https://jules.googleapis.com')` instead of `includes('jules.googleapis.com')`. This avoids CWE-285 vulnerabilities as noted in `.foundry/docs/knowledge_base/onboarding/autonomous_memory_protocol.md` and standard security practices.

--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -20,3 +20,6 @@ Verified empty state prompt inclusion in scheduled-agent workflow by extracting 
 
 ## 2026-04-29 (Update)
 - CodeQL caught incomplete substring matching of URL string in `.github/scripts/foundry-heartbeat.test.ts`. Fixed it to use `startsWith('https://jules.googleapis.com')` instead of `includes('jules.googleapis.com')`. This avoids CWE-285 vulnerabilities as noted in `.foundry/docs/knowledge_base/onboarding/autonomous_memory_protocol.md` and standard security practices.
+
+## 2026-04-29 (CodeQL Follow-up)
+- CodeQL caught incomplete substring matching of URL string in `.github/scripts/foundry-heartbeat.test.ts`. Modified `startsWith('https://jules.googleapis.com')` to `startsWith('https://jules.googleapis.com/')` (adding trailing slash) to satisfy the arbitrary host name vulnerability check (e.g. preventing `https://jules.googleapis.com.evil.com/`). This adheres to the strict URL validation principles outlined in `.foundry/docs/knowledge_base/onboarding/autonomous_memory_protocol.md` to prevent CWE-285 vulnerabilities.

--- a/.foundry/tasks/task-016-056-fix-heartbeat-test-types.md
+++ b/.foundry/tasks/task-016-056-fix-heartbeat-test-types.md
@@ -19,6 +19,6 @@ When enabling `oxlint`'s `--type-check` and `--type-aware` options, numerous typ
 To unblock the `oxlint` type-aware rollout, a `// @ts-nocheck` directive was temporarily added to `.github/scripts/foundry-heartbeat.test.ts`.
 
 ## Instructions
-1. Remove `// @ts-nocheck` from `.github/scripts/foundry-heartbeat.test.ts`.
-2. Properly type the mocks for `globalFetch.mockResolvedValue` and `globalFetch.mockImplementation`, using type assertions where appropriate (e.g. `as unknown as Response`), or using granular `// @ts-expect-error` comments.
-3. Ensure the test file passes the type-checking stage of `oxlint`.
+- [x] Remove `// @ts-nocheck` from `.github/scripts/foundry-heartbeat.test.ts`.
+- [x] Properly type the mocks for `globalFetch.mockResolvedValue` and `globalFetch.mockImplementation`, using type assertions where appropriate (e.g. `as unknown as Response`), or using granular `// @ts-expect-error` comments.
+- [x] Ensure the test file passes the type-checking stage of `oxlint`.

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -165,7 +165,7 @@ ok: true,
     // @ts-expect-error - Mock signature mismatch
     globalFetch.mockImplementation((url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : (url as URL).toString();
-      if (urlStr.startsWith('https://jules.googleapis.com')) {
+      if (urlStr.startsWith('https://jules.googleapis.com/')) {
         return Promise.resolve({
             ok: true,
             status: 200,
@@ -209,7 +209,7 @@ ok: true,
     // @ts-expect-error - Mock signature mismatch
     globalFetch.mockImplementation((url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : (url as URL).toString();
-      if (urlStr.startsWith('https://jules.googleapis.com')) {
+      if (urlStr.startsWith('https://jules.googleapis.com/')) {
         return Promise.resolve({
             ok: true,
             status: 200,
@@ -254,7 +254,7 @@ ok: true,
     // @ts-expect-error - Mock signature mismatch
     globalFetch.mockImplementation((url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : (url as URL).toString();
-      if (urlStr.startsWith('https://jules.googleapis.com')) {
+      if (urlStr.startsWith('https://jules.googleapis.com/')) {
         return Promise.resolve({
             ok: true,
             status: 200,

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -50,10 +49,10 @@ describe('Foundry Heartbeat', () => {
 
     // Mock API response
     globalFetch.mockResolvedValue({
-      ok: true,
+ok: true,
       status: 200,
       json: async () => ({ state: 'FAILED' })
-    });
+    } as unknown as Response);
 
     await main();
 
@@ -90,10 +89,10 @@ describe('Foundry Heartbeat', () => {
     vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
 
     globalFetch.mockResolvedValue({
-      ok: false,
+ok: false,
       status: 404,
       json: async () => ({ error: { status: 'NOT_FOUND' } })
-    });
+    } as unknown as Response);
 
     await main();
 
@@ -116,10 +115,10 @@ describe('Foundry Heartbeat', () => {
     vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
 
     globalFetch.mockResolvedValue({
-      ok: true,
+ok: true,
       status: 200,
       json: async () => ({ state: 'IN_PROGRESS' })
-    });
+    } as unknown as Response);
 
     await main();
 
@@ -163,21 +162,23 @@ describe('Foundry Heartbeat', () => {
     vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
     vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
 
-    globalFetch.mockImplementation((url: string) => {
-      if (url.includes('jules.googleapis.com')) {
+    // @ts-expect-error - Mock signature mismatch
+    globalFetch.mockImplementation((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : (url as URL).toString();
+      if (urlStr.includes('jules.googleapis.com')) {
         return Promise.resolve({
-          ok: true,
-          status: 200,
+            ok: true,
+            status: 200,
           json: async () => ({ 
-            state: 'COMPLETED', 
-            outputs: [{ pullRequest: { url: 'https://github.com/szubster/dexhelper/pull/402' } }] 
-          })
-        });
+              state: 'COMPLETED',
+              outputs: [{ pullRequest: { url: 'https://github.com/szubster/dexhelper/pull/402' } }]
+            })
+          });
       }
-      if (url.includes('pulls/402')) {
+      if (urlStr.includes('pulls/402')) {
         return Promise.resolve({
-          ok: true,
-          status: 200,
+            ok: true,
+            status: 200,
           json: async () => ({ number: 402, state: 'open', html_url: '...' })
         });
       }
@@ -205,21 +206,23 @@ describe('Foundry Heartbeat', () => {
     vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
     vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
 
-    globalFetch.mockImplementation((url) => {
-      if (url.includes('jules.googleapis.com')) {
+    // @ts-expect-error - Mock signature mismatch
+    globalFetch.mockImplementation((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : (url as URL).toString();
+      if (urlStr.includes('jules.googleapis.com')) {
         return Promise.resolve({
-          ok: true,
-          status: 200,
+            ok: true,
+            status: 200,
           json: async () => ({
-            state: 'COMPLETED',
-            outputs: [{ pullRequest: { url: 'https://github.com/szubster/dexhelper/pull/402' } }]
-          })
-        });
+              state: 'COMPLETED',
+              outputs: [{ pullRequest: { url: 'https://github.com/szubster/dexhelper/pull/402' } }]
+            })
+          });
       }
-      if (url.includes('pulls/402')) {
+      if (urlStr.includes('pulls/402')) {
         return Promise.resolve({
-          ok: true,
-          status: 200,
+            ok: true,
+            status: 200,
           json: async () => ({ number: 402, state: 'closed', merged: true })
         });
       }
@@ -248,25 +251,27 @@ describe('Foundry Heartbeat', () => {
     vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
     vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
 
-    globalFetch.mockImplementation((url: string) => {
-      if (url.includes('jules.googleapis.com')) {
+    // @ts-expect-error - Mock signature mismatch
+    globalFetch.mockImplementation((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : (url as URL).toString();
+      if (urlStr.includes('jules.googleapis.com')) {
         return Promise.resolve({
-          ok: true,
-          status: 200,
+            ok: true,
+            status: 200,
           json: async () => ({ state: 'COMPLETED' }) // No PR link here
         });
       }
-      if (url.includes('search/issues')) {
+      if (urlStr.includes('search/issues')) {
         return Promise.resolve({
-          ok: true,
-          status: 200,
+            ok: true,
+            status: 200,
           json: async () => ({ items: [] }) // Search fails
         });
       }
-      if (url.includes('repos/szubster/dexhelper/pulls?state=all')) {
+      if (urlStr.includes('repos/szubster/dexhelper/pulls?state=all')) {
         return Promise.resolve({
-          ok: true,
-          status: 200,
+            ok: true,
+            status: 200,
           json: async () => [{ number: 405, state: 'open', body: 'session-fallback' }] // Found in list!
         });
       }
@@ -318,8 +323,10 @@ describe('Foundry Heartbeat', () => {
       vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-human.md']);
       vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
 
-      globalFetch.mockImplementation((url: string) => {
-        if (url.includes('pulls/999')) {
+      // @ts-expect-error - Mock signature mismatch
+    globalFetch.mockImplementation((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : (url as URL).toString();
+        if (urlStr.includes('pulls/999')) {
           return Promise.resolve({
             ok: true,
             status: 200,
@@ -353,8 +360,10 @@ describe('Foundry Heartbeat', () => {
       vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-human.md']);
       vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
 
-      globalFetch.mockImplementation((url: string) => {
-        if (url.includes('pulls/888')) {
+      // @ts-expect-error - Mock signature mismatch
+    globalFetch.mockImplementation((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : (url as URL).toString();
+        if (urlStr.includes('pulls/888')) {
           return Promise.resolve({
             ok: true,
             status: 200,
@@ -388,8 +397,10 @@ describe('Foundry Heartbeat', () => {
       vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-human.md']);
       vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
 
-      globalFetch.mockImplementation((url: string) => {
-        if (url.includes('pulls/777')) {
+      // @ts-expect-error - Mock signature mismatch
+    globalFetch.mockImplementation((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : (url as URL).toString();
+        if (urlStr.includes('pulls/777')) {
           return Promise.resolve({
             ok: true,
             status: 200,

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -165,7 +165,7 @@ ok: true,
     // @ts-expect-error - Mock signature mismatch
     globalFetch.mockImplementation((url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : (url as URL).toString();
-      if (urlStr.includes('jules.googleapis.com')) {
+      if (urlStr.startsWith('https://jules.googleapis.com')) {
         return Promise.resolve({
             ok: true,
             status: 200,
@@ -209,7 +209,7 @@ ok: true,
     // @ts-expect-error - Mock signature mismatch
     globalFetch.mockImplementation((url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : (url as URL).toString();
-      if (urlStr.includes('jules.googleapis.com')) {
+      if (urlStr.startsWith('https://jules.googleapis.com')) {
         return Promise.resolve({
             ok: true,
             status: 200,
@@ -254,7 +254,7 @@ ok: true,
     // @ts-expect-error - Mock signature mismatch
     globalFetch.mockImplementation((url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : (url as URL).toString();
-      if (urlStr.includes('jules.googleapis.com')) {
+      if (urlStr.startsWith('https://jules.googleapis.com')) {
         return Promise.resolve({
             ok: true,
             status: 200,


### PR DESCRIPTION
Fixes the strict type errors in `foundry-heartbeat.test.ts` introduced by enabling `oxlint` type-aware linting. The `// @ts-nocheck` directive is removed, mock resolves are cast to `Response`, and the mock implementation is prefixed with an expect-error directive to handle `fetch` signature mismatches. Tests pass type-checks properly.

---
*PR created automatically by Jules for task [7848973367664665607](https://jules.google.com/task/7848973367664665607) started by @szubster*