### PR TITLE
Refactor: Remove legacy localStorage fallback from E2E Testing

### DIFF
--- a/.foundry/tasks/task-033-060-remove-localstorage-e2e.md
+++ b/.foundry/tasks/task-033-060-remove-localstorage-e2e.md
@@ -22,5 +22,5 @@ Remove the legacy `localStorage` injection from `tests/e2e/test-utils.ts` now th
 - Remove the backward compatibility comments.
 
 ## Acceptance Criteria
-- [ ] `localStorage` is no longer injected in `initializeWithSave`.
-- [ ] All E2E tests continue to pass.
+- [x] `localStorage` is no longer injected in `initializeWithSave`.
+- [x] All E2E tests continue to pass.

--- a/tests/e2e/test-utils.ts
+++ b/tests/e2e/test-utils.ts
@@ -27,10 +27,7 @@ export async function initializeWithSave(
 
     await page.evaluate(
       async ({ saveArray, base64String }) => {
-        // 1. LocalStorage injection (backward compatibility)
-        localStorage.setItem('last_save_file', base64String);
-
-        // 2. IndexedDB injection
+        // IndexedDB injection
         const SAVE_DB_NAME = 'SaveDB';
         const STORE_NAME = 'saves';
 

--- a/tests/e2e/test-utils.ts
+++ b/tests/e2e/test-utils.ts
@@ -23,10 +23,9 @@ export async function initializeWithSave(
       fileBuffer = Buffer.from(savePathOrData);
     }
     const saveArray = Array.from(fileBuffer);
-    const base64String = fileBuffer.toString('base64');
 
     await page.evaluate(
-      async ({ saveArray, base64String }) => {
+      async ({ saveArray }) => {
         // IndexedDB injection
         const SAVE_DB_NAME = 'SaveDB';
         const STORE_NAME = 'saves';
@@ -52,7 +51,7 @@ export async function initializeWithSave(
         });
         db.close();
       },
-      { saveArray, base64String },
+      { saveArray },
     );
 
     await page.reload();


### PR DESCRIPTION
Removes the legacy `localStorage` fallback from the `tests/e2e/test-utils.ts` file since E2E testing has successfully migrated to IndexedDB. This cleans up technical debt and simplifies the test setup logic. Also checked off the acceptance criteria in the corresponding task node. All E2E tests have been verified to pass.

---
*PR created automatically by Jules for task [17555759635743609130](https://jules.google.com/task/17555759635743609130) started by @szubster*