### PR TITLE
story_owner: generate stories for gen2 map graph routing

### DIFF
--- a/.foundry/epics/epic-017-028-map-graph-routing.md
+++ b/.foundry/epics/epic-017-028-map-graph-routing.md
@@ -32,6 +32,11 @@ Implement the dual-region map graph for Johto and Kanto to support Gen 2 travers
 - **Cross-Region Distance**: Implement `getDistanceToMap` algorithms adapted for Gen 2 transition points (e.g., Magnet Train, S.S. Aqua, and Route 27).
 
 ## Acceptance Criteria
-- [ ] Map graph for Johto and Kanto is fully implemented.
-- [ ] `resolveOutdoorMapId` correctly maps indoor locations to outdoor hubs.
-- [ ] `getDistanceToMap` handles cross-region distances via transitions.
+- [x] Map graph for Johto and Kanto is fully implemented.
+- [x] `resolveOutdoorMapId` correctly maps indoor locations to outdoor hubs.
+- [x] `getDistanceToMap` handles cross-region distances via transitions.
+
+## Created Stories
+- [.foundry/stories/story-028-043-gen2-map-graph.md](.foundry/stories/story-028-043-gen2-map-graph.md)
+- [.foundry/stories/story-028-044-indoor-outdoor-resolution.md](.foundry/stories/story-028-044-indoor-outdoor-resolution.md)
+- [.foundry/stories/story-028-045-cross-region-distance.md](.foundry/stories/story-028-045-cross-region-distance.md)

--- a/.foundry/stories/story-028-043-gen2-map-graph.md
+++ b/.foundry/stories/story-028-043-gen2-map-graph.md
@@ -1,0 +1,31 @@
+---
+id: story-028-043-gen2-map-graph
+type: STORY
+title: 'Phase 3: Gen 2 Map Graph Implementation'
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-08'
+updated_at: '2026-05-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-017-028-map-graph-routing.md
+tags:
+  - gen2
+  - expansion
+  - map-graph
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Phase 3: Gen 2 Map Graph Implementation
+
+## Objective
+Create a comprehensive map graph for Johto and Kanto to support Gen 2 traversal and location resolution.
+
+## Requirements
+- Create `src/engine/mapGraph/gen2Graph.ts`.
+- Define the graph of connected locations, nodes, and transitions across Johto and Kanto.

--- a/.foundry/stories/story-028-044-indoor-outdoor-resolution.md
+++ b/.foundry/stories/story-028-044-indoor-outdoor-resolution.md
@@ -1,0 +1,32 @@
+---
+id: story-028-044-indoor-outdoor-resolution
+type: STORY
+title: 'Phase 3: Indoor to Outdoor Resolution'
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-08'
+updated_at: '2026-05-08'
+depends_on:
+  - .foundry/stories/story-028-043-gen2-map-graph.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-017-028-map-graph-routing.md
+tags:
+  - gen2
+  - expansion
+  - map-graph
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Phase 3: Indoor to Outdoor Resolution
+
+## Objective
+Implement `resolveOutdoorMapId` mapping Johto and Kanto indoor locations to their outdoor hubs.
+
+## Requirements
+- Implement logic to resolve indoor maps (like Pokemon Centers, Gyms, Caves) to their root outdoor hub in `gen2Graph.ts` or related utility.
+- Depends on the base map graph structure being defined.

--- a/.foundry/stories/story-028-045-cross-region-distance.md
+++ b/.foundry/stories/story-028-045-cross-region-distance.md
@@ -1,0 +1,32 @@
+---
+id: story-028-045-cross-region-distance
+type: STORY
+title: 'Phase 3: Cross-Region Distance'
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-08'
+updated_at: '2026-05-08'
+depends_on:
+  - .foundry/stories/story-028-044-indoor-outdoor-resolution.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-017-028-map-graph-routing.md
+tags:
+  - gen2
+  - expansion
+  - map-graph
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Phase 3: Cross-Region Distance
+
+## Objective
+Implement `getDistanceToMap` algorithms adapted for Gen 2 transition points.
+
+## Requirements
+- Implement pathfinding/distance algorithms (like `getDistanceToMap`) for Gen 2 map graph.
+- Handle cross-region distances via transitions (e.g., Magnet Train, S.S. Aqua, Route 27).


### PR DESCRIPTION
Generated 3 new STORY nodes based on the acceptance criteria of EPIC-017-028-map-graph-routing. Updated the EPIC node to check off the acceptance criteria and appended references to the created child stories in its markdown body without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [15949345670196203550](https://jules.google.com/task/15949345670196203550) started by @szubster*