### PR TITLE
QA: Verify Orchestrator Preflight

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -4,3 +4,4 @@
 **Task**: task-032-060-qa-legacy-save-migration
 **Outcome**: FAILED
 **Notes**: Notified TPM and Agile Coach: The `depends_on` order was broken. The migration logic (`migrateLegacySave`) was not actually implemented in the codebase by the coder, despite the dependency being marked as COMPLETED.
+Completed task-034-059-qa-orchestrator-preflight. Verified preflight logic testing.

--- a/.foundry/tasks/task-034-059-qa-orchestrator-preflight.md
+++ b/.foundry/tasks/task-034-059-qa-orchestrator-preflight.md
@@ -21,5 +21,5 @@ notes: ""
 Write tests to verify the pre-flight logic implemented in `.github/scripts/foundry-orchestrator.ts`.
 
 ## Acceptance Criteria
-- [ ] Verify that if a target artifact already exists and is fully valid according to the schema, the orchestrator skips dispatch for the corresponding generation task.
-- [ ] Verify that if a target artifact exists but is invalid, it is either flagged or handled correctly according to the implemented logic.
+- [x] Verify that if a target artifact already exists and is fully valid according to the schema, the orchestrator skips dispatch for the corresponding generation task.
+- [x] Verify that if a target artifact exists but is invalid, it is either flagged or handled correctly according to the implemented logic.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -770,4 +770,60 @@ fs.writeFileSync(path.join(tmpDir, '.foundry/tasks/task-004-005.md'), `---\nid: 
 main();
 expect(fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-004-005.md'), 'utf-8')).toContain('status: READY');
 });
+
+  test('Preflight: bypasses dispatch and marks COMPLETED if target artifacts exist and are valid', () => {
+    createNode('.foundry/epics/epic-preflight-1.md', `id: epic-preflight-1
+type: EPIC
+title: "Epic 1"
+status: PENDING
+owner_persona: epic_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null`);
+
+    createNode('.foundry/stories/story-preflight-1.md', `id: story-preflight-1
+type: STORY
+title: "Story 1"
+status: COMPLETED
+owner_persona: story_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+parent: .foundry/epics/epic-preflight-1.md
+jules_session_id: null`);
+
+    const filePath = path.join(tmpDir, '.foundry/epics/epic-preflight-1.md');
+    fs.appendFileSync(filePath, '\nTarget artifact: [.foundry/stories/story-preflight-1.md](.foundry/stories/story-preflight-1.md)');
+
+    main();
+
+    const epicContent = fs.readFileSync(filePath, 'utf-8');
+    expect(epicContent).toContain('status: COMPLETED');
+  });
+
+  test('Preflight: does not bypass if target artifacts exist but are invalid', () => {
+    createNode('.foundry/epics/epic-preflight-2.md', `id: epic-preflight-2
+type: EPIC
+title: "Epic 2"
+status: PENDING
+owner_persona: epic_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null`);
+
+    // Invalid story (missing required fields)
+    const invalidStoryPath = path.join(tmpDir, '.foundry/stories/story-preflight-2-invalid.md');
+    fs.mkdirSync(path.dirname(invalidStoryPath), { recursive: true });
+    fs.writeFileSync(invalidStoryPath, `---\nid: story-preflight-2-invalid\nstatus: PENDING\n---\n\n# Title`, 'utf-8');
+
+    const filePath = path.join(tmpDir, '.foundry/epics/epic-preflight-2.md');
+    fs.appendFileSync(filePath, '\nTarget artifact: [.foundry/stories/story-preflight-2-invalid.md](.foundry/stories/story-preflight-2-invalid.md)');
+
+    main();
+
+    const epicContent = fs.readFileSync(filePath, 'utf-8');
+    expect(epicContent).toContain('status: READY'); // Promoted, not bypassed
+  });
 });


### PR DESCRIPTION
- Adds tests to `.github/scripts/foundry-orchestrator.test.ts` to cover the new pre-flight verification bypass logic.
- Verifies that nodes with valid target artifacts are successfully marked COMPLETED.
- Verifies that nodes with invalid target artifacts still dispatch successfully.
- Updates `.foundry/tasks/task-034-059-qa-orchestrator-preflight.md` with checked acceptance criteria.
- Adds QA completion log to `.foundry/journals/qa.md`.

---
*PR created automatically by Jules for task [10207459831221300012](https://jules.google.com/task/10207459831221300012) started by @szubster*