### PR TITLE
🧬 Oak: [Gen 1 NPC Trades Correction]

### DIFF
--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -27,3 +27,6 @@
 
 ## Data Integrity - Gen 2 Exclusives Refactoring
 * **Data Pipeline Gotchas:** Gen 2 Exclusives correctly vary between Gold and Silver for the base game logic, but Crystal version dictates its own specific missing list (like missing Vulpix, Mareep, Remoraid). Ensure that array indexes in `GEN2_VERSION_EXCLUSIVES` use safe bracket notation (`['crystal']`) with a `// biome-ignore lint/complexity/useLiteralKeys` directive to satisfy TypeScript's strict index signature checks while remaining compatible with Biome.
+
+## Data Integrity - Gen 1 NPC Trades
+* **ROM parsing quirks / Data Pipeline Gotchas:** When verifying in-game NPC trades (e.g., in `STATIC_NPC_TRADE_DATA`), verify that the `receivedId` and `offeredId` map correctly to the macro definitions in the decompiled ROMs (`npctrade GIVE_MON, GET_MON`). For example, in Yellow version, the `Lickitung for Dugtrio` trade was incorrectly mapped as receiving Lickitung, when the ROM actually dictates giving Lickitung to receive Dugtrio. Additionally, ensure that trades are correctly assigned to their respective game versions; the Red/Blue `Venonat for Tangela` trade was incorrectly marked as Yellow-exclusive, hiding the true Yellow-exclusive `Tangela for Parasect` trade.

--- a/src/engine/data/gen1/__tests__/assistantData.test.ts
+++ b/src/engine/data/gen1/__tests__/assistantData.test.ts
@@ -4,14 +4,14 @@ import { STATIC_NPC_TRADE_DATA } from '../assistantData';
 describe('STATIC_NPC_TRADE_DATA', () => {
   describe('Yellow Version Trades', () => {
     it('should correctly define Lickitung for Dugtrio (GURIO)', () => {
-      const trade = STATIC_NPC_TRADE_DATA.find(t => t.receivedOtName === 'GURIO' && t.versions?.includes('yellow'));
+      const trade = STATIC_NPC_TRADE_DATA.find((t) => t.receivedOtName === 'GURIO' && t.versions?.includes('yellow'));
       expect(trade).toBeDefined();
       expect(trade?.offeredId).toBe(108); // Lickitung
       expect(trade?.receivedId).toBe(51); // Dugtrio
     });
 
     it('should correctly define Tangela for Parasect (SPIKE)', () => {
-      const trade = STATIC_NPC_TRADE_DATA.find(t => t.receivedOtName === 'SPIKE' && t.versions?.includes('yellow'));
+      const trade = STATIC_NPC_TRADE_DATA.find((t) => t.receivedOtName === 'SPIKE' && t.versions?.includes('yellow'));
       expect(trade).toBeDefined();
       expect(trade?.offeredId).toBe(114); // Tangela
       expect(trade?.receivedId).toBe(47); // Parasect
@@ -20,7 +20,7 @@ describe('STATIC_NPC_TRADE_DATA', () => {
 
   describe('Red/Blue Version Trades', () => {
     it('should correctly define Venonat for Tangela (CRINKLES)', () => {
-      const trade = STATIC_NPC_TRADE_DATA.find(t => t.receivedOtName === 'CRINKLES' && t.versions?.includes('red'));
+      const trade = STATIC_NPC_TRADE_DATA.find((t) => t.receivedOtName === 'CRINKLES' && t.versions?.includes('red'));
       expect(trade).toBeDefined();
       expect(trade?.offeredId).toBe(49); // Venonat
       expect(trade?.receivedId).toBe(114); // Tangela
@@ -28,7 +28,7 @@ describe('STATIC_NPC_TRADE_DATA', () => {
     });
 
     it('should correctly define Slowbro for Lickitung (MARC)', () => {
-      const trade = STATIC_NPC_TRADE_DATA.find(t => t.receivedOtName === 'MARC' && t.versions?.includes('red'));
+      const trade = STATIC_NPC_TRADE_DATA.find((t) => t.receivedOtName === 'MARC' && t.versions?.includes('red'));
       expect(trade).toBeDefined();
       expect(trade?.offeredId).toBe(80); // Slowbro
       expect(trade?.receivedId).toBe(108); // Lickitung

--- a/src/engine/data/gen1/__tests__/assistantData.test.ts
+++ b/src/engine/data/gen1/__tests__/assistantData.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { STATIC_NPC_TRADE_DATA } from '../assistantData';
+
+describe('STATIC_NPC_TRADE_DATA', () => {
+  describe('Yellow Version Trades', () => {
+    it('should correctly define Lickitung for Dugtrio (GURIO)', () => {
+      const trade = STATIC_NPC_TRADE_DATA.find(t => t.receivedOtName === 'GURIO' && t.versions?.includes('yellow'));
+      expect(trade).toBeDefined();
+      expect(trade?.offeredId).toBe(108); // Lickitung
+      expect(trade?.receivedId).toBe(51); // Dugtrio
+    });
+
+    it('should correctly define Tangela for Parasect (SPIKE)', () => {
+      const trade = STATIC_NPC_TRADE_DATA.find(t => t.receivedOtName === 'SPIKE' && t.versions?.includes('yellow'));
+      expect(trade).toBeDefined();
+      expect(trade?.offeredId).toBe(114); // Tangela
+      expect(trade?.receivedId).toBe(47); // Parasect
+    });
+  });
+
+  describe('Red/Blue Version Trades', () => {
+    it('should correctly define Venonat for Tangela (CRINKLES)', () => {
+      const trade = STATIC_NPC_TRADE_DATA.find(t => t.receivedOtName === 'CRINKLES' && t.versions?.includes('red'));
+      expect(trade).toBeDefined();
+      expect(trade?.offeredId).toBe(49); // Venonat
+      expect(trade?.receivedId).toBe(114); // Tangela
+      expect(trade?.versions).toContain('blue');
+    });
+
+    it('should correctly define Slowbro for Lickitung (MARC)', () => {
+      const trade = STATIC_NPC_TRADE_DATA.find(t => t.receivedOtName === 'MARC' && t.versions?.includes('red'));
+      expect(trade).toBeDefined();
+      expect(trade?.offeredId).toBe(80); // Slowbro
+      expect(trade?.receivedId).toBe(108); // Lickitung
+    });
+  });
+});

--- a/src/engine/data/gen1/assistantData.ts
+++ b/src/engine/data/gen1/assistantData.ts
@@ -163,12 +163,22 @@ export const STATIC_NPC_TRADE_DATA: NpcTradeEntry[] = [
     versions: ['red', 'blue'],
     tradeIndex: 5,
   },
-  // Tangela for Venonat — Route 18 (trade house) — Yellow version only (TRADE_FOR_CRINKLES)
+  // Venonat for Tangela — Route 18 (trade house) — Red/Blue only (TRADE_FOR_CRINKLES)
   {
     receivedId: 114,
     offeredId: 49,
     location: 'Route 18 (trade house)',
     receivedOtName: 'CRINKLES',
+    gen: 1,
+    versions: ['red', 'blue'],
+    tradeIndex: 8,
+  },
+  // Tangela for Parasect — Route 18 (trade house) — Yellow only
+  {
+    receivedId: 47,
+    offeredId: 114,
+    location: 'Route 18 (trade house)',
+    receivedOtName: 'SPIKE',
     gen: 1,
     versions: ['yellow'],
     tradeIndex: 8,
@@ -185,8 +195,8 @@ export const STATIC_NPC_TRADE_DATA: NpcTradeEntry[] = [
   },
   // Lickitung for Dugtrio — Route 11 (east gate) — Yellow only
   {
-    receivedId: 108,
-    offeredId: 51,
+    receivedId: 51,
+    offeredId: 108,
     location: 'Route 11 (east gate)',
     receivedOtName: 'GURIO',
     gen: 1,


### PR DESCRIPTION
Fixes incorrect Gen 1 NPC trade data which caused the application to give incorrect trade suggestions.

---
*PR created automatically by Jules for task [10484933907166291961](https://jules.google.com/task/10484933907166291961) started by @szubster*