### PR TITLE
Architect: Document Gray-Matter Migration via ADR and Epic

### DIFF
--- a/.foundry/docs/adrs/006-gray-matter-parsing.md
+++ b/.foundry/docs/adrs/006-gray-matter-parsing.md
@@ -1,0 +1,20 @@
+# ADR 006: Gray-Matter Markdown Parsing Migration
+
+## Status
+Accepted
+
+## Context
+The Foundry system heavily relies on parsing Markdown files with YAML frontmatter to determine the Directed Acyclic Graph (DAG) state and workflow progression. Historically, we have used custom Regex manipulations (`/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*/m`) to extract and surgical replace strings in the frontmatter.
+
+While this approach preserved minor whitespace and formatting details to minimize git diff noise, it has become increasingly brittle and complex, particularly as the system scales and edge cases arise (e.g., quotes, multi-line values, or trailing characters).
+
+## Decision
+We will standardize on using the `gray-matter` library for ALL programmatic read and write operations related to Foundry nodes.
+- All custom regex manipulations for extracting or modifying frontmatter must be replaced.
+- Modifications should be made by mutating the parsed `data` object and re-serializing the file using `matter.stringify(parsed.content, parsed.data)`.
+- We accept the trade-off that `matter.stringify` may occasionally alter the exact serialization format (e.g., converting unquoted strings to quoted strings or reordering keys slightly) in exchange for robustness and predictability.
+
+## Consequences
+- The DAG orchestrator (`.github/scripts/foundry-orchestrator.ts`) and transition scripts (`.github/scripts/foundry-active.ts`) must be updated to use `matter.stringify`.
+- The strict "dumb" diff checks in `foundry-active.ts` that compare the raw `content` lengths will need to be relaxed or removed, as `gray-matter` might serialize the identical data with slight formatting differences.
+- Any future tooling or agents interacting with node files should use `gray-matter` instead of ad-hoc regex.

--- a/.foundry/epics/epic-011-022-implement-gray-matter.md
+++ b/.foundry/epics/epic-011-022-implement-gray-matter.md
@@ -1,0 +1,26 @@
+---
+id: epic-011-022-implement-gray-matter
+type: EPIC
+title: "Epic: Implement Gray-Matter parsing system-wide"
+status: PENDING
+owner_persona: "epic_planner"
+created_at: "2026-05-02"
+updated_at: "2026-05-02"
+depends_on:
+  - .foundry/prds/prd-012-011-gray-matter-parsing.md
+jules_session_id: null
+parent: ".foundry/prds/prd-012-011-gray-matter-parsing.md"
+tags: ["foundry", "parsing", "gray-matter", "maintenance"]
+notes: "Derived from PRD prd-012-011-gray-matter-parsing. Enforces ADR-006."
+---
+
+# Epic: Implement Gray-Matter parsing system-wide
+
+## Objective
+Standardize the parsing and serialization of Foundry nodes using `gray-matter` to replace the fragile regex-based custom parsers.
+
+## Acceptance Criteria
+- [ ] `foundry-orchestrator.ts` uses `gray-matter` stringification for status promotions.
+- [ ] `foundry-active.ts` uses `gray-matter` stringification for active transitions.
+- [ ] Strict "dumb" diff checks that break due to formatting changes are removed or updated to compare the parsed data objects instead of raw string lengths.
+- [ ] All tests pass.

--- a/.foundry/prds/prd-012-011-gray-matter-parsing.md
+++ b/.foundry/prds/prd-012-011-gray-matter-parsing.md
@@ -22,3 +22,7 @@ Regex manipulations of markdown and frontmatter are becoming increasingly fragil
 - Integrate `gray-matter` for parsing markdown files.
 - Replace existing regex-based parsers with `gray-matter`.
 - Ensure the DAG orchestrator properly uses the new parsing logic.
+
+## Implementation
+- ADR: .foundry/docs/adrs/006-gray-matter-parsing.md
+- Epic: .foundry/epics/epic-011-022-implement-gray-matter.md


### PR DESCRIPTION
This PR finalizes the architectural planning for the migration from regex-based frontmatter manipulation to `gray-matter` within the Foundry Engine.

As the `architect` persona, my role is to formulate the design and define the contracts, rather than execute the coding tasks. 
- Created **ADR 006**, formally deciding to migrate to `gray-matter`.
- Scaffolds **epic-011-022-implement-gray-matter.md** so the `tech_lead` and `coder` personas can implement the actual logic in `.github/scripts/`.
- Links these artifacts in the root PRD node.

---
*PR created automatically by Jules for task [4872568713400489361](https://jules.google.com/task/4872568713400489361) started by @szubster*