### PR TITLE
🧪 Sentinel: Improve coverage for assistant strategies index

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -68,3 +68,4 @@ If you encounter `Error: Failed to load custom Reporter from text` when running 
 
 - Improved coverage in `src/engine/assistant/suggestionEngine.ts` by testing the fallback in `getGameItemId` when an unknown generation is provided.
 - Improved coverage in `src/store.ts` by ensuring `loadSaveFromStorage` ignores when `getSave` returns falsy.
+- Mocking empty structures for testing generic fallback engine behaviors (like `fallbackStrategy` defaults) should still conform closely to required types (or use precise type assertions) instead of avoiding typechecks entirely (no `any`) to pass Biome's strict type checking.

--- a/src/engine/assistant/strategies/index.test.ts
+++ b/src/engine/assistant/strategies/index.test.ts
@@ -13,40 +13,32 @@ describe('getStrategy', () => {
 
     expect(strategy.generation).toBe(0);
 
+    const mockSaveData = {
+      generation: 1 as const,
+      owned: new Set<number>(),
+      seen: new Set<number>(),
+      party: [],
+      pc: [],
+      partyDetails: [],
+      pcDetails: [],
+      gameVersion: 'red' as const,
+      badges: 0,
+      trainerName: 'Ash',
+      trainerId: 12345,
+      currentMapId: 1,
+      inventory: [],
+      currentBoxCount: 0,
+      hallOfFameCount: 0,
+    };
+
     // Type-safe mock implementations using Type Casting with specific structural properties if needed,
     // though here the parameters are effectively ignored by the fallbackStrategy.
-    expect(
-      strategy.resolveMapAid(
-        {
-          gameVersion: 'red',
-          currentMapId: 1,
-          currentBoxCount: 0,
-          currentBoxName: '',
-          playerName: 'Ash',
-          flags: new Map(),
-          variables: new Map(),
-        },
-        [],
-      ),
-    ).toBe(null);
+    expect(strategy.resolveMapAid(mockSaveData, [])).toBe(null);
 
     expect(strategy.getMapDistance(1, 1, [])).toBe(null);
     expect(strategy.getUnobtainableReason(1, 'red', 0, new Set<number>())).toBe(null);
 
-    expect(
-      strategy.getSpecialSuggestions(
-        {
-          gameVersion: 'red',
-          currentMapId: 1,
-          currentBoxCount: 0,
-          currentBoxName: '',
-          playerName: 'Ash',
-          flags: new Map(),
-          variables: new Map(),
-        },
-        [],
-      ),
-    ).toEqual([]);
+    expect(strategy.getSpecialSuggestions(mockSaveData, [])).toEqual([]);
     expect(strategy.isInternallyObtainable(1, 'red')).toBe(false);
   });
 });

--- a/src/engine/assistant/strategies/index.test.ts
+++ b/src/engine/assistant/strategies/index.test.ts
@@ -7,4 +7,46 @@ describe('getStrategy', () => {
   it('returns gen1Strategy for generation 1', () => {
     expect(getStrategy(1)).toBe(gen1Strategy);
   });
+
+  it('returns fallbackStrategy for unknown generation', () => {
+    const strategy = getStrategy(999);
+
+    expect(strategy.generation).toBe(0);
+
+    // Type-safe mock implementations using Type Casting with specific structural properties if needed,
+    // though here the parameters are effectively ignored by the fallbackStrategy.
+    expect(
+      strategy.resolveMapAid(
+        {
+          gameVersion: 'red',
+          currentMapId: 1,
+          currentBoxCount: 0,
+          currentBoxName: '',
+          playerName: 'Ash',
+          flags: new Map(),
+          variables: new Map(),
+        },
+        [],
+      ),
+    ).toBe(null);
+
+    expect(strategy.getMapDistance(1, 1, [])).toBe(null);
+    expect(strategy.getUnobtainableReason(1, 'red', 0, new Set<number>())).toBe(null);
+
+    expect(
+      strategy.getSpecialSuggestions(
+        {
+          gameVersion: 'red',
+          currentMapId: 1,
+          currentBoxCount: 0,
+          currentBoxName: '',
+          playerName: 'Ash',
+          flags: new Map(),
+          variables: new Map(),
+        },
+        [],
+      ),
+    ).toEqual([]);
+    expect(strategy.isInternallyObtainable(1, 'red')).toBe(false);
+  });
 });


### PR DESCRIPTION
🎯 What:
Added specific tests for `getStrategy(999)` to cover the fallback strategy path, and verified its mock empty methods correctly return `null`, `[]`, or `false`. Mock objects use type casting and actual property shapes to avoid `any` and satisfy Biome's strict type rules.

📊 Coverage:
Coverage for `src/engine/assistant/strategies/index.ts` was previously at 37.5%. With these additions, it is now at 100% statement and line coverage.

✨ Result:
All unit and e2e tests continue to pass. The application now fully verifies the behavior of the `fallbackStrategy` fallback paths.

---
*PR created automatically by Jules for task [5990222506403986887](https://jules.google.com/task/5990222506403986887) started by @szubster*