### PR TITLE
🧭 Strategist: prompt improvement - Restrict Bolt to application performance

### DIFF
--- a/.jules/schedules/bolt.md
+++ b/.jules/schedules/bolt.md
@@ -28,6 +28,7 @@ Identify and implement ONE small performance improvement that makes the applicat
 - Introduce breaking changes
 - Sacrifice readability for micro-optimizations
 - Optimize cold paths without evidence of impact
+- Modify CI/CD pipelines (`.github/workflows/`), tooling config (`vite.config.ts`, `vitest.config.ts`, `biome.jsonc`), or the Foundry Orchestrator (`.github/scripts/`) — those belong to Infras or TPM
 
 ## Process
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -78,3 +78,9 @@
 **Outcome:** Rejected → journaled
 **Why:** There is already a TPM in foundry using a different scheduling mechanism.
 **Pattern:** Ensure we don't duplicate existing agents/roles even if they aren't directly represented in `.jules/schedules/`. If a role exists but is missing specific instructions, we should improve its prompt rather than creating a duplicate schedule.
+
+## 2026-06-07 - [Accepted] - Prompt improvement - Restrict Bolt to application performance
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The Bolt agent's journal showed it repeatedly optimizing CI pipelines, fixing DAG orchestrator bugs, and updating tooling configs (Biome, Vite, Vitest) instead of its domain of application performance.
+**Pattern:** Performance agents can easily drift into pipeline/tooling optimizations if their boundaries don't explicitly exclude infrastructure and CI/CD files.


### PR DESCRIPTION
The Bolt agent's journal shows it has been repeatedly performing tasks outside its primary domain of runtime application performance, instead engaging in CI pipeline optimization, tooling configuration updates, and orchestrator bug fixes. 

This PR proposes a prompt improvement that restricts Bolt to its intended focus area by adding a constraint to explicitly forbid modifying CI/CD pipelines, tooling configs, and the Foundry Orchestrator. The Strategist journal is also updated to reflect this learning.

---
*PR created automatically by Jules for task [6383262861023768639](https://jules.google.com/task/6383262861023768639) started by @szubster*