### PR TITLE
🧭 Strategist: Prompt improvement - Update Canvas aesthetic and verification

### DIFF
--- a/.jules/schedules/canvas.md
+++ b/.jules/schedules/canvas.md
@@ -34,9 +34,9 @@ You have no memory between sessions. Your only persistence is what's committed t
 - Read your journal before starting — it's your only memory
 - Include a journal entry for the current change in every PR you open
 - Run `pnpm lint` and `pnpm test` before pushing
-- Include before/after screenshots in the PR description
+- Call the `frontend_verification_instructions` tool and use Playwright to generate screenshots
 - Keep changes to a single component or page — ambitious but scoped
-- Adhere to the project's tactical hardware/snooping aesthetic
+- Adhere to the project's 'Ethereal Archive' design system ('Modern retro' with 'Glassmorphism')
 
 **Ask first:**
 - Nothing — just submit the PR. Rejection is expected and acceptable.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -60,3 +60,9 @@
 **Outcome:** Merged
 **Why:** The maintainer explicitly instructed that agents must not use `git log` or past commits for memory, and instead rely on journals. The Strategist prompt was still instructing itself to review agent PR history instead of agent journals.
 **Pattern:** Update prompts to ensure they align with the system constraint that cross-session memory is exclusively stored in `.jules/*.md` journal files, not git history.
+
+## 2026-06-05 - [Accepted] - Prompt improvement - Update Canvas aesthetic to Ethereal Archive
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The project transitioned to an 'Ethereal Archive' design system with a 'Digital Archaeology' / 'Modern retro' / 'Glassmorphism' aesthetic, but Canvas was still being instructed to use the old 'tactical hardware/snooping' aesthetic. Additionally, the screenshot instructions needed updating to mandate the `frontend_verification_instructions` tool.
+**Pattern:** Ensure agent schedules reflect the latest project-wide architectural or design constraints from memory, and use the correct internal tools for verification.


### PR DESCRIPTION
**Proposal**: Update `.jules/schedules/canvas.md` to enforce the 'Ethereal Archive' design system and mandate the `frontend_verification_instructions` tool for UI changes.
**Justification**: The project transitioned to a 'Digital Archaeology' / 'Modern retro' / 'Glassmorphism' aesthetic, but Canvas was still instructed to use the old 'tactical hardware/snooping' aesthetic. It was also instructed to simply include screenshots in the PR description instead of using the required `frontend_verification_instructions` tool to generate them.
**Evidence**: As documented in the memory, the project utilizes the 'Ethereal Archive' design system, and frontend changes require the `frontend_verification_instructions` tool.

---
*PR created automatically by Jules for task [7062158409393620212](https://jules.google.com/task/7062158409393620212) started by @szubster*