### PR TITLE
🛠️ Infras: resolve biome schema version mismatch

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: "2.4.13"
+          version: "2.4.14"
 
       - name: Run Biome
         run: biome ci --error-on-warnings .

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -41,3 +41,6 @@
 
 ## 2026-05-03 - Suppressed chunk size warning limit
 **Learning:** Added `chunkSizeWarningLimit: 1000` to `vite.config.ts` to suppress noisy terminal warnings (`Some chunks are larger than 500 kB`) during builds. The user previously decided to favor a single chunk setup because the app is small and splitting would marginalize caching benefits due to frequent updates. This cleans up the build DX while retaining the deliberate architectural choice.
+
+## 2026-05-04 - Fixed Biome Schema Version Mismatch
+**Learning:** The Biome CLI version (2.4.14) in `package.json` did not match the schema version (2.4.13) in `biome.jsonc` and `.github/workflows/biome.yml`, causing `knip` to throw schema mismatch warnings during `pnpm lint`. Used `biome migrate` to automatically resolve the `biome.jsonc` schema and manually updated the GitHub Action version to maintain alignment and clean CI output.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
**What:**
Updated the Biome `$schema` URL in `biome.jsonc` and the `biomejs/setup-biome` version in `.github/workflows/biome.yml` from `2.4.13` to `2.4.14` to match the installed package version.

**Why:**
The mismatched schema versions caused `knip` to throw schema mismatch warnings during `pnpm lint`, creating noise in the local and CI pipelines.

**Impact on DX/CI:**
Removes confusing schema warnings during linting, ensuring a clean and reliable pipeline output.

**Setup notes:**
Used `pnpm exec biome migrate --write` to automatically migrate the configuration, and manually aligned the GitHub Actions workflow.

---
*PR created automatically by Jules for task [2099243185311115669](https://jules.google.com/task/2099243185311115669) started by @szubster*