### PR TITLE
fix: extract hall of fame count for gen 2

### DIFF
--- a/.foundry/tasks/task-042-068-extract-hall-of-fame.md
+++ b/.foundry/tasks/task-042-068-extract-hall-of-fame.md
@@ -32,5 +32,5 @@ Update the Gen 2 save parser (`src/engine/saveParser/parsers/gen2.ts`) to extrac
 - Write unit tests using the existing `gold.sav` and `crystal.sav` fixtures.
 
 ## Acceptance Criteria
-- [ ] `gen2.ts` correctly extracts the Hall of Fame count.
-- [ ] Tests verify the extraction logic.
+- [x] `gen2.ts` correctly extracts the Hall of Fame count.
+- [x] Tests verify the extraction logic.

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -210,7 +210,7 @@ describe('gen2 parsers', () => {
       view.setUint8(0x288b, 1);
       view.setUint8(0x288b + 7, 1);
 
-      view.setUint8(0x24ec, 12); // GS HoF count
+      view.setUint8(0x248c, 12); // GS HoF count
 
       // Setup Entei (Species 244) as roaming in GS
       const roamingOffset = 0x28da;
@@ -237,7 +237,7 @@ describe('gen2 parsers', () => {
       view.setUint8(0x2866, 1);
       view.setUint8(0x2866 + 7, 1);
 
-      view.setUint8(0x24ce, 5); // Crystal HoF count
+      view.setUint8(0x248d, 5); // Crystal HoF count
 
       // Setup Suicune (Species 245) as roaming in Crystal
       const roamingOffset = 0x28b6;

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -380,7 +380,7 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
     }
   }
 
-  const hallOfFameOffset = isCrystal ? 0x24ce : 0x24ec;
+  const hallOfFameOffset = johtoBadgesOffset + 0xa8;
   const hallOfFameCount = view.getUint8(hallOfFameOffset);
 
   const roamingLegendaries: { speciesId: number; level: number; mapGroup: number; mapId: number }[] = [];


### PR DESCRIPTION
Update Gen 2 save parser to correctly extract Hall of Fame count.

---
*PR created automatically by Jules for task [17244156773014528258](https://jules.google.com/task/17244156773014528258) started by @szubster*