### PR TITLE
🛡️ Nurse: Replace unsafe as cast in SyncProgress with runtime type guard

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -38,3 +38,4 @@ Extracted the inline array into a constant `STATUS_OPTIONS` marked with `as cons
 **What the compiler now catches:**
 The compiler statically guarantees that the `StatusType` union and the `STATUS_OPTIONS` array are always in sync. It eliminates the unsafe `as StatusType` casts while maintaining identical runtime behavior.
 - Fixed an unsafe `as IDBValidKey` cast in `src/db/PokeDB.ts`'s `bulkGet` by assigning to a variable and checking for `undefined` before passing to `store.get`.
+- Replaced an unsafe `as` cast in `src/components/SyncProgress.tsx` with a runtime type guard `isSyncProgressDetail`. This ensures both type safety and runtime safety when handling custom events, specifically verifying the presence and types of `current`, `total`, and `stage` in the event detail.

--- a/src/components/SyncProgress.tsx
+++ b/src/components/SyncProgress.tsx
@@ -3,6 +3,25 @@ import { useEffect, useState } from 'react';
 import { pokeDB } from '../db/PokeDB';
 import { cn } from '../utils/cn';
 
+interface SyncProgressDetail {
+  current: number;
+  total: number;
+  stage: string;
+}
+
+function isSyncProgressDetail(detail: unknown): detail is SyncProgressDetail {
+  if (typeof detail !== 'object' || detail === null) return false;
+
+  return (
+    'current' in detail &&
+    typeof (detail as { current: unknown }).current === 'number' &&
+    'total' in detail &&
+    typeof (detail as { total: unknown }).total === 'number' &&
+    'stage' in detail &&
+    typeof (detail as { stage: unknown }).stage === 'string'
+  );
+}
+
 export function SyncProgress() {
   const [progress, setProgress] = useState<{ current: number; total: number; stage: string } | null>(null);
   const [isComplete, setIsComplete] = useState(false);
@@ -23,8 +42,10 @@ export function SyncProgress() {
       .catch(() => console.error('System: sync failed'));
 
     const handleProgress = (event: Event) => {
-      const customEvent = event as CustomEvent<{ current: number; total: number; stage: string }>;
-      const { current, total, stage } = customEvent.detail;
+      if (!(event instanceof CustomEvent)) return;
+      if (!isSyncProgressDetail(event.detail)) return;
+
+      const { current, total, stage } = event.detail;
       setProgress({ current, total, stage });
       setShouldRender(true);
 


### PR DESCRIPTION
Replaced an unsafe `as CustomEvent` cast with a `instanceof CustomEvent` validation and a custom type guard `isSyncProgressDetail` in `src/components/SyncProgress.tsx`. This avoids `as` casting while guaranteeing type safety and runtime safety.

---
*PR created automatically by Jules for task [10945353180099951313](https://jules.google.com/task/10945353180099951313) started by @szubster*