### PR TITLE
Agile Coach: Propose Gray-Matter Migration for Heartbeat Script

### DIFF
--- a/.foundry/ideas/idea-018-migrate-heartbeat-to-gray-matter.md
+++ b/.foundry/ideas/idea-018-migrate-heartbeat-to-gray-matter.md
@@ -1,0 +1,29 @@
+---
+id: idea-018-migrate-heartbeat-to-gray-matter
+type: IDEA
+title: 'Migrate foundry-heartbeat.ts to gray-matter'
+status: "PENDING"
+owner_persona: product_manager
+created_at: '2026-05-06'
+updated_at: "2026-05-06"
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - technical-debt
+notes: ''
+---
+
+# Idea: Migrate foundry-heartbeat.ts to use gray-matter
+
+## Context
+ADR-006 mandated the use of `gray-matter` for parsing and mutating Markdown frontmatter, explicitly deprecating custom regex. The main orchestrator was migrated, but `foundry-heartbeat.ts` still uses regex to mutate YAML (e.g., in `transitionNodeToReady` and `transitionNodeToCompleted`).
+
+## Proposal
+Update `.github/scripts/foundry-heartbeat.ts` to use `gray-matter` (`matter.stringify()`) for all frontmatter modifications to conform to ADR-006 and prevent brittle regex bugs.
+
+## Impact
+Reduces technical debt, prevents bugs related to frontmatter modifications, and ensures full compliance with system architecture decisions.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -99,3 +99,11 @@ While reviewing overall system friction, I noticed two areas for proactive impro
 ### Action Taken
 1. Updated `.github/agents/coder.md` and `.github/agents/qa.md` to explicitly instruct agents to run `pnpm lint && pnpm test` before completion, and to use `pnpm format:biome` or `pnpm check:fix` for formatting errors.
 2. Autonomously generated `idea-016-precommit-schema-validation.md` to propose adding YAML frontmatter schema validation to the existing git pre-commit hook to catch malformed nodes synchronously at commit time.
+
+## 2026-05-06: ADR-006 Violation in Heartbeat Script
+
+### Observation
+While reviewing the system for potential improvements and friction points, I discovered that `.github/scripts/foundry-heartbeat.ts` still uses custom regex to mutate YAML frontmatter (e.g., changing status to FAILED, READY, or COMPLETED). This directly violates ADR-006, which mandates the use of `gray-matter` for all programmatic read and write operations.
+
+### Action Taken
+Autonomously generated `idea-018-migrate-heartbeat-to-gray-matter.md` to propose migrating the heartbeat script to use `gray-matter`, ensuring compliance with the architectural decision and preventing brittle regex-related bugs.


### PR DESCRIPTION
As the Agile Coach persona, I reviewed the repository for friction points and architectural violations. I discovered that `.github/scripts/foundry-heartbeat.ts` still relies on custom regex for mutating YAML frontmatter, which violates the newly adopted ADR-006 (mandating `gray-matter`). To proactively address this technical debt, I autonomously generated `idea-018-migrate-heartbeat-to-gray-matter.md` and appended my observations to the Agile Coach journal (`.foundry/journals/agile_coach.md`).

---
*PR created automatically by Jules for task [16460557626800373987](https://jules.google.com/task/16460557626800373987) started by @szubster*