### PR TITLE
Fix Foundry DAG Resolution Warnings

### DIFF
--- a/.foundry/epics/epic-010-oxlint-config.md
+++ b/.foundry/epics/epic-010-oxlint-config.md
@@ -6,7 +6,7 @@ status: "COMPLETED"
 owner_persona: "story_owner"
 created_at: "2026-04-23"
 updated_at: "2026-05-01"
-parent: ""
+parent: null
 depends_on:
   - .foundry/stories/story-010-028-verify-jest-tests.md
   - .foundry/stories/story-010-017-fix-jest-rules.md

--- a/.foundry/prds/prd-017-017-dag-dashboard.md
+++ b/.foundry/prds/prd-017-017-dag-dashboard.md
@@ -9,7 +9,7 @@ updated_at: '2026-05-15'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: idea-017-dag-dashboard
+parent: .foundry/ideas/idea-017-dag-dashboard.md
 ---
 
 # PRD: DAG Dashboard Webview


### PR DESCRIPTION
The Foundry DAG orchestrator was encountering warnings due to invalid `parent` field values in some markdown files. Specifically, `prd-017-017-dag-dashboard.md` was using a node ID instead of a repo-relative path, and `epic-010-oxlint-config.md` was using an empty string.

I have updated these files to use the correct repo-relative paths or `null`, ensuring the orchestrator can build the dependency map correctly. I verified the fix by running the orchestrator in dry-run mode and confirming the warnings are gone.

Fixes #989

---
*PR created automatically by Jules for task [1795110985047597694](https://jules.google.com/task/1795110985047597694) started by @szubster*