### PR TITLE
chore(foundry): Apply Empty PR Policy for researcher persona Epic breakdown

### DIFF
--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -6,3 +6,7 @@ Outcome: The generated epics (epic-010, epic-011, epic-012) already exist and ar
 ## 2026-05-02
 Task: Break down PRD prd-005-010-late-binding-orchestrator.md
 Outcome: The generated epics (epic-010, epic-011, epic-012) already exist and are COMPLETED. The PRD is already fully broken down. Applying EMPTY PR POLICY.
+
+## 2026-05-02
+Task: Break down PRD prd-011-009-researcher-persona.md
+Outcome: The target epic (epic-011-021-researcher-persona.md) already exists and is complete. There is no new work to do. Applying EMPTY PR POLICY.


### PR DESCRIPTION
The target Epic (`epic-011-021-researcher-persona.md`) already exists, exactly matches the PRD's Acceptance Criteria (`prd-011-009-researcher-persona.md`), and is listed in the PRD's Implementation section. Following the Empty PR Policy and system schema rules, an entry has been added to the Epic Planner's journal to document that there is no new breakdown work to do.

---
*PR created automatically by Jules for task [7684700597915606290](https://jules.google.com/task/7684700597915606290) started by @szubster*