### PR TITLE
🧹 [code health improvement] Remove unused Suggestion import

### DIFF
--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -2,7 +2,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { Bug, Egg, Flag, Info, Loader2, Sparkles, Target, Zap } from 'lucide-react';
 import React from 'react';
 import type { SaveData } from '../engine/saveParser/index';
-import { type Suggestion, type SuggestionCategory, useAssistant } from '../hooks/useAssistant';
+import { type SuggestionCategory, useAssistant } from '../hooks/useAssistant';
 import { pokemonListQueryOptions } from '../utils/pokemonQueries';
 import { AssistantDebugView } from './assistant/AssistantDebugView';
 import { AssistantSuggestionCard } from './assistant/AssistantSuggestionCard';
@@ -120,7 +120,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
       ) : (
         <div className="space-y-8">
           {Object.entries(
-            suggestions.reduce<Partial<Record<SuggestionCategory, Suggestion[]>>>((acc, s) => {
+            suggestions.reduce<Partial<Record<SuggestionCategory, typeof suggestions>>>((acc, s) => {
               if (!acc[s.category]) acc[s.category] = [];
               acc[s.category]?.push(s);
               return acc;


### PR DESCRIPTION
🎯 **What:** Removed the explicit type `Suggestion` from imports in `src/components/AssistantPanel.tsx`.
💡 **Why:** The `Suggestion` type was only used once as a generic type argument for a `reduce` accumulator. By swapping `Suggestion[]` with `typeof suggestions`, we tied the type directly to the variable being reduced, effectively making the import unused and eligible for removal. This slightly reduces module interdependency and cleans up the imports list.
✅ **Verification:** Ran `pnpm type-check`, `pnpm check:biome`, and `pnpm test` locally. Confirmed the build output matches expectations and no regressions occurred.
✨ **Result:** Cleaner code in `AssistantPanel.tsx` with one less import!

---
*PR created automatically by Jules for task [76651620112055547](https://jules.google.com/task/76651620112055547) started by @szubster*