### PR TITLE
fix(e2e): stabilize save management initial screenshot

### DIFF
--- a/tests/e2e/save_management.spec.ts
+++ b/tests/e2e/save_management.spec.ts
@@ -7,6 +7,7 @@ test.describe('Save Management', () => {
   test('should upload a save file and persist it on reload', async ({ page }) => {
     await clearStorage(page);
     await page.goto('.');
+    await waitForSync(page);
 
     // 1. Initial State: Should show "Initialize Pokedex" button (clean state)
     await expect(page.getByText(/\[ INITIALIZE\.SYS \]/i)).toBeVisible();


### PR DESCRIPTION
Added `await waitForSync(page)` to `save_management.spec.ts` after the initial page navigation. This prevents race conditions where the priming modal (`<SyncProgress />`) was sporadically appearing in the `save-initial-state` Argos screenshot, causing CI visual regression failures.

---
*PR created automatically by Jules for task [5559693158840460246](https://jules.google.com/task/5559693158840460246) started by @szubster*