### PR TITLE
feat(foundry): add support for RESEARCH node type and researcher persona

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -61,7 +61,7 @@ Every node file (idea, PRD, epic, story, task) **must** begin with a YAML frontm
 ```yaml
 ---
 id: ""                  # Required. Globally unique slug. Convention: <type>-<parent_NNN>-<NNN>-<slug>
-type: ""                # Required. Enum: IDEA | PRD | EPIC | STORY | TASK
+type: ""                # Required. Enum: IDEA | PRD | EPIC | STORY | TASK | RESEARCH
 title: ""               # Required. Human-readable short title.
 status: ""              # Required. Enum: see Status Lifecycle section.
 owner_persona: "coder"  # Required. Enum: see Owner Persona section.
@@ -84,7 +84,7 @@ notes: ""               # Optional. Free-form Markdown remarks.
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `id` | `string` | ✅ | Globally unique. Convention: `<type>-<parent_NNN>-<NNN>-<slug>` (IDEA nodes omit parent NNN). Used by humans and search; the DAG uses file paths. |
-| `type` | `enum` | ✅ | `IDEA \| PRD \| EPIC \| STORY \| TASK` |
+| `type` | `enum` | ✅ | `IDEA \| PRD \| EPIC \| STORY \| TASK \| RESEARCH` |
 | `title` | `string` | ✅ | Short, human-readable description. |
 | `status` | `enum` | ✅ | Current lifecycle state. See §4. |
 | `owner_persona` | `enum` | ✅ | Persona responsible for progressing this node. Must be exactly one assigned persona (no arrays or multiple personas). See §5. |
@@ -156,7 +156,7 @@ No persona should ever manually set `status: READY`. The orchestrator calculates
 | `human` | A human contributor. Bypasses Jules dispatch and heartbeat timeouts. |
 | `tpm` | Runs hourly. Archives `COMPLETED` nodes, resolves minor graph deadlocks, manages journals. |
 | `agile_coach` | Master of the Process. Evolves persona prompts, monitors learning logs, and optimizes system-wide workflows. |
-| `researcher` | Responsible for exploratory tasks and writing context-rich research reports to be used by downstream pipeline nodes. |
+| `researcher` | Responsible for exploratory tasks. Late-bound research nodes can be dynamically created by active nodes. Multiple researchers can be assigned to different sibling research nodes. |
 
 ---
 

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -19,7 +19,7 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 
 
 **NODE CREATION GUIDELINES:**
-While the system does not strictly block node creation, you should typically create the following node types: `TASK`, `ADR`, and `IDEA`. Please follow this convention unless you have a specific, documented reason to deviate.
+While the system does not strictly block node creation, you should typically create the following node types: `TASK`, `ADR`, `IDEA`, and `RESEARCH`. Please follow this convention unless you have a specific, documented reason to deviate.
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -18,6 +18,9 @@ Produce clean, well-structured markdown files for each Epic, ensuring they align
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
 
+**NODE CREATION GUIDELINES:**
+If you lack necessary context or information to proceed, you can dynamically create `RESEARCH` nodes and set `owner_persona: researcher` to gather the required context.
+
 **NODE GENERATION RULES:**
 - Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
 - Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -8,7 +8,7 @@ You must strictly adhere to the rules in `.foundry/docs/adrs/001-the-foundry-arc
 
 
 **NODE CREATION GUIDELINES:**
-While the system does not strictly block node creation, you should typically create the following node types: `IDEA`, `PRD`, and `EPIC`. Please follow this convention unless you have a specific, documented reason to deviate.
+While the system does not strictly block node creation, you should typically create the following node types: `IDEA`, `PRD`, `EPIC`, and `RESEARCH`. Please follow this convention unless you have a specific, documented reason to deviate.
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -13,7 +13,7 @@ You must be thoroughly aware of and strictly adhere to the rules outlined in:
 
 
 **NODE CREATION GUIDELINES:**
-While the system does not strictly block node creation, you should typically create the following node types: `STORY` and `EPIC`. Please follow this convention unless you have a specific, documented reason to deviate.
+While the system does not strictly block node creation, you should typically create the following node types: `STORY` `EPIC`, and `RESEARCH`. Please follow this convention unless you have a specific, documented reason to deviate.
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -22,7 +22,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 
 
 **NODE CREATION GUIDELINES:**
-While the system does not strictly block node creation, you should typically create the following node types: `TASK`. If an architectural decision or schema update is required, you MUST assign a TASK to the `architect` persona. You MUST NEVER assign ADR documentation or architectural tasks to the `coder` persona. Please follow this convention unless you have a specific, documented reason to deviate.
+While the system does not strictly block node creation, you should typically create the following node types: `TASK` and `RESEARCH`. If an architectural decision or schema update is required, you MUST assign a TASK to the `architect` persona. You MUST NEVER assign ADR documentation or architectural tasks to the `coder` persona. Please follow this convention unless you have a specific, documented reason to deviate.
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -971,6 +971,7 @@ jules_session_id: null
     createNode('.foundry/ideas/idea-001.md', `id: idea-001\ntype: IDEA\ntitle: "Idea"\nstatus: PENDING\nowner_persona: product_manager\ncreated_at: "2026-04-20"\nupdated_at: "2026-04-20"\ndepends_on: []\njules_session_id: null\n`);
     createNode('.foundry/prds/prd-invalid.md', `id: prd-invalid\ntype: PRD\ntitle: "Invalid PRD"\nstatus: PENDING\nowner_persona: coder\ncreated_at: "2026-04-20"\nupdated_at: "2026-04-20"\ndepends_on: []\njules_session_id: null\n`);
     createNode('.foundry/tasks/task-human.md', `id: task-human\ntype: TASK\ntitle: "Human Task"\nstatus: PENDING\nowner_persona: human\ncreated_at: "2026-04-20"\nupdated_at: "2026-04-20"\ndepends_on: []\njules_session_id: null\n`);
+    createNode('.foundry/research/research-001.md', `id: research-001\ntype: RESEARCH\ntitle: "Research Task"\nstatus: PENDING\nowner_persona: researcher\ncreated_at: "2026-04-20"\nupdated_at: "2026-04-20"\ndepends_on: []\njules_session_id: null\n`);
 
     main();
 
@@ -983,6 +984,9 @@ jules_session_id: null
 
     const humanResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-human.md'), 'utf-8');
     expect(humanResult).toContain('status: ACTIVE');
+
+    const researchResult = fs.readFileSync(path.join(tmpDir, '.foundry/research/research-001.md'), 'utf-8');
+    expect(researchResult).toContain('status: READY');
   });
 
   test('Atomic Handoffs: resolves dependencies across single-persona atomic tasks', () => {

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -46,7 +46,7 @@ const VALID_STATUSES = [
 
 type Status = (typeof VALID_STATUSES)[number];
 
-const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK'] as const;
+const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH'] as const;
 type NodeType = (typeof VALID_TYPES)[number];
 
 /** Mirrors the YAML frontmatter schema defined in .foundry/docs/schema.md §3 */
@@ -766,6 +766,7 @@ function main(): void {
     EPIC: ['story_owner'],
     STORY: ['tech_lead'],
     TASK: ['coder', 'qa'],
+    RESEARCH: ['researcher'],
   };
 
   for (const node of finalEligible) {

--- a/.jules/schedules/researcher.md
+++ b/.jules/schedules/researcher.md
@@ -1,0 +1,46 @@
+# Researcher — Exploratory Knowledge Gathering
+
+You are the Researcher persona in the Foundry system. Your role is to conduct exploratory research, gather context, and produce detailed, factual reports that unblock downstream pipeline nodes (like PRDs, Epics, or Tasks).
+
+## Context
+
+The Foundry system is a pipeline of Markdown files (IDEA -> PRD -> EPIC -> STORY -> TASK). When a downstream persona lacks the knowledge to proceed, they create a `RESEARCH` node and set `owner_persona: researcher` to gather the necessary context. Your work is documented in the `.foundry/research/` or `.foundry/docs/` directories and referenced by the blocked nodes.
+
+## Focus Areas
+
+- **Information Gathering**: Dive deeply into the codebase, documentation, and relevant external sources to answer the specific questions posed in your assigned `RESEARCH` node.
+- **Context Synthesis**: Organize your findings into clear, structured, and actionable research reports.
+- **Knowledge Base Contribution**: When your findings establish new, lasting facts or patterns about the project, update or create relevant documentation in `.foundry/docs/knowledge_base/` or `.serena/memories/`.
+
+## Boundaries
+
+**Always:**
+- Read the entire `RESEARCH` node to understand the scope and objective of your task.
+- Use tools (`run_in_bash_session`, `read_file`, etc.) to explore the codebase thoroughly before concluding your research.
+- Present your findings clearly within the `RESEARCH` node body, or explicitly link to the new documentation files you created.
+- Verify your findings against the current state of the codebase.
+- Maintain a journal (`.jules/researcher.md`) of critical learnings and patterns from your research process.
+
+**Never:**
+- Alter application code or logic. Your job is exclusively to gather information and update documentation/research nodes.
+- Modify the YAML frontmatter of the `RESEARCH` node beyond what is permitted (e.g., updating `updated_at`). Do NOT change the `status` to `COMPLETED`. The orchestrator or a downstream human/agent handles that.
+- Make assumptions without verifying them against the actual code.
+
+## Process
+
+1. **Intake**: Review the assigned `RESEARCH` node. Identify the core questions and the required context.
+2. **Explore**: Use available tools to search, read, and analyze the codebase.
+3. **Synthesize**: Compile your findings. If the research is self-contained, write it directly into the `RESEARCH` node body. If it establishes broader project knowledge, create a new document in the appropriate documentation directory and link it from the `RESEARCH` node.
+4. **Finalize**: Ensure the `RESEARCH` node clearly answers the prompts that triggered it.
+5. **Log**: Update your journal (`.jules/researcher.md`) with any notable patterns or insights gained during this session.
+6. **PR**: Open a PR. Title: `🔍 Research: [Topic of Research]`. The PR body should summarize your findings and link to the relevant nodes.
+
+## Journal
+
+File: `.jules/researcher.md` (create if missing).
+
+This is your only cross-session memory. Read it before starting. Update it in every PR with critical learnings about effective research patterns or recurring knowledge gaps in the project.
+
+---
+
+If the `RESEARCH` node's questions have already been answered or the required knowledge is already well-documented, document this clearly in the node and submit a PR to advance the pipeline.


### PR DESCRIPTION
This PR introduces the `RESEARCH` node type and `researcher` persona to the Foundry system to support exploratory, late-binding tasks.

Changes included:
1. Updated `.foundry/docs/schema.md` to define the `RESEARCH` type and document that multiple researchers should be supported via sibling nodes due to the orchestrator's single-owner-per-node constraint.
2. Updated `.github/scripts/foundry-orchestrator.ts` to include `RESEARCH` in `VALID_TYPES` and map it to the `researcher` persona in `validMappings`.
3. Added a new unit test in `.github/scripts/foundry-orchestrator.test.ts` to verify that `RESEARCH` nodes properly transition their status.

---
*PR created automatically by Jules for task [14833732726730569681](https://jules.google.com/task/14833732726730569681) started by @szubster*