### PR TITLE
Fix DAG resolution warning for PRD node mapping

### DIFF
--- a/.foundry/prds/prd-018-018-migrate-heartbeat-to-gray-matter.md
+++ b/.foundry/prds/prd-018-018-migrate-heartbeat-to-gray-matter.md
@@ -2,8 +2,8 @@
 id: prd-018-018-migrate-heartbeat-to-gray-matter
 type: PRD
 title: Migrate foundry-heartbeat.ts to gray-matter
-status: BLOCKED
-owner_persona: tpm
+status: PENDING
+owner_persona: epic_planner
 created_at: '2026-05-06'
 updated_at: '2026-05-06'
 depends_on: []


### PR DESCRIPTION
Resolved a DAG resolution warning where a PRD node was incorrectly flagged with an invalid owner persona. Updated `.foundry/prds/prd-018-018-migrate-heartbeat-to-gray-matter.md` to set `owner_persona` to `epic_planner` and `status` to `PENDING`. Verified the fix using the orchestrator in dry-run mode and ran the full test suite to ensure no regressions.

Fixes #1009

---
*PR created automatically by Jules for task [12298554176163751055](https://jules.google.com/task/12298554176163751055) started by @szubster*