### PR TITLE
Create PRD from IDEA 013: Improve Late Binding Parent Completion

### DIFF
--- a/.foundry/prds/prd-013-012-improve-late-binding-completion.md
+++ b/.foundry/prds/prd-013-012-improve-late-binding-completion.md
@@ -1,15 +1,17 @@
 ---
-id: idea-013-improve-late-binding-completion
-type: IDEA
+id: prd-013-012-improve-late-binding-completion
+type: PRD
 title: Improve Late Binding Parent Completion
-status: READY
-owner_persona: product_manager
+status: PENDING
+owner_persona: "architect"
 created_at: "2026-05-02"
 updated_at: "2026-05-02"
 depends_on: []
 jules_session_id: null
-parent: null
+pr_number: null
+parent: .foundry/ideas/idea-013-improve-late-binding-completion.md
 tags: ["orchestrator", "late-binding", "bug"]
+research_references: []
 rejection_count: 0
 rejection_reason: ""
 notes: ""
@@ -26,6 +28,3 @@ Late binding in the foundry orchestrator should be handled better. Right now, wh
 1. Enhance the orchestrator to detect when a parent node is in a "wait & wake" state (e.g., `PENDING` due to late binding) and all its dynamically spawned children have been completed.
 2. Differentiate between a node that is just waiting for dependencies to complete so it can run again, and a node that is actually finished.
 3. Automatically mark the parent as `COMPLETED` or wake it up to `READY` state appropriately, instead of leaving it stuck in `PENDING` or requiring manual intervention.
-
-## Generated PRDs
-- .foundry/prds/prd-013-012-improve-late-binding-completion.md


### PR DESCRIPTION
This PR creates the PRD document corresponding to `idea-013-improve-late-binding-completion` as part of the Product Manager persona responsibilities, strictly following the Foundry pipeline process and schema rules.

---
*PR created automatically by Jules for task [3281802183203166158](https://jules.google.com/task/3281802183203166158) started by @szubster*