### PR TITLE
chore(foundry): apply empty PR policy for epic 010

### DIFF
--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -1,2 +1,5 @@
 ## Epic 012 (Gastown Orchestrator)
 All acceptance criteria in .foundry/epics/epic-012-gastown-orchestrator.md are already checked. No new STORY nodes need to be created. Applying EMPTY PR POLICY.
+
+## Epic 010 (Oxlint Config)
+All acceptance criteria in .foundry/epics/epic-010-oxlint-config.md are already met. There is no work to do. Applying EMPTY PR POLICY.


### PR DESCRIPTION
Applying EMPTY PR POLICY for epic-010-oxlint-config as all tasks are completed.

---
*PR created automatically by Jules for task [3624221429928060180](https://jules.google.com/task/3624221429928060180) started by @szubster*