### PR TITLE
Resolve Foundry DAG resolution warnings

### DIFF
--- a/.foundry/epics/epic-010-oxlint-config.md
+++ b/.foundry/epics/epic-010-oxlint-config.md
@@ -6,7 +6,7 @@ status: "COMPLETED"
 owner_persona: "story_owner"
 created_at: "2026-04-23"
 updated_at: "2026-05-01"
-parent: ""
+parent: null
 depends_on:
   - .foundry/stories/story-010-028-verify-jest-tests.md
   - .foundry/stories/story-010-017-fix-jest-rules.md

--- a/.foundry/prds/prd-017-017-dag-dashboard.md
+++ b/.foundry/prds/prd-017-017-dag-dashboard.md
@@ -9,7 +9,7 @@ updated_at: '2026-05-15'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: idea-017-dag-dashboard
+parent: .foundry/ideas/idea-017-dag-dashboard.md
 ---
 
 # PRD: DAG Dashboard Webview


### PR DESCRIPTION
Resolved the DAG resolution warnings in the Foundry Engine. The main issue was a PRD node using a shorthand ID for its parent instead of the required repo-relative path. I also updated an EPIC node to use `null` instead of `""` for its parent field to ensure consistency and prevent potential resolution ambiguities. Verified the fixes with a dry-run of the orchestrator and ensured all tests pass.

Fixes #985

---
*PR created automatically by Jules for task [8315063246964892709](https://jules.google.com/task/8315063246964892709) started by @szubster*