### PR TITLE
🧠 Trainer: Daycare Egg Recommendation Logic

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -17,3 +17,6 @@
 ## 2024-05-15 - Assistant Happiness Evolution Suggestion
 **Learning:** For happiness-based evolutions (`min_h`), the assistant previously only displayed a generic "Level up with high happiness to evolve" message without showing the actual friendship progress. The save data `PokemonInstance` actually provides the `friendship` stat.
 **Action:** Always check if `bestInstance.friendship` is defined for `min_h` evolutions. If it is >= `min_h`, update the priority to 90 and dynamically tell the user it is "Ready to Evolve!". Otherwise, display the current vs required friendship `(current/required)` to give the user a clear progression indicator.
+## 2024-05-18 - Assistant Daycare Egg Suggestion
+**Learning:** The Gen 2 Daycare breeding logic previously suggested "Leave your Pokémon at the Daycare to get an Egg!" even if the required Pokémon was already in the daycare, or if an egg was already waiting. We can extract `daycare` and `daycareHasEgg` from the parsed `SaveData`.
+**Action:** When evaluating `EVO_TRIGGER.BREED` (or general breeding recommendations), always check if `saveData.daycare` contains the needed species. If it does, and `saveData.daycareHasEgg` is true, suggest picking up the egg with a higher priority (95). If it is in the daycare but no egg is ready, tell the user to wait.

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { PokemonMetadata } from '../../../db/schema';
 import type { SaveData } from '../../saveParser/index';
 import { gen1Strategy } from '../strategies/gen1Strategy';
 import type { AssistantApiData } from '../suggestionEngine';
@@ -249,5 +250,108 @@ describe('generateSuggestions', () => {
 
     const tradeSuggestion = suggestions.find((s) => s.id === 'npc-trade-122');
     expect(tradeSuggestion).toBeUndefined();
+  });
+
+  it('should generate "Breed" suggestions for Gen 2 based on daycare egg status', () => {
+    const mockSaveData: SaveData = {
+      generation: 2,
+      gameVersion: 'crystal',
+      owned: new Set([153, ...Array.from({ length: 251 }, (_, i) => i + 1).filter((i) => i !== 152)]), // Missing 152 (Chikorita), owns 153 (Bayleef)
+      seen: new Set(),
+      party: [],
+      inventory: [],
+      currentMapId: 0,
+      eventFlags: new Uint8Array(300),
+      partyDetails: [],
+      pcDetails: [
+        {
+          speciesId: 153, // Bayleef
+          level: 20,
+          isShiny: false,
+          moves: [],
+          storageLocation: 'Box 1',
+        },
+      ],
+      trainerName: 'GOLD',
+      daycare: [
+        {
+          speciesId: 153, // Bayleef in daycare
+          level: 20,
+          isShiny: false,
+          moves: [],
+          storageLocation: 'Daycare',
+        },
+      ],
+      daycareHasEgg: true,
+    } as unknown as SaveData;
+
+    const mockApiData: AssistantApiData = {
+      localAid: 1,
+      localEncounters: [],
+      missingEncounters: {},
+      pokemonMetadata: {
+        152: {
+          // Chikorita
+          id: 152,
+          eto: [{ id: 153 }], // Evolves to 153
+          efrm: [],
+          det: [],
+        } as unknown as PokemonMetadata,
+        153: {
+          // Bayleef
+          id: 153,
+          eto: [],
+          efrm: [152],
+          det: [],
+        } as unknown as PokemonMetadata,
+      },
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    // Use a strategy with generation 2
+    const mockStrategy = {
+      ...gen1Strategy,
+      generation: 2, // Must be 2 for Gen2 logic
+    };
+
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, mockStrategy);
+
+    const breedSuggestion = suggestions.find((s) => s.id === 'breed-152');
+    expect(breedSuggestion).toBeDefined();
+    expect(breedSuggestion?.title).toBe('Egg Ready: #152!');
+    expect(breedSuggestion?.description).toBe('Pick up your Egg from the Daycare!');
+    expect(breedSuggestion?.priority).toBe(95);
+
+    // Test when no egg is ready
+    mockSaveData.daycareHasEgg = false;
+    const { suggestions: suggestionsWait } = generateSuggestions(
+      mockSaveData,
+      false,
+      'crystal',
+      mockApiData,
+      mockStrategy,
+    );
+    const breedSuggestionWait = suggestionsWait.find((s) => s.id === 'breed-152');
+    expect(breedSuggestionWait).toBeDefined();
+    expect(breedSuggestionWait?.title).toBe('Breeding in Progress: #152');
+    expect(breedSuggestionWait?.description).toBe('Wait for an Egg from the Daycare!');
+    expect(breedSuggestionWait?.priority).toBe(85);
+
+    // Test when pokemon not in daycare
+    mockSaveData.daycare = [];
+    const { suggestions: suggestionsNotInDaycare } = generateSuggestions(
+      mockSaveData,
+      false,
+      'crystal',
+      mockApiData,
+      mockStrategy,
+    );
+    const breedSuggestionNotInDaycare = suggestionsNotInDaycare.find((s) => s.id === 'breed-152');
+    expect(breedSuggestionNotInDaycare).toBeDefined();
+    expect(breedSuggestionNotInDaycare?.title).toBe('Breed: #152');
+    expect(breedSuggestionNotInDaycare?.description).toBe('Leave your #153 at the Daycare to get an Egg!');
+    expect(breedSuggestionNotInDaycare?.priority).toBe(85);
   });
 });

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -432,7 +432,10 @@ export function generateSuggestions(
       const stack = [...(p.eto || [])];
       while (stack.length > 0) {
         const evo = stack.pop();
-        if (evo && instancesBySpecies.has(evo.id)) {
+        if (
+          evo &&
+          (instancesBySpecies.has(evo.id) || (saveData.daycare?.some((d) => d.speciesId === evo.id) ?? false))
+        ) {
           canBreed = true;
           evolutionIdToBreed = evo.id;
           break;

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -443,13 +443,31 @@ export function generateSuggestions(
       }
 
       if (canBreed && evolutionIdToBreed) {
+        const isInDaycare = saveData.daycare?.some((d) => d.speciesId === evolutionIdToBreed) ?? false;
+
+        let description = `Leave your #${evolutionIdToBreed} at the Daycare to get an Egg!`;
+        let priority = 85;
+        let title = `Breed: #${targetId}`;
+
+        if (isInDaycare) {
+          if (saveData.daycareHasEgg) {
+            title = `Egg Ready: #${targetId}!`;
+            description = `Pick up your Egg from the Daycare!`;
+            priority = 95;
+          } else {
+            title = `Breeding in Progress: #${targetId}`;
+            description = `Wait for an Egg from the Daycare!`;
+            priority = 85;
+          }
+        }
+
         suggestions.push({
           id: `breed-${targetId}`,
           category: 'Breed',
-          title: `Breed: #${targetId}`,
-          description: `Leave your #${evolutionIdToBreed} at the Daycare to get an Egg!`,
+          title,
+          description,
           pokemonId: targetId,
-          priority: 85,
+          priority,
         });
       }
     });


### PR DESCRIPTION
Improves the Trainer assistant to check if an egg is waiting or breeding is in progress in the Daycare in Gen 2 saves instead of generically telling the user to drop the Pokémon off.

---
*PR created automatically by Jules for task [15082591499909975470](https://jules.google.com/task/15082591499909975470) started by @szubster*