### PR TITLE
QA: Validate Hall of Fame & Roamers Extraction

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -11,3 +11,7 @@ Completed task-034-059-qa-orchestrator-preflight. Verified preflight logic testi
 **Task**: task-036-063-qa-cascade-cancellation
 **Outcome**: COMPLETED
 **Notes**: Verified that the Coder's implementation of cascading cancellation in `.github/scripts/foundry-orchestrator.ts` meets requirements. Unit tests in `.github/scripts/foundry-orchestrator.test.ts` thoroughly cover the recursive cascading behavior, ensuring `COMPLETED` children are not overwritten, and maintaining idempotency. All tests pass cleanly.
+# QA Journal
+
+## 2026-05-10
+Verified implementation of Hall of Fame count and roaming legendary (Raikou, Entei, Suicune) map location extraction for Gen 2 save files. The implementation matches the technical contract (`SaveData` updated correctly with `roamingLegendaries` and `parseGen2` properly calculates Hall of Fame counts and roamer locations via specified offsets for GS/Crystal). All checks passed (`pnpm lint` and `pnpm test`), and the unit tests adequately cover the mock GS/Crystal offset behaviors. Since the feature is fully implemented and tested, I have updated the task's markdown acceptance criteria to complete. Because there are no legitimate code modifications left to make, an empty PR will be submitted to allow the DAG to progress per the empty PR policy.

--- a/.foundry/tasks/task-042-069-qa-hall-of-fame-roamers.md
+++ b/.foundry/tasks/task-042-069-qa-hall-of-fame-roamers.md
@@ -31,6 +31,6 @@ Verify the implementation of Hall of Fame count and roaming legendary (Raikou, E
 - `parseGen2` must correctly identify Hall of Fame counts and the locations for the roamers using the specified offsets (GS: 0x24EC, 0x28DA / Crystal: 0x24CE, 0x28B6).
 
 ## Acceptance Criteria
-- [ ] `SaveData` accurately represents the updated models.
-- [ ] Implementation parses the expected data.
-- [ ] Unit tests pass via `pnpm test` and properly mock both `GS` and `Crystal` offset behaviors.
+- [x] `SaveData` accurately represents the updated models.
+- [x] Implementation parses the expected data.
+- [x] Unit tests pass via `pnpm test` and properly mock both `GS` and `Crystal` offset behaviors.


### PR DESCRIPTION
QA validation for the Gen 2 Hall of Fame and Roamers save parsing logic. The task acceptance criteria are checked, and the QA journal is documented. Tests pass locally. No implementation changes are necessary since the provided solution works perfectly.

---
*PR created automatically by Jules for task [17175593280379824657](https://jules.google.com/task/17175593280379824657) started by @szubster*