### PR TITLE
🛠️ Infras: Add sort-package-json for pre-commit formatting

### DIFF
--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -49,3 +49,7 @@
 **Learning:** Configured `coverage` blocks in `vitest.config.ts` to exclusively `include: ['src/**/*.ts', 'src/**/*.tsx']` and explicitly `exclude: ['**/*.json']`. This stops `rolldown` (used by `@vitest/coverage-v8`) from attempting to parse statically imported `.json` files as modules, which caused noisy syntax errors during `pnpm test --coverage` runs and broke test suite exits.
 Critical learnings:
 - Removed `syncPromise` and `_resetSync` from `src/db/PokeDB.ts` completely to eliminate caching and rely exclusively on dataloader/react-query, which also successfully resolves the hanging Vitest process in the `node` test suite, preventing issues caused by dangling unhandled promises or unclosed requests.
+
+## 2026-05-10 - Added sort-package-json
+**Learning:** Added `sort-package-json` to the pipeline via `devDependencies` and `lefthook.yml` to automatically sort `package.json` locally. Note: Biome currently does not natively sort `package.json` correctly. We did not add it to the `pnpm lint` script as it currently modifies files instead of just checking them.
+- **Updated**: Added `lint:package-json` with `--check` flag to the `lint` command to enforce that `package.json` stays correctly sorted in CI pipelines.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,3 +16,7 @@ pre-commit:
       run: pnpm exec oxlint --type-aware --no-error-on-unmatched-pattern {staged_files}
     type-check:
       run: pnpm lint
+    sort-package-json:
+      run: pnpm exec sort-package-json {staged_files}
+      glob: "package.json"
+      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -1,35 +1,31 @@
 {
   "name": "dexhelper",
-  "private": true,
   "version": "0.0.0",
-  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
-  "engines": {
-    "node": ">=22.0.0",
-    "pnpm": ">=10.33.0"
-  },
+  "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --port=3000 --host=0.0.0.0",
-    "data:gen": "node --experimental-strip-types scripts/generate-pokedata.ts",
-    "data:gen-maps": "node --experimental-strip-types scripts/generateMapLocations.ts",
     "build": "vite build",
     "build:analyze": "ANALYZE=true vite build",
-    "preview": "vite preview",
+    "check:biome": "biome check --error-on-warnings .",
+    "check:fix": "biome check --write --unsafe .",
     "clean": "rm -rf dist",
-    "lint": "pnpm type-check && pnpm check:biome && pnpm exec oxlint --type-aware --type-check --import-plugin --promise-plugin . && pnpm knip",
+    "data:gen": "node --experimental-strip-types scripts/generate-pokedata.ts",
+    "data:gen-maps": "node --experimental-strip-types scripts/generateMapLocations.ts",
+    "dev": "vite --port=3000 --host=0.0.0.0",
+    "format:biome": "biome format .",
+    "postinstall": "lefthook install",
+    "knip": "knip",
+    "lint": "pnpm type-check && pnpm check:biome && pnpm exec oxlint --type-aware --type-check --import-plugin --promise-plugin . && pnpm knip && pnpm lint:package-json",
+    "lint:biome": "biome lint --error-on-warnings .",
+    "lint:package-json": "sort-package-json --check",
+    "preview": "vite preview",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:watch": "vitest",
+    "test:ct": "vitest --project browser",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:ct": "vitest --project browser",
-    "lint:biome": "biome lint --error-on-warnings .",
-    "format:biome": "biome format .",
-    "check:biome": "biome check --error-on-warnings .",
-    "type-check": "tsc --noEmit",
-    "check:fix": "biome check --write --unsafe .",
-    "postinstall": "lefthook install",
-    "knip": "knip"
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.100.9",
@@ -74,6 +70,7 @@
     "oxlint-tsgolint": "^0.22.1",
     "playwright": "^1.59.1",
     "rollup-plugin-visualizer": "^7.0.1",
+    "sort-package-json": "^3.6.1",
     "tailwindcss": "4.2.4",
     "typescript": "~6.0.3",
     "vite": "^8.0.11",
@@ -81,14 +78,19 @@
     "vitest": "^4.1.5",
     "vitest-browser-react": "^2.2.0"
   },
+  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
+  "engines": {
+    "node": ">=22.0.0",
+    "pnpm": ">=10.33.0"
+  },
   "pnpm": {
-    "overrides": {
-      "serialize-javascript": ">=7.0.5"
-    },
     "onlyBuiltDependencies": [
       "esbuild",
       "lefthook",
       "sharp"
-    ]
+    ],
+    "overrides": {
+      "serialize-javascript": ">=7.0.5"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.0.0-rc.18)(rollup@2.80.0)
+      sort-package-json:
+        specifier: ^3.6.1
+        version: 3.6.1
       tailwindcss:
         specifier: 4.2.4
         version: 4.2.4
@@ -2449,9 +2452,17 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  detect-indent@7.0.2:
+    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
+    engines: {node: '>=12.20'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-newline@4.0.1:
+    resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -2683,6 +2694,9 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  git-hooks-list@4.2.1:
+    resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -2860,6 +2874,10 @@ packages:
   is-obj@1.0.1:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -3599,6 +3617,14 @@ packages:
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
+
+  sort-object-keys@2.1.0:
+    resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
+
+  sort-package-json@3.6.1:
+    resolution: {integrity: sha512-Chgejw1+10p2D0U2tB7au1lHtz6TkFnxmvZktyBCRyV0GgmF6nl1IxXxAsPtJVsUyg/fo+BfCMAVVFUVRkAHrQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6308,7 +6334,11 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  detect-indent@7.0.2: {}
+
   detect-libc@2.1.2: {}
+
+  detect-newline@4.0.1: {}
 
   diff@8.0.4: {}
 
@@ -6601,6 +6631,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  git-hooks-list@4.2.1: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -6772,6 +6804,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-obj@1.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1:
     optional: true
@@ -7566,6 +7600,18 @@ snapshots:
   smob@1.6.1: {}
 
   smol-toml@1.6.1: {}
+
+  sort-object-keys@2.1.0: {}
+
+  sort-package-json@3.6.1:
+    dependencies:
+      detect-indent: 7.0.2
+      detect-newline: 4.0.1
+      git-hooks-list: 4.2.1
+      is-plain-obj: 4.1.0
+      semver: 7.7.4
+      sort-object-keys: 2.1.0
+      tinyglobby: 0.2.16
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## 🎯 What
Added `sort-package-json` to the pipeline as a devDependency to enforce consistent structure in `package.json`. It is now triggered automatically during pre-commit checks and validated during the CI linting pipeline.

## 💡 Why
Maintaining a well-structured `package.json` across a growing project ensures readability and standardizes the developer experience. Biome currently doesn't natively support automated `package.json` sorting properly, so this standard ecosystem tool fills that gap seamlessly. 

## 🛠️ Setup notes
Integrated into `lefthook.yml` to sort automatically on commit. Also added a `lint:package-json` check step to `pnpm lint` to prevent mis-sorted `package.json` files from passing CI.

## ✅ Verification
- Ran `pnpm exec sort-package-json package.json` (success)
- Ran `pnpm lint` locally (success)
- Ran `pnpm test` and `pnpm test:e2e` locally (success)
- Updated `.jules/infras.md` with learnings

---
*PR created automatically by Jules for task [17802668520447005275](https://jules.google.com/task/17802668520447005275) started by @szubster*