### PR TITLE
Introduce researcher persona in foundry

### DIFF
--- a/.foundry/ideas/idea-011-researcher-persona.md
+++ b/.foundry/ideas/idea-011-researcher-persona.md
@@ -1,0 +1,28 @@
+---
+id: idea-011-researcher-persona
+type: IDEA
+title: "Introduce Researcher Persona"
+status: PENDING
+owner_persona: product_manager
+created_at: "2026-04-30"
+updated_at: "2026-04-30"
+depends_on: []
+jules_session_id: null
+parent: null
+tags: ["foundry", "persona", "research"]
+notes: ""
+---
+
+# Idea: Introduce Researcher Persona
+
+## Context
+Foundry agents currently operate sequentially or parallelize execution tasks. However, context gathering or deep dives into particular architectural decisions or new tech stacks often lack a dedicated workflow.
+
+## Proposal
+Introduce a `researcher` persona within the Foundry system.
+- The researcher will be spawned for exploratory tasks or specifically invoked to write research reports.
+- It will provide critical context for downstream steps.
+- We need the ability to attach multiple specific research tasks for each step in the Foundry DAG (e.g. `STORY` -> multiple `TASK`s where some are research-specific).
+
+## Impact
+Better context injection for implementation steps, higher quality PRDs and Epics, and reduced context-switching overhead for implementation personas.


### PR DESCRIPTION
This IDEA proposes adding a `researcher` persona within the Foundry system. This persona will be spawned for exploratory tasks or explicitly invoked to write research reports, providing critical context for downstream implementation steps.

---
*PR created automatically by Jules for task [1792435214028772547](https://jules.google.com/task/1792435214028772547) started by @szubster*