### PR TITLE
🗃️ Archivist: Clarify pr_number usage contradiction

### DIFF
--- a/.foundry/docs/knowledge_base/foundry/lifecycle/conflict-resolution-v1.md
+++ b/.foundry/docs/knowledge_base/foundry/lifecycle/conflict-resolution-v1.md
@@ -5,10 +5,10 @@ Foundry engine was experiencing merge conflicts because multiple agents (Heartbe
 
 ## Resolution
 1. **Simplified Lifecycle**: Removed `IN_REVIEW` status. Tasks now stay `ACTIVE` while a PR is open.
-2. **Implicit PR Tracking**: Removed `pr_number` from frontmatter. The `foundry-heartbeat.ts` script now looks up PRs via the GitHub API using the `jules_session_id`.
+2. **Implicit PR Tracking**: Removed `pr_number` from automated tasks frontmatter (still optional for human-in-the-loop). The `foundry-heartbeat.ts` script now looks up PRs via the GitHub API using the `jules_session_id`.
 3. **Agent Constraints**: Added a strict rule for Jules agents (and updated the workflow prompt) forbidding modification of YAML frontmatter. Only the Foundry engine is allowed to change node metadata.
 4. **Resurrection Logic**: Updated the heartbeat to "resurrect" tasks (set status back to `READY`) if a PR is closed without merging.
-5. **Data Cleanliness**: Migrated all existing foundry nodes to remove `pr_number` and consolidate `IN_REVIEW` into `ACTIVE`.
+5. **Data Cleanliness**: Migrated all existing automated foundry nodes to remove `pr_number` and consolidate `IN_REVIEW` into `ACTIVE`.
 
 ## Files Impacted
 - `.foundry/docs/schema.md`

--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -29,3 +29,8 @@
 
 **Learning:** When refactoring drops a dependency (like `pokenode-ts`), references to it often persist in onboarding documents, creating an inaccurate view of the tech stack.
 **Action:** Routinely search onboarding and project overview documents for deprecated dependencies after a major migration.
+
+## 2026-05-15 - Archivist Run Learnings
+
+**Learning:** Memory entries describing the removal of fields (like `pr_number`) can become contradictory if later features (like `human-in-the-loop`) reintroduce them partially.
+**Action:** Updated `conflict-resolution-v1.md` to clarify that `pr_number` was only removed for automated tasks, resolving the contradiction with `human-in-the-loop.md`.


### PR DESCRIPTION
I've updated the `conflict-resolution-v1.md` knowledge base document to clarify that the `pr_number` field was only removed for automated tasks, and remains valid (and optional) for human-in-the-loop tasks. This resolves a contradiction I found with `human-in-the-loop.md` and aligns the documentation with the actual implementation in `foundry-heartbeat.ts`. I also recorded this contradiction pattern in `.jules/archivist.md` as a critical learning.

Verified with `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [6474864567862355845](https://jules.google.com/task/6474864567862355845) started by @szubster*