### PR TITLE
📜 Scribe: Documented PokeDB architecture and synchronization logic

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -60,3 +60,16 @@ Documenting these mechanical quirks is essential for future maintainability of t
 
 **What:** Documented `AppStore` interface and `useStore` hook in `src/store.ts`.
 **Why:** The `AppStore` interface mixes persisted user settings (via localStorage `partialize`, like `isLivingDex` and `filters`) with heavy transient data (like the entire parsed `saveData`) and lightweight UI view state (like `isSettingsOpen`). Documenting the *why* prevents future developers from accidentally persisting the massive `saveData` object into localStorage, which would bloat the storage quota and cause stale state bugs on reload.
+## 2025-05-18 - PokeDB and DexDataLoader Documentation
+
+**What:** Added JSDoc for `bulkGet` and `syncData` in `src/db/PokeDB.ts`.
+**Why:**
+- `bulkGet`: Internal utility that circumvents IndexedDB's lack of a native `getAll(keys)` method by firing parallel `store.get` requests within a single transaction. This prevents massive N+1 query bottlenecks during  and  operations.
+- `syncData`: Documents the build hash comparison logic (`__POKEDATA_HASH__`) that prevents redundant network downloads of `pokedata.json` during IDB hydration.
+
+## 2025-05-18 - PokeDB and DexDataLoader Documentation
+
+**What:** Added JSDoc for `bulkGet` and `syncData` in `src/db/PokeDB.ts`.
+**Why:**
+- `bulkGet`: Internal utility that circumvents IndexedDB's lack of a native `getAll(keys)` method by firing parallel `store.get` requests within a single transaction. This prevents massive N+1 query bottlenecks during suggestionEngine and dexDataLoader operations.
+- `syncData`: Documents the build hash comparison logic (`__POKEDATA_HASH__`) that prevents redundant network downloads of `pokedata.json` during IDB hydration.

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -12,6 +12,16 @@ import {
 let dbPromise: Promise<IDBPDatabase<PokeDBSchema>> | null = null;
 let syncPromise: Promise<void> | null = null;
 
+/**
+ * A utility function to fetch multiple records from IndexedDB by their keys simultaneously.
+ * Why it exists: IndexedDB lacks a native `getAll(keys)` method. To avoid the overhead of
+ * initiating separate transactions or sequential N+1 `get` requests, this function
+ * fires multiple `get` requests in parallel within the same transaction.
+ *
+ * @param store - The active IDBObjectStore to read from.
+ * @param ids - An array of valid keys to fetch.
+ * @returns A promise that resolves to an array of results matching the order of `ids`.
+ */
 async function bulkGet<T>(store: IDBObjectStore, ids: readonly number[]): Promise<T[]> {
   return new Promise<T[]>((resolve, reject) => {
     const res = Array.from<T>({ length: ids.length });
@@ -85,6 +95,17 @@ export const getDB = () => {
   return dbPromise;
 };
 
+/**
+ * Downloads the pre-built `pokedata.json` bundle from the server and hydrates
+ * the local IndexedDB stores.
+ *
+ * It prevents redundant network requests by comparing the application's current
+ * build hash (`__POKEDATA_HASH__`) against the hash stored in IndexedDB.
+ * If a sync is needed, it fetches the compact JSON, inflates nested data structures
+ * (like evolution chains and encounter details), and populates the stores.
+ *
+ * @returns A Promise that resolves when the synchronization is complete.
+ */
 const syncData = async () => {
   if (syncPromise) {
     return syncPromise;


### PR DESCRIPTION
Added documentation explaining why `bulkGet` exists (to batch IDB requests) and how `syncData` avoids redundant fetch calls by using a hash check. This prevents N+1 queries.

---
*PR created automatically by Jules for task [5146664318090118673](https://jules.google.com/task/5146664318090118673) started by @szubster*