### PR TITLE
chore: apply empty PR policy for automated branch cleanup epic

### DIFF
--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -33,3 +33,7 @@ Outcome: The generated epics (epic-007-atomic-handoff-schema.md, epic-008-atomic
 >> **Task:** PRD-018-018-migrate-heartbeat-to-gray-matter -> Epic epic-018-028-migrate-heartbeat-to-gray-matter
 >> **Decision:** The target artifact Epic `epic-018-028-migrate-heartbeat-to-gray-matter.md` already exists and is completed.
 >> **Action:** Per the Empty PR Policy, I did not make dummy updates or trivial formatting changes to force a git diff. Submitted PR directly.
+
+>> **Task:** PRD-019-019-automated-branch-cleanup -> Epic epic-019-030-automated-branch-cleanup
+>> **Decision:** The target artifact Epic `epic-019-030-automated-branch-cleanup.md` already exists and is completed.
+>> **Action:** Per the Empty PR Policy, I did not make dummy updates or trivial formatting changes to force a git diff. Submitted PR directly.

--- a/.foundry/prds/prd-019-019-automated-branch-cleanup.md
+++ b/.foundry/prds/prd-019-019-automated-branch-cleanup.md
@@ -29,4 +29,4 @@ Based on the `idea-019-automated-branch-cleanup`, the "Resurrection Loop" spawns
 
 
 ## Epic Breakdown
-- [ ] `.foundry/epics/epic-019-030-automated-branch-cleanup.md`
+- [x] `.foundry/epics/epic-019-030-automated-branch-cleanup.md`


### PR DESCRIPTION
Applies empty PR policy for prd-019-019-automated-branch-cleanup because epic-019-030-automated-branch-cleanup is already complete. Checked off parent node AC checkboxes.

---
*PR created automatically by Jules for task [16154974061077361911](https://jules.google.com/task/16154974061077361911) started by @szubster*