### PR TITLE
🎨 Palette: Add Clear Filters button to empty state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,7 @@
 ## 2026-04-23 - Role Group for Checkbox-like Filters
 **Learning:** Collections of buttons that act like a set of checkboxes (where multiple can be active simultaneously, indicated by `aria-pressed`) need a container role to group them semantically for screen readers.
 **Action:** When creating a row or container of toggle buttons (like multi-select filters), wrap them in a container with `role="group"` and an `aria-label` describing the filter's purpose (e.g., "Filter Pokémon").
+
+## 2026-04-20 - Clear Filters Button in Empty States
+**Learning:** Empty states caused by active search or filter parameters should provide a single-click action to reset the state. Relying on users to manually clear text inputs or deselect filters across the UI creates unnecessary friction.
+**Action:** When an empty state is triggered by a combination of filters, include a prominent "Clear Filters" button that programmatically resets all relevant filter/search states and returns the user to the default populated view.

--- a/src/components/PokedexGrid.tsx
+++ b/src/components/PokedexGrid.tsx
@@ -91,6 +91,17 @@ export function PokedexGrid({ pokemonList }: { pokemonList: { id: number; name: 
         <p className="mt-2 max-w-sm font-medium text-sm text-zinc-600">
           Try adjusting your search terms or clearing your filters to see more results.
         </p>
+        <button
+          type="button"
+          onClick={() => {
+            useStore.getState().setSearchTerm('');
+            useStore.getState().setFilters([]);
+            useStore.getState().setSelectedLocationId(null);
+          }}
+          className="mt-6 rounded-2xl border border-[var(--theme-primary)]/20 bg-[var(--theme-primary)]/10 px-6 py-2.5 font-black text-[11px] text-[var(--theme-primary)] uppercase tracking-widest transition-all duration-300 hover:bg-[var(--theme-primary)] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+        >
+          Clear Filters
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
🎯 **What:** Added a "Clear Filters" button to the empty state view of the `PokedexGrid`.
💡 **Why:** When users apply a combination of search terms and filters that yield no results, it can be frustrating to manually clear each input to return to the full list. Providing a single 1-click action to reset the state improves UX and adheres to standard patterns for filtered lists.
✅ **Before/After:** The "No Pokémon Found" screen now includes a prominent, styled button matching the rest of the application that clears the search term, location filter, and dex filters instantly.
♿ **Accessibility:** The button uses standard `<button>` semantics, an explicit `type="button"`, and receives the standard `focus-visible` outline treatments matching the rest of the application.

---
*PR created automatically by Jules for task [3042978130140677333](https://jules.google.com/task/3042978130140677333) started by @szubster*