### PR TITLE
🧠 Trainer: Suggest taking evolution items held by other Pokémon

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -27,3 +27,6 @@
 ## 2026-05-06 - Trade Evolution Held Item Equipped Support
 **Learning:** For Trade evolutions requiring a held item, the item could already be equipped on the Pokemon instead of being in the bag. The assistant was incorrectly suggesting to find the item if it was only equipped and not in the bag.
 **Action:** Modified `EVO_TRIGGER.TRADE` logic to search `evolvableInstances` and `ownedInstances` for the specific item and dynamically update the suggestion if the pre-evolution is already holding it.
+## 2024-05-22 - Suggestion Engine Held Evolution Items
+**Learning:** The suggestion engine previously only checked if a required evolution item (for `EVO_TRIGGER.TRADE` or `EVO_TRIGGER.USE_ITEM`) was in the player's bag or held by the specific pre-evolution being evaluated. If a non-target Pokémon was holding the required item, the assistant would incorrectly suggest finding a new one.
+**Action:** Updated the engine to scan `allInstances` (all Pokémon in party and PC) for the required item. If any Pokémon is holding the needed item, the assistant now correctly suggests taking the item from that Pokémon to evolve the target.

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -6,6 +6,79 @@ import type { AssistantApiData } from '../suggestionEngine';
 import { generateSuggestions } from '../suggestionEngine';
 
 describe('generateSuggestions', () => {
+  it('should generate suggestion to take held evolution item from another non-target Pokemon', () => {
+    const ownedSet = new Set(Array.from({ length: 251 }, (_, i) => i + 1));
+    ownedSet.delete(208); // Missing Steelix
+    const mockSaveData = {
+      generation: 2,
+      gameVersion: 'gold',
+      trainerName: 'ASH',
+      owned: ownedSet, // Owns Onix and Pidgey
+      party: [],
+      pc: [95, 16],
+      inventory: [{ id: 1, quantity: 5 }], // No Metal Coat (id: 0x8f) in bag
+      partyDetails: [],
+      pcDetails: [
+        {
+          speciesId: 95, // Onix
+          level: 20,
+          isShiny: false,
+          moves: [],
+          storageLocation: 'Box 1',
+          item: 0, // NOT holding Metal Coat
+          otName: 'ASH',
+        },
+        {
+          speciesId: 16, // Pidgey
+          level: 5,
+          isShiny: false,
+          moves: [],
+          storageLocation: 'Box 1',
+          item: 0x8f, // Holding Metal Coat!
+          otName: 'ASH',
+        },
+      ],
+    } as unknown as SaveData;
+
+    const mockApiData = {
+      pokemonMetadata: {
+        95: {
+          id: 95,
+          n: 'Onix',
+          cr: 45,
+          baby: false,
+          eto: [{ id: 208, eto: [], det: [{ tr: 2, held: 210 }], ef: 95 }],
+          efrm: [],
+          det: [],
+        },
+        208: {
+          id: 208,
+          n: 'Steelix',
+          cr: 25,
+          baby: false,
+          eto: [],
+          efrm: [95],
+          det: [{ tr: 2, held: 210 }],
+        },
+      },
+      missingEncounters: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const mockStrategy = {
+      ...gen1Strategy,
+      generation: 2,
+    };
+
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'gold', mockApiData, mockStrategy);
+    const suggestion = suggestions.find((s) => s.id === 'evo-trade-held-208');
+    expect(suggestion).toBeDefined();
+    expect(suggestion?.title).toBe('Ready to Trade Evolve: #208!');
+    expect(suggestion?.description).toBe(
+      'Take the Metal Coat from your other Pokémon, have your pre-evolution hold it, and trade to evolve!',
+    );
+  });
+
   it('should detect when an evolution item is already equipped for Trade evolutions', () => {
     const ownedSet = new Set(Array.from({ length: 251 }, (_, i) => i + 1));
     ownedSet.delete(208); // Missing Steelix
@@ -421,7 +494,7 @@ describe('generateSuggestions', () => {
     const mockSaveData: SaveData = {
       generation: 2,
       gameVersion: 'gold',
-      owned: new Set([133]), // Owns Eevee (133), missing Espeon (196)
+      owned: new Set([133, ...Array.from({ length: 195 }, (_, i) => i + 1)]), // Owns Eevee (133) and up to 195 so 196 is within first 100 missing
       seen: new Set(),
       party: [],
       inventory: [],

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -575,13 +575,23 @@ export function generateSuggestions(
         }
       } else if (tr === EVO_TRIGGER.USE_ITEM && item) {
         const gameItemId = getGameItemId(item, saveData.generation);
-        const hasStone = saveData.inventory.some((i) => i.id === gameItemId && i.quantity > 0);
+        const hasStoneInBag = saveData.inventory.some((i) => i.id === gameItemId && i.quantity > 0);
+        const holdingInstance = allInstances.find((inst) => inst.item === gameItemId);
+        const hasStone = hasStoneInBag || !!holdingInstance;
         const itemName = EVO_ITEM_NAMES[item] || 'item';
+
+        let description = `Find a ${itemName} to evolve it.`;
+        if (hasStoneInBag) {
+          description = `Use your ${itemName} to evolve it!`;
+        } else if (holdingInstance) {
+          description = `Take the ${itemName} from your Pokémon to evolve it!`;
+        }
+
         suggestions.push({
           id: `evo-item-${targetId}-${item}`,
           category: 'Evolve',
           title: hasStone ? `Ready to Evolve: #${targetId}!` : `Item Needed: #${targetId}`,
-          description: hasStone ? `Use your ${itemName} to evolve it!` : `Find a ${itemName} to evolve it.`,
+          description,
           pokemonId: targetId,
           priority: hasStone ? 95 : 40,
         });
@@ -589,17 +599,21 @@ export function generateSuggestions(
         if (held) {
           const gameHeldId = getGameItemId(held, saveData.generation);
           const hasHeldItemInBag = saveData.inventory.some((i) => i.id === gameHeldId && i.quantity > 0);
-          const holdingInstance =
+          const preEvoHoldingInstance =
             evolvableInstances.find((inst) => inst.item === gameHeldId) ||
             ownedInstances.find((inst) => inst.item === gameHeldId);
+          const otherHoldingInstance = allInstances.find((inst) => inst.item === gameHeldId);
+          const holdingInstance = preEvoHoldingInstance || otherHoldingInstance;
           const hasHeldItem = hasHeldItemInBag || !!holdingInstance;
           const itemName = EVO_ITEM_NAMES[held] || 'item';
 
           let description = `Find a ${itemName}, have your pre-evolution hold it, and trade to evolve.`;
-          if (holdingInstance) {
+          if (preEvoHoldingInstance) {
             description = `Your pre-evolution is already holding the ${itemName}! Trade it to evolve!`;
           } else if (hasHeldItemInBag) {
             description = `Have your pre-evolution hold the ${itemName} and trade it to evolve!`;
+          } else if (otherHoldingInstance) {
+            description = `Take the ${itemName} from your other Pokémon, have your pre-evolution hold it, and trade to evolve!`;
           }
 
           suggestions.push({


### PR DESCRIPTION
Updates the suggestion engine to check all physically owned Pokémon (`allInstances`) when verifying if the player possesses a required evolution item (for both `EVO_TRIGGER.TRADE` and `EVO_TRIGGER.USE_ITEM`).

Previously, if a non-target Pokémon was holding a required evolution item (like a Metal Coat or Water Stone) but it wasn't in the bag, the assistant would incorrectly suggest finding a new one. It now correctly suggests taking the item from the other Pokémon.

Adds a unit test to verify this behavior using a scenario where a Pidgey holds a Metal Coat needed to evolve Onix into Steelix.

---
*PR created automatically by Jules for task [2965629217674723196](https://jules.google.com/task/2965629217674723196) started by @szubster*