### PR TITLE
feat: orchestrator cascading cancellation tasks

### DIFF
--- a/.foundry/stories/story-023-036-implement-cascade-cancellation.md
+++ b/.foundry/stories/story-023-036-implement-cascade-cancellation.md
@@ -35,4 +35,8 @@ Update the Foundry DAG orchestrator script (`.github/scripts/foundry-orchestrato
 - Ensure idempotency: re-running on an already cancelled subtree shouldn't cause infinite loops or unnecessary file modifications.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break down into implementation tasks.
+- [x] Tech Lead: Break down into implementation tasks.
+
+## Child Tasks
+- [Task 062: Implement Cascading Cancellation in Orchestrator](.foundry/tasks/task-036-062-implement-cascade-cancellation.md)
+- [Task 063: QA Cascading Cancellation in Orchestrator](.foundry/tasks/task-036-063-qa-cascade-cancellation.md)

--- a/.foundry/tasks/task-036-062-implement-cascade-cancellation.md
+++ b/.foundry/tasks/task-036-062-implement-cascade-cancellation.md
@@ -1,0 +1,36 @@
+---
+id: task-036-062-implement-cascade-cancellation
+type: TASK
+title: "Implement Cascading Cancellation in Orchestrator"
+status: PENDING
+owner_persona: coder
+created_at: "2026-05-04"
+updated_at: "2026-05-04"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: ".foundry/stories/story-023-036-implement-cascade-cancellation.md"
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - cancellation
+notes: ""
+---
+
+# Task 062: Implement Cascading Cancellation in Orchestrator
+
+## Context
+The story requires the Foundry DAG orchestrator script (`.github/scripts/foundry-orchestrator.ts`) to automatically cascade the `CANCELLED` status from parent nodes to their descendants. The logic seems to be partially implemented in Phase 3.1 but requires unit tests to be written and the implementation to be fully verified.
+
+## Technical Blueprint
+1. Verify the cascading cancellation logic in `.github/scripts/foundry-orchestrator.ts`. Ensure that if a node explicitly marked as `status: "CANCELLED"` is found, any child nodes listing it as a `parent` are recursively transitioned to `CANCELLED`, but only if the child is not already `COMPLETED`. Ensure idempotency.
+2. Update `.github/scripts/foundry-orchestrator.test.ts` to include unit tests covering the cascading cancellation behavior.
+   - Test case 1: Explicitly cancelled parent node successfully cascades `CANCELLED` status to a pending child.
+   - Test case 2: Cascade operation does not overwrite a child node that is already `COMPLETED`.
+   - Test case 3: Recursive cascading works across multiple levels of descendants.
+
+## Acceptance Criteria
+- [ ] Unit tests for cascading cancellation logic are added to `.github/scripts/foundry-orchestrator.test.ts`.
+- [ ] Verification confirms that `foundry-orchestrator.ts` correctly applies the cascading rules.
+- [ ] `pnpm lint`, `pnpm test`, and `pnpm test:e2e` run successfully.

--- a/.foundry/tasks/task-036-063-qa-cascade-cancellation.md
+++ b/.foundry/tasks/task-036-063-qa-cascade-cancellation.md
@@ -1,0 +1,36 @@
+---
+id: task-036-063-qa-cascade-cancellation
+type: TASK
+title: "QA Cascading Cancellation in Orchestrator"
+status: PENDING
+owner_persona: qa
+created_at: "2026-05-04"
+updated_at: "2026-05-04"
+depends_on:
+  - .foundry/tasks/task-036-062-implement-cascade-cancellation.md
+jules_session_id: null
+pr_number: null
+parent: ".foundry/stories/story-023-036-implement-cascade-cancellation.md"
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - cancellation
+notes: ""
+---
+
+# Task 063: QA Cascading Cancellation in Orchestrator
+
+## Context
+The Coder has implemented and tested the cascading cancellation feature in the Foundry DAG orchestrator. This task is to verify that the implementation meets the technical requirements and handles edge cases appropriately without introducing regressions.
+
+## Validation Steps
+1. Review the unit tests in `.github/scripts/foundry-orchestrator.test.ts` to ensure thorough coverage of the cascading cancellation logic.
+2. Verify that the tests check whether the `CANCELLED` status successfully cascades recursively.
+3. Ensure that `COMPLETED` children are not erroneously marked as `CANCELLED`.
+4. Confirm that idempotency is maintained, meaning repeated runs do not cause issues.
+
+## Acceptance Criteria
+- [ ] Code review completed.
+- [ ] Unit tests reviewed and confirm correctness.
+- [ ] Tests execute and pass cleanly.


### PR DESCRIPTION
Break down the `story-023-036-implement-cascade-cancellation` into actionable tasks.

- Created `task-036-062-implement-cascade-cancellation.md` for the `coder` persona to write unit tests for the existing cascading logic.
- Created `task-036-063-qa-cascade-cancellation.md` for the `qa` persona to verify the cascading cancellation tests and code.
- Appended the tasks to the parent story and marked the acceptance criteria as completed.

---
*PR created automatically by Jules for task [6474976102412279043](https://jules.google.com/task/6474976102412279043) started by @szubster*