### PR TITLE
Fix Foundry DAG Persona Mappings

### DIFF
--- a/.foundry/prds/prd-020-020-enforce-acceptance-criteria-completion.md
+++ b/.foundry/prds/prd-020-020-enforce-acceptance-criteria-completion.md
@@ -2,7 +2,7 @@
 id: prd-020-020-enforce-acceptance-criteria-completion
 type: PRD
 title: Enforce Acceptance Criteria Checkbox Completion PRD
-status: FAILED
+status: PENDING
 owner_persona: architect
 created_at: '2026-05-11'
 updated_at: '2026-05-11'
@@ -13,7 +13,6 @@ parent: idea-020-enforce-acceptance-criteria-completion
 tags: []
 research_references: []
 rejection_count: 0
-rejection_reason: Invalid owner_persona mapping
 notes: ''
 ---
 

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1000,6 +1000,8 @@ describe('foundry-orchestrator', () => {
     createValidTestNode(tmpDir, '.foundry/prds/prd-invalid.md', { id: "prd-invalid", type: "PRD", title: "Invalid PRD", status: "PENDING", owner_persona: "coder", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
     createValidTestNode(tmpDir, '.foundry/tasks/task-human.md', { id: "task-human", type: "TASK", title: "Human Task", status: "PENDING", owner_persona: "human", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
     createValidTestNode(tmpDir, '.foundry/research/research-001.md', { id: "research-001", type: "RESEARCH", title: "Research Task", status: "PENDING", owner_persona: "researcher", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
+    createValidTestNode(tmpDir, '.foundry/prds/prd-architect.md', { id: "prd-architect", type: "PRD", title: "Architect PRD", status: "PENDING", owner_persona: "architect", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
+    createValidTestNode(tmpDir, '.foundry/tasks/task-tech-lead.md', { id: "task-tech-lead", type: "TASK", title: "Tech Lead Task", status: "PENDING", owner_persona: "tech_lead", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
 
     main();
 
@@ -1016,6 +1018,12 @@ describe('foundry-orchestrator', () => {
 
     const researchResult = fs.readFileSync(path.join(tmpDir, '.foundry/research/research-001.md'), 'utf-8');
     expect(researchResult).toContain('status: READY');
+
+    const prdArchitectResult = fs.readFileSync(path.join(tmpDir, '.foundry/prds/prd-architect.md'), 'utf-8');
+    expect(prdArchitectResult).toContain('status: READY');
+
+    const taskTechLeadResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-tech-lead.md'), 'utf-8');
+    expect(taskTechLeadResult).toContain('status: READY');
   });
 
   test('Atomic Handoffs: resolves dependencies across single-persona atomic tasks', () => {

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -790,10 +790,10 @@ function main(): void {
   const validatedEligible: ParsedNode[] = [];
   const validMappings: Record<string, string[]> = {
     IDEA: ['product_manager'],
-    PRD: ['epic_planner'],
-    EPIC: ['story_owner'],
-    STORY: ['tech_lead'],
-    TASK: ['coder', 'qa'],
+    PRD: ['epic_planner', 'architect', 'story_owner'],
+    EPIC: ['story_owner', 'epic_planner'],
+    STORY: ['tech_lead', 'story_owner', 'coder'],
+    TASK: ['coder', 'qa', 'tech_lead'],
     RESEARCH: ['researcher'],
   };
 

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -60,6 +60,16 @@ function validateSchema() {
     'product_manager', 'epic_planner', 'story_owner', 'architect',
     'tech_lead', 'coder', 'qa', 'human', 'tpm', 'agile_coach', 'researcher'
   ];
+
+  const validMappings: Record<string, string[]> = {
+    IDEA: ['product_manager'],
+    PRD: ['epic_planner', 'architect', 'story_owner'],
+    EPIC: ['story_owner', 'epic_planner'],
+    STORY: ['tech_lead', 'story_owner', 'coder'],
+    TASK: ['coder', 'qa', 'tech_lead'],
+    RESEARCH: ['researcher'],
+  };
+
   const requiredFields = ['id', 'title', 'created_at', 'updated_at', 'depends_on', 'jules_session_id'];
 
   for (const file of targetFiles) {
@@ -98,6 +108,15 @@ function validateSchema() {
     if (owner_persona && !validPersonas.includes(owner_persona)) {
       console.error(`Error: Invalid owner_persona enum '${owner_persona}' in file ${file}`);
       hasError = true;
+    }
+
+    // 2.5 Validate persona mapping
+    if (type && owner_persona && owner_persona !== 'human' && owner_persona !== 'tpm' && owner_persona !== 'agile_coach') {
+      const allowedPersonas = validMappings[type as string] || [];
+      if (!allowedPersonas.includes(owner_persona)) {
+        console.error(`Error: Invalid mapping: ${type} node '${file}' cannot be owned by '${owner_persona}'`);
+        hasError = true;
+      }
     }
 
     // 3. ID format & uniqueness


### PR DESCRIPTION
Resolved DAG resolution warnings where nodes were incorrectly flagged as FAILED due to strict (and incomplete) persona-to-type mappings. 

Expanded the `validMappings` in both the orchestrator and the pre-commit schema validation script to reflect actual repository usage patterns:
- PRD: epic_planner, architect, story_owner
- EPIC: story_owner, epic_planner
- STORY: tech_lead, story_owner, coder
- TASK: coder, qa, tech_lead

Restored the affected PRD node to `PENDING` state and verified all changes with the existing test suite and schema validation script.

Fixes #1181

---
*PR created automatically by Jules for task [14699461044619993347](https://jules.google.com/task/14699461044619993347) started by @szubster*