### PR TITLE
Create Gen 2 Expansion Epics

### DIFF
--- a/.foundry/epics/epic-015-026-save-parser-expansion.md
+++ b/.foundry/epics/epic-015-026-save-parser-expansion.md
@@ -1,0 +1,30 @@
+---
+id: epic-015-026-save-parser-expansion
+type: EPIC
+title: "Phase 1: Save Parser Expansion"
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-05-04"
+updated_at: "2026-05-04"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/prds/prd-006-015-gen2-expansion-phase-1-2.md
+tags: ["gen2", "save-parser"]
+research_references: [".foundry/docs/knowledge_base/development/gen2_implementation_plan.md"]
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Phase 1: Save Parser Expansion
+
+## Context
+The current save parser logic (`src/engine/saveParser/parsers/gen2.ts`) is missing parsing capabilities for several key aspects of Gen 2 structure, such as extended inventories and dynamic roamers. This Epic breaks down Phase 1 of the Gen 2 Implementation Plan.
+
+## Objectives
+Implement the missing data extraction layers for Gen 2 save files to provide accurate data for the engine.
+
+## High-level Acceptance Criteria
+- Detailed Inventory Parsing: Able to extract Key Items, Special Rods, TM/HMs (Headbutt, Rock Smash), Apricorns, and Evolution Items.
+- Hall of Fame & Roamers: Able to extract the Hall of Fame counts and the specific map locations of roaming legendaries (Raikou, Entei, Suicune).

--- a/.foundry/epics/epic-015-027-exclusives-and-static-data.md
+++ b/.foundry/epics/epic-015-027-exclusives-and-static-data.md
@@ -1,0 +1,31 @@
+---
+id: epic-015-027-exclusives-and-static-data
+type: EPIC
+title: "Phase 2: Exclusives & Static Data Setup"
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-05-04"
+updated_at: "2026-05-04"
+depends_on: [".foundry/epics/epic-015-026-save-parser-expansion.md"]
+jules_session_id: null
+pr_number: null
+parent: .foundry/prds/prd-006-015-gen2-expansion-phase-1-2.md
+tags: ["gen2", "data"]
+research_references: [".foundry/docs/knowledge_base/development/gen2_implementation_plan.md"]
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Phase 2: Exclusives & Static Data Setup
+
+## Context
+Gen 2 specific game mechanics and Pokémon availability require establishing the static knowledge base. This Epic breaks down Phase 2 of the Gen 2 Implementation Plan.
+
+## Objectives
+Define availability differences for Gen 2 and establish static configurations for gifts and trades.
+
+## High-level Acceptance Criteria
+- Define availability differences between Gold, Silver, and Crystal versions in the new Gen 2 Exclusives module.
+- Define static gift data (e.g., Togepi Egg, Eevee from Bill) for Gen 2.
+- Define static NPC trade data for Gen 2.

--- a/.foundry/prds/prd-006-015-gen2-expansion-phase-1-2.md
+++ b/.foundry/prds/prd-006-015-gen2-expansion-phase-1-2.md
@@ -42,4 +42,6 @@ Formalize the implementation scope for Phase 1 (Save Parser Expansion) and Phase
   - Define static NPC trade data.
 
 ## 4. Next Steps
-- [ ] **Epic Planner**: Break down this PRD into Epics for Phase 1 and Phase 2.
+- [x] **Epic Planner**: Break down this PRD into Epics for Phase 1 and Phase 2.
+  - Epic 1: [.foundry/epics/epic-015-026-save-parser-expansion.md](.foundry/epics/epic-015-026-save-parser-expansion.md)
+  - Epic 2: [.foundry/epics/epic-015-027-exclusives-and-static-data.md](.foundry/epics/epic-015-027-exclusives-and-static-data.md)


### PR DESCRIPTION
Generated the Epics from the Gen 2 Expansion PRD Phase 1 and 2, breaking down the save parser and static data tasks for story owners. The updates conform to The Foundry's Parent-Linked Distributed ID Schema and strict pipeline order handoffs.

---
*PR created automatically by Jules for task [16390708864537629693](https://jules.google.com/task/16390708864537629693) started by @szubster*