### PR TITLE
Story Owner: Create story for late binding completion

### DIFF
--- a/.foundry/epics/epic-012-024-improve-late-binding-completion.md
+++ b/.foundry/epics/epic-012-024-improve-late-binding-completion.md
@@ -36,4 +36,6 @@ Enhance the Foundry orchestrator (`.github/scripts/foundry-orchestrator.ts`) to 
 - None
 
 ## Acceptance Criteria
-- [ ] Story Owner: Break this Epic down into actionable stories.
+- [x] Story Owner: Break this Epic down into actionable stories.
+
+- `.foundry/stories/story-024-037-orchestrator-late-binding-completion.md`

--- a/.foundry/stories/story-024-037-orchestrator-late-binding-completion.md
+++ b/.foundry/stories/story-024-037-orchestrator-late-binding-completion.md
@@ -1,0 +1,38 @@
+---
+id: story-024-037-orchestrator-late-binding-completion
+type: STORY
+title: 'Story: Handle Late-Binding Parent Completion'
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-04'
+updated_at: '2026-05-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-012-024-improve-late-binding-completion.md
+tags:
+  - orchestrator
+  - late-binding
+  - bug
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Handle Late-Binding Parent Completion
+
+## Objective
+Update `.github/scripts/foundry-orchestrator.ts` to properly manage the waking up of late-binding parent nodes whose dynamically spawned children have been completed. Ensure parents transition to `COMPLETED` if no tasks remain, or push them to eligible to wake up to `READY` state if unchecked tasks (`- [ ]`) remain. Add unit tests.
+
+## Requirements
+1. Differentiate between a node waiting for dependencies to complete to run again vs a node that is actually finished.
+2. If no unchecked tasks remain in the body, transition to `COMPLETED`.
+3. If unchecked tasks remain, push to eligible to wake up to `READY` state.
+4. Provide unit tests in `.github/scripts/foundry-orchestrator.test.ts`.
+
+## Dependencies
+- None
+
+## Acceptance Criteria
+- [ ] Coder: Implement the orchestrator fix and add tests.


### PR DESCRIPTION
I created `.foundry/stories/story-024-037-orchestrator-late-binding-completion.md` which breaks down Epic 012-024 (Improve Late Binding Parent Completion) into an actionable technical story. The story aims to update `foundry-orchestrator.ts` so that it properly handles late-binding parent node waking up vs completion.

I then properly linked the story back into the body of the Epic and checked off the acceptance criteria, while ensuring that the `epic` file's YAML frontmatter was not modified, as required by the orchestrator schema guidelines.

---
*PR created automatically by Jules for task [1302385052519887842](https://jules.google.com/task/1302385052519887842) started by @szubster*