### PR TITLE
🛠️ Infras: Add pnpm audit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,27 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Audit Dependencies
+        run: pnpm audit --prod
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -35,3 +35,6 @@
 
 ## 2026-05-01 - Optimized CI Pipeline
 **Learning:** Evaluated current sequential CI setup. Discovered that splitting testing, linting, and building into parallel jobs decreases total CI run time for the `ci.yml` workflow. Added `concurrency` blocks across `ci.yml`, `playwright.yml`, and `biome.yml` to automatically cancel redundant in-progress runs when new commits are pushed, saving CI minutes and improving developer experience.
+
+## 2026-05-02 - Added pnpm audit to CI
+**Learning:** Added `pnpm audit` job to `.github/workflows/ci.yml` to automatically catch dependency vulnerabilities during CI runs. Configured it to run with `--prod` flag to avoid failing builds on devDependency vulnerabilities, as they are mostly harmless in this context and can block releases unnecessarily.


### PR DESCRIPTION
**What:** Added a `pnpm audit` job to the CI workflow (`.github/workflows/ci.yml`) to automatically check for dependency vulnerabilities.
**Why:** To catch vulnerabilities early during CI runs and prevent them from reaching production.
**Impact on DX/CI:** Improves security analysis natively in CI without adding new external tools. Used `--prod` to ignore `devDependency` vulnerabilities, which limits false positives blocking PRs unnecessarily.
**Setup notes:** None. Uses the native `pnpm audit` command directly in the CI runner.

---
*PR created automatically by Jules for task [12134840015654772675](https://jules.google.com/task/12134840015654772675) started by @szubster*