### PR TITLE
Implement idempotent node generation check for pre-existing artifacts

### DIFF
--- a/.foundry/tasks/task-034-058-implement-orchestrator-preflight.md
+++ b/.foundry/tasks/task-034-058-implement-orchestrator-preflight.md
@@ -21,6 +21,6 @@ notes: ""
 Modify `.github/scripts/foundry-orchestrator.ts` to implement a pre-flight file check before spawning Jules matrix jobs.
 
 ## Acceptance Criteria
-- [ ] Parse node generation tasks to identify if an expected target artifact already exists in `.foundry/`.
-- [ ] If target artifacts exist, successfully validate their schema against the definitions in `.foundry/docs/schema.md` (e.g., ensuring all required fields are present and valid).
-- [ ] Ensure that pre-existing, fully valid target nodes skip dispatch or are otherwise handled correctly to avoid re-generating work that is already done.
+- [x] Parse node generation tasks to identify if an expected target artifact already exists in `.foundry/`.
+- [x] If target artifacts exist, successfully validate their schema against the definitions in `.foundry/docs/schema.md` (e.g., ensuring all required fields are present and valid).
+- [x] Ensure that pre-existing, fully valid target nodes skip dispatch or are otherwise handled correctly to avoid re-generating work that is already done.

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -618,7 +618,40 @@ function main(): void {
     }
 
     if (!blocked) {
-      eligible.push(node);
+      // Preflight check
+      const regex = /\.foundry\/(ideas|prds|epics|stories|tasks)\/[a-zA-Z0-9_-]+\.md/g;
+      const body = node.rawContent.replace(/^---[\s\S]*?---\n/, '');
+      const matches = [...new Set(body.match(regex) || [])];
+
+      const targetArtifacts = matches.filter(m =>
+        m !== node.repoPath &&
+        m !== node.frontmatter.parent &&
+        !node.frontmatter.depends_on.includes(m)
+      );
+
+      let bypassDispatch = false;
+      if (targetArtifacts.length > 0) {
+        bypassDispatch = true;
+        for (const target of targetArtifacts) {
+          const targetPath = path.join(repoRoot, target);
+          if (!fs.existsSync(targetPath)) {
+            bypassDispatch = false;
+            break;
+          }
+          const targetNode = parseNodeFile(targetPath, repoRoot);
+          if (!targetNode) {
+            bypassDispatch = false;
+            break;
+          }
+        }
+      }
+
+      if (bypassDispatch) {
+        info(`Preflight success: Valid target artifacts exist. Bypassing dispatch for ${node.repoPath}`);
+        promoteNodeStatus(node, 'PENDING', 'COMPLETED');
+      } else {
+        eligible.push(node);
+      }
     }
   }
 


### PR DESCRIPTION
Modified the `foundry-orchestrator.ts` script to bypass session dispatch when generated target artifacts already exist and are fully valid. The orchestrator now performs a preflight check to parse expected target artifacts from the markdown body of `PENDING` nodes. If all identified artifacts are fully valid, the parent node bypasses dispatch and is marked as `COMPLETED`.

Acceptance criteria in `task-034-058-implement-orchestrator-preflight.md` have been marked as fulfilled.

---
*PR created automatically by Jules for task [5950990033860265452](https://jules.google.com/task/5950990033860265452) started by @szubster*