### PR TITLE
🛡️ Nurse: [type improvement] Use strict GameVersion in React props

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -1,4 +1,4 @@
-## $(date +%Y-%m-%d) - Typed `CATEGORY_STYLES` with `SuggestionCategory`
+## 2026-05-08 - Typed `CATEGORY_STYLES` with `SuggestionCategory`
 **Learning:** `Object.entries()` returns keys as `string`, which requires an explicit `as Type` cast when the original object uses a strict union or enum for its keys. Furthermore, when using `.reduce` to build an object with strict string literal keys, use `Partial<Record<TargetKey, ValueType>>` for the initial accumulator so it can start as an empty object (`{}`) without failing type-checks, as opposed to forcing it with `as Record<TargetKey, ValueType>`.
 **Action:** Use `Partial` instead of raw `Record` types when starting with empty objects in `.reduce()` functions if not all keys are guaranteed to be populated at start. Remember to cast keys yielded by `Object.entries()` if they need to map back to strict unions, or use `.reduce` instead with typed iterables.
 ## 2025-02-15 - Unsafe casts in DataLoader
@@ -27,7 +27,7 @@ The compiler ensures that DataLoader batch functions return valid values or Erro
 * **Issue:** When dealing with sets of valid literal string values (e.g., `['secured', 'missing', 'dex-only']`), components often use inline `as Type[]` assertions when iterating, and the union type itself is defined separately (`type FilterType = 'secured' | 'missing' | 'dex-only'`). This causes a disconnect where the array values can drift from the type definition, bypassing compiler checks.
 * **Solution:** Create an immutable array `export const FILTER_TYPES = [...] as const;` and derive the union type from it: `export type FilterType = (typeof FILTER_TYPES)[number];`.
 * **Learning:** This pattern completely eliminates the need for unsafe `as` casts in the consuming components (e.g., `FILTER_TYPES.map(...)` instead of `(['...'] as FilterType[]).map(...)`), guarantees that the type and the runtime array are always in perfect sync, and successfully compiles under strict mode while maintaining the identical runtime behavior.
-## $(date +%Y-%m-%d) - Nurse: Replaced inline string unions and array casting with `as const` derived array and type
+## 2026-05-08 - Nurse: Replaced inline string unions and array casting with `as const` derived array and type
 
 **What was unsafe:**
 The `StatusType` was defined as a string union `type StatusType = 'none' | 'sleep_freeze' | 'paralyze_burn_poison';`. Inside the component, an inline array of options mapped these values to labels, using `as StatusType` casts to avoid type errors since TypeScript infers string literal properties in arrays as generic `string`.
@@ -37,3 +37,6 @@ Extracted the inline array into a constant `STATUS_OPTIONS` marked with `as cons
 
 **What the compiler now catches:**
 The compiler statically guarantees that the `StatusType` union and the `STATUS_OPTIONS` array are always in sync. It eliminates the unsafe `as StatusType` casts while maintaining identical runtime behavior.
+## 2026-05-08 - Nurse: Tighten React Props to remove type casting
+**Learning:** By keeping React component prop types as strict as their underlying models (e.g. `GameVersion` instead of `string`), we can avoid using unsafe casts like `as keyof ...` when indexing into static data objects.
+**Action:** Changed `gameVersion: string` to `gameVersion: GameVersion` in `PokemonDetailsProps` and `PokemonLocationsProps` to eliminate the cast.

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { dexDataLoader } from '../db/DexDataLoader';
 import { type CompactChainLink, POKE_VERSION_MAP, REVERSE_METHOD_MAP } from '../db/schema';
 import { stadiumRewardsSummary } from '../engine/data/shared/staticData';
-import type { SaveData } from '../engine/saveParser/index';
+import type { GameVersion, SaveData } from '../engine/saveParser/index';
 import type { PokeballType } from '../store';
 import { cn } from '../utils/cn';
 import { getGenerationConfig } from '../utils/generationConfig';
@@ -18,7 +18,7 @@ import { PokemonSprite } from './pokemon/PokemonSprite';
 interface PokemonDetailsProps {
   pokemonId: number;
   pokemonName: string;
-  gameVersion: string;
+  gameVersion: GameVersion;
   saveData: SaveData | null;
   isLivingDex: boolean;
   pokeball: PokeballType;

--- a/src/components/pokemon/details/PokemonLocations.tsx
+++ b/src/components/pokemon/details/PokemonLocations.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, ArrowUpCircle, MapPin, Target } from 'lucide-react';
 import type { CompactEncounter, CompactEncounterDetail } from '../../../db/schema';
 import { POKE_VERSION_MAP, REVERSE_METHOD_MAP } from '../../../db/schema';
 import { staticEncounters } from '../../../engine/data/shared/staticData';
+import type { GameVersion } from '../../../engine/saveParser/index';
 
 interface EvoReq {
   fromId: number;
@@ -11,7 +12,7 @@ interface EvoReq {
 
 interface PokemonLocationsProps {
   pokemonId: number;
-  gameVersion: string;
+  gameVersion: GameVersion;
   encounters: CompactEncounter[];
   areaNames: Record<number, string> | undefined;
   evoReq: EvoReq | null;
@@ -44,7 +45,7 @@ export function PokemonLocations({
       ) : (
         <div className="relative z-10 grid grid-cols-1 gap-3" data-testid="location-list">
           {(() => {
-            const staticEnc = staticEncounters[pokemonId]?.[gameVersion as keyof (typeof staticEncounters)[number]];
+            const staticEnc = gameVersion !== 'unknown' ? staticEncounters[pokemonId]?.[gameVersion] : undefined;
             const versionEnc = encounters.filter((e) => e.v === currentVersionId);
 
             if ((staticEnc && staticEnc.length > 0) || versionEnc.length > 0 || evoReq) {
@@ -65,7 +66,7 @@ export function PokemonLocations({
                       </span>
                     </div>
                   )}
-                  {staticEnc?.map((loc, i) => (
+                  {staticEnc?.map((loc: string, i: number) => (
                     <div
                       // biome-ignore lint/suspicious/noArrayIndexKey: Array index is stable and required for duplicates
                       key={`static-${i}`}


### PR DESCRIPTION
**🎯 What**
We had a weak typing for `gameVersion` in `PokemonLocationsProps` and `PokemonDetailsProps` (`string` instead of the domain model `GameVersion`), which forced us to use an unsafe cast `as keyof (typeof staticEncounters)[number]` when looking up static encounters in `PokemonLocations.tsx`.

**💡 How it was fixed**
1. Imported `GameVersion` type and updated the `gameVersion` prop in `PokemonDetailsProps` and `PokemonLocationsProps` to use it instead of `string`.
2. Changed the unsafe static lookup to check `gameVersion !== 'unknown' ? staticEncounters[pokemonId]?.[gameVersion] : undefined`.

**✅ What the compiler now catches**
The TypeScript compiler now strictly enforces that only valid `GameVersion` strings can be passed down into `PokemonDetails` and `PokemonLocations`.

**✨ Result**
We successfully removed an unsafe indexing cast, improving React component strictness without altering runtime behavior.

---
*PR created automatically by Jules for task [10287699159172806585](https://jules.google.com/task/10287699159172806585) started by @szubster*