### PR TITLE
docs(foundry): PRD for migrating heartbeat to gray-matter

### DIFF
--- a/.foundry/ideas/idea-018-migrate-heartbeat-to-gray-matter.md
+++ b/.foundry/ideas/idea-018-migrate-heartbeat-to-gray-matter.md
@@ -27,3 +27,6 @@ Update `.github/scripts/foundry-heartbeat.ts` to use `gray-matter` (`matter.stri
 
 ## Impact
 Reduces technical debt, prevents bugs related to frontmatter modifications, and ensures full compliance with system architecture decisions.
+
+## Child Nodes
+- [x] PRD created: `.foundry/prds/prd-018-018-migrate-heartbeat-to-gray-matter.md`

--- a/.foundry/prds/prd-018-018-migrate-heartbeat-to-gray-matter.md
+++ b/.foundry/prds/prd-018-018-migrate-heartbeat-to-gray-matter.md
@@ -1,0 +1,32 @@
+---
+id: prd-018-018-migrate-heartbeat-to-gray-matter
+type: PRD
+title: Migrate foundry-heartbeat.ts to gray-matter
+status: PENDING
+owner_persona: "architect"
+created_at: "2026-05-06"
+updated_at: "2026-05-06"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/ideas/idea-018-migrate-heartbeat-to-gray-matter.md
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - technical-debt
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# PRD: Migrate foundry-heartbeat.ts to gray-matter
+
+## Context
+ADR-006 mandated the use of `gray-matter` for parsing and mutating Markdown frontmatter, explicitly deprecating custom regex. The main orchestrator was migrated, but `foundry-heartbeat.ts` still uses regex to mutate YAML (e.g., in `transitionNodeToReady` and `transitionNodeToCompleted`).
+
+## Requirements
+- Update `.github/scripts/foundry-heartbeat.ts` to use `gray-matter` (`matter.stringify()`) for all frontmatter modifications.
+- Ensure compliance with ADR-006.
+- Prevent brittle regex bugs in frontmatter modifications.


### PR DESCRIPTION
This PR creates the Product Requirements Document (PRD) for the migration of the `foundry-heartbeat.ts` script to use `gray-matter`. It satisfies the transition from IDEA to PRD for `idea-018-migrate-heartbeat-to-gray-matter.md`.

*   Creates `.foundry/prds/prd-018-018-migrate-heartbeat-to-gray-matter.md`
*   Updates the parent `idea-018-migrate-heartbeat-to-gray-matter.md` to reference the new PRD.
*   The `owner_persona` of the new PRD is correctly set to `architect` to continue the pipeline to `ADR`.
*   YAML frontmatter of the parent node was untouched as requested.

---
*PR created automatically by Jules for task [8259486336301315401](https://jules.google.com/task/8259486336301315401) started by @szubster*