### PR TITLE
🔐 Shield: Improve scheduled prompt with new scan vectors

### DIFF
--- a/.jules/schedules/shield.md
+++ b/.jules/schedules/shield.md
@@ -25,6 +25,9 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 - **NEW:** Prevent Cross-Site Request Forgery (CSRF) by auditing the use of anti-CSRF tokens in state-changing API requests.
 - **NEW:** Ensure the application implements a strong Content Security Policy (CSP) by auditing meta tags or server response headers.
 - **NEW:** Guard against GraphQL query injection by ensuring all queries are parameterized and user input is sanitized before executing.
+- **NEW:** Guard against Insecure Direct Object References (IDOR) by ensuring that access control checks are performed before granting access to resources.
+- **NEW:** Prevent Clickjacking by verifying that the `X-Frame-Options` header or CSP `frame-ancestors` directive is configured.
+- **NEW:** Guard against XML External Entity (XXE) injection by auditing any XML parsing logic and disabling external entities.
 
 
 ## Boundaries

--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -21,3 +21,6 @@
 
 ## Adding New Security Audit Vectors
 **Pattern:** Added Server-Side Request Forgery (SSRF), Cross-Site Request Forgery (CSRF), Content Security Policy (CSP) checking, and GraphQL query injection as new scan vectors to the scheduled prompt (`.jules/schedules/shield.md`). This expands the automated security checks to cover potential external communication vulnerabilities, insecure requests, and injection attacks.
+
+## Adding New Security Audit Vectors
+**Pattern:** Added Insecure Direct Object References (IDOR), Clickjacking, and XML External Entity (XXE) injection as new scan vectors to the scheduled prompt (`.jules/schedules/shield.md`). This expands the automated security checks to cover potential access control flaws, UI redressing, and XML parsing vulnerabilities.


### PR DESCRIPTION
🎯 What: Added Insecure Direct Object References (IDOR), Clickjacking, and XML External Entity (XXE) injection to the scheduled security prompt `.jules/schedules/shield.md`.

⚠️ Risk: Low. These changes strictly affect documentation for future security audits and introduce zero runtime risk to the application.

🛡️ Solution: Updated the fallback auditing instructions to systematically search for IDOR, missing clickjacking protection headers, and insecure XML parser configurations during routine checks.

---
*PR created automatically by Jules for task [8499280950683481779](https://jules.google.com/task/8499280950683481779) started by @szubster*