### PR TITLE
feat(foundry): PRD for Sibling Dependency Enforcement

### DIFF
--- a/.foundry/ideas/idea-012-sibling-dependency-enforcement.md
+++ b/.foundry/ideas/idea-012-sibling-dependency-enforcement.md
@@ -25,3 +25,4 @@ This will prevent premature dispatching, reduce agent confusion, and lower rejec
 
 ## Next Steps
 - [x] Product Manager: Convert this idea to a PRD.
+- Spawned PRD: .foundry/prds/prd-012-011-sibling-dependency-enforcement.md

--- a/.foundry/prds/prd-012-011-sibling-dependency-enforcement.md
+++ b/.foundry/prds/prd-012-011-sibling-dependency-enforcement.md
@@ -1,0 +1,27 @@
+---
+id: prd-012-011-sibling-dependency-enforcement
+type: PRD
+title: "Sibling Dependency Enforcement"
+status: READY
+owner_persona: "architect"
+created_at: "2026-05-01"
+updated_at: "2026-05-01"
+depends_on: []
+jules_session_id: null
+parent: .foundry/ideas/idea-012-sibling-dependency-enforcement.md
+tags: ["orchestrator", "dag", "reliability"]
+notes: ""
+---
+
+# PRD: Sibling Dependency Enforcement
+
+## Objective
+Establish a system-wide rule and corresponding validation logic to ensure that explicitly defined `depends_on` relationships are required between sibling nodes (e.g., tasks generated from the same story) when sequential dependencies exist. This mitigates premature DAG dispatching.
+
+## Requirements
+1. Define an ADR establishing the rule.
+2. Update the schema documentation (`.foundry/docs/schema.md`).
+3. Ensure the orchestrator or a pre-commit validation script can optionally enforce or warn against this pattern.
+
+## Acceptance Criteria
+- [ ] Create an ADR for Sibling Dependency Enforcement.


### PR DESCRIPTION
I have created a new PRD node (`prd-012-011-sibling-dependency-enforcement.md`) as requested by the Product Manager role to address the problem of sibling task dependencies missing from the orchestrator logic. The ID correctly maps to its parent (IDEA-012), and I assigned the node to the `architect` to draft the required ADR as per the Foundry Node Progression rules (Idea -> PRD -> ADR).

I updated the parent IDEA node by checking off the acceptance criteria and adding a link to the newly spawned PRD.

Testing was done using `pnpm test` (with required playwright browser dependencies fetched).

---
*PR created automatically by Jules for task [3998814947133359520](https://jules.google.com/task/3998814947133359520) started by @szubster*