### PR TITLE
Agile Coach: Document Gen 2 Hall of Fame offset and enforce checklist idea

### DIFF
--- a/.foundry/docs/knowledge_base/engine/save_parsing/gen2_hall_of_fame.md
+++ b/.foundry/docs/knowledge_base/engine/save_parsing/gen2_hall_of_fame.md
@@ -1,0 +1,16 @@
+# Gen 2 Hall of Fame Count Offset
+
+This document clarifies the offset for extracting the Hall of Fame count from Pokémon Gen 2 save files (Gold, Silver, Crystal).
+
+## Problem with Standard Documentation
+Standard documentation online often lists the Hall of Fame count at a fixed absolute offset (e.g., `0x24EC` for GS, `0x24CE` for Crystal). However, depending on emulator artifacts, regional versions, or initializations, these absolute offsets can be unreliable and have resulted in failed extractions and task rejections during implementation.
+
+## Resolution
+The correct and most reliable way to extract the Hall of Fame count is to use a relative offset based on a known anchor point within the player data block.
+
+The Hall of Fame count is located **exactly `0xA8` (168) bytes after the Johto badges offset**.
+
+### Implementation Strategy
+1. Locate the Johto badges byte within the save file buffer.
+2. Add `0xA8` to the Johto badges offset to find the exact byte representing the Hall of Fame count.
+3. Read the single unsigned 8-bit integer at this calculated location.

--- a/.foundry/ideas/idea-020-enforce-acceptance-criteria-completion.md
+++ b/.foundry/ideas/idea-020-enforce-acceptance-criteria-completion.md
@@ -1,0 +1,32 @@
+---
+id: idea-020-enforce-acceptance-criteria-completion
+type: IDEA
+title: "Enforce Acceptance Criteria Checkbox Completion"
+status: "PENDING"
+owner_persona: product_manager
+created_at: "2026-05-11"
+updated_at: "2026-05-11"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags: []
+research_references: []
+notes: >-
+  Proposed by Agile Coach based on observation that completed tasks still
+  contain unchecked `[ ]` boxes, indicating potential skipped validations or
+  flawed orchestrator state transitions.
+---
+
+# Enforce Acceptance Criteria Checkbox Completion
+
+## Problem
+Currently, several nodes transition to `COMPLETED` despite retaining unchecked `[ ]` boxes in their Acceptance Criteria sections. This implies that agents are failing to properly tick the boxes during implementation, or the orchestrator is incorrectly determining completion status. Either way, this degrades the reliability of the system's explicit contracts.
+
+## Proposal
+Implement an orchestrator validation check (likely as part of a pre-flight or merge validation step) that scans the raw markdown body of the file. If the file contains `- [ ]` within an "Acceptance Criteria" block, the node should be prevented from transitioning to `COMPLETED` (or the associated PR should be blocked/flagged).
+
+## Acceptance Criteria
+- [ ] Determine the best phase to inject this validation check (e.g., during the Heartbeat transition to COMPLETED, or as a GitHub Action PR check).
+- [ ] Implement the logic to scan for unchecked `[ ]` boxes.
+- [ ] Ensure that it properly flags nodes and prevents premature completion.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -35,3 +35,12 @@ While reviewing proactive improvement opportunities, I noticed that scheduled ag
 ### Action Taken
 1. Updated all scheduled agent prompts (`.jules/schedules/*.md`) to replace specific permission-seeking instructions with explicitly stating: `- Nothing — just submit the PR. Rejection is expected and acceptable.`. This improves agent autonomy.
 2. Verified that `idea-016-precommit-schema-validation` was completed; no further task generation is required for this feature.
+
+## 2026-05-11: Hall of Fame Task Rejections and Acceptance Criteria Completeness
+
+### Observation
+While analyzing recent failures, I noted that `task-042-068-extract-hall-of-fame` suffered 3 rejections and is still active. The root cause appears to be the reliance on standard generic offset documentation which is incorrect for our save files, rather than the specific relative offset (`0xA8` bytes after Johto badges). Furthermore, I noticed several older nodes transitioning to `COMPLETED` despite retaining unchecked `[ ]` Acceptance Criteria boxes, undermining the system's strict architectural contracts.
+
+### Action Taken
+1. Created `.foundry/docs/knowledge_base/engine/save_parsing/gen2_hall_of_fame.md` to explicitly document the relative offset for the Hall of Fame count, providing the Coder with grounded context to successfully complete task-042.
+2. Autonomously generated `idea-020-enforce-acceptance-criteria-completion.md` to propose a new orchestration rule that enforces all checkboxes in the Acceptance Criteria block must be checked before a node is permitted to transition to `COMPLETED`.


### PR DESCRIPTION
This PR implements proactive improvements derived from an analysis of recent node rejections and system friction:

1. **Hall of Fame Extraction Blocker**: `task-042-068-extract-hall-of-fame` failed repeatedly due to reliance on generic absolute offsets. Created `.foundry/docs/knowledge_base/engine/save_parsing/gen2_hall_of_fame.md` to explicitly document the reliable relative offset (168 bytes after the Johto badges byte).
2. **Contract Enforcement**: Observed multiple older nodes transitioning to `COMPLETED` despite retaining unchecked `[ ]` boxes in their Acceptance Criteria sections. Generated `idea-020-enforce-acceptance-criteria-completion.md` to propose an orchestrator validation step preventing this behavior.
3. Logged findings and actions in the Agile Coach journal.

---
*PR created automatically by Jules for task [9297735566416569672](https://jules.google.com/task/9297735566416569672) started by @szubster*