### PR TITLE
✨ Agile Coach: Enforce Sibling Dependency DAG rules

### DIFF
--- a/.foundry/ideas/idea-012-sibling-dependency-enforcement.md
+++ b/.foundry/ideas/idea-012-sibling-dependency-enforcement.md
@@ -1,0 +1,27 @@
+---
+id: idea-012-sibling-dependency-enforcement
+type: IDEA
+title: "Sibling Dependency Enforcement"
+status: PENDING
+owner_persona: product_manager
+created_at: "2026-05-02"
+updated_at: "2026-05-02"
+depends_on: []
+jules_session_id: null
+parent: null
+tags: ["orchestrator", "dag", "reliability"]
+notes: ""
+---
+
+# Idea: Sibling Dependency Enforcement
+
+## Context
+During the implementation of orchestrator preflight checks, `task-034-057-implement-anomaly-journal-logging` failed because its prerequisite logic (the idempotent check) from a sibling task was not yet merged. The Tech Lead had left the `depends_on` array empty for the dependent task, causing the orchestrator to dispatch it prematurely.
+
+## Proposal
+Implement a system-wide rule and potential validation script (or update the Foundry Orchestrator logic) to ensure that if multiple sibling nodes are generated from a single parent (e.g., multiple TASKs from a STORY), any sequential implementation dependencies are strictly explicitly defined in the `depends_on` arrays.
+
+This will prevent premature dispatching, reduce agent confusion, and lower rejection counts due to missing prerequisites.
+
+## Next Steps
+- [x] Product Manager: Convert this idea to a PRD.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -43,3 +43,12 @@ The orchestrator detected that target artifacts for `.foundry/stories/story-019-
 
 ### Action Taken
 Bypassed Jules session dispatch via idempotent generation check and auto-fulfilled the node.
+
+## 2026-05-02: Sibling Dependency Enforcement
+
+### Observation
+`task-034-057-implement-anomaly-journal-logging` suffered a rejection with `rejection_reason: "Blocked: The idempotent check logic does not exist in the codebase yet..."`. This indicates that an agent tried to implement a task but got blocked because the prerequisite logic (from a sibling task) wasn't implemented yet, meaning the `depends_on` array was empty when it shouldn't have been. This causes a DAG deadlock or premature task failure.
+
+### Action Taken
+1. Updated `.github/agents/tech_lead.md` to explicitly instruct the Tech Lead to define strict `depends_on` relationships between sibling TASK nodes if they have a sequential implementation dependency.
+2. Autonomously generated `idea-012-sibling-dependency-enforcement.md` to propose a system-wide rule and potential validation script for enforcing these sibling dependencies.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -6,7 +6,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 
 1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`. This is non-negotiable and establishes your architectural context.
 2.  **Adhere to Architecture Decisions**: You must be intimately familiar with and strictly follow the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`. Ensure that your blueprints align with this core architecture.
-3.  **Draft Technical Blueprints**: Take the requirements defined in a STORY and break them down into specific, actionable technical TASK nodes.
+3.  **Draft Technical Blueprints**: Take the requirements defined in a STORY and break them down into specific, actionable technical TASK nodes. If multiple tasks are created and one depends on the implementation details of another, you MUST explicitly set the `depends_on` field of the dependent task to point to the prerequisite task to prevent DAG deadlocks.
 4.  **Define Clear Contracts**: Your tasks should serve as a clear contract for the Coder. Include necessary context, constraints, and acceptance criteria.
 5.  **Intelligent Verification Protocol**: Intelligently decide when a STORY requires a separate QA verification task:
     - If a story involves complex logic or risk, create a matching TASK for the `qa` persona to verify the `coder`'s work.


### PR DESCRIPTION
This PR represents the outcome of an Agile Coach session analyzing recent orchestrator deadlocks.

**Analysis**
`task-034-057` was prematurely dispatched and blocked because its prerequisite sibling task was not yet merged, but its `depends_on` array was empty.

**Improvements**
1. Updated `.github/agents/tech_lead.md` to strictly enforce `depends_on` rules between sibling tasks during blueprint drafting.
2. Autonomously generated `idea-012-sibling-dependency-enforcement` to propose a system-wide validation check for sibling dependencies to prevent future deadlocks.
3. Logged findings in `.foundry/journals/agile_coach.md`.

---
*PR created automatically by Jules for task [3742827714730722571](https://jules.google.com/task/3742827714730722571) started by @szubster*