### PR TITLE
📦 Product Manager: Idea 016 to PRD

### DIFF
--- a/.foundry/ideas/idea-016-precommit-schema-validation.md
+++ b/.foundry/ideas/idea-016-precommit-schema-validation.md
@@ -26,4 +26,7 @@ Currently, the DAG orchestrator handles schema validation during its dispatch cy
 Expand the existing pre-commit hook (which currently checks links) to perform full YAML frontmatter schema validation against `schema.md` (e.g., checking `owner_persona`, `status`, `type` enums). This will prevent malformed nodes from ever entering the repository, catching errors at commit time and providing immediate feedback to agents or humans.
 
 ## Next Steps
-- [ ] Convert this idea into a detailed PRD defining the pre-commit hook expansion.
+- [x] Convert this idea into a detailed PRD defining the pre-commit hook expansion.
+
+### Child Nodes
+- `.foundry/prds/prd-016-016-precommit-schema-validation.md`

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -32,3 +32,6 @@ During the session for transforming IDEA-007 (Migrate Save Data to IndexedDB) in
 ## 2026-05-03: Pre-existing PRD Anomaly
 - During the session for transforming IDEA-013 (Improve Late Binding Parent Completion) into a PRD, the target PRD node (`.foundry/prds/prd-013-012-improve-late-binding-completion.md`) was already found existing in the repository and the acceptance criteria in IDEA-013 were already present.
 - Following the Empty PR Policy, no dummy changes are made, and this journal entry is documented to allow the DAG to progress. The Agile Coach should review this anomaly.
+
+## 2026-05-05: Idea 016 - Pre-commit Schema Validation
+- Created PRD `prd-016-016-precommit-schema-validation.md` from Idea `idea-016-precommit-schema-validation.md`.

--- a/.foundry/prds/prd-016-016-precommit-schema-validation.md
+++ b/.foundry/prds/prd-016-016-precommit-schema-validation.md
@@ -1,0 +1,47 @@
+---
+id: prd-016-016-precommit-schema-validation
+type: PRD
+title: 'Pre-commit Schema Validation'
+status: PENDING
+owner_persona: architect
+created_at: '2026-05-05'
+updated_at: '2026-05-05'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/ideas/idea-016-precommit-schema-validation.md
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - validation
+---
+
+# PRD: Pre-commit Schema Validation
+
+## Context & Problem
+Currently, malformed Foundry nodes (e.g. missing required YAML frontmatter fields, invalid `owner_persona`, invalid `status`, or invalid `type` enums) can be committed to the repository. The DAG orchestrator handles schema validation during its dispatch cycle, skipping malformed nodes and logging warnings. However, this clutters the repository history with invalid files and delays the detection of these errors, forcing asynchronous discovery and fix cycles.
+
+## Proposal
+Expand the existing Git pre-commit hooks (managed by `lefthook`) to include full YAML frontmatter schema validation against the rules defined in `.foundry/docs/schema.md`. This will catch errors at commit time, providing immediate synchronous feedback and preventing malformed nodes from entering the repository.
+
+## Requirements
+1. **Validation Script**: Create or update a script (e.g., `scripts/validate-foundry-schema.ts` or modifying `scripts/validate-foundry-ids.ts`) to validate the frontmatter of all staged `.foundry/**/*.md` files.
+2. **Schema Enforcement**:
+   - The `type` must be one of: `IDEA`, `PRD`, `EPIC`, `STORY`, `TASK`.
+   - The `status` must be one of: `PENDING`, `READY`, `ACTIVE`, `COMPLETED`, `FAILED`, `BLOCKED`, `CANCELLED`.
+   - The `owner_persona` must be exactly one string from the allowed list: `product_manager`, `epic_planner`, `story_owner`, `architect`, `tech_lead`, `coder`, `qa`, `human`, `tpm`, `agile_coach`, `researcher`.
+   - Required fields (`id`, `title`, `created_at`, `updated_at`, `depends_on`, `jules_session_id`) must be present.
+3. **Lefthook Integration**: Update `lefthook.yml` to run this validation script on `pre-commit` against `{staged_files}`.
+4. **Library Dependency**: Use `gray-matter` for parsing frontmatter as per ADR-006.
+
+## Non-Goals
+- We are not validating the markdown body content or structure beyond the required `id` slug formats (which is already covered by `validate-foundry-ids.ts`).
+- We are not implementing automated formatting/fixing of malformed nodes at commit time; the script should only check and fail the commit with clear error messages.
+
+## Acceptance Criteria
+- [ ] A validation script exists that correctly identifies invalid `owner_persona`, `status`, and `type` enums.
+- [ ] The script correctly identifies missing required fields.
+- [ ] `lefthook.yml` is updated to run this validation during `pre-commit`.
+- [ ] Staging a malformed Foundry node and attempting to commit results in a blocked commit with a clear error message.
+- [ ] Staging a valid Foundry node allows the commit to proceed.


### PR DESCRIPTION
This PR transitions `idea-016-precommit-schema-validation` into a detailed PRD node. The new node `prd-016-016-precommit-schema-validation` defines requirements for a pre-commit schema validation script to prevent malformed Foundry nodes from entering the repository. The PRD is assigned to the `architect` for the next transition step.

---
*PR created automatically by Jules for task [12657675245923925789](https://jules.google.com/task/12657675245923925789) started by @szubster*