### PR TITLE
Foundry: Epic Planner PRD Breakdown for Migrate Heartbeat to gray-matter

### DIFF
--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -29,3 +29,7 @@ Outcome: The generated epics (epic-007-atomic-handoff-schema.md, epic-008-atomic
 - Read the PRD `prd-006-017-gen2-expansion-phase-3-4.md`.
 - Generated `epic-017-028-map-graph-routing.md` to handle Johto/Kanto map graph requirements.
 - Generated `epic-017-029-strategy-engine-adaptations.md` to adapt the strategy engine for Gen 2 mechanics, establishing a sequential dependency on Epic 028.
+
+>> **Task:** PRD-018-018-migrate-heartbeat-to-gray-matter -> Epic epic-018-028-migrate-heartbeat-to-gray-matter
+>> **Decision:** The target artifact Epic `epic-018-028-migrate-heartbeat-to-gray-matter.md` already exists and is completed.
+>> **Action:** Per the Empty PR Policy, I did not make dummy updates or trivial formatting changes to force a git diff. Submitted PR directly.

--- a/.foundry/prds/prd-018-018-migrate-heartbeat-to-gray-matter.md
+++ b/.foundry/prds/prd-018-018-migrate-heartbeat-to-gray-matter.md
@@ -32,4 +32,4 @@ ADR-006 mandated the use of `gray-matter` for parsing and mutating Markdown fron
 - Prevent brittle regex bugs in frontmatter modifications.
 
 ## Epics
-- [ ] .foundry/epics/epic-018-028-migrate-heartbeat-to-gray-matter.md
+- [x] .foundry/epics/epic-018-028-migrate-heartbeat-to-gray-matter.md


### PR DESCRIPTION
Generated Epic `epic-018-028-migrate-heartbeat-to-gray-matter.md` based on `prd-018-018-migrate-heartbeat-to-gray-matter.md`. Upon inspection, the Epic file already existed. Consequently, I applied the Empty PR Policy by recording the occurrence in my journal (`.foundry/journals/epic_planner.md`) and checking off the corresponding acceptance criteria in the PRD, submitting the PR without making dummy updates to force a file creation diff.

---
*PR created automatically by Jules for task [17235013967061347566](https://jules.google.com/task/17235013967061347566) started by @szubster*