### PR TITLE
QA Verification: Implement Failure Handling for Validation Mismatches

### DIFF
--- a/.foundry/tasks/task-039-072-qa-failure-handling.md
+++ b/.foundry/tasks/task-039-072-qa-failure-handling.md
@@ -28,7 +28,7 @@ notes: ''
 Verify the implementation of `task-039-071-implement-failure-handling`.
 
 ## Acceptance Criteria
-- [ ] Nodes with invalid mapping are transitioned to `FAILED`.
-- [ ] A descriptive `rejection_reason` is set.
-- [ ] A warning/error is logged.
-- [ ] Ensure that `foundry-orchestrator.test.ts` passes and the test logic for mapping validation correctly reflects the new requirement (`FAILED` state and rejection reason).
+- [x] Nodes with invalid mapping are transitioned to `FAILED`.
+- [x] A descriptive `rejection_reason` is set.
+- [x] A warning/error is logged.
+- [x] Ensure that `foundry-orchestrator.test.ts` passes and the test logic for mapping validation correctly reflects the new requirement (`FAILED` state and rejection reason).


### PR DESCRIPTION
QA Verification: implement failure handling validation mismatches

Verified that the `foundry-orchestrator.ts` Phase 4.8 handles invalid mapping transitions properly to `FAILED` status, logging appropriately, and setting the proper `rejection_reason`.

Confirmed tests execute successfully and without regression.

Marked completion on the acceptance criteria in `task-039-072-qa-failure-handling.md` and bumped updated date.

---
*PR created automatically by Jules for task [5842516521809574346](https://jules.google.com/task/5842516521809574346) started by @szubster*