### PR TITLE
feat: Standardize orchestrator test factories

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -49,3 +49,6 @@ The mapping validation logic and unit tests are already implemented. Submitting 
   - Ensure to ignore active PR branches based on explicit requirements.
   - Used GitHub APIs to check active PRs for branches would be the consumer's responsibility. The identification logic accepts open PR refs and protects them.
 - 2026-05-10: Refactored `foundry-heartbeat.ts` to use `gray-matter`. Replaced regex frontmatter manipulations with `gray-matter` logic in `transitionNodeToFailed`, `transitionNodeToCompleted`, and `transitionNodeToReady`. `gray-matter` writes yaml strings unquoted, so tests were updated accordingly.
+
+## 2026-05-10
+Task task-046-077-standardize-orchestrator-test-factories: Implemented `foundry-test-utils.ts` and refactored the orchestrator tests to dynamically create mock nodes passing Phase 4.8 Mapping Validations. Ensure `gray-matter.stringify` is not used in frontmatter body replacements but we manually wrote a serializer for frontmatter stringification during mock file creation. Ensure `pr_number` handles null without TS errors.

--- a/.foundry/tasks/task-046-077-standardize-orchestrator-test-factories.md
+++ b/.foundry/tasks/task-046-077-standardize-orchestrator-test-factories.md
@@ -49,3 +49,7 @@ Implement a test utility function `createValidNode(overrides)` in `.github/scrip
 - [ ] Factory utility correctly assigns default frontmatter properties (e.g., valid `owner_persona` mapping based on node `type`).
 - [ ] Existing mock node configurations in `.github/scripts/foundry-orchestrator.test.ts` are refactored to use the factory.
 - [ ] The full test suite runs and passes without schema validation warnings or errors on mock nodes.
+- [x] Test factory utility function is successfully implemented.
+- [x] Factory utility correctly assigns default frontmatter properties (e.g., valid `owner_persona` mapping based on node `type`).
+- [x] Existing mock node configurations in `.github/scripts/foundry-orchestrator.test.ts` are refactored to use the factory.
+- [x] The full test suite runs and passes without schema validation warnings or errors on mock nodes.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { main } from './foundry-orchestrator';
+import { createValidTestNode } from './foundry-test-utils';
 
 describe('foundry-orchestrator', () => {
   let tmpDir: string;
@@ -29,40 +30,34 @@ describe('foundry-orchestrator', () => {
     vi.restoreAllMocks();
   });
 
-  function createNode(relPath: string, frontmatter: string, body: string = '# Title') {
-    const fullPath = path.join(tmpDir, relPath);
-    const dir = path.dirname(fullPath);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(fullPath, `---\n${frontmatter}\n---\n\n${body}`, 'utf-8');
-  }
+
 
   test('Happy Path: promotes PENDING to READY when all dependencies are COMPLETED', () => {
-    createNode('.foundry/ideas/idea-001.md', `
-id: idea-001
-type: IDEA
-title: "Idea 1"
-status: COMPLETED
-owner_persona: product_manager
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-pr_number: null
-`);
+    createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
+      id: "idea-001",
+      type: "IDEA",
+      title: "Idea 1",
+      status: "COMPLETED",
+      owner_persona: "product_manager",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
 
-    createNode('.foundry/epics/epic-001.md', `
-id: epic-001
-type: EPIC
-title: "Epic 1"
-status: PENDING
-owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - .foundry/ideas/idea-001.md
-jules_session_id: null
-pr_number: null
-`);
+    });
+
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/ideas/idea-001.md"],
+      jules_session_id: null,
+
+    });
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     main();
@@ -81,32 +76,31 @@ pr_number: null
   });
 
   test('Blocking: remains PENDING if a dependency is not COMPLETED', () => {
-    createNode('.foundry/ideas/idea-001.md', `
-id: idea-001
-type: IDEA
-title: "Idea 1"
-status: FAILED
-owner_persona: product_manager
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: "sess-123"
-pr_number: null
-`);
+    createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
+      id: "idea-001",
+      type: "IDEA",
+      title: "Idea 1",
+      status: "FAILED",
+      owner_persona: "product_manager",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: "sess-123",
 
-    createNode('.foundry/epics/epic-001.md', `
-id: epic-001
-type: EPIC
-title: "Epic 1"
-status: PENDING
-owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - .foundry/ideas/idea-001.md
-jules_session_id: null
-pr_number: null
-`);
+    });
+
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/ideas/idea-001.md"],
+      jules_session_id: null,
+
+    });
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     main();
@@ -121,15 +115,17 @@ pr_number: null
   });
 
   test('Validation: skips nodes with multiple owners (comma separated)', () => {
-    createNode('.foundry/tasks/task-multi-owner.md', `id: task-multi-owner
-type: TASK
-title: "Task with multiple owners"
-status: PENDING
-owner_persona: "coder, qa"
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-multi-owner.md', {
+      id: "task-multi-owner",
+      type: "TASK",
+      title: "Task with multiple owners",
+      status: "PENDING",
+      owner_persona: "coder, qa",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     main();
@@ -140,17 +136,17 @@ jules_session_id: null`);
   });
 
   test('Validation: skips nodes with array owners', () => {
-    createNode('.foundry/tasks/task-array-owner.md', `id: task-array-owner
-type: TASK
-title: "Task with array owners"
-status: PENDING
-owner_persona:
-  - coder
-  - qa
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-array-owner.md', {
+      id: "task-array-owner",
+      type: "TASK",
+      title: "Task with array owners",
+      status: "PENDING",
+      owner_persona: ["coder","qa"] as unknown as string,
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     main();
@@ -174,18 +170,18 @@ jules_session_id: null`);
   });
 
   test('Indegree Zero: promotes immediately if depends_on is empty', () => {
-    createNode('.foundry/ideas/idea-001.md', `
-id: idea-001
-type: IDEA
-title: "Idea 1"
-status: PENDING
-owner_persona: product_manager
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-pr_number: null
-`);
+    createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
+      id: "idea-001",
+      type: "IDEA",
+      title: "Idea 1",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+
+    });
 
     main();
 
@@ -194,18 +190,17 @@ pr_number: null
   });
 
   test('Unresolvable: logs warning and remains PENDING if dep is missing', () => {
-    createNode('.foundry/epics/epic-001.md', `
-id: epic-001
-type: EPIC
-title: "Epic 1"
-status: PENDING
-owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - .foundry/missing/ghost.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/missing/ghost.md"],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -215,46 +210,44 @@ jules_session_id: null
 
   test('Hierarchical Completion: blocks external dependent if dependency has incomplete children', () => {
     // Story 1: COMPLETED (Planned)
-    createNode('.foundry/stories/story-001.md', `
-id: story-001
-type: STORY
-title: "Story 1"
-status: COMPLETED
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     // Task 1: Child of Story 1, PENDING
-    createNode('.foundry/tasks/task-001.md', `
-id: task-001
-type: TASK
-title: "Task 1"
-status: PENDING
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - .foundry/stories/story-001.md
-parent: .foundry/stories/story-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-001.md', {
+      id: "task-001",
+      type: "TASK",
+      title: "Task 1",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/stories/story-001.md"],
+      parent: ".foundry/stories/story-001.md",
+      jules_session_id: null,
+    });
 
     // Story 2: Depends on Story 1, PENDING (External dependent)
-    createNode('.foundry/stories/story-002.md', `
-id: story-002
-type: STORY
-title: "Story 2"
-status: PENDING
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - .foundry/stories/story-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-002.md', {
+      id: "story-002",
+      type: "STORY",
+      title: "Story 2",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/stories/story-001.md"],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -269,31 +262,31 @@ jules_session_id: null
 
   test('Late-Binding: allows child of PENDING parent to proceed if parent already has children', () => {
     // Epic 1: PENDING (Waiting for children)
-    createNode('.foundry/epics/epic-001.md', `
-id: epic-001
-type: EPIC
-title: "Epic 1"
-status: PENDING
-owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     // Story 1: Child of Epic 1, PENDING
-    createNode('.foundry/stories/story-001.md', `
-id: story-001
-type: STORY
-title: "Story 1"
-status: PENDING
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: .foundry/epics/epic-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/epics/epic-001.md",
+      jules_session_id: null,
+    });
 
     main();
 
@@ -304,31 +297,31 @@ jules_session_id: null
 
   test('Late-Binding: Parent wakes up when children are COMPLETED', () => {
     // Epic 1: PENDING (Waiting for children)
-    createNode('.foundry/epics/epic-001.md', `
-id: epic-001
-type: EPIC
-title: "Epic 1"
-status: PENDING
-owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     // Story 1: Child of Epic 1, COMPLETED
-    createNode('.foundry/stories/story-001.md', `
-id: story-001
-type: STORY
-title: "Story 1"
-status: COMPLETED
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: .foundry/epics/epic-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/epics/epic-001.md",
+      jules_session_id: null,
+    });
 
     main();
 
@@ -338,33 +331,33 @@ jules_session_id: null
 
   test('Late-Binding: Parent wakes up to READY if it has unchecked tasks', () => {
     // Epic 1: PENDING (Waiting for children)
-    createNode('.foundry/epics/epic-001.md', `
-id: epic-001
-type: EPIC
-title: "Epic 1"
-status: PENDING
-owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`, `# Title
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    }, `# Title
 
 - [ ] Unchecked task`);
 
     // Story 1: Child of Epic 1, COMPLETED
-    createNode('.foundry/stories/story-001.md', `
-id: story-001
-type: STORY
-title: "Story 1"
-status: COMPLETED
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: .foundry/epics/epic-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/epics/epic-001.md",
+      jules_session_id: null,
+    });
 
     main();
 
@@ -373,32 +366,32 @@ jules_session_id: null
   });
 
   test('Late-Binding: Parent wakes up to ACTIVE if owned by human and it has unchecked tasks', () => {
-    createNode('.foundry/epics/epic-001.md', `
-id: epic-001
-type: EPIC
-title: "Epic 1"
-status: PENDING
-owner_persona: human
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`, `# Title
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "human",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    }, `# Title
 
 - [ ] Unchecked task`);
 
-    createNode('.foundry/stories/story-001.md', `
-id: story-001
-type: STORY
-title: "Story 1"
-status: COMPLETED
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: .foundry/epics/epic-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/epics/epic-001.md",
+      jules_session_id: null,
+    });
 
     main();
 
@@ -407,32 +400,32 @@ jules_session_id: null
   });
 
   test('Late-Binding: Parent does not wake up if dependencies are unresolvable', () => {
-    createNode('.foundry/epics/epic-001.md', `
-id: epic-001
-type: EPIC
-title: "Epic 1"
-status: PENDING
-owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: [".foundry/prds/missing-prd.md"]
-jules_session_id: null
-`, `# Title
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/prds/missing-prd.md"],
+      jules_session_id: null,
+    }, `# Title
 
 - [ ] Unchecked task`);
 
-    createNode('.foundry/stories/story-001.md', `
-id: story-001
-type: STORY
-title: "Story 1"
-status: COMPLETED
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: .foundry/epics/epic-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/epics/epic-001.md",
+      jules_session_id: null,
+    });
 
     main();
 
@@ -441,56 +434,56 @@ jules_session_id: null
   });
 
   test('Cascade Cancellation: cancels child nodes of CANCELLED parent recursively', () => {
-    createNode('.foundry/epics/epic-001.md', `
-id: epic-001
-type: EPIC
-title: "Cancelled Epic"
-status: CANCELLED
-owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Cancelled Epic",
+      status: "CANCELLED",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/stories/story-001.md', `
-id: story-001
-type: STORY
-title: "Story of Cancelled Epic"
-status: PENDING
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: ".foundry/epics/epic-001.md"
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story of Cancelled Epic",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/epics/epic-001.md",
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-001.md', `
-id: task-001
-type: TASK
-title: "Task of Story"
-status: READY
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: ".foundry/stories/story-001.md"
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-001.md', {
+      id: "task-001",
+      type: "TASK",
+      title: "Task of Story",
+      status: "READY",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/stories/story-001.md",
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-002.md', `
-id: task-002
-type: TASK
-title: "Completed Task of Story"
-status: COMPLETED
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: ".foundry/stories/story-001.md"
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-002.md', {
+      id: "task-002",
+      type: "TASK",
+      title: "Completed Task of Story",
+      status: "COMPLETED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/stories/story-001.md",
+      jules_session_id: null,
+    });
 
     main();
 
@@ -507,61 +500,58 @@ jules_session_id: null
 
   test('Deep Hierarchical Completion: blocks external dependent if dependency has deep incomplete children', () => {
     // Story 1: COMPLETED
-    createNode('.foundry/stories/story-001.md', `
-id: story-001
-type: STORY
-title: "Story 1"
-status: COMPLETED
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     // Task 1: Child of Story 1, COMPLETED
-    createNode('.foundry/tasks/task-001.md', `
-id: task-001
-type: TASK
-title: "Task 1"
-status: COMPLETED
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - .foundry/stories/story-001.md
-parent: .foundry/stories/story-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-001.md', {
+      id: "task-001",
+      type: "TASK",
+      title: "Task 1",
+      status: "COMPLETED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/stories/story-001.md"],
+      parent: ".foundry/stories/story-001.md",
+      jules_session_id: null,
+    });
 
     // Subtask 1: Child of Task 1, PENDING
-    createNode('.foundry/tasks/subtask-001.md', `
-id: subtask-001
-type: TASK
-title: "Subtask 1"
-status: PENDING
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - .foundry/tasks/task-001.md
-parent: .foundry/tasks/task-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/subtask-001.md', {
+      id: "subtask-001",
+      type: "TASK",
+      title: "Subtask 1",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/tasks/task-001.md"],
+      parent: ".foundry/tasks/task-001.md",
+      jules_session_id: null,
+    });
 
     // Story 2: Depends on Story 1, PENDING
-    createNode('.foundry/stories/story-002.md', `
-id: story-002
-type: STORY
-title: "Story 2"
-status: PENDING
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - .foundry/stories/story-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-002.md', {
+      id: "story-002",
+      type: "STORY",
+      title: "Story 2",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/stories/story-001.md"],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -571,17 +561,17 @@ jules_session_id: null
   });
 
   test('Human Task Bypass: PENDING human task promotes directly to ACTIVE', () => {
-    createNode('.foundry/tasks/task-001.md', `
-id: task-001
-type: TASK
-title: "Human Task 1"
-status: PENDING
-owner_persona: human
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-001.md', {
+      id: "task-001",
+      type: "TASK",
+      title: "Human Task 1",
+      status: "PENDING",
+      owner_persona: "human",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     main();
@@ -599,17 +589,17 @@ jules_session_id: null
 
   test('Human Task Bypass: existing READY human task upgrades to ACTIVE', () => {
     // Already READY, but owned by human
-    createNode('.foundry/tasks/task-002.md', `
-id: task-002
-type: TASK
-title: "Human Task 2"
-status: READY
-owner_persona: human
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-002.md', {
+      id: "task-002",
+      type: "TASK",
+      title: "Human Task 2",
+      status: "READY",
+      owner_persona: "human",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     main();
@@ -626,30 +616,29 @@ jules_session_id: null
   });
 
   test('Schema Compatibility: works with Parent-Linked Distributed ID Schema', () => {
-    createNode('.foundry/epics/epic-001-002-feature.md', `
-id: epic-001-002-feature
-type: EPIC
-title: "Epic 2"
-status: COMPLETED
-owner_persona: story_owner
-created_at: "2026-04-24"
-updated_at: "2026-04-24"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001-002-feature.md', {
+      id: "epic-001-002-feature",
+      type: "EPIC",
+      title: "Epic 2",
+      status: "COMPLETED",
+      owner_persona: "story_owner",
+      created_at: "2026-04-24",
+      updated_at: "2026-04-24",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/stories/story-002-005-impl.md', `
-id: story-002-005-impl
-type: STORY
-title: "Story 5"
-status: PENDING
-owner_persona: tech_lead
-created_at: "2026-04-24"
-updated_at: "2026-04-24"
-depends_on:
-  - .foundry/epics/epic-001-002-feature.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-002-005-impl.md', {
+      id: "story-002-005-impl",
+      type: "STORY",
+      title: "Story 5",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-24",
+      updated_at: "2026-04-24",
+      depends_on: [".foundry/epics/epic-001-002-feature.md"],
+      jules_session_id: null,
+    });
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     main();
@@ -666,30 +655,30 @@ jules_session_id: null
   });
 
   test('Parent-ID Resolution: resolves parent relationship using node ID', () => {
-    createNode('.foundry/ideas/idea-001.md', `
-id: idea-001
-type: IDEA
-title: "Idea 1"
-status: COMPLETED
-owner_persona: product_manager
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
+      id: "idea-001",
+      type: "IDEA",
+      title: "Idea 1",
+      status: "COMPLETED",
+      owner_persona: "product_manager",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/prds/prd-001.md', `
-id: prd-001
-type: PRD
-title: "PRD 1"
-status: PENDING
-owner_persona: epic_planner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-parent: idea-001
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/prds/prd-001.md', {
+      id: "prd-001",
+      type: "PRD",
+      title: "PRD 1",
+      status: "PENDING",
+      owner_persona: "epic_planner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: "idea-001",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -698,32 +687,32 @@ jules_session_id: null
   });
 
   test('Parent-ID Resolution: Late-Binding wakes up parent identified by ID', () => {
-    createNode('.foundry/ideas/idea-001.md', `
-id: idea-001
-type: IDEA
-title: "Idea 1"
-status: PENDING
-owner_persona: product_manager
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`, `# Title
+    createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
+      id: "idea-001",
+      type: "IDEA",
+      title: "Idea 1",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    }, `# Title
 - [ ] Unchecked task
 `);
 
-    createNode('.foundry/prds/prd-001.md', `
-id: prd-001
-type: PRD
-title: "PRD 1"
-status: COMPLETED
-owner_persona: epic_planner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-parent: idea-001
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/prds/prd-001.md', {
+      id: "prd-001",
+      type: "PRD",
+      title: "PRD 1",
+      status: "COMPLETED",
+      owner_persona: "epic_planner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: "idea-001",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -733,17 +722,17 @@ jules_session_id: null
 
 
   test('Wait and Wake: Suspends ACTIVE node if dependencies are unresolvable', () => {
-    createNode('.foundry/tasks/task-active.md', `
-id: task-active
-type: TASK
-title: "Active Task"
-status: ACTIVE
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: [".foundry/tasks/task-missing.md"]
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-active.md', {
+      id: "task-active",
+      type: "TASK",
+      title: "Active Task",
+      status: "ACTIVE",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/tasks/task-missing.md"],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -752,29 +741,29 @@ jules_session_id: null
   });
 
   test('Wait and Wake: Suspends ACTIVE node if dependency is incomplete', () => {
-    createNode('.foundry/tasks/task-incomplete.md', `
-id: task-incomplete
-type: TASK
-title: "Incomplete Task"
-status: PENDING
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-incomplete.md', {
+      id: "task-incomplete",
+      type: "TASK",
+      title: "Incomplete Task",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-active.md', `
-id: task-active
-type: TASK
-title: "Active Task"
-status: ACTIVE
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: [".foundry/tasks/task-incomplete.md"]
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-active.md', {
+      id: "task-active",
+      type: "TASK",
+      title: "Active Task",
+      status: "ACTIVE",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/tasks/task-incomplete.md"],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -783,42 +772,42 @@ jules_session_id: null
   });
 
   test('Wait and Wake: Suspends ACTIVE node if dependency is hierarchically incomplete', () => {
-    createNode('.foundry/stories/story-001.md', `
-id: story-001
-type: STORY
-title: "Story"
-status: COMPLETED
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-child.md', `
-id: task-child
-type: TASK
-title: "Child Task"
-status: PENDING
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: ".foundry/stories/story-001.md"
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-child.md', {
+      id: "task-child",
+      type: "TASK",
+      title: "Child Task",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/stories/story-001.md",
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-active.md', `
-id: task-active
-type: TASK
-title: "Active Task"
-status: ACTIVE
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: [".foundry/stories/story-001.md"]
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-active.md', {
+      id: "task-active",
+      type: "TASK",
+      title: "Active Task",
+      status: "ACTIVE",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/stories/story-001.md"],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -827,29 +816,29 @@ jules_session_id: null
   });
 
   test('Wait and Wake: Does not suspend ACTIVE node if all dependencies are COMPLETED', () => {
-    createNode('.foundry/tasks/task-complete.md', `
-id: task-complete
-type: TASK
-title: "Complete Task"
-status: COMPLETED
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-complete.md', {
+      id: "task-complete",
+      type: "TASK",
+      title: "Complete Task",
+      status: "COMPLETED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-active.md', `
-id: task-active
-type: TASK
-title: "Active Task"
-status: ACTIVE
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: [".foundry/tasks/task-complete.md"]
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-active.md', {
+      id: "task-active",
+      type: "TASK",
+      title: "Active Task",
+      status: "ACTIVE",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/tasks/task-complete.md"],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -859,25 +848,29 @@ jules_session_id: null
 
 
   test('Wait and Wake: Wakes PENDING node to READY if new dependency is COMPLETED', () => {
-    createNode('.foundry/tasks/task-complete.md', `id: task-complete
-type: TASK
-title: "Complete Task"
-status: COMPLETED
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-complete.md', {
+      id: "task-complete",
+      type: "TASK",
+      title: "Complete Task",
+      status: "COMPLETED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-pending.md', `id: task-pending
-type: TASK
-title: "Pending Task"
-status: PENDING
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: [".foundry/tasks/task-complete.md"]
-jules_session_id: null`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-pending.md', {
+      id: "task-pending",
+      type: "TASK",
+      title: "Pending Task",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/tasks/task-complete.md"],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -886,30 +879,29 @@ jules_session_id: null`);
   });
 
   test('Depends-On-ID Resolution: resolves dependencies using node ID', () => {
-    createNode('.foundry/tasks/task-001.md', `
-id: task-001
-type: TASK
-title: "Task 1"
-status: COMPLETED
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-001.md', {
+      id: "task-001",
+      type: "TASK",
+      title: "Task 1",
+      status: "COMPLETED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-002.md', `
-id: task-002
-type: TASK
-title: "Task 2"
-status: PENDING
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - task-001
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-002.md', {
+      id: "task-002",
+      type: "TASK",
+      title: "Task 2",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: ["task-001"],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -919,25 +911,29 @@ jules_session_id: null
 
 
   test('Wait and Wake: ACTIVE node transitions to PENDING when new incomplete dependency is added', () => {
-    createNode('.foundry/tasks/task-incomplete.md', `id: task-incomplete
-type: TASK
-title: "Incomplete Task"
-status: PENDING
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-incomplete.md', {
+      id: "task-incomplete",
+      type: "TASK",
+      title: "Incomplete Task",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-active.md', `id: task-active
-type: TASK
-title: "Active Task"
-status: ACTIVE
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: [".foundry/tasks/task-incomplete.md"]
-jules_session_id: "session-123"`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-active.md', {
+      id: "task-active",
+      type: "TASK",
+      title: "Active Task",
+      status: "ACTIVE",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/tasks/task-incomplete.md"],
+      jules_session_id: "session-123",
+    });
 
     main();
 
@@ -946,31 +942,31 @@ jules_session_id: "session-123"`);
   });
 
   test('Impossible Loop: wakes up parent if impossible child is FAILED with rejection_reason', () => {
-    createNode('.foundry/stories/story-001.md', `
-id: story-001
-type: STORY
-title: "Story"
-status: PENDING
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-impossible.md', `
-id: task-impossible
-type: TASK
-title: "Impossible Task"
-status: FAILED
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: ".foundry/stories/story-001.md"
-rejection_reason: "Feature not supported"
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-impossible.md', {
+      id: "task-impossible",
+      type: "TASK",
+      title: "Impossible Task",
+      status: "FAILED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/stories/story-001.md",
+      rejection_reason: "Feature not supported",
+      jules_session_id: null,
+    });
 
     main();
 
@@ -979,18 +975,18 @@ jules_session_id: null
   });
 
   test('Impossible Loop: flags node for tpm if no parent exists', () => {
-    createNode('.foundry/tasks/task-impossible-no-parent.md', `
-id: task-impossible-no-parent
-type: TASK
-title: "Impossible Task No Parent"
-status: FAILED
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-rejection_reason: "Feature not supported"
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-impossible-no-parent.md', {
+      id: "task-impossible-no-parent",
+      type: "TASK",
+      title: "Impossible Task No Parent",
+      status: "FAILED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      rejection_reason: "Feature not supported",
+      jules_session_id: null,
+    });
 
     main();
 
@@ -1000,10 +996,10 @@ jules_session_id: null
   });
 
   test('Mapping Validation: Enforces type to persona mappings before dispatch', () => {
-    createNode('.foundry/ideas/idea-001.md', `id: idea-001\ntype: IDEA\ntitle: "Idea"\nstatus: PENDING\nowner_persona: product_manager\ncreated_at: "2026-04-20"\nupdated_at: "2026-04-20"\ndepends_on: []\njules_session_id: null\n`);
-    createNode('.foundry/prds/prd-invalid.md', `id: prd-invalid\ntype: PRD\ntitle: "Invalid PRD"\nstatus: PENDING\nowner_persona: coder\ncreated_at: "2026-04-20"\nupdated_at: "2026-04-20"\ndepends_on: []\njules_session_id: null\n`);
-    createNode('.foundry/tasks/task-human.md', `id: task-human\ntype: TASK\ntitle: "Human Task"\nstatus: PENDING\nowner_persona: human\ncreated_at: "2026-04-20"\nupdated_at: "2026-04-20"\ndepends_on: []\njules_session_id: null\n`);
-    createNode('.foundry/research/research-001.md', `id: research-001\ntype: RESEARCH\ntitle: "Research Task"\nstatus: PENDING\nowner_persona: researcher\ncreated_at: "2026-04-20"\nupdated_at: "2026-04-20"\ndepends_on: []\njules_session_id: null\n`);
+    createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', { id: "idea-001", type: "IDEA", title: "Idea", status: "PENDING", owner_persona: "product_manager", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
+    createValidTestNode(tmpDir, '.foundry/prds/prd-invalid.md', { id: "prd-invalid", type: "PRD", title: "Invalid PRD", status: "PENDING", owner_persona: "coder", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
+    createValidTestNode(tmpDir, '.foundry/tasks/task-human.md', { id: "task-human", type: "TASK", title: "Human Task", status: "PENDING", owner_persona: "human", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
+    createValidTestNode(tmpDir, '.foundry/research/research-001.md', { id: "research-001", type: "RESEARCH", title: "Research Task", status: "PENDING", owner_persona: "researcher", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
 
     main();
 
@@ -1023,40 +1019,41 @@ jules_session_id: null
   });
 
   test('Atomic Handoffs: resolves dependencies across single-persona atomic tasks', () => {
-    createNode('.foundry/tasks/task-atomic-1.md', `id: task-atomic-1
-type: TASK
-title: "Tech Lead Task"
-status: COMPLETED
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-atomic-1.md', {
+      id: "task-atomic-1",
+      type: "TASK",
+      title: "Tech Lead Task",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-atomic-2.md', `id: task-atomic-2
-type: TASK
-title: "Coder Task"
-status: PENDING
-owner_persona: coder
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - .foundry/tasks/task-atomic-1.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-atomic-2.md', {
+      id: "task-atomic-2",
+      type: "TASK",
+      title: "Coder Task",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/tasks/task-atomic-1.md"],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/tasks/task-atomic-3.md', `id: task-atomic-3
-type: TASK
-title: "QA Task"
-status: PENDING
-owner_persona: qa
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on:
-  - .foundry/tasks/task-atomic-2.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/tasks/task-atomic-3.md', {
+      id: "task-atomic-3",
+      type: "TASK",
+      title: "QA Task",
+      status: "PENDING",
+      owner_persona: "qa",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/tasks/task-atomic-2.md"],
+      jules_session_id: null,
+    });
 
     main();
 
@@ -1096,26 +1093,30 @@ expect(fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-004-005.md'), 'utf
 });
 
   test('Preflight: bypasses dispatch and marks COMPLETED if target artifacts exist and are valid', () => {
-    createNode('.foundry/epics/epic-preflight-1.md', `id: epic-preflight-1
-type: EPIC
-title: "Epic 1"
-status: PENDING
-owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null`);
+    createValidTestNode(tmpDir, '.foundry/epics/epic-preflight-1.md', {
+      id: "epic-preflight-1",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
-    createNode('.foundry/stories/story-preflight-1.md', `id: story-preflight-1
-type: STORY
-title: "Story 1"
-status: COMPLETED
-owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: .foundry/epics/epic-preflight-1.md
-jules_session_id: null`);
+    createValidTestNode(tmpDir, '.foundry/stories/story-preflight-1.md', {
+      id: "story-preflight-1",
+      type: "STORY",
+      title: "Story 1",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/epics/epic-preflight-1.md",
+      jules_session_id: null,
+    });
 
     const filePath = path.join(tmpDir, '.foundry/epics/epic-preflight-1.md');
     fs.appendFileSync(filePath, '\nTarget artifact: [.foundry/stories/story-preflight-1.md](.foundry/stories/story-preflight-1.md)');
@@ -1127,15 +1128,17 @@ jules_session_id: null`);
   });
 
   test('Preflight: does not bypass if target artifacts exist but are invalid', () => {
-    createNode('.foundry/epics/epic-preflight-2.md', `id: epic-preflight-2
-type: EPIC
-title: "Epic 2"
-status: PENDING
-owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null`);
+    createValidTestNode(tmpDir, '.foundry/epics/epic-preflight-2.md', {
+      id: "epic-preflight-2",
+      type: "EPIC",
+      title: "Epic 2",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
 
     // Invalid story (missing required fields)
     const invalidStoryPath = path.join(tmpDir, '.foundry/stories/story-preflight-2-invalid.md');
@@ -1152,33 +1155,33 @@ jules_session_id: null`);
   });
 
   test('Late-Binding: Parent with unchecked tasks and completed children is promoted exactly once', () => {
-    createNode('.foundry/ideas/idea-001.md', `
-id: idea-001
-type: IDEA
-title: "Idea 1"
-status: PENDING
-owner_persona: product_manager
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-jules_session_id: null
-`, `# Title
+    createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
+      id: "idea-001",
+      type: "IDEA",
+      title: "Idea 1",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    }, `# Title
 - [ ] Unchecked task
 - Spawned: [.foundry/prds/prd-001.md](.foundry/prds/prd-001.md)
 `);
 
-    createNode('.foundry/prds/prd-001.md', `
-id: prd-001
-type: PRD
-title: "PRD 1"
-status: COMPLETED
-owner_persona: epic_planner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-depends_on: []
-parent: .foundry/ideas/idea-001.md
-jules_session_id: null
-`);
+    createValidTestNode(tmpDir, '.foundry/prds/prd-001.md', {
+      id: "prd-001",
+      type: "PRD",
+      title: "PRD 1",
+      status: "COMPLETED",
+      owner_persona: "epic_planner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/ideas/idea-001.md",
+      jules_session_id: null,
+    });
 
     const stderrSpy = vi.spyOn(process.stderr, 'write');
     main();

--- a/.github/scripts/foundry-test-utils.ts
+++ b/.github/scripts/foundry-test-utils.ts
@@ -1,0 +1,85 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { FoundryFrontmatter } from './foundry-orchestrator';
+
+export function getValidOwnerPersona(type: string): string {
+  switch (type) {
+    case 'IDEA': return 'product_manager';
+    case 'PRD': return 'epic_planner';
+    case 'EPIC': return 'story_owner';
+    case 'STORY': return 'tech_lead';
+    case 'TASK': return 'coder';
+    case 'RESEARCH': return 'researcher';
+    case 'ADR': return 'architect';
+    default: return 'coder';
+  }
+}
+
+export function createValidNodeFrontmatter(overrides: Partial<FoundryFrontmatter> & { type?: string; [key: string]: any } = {}): string {
+  const type = overrides.type || 'TASK';
+  const owner_persona = overrides.owner_persona || getValidOwnerPersona(type);
+
+  const frontmatter = {
+    id: overrides.id || `${type.toLowerCase()}-001`,
+    type,
+    title: overrides.title || `${type} Title`,
+    status: overrides.status || 'PENDING',
+    owner_persona,
+    created_at: overrides.created_at || '2026-04-20',
+    updated_at: overrides.updated_at || '2026-04-20',
+    depends_on: overrides.depends_on || [],
+    jules_session_id: overrides.jules_session_id !== undefined ? overrides.jules_session_id : null,
+    pr_number: overrides.pr_number !== undefined ? overrides.pr_number : null,
+    parent: overrides.parent,
+    tags: overrides.tags || [],
+    research_references: overrides.research_references || [],
+    rejection_count: overrides.rejection_count || 0,
+    rejection_reason: overrides.rejection_reason || '',
+    notes: overrides.notes || ''
+  };
+
+  let yaml = '';
+  for (const [key, value] of Object.entries(frontmatter)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        yaml += `${key}: []\n`;
+      } else {
+        yaml += `${key}:\n`;
+        for (const item of value) {
+          if (typeof item === 'string') {
+              yaml += `  - "${item}"\n`;
+          } else {
+              yaml += `  - ${JSON.stringify(item)}\n`;
+          }
+        }
+      }
+    } else if (value === null) {
+      yaml += `${key}: null\n`;
+    } else if (typeof value === 'string' && (key === 'title' || key === 'owner_persona' || key === 'created_at' || key === 'updated_at' || key === 'parent' || key === 'rejection_reason' || key === 'notes' || key === 'jules_session_id')) {
+      if (key === 'owner_persona') {
+          // Sometimes it is string with commas, in those bad test cases, wrap in quotes
+          if (value.includes(',')) {
+              yaml += `${key}: "${value}"\n`;
+          } else {
+              yaml += `${key}: ${value}\n`;
+          }
+      } else {
+          yaml += `${key}: "${value}"\n`;
+      }
+    } else {
+      yaml += `${key}: ${value}\n`;
+    }
+  }
+
+  return yaml.trim();
+}
+
+export function createValidTestNode(tmpDir: string, relPath: string, overrides: Partial<FoundryFrontmatter> & { type?: string; [key: string]: any } = {}, body: string = '# Title') {
+  const fullPath = path.join(tmpDir, relPath);
+  const dir = path.dirname(fullPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const frontmatter = createValidNodeFrontmatter(overrides);
+  fs.writeFileSync(fullPath, `---\n${frontmatter}\n---\n\n${body}`, 'utf-8');
+}


### PR DESCRIPTION
Implemented `createValidNodeFrontmatter` and `createValidTestNode` utilities in `foundry-test-utils.ts` to dynamically assign valid defaults (e.g. `owner_persona` mapping based on node `type`). Refactored the `foundry-orchestrator.test.ts` to cleanly use these utilities, preventing validation failures on mock test nodes.

---
*PR created automatically by Jules for task [14790392855257797686](https://jules.google.com/task/14790392855257797686) started by @szubster*