### PR TITLE
chore: make agent personas fully autonomous

### DIFF
--- a/.jules/schedules/archivist.md
+++ b/.jules/schedules/archivist.md
@@ -32,8 +32,7 @@ The following knowledge stores are in scope:
 - Keep one PR focused on one type of cleanup (e.g., "merge duplicate journals" or "remove stale migration memories")
 
 **Ask first:**
-- Deleting a memory that might still be partially relevant
-- Restructuring the topic hierarchy of `.serena/memories/`
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Modify `.jules/schedules/` — those are maintained manually

--- a/.jules/schedules/bolt.md
+++ b/.jules/schedules/bolt.md
@@ -20,8 +20,7 @@ Identify and implement ONE small performance improvement that makes the applicat
 - Keep changes under 50 lines
 
 **Ask first:**
-- Adding or swapping dependencies
-- Architectural changes
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Modify `package.json` or `tsconfig.json` without instruction

--- a/.jules/schedules/infras.md
+++ b/.jules/schedules/infras.md
@@ -19,8 +19,7 @@ Identify and implement ONE improvement to the development tooling, build pipelin
 - Keep changes focused — one tool or config change at a time
 
 **Ask first:**
-- Swapping a core tool (bundler, test runner, linter)
-- Adding a SaaS dependency
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Duplicate existing tooling — choose the best, replace if needed

--- a/.jules/schedules/mason.md
+++ b/.jules/schedules/mason.md
@@ -19,8 +19,7 @@ Identify and implement ONE React refactoring opportunity by extracting a reusabl
 - Verify that changes do not break any existing functionality.
 
 **Ask first:**
-- Introducing new UI libraries or dependencies.
-- Large-scale refactors that affect core application logic.
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Change the visual design or UX of the application.

--- a/.jules/schedules/nurse.md
+++ b/.jules/schedules/nurse.md
@@ -20,8 +20,7 @@ Find and fix ONE type-safety issue in the codebase. Tighten types, eliminate uns
 - Keep changes under 50 lines and focused on one type issue
 
 **Ask first:**
-- Changes that require refactoring multiple consumers
-- Introducing new generic type patterns
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Add `any` or `@ts-ignore` — you're here to remove them

--- a/.jules/schedules/oak.md
+++ b/.jules/schedules/oak.md
@@ -26,8 +26,7 @@ All Pokémon data is pre-generated at build time and committed to the repo. The 
 - Add or update unit tests to lock in the corrected data
 
 **Ask first:**
-- Changes to the data generation pipeline structure
-- Adding new canonical data sources
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Add runtime PokeAPI calls — the app must work fully offline

--- a/.jules/schedules/palette.md
+++ b/.jules/schedules/palette.md
@@ -20,8 +20,7 @@ Find and implement ONE micro-UX improvement that makes the interface more intuit
 - Keep changes under 50 lines
 
 **Ask first:**
-- Changes that affect multiple pages or layout
-- New design tokens or colors
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Complete page redesigns

--- a/.jules/schedules/scribe.md
+++ b/.jules/schedules/scribe.md
@@ -19,8 +19,7 @@ Pick ONE module and improve its documentation — JSDoc on exported APIs, inline
 - Keep explanations concise — document *why*, not *what* (the code says what)
 
 **Ask first:**
-- Creating new top-level documentation files
-- Documenting patterns that might change soon
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Modify application logic — documentation and comments only

--- a/.jules/schedules/sentinel.md
+++ b/.jules/schedules/sentinel.md
@@ -25,8 +25,7 @@ Identify ONE under-tested file or user journey and add focused tests to improve 
 - Keep each PR focused on one file or one user journey
 
 **Ask first:**
-- Adding new test dependencies or helpers
-- Changing existing test infrastructure
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Modify application source code — tests only

--- a/.jules/schedules/shield.md
+++ b/.jules/schedules/shield.md
@@ -36,8 +36,7 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 - If testing is too complex, provide a detailed rationale in the PR description.
 
 **Ask first:**
-- Upgrading or changing authentication mechanisms.
-- Modifying broad data storage encryption patterns.
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Ignore CWE-209 guidelines; always redact raw error objects in logs.

--- a/.jules/schedules/sweeper.md
+++ b/.jules/schedules/sweeper.md
@@ -17,8 +17,7 @@ Identify and resolve ONE piece of technical debt, dead code, or messy refactorin
 - When using `knip` or similar tools, be extremely careful about files/dependencies implicitly required by tests or CI (like `test-setup.ts` or `fake-indexeddb`). Always verify potential unused exports by doing a global repository search (`grep`) to ensure they aren't dynamically referenced before removing them.
 
 **Ask first:**
-- Refactoring core data parsing logic
-- Changing application architecture
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Add new features

--- a/.jules/schedules/trainer.md
+++ b/.jules/schedules/trainer.md
@@ -19,8 +19,7 @@ Identify and implement ONE improvement to the assistant — the core feature tha
 - Keep changes focused — one algorithm or UI improvement at a time
 
 **Ask first:**
-- Changes to the recommendation algorithm's core strategy
-- New data sources beyond save files and the committed `data/` directory
+- Nothing — just submit the PR. Rejection is expected and acceptable.
 
 **Never:**
 - Make runtime calls to PokeAPI — the app must work fully offline


### PR DESCRIPTION
Replaced the specific criteria under the `**Ask first:**` heading in all `.jules/schedules/*.md` files with a blanket instruction explicitly telling personas to never ask for permission and to expect that their PRs might be rejected. This completely removes the manual bottleneck for agent execution, maximizing their autonomy.

---
*PR created automatically by Jules for task [2853336233308398099](https://jules.google.com/task/2853336233308398099) started by @szubster*