### PR TITLE
🔧 Agile Coach: Enforce strict pipeline persona handoffs and correct invalid PRD

### DIFF
--- a/.foundry/ideas/idea-015-enforce-persona-pipeline.md
+++ b/.foundry/ideas/idea-015-enforce-persona-pipeline.md
@@ -1,0 +1,29 @@
+---
+id: idea-015-enforce-persona-pipeline
+type: IDEA
+title: 'DAG Feature: Enforce Persona Pipeline Handoffs'
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-05-04'
+updated_at: '2026-05-04'
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - validation
+notes: ''
+---
+
+# Idea: Enforce Persona Pipeline Handoffs in DAG Orchestrator
+
+## Context
+Nodes are occasionally being assigned to incorrect personas, breaking the required pipeline flow. For example, `prd-013-012` was assigned to `architect` instead of `epic_planner`, which resulted in silent failures and an endless resurrection loop.
+
+## Proposal
+The DAG Orchestrator should include a pre-flight schema validation check that ensures the `owner_persona` defined in the YAML frontmatter matches the expected persona for the given node `type` (e.g., `IDEA` -> `product_manager`, `PRD` -> `epic_planner`, `EPIC` -> `story_owner`, etc., with `architect` restricted to ADRs/architecture tasks). If there is a mismatch, the orchestrator should flag the node as invalid before attempting to dispatch it to a Jules session.
+
+## Next Steps
+- [ ] Convert this idea into a detailed PRD defining the allowed type-to-persona mappings.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -78,3 +78,13 @@ The Legacy Save Migration implementation failed during QA validation (`task-032-
 1. Updated all persona prompts (`qa`, `coder`, `tech_lead`, `story_owner`, `epic_planner`, `product_manager`, `architect`, `agile_coach`, `tpm`) to explicitly warn that the Empty PR policy is strictly for pre-existing successful artifacts.
 2. Directed agents to update the YAML frontmatter to `status: FAILED` or `CANCELLED` and provide a `rejection_reason` when aborting tasks.
 3. Generated `idea-014-cascade-cancellation.md` to propose a native DAG Orchestrator feature to cascade the `CANCELLED` status down the node tree.
+
+## 2026-05-03: Persona Pipeline Handoff Enforce
+
+### Observation
+The `prd-013-012-improve-late-binding-completion.md` node was crashing silently and triggering the resurrection loop constantly because its `owner_persona` was set to `architect` instead of the required `epic_planner` for PRDs.
+
+### Action Taken
+1. Updated `.github/agents/product_manager.md`, `.github/agents/epic_planner.md`, and `.github/agents/story_owner.md` to explicitly enforce the strict pipeline handoff order.
+2. Corrected the `owner_persona` field in `prd-013-012` to `epic_planner` so it will unblock cleanly.
+3. Created `idea-015-enforce-persona-pipeline.md` to propose adding a DAG orchestrator verification step that hard-fails nodes assigned to the wrong persona type.

--- a/.foundry/prds/prd-013-012-improve-late-binding-completion.md
+++ b/.foundry/prds/prd-013-012-improve-late-binding-completion.md
@@ -2,12 +2,12 @@
 id: prd-013-012-improve-late-binding-completion
 type: PRD
 title: Improve Late Binding Parent Completion
-status: ACTIVE
-owner_persona: architect
+status: PENDING
+owner_persona: epic_planner
 created_at: '2026-05-02'
 updated_at: '2026-05-03'
 depends_on: []
-jules_session_id: '8805444946951857009'
+jules_session_id: null
 pr_number: null
 parent: .foundry/ideas/idea-013-improve-late-binding-completion.md
 tags:
@@ -15,7 +15,7 @@ tags:
   - late-binding
   - bug
 research_references: []
-rejection_count: 3
+rejection_count: 0
 rejection_reason: ''
 notes: ''
 ---

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -21,6 +21,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 **NODE GENERATION RULES:**
 - Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
 - Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
+- The strict pipeline order and persona handoff for Foundry nodes is: IDEA (PM) -> PRD (PM) -> ADR (Architect) -> EPIC (Planner) -> STORY -> TASK.
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -18,6 +18,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When a target Foundry artifact (such as a downstream PRD or generated node file) unexpectedly exists prior to the session, create a small journal entry detailing the anomaly for the Agile Coach to review later.
 - Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
 - Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
+- The strict pipeline order and persona handoff for Foundry nodes is: IDEA (PM) -> PRD (PM) -> ADR (Architect) -> EPIC (Planner) -> STORY -> TASK.
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -22,6 +22,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 **NODE GENERATION RULES:**
 - Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
 - Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
+- The strict pipeline order and persona handoff for Foundry nodes is: IDEA (PM) -> PRD (PM) -> ADR (Architect) -> EPIC (Planner) -> STORY -> TASK.
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.


### PR DESCRIPTION
Enforce strict pipeline persona handoffs and correct invalid PRD

- Appended strict pipeline order mapping (IDEA -> PM, PRD -> PM, EPIC -> Planner, etc) to Product Manager, Epic Planner, and Story Owner persona prompts.
- Corrected `owner_persona` of `prd-013-012` from `architect` to `epic_planner` to fix silent crash loop.
- Added idea-015 to propose enforcing schema persona validation in orchestrator.
- Logged changes in agile coach journal.

---
*PR created automatically by Jules for task [14063194094170431998](https://jules.google.com/task/14063194094170431998) started by @szubster*