### PR TITLE
🧭 Strategist: prompt improvement - Update Sentinel to prevent flaky E2E tests and Vitest lint errors

### DIFF
--- a/.jules/schedules/sentinel.md
+++ b/.jules/schedules/sentinel.md
@@ -20,6 +20,8 @@ Identify ONE under-tested file or user journey and add focused tests to improve 
 - When writing E2E tests for visual components, use `argosScreenshot(page, 'name')` from `@argos-ci/playwright` to ensure visual fidelity
 - Use real save fixtures from `tests/fixtures` for integration and E2E tests
 - Use `initializeWithSave(page)` from `tests/e2e/test-utils.ts` to hydrate app state in E2E tests
+- Always call `await waitForSync(page)` in Playwright E2E tests after navigation to ensure IndexedDB sync completes
+- Always provide explicit type parameters to `vi.fn()` (e.g., `vi.fn<() => void>()`) to satisfy strict Biome type-checking and avoid `any` usage
 - Keep each PR focused on one file or one user journey
 
 **Ask first:**

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -60,3 +60,9 @@
 **Outcome:** Merged
 **Why:** The Sweeper journal explicitly noted that knip can hallucinate unused files that are implicitly used in configs or test runners, and that agents must use grep to verify. Additionally, system memory requires the PR title format to strictly be `🧹 [description]`.
 **Pattern:** Codify system memory constraints and specific tool-verification requirements into agent prompts to avoid regressions.
+
+## 2026-06-05 - [Accepted] - Prompt improvement - Update Sentinel to prevent flaky E2E tests and Vitest lint errors
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** Sentinel's history showed recurring issues with E2E tests failing due to un-awaited IndexedDB syncs after navigation, and Vitest tests failing Biome's strict type checking (`lint/suspicious/noExplicitAny`) when creating `vi.fn()` mocks without explicit type parameters.
+**Pattern:** Proposing changes to correctly configure testing tools and eliminate recurring developer friction caused by missing boundaries in agent prompts.


### PR DESCRIPTION
**Proposal**: Updated the Sentinel agent's scheduled prompt (`.jules/schedules/sentinel.md`) to explicitly enforce calling `await waitForSync(page)` in E2E tests after navigation, and requiring explicit generic parameters when using `vi.fn()` for Vitest mocks.
**Justification**: Sentinel creates tests that fail continuously in CI/local when these boundaries are ignored. IndexedDB initialization needs to finish before UI tests proceed, and Biome strict type checking (`lint/suspicious/noExplicitAny`) rejects untyped `vi.fn()` mocks.
**Evidence**: Journals and errors indicate test timeouts/flakes related to un-awaited IndexedDB databases (e.g. `saveDB`) during initialization, and Vitest testing instructions previously failed to mention the stricter `vi.fn<() => void>()` syntax needed to satisfy the project's linter settings.

---
*PR created automatically by Jules for task [1741546482377943709](https://jules.google.com/task/1741546482377943709) started by @szubster*