### PR TITLE
feat: create story for standardizing orchestrator test factories

### DIFF
--- a/.foundry/stories/story-030-046-standardize-orchestrator-test-factories.md
+++ b/.foundry/stories/story-030-046-standardize-orchestrator-test-factories.md
@@ -1,15 +1,15 @@
 ---
-id: epic-019-030-orchestrator-test-factories
-type: EPIC
-title: Standardized Orchestrator Test Factories
-status: READY
-owner_persona: story_owner
+id: story-030-046-standardize-orchestrator-test-factories
+type: STORY
+title: Standardize Orchestrator Test Factories
+status: PENDING
+owner_persona: tech_lead
 created_at: '2026-05-09'
 updated_at: '2026-05-09'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: prd-019-019-orchestrator-test-factories
+parent: epic-019-030-orchestrator-test-factories
 tags: []
 research_references: []
 rejection_count: 0
@@ -17,7 +17,7 @@ rejection_reason: ''
 notes: ''
 ---
 
-# Epic: Standardized Orchestrator Test Factories
+# Story: Standardize Orchestrator Test Factories
 
 ## 1. Overview
 Implement a standardized test node factory utility in the DAG Orchestrator test suite to automatically populate valid frontmatter defaults. This utility will prevent test fixtures from breaking due to unrelated strict schema validations, such as Phase 4.8 Mapping Validation. It ensures that the test suite remains robust as the system's schema evolves.
@@ -49,6 +49,6 @@ Implement a standardized test node factory utility in the DAG Orchestrator test 
 - [ ] Existing mock node configurations in `.github/scripts/foundry-orchestrator.test.ts` are entirely refactored to use the factory.
 - [ ] The full test suite runs and passes without schema validation warnings or errors on mock nodes.
 
-
-### Child Nodes
-- Spawned: [.foundry/stories/story-030-046-standardize-orchestrator-test-factories.md](.foundry/stories/story-030-046-standardize-orchestrator-test-factories.md)
+## 4. Tasks to Spawn
+1. Implement the node factory utility logic.
+2. Refactor existing test fixtures to use the new factory.


### PR DESCRIPTION
This PR fulfills the Story Owner persona responsibility by late-binding a new `STORY` node from the approved `EPIC` for test node factories. It creates the story markdown file following the schema, correctly links the ID in the parent field, and updates the parent epic's markdown body.

---
*PR created automatically by Jules for task [4381688714712914960](https://jules.google.com/task/4381688714712914960) started by @szubster*