### PR TITLE
🧪 Add tests for legacyNameMap.ts to validate schema mapping

### DIFF
--- a/src/engine/data/gen2/legacyNameMap.test.ts
+++ b/src/engine/data/gen2/legacyNameMap.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { gen2Items, gen2Locations } from './legacyNameMap';
+
+describe('legacyNameMap', () => {
+  describe('gen2Items', () => {
+    it('should be defined', () => {
+      expect(gen2Items).toBeDefined();
+    });
+
+    it('should map valid item IDs to strings', () => {
+      expect(gen2Items[1]).toBe('Master Ball');
+      expect(gen2Items[2]).toBe('Ultra Ball');
+      // Edge cases - last known item
+      expect(gen2Items[255]).toBe('Teru-sama');
+    });
+
+    it('should not contain undefined values for valid mapping IDs', () => {
+      // Get all values from the record
+      const values = Object.values(gen2Items);
+
+      // Ensure we have mappings
+      expect(values.length).toBeGreaterThan(0);
+
+      // Ensure no values are undefined or empty strings
+      values.forEach((value) => {
+        expect(value).toBeDefined();
+        expect(typeof value).toBe('string');
+        expect(value.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('gen2Locations', () => {
+    it('should be defined', () => {
+      expect(gen2Locations).toBeDefined();
+    });
+
+    it('should map valid location IDs to strings', () => {
+      expect(gen2Locations[1]).toBe('New Bark Town');
+      expect(gen2Locations[90]).toBe('Fast Ship');
+    });
+
+    it('should not contain undefined values for valid mapping IDs', () => {
+      // Get all values from the record
+      const values = Object.values(gen2Locations);
+
+      // Ensure we have mappings
+      expect(values.length).toBeGreaterThan(0);
+
+      // Ensure no values are undefined or empty strings
+      values.forEach((value) => {
+        expect(value).toBeDefined();
+        expect(typeof value).toBe('string');
+        expect(value.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing validation test for gen2Items and gen2Locations objects

📊 **Coverage:** What scenarios are now tested
- Validates the definition of `gen2Items` and `gen2Locations`.
- Maps existing integer IDs appropriately (e.g. `1` to `Master Ball`).
- Ensures that none of the object values return `undefined` or empty strings.
- Performs edge case verification.

✨ **Result:** The improvement in test coverage
- Confirmed correct key-value lookups, mitigating schema/structure issues directly.

---
*PR created automatically by Jules for task [2885764522949788388](https://jules.google.com/task/2885764522949788388) started by @szubster*