### PR TITLE
Story Owner: Create Gen 2 Assistant Data Story

### DIFF
--- a/.foundry/epics/epic-015-027-exclusives-and-static-data.md
+++ b/.foundry/epics/epic-015-027-exclusives-and-static-data.md
@@ -30,6 +30,9 @@ Gen 2 specific game mechanics and Pokémon availability require establishing the
 Define availability differences for Gen 2 and establish static configurations for gifts and trades.
 
 ## High-level Acceptance Criteria
-- Define availability differences between Gold, Silver, and Crystal versions in the new Gen 2 Exclusives module.
-- Define static gift data (e.g., Togepi Egg, Eevee from Bill) for Gen 2.
-- Define static NPC trade data for Gen 2.
+- [x] Define availability differences between Gold, Silver, and Crystal versions in the new Gen 2 Exclusives module.
+- [ ] Define static gift data (e.g., Togepi Egg, Eevee from Bill) for Gen 2.
+- [ ] Define static NPC trade data for Gen 2.
+
+## Stories
+- `.foundry/stories/story-027-049-gen2-assistant-data.md`

--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -41,3 +41,4 @@ All acceptance criteria in .foundry/epics/epic-014-025-enforce-persona-pipeline-
 - Created the first story (`story-029-048-evaluate-graph-libraries.md`) for Epic `epic-017-029-dag-dashboard-ui`.
 - Decided to evaluate graph rendering libraries (e.g., Mermaid.js, React Flow) as the initial step for the DAG Dashboard Visualization & UI.
 - The next step will depend on the outcome of the evaluation.
+- Created `story-027-049-gen2-assistant-data.md` for Epic `epic-015-027-exclusives-and-static-data`. The Exclusives file already existed so marked that criteria complete, and generated the story for the remaining static data files.

--- a/.foundry/stories/story-027-049-gen2-assistant-data.md
+++ b/.foundry/stories/story-027-049-gen2-assistant-data.md
@@ -1,0 +1,34 @@
+---
+id: story-027-049-gen2-assistant-data
+type: STORY
+title: 'Setup Gen 2 Assistant Data'
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-11'
+updated_at: '2026-05-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-015-027-exclusives-and-static-data
+tags:
+  - gen2
+  - data
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Setup Gen 2 Assistant Data
+
+## Context
+Gen 2 specific game mechanics and Pokémon availability require establishing the static knowledge base. The Gen 2 Exclusives module is already established. The next step in this phase is to establish static configurations for gifts and trades.
+
+## Objectives
+Establish static assistant configurations for gifts and trades in Gen 2.
+
+## Acceptance Criteria
+- [ ] Create `src/engine/data/gen2/assistantData.ts`.
+- [ ] Define `STATIC_GIFT_DATA` for Gen 2 (Togepi Egg, Eevee from Bill, Shuckle in Cianwood, Dratini, Tyrogue).
+- [ ] Define `STATIC_NPC_TRADE_DATA` (e.g., trading Bellsprout for Onix `Rocky`, Drowzee for Machop `Muscle`).


### PR DESCRIPTION
Created a new STORY node `story-027-049-gen2-assistant-data.md` to handle the setup of Gen 2 Assistant Data (`STATIC_GIFT_DATA` and `STATIC_NPC_TRADE_DATA`) as outlined in Phase 2 of the Gen 2 Implementation Plan. Checked off the `Gen 2 Exclusives` criteria in the parent epic as the module already exists. Logged actions to journal.

---
*PR created automatically by Jules for task [13346394393386091174](https://jules.google.com/task/13346394393386091174) started by @szubster*