### PR TITLE
test(saveParser): calculate Gen 2 checksum

### DIFF
--- a/src/engine/saveParser/index.test.ts
+++ b/src/engine/saveParser/index.test.ts
@@ -115,7 +115,7 @@ describe('saveParser - Error Handling and Fallbacks', () => {
     // Gen 2 checksum
     let gen2Sum = 0;
     for (let i = 0x2009; i <= 0x2d0c; i++) {
-      gen2Sum += buffer[i] ?? 0;
+      gen2Sum += buffer[i] as number;
     }
     const view = new DataView(buffer.buffer);
     view.setUint16(0x2d0d, gen2Sum, true);
@@ -133,7 +133,7 @@ describe('saveParser - Error Handling and Fallbacks', () => {
     // Gen 2 checksum
     let gen2Sum = 0;
     for (let i = 0x2009; i <= 0x2d0c; i++) {
-      gen2Sum += buffer[i] ?? 0;
+      gen2Sum += buffer[i] as number;
     }
     const view = new DataView(buffer.buffer);
     view.setUint16(0x2d0d, gen2Sum, true);
@@ -154,7 +154,7 @@ describe('saveParser - Error Handling and Fallbacks', () => {
     // Gen 2 checksum
     let gen2Sum = 0;
     for (let i = 0x2009; i <= 0x2d0c; i++) {
-      gen2Sum += buffer[i] ?? 0;
+      gen2Sum += buffer[i] as number;
     }
     const view = new DataView(buffer.buffer);
     view.setUint16(0x2d0d, gen2Sum, true);

--- a/src/engine/saveParser/saveParser.test.ts
+++ b/src/engine/saveParser/saveParser.test.ts
@@ -116,10 +116,10 @@ describe('saveParser - Pokémon Gen 2 Inventory', () => {
     buffer[ballsPocket + 2] = 99; // qty
     buffer[ballsPocket + 3] = 0xff;
 
-    // Fix Checksum
+    // Calculate Gen 2 Checksum
     let gen2Sum = 0;
     for (let i = 0x2009; i <= 0x2d0c; i++) {
-      gen2Sum += buffer[i] ?? 0;
+      gen2Sum += buffer[i] as number;
     }
     const view = new DataView(buffer.buffer);
     view.setUint16(0x2d0d, gen2Sum, true);


### PR DESCRIPTION
- Change 'Fix Checksum' comment to 'Calculate Gen 2 Checksum' to avoid it being flagged as a FIXME.
- Remove unnecessary `?? 0` and add explicit `as number` casting when summing bytes in `saveParser.test.ts` and `index.test.ts` tests.

---
*PR created automatically by Jules for task [13323199936702657936](https://jules.google.com/task/13323199936702657936) started by @szubster*