### PR TITLE
DAG Parser: Parse Frontmatter

### DIFF
--- a/.foundry/tasks/task-043-074-parse-frontmatter.md
+++ b/.foundry/tasks/task-043-074-parse-frontmatter.md
@@ -34,7 +34,7 @@ Implement a parsing function to extract frontmatter into structured objects.
 - Handle files that might not have valid YAML frontmatter gracefully (e.g., return `null` or skip).
 
 ## Acceptance Criteria
-- [ ] A parsing function is implemented and exported.
-- [ ] It uses `gray-matter` to parse the YAML frontmatter.
-- [ ] It correctly extracts `id`, `type`, `status`, `owner_persona`, and `depends_on`.
-- [ ] Unit tests verify correct extraction from valid markdown and graceful handling of invalid markdown.
+- [x] A parsing function is implemented and exported.
+- [x] It uses `gray-matter` to parse the YAML frontmatter.
+- [x] It correctly extracts `id`, `type`, `status`, `owner_persona`, and `depends_on`.
+- [x] Unit tests verify correct extraction from valid markdown and graceful handling of invalid markdown.

--- a/src/utils/dag/parser.test.ts
+++ b/src/utils/dag/parser.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { parseFoundryNode } from './parser';
+
+describe('parseFoundryNode', () => {
+  it('should parse valid frontmatter correctly', () => {
+    const rawContent = `---
+id: task-043-074-parse-frontmatter
+type: TASK
+status: READY
+owner_persona: coder
+depends_on:
+  - .foundry/tasks/task-043-073-read-foundry-files.md
+---
+# Content here`;
+    const result = parseFoundryNode(rawContent);
+    expect(result).toEqual({
+      id: 'task-043-074-parse-frontmatter',
+      type: 'TASK',
+      status: 'READY',
+      owner_persona: 'coder',
+      depends_on: ['.foundry/tasks/task-043-073-read-foundry-files.md'],
+    });
+  });
+
+  it('should handle empty depends_on correctly', () => {
+    const rawContent = `---
+id: task-1
+type: TASK
+status: PENDING
+owner_persona: coder
+depends_on: []
+---
+# Content here`;
+    const result = parseFoundryNode(rawContent);
+    expect(result).toEqual({
+      id: 'task-1',
+      type: 'TASK',
+      status: 'PENDING',
+      owner_persona: 'coder',
+      depends_on: [],
+    });
+  });
+
+  it('should return null if id is missing', () => {
+    const rawContent = `---
+type: TASK
+status: PENDING
+owner_persona: coder
+depends_on: []
+---`;
+    expect(parseFoundryNode(rawContent)).toBeNull();
+  });
+
+  it('should return null if depends_on is missing', () => {
+    const rawContent = `---
+id: task-1
+type: TASK
+status: PENDING
+owner_persona: coder
+---`;
+    expect(parseFoundryNode(rawContent)).toBeNull();
+  });
+
+  it('should return null if depends_on is not an array', () => {
+    const rawContent = `---
+id: task-1
+type: TASK
+status: PENDING
+owner_persona: coder
+depends_on: "not an array"
+---`;
+    expect(parseFoundryNode(rawContent)).toBeNull();
+  });
+
+  it('should return null if markdown has no frontmatter', () => {
+    const rawContent = `# Just a title
+    No frontmatter here`;
+    expect(parseFoundryNode(rawContent)).toBeNull();
+  });
+
+  it('should return null if frontmatter is invalid yaml', () => {
+    const rawContent = `---
+id: [unclosed array
+type: TASK
+---`;
+    expect(parseFoundryNode(rawContent)).toBeNull();
+  });
+});

--- a/src/utils/dag/parser.ts
+++ b/src/utils/dag/parser.ts
@@ -1,0 +1,48 @@
+import matter from 'gray-matter';
+
+export interface FoundryNodeData {
+  id: string;
+  type: string;
+  status: string;
+  owner_persona: string;
+  depends_on: string[];
+}
+
+export function parseFoundryNode(rawContent: string): FoundryNodeData | null {
+  try {
+    const parsed = matter(rawContent);
+    const data = parsed.data;
+
+    // Validate required fields
+    if (
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      typeof data['id'] !== 'string' ||
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      typeof data['type'] !== 'string' ||
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      typeof data['status'] !== 'string' ||
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      typeof data['owner_persona'] !== 'string' ||
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      !Array.isArray(data['depends_on'])
+    ) {
+      return null;
+    }
+
+    return {
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      id: data['id'],
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      type: data['type'],
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      status: data['status'],
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      owner_persona: data['owner_persona'],
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      depends_on: data['depends_on'],
+    };
+  } catch {
+    // If gray-matter fails to parse, return null
+    return null;
+  }
+}


### PR DESCRIPTION
Implemented `parseFoundryNode` using `gray-matter` to extract structured data from `Foundry` markdown files as part of the DAG parser story. Added rigorous Vitest tests.

---
*PR created automatically by Jules for task [2643383643396509597](https://jules.google.com/task/2643383643396509597) started by @szubster*