### PR TITLE
Epic Planner: Empty PR Policy for PRD 010-008

### DIFF
--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -10,3 +10,7 @@ Outcome: The generated epics (epic-010, epic-011, epic-012) already exist and ar
 ## 2026-05-02
 Task: Break down PRD prd-011-009-researcher-persona.md
 Outcome: The target epic (epic-011-021-researcher-persona.md) already exists and is complete. There is no new work to do. Applying EMPTY PR POLICY.
+
+## 2026-05-02
+Task: Break down PRD prd-010-008-idempotent-node-generation.md
+Outcome: The generated epics (epic-008-017, epic-008-018, epic-008-019) already exist and are valid. The PRD is fully broken down. Applying EMPTY PR POLICY.


### PR DESCRIPTION
The Epic Planner attempted to breakdown PRD `prd-010-008-idempotent-node-generation.md` but found that all generated Epics already existed and the PRD was fully updated. Following the EMPTY PR POLICY, it recorded the anomaly in `.foundry/journals/epic_planner.md` without making dummy modifications.

---
*PR created automatically by Jules for task [5144191461067686783](https://jules.google.com/task/5144191461067686783) started by @szubster*