### PR TITLE
🛠️ Infras: Clean up knip ignore configurations

### DIFF
--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -53,3 +53,6 @@ Critical learnings:
 ## 2026-05-10 - Added sort-package-json
 **Learning:** Added `sort-package-json` to the pipeline via `devDependencies` and `lefthook.yml` to automatically sort `package.json` locally. Note: Biome currently does not natively sort `package.json` correctly. We did not add it to the `pnpm lint` script as it currently modifies files instead of just checking them.
 - **Updated**: Added `lint:package-json` with `--check` flag to the `lint` command to enforce that `package.json` stays correctly sorted in CI pipelines.
+
+## 2026-05-11 - Cleaned up knip.json
+**Learning:** Removed outdated `ignore` and `ignoreDependencies` configurations from `knip.json` that were previously suggested by `pnpm knip`. This avoids unnecessary ignored files and configuration hints during linting.

--- a/knip.json
+++ b/knip.json
@@ -1,23 +1,12 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignoreDependencies": [
-    "bundlemon",
-    "gray-matter"
+    "bundlemon"
   ],
   "ignoreExportsUsedInFile": true,
   "ignore": [
-    ".github/scripts/**",
     "src/test-setup.ts",
-    "scripts/validate-foundry-schema.ts",
-    "src/node-setup.ts",
-    "tests/e2e/test-utils.ts",
-    "vite-plugins/pokedata-plugin.ts",
-    "scripts/check-links.ts",
-    "scripts/data/gen1/mapping.ts",
-    "scripts/data/gen2/mapping.ts",
-    "scripts/generate-pokedata.ts",
-    "scripts/generateMapLocations.ts",
-    "src/utils/argos.ts"
+    "scripts/validate-foundry-schema.ts"
   ],
   "rules": {
     "files": "warn",


### PR DESCRIPTION
**What:**
Removed unused `ignore` entries and `ignoreDependencies` for `gray-matter` from `knip.json` that were causing configuration hint warnings during the `pnpm lint` pipeline. 

**Why:**
`knip` was outputting multiple configuration hints about unused ignore rules. These files (e.g., github scripts, test setup files) are now properly resolved by `knip` or its plugins, so they no longer need explicit ignores. Keeping the config clean prevents terminal noise and ensures static analysis remains strict.

**Impact on DX/CI:**
- Cleaner terminal output during `pnpm lint`.
- No more configuration hints about unused ignores.

**Setup notes:**
- None. `knip` automatically picks up the updated configuration.

---
*PR created automatically by Jules for task [8892504606647044627](https://jules.google.com/task/8892504606647044627) started by @szubster*