### PR TITLE
chore(personas): enforce memory generation in agent schedules

### DIFF
--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -28,3 +28,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 - If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 - WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
+
+## Journal
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/agile_coach.md` or `.jules/agile_coach.md`).

--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -31,4 +31,4 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 ## Journal
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/agile_coach.md` or `.jules/agile_coach.md`).
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/agile_coach.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -30,3 +30,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Environment Troubleshooting
 If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
 If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
+
+## Journal
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/architect.md` or `.jules/architect.md`).

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -33,4 +33,4 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 
 ## Journal
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/architect.md` or `.jules/architect.md`).
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/architect.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -31,4 +31,4 @@ When modifying central systems like the DAG Orchestrator (`.github/scripts/found
 
 ## Journal
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/coder.md` or `.jules/coder.md`).
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/coder.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -28,3 +28,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 Before marking a task as COMPLETED, you MUST run `pnpm lint && pnpm test` to ensure project health and that no regressions are introduced.
 To automatically fix code formatting errors flagged by Biome during lint checks, run `pnpm check:fix` or `pnpm format:biome`.
 When modifying central systems like the DAG Orchestrator (`.github/scripts/foundry-orchestrator.ts`), you MUST also explicitly run its test suite (`cd .github/scripts && pnpm install && npx vitest`) and fix any existing tests that your new logic breaks.
+
+## Journal
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/coder.md` or `.jules/coder.md`).

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -31,3 +31,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Environment Troubleshooting
 If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
 If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
+
+## Journal
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/epic_planner.md` or `.jules/epic_planner.md`).

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -34,4 +34,4 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 
 ## Journal
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/epic_planner.md` or `.jules/epic_planner.md`).
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/epic_planner.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -27,3 +27,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Environment Troubleshooting
 If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
 If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
+
+## Journal
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/product_manager.md` or `.jules/product_manager.md`).

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -30,4 +30,4 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 
 ## Journal
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/product_manager.md` or `.jules/product_manager.md`).
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/product_manager.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -40,4 +40,4 @@ When verifying orchestrator logic tasks, ensure you explicitly run the specific 
 
 ## Journal
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/qa.md` or `.jules/qa.md`).
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/qa.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -37,3 +37,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 Before approving a task, you MUST run `pnpm lint && pnpm test` to ensure project health and verify that no regressions are introduced by the implementer.
 To automatically fix code formatting errors flagged by Biome during lint checks, run `pnpm check:fix` or `pnpm format:biome`.
 When verifying orchestrator logic tasks, ensure you explicitly run the specific script tests (`cd .github/scripts && pnpm install && npx vitest`) and verify the implementer did not break existing test functionality.
+
+## Journal
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/qa.md` or `.jules/qa.md`).

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -32,3 +32,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Environment Troubleshooting
 If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
 If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
+
+## Journal
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/story_owner.md` or `.jules/story_owner.md`).

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -35,4 +35,4 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 
 ## Journal
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/story_owner.md` or `.jules/story_owner.md`).
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/story_owner.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -43,4 +43,4 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 
 ## Journal
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/tech_lead.md` or `.jules/tech_lead.md`).
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/tech_lead.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -40,3 +40,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Environment Troubleshooting
 If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
 If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
+
+## Journal
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/tech_lead.md` or `.jules/tech_lead.md`).

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -32,3 +32,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Environment Troubleshooting
 If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
 If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
+
+## Journal
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/tpm.md` or `.jules/tpm.md`).

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -35,4 +35,4 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 
 ## Journal
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your corresponding journal file (e.g., `.foundry/journals/tpm.md` or `.jules/tpm.md`).
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/tpm.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.jules/schedules/archivist.md
+++ b/.jules/schedules/archivist.md
@@ -54,6 +54,8 @@ The following knowledge stores are in scope:
 Read `.jules/archivist.md` before starting (create if missing).
 Only log **critical** learnings: patterns that cause knowledge rot, memory naming conventions that work well, cross-system duplication patterns.
 
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+
 ---
 
 If no stale or problematic knowledge can be identified, do not create a PR.

--- a/.jules/schedules/archivist.md
+++ b/.jules/schedules/archivist.md
@@ -54,7 +54,7 @@ The following knowledge stores are in scope:
 Read `.jules/archivist.md` before starting (create if missing).
 Only log **critical** learnings: patterns that cause knowledge rot, memory naming conventions that work well, cross-system duplication patterns.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/archivist.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ---
 

--- a/.jules/schedules/bolt.md
+++ b/.jules/schedules/bolt.md
@@ -43,6 +43,8 @@ Identify and implement ONE small performance improvement that makes the applicat
 Read `.jules/bolt.md` before starting (create if missing).
 Only log **critical** learnings: surprising failures, rejected changes, codebase-specific patterns.
 
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+
 ---
 
 If no clear performance win can be identified, do not create a PR.

--- a/.jules/schedules/bolt.md
+++ b/.jules/schedules/bolt.md
@@ -43,7 +43,7 @@ Identify and implement ONE small performance improvement that makes the applicat
 Read `.jules/bolt.md` before starting (create if missing).
 Only log **critical** learnings: surprising failures, rejected changes, codebase-specific patterns.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/bolt.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ---
 

--- a/.jules/schedules/canvas.md
+++ b/.jules/schedules/canvas.md
@@ -51,7 +51,7 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 File: `.jules/canvas.md` (create if missing).
 
-This is your **only memory**. Read it first. Update it in every PR.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/canvas.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 Entry format:
 ```

--- a/.jules/schedules/infras.md
+++ b/.jules/schedules/infras.md
@@ -40,7 +40,7 @@ Identify and implement ONE improvement to the development tooling, build pipelin
 Read `.jules/infras.md` before starting (create if missing).
 Only log **critical** learnings: tool integration gotchas, rejected tooling decisions, CI-specific constraints.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/infras.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ---
 

--- a/.jules/schedules/infras.md
+++ b/.jules/schedules/infras.md
@@ -40,6 +40,8 @@ Identify and implement ONE improvement to the development tooling, build pipelin
 Read `.jules/infras.md` before starting (create if missing).
 Only log **critical** learnings: tool integration gotchas, rejected tooling decisions, CI-specific constraints.
 
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+
 ---
 
 If no clear tooling improvement can be identified, do not create a PR.

--- a/.jules/schedules/mason.md
+++ b/.jules/schedules/mason.md
@@ -39,4 +39,4 @@ Identify and implement ONE React refactoring opportunity by extracting a reusabl
 Read `.jules/mason.md` before starting (create if missing).
 Log critical learnings: recurring patterns, extraction challenges, or reusable logic wins.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/mason.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.jules/schedules/mason.md
+++ b/.jules/schedules/mason.md
@@ -38,3 +38,5 @@ Identify and implement ONE React refactoring opportunity by extracting a reusabl
 
 Read `.jules/mason.md` before starting (create if missing).
 Log critical learnings: recurring patterns, extraction challenges, or reusable logic wins.
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.

--- a/.jules/schedules/nurse.md
+++ b/.jules/schedules/nurse.md
@@ -42,6 +42,8 @@ Find and fix ONE type-safety issue in the codebase. Tighten types, eliminate uns
 Read `.jules/nurse.md` before starting (create if missing).
 Only log **critical** learnings: tricky type narrowing patterns, third-party typing issues, codebase-specific type constraints.
 
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+
 ---
 
 If no meaningful type-safety issue can be identified, do not create a PR.

--- a/.jules/schedules/nurse.md
+++ b/.jules/schedules/nurse.md
@@ -42,7 +42,7 @@ Find and fix ONE type-safety issue in the codebase. Tighten types, eliminate uns
 Read `.jules/nurse.md` before starting (create if missing).
 Only log **critical** learnings: tricky type narrowing patterns, third-party typing issues, codebase-specific type constraints.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/nurse.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ---
 

--- a/.jules/schedules/oak.md
+++ b/.jules/schedules/oak.md
@@ -49,7 +49,7 @@ All Pokémon data is pre-generated at build time and committed to the repo. The 
 Read `.jules/oak.md` before starting (create if missing).
 Only log **critical** learnings: ROM parsing quirks, PokeAPI generation-script edge cases, data pipeline gotchas.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/oak.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ---
 

--- a/.jules/schedules/oak.md
+++ b/.jules/schedules/oak.md
@@ -49,6 +49,8 @@ All Pokémon data is pre-generated at build time and committed to the repo. The 
 Read `.jules/oak.md` before starting (create if missing).
 Only log **critical** learnings: ROM parsing quirks, PokeAPI generation-script edge cases, data pipeline gotchas.
 
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+
 ---
 
 If no data discrepancy can be identified, do not create a PR.

--- a/.jules/schedules/palette.md
+++ b/.jules/schedules/palette.md
@@ -42,6 +42,8 @@ Find and implement ONE micro-UX improvement that makes the interface more intuit
 Read `.jules/palette.md` before starting (create if missing).
 Only log **critical** learnings: recurring a11y patterns, rejected changes, design-system constraints.
 
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+
 ---
 
 If no clear UX win can be identified, do not create a PR.

--- a/.jules/schedules/palette.md
+++ b/.jules/schedules/palette.md
@@ -42,7 +42,7 @@ Find and implement ONE micro-UX improvement that makes the interface more intuit
 Read `.jules/palette.md` before starting (create if missing).
 Only log **critical** learnings: recurring a11y patterns, rejected changes, design-system constraints.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/palette.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ---
 

--- a/.jules/schedules/scribe.md
+++ b/.jules/schedules/scribe.md
@@ -41,7 +41,7 @@ Pick ONE module and improve its documentation — JSDoc on exported APIs, inline
 Read `.jules/scribe.md` before starting (create if missing).
 Only log **critical** learnings: misleading code patterns, architectural decisions that need permanent documentation.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/scribe.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ---
 

--- a/.jules/schedules/scribe.md
+++ b/.jules/schedules/scribe.md
@@ -41,6 +41,8 @@ Pick ONE module and improve its documentation — JSDoc on exported APIs, inline
 Read `.jules/scribe.md` before starting (create if missing).
 Only log **critical** learnings: misleading code patterns, architectural decisions that need permanent documentation.
 
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+
 ---
 
 If no meaningful documentation gap can be identified, do not create a PR.

--- a/.jules/schedules/sentinel.md
+++ b/.jules/schedules/sentinel.md
@@ -47,7 +47,7 @@ Identify ONE under-tested file or user journey and add focused tests to improve 
 Read `.jules/sentinel.md` before starting (create if missing).
 Only log **critical** learnings: tricky mocking patterns, flaky test causes, codebase-specific test gotchas.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/sentinel.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ---
 

--- a/.jules/schedules/sentinel.md
+++ b/.jules/schedules/sentinel.md
@@ -47,6 +47,8 @@ Identify ONE under-tested file or user journey and add focused tests to improve 
 Read `.jules/sentinel.md` before starting (create if missing).
 Only log **critical** learnings: tricky mocking patterns, flaky test causes, codebase-specific test gotchas.
 
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+
 ---
 
 If no meaningful coverage gap can be identified, do not create a PR.

--- a/.jules/schedules/shield.md
+++ b/.jules/schedules/shield.md
@@ -56,4 +56,4 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 Read `.jules/shield.md` before starting (create if missing).
 Only log **critical** learnings: recurring vulnerability patterns or complex security rationales.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/shield.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.jules/schedules/shield.md
+++ b/.jules/schedules/shield.md
@@ -55,3 +55,5 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 
 Read `.jules/shield.md` before starting (create if missing).
 Only log **critical** learnings: recurring vulnerability patterns or complex security rationales.
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.

--- a/.jules/schedules/strategist.md
+++ b/.jules/schedules/strategist.md
@@ -61,7 +61,7 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 File: `.jules/strategist.md` (create if missing).
 
-This is your **only memory**. Read it first. Update it in every PR.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/strategist.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 Entry format:
 ```

--- a/.jules/schedules/sweeper.md
+++ b/.jules/schedules/sweeper.md
@@ -38,4 +38,4 @@ Identify and resolve ONE piece of technical debt, dead code, or messy refactorin
 Read `.jules/sweeper.md` before starting (create if missing).
 Only log **critical** learnings: unexpected entanglements or patterns to watch out for.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/sweeper.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.jules/schedules/sweeper.md
+++ b/.jules/schedules/sweeper.md
@@ -37,3 +37,5 @@ Identify and resolve ONE piece of technical debt, dead code, or messy refactorin
 
 Read `.jules/sweeper.md` before starting (create if missing).
 Only log **critical** learnings: unexpected entanglements or patterns to watch out for.
+
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.

--- a/.jules/schedules/trainer.md
+++ b/.jules/schedules/trainer.md
@@ -41,7 +41,7 @@ Identify and implement ONE improvement to the assistant — the core feature tha
 Read `.jules/trainer.md` before starting (create if missing).
 Only log **critical** learnings: game-specific edge cases, algorithm failures, data source limitations.
 
-This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/trainer.md`). If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ---
 

--- a/.jules/schedules/trainer.md
+++ b/.jules/schedules/trainer.md
@@ -41,6 +41,8 @@ Identify and implement ONE improvement to the assistant — the core feature tha
 Read `.jules/trainer.md` before starting (create if missing).
 Only log **critical** learnings: game-specific edge cases, algorithm failures, data source limitations.
 
+This is your **only memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating this file.
+
 ---
 
 If no clear assistant improvement can be identified, do not create a PR.


### PR DESCRIPTION
Updates the agent schedule prompts (`.jules/schedules/*.md`) to explicitly instruct personas that their journal is their ONLY memory and that they MUST generate a memory by updating it when encountering something worth remembering. This addresses the issue of journals being created but memories not being recorded.

---
*PR created automatically by Jules for task [15323395403554398353](https://jules.google.com/task/15323395403554398353) started by @szubster*