### PR TITLE
🧠 Trainer: Support equipped held items for trade evolutions

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -20,3 +20,6 @@
 ## 2024-05-18 - Assistant Daycare Egg Suggestion
 **Learning:** The Gen 2 Daycare breeding logic previously suggested "Leave your Pokémon at the Daycare to get an Egg!" even if the required Pokémon was already in the daycare, or if an egg was already waiting. We can extract `daycare` and `daycareHasEgg` from the parsed `SaveData`.
 **Action:** When evaluating `EVO_TRIGGER.BREED` (or general breeding recommendations), always check if `saveData.daycare` contains the needed species. If it does, and `saveData.daycareHasEgg` is true, suggest picking up the egg with a higher priority (95). If it is in the daycare but no egg is ready, tell the user to wait.
+## 2026-05-06 - Trade Evolution Held Item Equipped Support
+**Learning:** For Trade evolutions requiring a held item, the item could already be equipped on the Pokemon instead of being in the bag. The assistant was incorrectly suggesting to find the item if it was only equipped and not in the bag.
+**Action:** Modified `EVO_TRIGGER.TRADE` logic to search `evolvableInstances` and `ownedInstances` for the specific item and dynamically update the suggestion if the pre-evolution is already holding it.

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -6,6 +6,68 @@ import type { AssistantApiData } from '../suggestionEngine';
 import { generateSuggestions } from '../suggestionEngine';
 
 describe('generateSuggestions', () => {
+  it('should detect when an evolution item is already equipped for Trade evolutions', () => {
+    const ownedSet = new Set(Array.from({ length: 251 }, (_, i) => i + 1));
+    ownedSet.delete(208); // Missing Steelix
+    const mockSaveData = {
+      generation: 2,
+      gameVersion: 'gold',
+      trainerName: 'ASH',
+      owned: ownedSet, // Owns Onix
+      party: [],
+      pc: [95],
+      inventory: [{ id: 1, quantity: 5 }], // No Metal Coat (id: 0x8f) in bag
+      partyDetails: [],
+      pcDetails: [
+        {
+          speciesId: 95,
+          level: 20,
+          isShiny: false,
+          moves: [],
+          storageLocation: 'Box 1',
+          item: 0x8f, // Holding Metal Coat!
+          otName: 'ASH',
+        },
+      ],
+    } as unknown as SaveData;
+
+    const mockApiData = {
+      pokemonMetadata: {
+        95: {
+          id: 95,
+          n: 'Onix',
+          cr: 45,
+          baby: false,
+          eto: [{ id: 208, eto: [], det: [{ tr: 2, held: 210 }], ef: 95 }],
+          efrm: [],
+          det: [],
+        },
+        208: {
+          id: 208,
+          n: 'Steelix',
+          cr: 25,
+          baby: false,
+          eto: [],
+          efrm: [95],
+          det: [{ tr: 2, held: 210 }],
+        },
+      },
+      missingEncounters: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const mockStrategy = {
+      ...gen1Strategy,
+      generation: 2,
+    };
+
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'gold', mockApiData, mockStrategy);
+    const suggestion = suggestions.find((s) => s.id === 'evo-trade-held-208');
+    expect(suggestion).toBeDefined();
+    expect(suggestion?.title).toBe('Ready to Trade Evolve: #208!');
+    expect(suggestion?.description).toBe('Your pre-evolution is already holding the Metal Coat! Trade it to evolve!');
+  });
+
   it('should generate "Catch Right Here" (catch-local) suggestions', () => {
     const mockSaveData: SaveData = {
       generation: 1,

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -571,15 +571,25 @@ export function generateSuggestions(
       } else if (tr === EVO_TRIGGER.TRADE) {
         if (held) {
           const gameHeldId = getGameItemId(held, saveData.generation);
-          const hasHeldItem = saveData.inventory.some((i) => i.id === gameHeldId && i.quantity > 0);
+          const hasHeldItemInBag = saveData.inventory.some((i) => i.id === gameHeldId && i.quantity > 0);
+          const holdingInstance =
+            evolvableInstances.find((inst) => inst.item === gameHeldId) ||
+            ownedInstances.find((inst) => inst.item === gameHeldId);
+          const hasHeldItem = hasHeldItemInBag || !!holdingInstance;
           const itemName = EVO_ITEM_NAMES[held] || 'item';
+
+          let description = `Find a ${itemName}, have your pre-evolution hold it, and trade to evolve.`;
+          if (holdingInstance) {
+            description = `Your pre-evolution is already holding the ${itemName}! Trade it to evolve!`;
+          } else if (hasHeldItemInBag) {
+            description = `Have your pre-evolution hold the ${itemName} and trade it to evolve!`;
+          }
+
           suggestions.push({
             id: `evo-trade-held-${targetId}`,
             category: 'Evolve',
             title: hasHeldItem ? `Ready to Trade Evolve: #${targetId}!` : `Item Needed for Trade: #${targetId}`,
-            description: hasHeldItem
-              ? `Have your pre-evolution hold the ${itemName} and trade it to evolve!`
-              : `Find a ${itemName}, have your pre-evolution hold it, and trade to evolve.`,
+            description,
             pokemonId: targetId,
             priority: hasHeldItem ? 90 : 45,
           });


### PR DESCRIPTION
🧠 Trainer: Support equipped held items for trade evolutions

### 🎯 What
Updated the assistant's suggestion engine to correctly identify when a Pokémon is already holding the required item for a Trade Evolution, rather than solely checking the bag's inventory.

### 💡 Why
The engine previously only checked the player's inventory bag for required held items. If a user had already equipped the item (like a Metal Coat to Onix) to prepare for a trade, the engine would incorrectly inform the user that they needed to go find the item. This fixes that discrepancy.

### ✅ Verification
Added unit test `should detect when an evolution item is already equipped for Trade evolutions` in `src/engine/assistant/__tests__/generateSuggestions.test.ts`.

### ✨ Result
The assistant now correctly states "Your pre-evolution is already holding the [Item]! Trade it to evolve!" when the required item is equipped.

---
*PR created automatically by Jules for task [8174827893220386720](https://jules.google.com/task/8174827893220386720) started by @szubster*