### PR TITLE
Agile Coach: Proactive Quality Assurance & Pre-commit Validation

### DIFF
--- a/.foundry/ideas/idea-016-precommit-schema-validation.md
+++ b/.foundry/ideas/idea-016-precommit-schema-validation.md
@@ -1,0 +1,29 @@
+---
+id: idea-016-precommit-schema-validation
+type: IDEA
+title: 'DAG Feature: Pre-commit Schema Validation'
+status: "PENDING"
+owner_persona: product_manager
+created_at: '2026-05-04'
+updated_at: "2026-05-04"
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - validation
+notes: ''
+---
+
+# Idea: Pre-commit Schema Validation
+
+## Context
+Currently, the DAG orchestrator handles schema validation during its dispatch cycle, skipping malformed nodes and logging warnings. This allows malformed nodes to enter the repository, cluttering history and requiring asynchronous detection.
+
+## Proposal
+Expand the existing pre-commit hook (which currently checks links) to perform full YAML frontmatter schema validation against `schema.md` (e.g., checking `owner_persona`, `status`, `type` enums). This will prevent malformed nodes from ever entering the repository, catching errors at commit time and providing immediate feedback to agents or humans.
+
+## Next Steps
+- [ ] Convert this idea into a detailed PRD defining the pre-commit hook expansion.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -88,3 +88,14 @@ The `prd-013-012-improve-late-binding-completion.md` node was crashing silently 
 1. Updated `.github/agents/product_manager.md`, `.github/agents/epic_planner.md`, and `.github/agents/story_owner.md` to explicitly enforce the strict pipeline handoff order.
 2. Corrected the `owner_persona` field in `prd-013-012` to `epic_planner` so it will unblock cleanly.
 3. Created `idea-015-enforce-persona-pipeline.md` to propose adding a DAG orchestrator verification step that hard-fails nodes assigned to the wrong persona type.
+
+## 2026-05-05: Proactive Quality Assurance & Pre-commit Validation
+
+### Observation
+While reviewing overall system friction, I noticed two areas for proactive improvement:
+1. Agents occasionally omit running full test suites or linting auto-fixes before marking tasks as complete, relying on the QA phase or CI to catch issues.
+2. Malformed nodes can be committed to the repository because schema validation (enums, field existence) only happens asynchronously in the DAG orchestrator, resulting in skipped nodes.
+
+### Action Taken
+1. Updated `.github/agents/coder.md` and `.github/agents/qa.md` to explicitly instruct agents to run `pnpm lint && pnpm test` before completion, and to use `pnpm format:biome` or `pnpm check:fix` for formatting errors.
+2. Autonomously generated `idea-016-precommit-schema-validation.md` to propose adding YAML frontmatter schema validation to the existing git pre-commit hook to catch malformed nodes synchronously at commit time.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -20,3 +20,7 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
 - If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
+
+## Quality Assurance
+Before marking a task as COMPLETED, you MUST run `pnpm lint && pnpm test` to ensure project health and that no regressions are introduced.
+To automatically fix code formatting errors flagged by Biome during lint checks, run `pnpm check:fix` or `pnpm format:biome`.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -32,3 +32,7 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
 - If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
+
+## Quality Assurance
+Before approving a task, you MUST run `pnpm lint && pnpm test` to ensure project health and verify that no regressions are introduced by the implementer.
+To automatically fix code formatting errors flagged by Biome during lint checks, run `pnpm check:fix` or `pnpm format:biome`.


### PR DESCRIPTION
This PR represents a proactive session by the Agile Coach meta-agent to address observed system friction.

### Changes Made:
1.  **Persona Prompt Updates:** The `coder` and `qa` personas now have explicit "Quality Assurance" instructions. They are mandated to run the project's testing and linting suite (`pnpm lint && pnpm test`) and auto-fix formatting issues (`pnpm check:fix` or `pnpm format:biome`) before submitting or approving work. This prevents unverified code from reaching review.
2.  **New System Idea:** Autonomously generated `idea-016-precommit-schema-validation.md`. This idea proposes expanding the existing pre-commit hook to fully validate node YAML frontmatter against `schema.md` (e.g., checking enums like `owner_persona`, `status`, and `type`). Currently, the DAG orchestrator handles this asynchronously and simply skips malformed nodes, which clutters the repository. A synchronous pre-commit check will provide immediate feedback.
3.  **Journaling:** Logged the analysis and actions taken in `.foundry/journals/agile_coach.md`.

---
*PR created automatically by Jules for task [10717790949002325297](https://jules.google.com/task/10717790949002325297) started by @szubster*