### PR TITLE
Migrate foundry-heartbeat.ts frontmatter parsing to gray-matter

### DIFF
--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -64,7 +64,7 @@ ok: true,
     expect(fs.writeFileSync).toHaveBeenCalled();
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
     expect(writeCall[0]).toBe(mockNode.filePath);
-    expect(writeCall[1]).toContain('status: "FAILED"');
+    expect(writeCall[1]).toContain('status: FAILED');
     expect(writeCall[1]).toContain('jules_session_id: null');
 
     expect(fs.appendFileSync).toHaveBeenCalled();
@@ -127,7 +127,7 @@ ok: false,
 
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       '/mock/repo/.foundry/tasks/task-stuck.md',
-      expect.stringContaining('status: "FAILED"'),
+      expect.stringContaining('status: FAILED'),
       'utf-8'
     );
   });
@@ -221,7 +221,7 @@ ok: true,
     await main();
 
     // Should NOT flip to FAILED because PR was found via Jules link
-    expect(fs.writeFileSync).not.toHaveBeenCalledWith(expect.any(String), expect.stringContaining('status: "FAILED"'), expect.any(String));
+    expect(fs.writeFileSync).not.toHaveBeenCalledWith(expect.any(String), expect.stringContaining('status: FAILED'), expect.any(String));
   });
 
   it('should transition a node to PENDING if its PR is merged but it has unchecked tasks', async () => {
@@ -266,7 +266,7 @@ ok: true,
 
     expect(fs.writeFileSync).toHaveBeenCalled();
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    expect(writeCall[1]).toContain('status: "PENDING"');
+    expect(writeCall[1]).toContain('status: PENDING');
   });
 
   it('should transition a node to COMPLETED if PR from Jules session link is merged', async () => {
@@ -311,7 +311,7 @@ ok: true,
 
     expect(fs.writeFileSync).toHaveBeenCalled();
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-    expect(writeCall[1]).toContain('status: "COMPLETED"');
+    expect(writeCall[1]).toContain('status: COMPLETED');
   });
 
   it('should find PR from fallback list and NOT transition to FAILED', async () => {
@@ -358,7 +358,7 @@ ok: true,
 
     await main();
 
-    expect(fs.writeFileSync).not.toHaveBeenCalledWith(expect.any(String), expect.stringContaining('status: "FAILED"'), expect.any(String));
+    expect(fs.writeFileSync).not.toHaveBeenCalledWith(expect.any(String), expect.stringContaining('status: FAILED'), expect.any(String));
   });
 
   describe('Human Tasks', () => {
@@ -418,7 +418,7 @@ ok: true,
 
       expect(fs.writeFileSync).toHaveBeenCalled();
       const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-      expect(writeCall[1]).toContain('status: "COMPLETED"');
+      expect(writeCall[1]).toContain('status: COMPLETED');
     });
 
     it('should transition an ACTIVE human task to READY if PR is closed but unmerged', async () => {
@@ -455,7 +455,7 @@ ok: true,
 
       expect(fs.writeFileSync).toHaveBeenCalled();
       const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
-      expect(writeCall[1]).toContain('status: "READY"');
+      expect(writeCall[1]).toContain('status: READY');
     });
 
     it('should leave an ACTIVE human task as ACTIVE if PR is open', async () => {

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -9,6 +9,10 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { discoverNodeFiles, parseNodeFile } from './foundry-orchestrator.ts';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const matter = require('gray-matter') as typeof import('gray-matter');
+
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -35,17 +39,11 @@ export async function transitionNodeToFailed(node: any, repoRoot: string): Promi
   const dateStr = todayISO();
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
-  const fmBlockMatch = node.rawContent.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*/m);
-  if (!fmBlockMatch) return;
-
-  const originalFmBlock = fmBlockMatch[0];
-  let mutatedFmBlock = originalFmBlock;
-
-  mutatedFmBlock = mutatedFmBlock.replace(/^(status:\s*)["']?ACTIVE["']?([ \t]*)$/m, `$1"FAILED"$2`);
-  mutatedFmBlock = mutatedFmBlock.replace(/^(jules_session_id:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m, `$1null$2`);
-  mutatedFmBlock = mutatedFmBlock.replace(/^(updated_at:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m, `$1"${dateStr}"$2`);
-
-  const newContent = node.rawContent.replace(originalFmBlock, mutatedFmBlock);
+  const parsed = matter(node.rawContent);
+  parsed.data.status = "FAILED";
+  parsed.data.jules_session_id = null;
+  parsed.data.updated_at = dateStr;
+  const newContent = matter.stringify(parsed.content, parsed.data);
 
   if (!DRY_RUN) {
     fs.writeFileSync(node.filePath, newContent, 'utf-8');
@@ -59,22 +57,13 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
   const dateStr = todayISO();
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
-  const fmBlockMatch = node.rawContent.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*/m);
-  if (!fmBlockMatch) return;
-
-  const originalFmBlock = fmBlockMatch[0];
-  let mutatedFmBlock = originalFmBlock;
-
-  // Late-Binding Support: If unchecked tasks exist, transition back to PENDING instead of COMPLETED.
   const hasUncheckedTasks = /^\s*-\s*\[\s\]/m.test(node.rawContent);
-  // PENDING state keeps the late-binding parent alive to wait for children
   const targetStatus = hasUncheckedTasks ? "PENDING" : "COMPLETED";
-
-  mutatedFmBlock = mutatedFmBlock.replace(/^(status:\s*)["']?ACTIVE["']?([ \t]*)$/m, `$1"${targetStatus}"$2`);
-  mutatedFmBlock = mutatedFmBlock.replace(/^(jules_session_id:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m, `$1null$2`);
-  mutatedFmBlock = mutatedFmBlock.replace(/^(updated_at:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m, `$1"${dateStr}"$2`);
-
-  const newContent = node.rawContent.replace(originalFmBlock, mutatedFmBlock);
+  const parsed = matter(node.rawContent);
+  parsed.data.status = targetStatus;
+  parsed.data.jules_session_id = null;
+  parsed.data.updated_at = dateStr;
+  const newContent = matter.stringify(parsed.content, parsed.data);
 
   if (!DRY_RUN) {
     fs.writeFileSync(node.filePath, newContent, 'utf-8');
@@ -88,23 +77,12 @@ export async function transitionNodeToReady(node: any, repoRoot: string, reason:
   const dateStr = todayISO();
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
-  const fmBlockMatch = node.rawContent.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*/m);
-  if (!fmBlockMatch) return;
-
-  const originalFmBlock = fmBlockMatch[0];
-  let mutatedFmBlock = originalFmBlock;
-
-  mutatedFmBlock = mutatedFmBlock.replace(/^(status:\s*)["']?(?:FAILED|ACTIVE)["']?([ \t]*)$/m, `$1"READY"$2`);
-  mutatedFmBlock = mutatedFmBlock.replace(/^(jules_session_id:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m, `$1null$2`);
-
-  if (/^rejection_count:/m.test(mutatedFmBlock)) {
-    mutatedFmBlock = mutatedFmBlock.replace(/^rejection_count:\s*(\d+)/m, (_: string, count: string) => `rejection_count: ${parseInt(count, 10) + 1}`);
-  } else {
-    mutatedFmBlock = mutatedFmBlock.replace(/^status: READY/m, `status: READY\nrejection_count: 1`);
-  }
-  mutatedFmBlock = mutatedFmBlock.replace(/^(updated_at:\s*)(?:null|["']?.*?["']?)([ \t]*)$/m, `$1"${dateStr}"$2`);
-
-  const newContent = node.rawContent.replace(originalFmBlock, mutatedFmBlock);
+  const parsed = matter(node.rawContent);
+  parsed.data.status = "READY";
+  parsed.data.jules_session_id = null;
+  parsed.data.rejection_count = (parsed.data.rejection_count || 0) + 1;
+  parsed.data.updated_at = dateStr;
+  const newContent = matter.stringify(parsed.content, parsed.data);
 
   if (!DRY_RUN) {
     fs.writeFileSync(node.filePath, newContent, 'utf-8');


### PR DESCRIPTION
As per ADR-006, replaced custom regex frontmatter modifications in `.github/scripts/foundry-heartbeat.ts` with `gray-matter`. Updated `transitionNodeToFailed`, `transitionNodeToCompleted`, and `transitionNodeToReady` to parse content via `matter(node.rawContent)`, mutate properties in `parsed.data`, and re-serialize using `matter.stringify()`.
Updated `foundry-heartbeat.test.ts` to reflect the unquoted serialization format output by `gray-matter`.

---
*PR created automatically by Jules for task [11515886970183179496](https://jules.google.com/task/11515886970183179496) started by @szubster*