### PR TITLE
🧹 [clean up saveParser API and knip config]

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -9,3 +9,8 @@
 
 **Learning:** Duplicate agent learnings for tools like `knip` or `oxlint` can scatter across journals (e.g. `sweeper.md` and `strategist.md`).
 **Action:** Consolidate identical tool-specific learnings into a single comprehensive entry within the most relevant agent's journal to reduce noise and duplication.
+
+## 2026-05-02 - SaveParser API and Knip Cleanup
+
+**Learning:** Sometime a file may be mistakenly ignored in `knip.json` even if it is fully integrated into the module graph.
+**Action:** Run `pnpm exec knip` periodically and check the `Configuration hints` output to identify entries that can be safely removed from the `knip.json` `ignore` array.

--- a/knip.json
+++ b/knip.json
@@ -6,8 +6,7 @@
   "ignore": [
     ".github/scripts/**",
     "src/test-setup.ts",
-    "scripts/validate-foundry-ids.ts",
-    "src/engine/exclusives/gen2Exclusives.ts"
+    "scripts/validate-foundry-ids.ts"
   ],
   "rules": {
     "files": "warn",

--- a/src/engine/saveParser/index.ts
+++ b/src/engine/saveParser/index.ts
@@ -2,7 +2,6 @@ import type { GameVersion, PokemonInstance, SaveData } from './parsers/common';
 import { isGen1Save, parseGen1 } from './parsers/gen1';
 import { isGen2Save, parseGen2 } from './parsers/gen2';
 
-
 export type { GameVersion, PokemonInstance, SaveData };
 
 /**

--- a/src/engine/saveParser/index.ts
+++ b/src/engine/saveParser/index.ts
@@ -2,7 +2,6 @@ import type { GameVersion, PokemonInstance, SaveData } from './parsers/common';
 import { isGen1Save, parseGen1 } from './parsers/gen1';
 import { isGen2Save, parseGen2 } from './parsers/gen2';
 
-export { decodeGen12String } from './parsers/common';
 
 export type { GameVersion, PokemonInstance, SaveData };
 

--- a/src/engine/saveParser/saveParser.test.ts
+++ b/src/engine/saveParser/saveParser.test.ts
@@ -2,7 +2,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { GameVersion } from './index';
-import { decodeGen12String, parseSaveFile } from './index';
+import { parseSaveFile } from './index';
+import { decodeGen12String } from './parsers/common';
 
 describe('saveParser - Pokémon Gen 1 Validation', () => {
   const yellowSavPath = join(__dirname, '../../../tests/fixtures/yellow.sav');


### PR DESCRIPTION
🎯 What
- Removed the unnecessary export of `decodeGen12String` from `src/engine/saveParser/index.ts` and updated its usage in `saveParser.test.ts` to import directly from its source.
- Removed `src/engine/exclusives/gen2Exclusives.ts` from the `ignore` array in `knip.json`, resolving a configuration hint since the file is actively used.
- Logged the learning about Knip configuration hints in `.jules/sweeper.md`.

💡 Why
- `decodeGen12String` is an internal parsing utility and should not be exposed in the public `saveParser` API, improving modularity and reducing the public interface surface area.
- Cleaning up the `knip.json` configuration ensures that the file is correctly checked for dead code in the future and resolves annoying CLI warnings.

✅ Verification
- Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` successfully without any regressions or warnings.
- Ran `pnpm exec knip` locally to ensure no unexpected warnings triggered from the changed files.

✨ Result
- Cleaner, more accurately scoped public module APIs.
- Updated infrastructure config reflecting the actual repo state.

---
*PR created automatically by Jules for task [9586684382612477633](https://jules.google.com/task/9586684382612477633) started by @szubster*