### PR TITLE
fix(foundry): remove deep pending dependency from idea-006

### DIFF
--- a/.foundry/ideas/idea-006-gen2-expansion.md
+++ b/.foundry/ideas/idea-006-gen2-expansion.md
@@ -9,7 +9,6 @@ updated_at: "2026-04-21"
 jules_session_id: null
 depends_on:
   - .foundry/ideas/idea-001-the-foundry.md
-  - .foundry/ideas/idea-003-atomic-handoff-foundation.md
 ---
 
 # Gen 2 Support Expansion: Johto/Kanto Lifecycle


### PR DESCRIPTION
The Gen 2 expansion idea (`idea-006-gen2-expansion.md`) was blocked by
the DAG orchestrator because it depended on `idea-003-atomic-handoff-foundation.md`.
While idea-003 itself was marked COMPLETED, the orchestrator evaluates
hierarchical completeness recursively (`isHierarchicallyIncomplete`). Idea-003
spawned a PRD, Epics, Stories, and Tasks that were still in PENDING or ACTIVE states.
Because of this, `idea-003` was deemed incomplete for dependent nodes.

By removing `idea-003` from `idea-006`'s `depends_on` array (since it was
not a hard requirement for starting Gen 2 work), `idea-006` is now unblocked
and will be scheduled properly.

---
*PR created automatically by Jules for task [9970045672530029170](https://jules.google.com/task/9970045672530029170) started by @szubster*