### PR TITLE
🎨 Palette: Add title tooltips to BottomNav

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,5 @@
 ## 2024-05-19 - File Upload Input Keyboard Navigation
 **Learning:** Using `tabIndex={-1}` on a hidden `<input type="file">` prevents it from receiving keyboard focus. If the input is wrapped in a `<label>` to act as a custom upload button, the `<label>` itself does not natively receive focus, breaking keyboard navigation entirely.
 **Action:** When creating custom file upload buttons with hidden inputs, do not use a `<label>` wrapper. Instead, use a semantic `<button type="button">` with `focus-visible` styles, and use an `onClick` handler to programmatically trigger the click on the sibling `<input type="file">` via its ID or a React ref.
+
+- Added title tooltips to BottomNav elements corresponding to their aria-labels to improve usability for non-screenreader users.

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -45,6 +45,7 @@ export function BottomNav() {
         <Link
           to="/"
           aria-label="Pokedex"
+          title="Pokedex"
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isDex ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
@@ -63,6 +64,7 @@ export function BottomNav() {
         <Link
           to="/storage"
           aria-label="Storage"
+          title="Storage"
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isStorage ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
@@ -81,6 +83,7 @@ export function BottomNav() {
         <Link
           to="/assistant"
           aria-label="Assistant"
+          title="Assistant"
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isAssistant ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
@@ -100,6 +103,7 @@ export function BottomNav() {
           type="button"
           onClick={() => setIsSettingsOpen(true)}
           aria-label="Open settings menu"
+          title="Open settings menu"
           className="group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 text-zinc-600 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
           <div className="transition-transform active:scale-90">


### PR DESCRIPTION
## What
Added `title` attributes (tooltips) to the icon-centric bottom navigation links and button.

## Why
While they had `aria-label`s for screenreaders, sighted users hovering over the icons (which only have highly-stylized abbreviations like "SYS.DEX" and "SYS.STRG" beneath them) did not receive native OS tooltips to explicitly explain their function. This aligns with the "Missing tooltips for icon-only buttons" focus area.

## Verification
- Added `title`s to "Pokedex", "Storage", "Assistant", and "Open settings menu".
- `pnpm lint` passed.
- `pnpm test` passed.
- `pnpm test:e2e` passed.
- Playwright screenshot/video verification confirmed tooltips appear on hover and don't visually break the UI structure.
- Appended to `.jules/palette.md`.

---
*PR created automatically by Jules for task [3264071081841213693](https://jules.google.com/task/3264071081841213693) started by @szubster*