### PR TITLE
QA Verification - Refactor heartbeat script to use gray-matter

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -15,3 +15,8 @@ Completed task-034-059-qa-orchestrator-preflight. Verified preflight logic testi
 
 ## 2026-05-10
 Verified implementation of Hall of Fame count and roaming legendary (Raikou, Entei, Suicune) map location extraction for Gen 2 save files. The implementation matches the technical contract (`SaveData` updated correctly with `roamingLegendaries` and `parseGen2` properly calculates Hall of Fame counts and roamer locations via specified offsets for GS/Crystal). All checks passed (`pnpm lint` and `pnpm test`), and the unit tests adequately cover the mock GS/Crystal offset behaviors. Since the feature is fully implemented and tested, I have updated the task's markdown acceptance criteria to complete. Because there are no legitimate code modifications left to make, an empty PR will be submitted to allow the DAG to progress per the empty PR policy.
+
+## [2026-05-10] QA Validation: task-043-074-qa-refactor-heartbeat-matter
+- Verified that regex frontmatter manipulation in `foundry-heartbeat.ts` was successfully replaced with `gray-matter` compliant with ADR-006.
+- Checked code in `transitionNodeToFailed` and `transitionNodeToReady` handles state updating cleanly using `matter.stringify` without regex.
+- Verified tests successfully run indicating no regressions.

--- a/.foundry/tasks/task-043-074-qa-refactor-heartbeat-matter.md
+++ b/.foundry/tasks/task-043-074-qa-refactor-heartbeat-matter.md
@@ -34,5 +34,5 @@ The coder has refactored `.github/scripts/foundry-heartbeat.ts` to use `gray-mat
 4. Verify that the markdown body is preserved correctly.
 
 ## Acceptance Criteria
-- [ ] Code review confirms no regex mutations are used for frontmatter.
-- [ ] Tests pass.
+- [x] Code review confirms no regex mutations are used for frontmatter.
+- [x] Tests pass.


### PR DESCRIPTION
QA Validation for task `task-043-074-qa-refactor-heartbeat-matter`.

Verified the implementation of `task-043-073-refactor-heartbeat-matter` which migrated the `.github/scripts/foundry-heartbeat.ts` script to use `gray-matter`.
Checked that no regex mutations remain for the frontmatter and verified that the test suite continues to pass. 
Updated the task's markdown checkboxes to complete, and recorded the review log in `.foundry/journals/qa.md`. No changes were made to the YAML frontmatter.

---
*PR created automatically by Jules for task [1127774239462736510](https://jules.google.com/task/1127774239462736510) started by @szubster*