### PR TITLE
epic_planner: empty PR for prd-001-v2-lifecycle.md

### DIFF
--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -10,3 +10,7 @@ Outcome: The generated epics (epic-010, epic-011, epic-012) already exist and ar
 ## 2026-05-02
 Task: Break down PRD prd-011-009-researcher-persona.md
 Outcome: The target epic (epic-011-021-researcher-persona.md) already exists and is complete. There is no new work to do. Applying EMPTY PR POLICY.
+
+## 2026-05-02
+Task: Break down PRD prd-001-v2-lifecycle.md
+Outcome: The generated epics (epic-007-atomic-handoff-schema.md, epic-008-atomic-handoff-orchestrator.md, epic-009-atomic-handoff-testing.md) already exist and are complete. There is no new work to do. Applying EMPTY PR POLICY.


### PR DESCRIPTION
Recorded the outcome in the epic_planner journal and applying the empty PR policy. The generated epics already exist and are complete, so there is no new work to do.

---
*PR created automatically by Jules for task [16893722396304632660](https://jules.google.com/task/16893722396304632660) started by @szubster*