### PR TITLE
[Empty PR] tech_lead: story-025-040-write-validation-tests

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -29,3 +29,8 @@ All sibling tasks were explicitly linked via `depends_on` to ensure execution se
 - **Task:** Implement Failure Handling for Validation Mismatches (story-025-039-implement-failure-handling)
 - **Observation:** The generated artifacts (`task-039-071-implement-failure-handling.md` and `task-039-072-qa-failure-handling.md`) already exist and are marked as COMPLETED.
 - **Action:** Since there is no further work to do, I checked off the remaining acceptance criteria boxes in the parent STORY markdown, as the required artifacts are fully generated and the story requirements are fulfilled. I am submitting this empty PR to allow the DAG to progress.
+
+## Story 025-040: Write Validation Tests for Orchestrator Pipeline Handoff
+- **Target Node**: `.foundry/stories/story-025-040-write-validation-tests.md`
+- **Action Taken**: NO WORK REQUIRED. The validation tests (Mapping Validation: Enforces type to persona mappings before dispatch) already exist and are fully implemented in `.github/scripts/foundry-orchestrator.test.ts`.
+- **Outcome**: Executing Empty PR Policy.

--- a/.foundry/stories/story-025-040-write-validation-tests.md
+++ b/.foundry/stories/story-025-040-write-validation-tests.md
@@ -29,9 +29,9 @@ notes: ''
 Add unit tests to `foundry-orchestrator.test.ts` covering valid, invalid, and `human` ownership mappings.
 
 ## Acceptance Criteria
-- [ ] Write test cases verifying correct type-to-persona mappings successfully dispatch.
-- [ ] Write test cases verifying incorrect mapping transitions node to `FAILED` with specific `rejection_reason`.
-- [ ] Write test case verifying `human` mapping skips validation.
+- [x] Write test cases verifying correct type-to-persona mappings successfully dispatch.
+- [x] Write test cases verifying incorrect mapping transitions node to `FAILED` with specific `rejection_reason`.
+- [x] Write test case verifying `human` mapping skips validation.
 
 ## Next Step
-- [ ] Create Task for testing.
+- [x] Create Task for testing.


### PR DESCRIPTION
This PR satisfies the requirements for `story-025-040-write-validation-tests`.

Since the requested tests for mapping validation are already present in `.github/scripts/foundry-orchestrator.test.ts`, I am applying the Empty PR Policy. I have documented this decision in my journal and updated the story's acceptance criteria to reflect completion.

---
*PR created automatically by Jules for task [9824115300419320307](https://jules.google.com/task/9824115300419320307) started by @szubster*