### PR TITLE
📋 Epic Planner: Create Epic for Orchestrator Test Factories

### DIFF
--- a/.foundry/epics/epic-019-030-orchestrator-test-factories.md
+++ b/.foundry/epics/epic-019-030-orchestrator-test-factories.md
@@ -1,0 +1,50 @@
+---
+id: epic-019-030-orchestrator-test-factories
+type: EPIC
+title: Standardized Orchestrator Test Factories
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-09'
+updated_at: '2026-05-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-019-019-orchestrator-test-factories
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Standardized Orchestrator Test Factories
+
+## 1. Overview
+Implement a standardized test node factory utility in the DAG Orchestrator test suite to automatically populate valid frontmatter defaults. This utility will prevent test fixtures from breaking due to unrelated strict schema validations, such as Phase 4.8 Mapping Validation. It ensures that the test suite remains robust as the system's schema evolves.
+
+## 2. Requirements
+
+### 2.1 Test Node Factory Utility
+- Create a test utility function (e.g., `createValidNode(overrides)`) in `.github/scripts/foundry-orchestrator.test.ts` or an appropriate test utility file.
+- The utility must return a complete, valid node object passing all strict schema checks, particularly Phase 4.8 Mapping Validation.
+- Must dynamically map `type` to a valid `owner_persona`:
+  - `IDEA` -> `product_manager`
+  - `PRD` -> `epic_planner`
+  - `EPIC` -> `story_owner`
+  - `STORY` -> `tech_lead`
+  - `TASK` -> `coder` or `qa`
+  - `ADR` -> `architect`
+- Must allow overriding any default field with custom values provided by the test via an `overrides` parameter.
+
+### 2.2 Test Refactoring
+- Systematically refactor existing test fixtures in `.github/scripts/foundry-orchestrator.test.ts` to utilize the new factory utility instead of hardcoded mock objects.
+
+### 2.3 Non-Functional Requirements
+- Ensure changes are isolated to the test suite, without altering actual orchestrator logic or production schema validations.
+- Verify that the CI pipeline (`pnpm test` in `.github/scripts`) passes successfully after refactoring.
+
+## 3. High-Level Acceptance Criteria
+- [ ] Test factory utility function is successfully implemented and accessible for tests.
+- [ ] Factory utility correctly assigns default frontmatter properties (e.g., valid `owner_persona` mapping based on node `type`).
+- [ ] Existing mock node configurations in `.github/scripts/foundry-orchestrator.test.ts` are entirely refactored to use the factory.
+- [ ] The full test suite runs and passes without schema validation warnings or errors on mock nodes.

--- a/.foundry/prds/prd-019-019-orchestrator-test-factories.md
+++ b/.foundry/prds/prd-019-019-orchestrator-test-factories.md
@@ -55,3 +55,6 @@ These failures cause CI delays and force developers to constantly update test fi
 1. **Define the Factory:** Create the factory function, defining a baseline valid node and merging it with the provided overrides. Ensure the logic correctly assigns `owner_persona` based on the (potentially overridden) `type`.
 2. **Refactor Tests:** Systematically replace inline mock node definitions in `.github/scripts/foundry-orchestrator.test.ts` with calls to the new factory.
 3. **Verify:** Run the test suite (`pnpm test`) to ensure no regressions and that the factory correctly supports the required test scenarios.
+
+## Derived Epics
+- .foundry/epics/epic-019-030-orchestrator-test-factories.md


### PR DESCRIPTION
Creates the Epic node for the Standardized Orchestrator Test Factories PRD. Assures downstream transition to `story_owner` without introducing circular dependencies. Appends the reference in the parent PRD cleanly.

---
*PR created automatically by Jules for task [15372542540874355486](https://jules.google.com/task/15372542540874355486) started by @szubster*