### PR TITLE
Fix Foundry DAG Resolution Warnings

### DIFF
--- a/.foundry/epics/epic-010-oxlint-config.md
+++ b/.foundry/epics/epic-010-oxlint-config.md
@@ -6,7 +6,7 @@ status: "COMPLETED"
 owner_persona: "story_owner"
 created_at: "2026-04-23"
 updated_at: "2026-05-01"
-parent: ""
+parent: null
 depends_on:
   - .foundry/stories/story-010-028-verify-jest-tests.md
   - .foundry/stories/story-010-017-fix-jest-rules.md

--- a/.foundry/prds/prd-017-017-dag-dashboard.md
+++ b/.foundry/prds/prd-017-017-dag-dashboard.md
@@ -9,7 +9,7 @@ updated_at: '2026-05-15'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: idea-017-dag-dashboard
+parent: .foundry/ideas/idea-017-dag-dashboard.md
 ---
 
 # PRD: DAG Dashboard Webview


### PR DESCRIPTION
This PR resolves DAG resolution warnings in the Foundry orchestrator by correcting invalid parent references. Specifically, it fixes a broken shorthand reference in a PRD and an empty string parent in an EPIC, both of which caused the orchestrator to fail resolution in strict mode.

Fixes #983

---
*PR created automatically by Jules for task [17169087130458482904](https://jules.google.com/task/17169087130458482904) started by @szubster*