### PR TITLE
fix(heartbeat): assume Jules sessions >24h old are dead

### DIFF
--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -99,6 +99,39 @@ ok: false,
     expect(fs.writeFileSync).toHaveBeenCalled();
   });
 
+
+  it('should transition a node to FAILED if its Jules session has been IN_PROGRESS for >24h', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-stuck.md',
+      repoPath: '.foundry/tasks/task-stuck.md',
+      frontmatter: {
+        id: 'task-stuck',
+        status: 'ACTIVE',
+        jules_session_id: 'session-stuck'
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: "session-stuck"\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-stuck.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    // Mock API response with an update time > 24 hours ago
+    const pastDate = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    globalFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ state: 'IN_PROGRESS', updateTime: pastDate })
+    } as unknown as Response);
+
+    await main();
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      '/mock/repo/.foundry/tasks/task-stuck.md',
+      expect.stringContaining('status: "FAILED"'),
+      'utf-8'
+    );
+  });
+
   it('should NOT transition a node if its Jules session is IN_PROGRESS', async () => {
     const mockNode = {
       filePath: '/mock/repo/.foundry/tasks/task-1.md',
@@ -117,7 +150,7 @@ ok: false,
     globalFetch.mockResolvedValue({
 ok: true,
       status: 200,
-      json: async () => ({ state: 'IN_PROGRESS' })
+      json: async () => ({ state: 'IN_PROGRESS', updateTime: new Date().toISOString() })
     } as unknown as Response);
 
     await main();

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -118,9 +118,12 @@ async function findPRForSession(
   githubToken: string,
   julesKey: string,
   sessionId: string
-): Promise<{ pr: any; sessionStatus: string | null }> {
+): Promise<{ pr: any; sessionStatus: string | null; updateTime?: string }> {
   let sessionStatus: string | null = null;
+  let updateTime: string | undefined;
+
   let prData: any = null;
+
 
   // 1. Fetch Jules session details (Primary Source of Truth)
   try {
@@ -130,6 +133,7 @@ async function findPRForSession(
     if (res.ok) {
       const data = await res.json() as any;
       sessionStatus = data.state || null;
+      updateTime = data.updateTime;
       
       const prUrl = data.outputs?.find((o: any) => o.pullRequest?.url)?.pullRequest.url;
       if (prUrl) {
@@ -151,7 +155,7 @@ async function findPRForSession(
     process.stderr.write(`[heartbeat] Jules API error: ${String(err)}\n`);
   }
 
-  if (prData) return { pr: prData, sessionStatus };
+  if (prData) return { pr: prData, sessionStatus, updateTime };
 
   // 2. Fallback to GitHub Search API (Index-dependent)
   try {
@@ -159,7 +163,7 @@ async function findPRForSession(
       headers: { 'Authorization': `Bearer ${githubToken}`, 'Accept': 'application/vnd.github.v3+json' }
     });
     const searchJson = await searchRes.json() as any;
-    if (searchJson.items?.[0]) return { pr: searchJson.items[0], sessionStatus };
+    if (searchJson.items?.[0]) return { pr: searchJson.items[0], sessionStatus, updateTime };
   } catch { /* ignore search error */ }
 
   // 3. Fallback to listing recent PRs (Index-independent)
@@ -171,13 +175,13 @@ async function findPRForSession(
     if (Array.isArray(pulls)) {
       for (const pr of pulls) {
         if (pr.body?.includes(sessionId) || pr.head?.ref?.includes(sessionId)) {
-          return { pr, sessionStatus };
+          return { pr, sessionStatus, updateTime };
         }
       }
     }
   } catch { /* ignore list error */ }
 
-  return { pr: null, sessionStatus };
+  return { pr: null, sessionStatus, updateTime };
 }
 
 function logToJournal(repoRoot: string, entry: string): void {
@@ -223,6 +227,7 @@ export async function main() {
 
     let pr: any = null;
     let sessionStatus: string | null = null;
+  let updateTime: string | undefined;
 
     if (isHuman) {
       const prNumber = node.frontmatter.pr_number;
@@ -243,6 +248,7 @@ export async function main() {
       const res = await findPRForSession(repoFullName, githubToken, julesKey, sessionId as string);
       pr = res.pr;
       sessionStatus = res.sessionStatus;
+      updateTime = res.updateTime;
     }
 
     if (pr) {
@@ -275,6 +281,15 @@ export async function main() {
       if (sessionStatus === 'NOT_FOUND' || (sessionStatus && TERMINAL_STATES.includes(sessionStatus))) {
         info(`Session ${sessionId} (Status: ${sessionStatus}) terminated without PR. Failing.`);
         await transitionNodeToFailed(node, repoRoot);
+      } else if (updateTime) {
+        const lastUpdate = new Date(updateTime).getTime();
+        const now = Date.now();
+        const hoursElapsed = (now - lastUpdate) / (1000 * 60 * 60);
+
+        if (hoursElapsed > 24) {
+          info(`Session ${sessionId} has been IN_PROGRESS for >24h. Assuming dead. Failing.`);
+          await transitionNodeToFailed(node, repoRoot);
+        }
       }
     }
   }


### PR DESCRIPTION
Checks the `updateTime` from the Jules API response and fails sessions that have been IN_PROGRESS for more than 24 hours. The session status itself is safely ignored if it's not explicitly a terminal state, falling through directly to the time check.

---
*PR created automatically by Jules for task [947498416196668832](https://jules.google.com/task/947498416196668832) started by @szubster*