### PR TITLE
[Tech Lead] Blueprint DAG Parser implementation

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -10,3 +10,14 @@ Anomaly for Agile Coach: The target task artifact .foundry/archive/tasks/task-02
 - Reviewed story `story-026-041-inventory-parsing`.
 - Created implementation task `task-041-066-implement-inventory-parsing` assigned to `coder`.
 - Created QA verification task `task-041-067-qa-inventory-parsing` assigned to `qa` with a dependency on the implementation task.
+
+## 2026-05-09: DAG Parser Implementation Blueprint
+
+Processed STORY `story-028-043-implement-dag-parser`.
+Created four subsequent TASK nodes for implementation to break down the parsing problem space:
+- `task-043-073-read-foundry-files`: Implement raw file reader utility using node `fs`.
+- `task-043-074-parse-frontmatter`: Implement parsing using `gray-matter` to enforce schema adherence. Depends on reading task.
+- `task-043-075-build-dag-graph`: Construct the final JSON graph schema suitable for React Flow or similar. Depends on parsing task.
+- `task-043-076-qa-dag-parser`: QA task using Intelligent Verification Protocol, as DAG parsing forms the backbone of the entire UI and has medium-high complexity.
+
+All sibling tasks were explicitly linked via `depends_on` to ensure execution sequentiality and avoid orchestrator DAG deadlocks as specified by ADR 005.

--- a/.foundry/stories/story-028-043-implement-dag-parser.md
+++ b/.foundry/stories/story-028-043-implement-dag-parser.md
@@ -32,6 +32,11 @@ This Story covers the backend/data layer for the DAG Dashboard Webview. It is re
 - Build a structured JSON representation of the nodes and their directed edges (dependencies) suitable for a frontend visualization library.
 
 ## Acceptance Criteria
-- [ ] Create a TASK to implement a utility function to read all relevant `.foundry` files.
-- [ ] Create a TASK to implement a parsing function to extract frontmatter into structured objects.
-- [ ] Create a TASK to implement a builder function that outputs the final node/edge graph data structure.
+- [x] Create a TASK to implement a utility function to read all relevant `.foundry` files.
+  - See `.foundry/tasks/task-043-073-read-foundry-files.md`
+- [x] Create a TASK to implement a parsing function to extract frontmatter into structured objects.
+  - See `.foundry/tasks/task-043-074-parse-frontmatter.md`
+- [x] Create a TASK to implement a builder function that outputs the final node/edge graph data structure.
+  - See `.foundry/tasks/task-043-075-build-dag-graph.md`
+- [x] Create a QA TASK to verify the functionality of the DAG parser.
+  - See `.foundry/tasks/task-043-076-qa-dag-parser.md`

--- a/.foundry/tasks/task-043-073-read-foundry-files.md
+++ b/.foundry/tasks/task-043-073-read-foundry-files.md
@@ -1,0 +1,43 @@
+---
+id: task-043-073-read-foundry-files
+type: TASK
+title: "DAG Parser: Read Files Utility"
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-09'
+updated_at: '2026-05-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-028-043-implement-dag-parser
+tags:
+  - dag
+  - dashboard
+  - data
+  - backend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# DAG Parser: Read Files Utility
+
+## Objective
+Implement a utility function to read all relevant `.foundry` files.
+
+## Requirements
+- Create a utility function, for example `readFoundryFiles()`.
+- The function should recursively (or systematically) read all markdown (`.md`) files in the following directories:
+  - `.foundry/ideas/`
+  - `.foundry/prds/`
+  - `.foundry/epics/`
+  - `.foundry/stories/`
+  - `.foundry/tasks/`
+- It should return an array of objects containing the file path and the raw string content of each file.
+- Use native Node.js `fs` or `fs/promises` module.
+
+## Acceptance Criteria
+- [ ] A utility function is implemented and exported.
+- [ ] It correctly reads all markdown files from the specified directories.
+- [ ] Unit tests verify that it returns the expected file paths and raw contents.

--- a/.foundry/tasks/task-043-074-parse-frontmatter.md
+++ b/.foundry/tasks/task-043-074-parse-frontmatter.md
@@ -1,0 +1,40 @@
+---
+id: task-043-074-parse-frontmatter
+type: TASK
+title: "DAG Parser: Parse Frontmatter"
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-09'
+updated_at: '2026-05-09'
+depends_on:
+  - .foundry/tasks/task-043-073-read-foundry-files.md
+jules_session_id: null
+pr_number: null
+parent: story-028-043-implement-dag-parser
+tags:
+  - dag
+  - dashboard
+  - data
+  - backend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# DAG Parser: Parse Frontmatter
+
+## Objective
+Implement a parsing function to extract frontmatter into structured objects.
+
+## Requirements
+- Create a parsing function, for example `parseFoundryNode(rawContent: string)`.
+- Use the `gray-matter` library to parse the YAML frontmatter from the raw markdown string.
+- Extract and strongly type the following required fields: `id`, `type`, `status`, `owner_persona`, and `depends_on`.
+- Handle files that might not have valid YAML frontmatter gracefully (e.g., return `null` or skip).
+
+## Acceptance Criteria
+- [ ] A parsing function is implemented and exported.
+- [ ] It uses `gray-matter` to parse the YAML frontmatter.
+- [ ] It correctly extracts `id`, `type`, `status`, `owner_persona`, and `depends_on`.
+- [ ] Unit tests verify correct extraction from valid markdown and graceful handling of invalid markdown.

--- a/.foundry/tasks/task-043-075-build-dag-graph.md
+++ b/.foundry/tasks/task-043-075-build-dag-graph.md
@@ -1,0 +1,47 @@
+---
+id: task-043-075-build-dag-graph
+type: TASK
+title: "DAG Parser: Build DAG Graph"
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-09'
+updated_at: '2026-05-09'
+depends_on:
+  - .foundry/tasks/task-043-074-parse-frontmatter.md
+jules_session_id: null
+pr_number: null
+parent: story-028-043-implement-dag-parser
+tags:
+  - dag
+  - dashboard
+  - data
+  - backend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# DAG Parser: Build DAG Graph
+
+## Objective
+Implement a builder function that outputs the final node/edge graph data structure.
+
+## Requirements
+- Create a builder function, for example `buildDagGraph(parsedNodes: ParsedNode[])`.
+- It should take the parsed nodes from the previous steps.
+- Build a structured JSON representation of the nodes and their directed edges (dependencies) suitable for a frontend visualization library (like React Flow or similar).
+- A common structure might look like:
+  ```json
+  {
+    "nodes": [ { "id": "node-1", "data": { "type": "TASK", "status": "COMPLETED", "owner_persona": "coder" } } ],
+    "edges": [ { "source": "node-1", "target": "node-2" } ]
+  }
+  ```
+- Ensure the `depends_on` array (which contains file paths) is correctly mapped to node `id`s for the edges. You may need to map paths to node IDs.
+
+## Acceptance Criteria
+- [ ] A builder function is implemented and exported.
+- [ ] It produces a structured JSON output with `nodes` and `edges`.
+- [ ] `depends_on` paths are correctly translated into edges linking node IDs.
+- [ ] Unit tests verify the correct generation of the graph structure from mock parsed nodes.

--- a/.foundry/tasks/task-043-076-qa-dag-parser.md
+++ b/.foundry/tasks/task-043-076-qa-dag-parser.md
@@ -1,0 +1,39 @@
+---
+id: task-043-076-qa-dag-parser
+type: TASK
+title: "DAG Parser: QA Verification"
+status: PENDING
+owner_persona: qa
+created_at: '2026-05-09'
+updated_at: '2026-05-09'
+depends_on:
+  - .foundry/tasks/task-043-075-build-dag-graph.md
+jules_session_id: null
+pr_number: null
+parent: story-028-043-implement-dag-parser
+tags:
+  - dag
+  - dashboard
+  - data
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# DAG Parser: QA Verification
+
+## Objective
+Verify the implementation of the DAG parser components.
+
+## Requirements
+- Verify that the `readFoundryFiles` utility correctly reads all target directories without crashing or skipping valid `.md` files.
+- Verify that `parseFoundryNode` correctly utilizes `gray-matter` and extracts all required fields precisely.
+- Verify that `buildDagGraph` correctly constructs nodes and correctly resolves `depends_on` file paths to actual node IDs to create accurate edges.
+- Ensure all automated unit tests written by the `coder` pass and provide adequate coverage.
+
+## Acceptance Criteria
+- [ ] All DAG parser utilities function correctly.
+- [ ] Unit tests are robust and pass.
+- [ ] The generated DAG structure accurately represents the state of the `.foundry` directory.


### PR DESCRIPTION
Processed `story-028-043-implement-dag-parser` as the Tech Lead. Broke down the story into four distinct tasks (three for the `coder` and one for `qa`) to implement the backend logic for parsing the Foundry DAG.

All sibling tasks have sequential `depends_on` configurations to avoid DAG deadlocks, complying with ADR 005. Frontmatter was carefully constructed according to the system schema and the parent STORY's acceptance criteria was updated without modifying the frontmatter itself.

---
*PR created automatically by Jules for task [998667721478035076](https://jules.google.com/task/998667721478035076) started by @szubster*