### PR TITLE
fix: resolve frontmatter paths dynamically and correct epic parent links

### DIFF
--- a/.foundry/epics/epic-010-persona-permissions.md
+++ b/.foundry/epics/epic-010-persona-permissions.md
@@ -8,7 +8,7 @@ created_at: "2026-04-23"
 updated_at: "2026-04-23"
 depends_on: []
 jules_session_id: null
-parent: ".foundry/prds/prd-002-late-binding-orchestrator.md"
+parent: ".foundry/prds/prd-005-010-late-binding-orchestrator.md"
 tags:
   - foundry-v2
   - architecture

--- a/.foundry/epics/epic-011-wait-and-wake-protocol.md
+++ b/.foundry/epics/epic-011-wait-and-wake-protocol.md
@@ -9,7 +9,7 @@ updated_at: "2026-04-25"
 depends_on:
   - .foundry/epics/epic-010-persona-permissions.md
 jules_session_id: null
-parent: ".foundry/prds/prd-002-late-binding-orchestrator.md"
+parent: ".foundry/prds/prd-005-010-late-binding-orchestrator.md"
 tags:
   - foundry-v2
   - architecture

--- a/.foundry/epics/epic-012-gastown-orchestrator.md
+++ b/.foundry/epics/epic-012-gastown-orchestrator.md
@@ -12,7 +12,7 @@ depends_on:
   - .foundry/stories/story-012-027-design-sync-mechanism.md
   - .foundry/stories/story-012-026-evaluate-cloudflare-storage.md
 jules_session_id: null
-parent: ".foundry/prds/prd-002-late-binding-orchestrator.md"
+parent: ".foundry/prds/prd-005-010-late-binding-orchestrator.md"
 tags:
   - foundry-v2
   - architecture

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -1,6 +1,34 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+function resolveNodeIdToPath(nodeId: string): string {
+  if (nodeId.includes('/') || nodeId.endsWith('.md')) {
+    return nodeId;
+  }
+  const type = nodeId.split('-')[0];
+  const folderMap: Record<string, string> = {
+    idea: 'ideas',
+    prd: 'prds',
+    epic: 'epics',
+    story: 'stories',
+    task: 'tasks',
+    adr: 'docs/adrs'
+  };
+  if (!type) return nodeId;
+  const folder = folderMap[type];
+  if (!folder) return nodeId;
+
+  const basePath = `.foundry/${folder}/${nodeId}.md`;
+  if (fs.existsSync(basePath)) {
+    return basePath;
+  }
+  const archivePath = `.foundry/archive/${folder}/${nodeId}.md`;
+  if (fs.existsSync(archivePath)) {
+    return archivePath;
+  }
+  return nodeId;
+}
+
 function extractFrontmatterPaths(fm: string): string[] {
   const paths: string[] = [];
   const lines = fm.split('\n');
@@ -12,7 +40,7 @@ function extractFrontmatterPaths(fm: string): string[] {
       if (remainder.startsWith('[')) {
         const arrStr = remainder.slice(1, remainder.indexOf(']'));
         const items = arrStr.split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
-        paths.push(...items);
+        paths.push(...items.map(resolveNodeIdToPath));
         inDependsOn = false;
       } else {
         inDependsOn = true;
@@ -24,7 +52,7 @@ function extractFrontmatterPaths(fm: string): string[] {
       if (line.match(/^\s*-/)) {
         const pathStr = line.replace(/^\s*-/, '').trim().replace(/^["']|["']$/g, '');
         if (pathStr) {
-          paths.push(pathStr);
+          paths.push(resolveNodeIdToPath(pathStr));
         }
         continue;
       } else if (line.match(/^[a-zA-Z0-9_-]+:/)) {
@@ -36,7 +64,7 @@ function extractFrontmatterPaths(fm: string): string[] {
       inDependsOn = false;
       const parentVal = line.slice('parent:'.length).trim().replace(/^["']|["']$/g, '');
       if (parentVal && parentVal !== 'null') {
-        paths.push(parentVal);
+        paths.push(resolveNodeIdToPath(parentVal));
       }
     }
   }


### PR DESCRIPTION
This PR fixes several broken link issues identified during repository checks. 

1. **Frontmatter path resolution:** `scripts/check-links.ts` has been updated to correctly resolve frontmatter ID references (e.g. `idea-019-orchestrator-test-factories`) to file paths. This maintains the constraint that parent/depends_on frontmatter links use node IDs rather than hardcoded `.md` paths.

2. **Epic parent fixes:** `.foundry/epics/epic-010-persona-permissions.md`, `epic-011-wait-and-wake-protocol.md`, and `epic-012-gastown-orchestrator.md` were pointing to `.foundry/prds/prd-002-late-binding-orchestrator.md`, which does not exist. These have been updated to `.foundry/prds/prd-005-010-late-binding-orchestrator.md`, the actual name of the file.

---
*PR created automatically by Jules for task [13202893357737114614](https://jules.google.com/task/13202893357737114614) started by @szubster*