### PR TITLE
🧹 Sweeper: Remove unused export GEN2_VERSION_EXCLUSIVES

### DIFF
--- a/src/engine/exclusives/gen2Exclusives.ts
+++ b/src/engine/exclusives/gen2Exclusives.ts
@@ -1,4 +1,4 @@
-export const GEN2_VERSION_EXCLUSIVES: Record<string, number[]> = {
+const GEN2_VERSION_EXCLUSIVES: Record<string, number[]> = {
   gold: [
     56,
     57,


### PR DESCRIPTION
🎯 What
Removed the `export` keyword from `GEN2_VERSION_EXCLUSIVES` in `src/engine/exclusives/gen2Exclusives.ts`.

💡 Why
`knip` reported `GEN2_VERSION_EXCLUSIVES` as an unused export. After investigation, it was confirmed that this constant is only used locally within the `src/engine/exclusives/gen2Exclusives.ts` file by the `getGen2UnobtainableReason` function. Dropping the `export` keyword cleans up the dead export while keeping the required logic intact, improving the health of the codebase.

✅ Verification
- `pnpm knip` no longer reports `GEN2_VERSION_EXCLUSIVES` as an unused export.
- `pnpm lint` completed with 0 errors or warnings.
- `pnpm test` (Vitest) passed all 258 tests.
- `pnpm test:e2e` (Playwright) passed all 37 E2E tests successfully.

✨ Result
A cleaner codebase with less dead code and reduced noise from analysis tools.

---
*PR created automatically by Jules for task [17022970634861095927](https://jules.google.com/task/17022970634861095927) started by @szubster*