### PR TITLE
🗃️ Archivist: update agent roster in dispatch docs

### DIFF
--- a/.foundry/docs/knowledge_base/infrastructure/jules_agents_dispatch.md
+++ b/.foundry/docs/knowledge_base/infrastructure/jules_agents_dispatch.md
@@ -20,7 +20,7 @@ Just add or remove a `.md` file in `.jules/schedules/`. No workflow changes need
 
 - `JULES_API_KEY` — set in repo Settings → Secrets → Actions
 
-### Current roster (14 agents)
+### Current roster (15 agents)
 
 | Agent | Emoji | Domain |
 |---|---|---|
@@ -32,6 +32,7 @@ Just add or remove a `.md` file in `.jules/schedules/`. No workflow changes need
 | nurse | 🛡️ | Type safety |
 | oak | 🧬 | Data integrity |
 | palette | 🎨 | UX & accessibility |
+| researcher | 🔎 | Exploratory research & context gathering |
 | scribe | 📜 | Documentation |
 | sentinel | 🧪 | Test coverage |
 | shield | 🔒 | Security & Cryptography |

--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -34,3 +34,8 @@
 
 **Learning:** Memory entries describing the removal of fields (like `pr_number`) can become contradictory if later features (like `human-in-the-loop`) reintroduce them partially.
 **Action:** Updated `conflict-resolution-v1.md` to clarify that `pr_number` was only removed for automated tasks, resolving the contradiction with `human-in-the-loop.md`.
+
+## 2026-06-25 - Archivist Run Learnings
+
+**Learning:** `.foundry/docs/knowledge_base/infrastructure/jules_agents_dispatch.md` had an outdated list of agents.
+**Action:** Updated it to properly reflect the 15 agents deployed, by adding the missing `researcher` agent to the list.


### PR DESCRIPTION
**What was stale/wrong:**
The `jules_agents_dispatch.md` document listed 14 active agents, but there are actually 15 `.md` schedule files in `.jules/schedules/`. The `researcher` agent was missing from the documentation.

**How it was verified:**
Ran `ls -1 .jules/schedules | wc -l` to verify the count.
Cross-referenced the list in `jules_agents_dispatch.md` with the files in `.jules/schedules/` to identify `researcher` as the missing agent.
Ran `pnpm lint` and `pnpm test` to ensure no workflow regressions.

**What was removed/updated:**
Updated the count from 14 to 15 and added the `researcher` agent entry to the `jules_agents_dispatch.md` table.
Logged the finding in `.jules/archivist.md`.

---
*PR created automatically by Jules for task [4447031332915630649](https://jules.google.com/task/4447031332915630649) started by @szubster*