### PR TITLE
🗃️ Archivist: [Update agent count and roster to include Mason]

### DIFF
--- a/.foundry/docs/knowledge_base/infrastructure/jules_agents_dispatch.md
+++ b/.foundry/docs/knowledge_base/infrastructure/jules_agents_dispatch.md
@@ -20,7 +20,7 @@ Just add or remove a `.md` file in `.jules/schedules/`. No workflow changes need
 
 - `JULES_API_KEY` — set in repo Settings → Secrets → Actions
 
-### Current roster (13 agents)
+### Current roster (14 agents)
 
 | Agent | Emoji | Domain |
 |---|---|---|
@@ -28,6 +28,7 @@ Just add or remove a `.md` file in `.jules/schedules/`. No workflow changes need
 | bolt | ⚡ | Performance |
 | canvas | 🖼️ | Bold UI redesigns |
 | infras | 🔧 | Developer tooling |
+| mason | 🧱 | React Component Refactoring |
 | nurse | 🛡️ | Type safety |
 | oak | 🧬 | Data integrity |
 | palette | 🎨 | UX & accessibility |


### PR DESCRIPTION
Updates the `.foundry/docs/knowledge_base/infrastructure/jules_agents_dispatch.md` to reflect the newly added `mason` agent (which refactors React components) and increments the agent total count to 14. Tested changes with `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [4149935496042535273](https://jules.google.com/task/4149935496042535273) started by @szubster*