### PR TITLE
QA: Reject missing remote branch cleanup implementation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -23,3 +23,7 @@ Verified implementation of Hall of Fame count and roaming legendary (Raikou, Ent
 - Verified that regex frontmatter manipulation in `foundry-heartbeat.ts` was successfully replaced with `gray-matter` compliant with ADR-006.
 - Checked code in `transitionNodeToFailed` and `transitionNodeToReady` handles state updating cleanly using `matter.stringify` without regex.
 - Verified tests successfully run indicating no regressions.
+
+## 2026-05-11: QA Rejected Task 047-078
+Rejected `task-047-078-implement-cleanup-remote-branches` and marked `task-047-079-qa-cleanup-remote-branches` as FAILED.
+The QA check failed because the coder did not implement the `cleanupRemoteBranches` function in `.github/scripts/foundry-heartbeat.ts` nor did they write the required tests in `.github/scripts/foundry-heartbeat.test.ts`. I have updated the markdown bodies of both task nodes and recorded the rejection reasons.

--- a/.foundry/tasks/task-047-078-implement-cleanup-remote-branches.md
+++ b/.foundry/tasks/task-047-078-implement-cleanup-remote-branches.md
@@ -18,6 +18,8 @@ rejection_reason: ''
 notes: ''
 ---
 
+**QA REJECTION:** Validation failed because the `coder` did not implement the `cleanupRemoteBranches` function in `.github/scripts/foundry-heartbeat.ts` nor did they write the required tests in `.github/scripts/foundry-heartbeat.test.ts`.
+
 # Implement Remote Branch Cleanup
 
 ## Context

--- a/.foundry/tasks/task-047-079-qa-cleanup-remote-branches.md
+++ b/.foundry/tasks/task-047-079-qa-cleanup-remote-branches.md
@@ -20,6 +20,8 @@ rejection_reason: ''
 notes: ''
 ---
 
+**QA REJECTION:** Validation failed because the `coder` did not implement the `cleanupRemoteBranches` function in `.github/scripts/foundry-heartbeat.ts` nor did they write the required tests in `.github/scripts/foundry-heartbeat.test.ts`.
+
 # QA Remote Branch Cleanup
 
 ## Context


### PR DESCRIPTION
QA validation for task-047-078-implement-cleanup-remote-branches. The validation failed because the requested code changes in `.github/scripts/foundry-heartbeat.ts` and its test file were completely missing. The task nodes have been updated with rejection notices in their markdown bodies, and the failure has been logged to `.foundry/journals/qa.md`.

---
*PR created automatically by Jules for task [3896700376474406018](https://jules.google.com/task/3896700376474406018) started by @szubster*