### PR TITLE
feat(dag): implement DAG graph builder

### DIFF
--- a/.foundry/tasks/task-043-075-build-dag-graph.md
+++ b/.foundry/tasks/task-043-075-build-dag-graph.md
@@ -41,7 +41,7 @@ Implement a builder function that outputs the final node/edge graph data structu
 - Ensure the `depends_on` array (which contains file paths) is correctly mapped to node `id`s for the edges. You may need to map paths to node IDs.
 
 ## Acceptance Criteria
-- [ ] A builder function is implemented and exported.
-- [ ] It produces a structured JSON output with `nodes` and `edges`.
-- [ ] `depends_on` paths are correctly translated into edges linking node IDs.
-- [ ] Unit tests verify the correct generation of the graph structure from mock parsed nodes.
+- [x] A builder function is implemented and exported.
+- [x] It produces a structured JSON output with `nodes` and `edges`.
+- [x] `depends_on` paths are correctly translated into edges linking node IDs.
+- [x] Unit tests verify the correct generation of the graph structure from mock parsed nodes.

--- a/src/utils/dag/builder.test.ts
+++ b/src/utils/dag/builder.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { buildDagGraph, type ParsedNode } from './builder';
+
+describe('buildDagGraph', () => {
+  it('should build a DAG graph with nodes and correctly mapped edges', () => {
+    const parsedNodes: ParsedNode[] = [
+      {
+        filePath: '.foundry/tasks/task-1.md',
+        data: {
+          id: 'task-1',
+          type: 'TASK',
+          status: 'COMPLETED',
+          owner_persona: 'coder',
+          depends_on: [],
+        },
+      },
+      {
+        filePath: '.foundry/tasks/task-2.md',
+        data: {
+          id: 'task-2',
+          type: 'TASK',
+          status: 'PENDING',
+          owner_persona: 'qa',
+          depends_on: ['.foundry/tasks/task-1.md'],
+        },
+      },
+    ];
+
+    const result = buildDagGraph(parsedNodes);
+
+    expect(result).toEqual({
+      nodes: [
+        {
+          id: 'task-1',
+          data: {
+            type: 'TASK',
+            status: 'COMPLETED',
+            owner_persona: 'coder',
+          },
+        },
+        {
+          id: 'task-2',
+          data: {
+            type: 'TASK',
+            status: 'PENDING',
+            owner_persona: 'qa',
+          },
+        },
+      ],
+      edges: [
+        {
+          source: 'task-1',
+          target: 'task-2',
+        },
+      ],
+    });
+  });
+
+  it('should handle path variations (with or without ./)', () => {
+    const parsedNodes: ParsedNode[] = [
+      {
+        filePath: '.foundry/tasks/task-1.md',
+        data: {
+          id: 'task-1',
+          type: 'TASK',
+          status: 'COMPLETED',
+          owner_persona: 'coder',
+          depends_on: [],
+        },
+      },
+      {
+        filePath: '.foundry/tasks/task-2.md',
+        data: {
+          id: 'task-2',
+          type: 'TASK',
+          status: 'PENDING',
+          owner_persona: 'qa',
+          depends_on: ['./.foundry/tasks/task-1.md'],
+        },
+      },
+    ];
+
+    const result = buildDagGraph(parsedNodes);
+
+    expect(result.edges).toEqual([
+      {
+        source: 'task-1',
+        target: 'task-2',
+      },
+    ]);
+  });
+
+  it('should ignore dependencies that do not exist in the parsed nodes', () => {
+    const parsedNodes: ParsedNode[] = [
+      {
+        filePath: '.foundry/tasks/task-1.md',
+        data: {
+          id: 'task-1',
+          type: 'TASK',
+          status: 'PENDING',
+          owner_persona: 'coder',
+          depends_on: ['.foundry/tasks/unknown-task.md'],
+        },
+      },
+    ];
+
+    const result = buildDagGraph(parsedNodes);
+
+    expect(result).toEqual({
+      nodes: [
+        {
+          id: 'task-1',
+          data: {
+            type: 'TASK',
+            status: 'PENDING',
+            owner_persona: 'coder',
+          },
+        },
+      ],
+      edges: [],
+    });
+  });
+
+  it('should handle multiple dependencies', () => {
+    const parsedNodes: ParsedNode[] = [
+      {
+        filePath: 'task-1.md',
+        data: { id: 't1', type: 'TASK', status: 'COMPLETED', owner_persona: 'coder', depends_on: [] },
+      },
+      {
+        filePath: 'task-2.md',
+        data: { id: 't2', type: 'TASK', status: 'COMPLETED', owner_persona: 'coder', depends_on: [] },
+      },
+      {
+        filePath: 'task-3.md',
+        data: {
+          id: 't3',
+          type: 'TASK',
+          status: 'READY',
+          owner_persona: 'coder',
+          depends_on: ['task-1.md', 'task-2.md'],
+        },
+      },
+    ];
+
+    const result = buildDagGraph(parsedNodes);
+
+    expect(result.edges).toEqual([
+      { source: 't1', target: 't3' },
+      { source: 't2', target: 't3' },
+    ]);
+  });
+
+  it('should return empty nodes and edges for empty input', () => {
+    const result = buildDagGraph([]);
+    expect(result).toEqual({ nodes: [], edges: [] });
+  });
+});

--- a/src/utils/dag/builder.ts
+++ b/src/utils/dag/builder.ts
@@ -1,0 +1,80 @@
+import type { FoundryNodeData } from './parser';
+
+export interface ParsedNode {
+  filePath: string;
+  data: FoundryNodeData;
+}
+
+export interface GraphNode {
+  id: string;
+  data: {
+    type: string;
+    status: string;
+    owner_persona: string;
+  };
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+}
+
+export interface DagGraph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export function buildDagGraph(parsedNodes: ParsedNode[]): DagGraph {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+
+  const pathToIdMap = new Map<string, string>();
+
+  // First pass: Build nodes and the path-to-ID map
+  for (const node of parsedNodes) {
+    const id = node.data.id;
+
+    // Some paths in depends_on might not include the leading `./` or might vary slightly.
+    // Assuming parsedNodes provides paths consistent with depends_on.
+    // If not, path normalization might be needed. We map exactly what's given.
+    pathToIdMap.set(node.filePath, id);
+    // Also try to map without leading ./ if present, or add if not, to handle variations
+    if (node.filePath.startsWith('./')) {
+      pathToIdMap.set(node.filePath.slice(2), id);
+    } else {
+      pathToIdMap.set(`./${node.filePath}`, id);
+    }
+
+    nodes.push({
+      id,
+      data: {
+        type: node.data.type,
+        status: node.data.status,
+        owner_persona: node.data.owner_persona,
+      },
+    });
+  }
+
+  // Second pass: Build edges using the path-to-ID map
+  for (const node of parsedNodes) {
+    const targetId = node.data.id;
+
+    for (const depPath of node.data.depends_on) {
+      const sourceId = pathToIdMap.get(depPath);
+
+      if (sourceId) {
+        edges.push({
+          source: sourceId,
+          target: targetId,
+        });
+      }
+      // If a dependency path is not found in the map, we skip creating an edge.
+      // This matches the test requirement "ignore edge if dependency path does not exist".
+    }
+  }
+
+  return {
+    nodes,
+    edges,
+  };
+}


### PR DESCRIPTION
Fixes TASK `task-043-075-build-dag-graph`.

Implemented the `buildDagGraph` builder function that outputs a structured `{ nodes, edges }` JSON structure suitable for frontend visualization libraries by traversing parsed frontmatter dependencies. Added exhaustive Vitest unit testing to cover edge cases like unknown dependencies and paths mapping properly. Updated task node.

---
*PR created automatically by Jules for task [4105294264554563478](https://jules.google.com/task/4105294264554563478) started by @szubster*