### PR TITLE
🛡️ Nurse: Replace unsafe IDBValidKey cast with runtime type guard

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -37,3 +37,4 @@ Extracted the inline array into a constant `STATUS_OPTIONS` marked with `as cons
 
 **What the compiler now catches:**
 The compiler statically guarantees that the `StatusType` union and the `STATUS_OPTIONS` array are always in sync. It eliminates the unsafe `as StatusType` casts while maintaining identical runtime behavior.
+- Fixed an unsafe `as IDBValidKey` cast in `src/db/PokeDB.ts`'s `bulkGet` by assigning to a variable and checking for `undefined` before passing to `store.get`.

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -18,7 +18,12 @@ async function bulkGet<T>(store: IDBObjectStore, ids: readonly number[]): Promis
     let pending = ids.length;
     if (pending === 0) return resolve([]);
     for (let i = 0; i < ids.length; i++) {
-      const req = store.get(ids[i] as IDBValidKey);
+      const id = ids[i];
+      if (id === undefined) {
+        if (--pending === 0) resolve(res);
+        continue;
+      }
+      const req = store.get(id);
       req.onsuccess = () => {
         res[i] = req.result;
         if (--pending === 0) resolve(res);


### PR DESCRIPTION
Fixes an unsafe type coercion smell in `PokeDB.ts`.

---
*PR created automatically by Jules for task [10165869551624967997](https://jules.google.com/task/10165869551624967997) started by @szubster*