### PR TITLE
🧱 Mason: GlassCard extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -14,3 +14,7 @@ Record critical learnings from React refactoring sessions.
 - Identified recurring standard button patterns with identical styling across SearchAndFilters and ClearStorageButton.
 - Successfully extracted this into `src/components/TacticalButton.tsx` to manage standard, primary, and danger variants along with internal crosshairs logic.
 - Faced Playwright issues with intercepting pointer events, requiring `force=True` on locator clicks due to transparent full-screen overlay/fade-in animations.
+2024-05-18 - Extracted `glass-card` styling into reusable `<GlassCard>` component.
+- Pattern: Many components used the same `glass-card` CSS class with varied tailwind colored background/border opacity patterns (e.g. `border-emerald-500/10 bg-emerald-500/5`).
+- Challenge: Determining the base variants. Handled by passing a string prop mapping to the common tailwind combinations.
+- Win: Centralized styling logic, eliminated redundant classes across multiple `PokemonDetails` subcomponents.

--- a/src/components/GlassCard.tsx
+++ b/src/components/GlassCard.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { cn } from '../utils/cn';
+
+interface GlassCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: 'emerald' | 'red' | 'purple' | 'blue' | 'pink' | 'white' | 'default';
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export const GlassCard = React.forwardRef<HTMLDivElement, GlassCardProps>(
+  ({ variant = 'default', className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'glass-card relative overflow-hidden',
+          {
+            'border-emerald-500/10 bg-emerald-500/5': variant === 'emerald',
+            'border-red-500/10 bg-red-500/5': variant === 'red',
+            'border-purple-500/10 bg-purple-500/5': variant === 'purple',
+            'border-blue-500/10 bg-blue-500/5': variant === 'blue',
+            'border-pink-500/10 bg-pink-500/5': variant === 'pink',
+            'border border-white/10 bg-white/5': variant === 'white',
+            'border border-white/5 bg-white/5': variant === 'default',
+          },
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+GlassCard.displayName = 'GlassCard';

--- a/src/components/pokemon/details/PokemonCatchProbability.tsx
+++ b/src/components/pokemon/details/PokemonCatchProbability.tsx
@@ -2,6 +2,7 @@ import { Target } from 'lucide-react';
 import { useState } from 'react';
 import type { PokeballType } from '../../../store';
 import { cn } from '../../../utils/cn';
+import { GlassCard } from '../../GlassCard';
 
 interface PokemonCatchProbabilityProps {
   catchRate: number;
@@ -21,7 +22,7 @@ export function PokemonCatchProbability({ catchRate, effectivePokeball }: Pokemo
   const [status, setStatus] = useState<StatusType>('none');
 
   return (
-    <div className="glass-card relative space-y-8 overflow-hidden rounded-[2.5rem] border-emerald-500/10 bg-emerald-500/5 p-8">
+    <GlassCard variant="emerald" className="space-y-8 rounded-[2.5rem] p-8">
       <div className="absolute top-0 right-0 p-4 opacity-5">
         <Target size={120} />
       </div>
@@ -114,6 +115,6 @@ export function PokemonCatchProbability({ catchRate, effectivePokeball }: Pokemo
           </div>
         </div>
       </div>
-    </div>
+    </GlassCard>
   );
 }

--- a/src/components/pokemon/details/PokemonCaughtDetails.tsx
+++ b/src/components/pokemon/details/PokemonCaughtDetails.tsx
@@ -1,6 +1,7 @@
 import { CheckCircle2, CircleDot, MapPin, Sparkles } from 'lucide-react';
 import { gen2Items, gen2Locations } from '../../../engine/data/gen2/legacyNameMap';
 import type { PokemonInstance } from '../../../engine/saveParser/index';
+import { GlassCard } from '../../GlassCard';
 
 interface PokemonCaughtDetailsProps {
   yourPokemon: (PokemonInstance & { location: string })[];
@@ -16,9 +17,10 @@ export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps)
       </h3>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {yourPokemon.map((p, i) => (
-          <div
+          <GlassCard
             key={`${p.storageLocation}-${p.slot || i}`}
-            className="glass-card group relative space-y-5 overflow-hidden rounded-[2rem] border border-white/10 bg-white/5 p-6"
+            variant="white"
+            className="group space-y-5 rounded-[2rem] p-6"
           >
             <div className="absolute top-0 right-0 p-3 opacity-10 transition-transform group-hover:scale-110">
               {p.isShiny ? (
@@ -81,7 +83,7 @@ export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps)
                 </div>
               </div>
             )}
-          </div>
+          </GlassCard>
         ))}
       </div>
     </div>

--- a/src/components/pokemon/details/PokemonEvolutions.tsx
+++ b/src/components/pokemon/details/PokemonEvolutions.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { stadiumRewardsData } from '../../../engine/data/shared/staticData';
 import type { SaveData } from '../../../engine/saveParser/index';
 import { cn } from '../../../utils/cn';
+import { GlassCard } from '../../GlassCard';
 
 interface EvoReq {
   fromId: number;
@@ -48,7 +49,7 @@ function ProcurementStrategy({
   onNavigate: (id: number, name: string) => void;
 }) {
   return (
-    <div className="glass-card group relative col-span-1 space-y-4 overflow-hidden rounded-[2rem] border-red-500/10 bg-red-500/5 p-6 sm:col-span-2">
+    <GlassCard variant="red" className="group col-span-1 space-y-4 rounded-[2rem] p-6 sm:col-span-2">
       <div className="absolute top-0 right-0 p-4 opacity-5 transition-transform group-hover:scale-110">
         <AlertTriangle size={80} />
       </div>
@@ -93,7 +94,7 @@ function ProcurementStrategy({
           );
         })()}
       </div>
-    </div>
+    </GlassCard>
   );
 }
 
@@ -107,7 +108,7 @@ function EvolutionFrom({
   onNavigate: (id: number, name: string) => void;
 }) {
   return (
-    <div className="glass-card group relative space-y-4 overflow-hidden rounded-[2rem] border-purple-500/10 bg-purple-500/5 p-6">
+    <GlassCard variant="purple" className="group space-y-4 rounded-[2rem] p-6">
       <div className="absolute top-0 right-0 p-4 opacity-5 transition-transform group-hover:rotate-12">
         <ArrowUpCircle size={80} />
       </div>
@@ -134,7 +135,7 @@ function EvolutionFrom({
       >
         {hasPreEvo ? <Check size={12} /> : <X size={12} />} {hasPreEvo ? 'OWNED' : 'UNAVAILABLE'}
       </div>
-    </div>
+    </GlassCard>
   );
 }
 
@@ -147,7 +148,7 @@ function EvolutionTo({
 }) {
   if (!evolvesTo || evolvesTo.length === 0) return null;
   return (
-    <div className="glass-card group relative space-y-4 overflow-hidden rounded-[2rem] border-blue-500/10 bg-blue-500/5 p-6">
+    <GlassCard variant="blue" className="group space-y-4 rounded-[2rem] p-6">
       <div className="absolute top-0 right-0 p-4 opacity-5 transition-transform group-hover:-rotate-12">
         <ChevronRight size={80} />
       </div>
@@ -170,7 +171,7 @@ function EvolutionTo({
           </div>
         ))}
       </div>
-    </div>
+    </GlassCard>
   );
 }
 
@@ -182,7 +183,7 @@ function BreedingProtocol({
   onNavigate: (id: number, name: string) => void;
 }) {
   return (
-    <div className="glass-card group relative col-span-1 space-y-4 overflow-hidden rounded-[2rem] border-pink-500/10 bg-pink-500/5 p-6 sm:col-span-2">
+    <GlassCard variant="pink" className="group col-span-1 space-y-4 rounded-[2rem] p-6 sm:col-span-2">
       <div className="absolute top-0 right-0 p-4 opacity-5 transition-transform group-hover:scale-110">
         <Heart size={80} />
       </div>
@@ -211,7 +212,7 @@ function BreedingProtocol({
       <div className="relative z-10 rounded-xl border border-pink-500/10 bg-pink-500/5 p-3 font-black text-[9px] text-pink-400/60 uppercase italic leading-relaxed tracking-widest">
         {breedingInfo.method}
       </div>
-    </div>
+    </GlassCard>
   );
 }
 

--- a/src/components/pokemon/details/PokemonLocations.tsx
+++ b/src/components/pokemon/details/PokemonLocations.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, ArrowUpCircle, MapPin, Target } from 'lucide-react';
 import type { CompactEncounter, CompactEncounterDetail } from '../../../db/schema';
 import { POKE_VERSION_MAP, REVERSE_METHOD_MAP } from '../../../db/schema';
 import { staticEncounters } from '../../../engine/data/shared/staticData';
+import { GlassCard } from '../../GlassCard';
 
 interface EvoReq {
   fromId: number;
@@ -40,7 +41,7 @@ export function PokemonLocations({
       </div>
 
       {loading ? (
-        <div className="glass-card h-40 animate-pulse rounded-3xl border border-white/5 bg-white/5" />
+        <GlassCard className="h-40 animate-pulse rounded-3xl" />
       ) : (
         <div className="relative z-10 grid grid-cols-1 gap-3" data-testid="location-list">
           {(() => {


### PR DESCRIPTION
🎯 What
Extracted repeated `glass-card` CSS classes and tailwind color pattern strings into a central `<GlassCard>` component.

💡 Why
To improve component modularity and reduce duplicated styling code scattered across various Pokemon details subcomponents.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to confirm no visual or behavioral regressions.

✨ Result
Centralized styling makes the detail components much cleaner and simplifies adding new colored cards in the future.

---
*PR created automatically by Jules for task [6773881139374183030](https://jules.google.com/task/6773881139374183030) started by @szubster*