### PR TITLE
fix: Improve Late Binding Parent Completion

### DIFF
--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -191,6 +191,51 @@ ok: true,
     expect(fs.writeFileSync).not.toHaveBeenCalledWith(expect.any(String), expect.stringContaining('status: "FAILED"'), expect.any(String));
   });
 
+  it('should transition a node to PENDING if its PR is merged but it has unchecked tasks', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: 'session-123'
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: "session-123"\nupdated_at: "2023-01-01"\n---\nBody\n- [ ] Unchecked task'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    // @ts-expect-error
+    globalFetch.mockImplementation((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : (url as URL).toString();
+      if (urlStr.startsWith('https://jules.googleapis.com/')) {
+        return Promise.resolve({
+            ok: true,
+            status: 200,
+          json: async () => ({
+              state: 'COMPLETED',
+              outputs: [{ pullRequest: { url: 'https://github.com/szubster/dexhelper/pull/402' } }]
+            })
+          });
+      }
+      if (urlStr.includes('pulls/402')) {
+        return Promise.resolve({
+            ok: true,
+            status: 200,
+          json: async () => ({ number: 402, state: 'closed', merged: true })
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+    });
+
+    await main();
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(writeCall[1]).toContain('status: "PENDING"');
+  });
+
   it('should transition a node to COMPLETED if PR from Jules session link is merged', async () => {
     const mockNode = {
       filePath: '/mock/repo/.foundry/tasks/task-1.md',

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -65,9 +65,10 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
   const originalFmBlock = fmBlockMatch[0];
   let mutatedFmBlock = originalFmBlock;
 
-  // With the shift to strict DAG dependencies, we no longer rely on checkboxes.
-  // A node is COMPLETED when its PR is merged. Downstream blocking is handled by the DAG.
-  const targetStatus = "COMPLETED";
+  // Late-Binding Support: If unchecked tasks exist, transition back to PENDING instead of COMPLETED.
+  const hasUncheckedTasks = /^\s*-\s*\[\s\]/m.test(node.rawContent);
+  // PENDING state keeps the late-binding parent alive to wait for children
+  const targetStatus = hasUncheckedTasks ? "PENDING" : "COMPLETED";
 
   mutatedFmBlock = mutatedFmBlock.replace(/^(status:\s*)["']?ACTIVE["']?([ \t]*)$/m, `$1"${targetStatus}"$2`);
   mutatedFmBlock = mutatedFmBlock.replace(/^(jules_session_id:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m, `$1null$2`);

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -29,11 +29,11 @@ describe('foundry-orchestrator', () => {
     vi.restoreAllMocks();
   });
 
-  function createNode(relPath: string, frontmatter: string) {
+  function createNode(relPath: string, frontmatter: string, body: string = '# Title') {
     const fullPath = path.join(tmpDir, relPath);
     const dir = path.dirname(fullPath);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(fullPath, `---\n${frontmatter}\n---\n\n# Title`, 'utf-8');
+    fs.writeFileSync(fullPath, `---\n${frontmatter}\n---\n\n${body}`, 'utf-8');
   }
 
   test('Happy Path: promotes PENDING to READY when all dependencies are COMPLETED', () => {
@@ -334,6 +334,42 @@ jules_session_id: null
 
     const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
     expect(epicContent).toContain('status: COMPLETED');
+  });
+
+  test('Late-Binding: Parent wakes up to READY if it has unchecked tasks', () => {
+    // Epic 1: PENDING (Waiting for children)
+    createNode('.foundry/epics/epic-001.md', `
+id: epic-001
+type: EPIC
+title: "Epic 1"
+status: PENDING
+owner_persona: epic_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`, `# Title
+
+- [ ] Unchecked task`);
+
+    // Story 1: Child of Epic 1, COMPLETED
+    createNode('.foundry/stories/story-001.md', `
+id: story-001
+type: STORY
+title: "Story 1"
+status: COMPLETED
+owner_persona: story_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+parent: .foundry/epics/epic-001.md
+jules_session_id: null
+`);
+
+    main();
+
+    const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
+    expect(epicContent).toContain('status: READY');
   });
 
   test('Cascade Cancellation: cancels child nodes of CANCELLED parent recursively', () => {

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -610,8 +610,14 @@ function main(): void {
         info(`Preflight success: Valid target artifacts exist and are completed. Bypassing dispatch for ${node.repoPath}`);
         promoteNodeStatus(node, 'PENDING', 'COMPLETED');
       } else if (targetArtifacts.length === 0 && children.length > 0) {
-        info(`Late binding completion: ${node.repoPath} has no pending target artifacts and all spawned children are complete.`);
-        promoteNodeStatus(node, 'PENDING', 'COMPLETED');
+        const hasUncheckedTasks = /^\s*-\s*\[\s\]/m.test(node.body);
+        if (hasUncheckedTasks) {
+          info(`Late-Binding Parent Waking Up: ${node.repoPath} has completed children, but still has unchecked tasks. Promoting to READY.`);
+          eligible.push(node);
+        } else {
+          info(`Late binding completion: ${node.repoPath} has no pending target artifacts and all spawned children are complete.`);
+          promoteNodeStatus(node, 'PENDING', 'COMPLETED');
+        }
       } else {
         eligible.push(node);
       }
@@ -645,12 +651,24 @@ function main(): void {
           }
 
           if (!isDepIncomplete) {
-            info(`Late-Binding Parent Complete: ${node.repoPath} has children and all are COMPLETED. Promoting directly to COMPLETED.`);
-            promoteNodeStatus(node, 'PENDING', 'COMPLETED');
-            // Remove from eligible if it was added
-            const idx = eligible.indexOf(node);
-            if (idx !== -1) {
-              eligible.splice(idx, 1);
+            const hasUncheckedTasks = /^\s*-\s*\[\s\]/m.test(node.body);
+            if (hasUncheckedTasks) {
+              info(`Late-Binding Parent Waking Up: ${node.repoPath} has completed children, but still has unchecked tasks. Promoting to READY.`);
+              // Directly promote to READY
+              if (node.frontmatter.owner_persona === 'human') {
+                promoteNodeStatus(node, 'PENDING', 'ACTIVE');
+              } else {
+                promoteNodeStatus(node, 'PENDING', 'READY');
+              }
+              // Prevent promotion to COMPLETED by bypassing the else branch
+            } else {
+              info(`Late-Binding Parent Complete: ${node.repoPath} has children and all are COMPLETED. Promoting directly to COMPLETED.`);
+              promoteNodeStatus(node, 'PENDING', 'COMPLETED');
+              // Remove from eligible if it was added
+              const idx = eligible.indexOf(node);
+              if (idx !== -1) {
+                eligible.splice(idx, 1);
+              }
             }
           } else {
             info(`Late-Binding Parent: ${node.repoPath} has completed children, but is waiting on dependencies.`);


### PR DESCRIPTION
The Foundry orchestrator and heartbeat were treating Late-Binding parents as `COMPLETED` when all currently known children completed, even if the parent still had unchecked tasks in its body indicating more children need to be generated. 

This commit fixes the lifecycle by:
1. Updating `foundry-heartbeat.ts` to transition nodes back to `PENDING` instead of `COMPLETED` on PR merge if unchecked tasks exist.
2. Updating `foundry-orchestrator.ts` Phase 4.1 to detect when children complete. If the parent still has unchecked tasks, it is pushed to the `eligible` array and promoted to `READY` (or `ACTIVE`) to trigger the next dispatch cycle.

Tests are updated and newly added for both heartbeat and orchestrator to cover this.

---
*PR created automatically by Jules for task [8805444946951857009](https://jules.google.com/task/8805444946951857009) started by @szubster*