### PR TITLE
chore(task): update coder journal and task AC for task-042-069

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -55,3 +55,6 @@ The mapping validation logic and unit tests are already implemented. Submitting 
 - We successfully implemented `src/engine/mapGraph/gen2Graph.ts` with explicit definition of `gen2MapGraph` which contains nodes and connections across Johto and Kanto.
 ## 2026-05-10
 Task task-046-077-standardize-orchestrator-test-factories: Implemented `foundry-test-utils.ts` and refactored the orchestrator tests to dynamically create mock nodes passing Phase 4.8 Mapping Validations. Ensure `gray-matter.stringify` is not used in frontmatter body replacements but we manually wrote a serializer for frontmatter stringification during mock file creation. Ensure `pr_number` handles null without TS errors.
+
+## 2026-05-12 - task-042-069-extract-roamers
+The roamer location extraction logic for Gen 2 (Raikou, Entei, Suicune) is already implemented in `src/engine/saveParser/parsers/gen2.ts`, and the corresponding tests exist in `src/engine/saveParser/parsers/gen2.test.ts`. Submitting an empty PR to allow the DAG to progress.

--- a/.foundry/tasks/task-042-069-extract-roamers.md
+++ b/.foundry/tasks/task-042-069-extract-roamers.md
@@ -33,5 +33,5 @@ Update the Gen 2 save parser (`src/engine/saveParser/parsers/gen2.ts`) to extrac
 - Add unit tests to verify the location extraction.
 
 ## Acceptance Criteria
-- [ ] `gen2.ts` correctly extracts map locations for Raikou, Entei, and Suicune.
-- [ ] Tests verify the extraction logic.
+- [x] `gen2.ts` correctly extracts map locations for Raikou, Entei, and Suicune.
+- [x] Tests verify the extraction logic.


### PR DESCRIPTION
The task task-042-069-extract-roamers was to "Implement Roamer location extraction for Gen 2". I researched the codebase and discovered the extraction logic is already fully implemented in `src/engine/saveParser/parsers/gen2.ts` and the tests in `src/engine/saveParser/parsers/gen2.test.ts`. I recorded this in the Coder journal and checked off the acceptance criteria, finalizing the work to submit this PR to allow the DAG to continue.

---
*PR created automatically by Jules for task [12440413083620198811](https://jules.google.com/task/12440413083620198811) started by @szubster*