### PR TITLE
Draft Technical Tasks for Inventory Parsing Story

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -5,3 +5,8 @@ All tasks for this story have already been generated, and all acceptance criteri
 All tasks for this story have already been generated, and all acceptance criteria are checked off in the story markdown body. No further blueprinting is required. Applying EMPTY PR POLICY.
 ## story-014-026-refactor-state-store-sync
 Anomaly for Agile Coach: The target task artifact .foundry/tasks/task-026-044-refactor-state-store-sync.md unexpectedly existed prior to the session and is already marked as COMPLETED. No further blueprinting is required. Applying EMPTY PR POLICY.
+
+## 2025-05-15
+- Reviewed story `story-026-041-inventory-parsing`.
+- Created implementation task `task-041-066-implement-inventory-parsing` assigned to `coder`.
+- Created QA verification task `task-041-067-qa-inventory-parsing` assigned to `qa` with a dependency on the implementation task.

--- a/.foundry/stories/story-026-041-inventory-parsing.md
+++ b/.foundry/stories/story-026-041-inventory-parsing.md
@@ -29,8 +29,12 @@ The Gen 2 Save Parser Expansion Epic requires detailed inventory parsing to prov
 - Implement the missing data extraction layer for detailed inventory parsing.
 
 ## Acceptance Criteria
-- [ ] Able to extract Key Items.
-- [ ] Able to extract Special Rods.
-- [ ] Able to extract TM/HMs (Headbutt, Rock Smash).
-- [ ] Able to extract Apricorns.
-- [ ] Able to extract Evolution Items.
+- [x] Able to extract Key Items.
+- [x] Able to extract Special Rods.
+- [x] Able to extract TM/HMs (Headbutt, Rock Smash).
+- [x] Able to extract Apricorns.
+- [x] Able to extract Evolution Items.
+
+### Child Tasks
+- `.foundry/tasks/task-041-066-implement-inventory-parsing.md`
+- `.foundry/tasks/task-041-067-qa-inventory-parsing.md`

--- a/.foundry/tasks/task-041-066-implement-inventory-parsing.md
+++ b/.foundry/tasks/task-041-066-implement-inventory-parsing.md
@@ -1,0 +1,36 @@
+---
+id: task-041-066-implement-inventory-parsing
+type: TASK
+title: 'Implement Detailed Inventory Parsing'
+status: PENDING
+owner_persona: coder
+created_at: '2025-05-15'
+updated_at: '2025-05-15'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/stories/story-026-041-inventory-parsing.md
+tags:
+  - gen2
+  - save-parser
+  - inventory
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Detailed Inventory Parsing
+
+## Context
+The Gen 2 Save Parser needs to be expanded to extract detailed inventory data to accurately populate the engine's internal representation.
+
+## Objectives
+- Implement the missing data extraction layer for detailed inventory parsing.
+
+## Acceptance Criteria
+- [ ] Able to extract Key Items.
+- [ ] Able to extract Special Rods.
+- [ ] Able to extract TM/HMs (Headbutt, Rock Smash).
+- [ ] Able to extract Apricorns.
+- [ ] Able to extract Evolution Items.

--- a/.foundry/tasks/task-041-067-qa-inventory-parsing.md
+++ b/.foundry/tasks/task-041-067-qa-inventory-parsing.md
@@ -1,0 +1,37 @@
+---
+id: task-041-067-qa-inventory-parsing
+type: TASK
+title: 'QA: Detailed Inventory Parsing'
+status: PENDING
+owner_persona: qa
+created_at: '2025-05-15'
+updated_at: '2025-05-15'
+depends_on:
+  - .foundry/tasks/task-041-066-implement-inventory-parsing.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/stories/story-026-041-inventory-parsing.md
+tags:
+  - gen2
+  - save-parser
+  - inventory
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA: Detailed Inventory Parsing
+
+## Context
+The coder has implemented the detailed inventory parsing for the Gen 2 Save Parser. We need to verify that all the required items are extracted correctly.
+
+## Objectives
+- Verify the detailed inventory parsing extraction logic.
+
+## Acceptance Criteria
+- [ ] Verified extraction of Key Items.
+- [ ] Verified extraction of Special Rods.
+- [ ] Verified extraction of TM/HMs (Headbutt, Rock Smash).
+- [ ] Verified extraction of Apricorns.
+- [ ] Verified extraction of Evolution Items.


### PR DESCRIPTION
As the Tech Lead, I have reviewed `story-026-041-inventory-parsing.md` and created two task nodes:
1. `task-041-066-implement-inventory-parsing`: An implementation task assigned to the `coder` persona to build the detailed inventory data extraction layer.
2. `task-041-067-qa-inventory-parsing`: A verification task assigned to the `qa` persona, depending on the implementation task, to verify the extraction logic.

The parent story's markdown body has been updated to check off the acceptance criteria and append the child task paths, adhering strictly to the architectural constraints by not modifying the YAML frontmatter. The `tech_lead` journal has also been updated to document this action.

---
*PR created automatically by Jules for task [17004514495483676047](https://jules.google.com/task/17004514495483676047) started by @szubster*