### PR TITLE
🛠️ Infras: Suppress Vite chunk size warning limit

### DIFF
--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -38,3 +38,6 @@
 
 ## 2026-05-02 - Added pnpm audit to CI
 **Learning:** Added `pnpm audit` job to `.github/workflows/ci.yml` to automatically catch dependency vulnerabilities during CI runs. Configured it to run with `--prod` flag to avoid failing builds on devDependency vulnerabilities, as they are mostly harmless in this context and can block releases unnecessarily.
+
+## 2026-05-03 - Suppressed chunk size warning limit
+**Learning:** Added `chunkSizeWarningLimit: 1000` to `vite.config.ts` to suppress noisy terminal warnings (`Some chunks are larger than 500 kB`) during builds. The user previously decided to favor a single chunk setup because the app is small and splitting would marginalize caching benefits due to frequent updates. This cleans up the build DX while retaining the deliberate architectural choice.

--- a/knip.json
+++ b/knip.json
@@ -6,8 +6,7 @@
   "ignore": [
     ".github/scripts/**",
     "src/test-setup.ts",
-    "scripts/validate-foundry-ids.ts",
-    "src/engine/exclusives/gen2Exclusives.ts"
+    "scripts/validate-foundry-ids.ts"
   ],
   "rules": {
     "files": "warn",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,6 +85,7 @@ export default defineConfig(() => {
     },
     build: {
       target,
+      chunkSizeWarningLimit: 1000,
       cssMinify: 'lightningcss' as const,
       cssCodeSplit: false,
       assetsInlineLimit: 102400, // Inline assets up to 100KB


### PR DESCRIPTION
Implemented ONE developer experience improvement to the Vite build configuration: suppressed the noisy chunk size warning (`Some chunks are larger than 500 kB after minification`). As documented in `.jules/infras.md`, the user explicitly prefers a single chunk because the app is small, and separating chunks does not offer strong caching benefits. This change cleans up the CI build output while respecting that architectural decision. Also slightly cleaned up an outdated configuration ignore entry for `knip.json`.

---
*PR created automatically by Jules for task [16327039115411021498](https://jules.google.com/task/16327039115411021498) started by @szubster*