### PR TITLE
🧹 fix: remove unused CompactChainLink import

### DIFF
--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { AlertCircle, CheckCircle2, Monitor, Sparkles, X } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { dexDataLoader } from '../db/DexDataLoader';
-import { type CompactChainLink, POKE_VERSION_MAP, REVERSE_METHOD_MAP } from '../db/schema';
+import { POKE_VERSION_MAP, REVERSE_METHOD_MAP } from '../db/schema';
 import { stadiumRewardsSummary } from '../engine/data/shared/staticData';
 import type { SaveData } from '../engine/saveParser/index';
 import type { PokeballType } from '../store';
@@ -89,7 +89,7 @@ export function PokemonDetails({
     if (!evos || evos.length === 0) return [];
 
     return evos
-      .map((evo: CompactChainLink) => {
+      .map((evo) => {
         const id = evo.id;
         if (saveData && id > getGenerationConfig(saveData.generation).maxDex) return null;
 


### PR DESCRIPTION
🎯 **What**: Removed the unused `CompactChainLink` import from `src/components/PokemonDetails.tsx` and its corresponding type annotation.
💡 **Why**: Clean up dead code and resolve a linting issue as per code health requirements.
✅ **Verification**: Ran `pnpm type-check`, `pnpm lint`, and `pnpm test` with all checks passing successfully.
✨ **Result**: Codebase maintains health without altering functionality.

---
*PR created automatically by Jules for task [2331282913237393702](https://jules.google.com/task/2331282913237393702) started by @szubster*