### PR TITLE
feat: add story to migrate heartbeat to gray-matter

### DIFF
--- a/.foundry/epics/epic-018-028-migrate-heartbeat-to-gray-matter.md
+++ b/.foundry/epics/epic-018-028-migrate-heartbeat-to-gray-matter.md
@@ -36,3 +36,6 @@ ADR-006 mandated the use of `gray-matter` for parsing and mutating Markdown fron
 - `transitionNodeToCompleted` uses `gray-matter` to parse and mutate frontmatter instead of regex.
 - `transitionNodeToReady` uses `gray-matter` to parse and mutate frontmatter instead of regex.
 - All modifications write the new node contents via `matter.stringify()`.
+
+## Stories
+- [ ] .foundry/stories/story-028-043-migrate-heartbeat-to-gray-matter.md

--- a/.foundry/stories/story-028-043-migrate-heartbeat-to-gray-matter.md
+++ b/.foundry/stories/story-028-043-migrate-heartbeat-to-gray-matter.md
@@ -1,0 +1,35 @@
+---
+id: story-028-043-migrate-heartbeat-to-gray-matter
+type: STORY
+title: Rewrite heartbeat regex mutations using gray-matter
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-08'
+updated_at: '2026-05-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-018-028-migrate-heartbeat-to-gray-matter.md
+tags:
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Rewrite heartbeat regex mutations using gray-matter
+
+## Goal
+In `.github/scripts/foundry-heartbeat.ts`, we currently use fragile regex patterns to modify YAML frontmatter. We need to transition these modifications to use `gray-matter` for parsing and serialization, compliant with ADR-006.
+
+## Tasks Required
+1. Import `matter` from `gray-matter` in `foundry-heartbeat.ts` if not already imported.
+2. Refactor `transitionNodeToFailed` to parse the file with `matter`, update `status`, `rejection_count`, and `jules_session_id`, then write it back using `matter.stringify()`.
+3. Refactor `transitionNodeToReady` similarly.
+4. Refactor `transitionNodeToCompleted` similarly.
+5. Ensure that the original markdown body is preserved during `matter.stringify()`.
+
+## Acceptance Criteria
+- [ ] Tasks are outlined and delegated.


### PR DESCRIPTION
Created a new STORY node `story-028-043-migrate-heartbeat-to-gray-matter.md` to track the migration of the `foundry-heartbeat.ts` script to use `gray-matter` for parsing and writing markdown frontmatter, dropping fragile regex parsing. Updated the parent EPIC `epic-018-028-migrate-heartbeat-to-gray-matter.md` to reference the new story.

---
*PR created automatically by Jules for task [4491066594629300554](https://jules.google.com/task/4491066594629300554) started by @szubster*