### PR TITLE
Fix Foundry DAG resolution warnings for DAG Dashboard PRD

### DIFF
--- a/.foundry/epics/epic-010-oxlint-config.md
+++ b/.foundry/epics/epic-010-oxlint-config.md
@@ -6,7 +6,7 @@ status: "COMPLETED"
 owner_persona: "story_owner"
 created_at: "2026-04-23"
 updated_at: "2026-05-01"
-parent: ""
+parent: null
 depends_on:
   - .foundry/stories/story-010-028-verify-jest-tests.md
   - .foundry/stories/story-010-017-fix-jest-rules.md

--- a/.foundry/prds/prd-017-017-dag-dashboard.md
+++ b/.foundry/prds/prd-017-017-dag-dashboard.md
@@ -9,7 +9,7 @@ updated_at: '2026-05-15'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: idea-017-dag-dashboard
+parent: .foundry/ideas/idea-017-dag-dashboard.md
 ---
 
 # PRD: DAG Dashboard Webview


### PR DESCRIPTION
Corrected the parent path in .foundry/prds/prd-017-017-dag-dashboard.md to use a repository-relative path. Also standardized the parent field in .foundry/epics/epic-010-oxlint-config.md to null. These changes resolve "Parent not found" warnings during Foundry DAG orchestration.

Fixes #987

---
*PR created automatically by Jules for task [11783060459071477648](https://jules.google.com/task/11783060459071477648) started by @szubster*