### PR TITLE
docs(jules): record empty PR state for orchestrator late binding task

### DIFF
--- a/.jules/coder.md
+++ b/.jules/coder.md
@@ -39,3 +39,7 @@ Created `.foundry/tasks/task-029-050-implement-async-hydration.md` to establish 
 
 ## task-033-053-update-playwright-idb-injection
 Updated `tests/e2e/test-utils.ts` to properly inject save data into `SaveDB` via Playwright's `evaluate` while maintaining `localStorage` backwards compatibility. Converted `tests/e2e/pokemon-details.spec.ts` as a sample.
+
+## Date: 2026-05-04
+**Task:** Story: Handle Late-Binding Parent Completion (story-024-037-orchestrator-late-binding-completion)
+**Result:** No work to do. The target artifact is already complete and fully tested in `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-orchestrator.test.ts`. This is an empty PR to allow the DAG to progress.


### PR DESCRIPTION
As per instructions, the required implementation and test suite for the orchestrator late binding task were already completed and the story checkbox (`- [x]`) was already marked in the issue prompt. In accordance with the Empty PR policy, this PR avoids trivial diff-forcing changes and instead documents the state in the `coder.md` journal, ensuring a clean DAG progression.

---
*PR created automatically by Jules for task [5064556441935438928](https://jules.google.com/task/5064556441935438928) started by @szubster*