### PR TITLE
Support ID-based node resolution in Foundry DAG Orchestrator

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -326,17 +326,32 @@ function main(): void {
   // ── Phase 3: BUILD MAPS ────────────────────────────────────────────────────
   info('Phase 3: Building dependency resolution map...');
   const nodeMap = new Map<string, ParsedNode>();
+  const idToNodeMap = new Map<string, ParsedNode>();
   const parentToChildren = new Map<string, ParsedNode[]>();
+
+  /**
+   * Resolves a node reference (either repo-relative path or node ID) to its ParsedNode.
+   */
+  function resolveNode(ref: string): ParsedNode | undefined {
+    return nodeMap.get(ref) || idToNodeMap.get(ref);
+  }
 
   for (const node of nodes) {
     nodeMap.set(node.repoPath, node);
+    idToNodeMap.set(node.frontmatter.id, node);
+  }
 
-    const parentPath = node.frontmatter.parent;
-    if (parentPath) {
-      if (!parentToChildren.has(parentPath)) {
-        parentToChildren.set(parentPath, []);
+  for (const node of nodes) {
+    const parentRef = node.frontmatter.parent;
+    if (parentRef) {
+      const parentNode = resolveNode(parentRef);
+      if (parentNode) {
+        const parentPath = parentNode.repoPath;
+        if (!parentToChildren.has(parentPath)) {
+          parentToChildren.set(parentPath, []);
+        }
+        parentToChildren.get(parentPath)!.push(node);
       }
-      parentToChildren.get(parentPath)!.push(node);
     }
   }
 
@@ -379,8 +394,9 @@ function main(): void {
   function isDescendant(childPath: string, ancestorPath: string): boolean {
     let curr = nodeMap.get(childPath)?.frontmatter.parent;
     while (curr) {
-      if (curr === ancestorPath) return true;
-      curr = nodeMap.get(curr)?.frontmatter.parent;
+      const parentNode = resolveNode(curr);
+      if (parentNode?.repoPath === ancestorPath) return true;
+      curr = parentNode?.frontmatter.parent;
     }
     return false;
   }
@@ -424,7 +440,9 @@ function main(): void {
       }
     }
 
-    for (const depPath of node.frontmatter.depends_on) {
+    for (const depRef of node.frontmatter.depends_on) {
+      const depNode = resolveNode(depRef);
+      const depPath = depNode ? depNode.repoPath : depRef;
       if (isHierarchicallyIncomplete(depPath, evaluatingFor)) {
         return true;
       }
@@ -440,18 +458,19 @@ function main(): void {
     if (node.frontmatter.status !== 'ACTIVE' && node.frontmatter.status !== 'COMPLETED') continue;
 
     let shouldSuspend = false;
-    for (const depPath of node.frontmatter.depends_on) {
-      const dep = nodeMap.get(depPath);
+    for (const depRef of node.frontmatter.depends_on) {
+      const dep = resolveNode(depRef);
       if (!dep) {
-        if (fs.existsSync(path.join(repoRoot, depPath))) {
+        if (fs.existsSync(path.join(repoRoot, depRef))) {
           continue;
         }
-        warn(`Unresolvable dependency '${depPath}' referenced by ${node.frontmatter.status} node: ${node.repoPath}`);
+        warn(`Unresolvable dependency '${depRef}' referenced by ${node.frontmatter.status} node: ${node.repoPath}`);
         hasUnresolvableDeps = true;
         shouldSuspend = true;
         break;
       }
 
+      const depPath = dep.repoPath;
       // If it is an ancestor, we only care that it is status ACTIVE or COMPLETED.
       if (!isDescendant(node.repoPath, depPath)) {
         if (isHierarchicallyIncomplete(depPath, node.repoPath)) {
@@ -479,7 +498,7 @@ function main(): void {
   for (const node of nodes) {
     if (node.frontmatter.status === 'FAILED' && node.frontmatter.rejection_reason) {
       if (node.frontmatter.parent) {
-        const parentNode = nodeMap.get(node.frontmatter.parent);
+        const parentNode = resolveNode(node.frontmatter.parent);
         if (parentNode && parentNode.frontmatter.status !== 'ACTIVE') {
           info(`Impossible Loop: waking up parent ${parentNode.repoPath}`);
           promoteNodeStatus(parentNode, parentNode.frontmatter.status, 'ACTIVE');
@@ -506,23 +525,25 @@ function main(): void {
     let blocked = false;
 
         // Check parent inheritance
-    let currParent = node.frontmatter.parent;
-    while (currParent) {
+    let currParentRef = node.frontmatter.parent;
+    while (currParentRef) {
       let parentStatus: string | undefined = undefined;
       let nextParent: string | undefined | null = undefined;
+      let parentRepoPath: string | undefined = undefined;
 
-      const parentNode = nodeMap.get(currParent);
+      const parentNode = resolveNode(currParentRef);
       if (!parentNode) {
-        warn(`Parent '${currParent}' not found for: ${node.repoPath}`);
+        warn(`Parent '${currParentRef}' not found for: ${node.repoPath}`);
         blocked = true;
         break;
       } else {
         parentStatus = parentNode.frontmatter.status;
         nextParent = parentNode.frontmatter.parent;
+        parentRepoPath = parentNode.repoPath;
       }
 
       if (parentStatus !== 'ACTIVE' && parentStatus !== 'COMPLETED') {
-        const parentChildren = parentToChildren.get(currParent) || [];
+        const parentChildren = parentToChildren.get(parentRepoPath) || [];
         if (parentStatus === 'PENDING' && parentChildren.length > 0) {
           // Exception for Late-Binding: If parent is PENDING and has children,
           // it is waiting for those children. Do not block the child.
@@ -531,7 +552,7 @@ function main(): void {
           break;
         }
       }
-      currParent = nextParent;
+      currParentRef = nextParent;
     }
 
     if (blocked) continue;
@@ -549,18 +570,19 @@ function main(): void {
 
     const deps = node.frontmatter.depends_on;
 
-    for (const depPath of deps) {
-      const dep = nodeMap.get(depPath);
+    for (const depRef of deps) {
+      const dep = resolveNode(depRef);
       if (!dep) {
-        if (fs.existsSync(path.join(repoRoot, depPath))) {
+        if (fs.existsSync(path.join(repoRoot, depRef))) {
           continue;
         }
-        warn(`Unresolvable dependency '${depPath}' referenced by: ${node.repoPath}`);
+        warn(`Unresolvable dependency '${depRef}' referenced by: ${node.repoPath}`);
         hasUnresolvableDeps = true;
         blocked = true;
         break;
       }
 
+      const depPath = dep.repoPath;
       // If it is an ancestor, we only care that it is status ACTIVE or COMPLETED.
       if (!isDescendant(node.repoPath, depPath)) {
         if (isHierarchicallyIncomplete(depPath, node.repoPath)) {
@@ -581,10 +603,18 @@ function main(): void {
       const body = node.body;
       const matches = [...new Set(body.match(regex) || [])];
 
+      const parentNode = node.frontmatter.parent ? resolveNode(node.frontmatter.parent) : null;
+      const parentRepoPath = parentNode?.repoPath || node.frontmatter.parent;
+
+      const depRepoPaths = node.frontmatter.depends_on.map(d => {
+        const dn = resolveNode(d);
+        return dn ? dn.repoPath : d;
+      });
+
       const targetArtifacts = matches.filter(m =>
         m !== node.repoPath &&
-        m !== node.frontmatter.parent &&
-        !node.frontmatter.depends_on.includes(m)
+        m !== parentRepoPath &&
+        !depRepoPaths.includes(m)
       );
 
       let bypassDispatch = false;
@@ -593,7 +623,7 @@ function main(): void {
       if (targetArtifacts.length > 0) {
         allTargetsCompleted = true;
         for (const target of targetArtifacts) {
-          const targetNode = nodeMap.get(target);
+          const targetNode = resolveNode(target);
           if (!targetNode || targetNode.frontmatter.status !== 'COMPLETED') {
             allTargetsCompleted = false;
             break;
@@ -649,7 +679,9 @@ function main(): void {
 
         if (allChildrenCompleted) {
           let isDepIncomplete = false;
-          for (const depPath of node.frontmatter.depends_on) {
+          for (const depRef of node.frontmatter.depends_on) {
+            const depNode = resolveNode(depRef);
+            const depPath = depNode ? depNode.repoPath : depRef;
             if (isHierarchicallyIncomplete(depPath, node.repoPath)) {
               isDepIncomplete = true;
               break;
@@ -697,10 +729,12 @@ function main(): void {
       const links = [...body.matchAll(linkRegex)].map(m => m[1]);
 
       if (links.length > 0) {
-        const allExist = links.every(l => nodeMap.has(l));
+        const allExist = links.every(l => !!resolveNode(l));
         const hasChild = links.some(l => {
-          const childNode = nodeMap.get(l);
-          return !!childNode && childNode.frontmatter.parent === node.repoPath;
+          const childNode = resolveNode(l);
+          if (!childNode || !childNode.frontmatter.parent) return false;
+          const childParentNode = resolveNode(childNode.frontmatter.parent);
+          return childParentNode?.repoPath === node.repoPath;
         });
 
         if (allExist && hasChild) {


### PR DESCRIPTION
This PR enables the Foundry DAG orchestrator to correctly resolve parent and dependency references when they use a node's unique ID (from YAML frontmatter) instead of just its file path. 

Key changes:
- Introduced `idToNodeMap` to index all nodes by their `id` field during Phase 3.
- Added a `resolveNode` helper function that checks both path-based and ID-based maps.
- Updated recursive hierarchy checks (`isDescendant`, `isHierarchicallyIncomplete`) and dependency suspension logic to use the new resolution helper.
- Fixed the pre-flight filtering logic to correctly identify target artifacts when parents or dependencies are referenced by ID.
- Verified the fix with a new test case and ensured no regressions by running the full orchestrator test suite.

Fixes #981

---
*PR created automatically by Jules for task [15312383621626546164](https://jules.google.com/task/15312383621626546164) started by @szubster*