### PR TITLE
QA: Branch Identification Logic Validation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -15,3 +15,7 @@ Completed task-034-059-qa-orchestrator-preflight. Verified preflight logic testi
 
 ## 2026-05-10
 Verified implementation of Hall of Fame count and roaming legendary (Raikou, Entei, Suicune) map location extraction for Gen 2 save files. The implementation matches the technical contract (`SaveData` updated correctly with `roamingLegendaries` and `parseGen2` properly calculates Hall of Fame counts and roamer locations via specified offsets for GS/Crystal). All checks passed (`pnpm lint` and `pnpm test`), and the unit tests adequately cover the mock GS/Crystal offset behaviors. Since the feature is fully implemented and tested, I have updated the task's markdown acceptance criteria to complete. Because there are no legitimate code modifications left to make, an empty PR will be submitted to allow the DAG to progress per the empty PR policy.
+
+## [task-046-074-qa-branch-identification]
+- Validated `identifyBranchesForCleanup` logic for branch identification corresponding to `FAILED` or `CANCELLED` nodes.
+- Implementation for `FAILED` status was correct, but missing a test for `CANCELLED` nodes. Appended a new test case explicitly testing `CANCELLED` nodes to verify full coverage.

--- a/.foundry/tasks/task-046-074-qa-branch-identification.md
+++ b/.foundry/tasks/task-046-074-qa-branch-identification.md
@@ -30,4 +30,4 @@ The Coder has completed the technical implementation for branch identification l
 - **Testing:** Verify that tests exist or add tests for the branch identification logic ensuring safety checks properly prevent deletion of `main`, active PR branches, or branches associated with `PENDING`, `READY`, `ACTIVE`, or `COMPLETED` nodes (with mocked Git/GitHub API calls).
 
 ## Acceptance Criteria
-- [ ] Tests verify the branch identification logic (with mocked Git/GitHub API calls).
+- [x] Tests verify the branch identification logic (with mocked Git/GitHub API calls).

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -508,6 +508,18 @@ ok: true,
       expect(result).toEqual(['origin/branch-session-fail']);
     });
 
+    it('should return candidate branches for CANCELLED nodes', async () => {
+      const mockCancelledNode = {
+        frontmatter: { status: 'CANCELLED', jules_session_id: 'session-cancelled' }
+      };
+
+      vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['cancelled.md']);
+      vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockCancelledNode as any);
+
+      const result = await identifyBranchesForCleanup('/mock', ['origin/branch-session-cancelled']);
+      expect(result).toEqual(['origin/branch-session-cancelled']);
+    });
+
     it('should NOT return safe branches even if they contain candidate session IDs', async () => {
       const mockFailedNode = {
         frontmatter: { status: 'FAILED', jules_session_id: 'session-fail' }


### PR DESCRIPTION
QA task validation revealed that the technical implementation properly handled both `FAILED` and `CANCELLED` branches, but was missing test coverage for `CANCELLED` nodes. Added the missing unit test in `.github/scripts/foundry-heartbeat.test.ts`. Marked the task acceptance criteria as complete and documented findings in `qa.md`.

---
*PR created automatically by Jules for task [14838126005618852237](https://jules.google.com/task/14838126005618852237) started by @szubster*