### PR TITLE
Phase 1 & 2 PRD for Gen 2 Expansion

### DIFF
--- a/.foundry/ideas/idea-006-gen2-expansion.md
+++ b/.foundry/ideas/idea-006-gen2-expansion.md
@@ -44,5 +44,6 @@ Inject Gen 2 logic into the Assistant's core:
 - **Interaction Logic**: Handle Headbutt/Rock Smash encounters and stat-based evolutions (Tyrogue).
 
 ## Next Steps
-- [ ] **Product Manager**: Draft the Gen 2 Expansion PRD, formalizing the scope for Phase 1 and 2.
+- [x] **Product Manager**: Draft the Gen 2 Expansion PRD, formalizing the scope for Phase 1 and 2.
+  - Spawned: [.foundry/prds/prd-006-015-gen2-expansion-phase-1-2.md](.foundry/prds/prd-006-015-gen2-expansion-phase-1-2.md)
 - [ ] **Architect**: Review the Map Graph design to ensure it scales for dual-region routing.

--- a/.foundry/prds/prd-006-015-gen2-expansion-phase-1-2.md
+++ b/.foundry/prds/prd-006-015-gen2-expansion-phase-1-2.md
@@ -1,0 +1,45 @@
+---
+id: prd-006-015-gen2-expansion-phase-1-2
+type: PRD
+title: 'Gen 2 Expansion PRD: Phase 1 and 2'
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-05-04'
+updated_at: '2026-05-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/ideas/idea-006-gen2-expansion.md
+tags:
+  - gen2
+  - expansion
+  - save-parser
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen 2 Expansion PRD: Phase 1 and 2
+
+## 1. Context and Problem Statement
+Currently, the application supports basic parsing of Gen 2 save files but lacks the necessary generation-specific logic for full support. Phase 1 and Phase 2 focus on expanding the Save Parser to handle Gen 2 structs and establishing the static knowledge base for Gen 2.
+
+## 2. Objective
+Formalize the implementation scope for Phase 1 (Save Parser Expansion) and Phase 2 (Exclusives & Static Data Setup) to provide the engineering team with clear deliverables.
+
+## 3. Requirements
+
+### Phase 1: Save Parser Expansion (Engine Data Layer)
+- **Detailed Inventory Parsing**: Implement extraction for Key Items, special Rods, TM/HMs (Headbutt, Rock Smash), Apricorns, and Evolution Items.
+- **Hall of Fame & Roamers**: Extract Hall of Fame counts and the dynamic map locations of roaming legendaries (Raikou, Entei, Suicune) directly from RAM.
+
+### Phase 2: Exclusives & Static Data Setup
+- **Gen 2 Exclusives Module**: Define availability differences between Gold, Silver, and Crystal versions.
+- **Assistant Configuration**:
+  - Define static gift data (e.g., Togepi Egg, Eevee from Bill, Shuckle in Cianwood, Dratini, Tyrogue).
+  - Define static NPC trade data.
+
+## 4. Next Steps
+- [ ] **Epic Planner**: Break down this PRD into Epics for Phase 1 and Phase 2.


### PR DESCRIPTION
Generates a PRD node formalizing the implementation scope for the first two phases of the Gen 2 support expansion, and updates the parent IDEA node accordingly.

---
*PR created automatically by Jules for task [143407663696359906](https://jules.google.com/task/143407663696359906) started by @szubster*