### PR TITLE
🧹 [code health improvement] src/components/PokemonDetails.tsx

### DIFF
--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { AlertCircle, CheckCircle2, Monitor, Sparkles, X } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { dexDataLoader } from '../db/DexDataLoader';
-import { type CompactChainLink, POKE_VERSION_MAP, REVERSE_METHOD_MAP } from '../db/schema';
+import { POKE_VERSION_MAP, REVERSE_METHOD_MAP } from '../db/schema';
 import { stadiumRewardsSummary } from '../engine/data/shared/staticData';
 import type { SaveData } from '../engine/saveParser/index';
 import type { PokeballType } from '../store';
@@ -89,7 +89,7 @@ export function PokemonDetails({
     if (!evos || evos.length === 0) return [];
 
     return evos
-      .map((evo: CompactChainLink) => {
+      .map((evo) => {
         const id = evo.id;
         if (saveData && id > getGenerationConfig(saveData.generation).maxDex) return null;
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `CompactChainLink` import from `src/components/PokemonDetails.tsx` and updated the `map` callback to rely on TypeScript's inference.

💡 **Why:** Explicitly importing and typing a map callback when inference works perfectly adds visual clutter and can trigger unused import warnings in certain strict tooling setups. Removing it improves file maintainability and readability without sacrificing type safety.

✅ **Verification:** 
- Ran `pnpm type-check`, `pnpm lint`, and `pnpm test` locally to ensure no typings were broken and no regressions occurred. 
- Playwright end-to-end tests completed without errors.
- Verified through local code review that the correct changes were safely applied.

✨ **Result:** Cleaner, strictly-typed code leveraging built-in inference, with the unused import successfully removed.

---
*PR created automatically by Jules for task [491547628140648408](https://jules.google.com/task/491547628140648408) started by @szubster*