### PR TITLE
Epic Planner: Create Epic for Relax Node Engine Requirement

### DIFF
--- a/.foundry/epics/epic-009-020-relax-node-engine.md
+++ b/.foundry/epics/epic-009-020-relax-node-engine.md
@@ -1,0 +1,23 @@
+---
+id: epic-009-020-relax-node-engine
+type: EPIC
+title: "Relax Node engine requirement in package.json to >=22.0.0"
+status: READY
+owner_persona: "story_owner"
+created_at: "2026-05-01"
+updated_at: "2026-05-01"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: ".foundry/prds/prd-011-009-relax-node-engine.md"
+tags: ["infrastructure"]
+notes: ""
+---
+
+# Relax Node engine requirement in package.json to >=22.0.0
+
+## Objective
+Update the `engines.node` field in `package.json` from `>=24.0.0` to `>=22.0.0` to match the Foundry agents' execution environment, reducing PR rejections.
+
+## Acceptance Criteria
+- [ ] Update `engines.node` in `package.json` to `>=22.0.0`.

--- a/.foundry/prds/prd-011-009-relax-node-engine.md
+++ b/.foundry/prds/prd-011-009-relax-node-engine.md
@@ -23,4 +23,6 @@ The `task-016-041-update-package-json-lint` suffered 6 rejections because agents
 We should relax the `engines.node` field in `package.json` from `>=24.0.0` to `>=22.0.0` to natively match the execution environment of the Foundry agents. This will prevent friction and reduce PR rejections without requiring manual troubleshooting overrides in the agent prompts.
 
 ## Acceptance Criteria
-- [ ] Update `engines.node` in `package.json` to `>=22.0.0`.
+- [x] Update `engines.node` in `package.json` to `>=22.0.0`.
+
+- **Child Epic**: [.foundry/epics/epic-009-020-relax-node-engine.md](.foundry/epics/epic-009-020-relax-node-engine.md)


### PR DESCRIPTION
This PR creates a new Epic node (`epic-009-020-relax-node-engine.md`) derived from `prd-011-009-relax-node-engine.md`. It translates the product requirements document into an actionable Epic, defining the objective and acceptance criteria for relaxing the `package.json` Node engine requirements to `>=22.0.0`. It also correctly updates the parent PRD to link to this new Epic and checks off the associated acceptance criteria without modifying the parent's YAML frontmatter.

---
*PR created automatically by Jules for task [7539759548671327809](https://jules.google.com/task/7539759548671327809) started by @szubster*