### PR TITLE
Resolve DAG Resolution Warnings

### DIFF
--- a/.foundry/prds/prd-006-017-gen2-expansion-phase-3-4.md
+++ b/.foundry/prds/prd-006-017-gen2-expansion-phase-3-4.md
@@ -2,8 +2,8 @@
 id: prd-006-017-gen2-expansion-phase-3-4
 type: PRD
 title: 'Gen 2 Expansion PRD: Phase 3 and 4'
-status: BLOCKED
-owner_persona: tpm
+status: PENDING
+owner_persona: epic_planner
 created_at: '2026-05-06'
 updated_at: '2026-05-06'
 depends_on: []

--- a/.foundry/prds/prd-017-017-dag-dashboard.md
+++ b/.foundry/prds/prd-017-017-dag-dashboard.md
@@ -2,8 +2,8 @@
 id: prd-017-017-dag-dashboard
 type: PRD
 title: DAG Dashboard Webview PRD
-status: BLOCKED
-owner_persona: tpm
+status: PENDING
+owner_persona: epic_planner
 created_at: '2026-05-15'
 updated_at: '2026-05-06'
 depends_on: []


### PR DESCRIPTION
Corrected the owner_persona from 'tpm' to 'epic_planner' for prd-006-017 and prd-017-017. Updated their status from 'BLOCKED' to 'PENDING' to allow the Foundry orchestrator to progress them. Verified the fix with a dry-run of the orchestrator.

Fixes #997

---
*PR created automatically by Jules for task [14402830973969633151](https://jules.google.com/task/14402830973969633151) started by @szubster*