### PR TITLE
feat: Create PRD for Researcher Persona

### DIFF
--- a/.foundry/ideas/idea-011-researcher-persona.md
+++ b/.foundry/ideas/idea-011-researcher-persona.md
@@ -26,3 +26,5 @@ Introduce a `researcher` persona within the Foundry system.
 
 ## Impact
 Better context injection for implementation steps, higher quality PRDs and Epics, and reduced context-switching overhead for implementation personas.
+
+Child PRD: .foundry/prds/prd-011-009-researcher-persona.md

--- a/.foundry/prds/prd-011-009-researcher-persona.md
+++ b/.foundry/prds/prd-011-009-researcher-persona.md
@@ -1,0 +1,30 @@
+---
+id: prd-011-009-researcher-persona
+type: PRD
+title: "PRD: Introduce Researcher Persona"
+status: PENDING
+owner_persona: "architect"
+created_at: "2026-05-01"
+updated_at: "2026-05-01"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: ".foundry/ideas/idea-011-researcher-persona.md"
+tags: ["foundry", "persona", "research"]
+notes: ""
+---
+
+# PRD: Introduce Researcher Persona
+
+## Problem Statement
+Currently, Foundry agents lack a dedicated workflow for deep context gathering or exploring new architectural decisions. This causes downstream agents to switch context frequently and results in lower quality execution steps.
+
+## Proposed Solution
+Introduce a new `researcher` persona to the Foundry system. This persona will be responsible for exploratory tasks and writing context-rich research reports to be used by downstream pipeline nodes. We need to be able to attach these research tasks to existing node workflows.
+
+## Acceptance Criteria
+- [ ] Add the `researcher` persona to the GitHub agents list.
+- [ ] Create a `researcher.md` prompt framework in `.github/agents/`.
+- [ ] Create a `researcher.md` journal policy/file in `.foundry/journals/`.
+- [ ] Update the system schema (`.foundry/docs/schema.md`) to include the new persona and its responsibilities.
+- [ ] Implement the ability to attach research nodes (TASKs) as explicit dependencies for implementation TASKs to inject context safely into the DAG.

--- a/.foundry/prds/prd-011-009-researcher-persona.md
+++ b/.foundry/prds/prd-011-009-researcher-persona.md
@@ -26,5 +26,7 @@ Introduce a new `researcher` persona to the Foundry system. This persona will be
 - [ ] Add the `researcher` persona to the GitHub agents list.
 - [ ] Create a `researcher.md` prompt framework in `.github/agents/`.
 - [ ] Create a `researcher.md` journal policy/file in `.foundry/journals/`.
+- [ ] Create a dedicated storage directory `.foundry/research/` for research output nodes.
 - [ ] Update the system schema (`.foundry/docs/schema.md`) to include the new persona and its responsibilities.
-- [ ] Implement the ability to attach research nodes (TASKs) as explicit dependencies for implementation TASKs to inject context safely into the DAG.
+- [ ] Update schema to allow attaching `research_references` array to any node type to inject research context safely.
+- [ ] Implement logic in `foundry-orchestrator.ts` and `foundry-engine.yml` so every agent automatically retrieves and includes all research references from its parent chain.


### PR DESCRIPTION
Creates a new PRD node for the researcher persona, advancing IDEA-011 in the Foundry DAG. Adheres strictly to the parent-linked ID schema and avoids cyclic dependencies.

---
*PR created automatically by Jules for task [9188008043301691047](https://jules.google.com/task/9188008043301691047) started by @szubster*