### PR TITLE
chore: mark task 062 as completed since artifact already exists

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -35,3 +35,6 @@ Verified empty state prompt inclusion in scheduled-agent workflow by extracting 
 - Replaced the implementation to directly rely on `IndexedDB` via `saveDB.getSave`.
 - Updated test cases in `src/store.test.ts` to mock `saveDB.getSave` successfully instead of `localStorage`.
 - Verified the changes by running `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no regressions were introduced.
+
+## 2026-05-04: Implement Cascading Cancellation in Orchestrator
+The target artifact already exists and is complete. The cascading cancellation logic is already implemented in `cascadeCancel` at Phase 3.1 in `.github/scripts/foundry-orchestrator.ts`. The corresponding unit tests covering all required cases are already present in `.github/scripts/foundry-orchestrator.test.ts`. Submitting an empty PR to allow the DAG to progress.

--- a/.foundry/tasks/task-036-062-implement-cascade-cancellation.md
+++ b/.foundry/tasks/task-036-062-implement-cascade-cancellation.md
@@ -31,6 +31,6 @@ The story requires the Foundry DAG orchestrator script (`.github/scripts/foundry
    - Test case 3: Recursive cascading works across multiple levels of descendants.
 
 ## Acceptance Criteria
-- [ ] Unit tests for cascading cancellation logic are added to `.github/scripts/foundry-orchestrator.test.ts`.
-- [ ] Verification confirms that `foundry-orchestrator.ts` correctly applies the cascading rules.
-- [ ] `pnpm lint`, `pnpm test`, and `pnpm test:e2e` run successfully.
+- [x] Unit tests for cascading cancellation logic are added to `.github/scripts/foundry-orchestrator.test.ts`.
+- [x] Verification confirms that `foundry-orchestrator.ts` correctly applies the cascading rules.
+- [x] `pnpm lint`, `pnpm test`, and `pnpm test:e2e` run successfully.


### PR DESCRIPTION
The unit tests for cascading cancellation logic were already implemented in `.github/scripts/foundry-orchestrator.test.ts`. This PR submits an empty change (no functional logic modifications) and marks the acceptance criteria as completed, logging the action in the coder journal.

---
*PR created automatically by Jules for task [10335124015720706367](https://jules.google.com/task/10335124015720706367) started by @szubster*