### PR TITLE
Fix Foundry DAG resolution warnings

### DIFF
--- a/.foundry/epics/epic-010-oxlint-config.md
+++ b/.foundry/epics/epic-010-oxlint-config.md
@@ -6,7 +6,7 @@ status: "COMPLETED"
 owner_persona: "story_owner"
 created_at: "2026-04-23"
 updated_at: "2026-05-01"
-parent: ""
+parent: null
 depends_on:
   - .foundry/stories/story-010-028-verify-jest-tests.md
   - .foundry/stories/story-010-017-fix-jest-rules.md

--- a/.foundry/prds/prd-017-017-dag-dashboard.md
+++ b/.foundry/prds/prd-017-017-dag-dashboard.md
@@ -9,7 +9,7 @@ updated_at: '2026-05-15'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: idea-017-dag-dashboard
+parent: .foundry/ideas/idea-017-dag-dashboard.md
 ---
 
 # PRD: DAG Dashboard Webview


### PR DESCRIPTION
Corrected the parent field in .foundry/prds/prd-017-017-dag-dashboard.md to use a repo-relative path and updated .foundry/epics/epic-010-oxlint-config.md to use null for the parent field instead of an empty string. These changes resolve orchestrator warnings and allow for proper DAG resolution.

Fixes #992

---
*PR created automatically by Jules for task [17218673646957003249](https://jules.google.com/task/17218673646957003249) started by @szubster*