### PR TITLE
fix: empty dependencies blocking node transition

### DIFF
--- a/.foundry/epics/epic-008-017-orchestrator-preflight-checks.md
+++ b/.foundry/epics/epic-008-017-orchestrator-preflight-checks.md
@@ -1,18 +1,21 @@
 ---
 id: epic-008-017-orchestrator-preflight-checks
 type: EPIC
-title: "Orchestrator Pre-flight Generation Validation"
-status: PENDING
+title: Orchestrator Pre-flight Generation Validation
+status: READY
 owner_persona: story_owner
-created_at: "2026-04-29"
-updated_at: "2026-04-30"
+created_at: '2026-04-29'
+updated_at: '2026-04-30'
 depends_on: []
 jules_session_id: null
 parent: .foundry/prds/prd-010-008-idempotent-node-generation.md
-tags: ["orchestrator", "generation", "efficiency"]
+tags:
+  - orchestrator
+  - generation
+  - efficiency
 rejection_count: 0
-rejection_reason: ""
-notes: ""
+rejection_reason: ''
+notes: ''
 ---
 
 # Epic: Orchestrator Pre-flight Generation Validation

--- a/.foundry/ideas/idea-003-atomic-handoff-foundation.md
+++ b/.foundry/ideas/idea-003-atomic-handoff-foundation.md
@@ -1,11 +1,11 @@
 ---
 id: idea-003-atomic-handoff-foundation
 type: IDEA
-title: "Foundry V2: Atomic Handoffs & Single-Persona Ownership"
-status: PENDING
+title: 'Foundry V2: Atomic Handoffs & Single-Persona Ownership'
+status: READY
 owner_persona: product_manager
-created_at: "2026-04-21"
-updated_at: "2026-04-27"
+created_at: '2026-04-21'
+updated_at: '2026-04-27'
 depends_on: []
 jules_session_id: null
 ---

--- a/.foundry/ideas/idea-010-idempotent-node-generation.md
+++ b/.foundry/ideas/idea-010-idempotent-node-generation.md
@@ -1,18 +1,21 @@
 ---
 id: idea-010-idempotent-node-generation
 type: IDEA
-title: "Idempotent Node Generation Mechanism"
-status: PENDING
+title: Idempotent Node Generation Mechanism
+status: READY
 owner_persona: product_manager
-created_at: "2026-04-29"
-updated_at: "2026-04-29"
+created_at: '2026-04-29'
+updated_at: '2026-04-29'
 depends_on: []
 jules_session_id: null
 parent: null
-tags: ["orchestrator", "generation", "efficiency"]
+tags:
+  - orchestrator
+  - generation
+  - efficiency
 rejection_count: 0
-rejection_reason: ""
-notes: ""
+rejection_reason: ''
+notes: ''
 ---
 
 # Idea: Idempotent Node Generation Mechanism

--- a/.foundry/prds/prd-001-v2-lifecycle.md
+++ b/.foundry/prds/prd-001-v2-lifecycle.md
@@ -1,17 +1,17 @@
 ---
-id: "prd-001-v2-lifecycle"
-type: "PRD"
-title: "Foundry V2: Atomic Handoffs & Single-Persona Ownership Lifecycle"
-status: PENDING
-owner_persona: "epic_planner"
-created_at: "2026-04-21"
-updated_at: "2026-04-27"
+id: prd-001-v2-lifecycle
+type: PRD
+title: 'Foundry V2: Atomic Handoffs & Single-Persona Ownership Lifecycle'
+status: READY
+owner_persona: epic_planner
+created_at: '2026-04-21'
+updated_at: '2026-04-27'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/ideas/idea-003-atomic-handoff-foundation.md"
+parent: .foundry/ideas/idea-003-atomic-handoff-foundation.md
 tags:
-  - "v2-architecture"
-  - "lifecycle"
+  - v2-architecture
+  - lifecycle
 ---
 
 # PRD: Foundry V2: Atomic Handoffs & Single-Persona Ownership Lifecycle

--- a/.foundry/prds/prd-010-008-idempotent-node-generation.md
+++ b/.foundry/prds/prd-010-008-idempotent-node-generation.md
@@ -1,18 +1,21 @@
 ---
 id: prd-010-008-idempotent-node-generation
 type: PRD
-title: "Idempotent Node Generation Mechanism"
-status: PENDING
+title: Idempotent Node Generation Mechanism
+status: READY
 owner_persona: epic_planner
-created_at: "2026-04-29"
-updated_at: "2026-04-29"
+created_at: '2026-04-29'
+updated_at: '2026-04-29'
 depends_on: []
 jules_session_id: null
 parent: .foundry/ideas/idea-010-idempotent-node-generation.md
-tags: ["orchestrator", "generation", "efficiency"]
+tags:
+  - orchestrator
+  - generation
+  - efficiency
 rejection_count: 0
-rejection_reason: ""
-notes: ""
+rejection_reason: ''
+notes: ''
 ---
 
 # PRD: Idempotent Node Generation Mechanism


### PR DESCRIPTION
Updates the status of Foundry nodes with an empty \`depends_on\` list from \`PENDING\` to \`READY\`. This unblocks the DAG so the orchestrator can properly schedule the nodes.

---
*PR created automatically by Jules for task [2838466324650875557](https://jules.google.com/task/2838466324650875557) started by @szubster*