### PR TITLE
🎨 Palette: Fix segmented control ARIA roles in PokemonCatchProbability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -45,3 +45,7 @@
 **Action:** When creating custom file upload buttons with hidden inputs, do not use a `<label>` wrapper. Instead, use a semantic `<button type="button">` with `focus-visible` styles, and use an `onClick` handler to programmatically trigger the click on the sibling `<input type="file">` via its ID or a React ref.
 
 - Added title tooltips to BottomNav elements corresponding to their aria-labels to improve usability for non-screenreader users.
+
+## 2024-05-20 - Missing ARIA roles on segmented controls
+**Learning:** When using `role="radiogroup"` on a container, the interactive child elements representing the mutually exclusive options must have `role="radio"` and `aria-checked` attributes, not generic `button` behaviors with `aria-pressed`. Otherwise, screen readers will interpret them as independent toggle buttons instead of a single choice group.
+**Action:** Ensure custom segmented controls have `role="radio"` and `aria-checked` on the buttons, and that they use the correct tag, such as `<button>` with `oxlint-disable jsx-a11y/prefer-tag-over-role` and `biome-ignore lint/a11y/useSemanticElements` if styling constraints forbid native radio inputs.

--- a/src/components/pokemon/details/PokemonCatchProbability.tsx
+++ b/src/components/pokemon/details/PokemonCatchProbability.tsx
@@ -53,10 +53,13 @@ export function PokemonCatchProbability({ catchRate, effectivePokeball }: Pokemo
 
         <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Target Status">
           {STATUS_OPTIONS.map((item) => (
+            // oxlint-disable jsx-a11y/prefer-tag-over-role
+            // biome-ignore lint/a11y/useSemanticElements: custom radio segmented control needs proper styling
             <button
               type="button"
+              role="radio"
               key={item.id}
-              aria-pressed={status === item.id}
+              aria-checked={status === item.id}
               onClick={() => setStatus(item.id)}
               className={cn(
                 'rounded-2xl border py-3 font-black text-[9px] uppercase tracking-widest outline-none transition-all focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-95',


### PR DESCRIPTION
**🎯 What**
Adds `role="radio"` and changes `aria-pressed` to `aria-checked` on the status selection buttons in `PokemonCatchProbability.tsx`. 

**💡 Why**
The container already uses `role="radiogroup"`. Screen readers expect child elements within a radiogroup to have `role="radio"` and use `aria-checked` to determine state. Using `aria-pressed` with a generic button role implies independent toggle buttons rather than a mutually exclusive choice, causing confusion for assistive technology users.

**✅ Verification**
- Passes `pnpm lint`
- Passes `pnpm test`
- Passes `pnpm test:e2e`

**✨ Accessibility notes**
Added linter disables to allow `<button role="radio">` where visual design prevents native `<input type="radio">`. Documented in `.jules/palette.md`.

---
*PR created automatically by Jules for task [14175836045857903489](https://jules.google.com/task/14175836045857903489) started by @szubster*