### PR TITLE
🧹 Improve Orchestrator Late-Binding Completion

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -302,6 +302,40 @@ jules_session_id: null
     expect(storyContent).toContain('status: READY');
   });
 
+  test('Late-Binding: Parent wakes up when children are COMPLETED', () => {
+    // Epic 1: PENDING (Waiting for children)
+    createNode('.foundry/epics/epic-001.md', `
+id: epic-001
+type: EPIC
+title: "Epic 1"
+status: PENDING
+owner_persona: epic_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    // Story 1: Child of Epic 1, COMPLETED
+    createNode('.foundry/stories/story-001.md', `
+id: story-001
+type: STORY
+title: "Story 1"
+status: COMPLETED
+owner_persona: story_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+parent: .foundry/epics/epic-001.md
+jules_session_id: null
+`);
+
+    main();
+
+    const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
+    expect(epicContent).toContain('status: COMPLETED');
+  });
+
   test('Deep Hierarchical Completion: blocks external dependent if dependency has deep incomplete children', () => {
     // Story 1: COMPLETED
     createNode('.foundry/stories/story-001.md', `

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -584,6 +584,46 @@ function main(): void {
 
   info(`${eligible.length} node(s) eligible for promotion to READY.`);
 
+  // ── Phase 4.1: Late-Binding Completion ────────────────────────────────────
+  info('Phase 4.1: Checking for completed Late-Binding parents...');
+  for (const node of nodes) {
+    if (node.frontmatter.status === 'PENDING') {
+      const children = parentToChildren.get(node.repoPath) || [];
+      if (children.length > 0) {
+        // Parent is PENDING and has children. Check if ALL children are COMPLETED.
+        let allChildrenCompleted = true;
+        for (const child of children) {
+          if (child.frontmatter.status !== 'COMPLETED') {
+            allChildrenCompleted = false;
+            break;
+          }
+        }
+
+        if (allChildrenCompleted) {
+          let isDepIncomplete = false;
+          for (const depPath of node.frontmatter.depends_on) {
+            if (isHierarchicallyIncomplete(depPath, node.repoPath)) {
+              isDepIncomplete = true;
+              break;
+            }
+          }
+
+          if (!isDepIncomplete) {
+            info(`Late-Binding Parent Complete: ${node.repoPath} has children and all are COMPLETED. Promoting directly to COMPLETED.`);
+            promoteNodeStatus(node, 'PENDING', 'COMPLETED');
+            // Remove from eligible if it was added
+            const idx = eligible.indexOf(node);
+            if (idx !== -1) {
+              eligible.splice(idx, 1);
+            }
+          } else {
+            info(`Late-Binding Parent: ${node.repoPath} has completed children, but is waiting on dependencies.`);
+          }
+        }
+      }
+    }
+  }
+
   // ── Phase 4.5: IDEMPOTENT GENERATION CHECK ────────────────────────────────
   info('Phase 4.5: Performing idempotent generation checks...');
   const finalEligible: ParsedNode[] = [];

--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -15,3 +15,6 @@ Removed unused type ClassValue import from src/utils/cn.ts by utilizing Paramete
 
 **Learning:** Sometime a file may be mistakenly ignored in `knip.json` even if it is fully integrated into the module graph.
 **Action:** Run `pnpm exec knip` periodically and check the `Configuration hints` output to identify entries that can be safely removed from the `knip.json` `ignore` array.
+
+## 2026-05-03 - Improved Orchestrator Late-Binding Completion
+**Learning:** Addressed a bug in `.github/scripts/foundry-orchestrator.ts` where Late-Binding parent nodes (nodes waiting for dynamically generated children to complete) would remain stuck in a PENDING state indefinitely even after all children successfully completed. Added a dedicated detection phase (Phase 4.1) to find these specific `PENDING` nodes, verify they possess children, check if strictly all children are `COMPLETED`, ensure no implicit/explicit dependencies are unfulfilled, and directly promote the parent node to `COMPLETED`. Unit tested and validated to maintain DAG integrity.


### PR DESCRIPTION
🎯 What
Added logic in the orchestrator to automatically detect Late-Binding parents (nodes stuck in PENDING status that have dynamically spawned children) and transition them directly to COMPLETED when all their children are COMPLETED and they have no other incomplete dependencies.

💡 Why
Currently, Late-Binding parent nodes wait for children to complete before continuing, but after all children are done, the orchestrator left them in the PENDING state indefinitely without waking them. This blocks the DAG completion process.

✅ Verification
Ran the test suite successfully and added a test specifically verifying that `Late-Binding: Parent wakes up when children are COMPLETED`.

✨ Result
Late-Binding works as designed and parent nodes successfully complete and pass their COMPLETED state down the pipeline.

---
*PR created automatically by Jules for task [5238691986651774183](https://jules.google.com/task/5238691986651774183) started by @szubster*