### PR TITLE
🧠 Trainer: Assistant Recursive Evolution Suggestion

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -27,3 +27,6 @@
 ## 2026-05-06 - Trade Evolution Held Item Equipped Support
 **Learning:** For Trade evolutions requiring a held item, the item could already be equipped on the Pokemon instead of being in the bag. The assistant was incorrectly suggesting to find the item if it was only equipped and not in the bag.
 **Action:** Modified `EVO_TRIGGER.TRADE` logic to search `evolvableInstances` and `ownedInstances` for the specific item and dynamically update the suggestion if the pre-evolution is already holding it.
+## 2024-05-19 - Assistant Recursive Evolution Suggestion
+**Learning:** For multi-stage evolutions (e.g., Charmander -> Charmeleon -> Charizard), if a player had a missing target of the stage 2 evolution (Charizard), owned the dex entry for stage 1 (Charmeleon), but physically only possessed the base stage (Charmander), the assistant would fail to suggest any evolution because it only looked at the immediate parent (`p.efrm[0]`).
+**Action:** Modified `generateEvolutionAndBreedingSuggestions` in `suggestionEngine.ts` to iterate backwards through the entire `p.efrm` ancestor array. It now finds the *closest* ancestor the player physically possesses and correctly determines the *immediate next stage* in the evolutionary line as the target for the suggestion (e.g., suggesting to evolve Charmander -> Charmeleon to progress towards Charizard).

--- a/src/engine/assistant/__tests__/recursive-evo.test.ts
+++ b/src/engine/assistant/__tests__/recursive-evo.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { gen1Strategy } from '../strategies/gen1Strategy';
+import { generateSuggestions } from '../suggestionEngine';
+
+describe('Recursive Evolution Suggestions', () => {
+  it('should suggest evolving Charmander into Charmeleon if missing Charizard, owns Charmeleon dex entry, but only physically has Charmander', () => {
+    const mockSaveData = {
+      generation: 1,
+      gameVersion: 'red',
+      owned: new Set([4, 5]), // Owns Charmander and Charmeleon in dex
+      seen: new Set([4, 5, 6]),
+      party: [],
+      pc: [],
+      partyDetails: [{ speciesId: 4, level: 36, isShiny: false, moves: [], storageLocation: 'party' }],
+      pcDetails: [],
+      inventory: [],
+      trainerName: 'ASH',
+    };
+
+    const mockApiData = {
+      localAid: null,
+      localEncounters: [],
+      missingEncounters: {},
+      pokemonMetadata: {
+        4: { id: 4, efrm: [], det: [] },
+        5: { id: 5, efrm: [4], det: [{ tr: 1, ml: 16 }] },
+        6: { id: 6, efrm: [5, 4], det: [{ tr: 1, ml: 36 }] }, // efrm actually contains [5, 4] for Charizard!
+      },
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    };
+
+    const mockStrategy = { ...gen1Strategy, getSpecialSuggestions: () => [] };
+    const { suggestions } = generateSuggestions(
+      mockSaveData as unknown as import('../../saveParser/index').SaveData,
+      false,
+      null,
+      mockApiData as unknown as import('../suggestionEngine').AssistantApiData,
+      mockStrategy,
+    );
+
+    // Should suggest evolving Charmander -> Charmeleon (since missing #6 and #5 is immediate target)
+    const evoSuggestion = suggestions.find((s) => s.pokemonId === 6);
+    expect(evoSuggestion).toBeDefined();
+    expect(evoSuggestion?.category).toBe('Evolve');
+    expect(evoSuggestion?.description).toContain('Lv. 16');
+  });
+});

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -478,12 +478,29 @@ function generateEvolutionAndBreedingSuggestions(
     const p = apiData.pokemonMetadata?.[targetId];
     if (!p) return;
 
-    const parentId = p.efrm[0];
-    if (parentId === undefined) return;
-    const ownedInstances = instancesBySpecies.get(parentId) || [];
+    let closestOwnedParentId: number | undefined;
+    let immediateEvoTargetId: number = targetId;
+
+    for (let i = 0; i < p.efrm.length; i++) {
+      const ancestorId = p.efrm[i];
+      if (ancestorId !== undefined && instancesBySpecies.has(ancestorId)) {
+        closestOwnedParentId = ancestorId;
+        const nextTarget = i === 0 ? targetId : p.efrm[i - 1];
+        if (nextTarget !== undefined) {
+          immediateEvoTargetId = nextTarget;
+        }
+        break;
+      }
+    }
+
+    if (closestOwnedParentId === undefined) return;
+    const ownedInstances = instancesBySpecies.get(closestOwnedParentId) || [];
     if (ownedInstances.length === 0) return;
 
-    const details = p.det;
+    const immediateEvoTarget = apiData.pokemonMetadata?.[immediateEvoTargetId];
+    if (!immediateEvoTarget) return;
+
+    const details = immediateEvoTarget.det;
     if (!details || details.length === 0) return;
 
     for (const detail of details) {
@@ -497,7 +514,7 @@ function generateEvolutionAndBreedingSuggestions(
 
       // Filter out Yellow Starter Pikachu as it refuses to evolve
       const evolvableInstances = ownedInstances.filter(
-        (inst) => !(displayVersion === 'yellow' && parentId === 25 && inst.otName === saveData.trainerName),
+        (inst) => !(displayVersion === 'yellow' && closestOwnedParentId === 25 && inst.otName === saveData.trainerName),
       );
 
       if (evolvableInstances.length === 0) continue;


### PR DESCRIPTION
### What
Updated the assistant's evolution generation logic in `suggestionEngine.ts` to properly handle recursive, multi-stage evolution paths (e.g., Charmander -> Charmeleon -> Charizard).

### Why
Previously, the assistant logic only checked if the player physically possessed the *immediate* parent (`p.efrm[0]`) of the target missing Pokémon. If a player was aiming to catch a Charizard (Stage 2) and owned the Pokédex entry for Charmeleon (Stage 1) but *physically* only possessed a Charmander (Base), the logic would fail. It would look for physical instances of Charmeleon, find none, and abort. This meant the user never received a suggestion to start evolving their Charmander.

### Impact on recommendation quality
The assistant now correctly guides players step-by-step up an evolutionary chain. By iterating backwards through all ancestors (`p.efrm`), it identifies the *closest physically owned ancestor* and sets the *immediate next evolutionary stage* as the actionable target. This means a user missing Charizard but owning Charmander will now correctly receive a suggestion to "Evolve your Charmander into Charmeleon".

### Test coverage
Added `recursive-evo.test.ts` to explicitly verify this edge case where a stage 1 dex entry is owned, but only a base stage physical instance exists. All existing unit and E2E test suites passed.

---
*PR created automatically by Jules for task [5355038662991255264](https://jules.google.com/task/5355038662991255264) started by @szubster*