### PR TITLE
🧪 Testing: Add RangeError handling test for decodeGen12String

### DIFF
--- a/src/engine/saveParser/parsers/common.test.ts
+++ b/src/engine/saveParser/parsers/common.test.ts
@@ -114,6 +114,15 @@ describe('common parsers', () => {
       expect(decodeGen12String(view, 0, -1)).toBe('');
     });
 
+    test('catches explicit RangeError and stops decoding', () => {
+      const buffer = new ArrayBuffer(4);
+      const view = new DataView(buffer);
+      vi.spyOn(view, 'getUint8').mockImplementation(() => {
+        throw new RangeError('Out of bounds');
+      });
+      expect(decodeGen12String(view, 0)).toBe('');
+    });
+
     test('rethrows non-RangeError exceptions', () => {
       const buffer = new ArrayBuffer(4);
       const view = new DataView(buffer);


### PR DESCRIPTION
🎯 **What:** Adds a test to cover the `catch` block for `RangeError` inside `decodeGen12String`.
📊 **Coverage:** The test explicitly covers the scenario where `DataView.prototype.getUint8` throws a `RangeError`, verifying that the function breaks the loop and returns the parsed string so far (or an empty string if caught on the first read) instead of crashing.
✨ **Result:** Improved test coverage and explicit guarantees for the error-handling behavior of legacy string decoding.

---
*PR created automatically by Jules for task [909297769238621459](https://jules.google.com/task/909297769238621459) started by @szubster*