### PR TITLE
🧬 Oak: [data correction] Fix incomplete and duplicated Gen 2 version exclusives

### DIFF
--- a/data/db/metadata.json
+++ b/data/db/metadata.json
@@ -1,4 +1,4 @@
 {
   "sourceSha": "",
-  "generatedAt": "2026-04-29T07:55:23.234Z"
+  "generatedAt": "2026-05-01T06:07:56.600Z"
 }

--- a/data/db/pokemon.jsonl
+++ b/data/db/pokemon.jsonl
@@ -120,7 +120,7 @@
 {"id":120,"n":"Staryu","cr":225,"gr":-1,"eto":[{"id":121,"det":[{"tr":3,"item":84}],"ef":120}]}
 {"id":121,"n":"Starmie","cr":60,"gr":-1,"efrm":[120],"det":[{"tr":3,"item":84}]}
 {"id":122,"n":"Mr. Mime","cr":45,"eto":[{"id":866,"ef":122}],"efrm":[439],"det":[{},{}]}
-{"id":123,"n":"Scyther","cr":45,"eto":[{"id":212,"det":[{"tr":2,"held":210}],"ef":123},{"id":900,"det":[{"tr":3,"item":10001}],"ef":123}]}
+{"id":123,"n":"Scyther","cr":45,"eto":[{"id":212,"det":[{"tr":2,"held":210}],"ef":123},{"id":900,"det":[{"tr":3,"item":2230}],"ef":123}]}
 {"id":124,"n":"Jynx","cr":45,"gr":8,"efrm":[238],"det":[{"ml":30}]}
 {"id":125,"n":"Electabuzz","cr":45,"gr":2,"eto":[{"id":466,"det":[{"tr":2,"held":299}],"ef":125}],"efrm":[239],"det":[{"ml":30}]}
 {"id":126,"n":"Magmar","cr":45,"gr":2,"eto":[{"id":467,"det":[{"tr":2,"held":300}],"ef":126}],"efrm":[240],"det":[{"ml":30}]}
@@ -213,8 +213,8 @@
 {"id":213,"n":"Shuckle","cr":190}
 {"id":214,"n":"Heracross","cr":45}
 {"id":215,"n":"Sneasel","cr":60,"eto":[{"id":461,"det":[{"held":303,"time":2}],"ef":215},{"id":903,"ef":215}]}
-{"id":216,"n":"Teddiursa","cr":120,"eto":[{"id":217,"eto":[{"id":901,"det":[{"tr":3,"item":10002}],"ef":217}],"det":[{"ml":30}],"ef":216}]}
-{"id":217,"n":"Ursaring","cr":60,"eto":[{"id":901,"det":[{"tr":3,"item":10002}],"ef":217}],"efrm":[216],"det":[{"ml":30}]}
+{"id":216,"n":"Teddiursa","cr":120,"eto":[{"id":217,"eto":[{"id":901,"det":[{"tr":3,"item":2231}],"ef":217}],"det":[{"ml":30}],"ef":216}]}
+{"id":217,"n":"Ursaring","cr":60,"eto":[{"id":901,"det":[{"tr":3,"item":2231}],"ef":217}],"efrm":[216],"det":[{"ml":30}]}
 {"id":218,"n":"Slugma","cr":190,"eto":[{"id":219,"det":[{"ml":38}],"ef":218}]}
 {"id":219,"n":"Magcargo","cr":75,"efrm":[218],"det":[{"ml":38}]}
 {"id":220,"n":"Swinub","cr":225,"eto":[{"id":221,"eto":[{"id":473,"det":[{}],"ef":221}],"det":[{"ml":33}],"ef":220}]}

--- a/src/engine/exclusives/gen2Exclusives.ts
+++ b/src/engine/exclusives/gen2Exclusives.ts
@@ -1,28 +1,9 @@
+export const goldExclusives = [10, 11, 12, 27, 28, 56, 57, 58, 59, 167, 168, 207, 216, 217, 226];
+export const silverExclusives = [13, 14, 15, 23, 24, 37, 38, 52, 53, 165, 166, 225, 227, 231, 232];
+
 export const GEN2_VERSION_EXCLUSIVES: Record<string, number[]> = {
-  gold: [
-    56,
-    57,
-    58,
-    59, // Mankey, Primeape, Growlithe, Arcanine
-    167,
-    168, // Spinarak, Ariados
-    226, // Mantine
-    207, // Gligar
-    216,
-    217, // Teddiursa, Ursaring
-  ],
-  silver: [
-    37,
-    38, // Vulpix, Ninetales
-    52,
-    53, // Meowth, Persian
-    165,
-    166, // Ledyba, Ledian
-    225, // Delibird
-    227, // Skarmory
-    231,
-    232, // Phanpy, Donphan
-  ],
+  gold: goldExclusives,
+  silver: silverExclusives,
 };
 
 export function getGen2UnobtainableReason(

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -1,5 +1,6 @@
 import gen2Landmarks from '../../data/gen2/landmarks.json';
 import gen2MapLocations from '../../data/gen2/mapLocations.json';
+import { goldExclusives, silverExclusives } from '../../exclusives/gen2Exclusives';
 import type { GameVersion, PokemonInstance, SaveData } from './common';
 import { checkShiny, decodeGen12String, parseDVs } from './common';
 
@@ -98,9 +99,6 @@ function parseGen2PokemonInstance(
  * @returns 'gold', 'silver', or 'unknown'.
  */
 export function detectGen2GameVersion(owned: Set<number>, seen: Set<number>): GameVersion {
-  const goldExclusives = [56, 57, 58, 59, 167, 168, 207, 216, 217, 226];
-  const silverExclusives = [37, 38, 52, 53, 165, 166, 225, 227, 231, 232];
-
   let goldScore = 0;
   let silverScore = 0;
 


### PR DESCRIPTION
The Gen 2 game detection heuristic in the save parser was using an incomplete, hardcoded list of version exclusives that missed early-game Bug and Poison types like Caterpie and Ekans. Furthermore, the `gen2Exclusives.ts` lists were similarly incomplete and duplicated. This commit refactors the codebase to use a single, complete source of truth for Gen 2 version exclusives exported from `gen2Exclusives.ts`, bringing the engine's internal data into alignment with PokeAPI.

---
*PR created automatically by Jules for task [5787115789688589798](https://jules.google.com/task/5787115789688589798) started by @szubster*