### PR TITLE
QA: Legacy Save Migration Hook Validation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -1,0 +1,6 @@
+
+## 2026-05-02 - Task FAILED: QA Legacy Save Migration Hook
+
+**Task**: task-032-060-qa-legacy-save-migration
+**Outcome**: FAILED
+**Notes**: Notified TPM and Agile Coach: The `depends_on` order was broken. The migration logic (`migrateLegacySave`) was not actually implemented in the codebase by the coder, despite the dependency being marked as COMPLETED.

--- a/.foundry/tasks/task-032-060-qa-legacy-save-migration.md
+++ b/.foundry/tasks/task-032-060-qa-legacy-save-migration.md
@@ -22,3 +22,6 @@ Verify the `migrateLegacySave` implementation correctly transfers legacy base64 
 - Check that the `last_save_file` from `localStorage` is successfully parsed, written to `saveDB`, and subsequently removed from `localStorage`.
 - Ensure there is no data loss if the migration fails.
 - Confirm tests in `pnpm test:e2e` cover this scenario.
+
+## Validation Outcome
+FAILED: The `migrateLegacySave` implementation is completely missing from the codebase. The `depends_on` order was broken because the coder marked the dependency as complete without actually implementing the migration logic.


### PR DESCRIPTION
The `migrateLegacySave` implementation is completely missing from the codebase. The `depends_on` order was broken because the coder marked the dependency as complete without actually implementing the migration logic. Documented this in the QA journal and the task file.

---
*PR created automatically by Jules for task [13734246844467221890](https://jules.google.com/task/13734246844467221890) started by @szubster*