### PR TITLE
📜 Scribe: Added JSDoc for parseGen2 in Gen 2 save parser

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -49,3 +49,9 @@ Documenting these mechanical quirks is essential for future maintainability of t
 - Gen 1 saves lack explicit version bytes, requiring heuristic detection via Pokédex exclusives and Pikachu markers.
 - Yellow version shifts many memory offsets by +1 byte, requiring dynamic probing at offsets `0x25A3` and `0x25A4` to determine the correct alignment before extracting data.
 - Documented these binary offsets and heuristics in `src/engine/saveParser/README.md` to prevent future regressions.
+## 2026-04-20 - Gen 2 Save Parser Memory Map Dynamic Selection
+**What:** Added JSDoc explaining the dynamic memory map selection in  ().
+**Why:** Gen 2 memory offsets differ significantly between Gold/Silver and Crystal due to engine additions shifting data blocks. The parser dynamically probes party count locations to identify the correct map. The  parameter was also documented as a fallback override for early-game saves.
+## 2026-04-20 - Gen 2 Save Parser Memory Map Dynamic Selection
+**What:** Added JSDoc explaining the dynamic memory map selection in `parseGen2` (`src/engine/saveParser/parsers/gen2.ts`).
+**Why:** Gen 2 memory offsets differ significantly between Gold/Silver and Crystal due to engine additions shifting data blocks. The parser dynamically probes party count locations to identify the correct map. The `forceCrystal` parameter was also documented as a fallback override for early-game saves.

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -143,13 +143,18 @@ export function isGen2Save(view: DataView, crystal: boolean): boolean {
 
 /**
  * Extracts all relevant game data (party, PC boxes, inventory, Pokédex, etc.) from a Gen 2 save.
- * Memory offsets differ significantly between Gold/Silver and Crystal. This function detects Crystal
- * by checking party sizes at the different offset locations, and dynamically selects the correct
- * memory map before extraction.
  *
- * @param view - The raw save file view.
- * @param forceCrystal - An optional flag to force the parser to use Crystal memory offsets.
- * @returns The structured SaveData object.
+ * Unlike Gen 1 where offsets are mostly static (with minor shifts in Yellow), Gen 2 memory offsets
+ * differ significantly between Gold/Silver and Crystal due to engine additions (like the Battle Tower)
+ * shifting data blocks down in memory.
+ *
+ * This function dynamically determines the correct memory map by probing both potential party offset
+ * locations (0x288a for GS, 0x2865 for Crystal). Since party sizes are strictly bounded between 1-6,
+ * reading a valid count at one offset and an invalid value at the other reliably identifies the version.
+ *
+ * @param view - The raw save file DataView.
+ * @param forceCrystal - An optional boolean flag to override dynamic detection and force the parser to use Crystal memory offsets. Useful for uninitialized early-game saves.
+ * @returns The fully parsed and structured SaveData object.
  */
 export function parseGen2(view: DataView, forceCrystal = false): SaveData {
   let isCrystal = forceCrystal;


### PR DESCRIPTION
**What**: Added comprehensive JSDoc to the `parseGen2` function in `src/engine/saveParser/parsers/gen2.ts`.

**Why**: This function is a core piece of the save parsing engine. Due to engine differences between Gold/Silver and Crystal, the memory offsets shift significantly. The function dynamically handles this by probing memory locations. Documenting this reasoning, as well as the `forceCrystal` fallback parameter, ensures future maintainers understand the *why* behind the complex binary extraction logic without having to reverse-engineer it.

**Summary of additions**:
- Explained dynamic memory map selection between Gold/Silver and Crystal based on bounds-checking party sizes.
- Documented `forceCrystal` override parameter for uninitialized early-game saves.

---
*PR created automatically by Jules for task [6318413219044804484](https://jules.google.com/task/6318413219044804484) started by @szubster*