### PR TITLE
🎨 Palette: Add tooltip to Living Dex toggle switch

### DIFF
--- a/src/components/settings/SettingsControls.tsx
+++ b/src/components/settings/SettingsControls.tsx
@@ -65,6 +65,7 @@ export function SettingsControls({
           role="switch"
           aria-checked={isLivingDex}
           aria-label="Toggle Living Dex Mode"
+          title="Toggle Living Dex Mode"
           onClick={() => setIsLivingDex(!isLivingDex)}
           className={`relative inline-flex h-7 w-12 items-center border border-dashed transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${isLivingDex ? 'border-emerald-500/50 bg-emerald-950/50' : 'border-zinc-800 bg-zinc-900'}`}
         >


### PR DESCRIPTION
## What
Added a native `title="Toggle Living Dex Mode"` attribute to the custom segmented control/switch used for toggling the Living Dex mode in the Settings panel.

## Why
This provides a native tooltip on hover, improving usability and accessibility for sighted users who rely on mouse interactions to understand icon-only interactive elements (like the toggle switch). This explicitly follows the findings documented in `.jules/palette.md` to ensure icon-only buttons have descriptive `title` attributes.

## Verification
✅ `pnpm lint` passed.
✅ `pnpm type-check` passed.
✅ `pnpm test` passed.
✅ `pnpm test:e2e` passed.
✅ Visual Playwright verification script captured the tooltip state.

---
*PR created automatically by Jules for task [800409122051397055](https://jules.google.com/task/800409122051397055) started by @szubster*