### PR TITLE
Add epic for cascading cancellation in orchestrator

### DIFF
--- a/.foundry/epics/epic-013-023-orchestrator-cascade-cancellation.md
+++ b/.foundry/epics/epic-013-023-orchestrator-cascade-cancellation.md
@@ -1,0 +1,41 @@
+---
+id: epic-013-023-orchestrator-cascade-cancellation
+type: EPIC
+title: 'Epic: Implement Cascading Cancellation in Orchestrator'
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-03'
+updated_at: '2026-05-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/prds/prd-014-013-cascade-cancellation.md
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - cancellation
+notes: ''
+---
+
+# Epic: Implement Cascading Cancellation in Orchestrator
+
+## Objective
+Update the Foundry DAG orchestrator script (`.github/scripts/foundry-orchestrator.ts`) to automatically cascade the `CANCELLED` status from parent nodes to their descendants.
+
+## Requirements
+1. The script must identify nodes explicitly marked as `status: "CANCELLED"`.
+2. It must identify child nodes that list the cancelled node as a `parent`.
+3. It must recursively transition the status of these child nodes to `CANCELLED`, but **only if** the child node is not already `COMPLETED`.
+4. It must use `matter.stringify()` (from the `gray-matter` library) to write changes securely back to the file system, ensuring `updated_at` is bumped.
+5. Provide unit tests to verify the new functionality in `.github/scripts/foundry-orchestrator.test.ts`.
+
+## Dependencies
+- Does not strictly block anything at the moment. It is an independent enhancement to the orchestrator script.
+
+## Technical Notes
+- Execution of this logic should happen before the main dependency resolution phases (e.g. before "RESOLVE" phase).
+- Ensure idempotency: re-running on an already cancelled subtree shouldn't cause infinite loops or unnecessary file modifications.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into actionable stories.

--- a/.foundry/prds/prd-014-013-cascade-cancellation.md
+++ b/.foundry/prds/prd-014-013-cascade-cancellation.md
@@ -45,4 +45,5 @@ While agents have been explicitly instructed to use the `FAILED` or `CANCELLED` 
 
 ## Acceptance Criteria
 
-- [ ] Epic Planner: Break this PRD down into actionable Epics.
+- [x] Epic Planner: Break this PRD down into actionable Epics.
+  - >> .foundry/epics/epic-013-023-orchestrator-cascade-cancellation.md


### PR DESCRIPTION
Created an Epic based on the `prd-014-013-cascade-cancellation.md` document, which outlines the implementation steps to cascade `CANCELLED` status recursively down the DAG nodes in the `.github/scripts/foundry-orchestrator.ts` script.

The new Epic (`.foundry/epics/epic-013-023-orchestrator-cascade-cancellation.md`) correctly follows the `owner_persona`, naming schema, and `depends_on` rules for the Foundry system. The PRD was also appropriately updated with a checkmark for the completed acceptance criteria.

---
*PR created automatically by Jules for task [8000738141856617443](https://jules.google.com/task/8000738141856617443) started by @szubster*