### PR TITLE
Fix late-binding orchestrator completion

### DIFF
--- a/.foundry/stories/story-024-037-orchestrator-late-binding-completion.md
+++ b/.foundry/stories/story-024-037-orchestrator-late-binding-completion.md
@@ -35,4 +35,4 @@ Update `.github/scripts/foundry-orchestrator.ts` to properly manage the waking u
 - None
 
 ## Acceptance Criteria
-- [ ] Coder: Implement the orchestrator fix and add tests.
+- [x] Coder: Implement the orchestrator fix and add tests.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -372,6 +372,74 @@ jules_session_id: null
     expect(epicContent).toContain('status: READY');
   });
 
+  test('Late-Binding: Parent wakes up to ACTIVE if owned by human and it has unchecked tasks', () => {
+    createNode('.foundry/epics/epic-001.md', `
+id: epic-001
+type: EPIC
+title: "Epic 1"
+status: PENDING
+owner_persona: human
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`, `# Title
+
+- [ ] Unchecked task`);
+
+    createNode('.foundry/stories/story-001.md', `
+id: story-001
+type: STORY
+title: "Story 1"
+status: COMPLETED
+owner_persona: story_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+parent: .foundry/epics/epic-001.md
+jules_session_id: null
+`);
+
+    main();
+
+    const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
+    expect(epicContent).toContain('status: ACTIVE');
+  });
+
+  test('Late-Binding: Parent does not wake up if dependencies are unresolvable', () => {
+    createNode('.foundry/epics/epic-001.md', `
+id: epic-001
+type: EPIC
+title: "Epic 1"
+status: PENDING
+owner_persona: epic_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: [".foundry/prds/missing-prd.md"]
+jules_session_id: null
+`, `# Title
+
+- [ ] Unchecked task`);
+
+    createNode('.foundry/stories/story-001.md', `
+id: story-001
+type: STORY
+title: "Story 1"
+status: COMPLETED
+owner_persona: story_owner
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+parent: .foundry/epics/epic-001.md
+jules_session_id: null
+`);
+
+    main();
+
+    const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
+    expect(epicContent).toContain('status: PENDING');
+  });
+
   test('Cascade Cancellation: cancels child nodes of CANCELLED parent recursively', () => {
     createNode('.foundry/epics/epic-001.md', `
 id: epic-001

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -660,6 +660,10 @@ function main(): void {
               } else {
                 promoteNodeStatus(node, 'PENDING', 'READY');
               }
+              // Add to eligible if not already there, so it's picked up by subsequent phases
+              if (!eligible.includes(node)) {
+                eligible.push(node);
+              }
               // Prevent promotion to COMPLETED by bypassing the else branch
             } else {
               info(`Late-Binding Parent Complete: ${node.repoPath} has children and all are COMPLETED. Promoting directly to COMPLETED.`);


### PR DESCRIPTION
Fixes an orchestrator bug where late-binding parent nodes failed to transition to `READY`/`ACTIVE` when their children completed but unchecked tasks remained, because they were missing from the `eligible` queue. Added unit tests for validation.

---
*PR created automatically by Jules for task [16125954970848414201](https://jules.google.com/task/16125954970848414201) started by @szubster*