### PR TITLE
Create Epic for late binding parent completion

### DIFF
--- a/.foundry/epics/epic-012-024-improve-late-binding-completion.md
+++ b/.foundry/epics/epic-012-024-improve-late-binding-completion.md
@@ -1,0 +1,39 @@
+---
+id: epic-012-024-improve-late-binding-completion
+type: EPIC
+title: "Epic: Improve Late Binding Parent Completion"
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-05-04"
+updated_at: "2026-05-04"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/prds/prd-013-012-improve-late-binding-completion.md
+tags:
+  - orchestrator
+  - late-binding
+  - bug
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Improve Late Binding Parent Completion
+
+## Objective
+Enhance the Foundry orchestrator (`.github/scripts/foundry-orchestrator.ts`) to properly handle the completion and waking up of late-binding parent nodes whose dynamically spawned children have been completed.
+
+## Requirements
+1. The orchestrator must detect when a parent node is in a "wait & wake" state (e.g., `PENDING` due to late binding) and all its dynamically spawned children are completed.
+2. Differentiate between a node waiting for dependencies to complete to run again versus a node that is actually finished.
+3. If no unchecked tasks (`- [ ]`) remain in the markdown body of the parent, transition its status to `COMPLETED`.
+4. If unchecked tasks (`- [ ]`) remain in the markdown body, push it to eligible to wake up to `READY` state so it can be dispatched again to spawn new work.
+5. Provide unit tests to verify the new functionality in `.github/scripts/foundry-orchestrator.test.ts`.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into actionable stories.

--- a/.foundry/prds/prd-013-012-improve-late-binding-completion.md
+++ b/.foundry/prds/prd-013-012-improve-late-binding-completion.md
@@ -31,3 +31,6 @@ Late binding in the foundry orchestrator should be handled better. Right now, wh
 1. Enhance the orchestrator to detect when a parent node is in a "wait & wake" state (e.g., `PENDING` due to late binding) and all its dynamically spawned children have been completed.
 2. Differentiate between a node that is just waiting for dependencies to complete so it can run again, and a node that is actually finished.
 3. Automatically mark the parent as `COMPLETED` or wake it up to `READY` state appropriately, instead of leaving it stuck in `PENDING` or requiring manual intervention.
+
+## Generated Epics
+- .foundry/epics/epic-012-024-improve-late-binding-completion.md


### PR DESCRIPTION
Create Epic for late binding parent completion

Translates PRD 013-012 into Epic 012-024 to implement orchestrator improvements for late binding completion. Updating orchestrator to detect wait and wake states, evaluate completion of dynamically spawned children, and appropriately transition parent status.

---
*PR created automatically by Jules for task [10212097823144284437](https://jules.google.com/task/10212097823144284437) started by @szubster*