### PR TITLE
feat: Implement explicit failure handling for validation mismatches

### DIFF
--- a/.foundry/tasks/task-039-071-implement-failure-handling.md
+++ b/.foundry/tasks/task-039-071-implement-failure-handling.md
@@ -30,8 +30,8 @@ Handle the state transition when an invalid `owner_persona` mapping is detected 
 When `.github/scripts/foundry-orchestrator.ts` detects an invalid `owner_persona` mapping during Phase 4.8, it currently transitions the node to `BLOCKED` with `owner_persona: tpm`. The acceptance criteria dictate that we should mark the node as `FAILED` instead, and provide a `rejection_reason` explaining the failure, so that the Resurrection Loop can retry or surface it differently.
 
 ## Acceptance Criteria
-- [ ] Nodes with invalid mapping are transitioned to `FAILED`.
-- [ ] A descriptive `rejection_reason` is set (e.g. "Invalid owner_persona mapping").
-- [ ] The `owner_persona` should not be overridden to `tpm` for this specific failure path.
-- [ ] A warning/error is logged (the existing `warn()` call should be kept).
-- [ ] The tests in `foundry-orchestrator.test.ts` regarding mapping validation should be updated to reflect this new behaviour (expecting `FAILED` instead of `BLOCKED` and `tpm` persona).
+- [x] Nodes with invalid mapping are transitioned to `FAILED`.
+- [x] A descriptive `rejection_reason` is set (e.g. "Invalid owner_persona mapping").
+- [x] The `owner_persona` should not be overridden to `tpm` for this specific failure path.
+- [x] A warning/error is logged (the existing `warn()` call should be kept).
+- [x] The tests in `foundry-orchestrator.test.ts` regarding mapping validation should be updated to reflect this new behaviour (expecting `FAILED` instead of `BLOCKED` and `tpm` persona).

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -978,8 +978,9 @@ jules_session_id: null
     expect(ideaResult).toContain('status: READY');
 
     const prdResult = fs.readFileSync(path.join(tmpDir, '.foundry/prds/prd-invalid.md'), 'utf-8');
-    expect(prdResult).toContain('status: BLOCKED');
-    expect(prdResult).toContain('owner_persona: tpm');
+    expect(prdResult).toContain('status: FAILED');
+    expect(prdResult).toContain('rejection_reason: Invalid owner_persona mapping');
+    expect(prdResult).toContain('owner_persona: coder');
 
     const humanResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-human.md'), 'utf-8');
     expect(humanResult).toContain('status: ACTIVE');

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -290,6 +290,29 @@ function promoteNodeToTpm(node: ParsedNode): void {
   info(`${dryTag}Flagged node for TPM: ${node.repoPath}`);
 }
 
+function promoteNodeToFailedWithReason(node: ParsedNode, reason: string): void {
+  const dateStr = todayISO();
+  const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
+
+  const newData = { ...node.frontmatter, status: 'FAILED' as Status, rejection_reason: reason, updated_at: dateStr };
+  const newContent = matter.stringify(node.body, newData);
+
+  if (!DRY_RUN) {
+    try {
+      fs.writeFileSync(node.filePath, newContent, 'utf-8');
+    } catch (e) {
+      warn(`Failed to write file: ${node.repoPath} — ${String(e)}`);
+      return;
+    }
+  }
+
+  node.frontmatter = newData as FoundryFrontmatter;
+  node.rawContent = newContent;
+
+  info(`${dryTag}Flagged node as FAILED due to ${reason}: ${node.repoPath}`);
+}
+
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 function main(): void {
@@ -777,7 +800,7 @@ function main(): void {
     const validPersonas = validMappings[node.frontmatter.type] || [];
     if (!validPersonas.includes(node.frontmatter.owner_persona)) {
       warn(`Invalid mapping: ${node.frontmatter.type} node '${node.repoPath}' cannot be owned by '${node.frontmatter.owner_persona}'`);
-      promoteNodeToTpm(node);
+      promoteNodeToFailedWithReason(node, 'Invalid owner_persona mapping');
     } else {
       validatedEligible.push(node);
     }


### PR DESCRIPTION
This change updates the `foundry-orchestrator.ts` script to handle invalid `owner_persona` mappings more gracefully.

When `.github/scripts/foundry-orchestrator.ts` detects an invalid `owner_persona` mapping during Phase 4.8, it previously transitioned the node to `BLOCKED` with an `owner_persona` of `tpm`.

To allow the Resilience Loop to surface and retry appropriately, the state transition has been updated to mark the node as `FAILED` with a specific `rejection_reason` explaining the failure without altering its originally assigned `owner_persona`. 

All applicable tests have been updated alongside the script.

---
*PR created automatically by Jules for task [4464332084039654777](https://jules.google.com/task/4464332084039654777) started by @szubster*