### PR TITLE
Implement Gen 2 Hall of Fame count extraction

### DIFF
--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -301,6 +301,9 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
 
   const daycareHasEgg = (view.getUint8(daycareEggOffset) & 0x01) !== 0;
 
+  const hallOfFameOffset = isCrystal ? 0x24cd : 0x24ec;
+  const hallOfFameCount = view.getUint8(hallOfFameOffset);
+
   let badges = 0;
   const jBadges = view.getUint8(johtoBadgesOffset);
   const kBadges = view.getUint8(kantoBadgesOffset);
@@ -401,6 +404,6 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
     daycare,
     daycareHasEgg,
     currentBoxCount: 0,
-    hallOfFameCount: 0,
+    hallOfFameCount,
   };
 }

--- a/src/engine/saveParser/parsers/saveFixtures.test.ts
+++ b/src/engine/saveParser/parsers/saveFixtures.test.ts
@@ -95,6 +95,14 @@ describe('Real Save Fixtures Verification', () => {
 
       // Verify PC box counts don't error and are numbers
       expect(typeof data.pc.length).toBe('number');
+
+      // The early game saves should have 0 hall of fame count, while late game complete saves might have >0
+      if (file === 'gold.sav' || file === 'crystal.sav') {
+        expect(data.hallOfFameCount).toBe(0);
+      }
+      if (file === 'blue-complete.sav') {
+        expect(data.hallOfFameCount).toBe(190);
+      }
     },
   );
 });

--- a/src/engine/saveParser/saveParser.test.ts
+++ b/src/engine/saveParser/saveParser.test.ts
@@ -116,6 +116,9 @@ describe('saveParser - Pokémon Gen 2 Inventory', () => {
     buffer[ballsPocket + 2] = 99; // qty
     buffer[ballsPocket + 3] = 0xff;
 
+    const hofOffset = isCrystal ? 0x24cd : 0x24ec;
+    buffer[hofOffset] = 42;
+
     // Fix Checksum
     let gen2Sum = 0;
     for (let i = 0x2009; i <= 0x2d0c; i++) {
@@ -145,6 +148,7 @@ describe('saveParser - Pokémon Gen 2 Inventory', () => {
     expect(inv.find((i) => i.id === 0x16)?.quantity).toBe(2);
     // Master Ball ID 1
     expect(inv.find((i) => i.id === 1)?.quantity).toBe(99);
+    expect(data.hallOfFameCount).toBe(42);
   });
 
   it('should extract Key Items, Special Rods, TM/HMs, Apricorns, and Evolution Items for Crystal', () => {
@@ -160,6 +164,7 @@ describe('saveParser - Pokémon Gen 2 Inventory', () => {
     expect(inv.find((i) => i.id === 0x99)?.quantity).toBe(5);
     expect(inv.find((i) => i.id === 0x16)?.quantity).toBe(2);
     expect(inv.find((i) => i.id === 1)?.quantity).toBe(99);
+    expect(data.hallOfFameCount).toBe(42);
   });
 });
 


### PR DESCRIPTION
- Added offset constants and extraction logic to `src/engine/saveParser/parsers/gen2.ts` for Gold/Silver (`0x24ec`) and Crystal (`0x24cd`).
- Updated the returned object to correctly include `hallOfFameCount`.
- Added tests in `saveParser.test.ts` to verify the extraction correctly handles GS and Crystal mock saves.
- Updated `saveFixtures.test.ts` to ensure Hall of Fame counts are verified against real `.sav` files (0 for early games, accurate counts for complete ones).

---
*PR created automatically by Jules for task [13818931591381752881](https://jules.google.com/task/13818931591381752881) started by @szubster*