### PR TITLE
🧹 [code health improvement] remove unused import

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -29,3 +29,8 @@ Removed unused type ClassValue import from src/utils/cn.ts by utilizing Paramete
 **Learning:** Files that serve only as re-exports for "backward compatibility" (like `src/utils/data.ts` re-exporting `src/engine/data/shared/staticData.ts`) introduce unnecessary indirection. While `knip` might not flag them if they are actively used, manually tracing their usage and updating call sites to point directly to the actual source file is a safe and effective way to reduce technical debt and simplify the module graph.
 **Action:** When encountering a file that purely re-exports contents from another file without adding value, trace its usage using `grep`, update the imports at the call sites, and delete the obsolete abstraction file. Always verify the refactor by running `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no consumers were broken during the transition.
 ## 2026-06-07 - Knip dependency resolution\n\n**Learning:** Sometime a dependency or file may no longer need to be explicitly ignored in `knip.json` because `knip` successfully figures out the usage. \n**Action:** Pay attention to configuration hints in `knip` to remove `bundlemon` and `gray-matter` from `knip.json` `ignoreDependencies`.
+
+## 2026-06-08 - Target artifact already complete
+
+**Learning:** When attempting to remove an unused import (`CompactChainLink` in `PokemonDetails.tsx`), I noticed the target artifact was already complete and the unused import was no longer present in the codebase.
+**Action:** According to the Foundry guidelines, if a target artifact already exists and is complete, do not make trivial formatting changes or dummy updates to force a diff. Instead, document the lack of work in the persona journal and submit an empty PR to progress the Foundry DAG.


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The reported unused import (`CompactChainLink`) in `PokemonDetails.tsx` was actually already removed by prior commits in the branch state. Therefore, no application file edits were needed. The agent learning journal (`.jules/sweeper.md`) has been updated to document this condition and comply with the "Empty PR" workflow rule.

💡 **Why:** How this improves maintainability
Recognizing when an artifact is already complete prevents useless "dummy updates" and ensures only meaningful changes enter the codebase.

✅ **Verification:** How you confirmed the change is safe
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure the codebase and its tests remain passing.

✨ **Result:** The improvement achieved
Progressed the task with an empty PR per the user's explicit instructions and the agent system rules without corrupting or uselessly mutating application files.

---
*PR created automatically by Jules for task [7429898599687755987](https://jules.google.com/task/7429898599687755987) started by @szubster*