### PR TITLE
Foundry: Draft validation failure handling tasks

### DIFF
--- a/.foundry/stories/story-025-039-implement-failure-handling.md
+++ b/.foundry/stories/story-025-039-implement-failure-handling.md
@@ -33,4 +33,6 @@ Handle the state transition when an invalid `owner_persona` mapping is detected.
 - [ ] A warning/error is logged.
 
 ## Next Step
-- [ ] Create Task to add failure handling logic.
+- [x] Create Task to add failure handling logic.
+- Spawned Blueprint: [.foundry/tasks/task-039-071-implement-failure-handling.md](.foundry/tasks/task-039-071-implement-failure-handling.md)
+- Spawned QA: [.foundry/tasks/task-039-072-qa-failure-handling.md](.foundry/tasks/task-039-072-qa-failure-handling.md)

--- a/.foundry/tasks/task-039-071-implement-failure-handling.md
+++ b/.foundry/tasks/task-039-071-implement-failure-handling.md
@@ -1,0 +1,37 @@
+---
+id: task-039-071-implement-failure-handling
+type: TASK
+title: "Implement Failure Handling for Validation Mismatches"
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-09'
+updated_at: '2026-05-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-025-039-implement-failure-handling
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - validation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Failure Handling for Validation Mismatches
+
+## Overview
+Handle the state transition when an invalid `owner_persona` mapping is detected in `foundry-orchestrator.ts`.
+
+## Context
+When `.github/scripts/foundry-orchestrator.ts` detects an invalid `owner_persona` mapping during Phase 4.8, it currently transitions the node to `BLOCKED` with `owner_persona: tpm`. The acceptance criteria dictate that we should mark the node as `FAILED` instead, and provide a `rejection_reason` explaining the failure, so that the Resurrection Loop can retry or surface it differently.
+
+## Acceptance Criteria
+- [ ] Nodes with invalid mapping are transitioned to `FAILED`.
+- [ ] A descriptive `rejection_reason` is set (e.g. "Invalid owner_persona mapping").
+- [ ] The `owner_persona` should not be overridden to `tpm` for this specific failure path.
+- [ ] A warning/error is logged (the existing `warn()` call should be kept).
+- [ ] The tests in `foundry-orchestrator.test.ts` regarding mapping validation should be updated to reflect this new behaviour (expecting `FAILED` instead of `BLOCKED` and `tpm` persona).

--- a/.foundry/tasks/task-039-072-qa-failure-handling.md
+++ b/.foundry/tasks/task-039-072-qa-failure-handling.md
@@ -1,0 +1,34 @@
+---
+id: task-039-072-qa-failure-handling
+type: TASK
+title: "QA: Implement Failure Handling for Validation Mismatches"
+status: PENDING
+owner_persona: qa
+created_at: '2026-05-09'
+updated_at: '2026-05-09'
+depends_on:
+  - .foundry/tasks/task-039-071-implement-failure-handling.md
+jules_session_id: null
+pr_number: null
+parent: story-025-039-implement-failure-handling
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - validation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Verification: Implement Failure Handling for Validation Mismatches
+
+## Overview
+Verify the implementation of `task-039-071-implement-failure-handling`.
+
+## Acceptance Criteria
+- [ ] Nodes with invalid mapping are transitioned to `FAILED`.
+- [ ] A descriptive `rejection_reason` is set.
+- [ ] A warning/error is logged.
+- [ ] Ensure that `foundry-orchestrator.test.ts` passes and the test logic for mapping validation correctly reflects the new requirement (`FAILED` state and rejection reason).


### PR DESCRIPTION
Transforms the product story `story-025-039-implement-failure-handling.md` into concrete `TASK` nodes for the `coder` and `qa` personas, specifically dealing with the changes in mapping validation failure behaviour (`FAILED` state and rejection reason vs `BLOCKED` with TPM). 

Changes include:
- Generating `task-039-071-implement-failure-handling` for the `coder`.
- Generating `task-039-072-qa-failure-handling` for the `qa` persona based on the Intelligent Verification Protocol.
- Updating the markdown body of the parent story to check off the ACs and link the new blueprints without mutating frontmatter.

---
*PR created automatically by Jules for task [3435582296774258552](https://jules.google.com/task/3435582296774258552) started by @szubster*