### PR TITLE
Fix Foundry DAG Resolution for Node IDs in depends_on

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -885,6 +885,38 @@ jules_session_id: null`);
     expect(result).toContain('status: READY');
   });
 
+  test('Depends-On-ID Resolution: resolves dependencies using node ID', () => {
+    createNode('.foundry/tasks/task-001.md', `
+id: task-001
+type: TASK
+title: "Task 1"
+status: COMPLETED
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on: []
+jules_session_id: null
+`);
+
+    createNode('.foundry/tasks/task-002.md', `
+id: task-002
+type: TASK
+title: "Task 2"
+status: PENDING
+owner_persona: coder
+created_at: "2026-04-20"
+updated_at: "2026-04-20"
+depends_on:
+  - task-001
+jules_session_id: null
+`);
+
+    main();
+
+    const task2Content = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-002.md'), 'utf-8');
+    expect(task2Content).toContain('status: READY');
+  });
+
 
   test('Wait and Wake: ACTIVE node transitions to PENDING when new incomplete dependency is added', () => {
     createNode('.foundry/tasks/task-incomplete.md', `id: task-incomplete

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -373,12 +373,12 @@ function main(): void {
   }
 
   /**
-   * Helper to resolve a parent reference (either ID or path) to a repo-relative path.
+   * Helper to resolve a node reference (either ID or path) to a repo-relative path.
    */
-  function resolveParentPath(parentRef: string | null | undefined): string | null {
-    if (!parentRef) return null;
-    if (idToPathMap.has(parentRef)) return idToPathMap.get(parentRef)!;
-    return parentRef;
+  function resolveNodePath(ref: string | null | undefined): string | null {
+    if (!ref) return null;
+    if (idToPathMap.has(ref)) return idToPathMap.get(ref)!;
+    return ref;
   }
 
   // ── Phase 3.1: CASCADE CANCELLATIONS ───────────────────────────────────────
@@ -418,10 +418,10 @@ function main(): void {
 
   // Helper to safely check if 'child' is a deep descendant of 'ancestor'
   function isDescendant(childPath: string, ancestorPath: string): boolean {
-    let curr = resolveParentPath(nodeMap.get(childPath)?.frontmatter.parent);
+    let curr = resolveNodePath(nodeMap.get(childPath)?.frontmatter.parent);
     while (curr) {
       if (curr === ancestorPath) return true;
-      curr = resolveParentPath(nodeMap.get(curr)?.frontmatter.parent);
+      curr = resolveNodePath(nodeMap.get(curr)?.frontmatter.parent);
     }
     return false;
   }
@@ -465,7 +465,8 @@ function main(): void {
       }
     }
 
-    for (const depPath of node.frontmatter.depends_on) {
+    for (const depRef of node.frontmatter.depends_on) {
+      const depPath = resolveNodePath(depRef)!;
       if (isHierarchicallyIncomplete(depPath, evaluatingFor)) {
         return true;
       }
@@ -481,13 +482,14 @@ function main(): void {
     if (node.frontmatter.status !== 'ACTIVE' && node.frontmatter.status !== 'COMPLETED') continue;
 
     let shouldSuspend = false;
-    for (const depPath of node.frontmatter.depends_on) {
+    for (const depRef of node.frontmatter.depends_on) {
+      const depPath = resolveNodePath(depRef)!;
       const dep = nodeMap.get(depPath);
       if (!dep) {
         if (fs.existsSync(path.join(repoRoot, depPath))) {
           continue;
         }
-        warn(`Unresolvable dependency '${depPath}' referenced by ${node.frontmatter.status} node: ${node.repoPath}`);
+        warn(`Unresolvable dependency '${depRef}' referenced by ${node.frontmatter.status} node: ${node.repoPath}`);
         hasUnresolvableDeps = true;
         shouldSuspend = true;
         break;
@@ -519,7 +521,7 @@ function main(): void {
   info('Phase 3.6: Checking for Impossible Loop conditions...');
   for (const node of nodes) {
     if (node.frontmatter.status === 'FAILED' && node.frontmatter.rejection_reason) {
-      const parentPath = resolveParentPath(node.frontmatter.parent);
+      const parentPath = resolveNodePath(node.frontmatter.parent);
       if (parentPath) {
         const parentNode = nodeMap.get(parentPath);
         if (parentNode && parentNode.frontmatter.status !== 'ACTIVE') {
@@ -548,7 +550,7 @@ function main(): void {
     let blocked = false;
 
         // Check parent inheritance
-    let currParent = resolveParentPath(node.frontmatter.parent);
+    let currParent = resolveNodePath(node.frontmatter.parent);
     while (currParent) {
       let parentStatus: string | undefined = undefined;
       let nextParent: string | undefined | null = undefined;
@@ -560,7 +562,7 @@ function main(): void {
         break;
       } else {
         parentStatus = parentNode.frontmatter.status;
-        nextParent = resolveParentPath(parentNode.frontmatter.parent);
+        nextParent = resolveNodePath(parentNode.frontmatter.parent);
       }
 
       if (parentStatus !== 'ACTIVE' && parentStatus !== 'COMPLETED') {
@@ -591,13 +593,14 @@ function main(): void {
 
     const deps = node.frontmatter.depends_on;
 
-    for (const depPath of deps) {
+    for (const depRef of deps) {
+      const depPath = resolveNodePath(depRef)!;
       const dep = nodeMap.get(depPath);
       if (!dep) {
         if (fs.existsSync(path.join(repoRoot, depPath))) {
           continue;
         }
-        warn(`Unresolvable dependency '${depPath}' referenced by: ${node.repoPath}`);
+        warn(`Unresolvable dependency '${depRef}' referenced by: ${node.repoPath}`);
         hasUnresolvableDeps = true;
         blocked = true;
         break;
@@ -623,11 +626,12 @@ function main(): void {
       const body = node.body;
       const matches = [...new Set(body.match(regex) || [])];
 
-      const parentPath = resolveParentPath(node.frontmatter.parent);
+      const parentPath = resolveNodePath(node.frontmatter.parent);
+      const resolvedDeps = node.frontmatter.depends_on.map(d => resolveNodePath(d));
       const targetArtifacts = matches.filter(m =>
         m !== node.repoPath &&
         m !== parentPath &&
-        !node.frontmatter.depends_on.includes(m)
+        !resolvedDeps.includes(m)
       );
 
       let bypassDispatch = false;
@@ -692,7 +696,8 @@ function main(): void {
 
         if (allChildrenCompleted) {
           let isDepIncomplete = false;
-          for (const depPath of node.frontmatter.depends_on) {
+          for (const depRef of node.frontmatter.depends_on) {
+            const depPath = resolveNodePath(depRef)!;
             if (isHierarchicallyIncomplete(depPath, node.repoPath)) {
               isDepIncomplete = true;
               break;


### PR DESCRIPTION
This PR fixes a bug in the Foundry DAG orchestrator where node IDs used in the `depends_on` field of frontmatter were treated as literal (and thus unresolvable) file paths. The orchestrator now correctly resolves both repo-relative paths and node IDs in `depends_on`, consistent with how it handles the `parent` field.

Changes:
- Generalizes `resolveParentPath` to `resolveNodePath`.
- Consistently applies `resolveNodePath` across all orchestration phases (Hierarchical Completion, Suspension, Resolve, Preflight, etc.).
- Adds a regression test case in `foundry-orchestrator.test.ts`.
- Confirmed that the `Unresolvable dependency 'task-046-073-implement-branch-identification'` warning is resolved in the current repository.

Fixes #1128

---
*PR created automatically by Jules for task [2915387366178840709](https://jules.google.com/task/2915387366178840709) started by @szubster*