### PR TITLE
feat(foundry): Enforce Acceptance Criteria Checkbox Completion

### DIFF
--- a/.foundry/docs/adrs/007-enforce-acceptance-criteria-checkboxes.md
+++ b/.foundry/docs/adrs/007-enforce-acceptance-criteria-checkboxes.md
@@ -1,0 +1,26 @@
+# ADR 007: Enforce Acceptance Criteria Checkboxes
+
+## Date
+2026-05-11
+
+## Status
+Accepted
+
+## Context
+Currently, several Foundry nodes successfully transition to `COMPLETED` even though they still retain unchecked `[ ]` checkboxes in their Acceptance Criteria sections. This implies tasks are skipping validations or the orchestrator is transitioning states prematurely without enforcing completeness.
+
+While the existing `foundry-heartbeat.ts` script catches unchecked tasks and demotes the node to `PENDING` (to support late-binding parent node awakening), this logic acts indiscriminately. It effectively prevents standard leaf tasks with unchecked boxes from being `COMPLETED`, but leaves them permanently stuck in a `PENDING` state with no mechanism to fail or notify the user unless they happen to be parents that spawn children.
+
+We need a formal architectural directive enforcing that unchecked tasks prevent completion and detailing how different node types must handle this.
+
+## Decision
+1. **Strict Completion Enforcement**: No node can transition to `COMPLETED` if it contains an unchecked markdown task box (e.g., `- [ ]`).
+2. **Late-Binding vs Leaf Tasks**:
+   - If a node is a late-binding parent (it spawns child nodes), containing an unchecked box acts as an intentional signal to the orchestrator to keep the node alive (`PENDING`).
+   - If a node is a leaf task (no child generation) and is merged with unchecked boxes, the system must recognize it as an invalid completion attempt. It should be flagged (e.g., set to `FAILED` or a similar failure state) rather than kept perpetually `PENDING`.
+3. **Orchestrator Responsibility**: The validation logic checking for `/^\s*-\s*\[\s\]/m` is already present. The orchestrator must be augmented to distinguish between valid late-binding wait states and invalid leaf completions.
+
+## Consequences
+- **Positive**: Hardens the system contract. QA and Coder nodes must physically check off acceptance criteria before PR merge.
+- **Positive**: Eliminates zombie leaf tasks stuck in `PENDING` because the author forgot to check a box.
+- **Negative**: Adds slightly more complexity to the orchestrator state machine to distinguish parent nodes from leaf nodes.

--- a/.foundry/epics/epic-020-031-enforce-acceptance-criteria-completion.md
+++ b/.foundry/epics/epic-020-031-enforce-acceptance-criteria-completion.md
@@ -1,0 +1,33 @@
+---
+id: epic-020-031-enforce-acceptance-criteria-completion
+type: EPIC
+title: Enforce Acceptance Criteria Checkbox Completion Epic
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-05-11"
+updated_at: "2026-05-11"
+depends_on: [".foundry/prds/prd-020-020-enforce-acceptance-criteria-completion.md"]
+jules_session_id: null
+pr_number: null
+parent: "prd-020-020-enforce-acceptance-criteria-completion"
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Enforce Acceptance Criteria Checkbox Completion Epic
+
+## Background
+According to ADR 007, standard leaf tasks that are merged with unchecked acceptance criteria checkboxes are currently demoted to `PENDING` by the `foundry-heartbeat.ts` script. This leads to them being stuck indefinitely since they do not generate child nodes. We need to explicitly differentiate between a late-binding parent (which stays `PENDING`) and a regular task (which should fail).
+
+## Scope
+1. Update `foundry-heartbeat.ts` to check if a node has children (via `foundry-orchestrator`'s mapping) before deciding to keep it in `PENDING` due to unchecked tasks.
+2. If it is a leaf task without children but contains unchecked boxes, transition it to `FAILED` with an appropriate journal message indicating that the PR was merged with unfulfilled acceptance criteria.
+3. Update `foundry-orchestrator.ts` preflight and idempotent checks to ensure they don't improperly promote nodes with unchecked boxes to `READY` if they aren't supposed to be.
+
+## Tasks Required
+- [ ] Investigate how `foundry-heartbeat.ts` can reliably determine if a node is a late-binding parent versus a leaf task.
+- [ ] Implement the `FAILED` fallback state for leaf tasks with unchecked boxes in `foundry-heartbeat.ts`.
+- [ ] Add unit tests in `foundry-heartbeat.test.ts` to verify the different handling of leaf tasks versus parent nodes with unchecked boxes.

--- a/.foundry/prds/prd-020-020-enforce-acceptance-criteria-completion.md
+++ b/.foundry/prds/prd-020-020-enforce-acceptance-criteria-completion.md
@@ -47,6 +47,6 @@ Currently, several Foundry nodes successfully transition to `COMPLETED` even tho
 - It should properly identify unchecked boxes only, ignoring `[x]` or `[X]`.
 
 ## 5. Acceptance Criteria
-- [ ] Investigate and document the best phase/location to inject this validation logic in the codebase.
-- [ ] Implement the parsing logic to detect unchecked `- [ ]` boxes in a node's body.
-- [ ] Integrate the logic to block or revert the node's transition to `COMPLETED` if unchecked boxes are found.
+- [x] Investigate and document the best phase/location to inject this validation logic in the codebase.
+- [x] Implement the parsing logic to detect unchecked `- [ ]` boxes in a node's body.
+- [x] Integrate the logic to block or revert the node's transition to `COMPLETED` if unchecked boxes are found.

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -38,6 +38,7 @@ describe('Foundry Heartbeat', () => {
       repoPath: '.foundry/tasks/task-1.md',
       frontmatter: {
         id: 'task-1',
+        type: 'TASK',
         status: 'ACTIVE',
         jules_session_id: 'session-123'
       },
@@ -79,6 +80,7 @@ ok: true,
       repoPath: '.foundry/tasks/task-1.md',
       frontmatter: {
         id: 'task-1',
+        type: 'TASK',
         status: 'ACTIVE',
         jules_session_id: 'session-404'
       },
@@ -242,10 +244,11 @@ ok: true,
       repoPath: '.foundry/tasks/task-1.md',
       frontmatter: {
         id: 'task-1',
+        type: 'STORY',
         status: 'ACTIVE',
         jules_session_id: 'session-123'
       },
-      rawContent: '---\nstatus: ACTIVE\njules_session_id: "session-123"\nupdated_at: "2023-01-01"\n---\nBody\n- [ ] Unchecked task'
+      rawContent: '---\ntype: STORY\nstatus: ACTIVE\njules_session_id: "session-123"\nupdated_at: "2023-01-01"\n---\nBody\n- [ ] Unchecked task'
     };
 
     vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
@@ -279,6 +282,52 @@ ok: true,
     expect(fs.writeFileSync).toHaveBeenCalled();
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
     expect(writeCall[1]).toContain('status: PENDING');
+  });
+
+  it('should transition a leaf task to FAILED if its PR is merged but it has unchecked tasks', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-2.md',
+      repoPath: '.foundry/tasks/task-2.md',
+      frontmatter: {
+        id: 'task-2',
+        type: 'TASK',
+        status: 'ACTIVE',
+        jules_session_id: 'session-123'
+      },
+      rawContent: '---\ntype: TASK\nstatus: ACTIVE\njules_session_id: "session-123"\nupdated_at: "2023-01-01"\n---\nBody\n- [ ] Unchecked task'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-2.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    // @ts-expect-error
+    globalFetch.mockImplementation((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : (url as URL).toString();
+      if (urlStr.startsWith('https://jules.googleapis.com/')) {
+        return Promise.resolve({
+            ok: true,
+            status: 200,
+          json: async () => ({
+              state: 'COMPLETED',
+              outputs: [{ pullRequest: { url: 'https://github.com/szubster/dexhelper/pull/402' } }]
+            })
+          });
+      }
+      if (urlStr.startsWith('https://api.github.com/repos/szubster/dexhelper/pulls/402')) {
+        return Promise.resolve({
+            ok: true,
+            status: 200,
+          json: async () => ({ number: 402, state: 'closed', merged: true })
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+    });
+
+    await main();
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[vi.mocked(fs.writeFileSync).mock.calls.length - 1];
+    expect(writeCall[1]).toContain('status: FAILED');
   });
 
   it('should transition a node to COMPLETED if PR from Jules session link is merged', async () => {

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -57,20 +57,51 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
 
   const parsed = matter(node.rawContent);
 
-  // Late-Binding Support: If unchecked tasks exist, transition back to PENDING instead of COMPLETED.
+  // Late-Binding Support: If unchecked tasks exist, check if node is a parent.
   const hasUncheckedTasks = /^\s*-\s*\[\s\]/m.test(parsed.content);
-  // PENDING state keeps the late-binding parent alive to wait for children
-  const targetStatus = hasUncheckedTasks ? "PENDING" : "COMPLETED";
+
+  let targetStatus = "COMPLETED";
+  let rejectionReason = "";
+  let message = `PR #${prNumber} merged.`;
+
+  if (hasUncheckedTasks) {
+    // Determine if it's a late-binding parent
+    // Build a quick children check
+    const filePaths = discoverNodeFiles(path.join(repoRoot, '.foundry'));
+    let hasChildren = false;
+    for (const fp of filePaths) {
+      if (fp === node.filePath) continue;
+      const childNode = parseNodeFile(fp, repoRoot);
+      if (childNode && (childNode.frontmatter.parent === node.repoPath || childNode.frontmatter.parent === node.frontmatter.id)) {
+        hasChildren = true;
+        break;
+      }
+    }
+
+    const type = parsed.data.type || node.frontmatter.type;
+
+    if (hasChildren || ["IDEA", "PRD", "EPIC", "STORY"].includes(type)) {
+       targetStatus = "PENDING";
+    } else {
+       targetStatus = "FAILED";
+       rejectionReason = "Merged with unfulfilled acceptance criteria";
+       message = `PR #${prNumber} merged with unchecked tasks.`;
+    }
+  }
 
   parsed.data.status = targetStatus;
   parsed.data.jules_session_id = null;
   parsed.data.updated_at = dateStr;
 
+  if (targetStatus === 'FAILED' && rejectionReason) {
+    parsed.data.rejection_reason = rejectionReason;
+  }
+
   const newContent = matter.stringify(parsed.content, parsed.data);
 
   if (!DRY_RUN) {
     fs.writeFileSync(node.filePath, newContent, 'utf-8');
-    logToJournal(repoRoot, `\n- **${dateStr}**: PR #${prNumber} merged. \`${node.frontmatter.id}\` is now ${targetStatus}.\n`);
+    logToJournal(repoRoot, `\n- **${dateStr}**: ${message} \`${node.frontmatter.id}\` is now ${targetStatus}.\n`);
   }
   info(`${dryTag}Transitioned ACTIVE → ${targetStatus}: ${node.repoPath} (PR #${prNumber})`);
 }
@@ -305,7 +336,9 @@ export async function cleanupRemoteBranches(repoRoot: string, repoFullName: stri
     let openPrHeadRefs: string[] = [];
     if (openPrsRes.ok) {
       const openPrs = await openPrsRes.json() as any[];
-      openPrHeadRefs = openPrs.map(pr => pr.head.ref).filter(Boolean);
+      if (Array.isArray(openPrs)) {
+        openPrHeadRefs = openPrs.map(pr => pr?.head?.ref).filter(Boolean);
+      }
     } else {
       warn(`Failed to fetch open PRs: ${openPrsRes.status} ${openPrsRes.statusText}`);
       return;


### PR DESCRIPTION
This PR implements ADR 007 and updates `foundry-heartbeat.ts` to transition leaf tasks to `FAILED` instead of `PENDING` if they are merged while containing unchecked acceptance criteria checkboxes. This addresses the issue of zombie leaf tasks permanently stuck in `PENDING` state and hardens the completion contracts of the DAG.

---
*PR created automatically by Jules for task [10163826134294175262](https://jules.google.com/task/10163826134294175262) started by @szubster*