### PR TITLE
🔐 Add XXE injection to security scan vectors

### DIFF
--- a/.jules/schedules/shield.md
+++ b/.jules/schedules/shield.md
@@ -25,6 +25,7 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 - **NEW:** Prevent Cross-Site Request Forgery (CSRF) by auditing the use of anti-CSRF tokens in state-changing API requests.
 - **NEW:** Ensure the application implements a strong Content Security Policy (CSP) by auditing meta tags or server response headers.
 - **NEW:** Guard against GraphQL query injection by ensuring all queries are parameterized and user input is sanitized before executing.
+- **NEW:** Guard against XML External Entity (XXE) injection by auditing any XML parsing logic and ensuring external entities are disabled.
 
 
 ## Boundaries
@@ -44,7 +45,7 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 
 ## Process
 
-1. **Scan** — look for insecure patterns, raw error logging, non-native crypto usage, XSS vectors, unsafe links, or `url.includes()`. (Hint: check for `Math.random`, `console.error(err)` without `.message`, `dangerouslySetInnerHTML`, `target="_blank"`, `url.includes`, `Object.assign`, `eval(`, `window.location`, `window.postMessage`, complex regex, `window.open`, `import.meta.env`, `fetch`, `graphql`, `csp`, and `csrf`)
+1. **Scan** — look for insecure patterns, raw error logging, non-native crypto usage, XSS vectors, unsafe links, or `url.includes()`. (Hint: check for `Math.random`, `console.error(err)` without `.message`, `dangerouslySetInnerHTML`, `target="_blank"`, `url.includes`, `Object.assign`, `eval(`, `window.location`, `window.postMessage`, complex regex, `window.open`, `import.meta.env`, `fetch`, `graphql`, `csp`, `csrf`, and `DOMParser`)
 2. **Select** — pick the most actionable security fix. If no specific application code vulnerability is found, improve this scheduled prompt itself or perform a dependency audit.
 3. **Secure** — implement the fix and add validating tests if possible.
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`.

--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -21,3 +21,6 @@
 
 ## Adding New Security Audit Vectors
 **Pattern:** Added Server-Side Request Forgery (SSRF), Cross-Site Request Forgery (CSRF), Content Security Policy (CSP) checking, and GraphQL query injection as new scan vectors to the scheduled prompt (`.jules/schedules/shield.md`). This expands the automated security checks to cover potential external communication vulnerabilities, insecure requests, and injection attacks.
+
+## Adding New Security Audit Vectors
+**Pattern:** Added XML External Entity (XXE) injection and `DOMParser` scanning as new scan vectors to the scheduled prompt (`.jules/schedules/shield.md`). This expands the automated security checks to cover potential vulnerabilities when parsing XML inputs.


### PR DESCRIPTION
🎯 What: Added a new security audit vector to the Shield scheduled prompt targeting XML External Entity (XXE) injection vulnerabilities.
⚠️ Risk: The Shield schedule runs periodically but might miss checking for XXE attacks if the application ever adopts XML parsing (e.g. via DOMParser). Failing to update the schedule allows such vectors to remain unaudited.
🛡️ Solution: Added XXE and DOMParser scanning to .jules/schedules/shield.md and documented this in the shield journal. No code vulnerabilities were found in the current sweep.

---
*PR created automatically by Jules for task [5273927458068089481](https://jules.google.com/task/5273927458068089481) started by @szubster*