### PR TITLE
🎨 Palette: Add missing ARIA labels to icon buttons

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -195,6 +195,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
               <button
                 type="button"
                 data-testid="version-selector"
+                aria-label="Select Game Version"
                 onClick={() => setIsVersionModalOpen(true)}
                 className={cn(
                   'group zoom-in-95 fade-in relative animate-in overflow-hidden rounded-2xl border px-5 py-2.5 font-black text-[11px] uppercase tracking-widest transition-all duration-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -44,6 +44,7 @@ export function BottomNav() {
 
         <Link
           to="/"
+          aria-label="Pokedex"
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isDex ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
@@ -61,6 +62,7 @@ export function BottomNav() {
 
         <Link
           to="/storage"
+          aria-label="Storage"
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isStorage ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
@@ -78,6 +80,7 @@ export function BottomNav() {
 
         <Link
           to="/assistant"
+          aria-label="Assistant"
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isAssistant ? 'text-[var(--theme-primary)]' : 'text-zinc-600',

--- a/src/components/PokedexGrid.tsx
+++ b/src/components/PokedexGrid.tsx
@@ -93,6 +93,7 @@ export function PokedexGrid({ pokemonList }: { pokemonList: { id: number; name: 
         </p>
         <button
           type="button"
+          aria-label="Clear all filters"
           onClick={() => {
             useStore.getState().setSearchTerm('');
             useStore.getState().setFilters([]);

--- a/src/components/VersionModal.tsx
+++ b/src/components/VersionModal.tsx
@@ -33,6 +33,7 @@ export function VersionModal() {
             <button
               type="button"
               key={v.id}
+              aria-label={`Select ${v.label} version`}
               onClick={() => {
                 setManualVersion(v.id as GameVersion);
                 setIsVersionModalOpen(false);

--- a/src/components/pokemon/details/PokemonEvolutions.tsx
+++ b/src/components/pokemon/details/PokemonEvolutions.tsx
@@ -62,6 +62,7 @@ function ProcurementStrategy({
             {' '}
             <button
               type="button"
+              aria-label={`Navigate to ${evoReq.fromName} details`}
               onClick={() => onNavigate(evoReq.fromId, evoReq.fromName)}
               className="rounded-sm text-red-400 underline decoration-red-500/30 underline-offset-4 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
@@ -117,6 +118,7 @@ function EvolutionFrom({
         FROM{' '}
         <button
           type="button"
+          aria-label={`Navigate to ${evoReq.fromName} details`}
           onClick={() => onNavigate(evoReq.fromId, evoReq.fromName)}
           className="rounded-sm text-white underline decoration-purple-500/30 underline-offset-4 transition-colors hover:text-purple-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
@@ -158,6 +160,7 @@ function EvolutionTo({
             TO{' '}
             <button
               type="button"
+              aria-label={`Navigate to ${evo.name} details`}
               onClick={() => onNavigate(evo.id, evo.name)}
               className="rounded-sm text-white underline decoration-blue-500/30 underline-offset-4 transition-colors hover:text-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
@@ -192,6 +195,7 @@ function BreedingProtocol({
           <React.Fragment key={name}>
             <button
               type="button"
+              aria-label={`Navigate to ${name} details`}
               onClick={() => {
                 const id = breedingInfo.parentIds[i];
                 if (id) onNavigate(id, name);

--- a/src/components/settings/ClearStorageButton.tsx
+++ b/src/components/settings/ClearStorageButton.tsx
@@ -10,6 +10,7 @@ export function ClearStorageButton({ onClear }: { onClear: () => void }) {
       <div className="fade-in zoom-in-95 flex w-full animate-in gap-2 duration-200">
         <button
           type="button"
+          aria-label="Abort purge"
           onClick={() => setIsConfirming(false)}
           className="flex-1 border border-zinc-700 border-dashed bg-zinc-900 p-5 font-bold font-mono text-[10px] text-zinc-400 uppercase tracking-widest transition-all hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
@@ -17,6 +18,7 @@ export function ClearStorageButton({ onClear }: { onClear: () => void }) {
         </button>
         <button
           type="button"
+          aria-label="Confirm purge"
           onClick={onClear}
           className="group relative flex flex-1 items-center justify-center gap-2 border border-red-500 border-dashed bg-red-950/50 p-5 font-bold font-mono text-[10px] text-red-500 uppercase tracking-widest transition-all hover:bg-red-900/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
@@ -30,6 +32,7 @@ export function ClearStorageButton({ onClear }: { onClear: () => void }) {
   return (
     <button
       type="button"
+      aria-label="Initiate system purge"
       onClick={() => setIsConfirming(true)}
       className="group fade-in zoom-in-95 relative flex w-full animate-in items-center justify-center gap-3 border border-red-900/50 border-dashed bg-red-950/20 p-5 font-bold font-mono text-[10px] text-red-500/80 uppercase tracking-widest transition-all duration-200 hover:border-red-500/50 hover:bg-red-950/40 hover:text-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
     >

--- a/tests/e2e/assistant.spec.ts
+++ b/tests/e2e/assistant.spec.ts
@@ -9,7 +9,7 @@ test.describe('Assistant Page', () => {
 
     // 2. Navigate to Assistant page via Sidebar or BottomNav
     if (isMobile) {
-      const assistantLink = page.getByRole('link', { name: /SYS.ASST/i });
+      const assistantLink = page.getByRole('link', { name: 'Assistant' });
       await expect(assistantLink).toBeVisible();
       await assistantLink.click();
     } else {

--- a/tests/e2e/version_selection.spec.ts
+++ b/tests/e2e/version_selection.spec.ts
@@ -13,14 +13,14 @@ test.describe('Version Selection', () => {
     await versionBtn.click();
 
     // 2. Select Red in the modal
-    await page.getByRole('button', { name: 'Red', exact: true }).click();
+    await page.getByRole('button', { name: /Select Red version/i }).click();
 
     // 3. Check if the version indicator updated
     await expect(page.getByText(/RED/i).first()).toBeVisible();
 
     // 4. Toggle back to YELLOW via header
     await page.getByTestId('version-selector').click();
-    await page.getByRole('button', { name: 'Yellow', exact: true }).click();
+    await page.getByRole('button', { name: /Select Yellow version/i }).click();
     await expect(page.getByText(/YELLOW/i).first()).toBeVisible();
 
     await argosScreenshot(page, 'version-selected-yellow');
@@ -31,7 +31,7 @@ test.describe('Version Selection', () => {
 
     // Select Blue
     await page.getByTestId('version-selector').click();
-    await page.getByRole('button', { name: 'Blue', exact: true }).click();
+    await page.getByRole('button', { name: /Select Blue version/i }).click();
     await expect(page.getByText(/BLUE/i).first()).toBeVisible();
 
     // Reload


### PR DESCRIPTION
- Added `aria-label` to `AppLayout` version selector.
- Added `aria-label` to `BottomNav` links.
- Added `aria-label` to `PokedexGrid` clear filters button.
- Added `aria-label` to `VersionModal` version buttons.
- Added `aria-label` to `PokemonEvolutions` navigation buttons.
- Added `aria-label` to `ClearStorageButton` confirm/abort/initiate buttons.
- Updated e2e tests to use the new `aria-label` attributes.

---
*PR created automatically by Jules for task [3057089557416622918](https://jules.google.com/task/3057089557416622918) started by @szubster*