### PR TITLE
Fix Foundry DAG ID Resolution

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -326,17 +326,28 @@ function main(): void {
   // ── Phase 3: BUILD MAPS ────────────────────────────────────────────────────
   info('Phase 3: Building dependency resolution map...');
   const nodeMap = new Map<string, ParsedNode>();
+  const idToNodeMap = new Map<string, ParsedNode>();
   const parentToChildren = new Map<string, ParsedNode[]>();
 
   for (const node of nodes) {
     nodeMap.set(node.repoPath, node);
+    idToNodeMap.set(node.frontmatter.id, node);
+  }
 
-    const parentPath = node.frontmatter.parent;
-    if (parentPath) {
-      if (!parentToChildren.has(parentPath)) {
-        parentToChildren.set(parentPath, []);
+  /** Resolves a reference (id or repoPath) to a ParsedNode */
+  function resolveNode(ref: string): ParsedNode | undefined {
+    return nodeMap.get(ref) || idToNodeMap.get(ref);
+  }
+
+  for (const node of nodes) {
+    const parentRef = node.frontmatter.parent;
+    if (parentRef) {
+      const parentNode = resolveNode(parentRef);
+      const parentKey = parentNode ? parentNode.repoPath : parentRef;
+      if (!parentToChildren.has(parentKey)) {
+        parentToChildren.set(parentKey, []);
       }
-      parentToChildren.get(parentPath)!.push(node);
+      parentToChildren.get(parentKey)!.push(node);
     }
   }
 
@@ -379,8 +390,10 @@ function main(): void {
   function isDescendant(childPath: string, ancestorPath: string): boolean {
     let curr = nodeMap.get(childPath)?.frontmatter.parent;
     while (curr) {
-      if (curr === ancestorPath) return true;
-      curr = nodeMap.get(curr)?.frontmatter.parent;
+      const parentNode = resolveNode(curr);
+      if (!parentNode) break;
+      if (parentNode.repoPath === ancestorPath) return true;
+      curr = parentNode.frontmatter.parent;
     }
     return false;
   }
@@ -399,7 +412,7 @@ function main(): void {
     // skip caching as it causes test issues since tests mock multiple times within same global env
     // if (evalCache.has(cacheKey)) return evalCache.get(cacheKey)!;
 
-    const node = nodeMap.get(nodePath);
+    const node = resolveNode(nodePath);
 
     if (!node) {
       hasUnresolvableDeps = true;
@@ -441,7 +454,7 @@ function main(): void {
 
     let shouldSuspend = false;
     for (const depPath of node.frontmatter.depends_on) {
-      const dep = nodeMap.get(depPath);
+      const dep = resolveNode(depPath);
       if (!dep) {
         if (fs.existsSync(path.join(repoRoot, depPath))) {
           continue;
@@ -479,7 +492,7 @@ function main(): void {
   for (const node of nodes) {
     if (node.frontmatter.status === 'FAILED' && node.frontmatter.rejection_reason) {
       if (node.frontmatter.parent) {
-        const parentNode = nodeMap.get(node.frontmatter.parent);
+        const parentNode = resolveNode(node.frontmatter.parent);
         if (parentNode && parentNode.frontmatter.status !== 'ACTIVE') {
           info(`Impossible Loop: waking up parent ${parentNode.repoPath}`);
           promoteNodeStatus(parentNode, parentNode.frontmatter.status, 'ACTIVE');
@@ -511,7 +524,7 @@ function main(): void {
       let parentStatus: string | undefined = undefined;
       let nextParent: string | undefined | null = undefined;
 
-      const parentNode = nodeMap.get(currParent);
+      const parentNode = resolveNode(currParent);
       if (!parentNode) {
         warn(`Parent '${currParent}' not found for: ${node.repoPath}`);
         blocked = true;
@@ -550,7 +563,7 @@ function main(): void {
     const deps = node.frontmatter.depends_on;
 
     for (const depPath of deps) {
-      const dep = nodeMap.get(depPath);
+      const dep = resolveNode(depPath);
       if (!dep) {
         if (fs.existsSync(path.join(repoRoot, depPath))) {
           continue;
@@ -593,7 +606,7 @@ function main(): void {
       if (targetArtifacts.length > 0) {
         allTargetsCompleted = true;
         for (const target of targetArtifacts) {
-          const targetNode = nodeMap.get(target);
+          const targetNode = resolveNode(target);
           if (!targetNode || targetNode.frontmatter.status !== 'COMPLETED') {
             allTargetsCompleted = false;
             break;
@@ -697,10 +710,12 @@ function main(): void {
       const links = [...body.matchAll(linkRegex)].map(m => m[1]);
 
       if (links.length > 0) {
-        const allExist = links.every(l => nodeMap.has(l));
+        const allExist = links.every(l => !!resolveNode(l));
         const hasChild = links.some(l => {
-          const childNode = nodeMap.get(l);
-          return !!childNode && childNode.frontmatter.parent === node.repoPath;
+          const childNode = resolveNode(l);
+          if (!childNode || !childNode.frontmatter.parent) return false;
+          const resolvedParent = resolveNode(childNode.frontmatter.parent);
+          return resolvedParent?.repoPath === node.repoPath;
         });
 
         if (allExist && hasChild) {


### PR DESCRIPTION
Updated the Foundry DAG orchestrator to support resolving node references (parent and depends_on) using either the logical ID or the repo-relative file path. This fixes "Parent not found" warnings when nodes use IDs in their frontmatter.

Fixes #979

---
*PR created automatically by Jules for task [16749624677577038683](https://jules.google.com/task/16749624677577038683) started by @szubster*