### PR TITLE
🔐 Shield: Add Prototype Pollution scan vector to scheduled prompt

### DIFF
--- a/.jules/schedules/shield.md
+++ b/.jules/schedules/shield.md
@@ -12,6 +12,8 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 - **NEW:** Ensuring secure random number generation (`crypto.getRandomValues`) instead of `Math.random` when dealing with anything remotely sensitive (like tokens or IDs).
 - **NEW:** Guard against Cross-Site Scripting (XSS) by auditing the use of `dangerouslySetInnerHTML`.
 - **NEW:** Ensure safe link handling by including `rel="noopener noreferrer"` for `target="_blank"` links.
+- **NEW:** Guard against Prototype Pollution by auditing the use of `Object.assign` or recursive merge functions without proper validation.
+
 
 ## Boundaries
 
@@ -30,7 +32,7 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 
 ## Process
 
-1. **Scan** — look for insecure patterns, raw error logging, non-native crypto usage, XSS vectors, unsafe links, or `url.includes()`. (Hint: check for `Math.random`, `console.error(err)` without `.message`, `dangerouslySetInnerHTML`, `target="_blank"`, and `url.includes`)
+1. **Scan** — look for insecure patterns, raw error logging, non-native crypto usage, XSS vectors, unsafe links, or `url.includes()`. (Hint: check for `Math.random`, `console.error(err)` without `.message`, `dangerouslySetInnerHTML`, `target="_blank"`, `url.includes`, and `Object.assign`)
 2. **Select** — pick the most actionable security fix. If no specific application code vulnerability is found, improve this scheduled prompt itself or perform a dependency audit.
 3. **Secure** — implement the fix and add validating tests if possible.
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`.

--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -7,3 +7,5 @@
 ## IndexedDB Save Storage
 **Pattern:** The `window.atob` Base64 decoder is insecure. Instead of doing base64 serialization with handwritten code, or installing base-64 dependencies, the save file storage logic should be migrated completely to `IndexedDB` which natively supports ArrayBuffers and avoids this issue altogether.
 \n**Pattern:** Directly passing the error object (e.g., `catch(console.error)`) or even conditionally logging `err.message` or `String(err)` can leak sensitive stack traces, paths, and internal state. Explicitly replace raw error messages with static generic strings in generic `console.error` handlers (e.g., `console.error('System: sync failed')`) to prevent leaking sensitive state and fully mitigate CWE-209.
+## Improving Scheduled Prompts
+**Pattern:** If no specific code vulnerability is found and the task instructs to improve the scheduled prompt or perform a dependency audit (`pnpm audit`), you can add new scan vectors to the scheduled prompt, such as Prototype Pollution with `Object.assign`.


### PR DESCRIPTION
🎯 What: Added `Object.assign` and Prototype Pollution as a scanning heuristic in `.jules/schedules/shield.md`.
⚠️ Risk: The application lacked explicit reminders to check for Prototype Pollution in recursive object merging or assignment.
🛡️ Solution: Updated the scheduled prompt and journal to explicitly instruct future Shield persona runs to look for unsafe Object.assign or deep merge operations. No specific code vulnerabilities were found in the application logic during this scan, so the fallback instructions to improve the prompt were followed.

---
*PR created automatically by Jules for task [2221588413307994160](https://jules.google.com/task/2221588413307994160) started by @szubster*