### PR TITLE
chore(foundry): document empty PR for epic 014-025

### DIFF
--- a/.foundry/epics/epic-014-025-enforce-persona-pipeline-handoffs.md
+++ b/.foundry/epics/epic-014-025-enforce-persona-pipeline-handoffs.md
@@ -46,10 +46,10 @@ The orchestrator must enforce these ownership rules:
 - None
 
 ## High-Level Acceptance Criteria
-- [ ] Orchestrator reads and validates the `owner_persona` against the node `type`.
-- [ ] Nodes with incorrect `owner_persona` are blocked from dispatch (e.g., transitioned to `FAILED`).
-- [ ] Nodes owned by `human` bypass this validation constraint.
-- [ ] Test cases are added to `foundry-orchestrator.test.ts` to verify the validation logic.
+- [x] Orchestrator reads and validates the `owner_persona` against the node `type`.
+- [x] Nodes with incorrect `owner_persona` are blocked from dispatch (e.g., transitioned to `FAILED`).
+- [x] Nodes owned by `human` bypass this validation constraint.
+- [x] Test cases are added to `foundry-orchestrator.test.ts` to verify the validation logic.
 
 ## Subsequent Work (Stories)
 - [x] Create Story to implement the mapping validation logic in the orchestrator.

--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -41,3 +41,6 @@ All acceptance criteria in .foundry/epics/epic-014-025-enforce-persona-pipeline-
 - Created the first story (`story-029-048-evaluate-graph-libraries.md`) for Epic `epic-017-029-dag-dashboard-ui`.
 - Decided to evaluate graph rendering libraries (e.g., Mermaid.js, React Flow) as the initial step for the DAG Dashboard Visualization & UI.
 - The next step will depend on the outcome of the evaluation.
+
+## Epic 014-025 (Enforce Persona Pipeline Handoffs in DAG Orchestrator)
+All acceptance criteria in .foundry/epics/epic-014-025-enforce-persona-pipeline-handoffs.md are fulfilled. The three stories listed in the epic are created and COMPLETED. There is no new STORY to create. Applying EMPTY PR POLICY.


### PR DESCRIPTION
Since all necessary child stories have already been written and are marked `COMPLETED` for `epic-014-025-enforce-persona-pipeline-handoffs.md`, I am executing the empty PR policy.

- Updated `.foundry/epics/epic-014-025-enforce-persona-pipeline-handoffs.md` to check off the High-Level Acceptance Criteria.
- Updated `.foundry/journals/story_owner.md` to reflect this context.

---
*PR created automatically by Jules for task [8239836119824960275](https://jules.google.com/task/8239836119824960275) started by @szubster*