### PR TITLE
agile-coach: Process improvements for orchestrator tests

### DIFF
--- a/.foundry/ideas/idea-019-orchestrator-test-factories.md
+++ b/.foundry/ideas/idea-019-orchestrator-test-factories.md
@@ -1,0 +1,20 @@
+---
+id: idea-019-orchestrator-test-factories
+type: IDEA
+title: Standardized Orchestrator Test Factories
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-05-07'
+updated_at: '2026-05-07'
+depends_on: []
+jules_session_id: null
+pr_number: null
+---
+
+# Standardized Orchestrator Test Factories
+
+## Context
+When implementing strict validation rules in the DAG Orchestrator (such as Phase 4.8 Mapping Validation), existing test fixtures in `.github/scripts/foundry-orchestrator.test.ts` frequently break because they were written with invalid or nonsensical frontmatter (e.g., an `IDEA` node owned by a `coder`). This causes cascading CI failures and repetitive PR rejections for tasks that are otherwise implemented correctly.
+
+## Proposal
+Implement a standardized test node factory utility (e.g., `createValidNode(overrides)`) in the test suite. This utility should automatically populate valid frontmatter defaults (like the correct `owner_persona` based on `type`) so tests remain robust and focus only on the specific behavior being tested, rather than failing due to unrelated strict schema evolutions.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -107,3 +107,12 @@ While reviewing the system for potential improvements and friction points, I dis
 
 ### Action Taken
 Autonomously generated `idea-018-migrate-heartbeat-to-gray-matter.md` to propose migrating the heartbeat script to use `gray-matter`, ensuring compliance with the architectural decision and preventing brittle regex-related bugs.
+
+## 2026-05-07: Mapping Validation Breaking Tests
+
+### Observation
+`task-038-064-implement-mapping-validation` and `task-034-059-qa-orchestrator-preflight` suffered 2 rejections each. The root cause for `task-038-064` is that the implementation of Phase 4.8 (Mapping Validation) broke existing orchestrator tests in `.github/scripts/foundry-orchestrator.test.ts`. The old tests created nodes with invalid personas (like an `IDEA` node owned by `coder`), which previously worked but now cause the tests to fail because they are correctly `BLOCKED` instead of `READY`. The `coder` failed to update the existing test fixtures when adding new validation rules.
+
+### Action Taken
+1. Updated `.github/agents/coder.md` and `.github/agents/qa.md` to explicitly instruct agents to run the `.github/scripts` vitest suite and update any broken test fixtures when modifying orchestrator logic.
+2. Generated `idea-019-orchestrator-test-factories.md` to propose a standardized testing factory to avoid hard-coded YAML frontmatter strings in tests, preventing future breakages when schema validations evolve.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -24,3 +24,4 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Quality Assurance
 Before marking a task as COMPLETED, you MUST run `pnpm lint && pnpm test` to ensure project health and that no regressions are introduced.
 To automatically fix code formatting errors flagged by Biome during lint checks, run `pnpm check:fix` or `pnpm format:biome`.
+When modifying central systems like the DAG Orchestrator (`.github/scripts/foundry-orchestrator.ts`), you MUST also explicitly run its test suite (`cd .github/scripts && pnpm install && npx vitest`) and fix any existing tests that your new logic breaks.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -36,3 +36,4 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Quality Assurance
 Before approving a task, you MUST run `pnpm lint && pnpm test` to ensure project health and verify that no regressions are introduced by the implementer.
 To automatically fix code formatting errors flagged by Biome during lint checks, run `pnpm check:fix` or `pnpm format:biome`.
+When verifying orchestrator logic tasks, ensure you explicitly run the specific script tests (`cd .github/scripts && pnpm install && npx vitest`) and verify the implementer did not break existing test functionality.


### PR DESCRIPTION
As the Agile Coach, analyzed the rejections for `task-038-064-implement-mapping-validation` and identified that the tests broke because they used invalid personas in test fixtures which the new validation rules caught. Updated the coder and qa persona guidelines to enforce running script tests when modifying the orchestrator. Created an IDEA node to propose robust test factories.

---
*PR created automatically by Jules for task [3358612497746547050](https://jules.google.com/task/3358612497746547050) started by @szubster*