### PR TITLE
🛡️ Nurse: [type improvement] replacing 'as' casts with a Record typecast in isSyncProgressDetail

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -39,13 +39,3 @@ Extracted the inline array into a constant `STATUS_OPTIONS` marked with `as cons
 The compiler statically guarantees that the `StatusType` union and the `STATUS_OPTIONS` array are always in sync. It eliminates the unsafe `as StatusType` casts while maintaining identical runtime behavior.
 - Fixed an unsafe `as IDBValidKey` cast in `src/db/PokeDB.ts`'s `bulkGet` by assigning to a variable and checking for `undefined` before passing to `store.get`.
 - Replaced an unsafe `as` cast in `src/components/SyncProgress.tsx` with a runtime type guard `isSyncProgressDetail`. This ensures both type safety and runtime safety when handling custom events, specifically verifying the presence and types of `current`, `total`, and `stage` in the event detail.
-## $(date +%Y-%m-%d) - Type Narrowing `unknown` Event Detail Objects
-
-**What was unsafe:**
-Multiple type assertions in `isSyncProgressDetail` were mapping an `unknown` detail parameter manually property-by-property `typeof (detail as { current: unknown }).current === 'number'`. This is verbose and potentially unsafe if the shape is complex.
-
-**How it was fixed:**
-Replaced the individual property casts with a single `const d = detail as Record<string, unknown>;` before evaluating properties natively (e.g., `typeof d['current'] === 'number'`).
-
-**What the compiler now catches:**
-The compiler enforces explicit type checks for each value obtained from the `Record<string, unknown>` indexing, and completely eliminates verbose and repetitive object literal typecasts.

--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -39,3 +39,13 @@ Extracted the inline array into a constant `STATUS_OPTIONS` marked with `as cons
 The compiler statically guarantees that the `StatusType` union and the `STATUS_OPTIONS` array are always in sync. It eliminates the unsafe `as StatusType` casts while maintaining identical runtime behavior.
 - Fixed an unsafe `as IDBValidKey` cast in `src/db/PokeDB.ts`'s `bulkGet` by assigning to a variable and checking for `undefined` before passing to `store.get`.
 - Replaced an unsafe `as` cast in `src/components/SyncProgress.tsx` with a runtime type guard `isSyncProgressDetail`. This ensures both type safety and runtime safety when handling custom events, specifically verifying the presence and types of `current`, `total`, and `stage` in the event detail.
+## $(date +%Y-%m-%d) - Type Narrowing `unknown` Event Detail Objects
+
+**What was unsafe:**
+Multiple type assertions in `isSyncProgressDetail` were mapping an `unknown` detail parameter manually property-by-property `typeof (detail as { current: unknown }).current === 'number'`. This is verbose and potentially unsafe if the shape is complex.
+
+**How it was fixed:**
+Replaced the individual property casts with a single `const d = detail as Record<string, unknown>;` before evaluating properties natively (e.g., `typeof d['current'] === 'number'`).
+
+**What the compiler now catches:**
+The compiler enforces explicit type checks for each value obtained from the `Record<string, unknown>` indexing, and completely eliminates verbose and repetitive object literal typecasts.

--- a/src/components/SyncProgress.tsx
+++ b/src/components/SyncProgress.tsx
@@ -12,13 +12,14 @@ interface SyncProgressDetail {
 function isSyncProgressDetail(detail: unknown): detail is SyncProgressDetail {
   if (typeof detail !== 'object' || detail === null) return false;
 
+  const d = detail as Record<string, unknown>;
   return (
-    'current' in detail &&
-    typeof (detail as { current: unknown }).current === 'number' &&
-    'total' in detail &&
-    typeof (detail as { total: unknown }).total === 'number' &&
-    'stage' in detail &&
-    typeof (detail as { stage: unknown }).stage === 'string'
+    // biome-ignore lint/complexity/useLiteralKeys: Using literals causes TS errors with strictest TSConfig
+    typeof d['current'] === 'number' &&
+    // biome-ignore lint/complexity/useLiteralKeys: Using literals causes TS errors with strictest TSConfig
+    typeof d['total'] === 'number' &&
+    // biome-ignore lint/complexity/useLiteralKeys: Using literals causes TS errors with strictest TSConfig
+    typeof d['stage'] === 'string'
   );
 }
 


### PR DESCRIPTION
**What was unsafe:**
The `isSyncProgressDetail` function used verbose and somewhat unreadable inline `as { property: unknown }` casts for every single property check.

**How it was fixed:**
Narrowed the type locally with `const d = detail as Record<string, unknown>;` and used native bracket notation for the `typeof` checks (e.g. `typeof d['current'] === 'number'`), including the necessary inline biome ignores to allow bracket notation in strict configurations.

**What the compiler now catches:**
The compiler still safely validates the structure while reducing the use of explicit clunky casts.

---
*PR created automatically by Jules for task [9232398914931300864](https://jules.google.com/task/9232398914931300864) started by @szubster*