### PR TITLE
🖼️ Canvas: Tactical AssistantPanel Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -74,3 +74,9 @@
 **Outcome:** Accepted
 **Why:** Brings the version conflict resolution interface in line with the rest of the application's tactical hardware motif (matching AppLayout, Settings, and SyncProgress).
 **Pattern:** Consistently eliminate generic web UI patterns (rounded corners, soft hover states) in favor of sharp, high-contrast, terminal-like aesthetics for modals.
+
+## 2026-05-06 - [Accepted] - 🖼️ Canvas: Tactical AssistantPanel Redesign
+**What:** Redesigned the `AssistantPanel` component to match the utility-driven tactical "snooping" aesthetic, replacing rounded glassmorphism with sharp borders, corner crosshairs, and monospaced telemetry text.
+**Outcome:** Accepted
+**Why:** Continues the successful strategy of establishing a specialized hardware UI aesthetic, improving visual cohesion across the application's structural and assistant views.
+**Pattern:** Consistently apply the tactical hardware motif (sharp edges, dashed outlines, monospace text) to major panels to maintain the illusion of a specialized device.

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -6,6 +6,7 @@ import { type SuggestionCategory, useAssistant } from '../hooks/useAssistant';
 import { pokemonListQueryOptions } from '../utils/pokemonQueries';
 import { AssistantDebugView } from './assistant/AssistantDebugView';
 import { AssistantSuggestionCard } from './assistant/AssistantSuggestionCard';
+import { CornerCrosshairs } from './CornerCrosshairs';
 
 interface AssistantPanelProps {
   saveData: SaveData;
@@ -80,41 +81,49 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
 
   return (
     <div className="flex-1 space-y-6">
-      <div className="relative flex flex-col justify-between gap-4 overflow-hidden rounded-[2rem] border border-zinc-800 bg-zinc-900 p-6 shadow-xl sm:flex-row sm:items-center">
-        <div className="absolute top-0 left-0 h-1 w-full bg-gradient-to-r from-emerald-500 via-amber-500 to-purple-500" />
+      <div className="relative flex flex-col justify-between gap-4 border border-zinc-800/80 bg-zinc-900/50 p-6 sm:flex-row sm:items-center">
+        <CornerCrosshairs thickness={2} className="h-2 w-2 border-white/20" />
+        <div className="absolute top-0 left-0 h-[2px] w-full bg-gradient-to-r from-emerald-500/50 via-amber-500/50 to-purple-500/50" />
+        <div className="pointer-events-none absolute -top-2.5 left-4 bg-zinc-950 px-1 font-mono text-[9px] text-[var(--theme-primary)] uppercase tracking-widest">
+          SYS.ASST
+        </div>
 
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-3">
             <h2 className="flex items-center gap-3 font-black font-display text-2xl text-white uppercase tracking-tight">
-              <Sparkles className="text-amber-400" size={24} />
+              <Sparkles className="text-[var(--theme-primary)]" size={24} />
               AI Assistant
             </h2>
             <button
               type="button"
               onClick={() => setShowDebug(!showDebug)}
-              className={`rounded-xl border p-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${showDebug ? 'border-amber-500/50 bg-amber-500/20 text-amber-400' : 'border-zinc-700 bg-zinc-800 text-zinc-500 hover:text-zinc-300'}`}
+              className={`border border-dashed p-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${showDebug ? 'border-[var(--theme-primary)]/50 bg-[var(--theme-primary)]/10 text-[var(--theme-primary)]' : 'border-zinc-700 bg-zinc-800 text-zinc-500 hover:text-zinc-300'}`}
               title="Toggle Debug Mode"
               aria-label="Toggle Debug Mode"
             >
               <Bug size={18} />
             </button>
           </div>
-          <p className="mt-1 font-bold text-xs text-zinc-500 uppercase tracking-widest">
-            Smart suggestions based on your save file
+          <p className="mt-1 font-mono text-[10px] text-zinc-500 uppercase tracking-widest">
+            [ SMART SUGGESTIONS GENERATED FROM SAVE TELEMETRY ]
           </p>
         </div>
       </div>
 
       {isLoading ? (
-        <div className="flex items-center justify-center rounded-[2rem] border border-zinc-800/50 bg-zinc-900/50 p-12">
+        <div className="relative flex items-center justify-center border border-zinc-800/50 bg-zinc-900/50 p-12">
+          <CornerCrosshairs thickness={2} className="h-2 w-2 border-white/20" />
           <Loader2 className="animate-spin text-zinc-500" size={32} />
         </div>
       ) : suggestions.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-[2rem] border border-zinc-800/50 bg-zinc-900/50 p-12 text-center">
+        <div className="relative flex flex-col items-center justify-center border border-zinc-800/50 bg-zinc-900/50 p-12 text-center">
+          <CornerCrosshairs thickness={2} className="h-2 w-2 border-white/20" />
           <Sparkles className="mb-4 text-zinc-700" size={48} />
-          <h3 className="font-bold text-lg text-zinc-400 uppercase tracking-wide">You're all caught up!</h3>
-          <p className="mt-2 max-w-sm font-medium text-sm text-zinc-600">
-            No new suggestions at the moment. Keep exploring to discover more Pokémon!
+          <h3 className="font-bold font-mono text-lg text-zinc-400 uppercase tracking-wide">
+            [ YOU'RE ALL CAUGHT UP! ]
+          </h3>
+          <p className="mt-2 max-w-sm font-medium font-mono text-xs text-zinc-600">
+            NO NEW SUGGESTIONS AT THE MOMENT. KEEP EXPLORING TO DISCOVER MORE POKÉMON!
           </p>
         </div>
       ) : (
@@ -141,12 +150,18 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
                 <div key={category} className="space-y-4">
                   <div className="flex items-center gap-3 px-2">
                     <div
-                      className={`rounded-xl border p-2 ${catStyle.bg} ${catStyle.color.replace('border-', 'text-')}`}
+                      className={`border border-dashed p-2 ${catStyle.bg} ${catStyle.color.replace('border-', 'text-')}`}
                     >
                       {catStyle.icon}
                     </div>
-                    <h3 className="font-black font-display text-white text-xl uppercase tracking-widest">
-                      {category === 'Catch' ? 'Wild Encounters' : category === 'Trade' ? 'Trade Required' : category}
+                    <h3 className="font-black font-mono text-lg text-white uppercase tracking-widest">
+                      [{' '}
+                      {category === 'Catch'
+                        ? 'WILD ENCOUNTERS'
+                        : category === 'Trade'
+                          ? 'TRADE REQUIRED'
+                          : category.toUpperCase()}{' '}
+                      ]
                     </h3>
                   </div>
 


### PR DESCRIPTION
Redesigned the `AssistantPanel` component to match the utility-driven tactical "snooping" aesthetic, replacing rounded glassmorphism with sharp borders, corner crosshairs, and monospaced telemetry text.

*   Replaced the rounded `[2rem]` main container with sharp edges and dashed/solid `zinc-800` borders.
*   Added `CornerCrosshairs` components to the main headers and state views.
*   Replaced generic rounded glassmorphic labels with a `SYS.ASST` telemetry badge.
*   Removed soft descriptive text in favor of terminal-style bracketed monospace logs `[ SMART SUGGESTIONS GENERATED FROM SAVE TELEMETRY ]`.
*   Replaced generic soft gradients and categories with monospace, bracketed, uppercase titles.
*   Updated `.jules/canvas.md` with the session's pattern.
*   Verified that all existing components continue to function (all tests passed) and that visual regressions were eliminated.

---
*PR created automatically by Jules for task [12624677735118884602](https://jules.google.com/task/12624677735118884602) started by @szubster*