### PR TITLE
🧪 Add test coverage for STATIC_GIFT_DATA

### DIFF
--- a/.jules/testing.md
+++ b/.jules/testing.md
@@ -1,0 +1,1 @@
+Added unit tests for STATIC_GIFT_DATA in src/engine/data/gen1/__tests__/assistantData.test.ts to verify the structure and content of static gift encounters.

--- a/src/engine/data/gen1/__tests__/assistantData.test.ts
+++ b/src/engine/data/gen1/__tests__/assistantData.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from 'vitest';
-import { STATIC_NPC_TRADE_DATA } from '../assistantData';
+import { STATIC_GIFT_DATA, STATIC_NPC_TRADE_DATA } from '../assistantData';
+
+describe('STATIC_GIFT_DATA', () => {
+  it('should have basic valid structure for all entries', () => {
+    Object.values(STATIC_GIFT_DATA).forEach((gift) => {
+      expect(typeof gift.name).toBe('string');
+      expect(gift.name.length).toBeGreaterThan(0);
+      expect(typeof gift.location).toBe('string');
+      expect(gift.location.length).toBeGreaterThan(0);
+      expect(typeof gift.reason).toBe('string');
+      expect(gift.reason.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('should correctly define Bulbasaur (ID 1)', () => {
+    const bulbasaur = STATIC_GIFT_DATA[1];
+    expect(bulbasaur).toBeDefined();
+    expect(bulbasaur?.name).toBe('Bulbasaur');
+    expect(bulbasaur?.location).toBe('Cerulean City');
+    expect(bulbasaur?.gen).toBe(1);
+    expect(bulbasaur?.eventFlag).toBe(0x2a1);
+    expect(bulbasaur?.requiredBadges).toBe(1);
+  });
+});
 
 describe('STATIC_NPC_TRADE_DATA', () => {
   describe('Yellow Version Trades', () => {


### PR DESCRIPTION
🎯 What
Added missing tests for the `STATIC_GIFT_DATA` export in `src/engine/data/gen1/assistantData.ts`. This was a gap in our coverage, leaving the static encounter gift definitions unverified.

📊 Coverage
Added a structural validation test to verify that all entries have a `name`, `location`, and `reason` of type `string` with a length > 0.
Added a specific edge case test for `Bulbasaur` (ID 1) to verify specific expected property mappings (`gen`, `eventFlag`, `requiredBadges`, etc.).

✨ Result
Improved safety net for modifications to Generation 1 static gift data with specific coverage tests running cleanly in Vitest.

---
*PR created automatically by Jules for task [1277792532601635580](https://jules.google.com/task/1277792532601635580) started by @szubster*