### PR TITLE
🧠 Trainer: Improve happiness evolution recommendations using save data

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -14,3 +14,6 @@
 ## 2024-04-29 - Tyrogue Relative Physical Stats Evolution
 **Learning:** Tyrogue evolves at level 20 into Hitmonlee, Hitmonchan, or Hitmontop depending on its Relative Physical Stats (`rps`). The `rps` is calculated as Atk > Def (1), Atk < Def (-1), or Atk = Def (0). We do not have access to PC boxed Pokémon's exact stats, but adding general instructions about these requirements significantly improves assistant suggestion quality.
 **Action:** Extract `detail.rps` when iterating over `p.det` during evolution suggestion generation. Map `rps` values to human-readable strings (e.g., `, Atk > Def`) and append them to the specific level requirement string.
+## 2024-05-15 - Assistant Happiness Evolution Suggestion
+**Learning:** For happiness-based evolutions (`min_h`), the assistant previously only displayed a generic "Level up with high happiness to evolve" message without showing the actual friendship progress. The save data `PokemonInstance` actually provides the `friendship` stat.
+**Action:** Always check if `bestInstance.friendship` is defined for `min_h` evolutions. If it is >= `min_h`, update the priority to 90 and dynamically tell the user it is "Ready to Evolve!". Otherwise, display the current vs required friendship `(current/required)` to give the user a clear progression indicator.

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -425,13 +425,19 @@ export function generateSuggestions(
           });
         } else if (min_h) {
           const todMsg = tod ? ` during the ${tod}` : '';
+          const isFriendlyEnough = bestInstance.friendship !== undefined && bestInstance.friendship >= min_h;
+          const friendshipStatus =
+            bestInstance.friendship !== undefined ? ` (${bestInstance.friendship}/${min_h})` : '';
+
           suggestions.push({
             id: `evo-happy-${targetId}`,
             category: 'Evolve',
-            title: `Happiness Evolution: #${targetId}`,
-            description: `Level up your pre-evolution with high happiness to evolve${todMsg}!`,
+            title: isFriendlyEnough ? `Ready to Evolve: #${targetId}!` : `Happiness Evolution: #${targetId}`,
+            description: isFriendlyEnough
+              ? `Your pre-evolution is friendly enough${friendshipStatus}! Level it up${todMsg} to evolve.`
+              : `Level up your pre-evolution with high happiness${friendshipStatus} to evolve${todMsg}!`,
             pokemonId: targetId,
-            priority: 80,
+            priority: isFriendlyEnough ? 90 : 80,
           });
         }
       } else if (tr === EVO_TRIGGER.USE_ITEM && item) {


### PR DESCRIPTION
**What**: Improved the assistant's recommendation logic for happiness-based evolutions (`min_h`).
**Why**: The assistant previously displayed a generic "Level up with high happiness to evolve" message, lacking insight into the Pokémon's actual friendship value. The parsed save data provides the `friendship` stat, allowing us to give clear progression indicators and accurately notify users when a Pokémon is ready to evolve.
**Impact on recommendation quality**: Evolution suggestions are now much smarter. They properly reflect if the pre-evolution is ready to evolve (bumping priority from 80 to 90) or shows current progress (e.g., `(100/220)`).
**Test coverage**: Unit test coverage remains solid and `pnpm test` + `pnpm test:e2e` pass cleanly. I wrote a standalone test fixture to confirm it successfully identifies the required friendship values correctly against the `crystal.sav` fixture.

---
*PR created automatically by Jules for task [3537189219082325946](https://jules.google.com/task/3537189219082325946) started by @szubster*