### PR TITLE
docs(foundry): apply empty PR policy for state store migration epic

### DIFF
--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -3,3 +3,6 @@ All acceptance criteria in .foundry/epics/epic-012-gastown-orchestrator.md are a
 
 ## Epic 010 (Oxlint Config)
 All acceptance criteria in .foundry/epics/epic-010-oxlint-config.md are already met. There is no work to do. Applying EMPTY PR POLICY.
+
+## Epic 014 (State Store Migration)
+All acceptance criteria in .foundry/epics/epic-005-014-state-store-migration.md are already met. No new STORY nodes need to be created. Applying EMPTY PR POLICY.


### PR DESCRIPTION
The `epic-005-014-state-store-migration.md` node already lists generated stories that satisfy all of its acceptance criteria. In accordance with the system's Empty PR Policy, no new `STORY` nodes were generated. Instead, this outcome has been documented in `.foundry/journals/story_owner.md` to trigger the automatic merge of an empty PR, which will allow the Foundry DAG to continue progressing normally.

---
*PR created automatically by Jules for task [92390769330479930](https://jules.google.com/task/92390769330479930) started by @szubster*