### PR TITLE
Fix Foundry DAG resolution for ID-based references

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -326,17 +326,28 @@ function main(): void {
   // ── Phase 3: BUILD MAPS ────────────────────────────────────────────────────
   info('Phase 3: Building dependency resolution map...');
   const nodeMap = new Map<string, ParsedNode>();
+  const idToNodeMap = new Map<string, ParsedNode>();
   const parentToChildren = new Map<string, ParsedNode[]>();
 
   for (const node of nodes) {
     nodeMap.set(node.repoPath, node);
+    idToNodeMap.set(node.frontmatter.id, node);
+  }
 
-    const parentPath = node.frontmatter.parent;
-    if (parentPath) {
-      if (!parentToChildren.has(parentPath)) {
-        parentToChildren.set(parentPath, []);
+  /** Resolves a reference (either repoPath or ID) to a ParsedNode. */
+  function resolveNode(ref: string): ParsedNode | undefined {
+    return nodeMap.get(ref) || idToNodeMap.get(ref);
+  }
+
+  for (const node of nodes) {
+    const parentRef = node.frontmatter.parent;
+    if (parentRef) {
+      const parentNode = resolveNode(parentRef);
+      const parentKey = parentNode ? parentNode.repoPath : parentRef;
+      if (!parentToChildren.has(parentKey)) {
+        parentToChildren.set(parentKey, []);
       }
-      parentToChildren.get(parentPath)!.push(node);
+      parentToChildren.get(parentKey)!.push(node);
     }
   }
 
@@ -377,10 +388,15 @@ function main(): void {
 
   // Helper to safely check if 'child' is a deep descendant of 'ancestor'
   function isDescendant(childPath: string, ancestorPath: string): boolean {
-    let curr = nodeMap.get(childPath)?.frontmatter.parent;
+    const childNode = resolveNode(childPath);
+    const ancestorNode = resolveNode(ancestorPath);
+    if (!childNode || !ancestorNode) return false;
+
+    let curr = childNode.frontmatter.parent;
     while (curr) {
-      if (curr === ancestorPath) return true;
-      curr = nodeMap.get(curr)?.frontmatter.parent;
+      const currNode = resolveNode(curr);
+      if (currNode?.repoPath === ancestorNode.repoPath) return true;
+      curr = currNode?.frontmatter.parent;
     }
     return false;
   }
@@ -394,12 +410,12 @@ function main(): void {
    * 2. ANY of its recursive children (sub-tasks/stories) are incomplete.
    * 3. ANY of its recursive dependencies are incomplete.
    */
-  function isHierarchicallyIncomplete(nodePath: string, evaluatingFor?: string): boolean {
-    const cacheKey = evaluatingFor ? `${nodePath}|${evaluatingFor}` : nodePath;
+  function isHierarchicallyIncomplete(ref: string, evaluatingFor?: string): boolean {
+    const cacheKey = evaluatingFor ? `${ref}|${evaluatingFor}` : ref;
     // skip caching as it causes test issues since tests mock multiple times within same global env
     // if (evalCache.has(cacheKey)) return evalCache.get(cacheKey)!;
 
-    const node = nodeMap.get(nodePath);
+    const node = resolveNode(ref);
 
     if (!node) {
       hasUnresolvableDeps = true;
@@ -414,7 +430,7 @@ function main(): void {
 
     evalCache.set(cacheKey, true);
 
-    const children = parentToChildren.get(nodePath) || [];
+    const children = parentToChildren.get(node.repoPath) || [];
     for (const child of children) {
       if (evaluatingFor && (child.repoPath === evaluatingFor || isDescendant(evaluatingFor, child.repoPath))) {
         continue;
@@ -441,7 +457,7 @@ function main(): void {
 
     let shouldSuspend = false;
     for (const depPath of node.frontmatter.depends_on) {
-      const dep = nodeMap.get(depPath);
+      const dep = resolveNode(depPath);
       if (!dep) {
         if (fs.existsSync(path.join(repoRoot, depPath))) {
           continue;
@@ -479,7 +495,7 @@ function main(): void {
   for (const node of nodes) {
     if (node.frontmatter.status === 'FAILED' && node.frontmatter.rejection_reason) {
       if (node.frontmatter.parent) {
-        const parentNode = nodeMap.get(node.frontmatter.parent);
+        const parentNode = resolveNode(node.frontmatter.parent);
         if (parentNode && parentNode.frontmatter.status !== 'ACTIVE') {
           info(`Impossible Loop: waking up parent ${parentNode.repoPath}`);
           promoteNodeStatus(parentNode, parentNode.frontmatter.status, 'ACTIVE');
@@ -511,7 +527,7 @@ function main(): void {
       let parentStatus: string | undefined = undefined;
       let nextParent: string | undefined | null = undefined;
 
-      const parentNode = nodeMap.get(currParent);
+      const parentNode = resolveNode(currParent);
       if (!parentNode) {
         warn(`Parent '${currParent}' not found for: ${node.repoPath}`);
         blocked = true;
@@ -522,7 +538,7 @@ function main(): void {
       }
 
       if (parentStatus !== 'ACTIVE' && parentStatus !== 'COMPLETED') {
-        const parentChildren = parentToChildren.get(currParent) || [];
+        const parentChildren = parentToChildren.get(parentNode.repoPath) || [];
         if (parentStatus === 'PENDING' && parentChildren.length > 0) {
           // Exception for Late-Binding: If parent is PENDING and has children,
           // it is waiting for those children. Do not block the child.
@@ -550,7 +566,7 @@ function main(): void {
     const deps = node.frontmatter.depends_on;
 
     for (const depPath of deps) {
-      const dep = nodeMap.get(depPath);
+      const dep = resolveNode(depPath);
       if (!dep) {
         if (fs.existsSync(path.join(repoRoot, depPath))) {
           continue;
@@ -593,7 +609,7 @@ function main(): void {
       if (targetArtifacts.length > 0) {
         allTargetsCompleted = true;
         for (const target of targetArtifacts) {
-          const targetNode = nodeMap.get(target);
+          const targetNode = resolveNode(target);
           if (!targetNode || targetNode.frontmatter.status !== 'COMPLETED') {
             allTargetsCompleted = false;
             break;
@@ -697,9 +713,9 @@ function main(): void {
       const links = [...body.matchAll(linkRegex)].map(m => m[1]);
 
       if (links.length > 0) {
-        const allExist = links.every(l => nodeMap.has(l));
+        const allExist = links.every(l => !!resolveNode(l));
         const hasChild = links.some(l => {
-          const childNode = nodeMap.get(l);
+          const childNode = resolveNode(l);
           return !!childNode && childNode.frontmatter.parent === node.repoPath;
         });
 


### PR DESCRIPTION
Introduced `idToNodeMap` and a `resolveNode` helper in the Foundry orchestrator to allow resolving parents, dependencies, and artifacts using either their repository path or their unique ID. This fixes "Parent not found" warnings when nodes are linked via IDs.

Fixes #975

---
*PR created automatically by Jules for task [4388319142620727402](https://jules.google.com/task/4388319142620727402) started by @szubster*