### PR TITLE
feat: cascade cancelled status

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -336,6 +336,71 @@ jules_session_id: null
     expect(epicContent).toContain('status: COMPLETED');
   });
 
+  test('Cascade Cancellation: cancels child nodes of CANCELLED parent recursively', () => {
+    createNode('.foundry/epics/epic-001.md', `
+id: epic-001
+type: EPIC
+title: "Cancelled Epic"
+status: CANCELLED
+owner_persona: epic_planner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    createNode('.foundry/stories/story-001.md', `
+id: story-001
+type: STORY
+title: "Story of Cancelled Epic"
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+parent: ".foundry/epics/epic-001.md"
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-001.md', `
+id: task-001
+type: TASK
+title: "Task of Story"
+status: READY
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+parent: ".foundry/stories/story-001.md"
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-002.md', `
+id: task-002
+type: TASK
+title: "Completed Task of Story"
+status: COMPLETED
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+parent: ".foundry/stories/story-001.md"
+jules_session_id: null
+`);
+
+    main();
+
+    const storyResult = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-001.md'), 'utf-8');
+    expect(storyResult).toContain('status: CANCELLED');
+
+    const task1Result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-001.md'), 'utf-8');
+    expect(task1Result).toContain('status: CANCELLED');
+
+    // Should not overwrite COMPLETED
+    const task2Result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-002.md'), 'utf-8');
+    expect(task2Result).toContain('status: COMPLETED');
+  });
+
   test('Deep Hierarchical Completion: blocks external dependent if dependency has deep incomplete children', () => {
     // Story 1: COMPLETED
     createNode('.foundry/stories/story-001.md', `

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -340,6 +340,32 @@ function main(): void {
     }
   }
 
+  // ── Phase 3.1: CASCADE CANCELLATIONS ───────────────────────────────────────
+  info('Phase 3.1: Cascading CANCELLED statuses...');
+  // Find all explicitly cancelled nodes
+  const cancelledNodes = new Set<string>();
+  for (const node of nodes) {
+    if (node.frontmatter.status === 'CANCELLED') {
+      cancelledNodes.add(node.repoPath);
+    }
+  }
+
+  // Helper to cascade cancellation to children recursively
+  function cascadeCancel(parentPath: string) {
+    const children = parentToChildren.get(parentPath) || [];
+    for (const child of children) {
+      if (child.frontmatter.status !== 'COMPLETED' && child.frontmatter.status !== 'CANCELLED') {
+        promoteNodeStatus(child, child.frontmatter.status, 'CANCELLED');
+        cancelledNodes.add(child.repoPath);
+        cascadeCancel(child.repoPath); // Recursive call
+      }
+    }
+  }
+
+  for (const cancelledPath of Array.from(cancelledNodes)) {
+    cascadeCancel(cancelledPath);
+  }
+
   let hasUnresolvableDeps = false;
 
   // Helper to recursively check if a node is blocked.


### PR DESCRIPTION
Implemented cascading cancellation feature in the Foundry DAG Orchestrator (`foundry-orchestrator.ts`). When a node is marked CANCELLED, all of its uncompleted child nodes (and their children, recursively) are also set to CANCELLED.

Added unit testing for this cascading behavior.

---
*PR created automatically by Jules for task [1775410897363280113](https://jules.google.com/task/1775410897363280113) started by @szubster*