### PR TITLE
Foundry: Reject task-043-074 due to incomplete coder implementation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -11,3 +11,10 @@ Completed task-034-059-qa-orchestrator-preflight. Verified preflight logic testi
 **Task**: task-036-063-qa-cascade-cancellation
 **Outcome**: COMPLETED
 **Notes**: Verified that the Coder's implementation of cascading cancellation in `.github/scripts/foundry-orchestrator.ts` meets requirements. Unit tests in `.github/scripts/foundry-orchestrator.test.ts` thoroughly cover the recursive cascading behavior, ensuring `COMPLETED` children are not overwritten, and maintaining idempotency. All tests pass cleanly.
+
+
+## 2026-05-10: Validation Failure for task-043-074-qa-refactor-heartbeat-matter
+
+While validating task-043-073 (Refactor heartbeat script to use gray-matter), I found that the coder implementation was missing or incomplete. The file `.github/scripts/foundry-heartbeat.ts` still uses regex mutations for frontmatter parsing (`/^---[ 	]*?
+([sS]*?)?
+---[ 	]*/m`) in `transitionNodeToFailed`, `transitionNodeToReady`, and `transitionNodeToCompleted`. As per The Foundry rules, I am rejecting my QA task with a validation failure rather than submitting an empty PR or modifying the code directly, since this is not a regression but an incomplete feature implementation.

--- a/.foundry/tasks/task-043-074-qa-refactor-heartbeat-matter.md
+++ b/.foundry/tasks/task-043-074-qa-refactor-heartbeat-matter.md
@@ -36,3 +36,7 @@ The coder has refactored `.github/scripts/foundry-heartbeat.ts` to use `gray-mat
 ## Acceptance Criteria
 - [ ] Code review confirms no regex mutations are used for frontmatter.
 - [ ] Tests pass.
+
+
+### QA Validation Failure
+Validation failed: The `foundry-heartbeat.ts` script still contains regex mutations for frontmatter parsing and was not refactored to use `gray-matter` as required by task-043-073.


### PR DESCRIPTION
The QA agent verified `task-043-073-refactor-heartbeat-matter` and found that the `foundry-heartbeat.ts` script still utilizes regex mutations for frontmatter parsing. As per The Foundry rules, I have rejected the QA task with a validation failure and documented this decision in `.foundry/journals/qa.md` and appended the rejection reason to the Markdown body of the task.

---
*PR created automatically by Jules for task [2047569438843876654](https://jules.google.com/task/2047569438843876654) started by @szubster*