### PR TITLE
chore(foundry): generate tasks for indoor to outdoor resolution

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -43,3 +43,8 @@ All sibling tasks were explicitly linked via `depends_on` to ensure execution se
 - **Task:** Phase 3: Gen 2 Map Graph Implementation (story-028-043-gen2-map-graph)
 - **Observation:** The generated artifacts (`task-043-071-implement-gen2-map-graph.md` and `task-043-072-qa-gen2-map-graph.md`) already exist and are marked as COMPLETED.
 - **Action:** Executing Empty PR Policy. Since the requested target node already exists and is complete, I will not modify any parent node checkboxes or files to force a git diff. There is no work to do, submitting an empty PR.
+
+## 2026-05-11
+- Processed STORY: `story-028-044-indoor-outdoor-resolution`.
+- Created technical blueprint `task-044-080-implement-indoor-outdoor-resolution` assigned to `coder` to implement recursive multi-level indoor map resolution to their root outdoor hubs.
+- Used Intelligent Verification Protocol to create QA task `task-044-081-qa-indoor-outdoor-resolution` assigned to `qa` to verify the logic and ensure no infinite loops occur with `prnt` references.

--- a/.foundry/stories/story-028-044-indoor-outdoor-resolution.md
+++ b/.foundry/stories/story-028-044-indoor-outdoor-resolution.md
@@ -30,3 +30,10 @@ Implement `resolveOutdoorMapId` mapping Johto and Kanto indoor locations to thei
 ## Requirements
 - Implement logic to resolve indoor maps (like Pokemon Centers, Gyms, Caves) to their root outdoor hub in `gen2Graph.ts` or related utility.
 - Depends on the base map graph structure being defined.
+
+## Acceptance Criteria
+- [ ] `resolveOutdoorMapId` correctly maps indoor locations to outdoor hubs.
+
+## Generated Tasks
+- [.foundry/tasks/task-044-080-implement-indoor-outdoor-resolution.md](.foundry/tasks/task-044-080-implement-indoor-outdoor-resolution.md)
+- [.foundry/tasks/task-044-081-qa-indoor-outdoor-resolution.md](.foundry/tasks/task-044-081-qa-indoor-outdoor-resolution.md)

--- a/.foundry/tasks/task-044-080-implement-indoor-outdoor-resolution.md
+++ b/.foundry/tasks/task-044-080-implement-indoor-outdoor-resolution.md
@@ -1,0 +1,41 @@
+---
+id: task-044-080-implement-indoor-outdoor-resolution
+type: TASK
+title: Implement Gen 2 Indoor to Outdoor Map Resolution
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-11'
+updated_at: '2026-05-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-028-044-indoor-outdoor-resolution
+tags:
+  - gen2
+  - expansion
+  - map-graph
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 2 Indoor to Outdoor Map Resolution
+
+## Context
+As part of the Gen 2 map routing infrastructure, we need to correctly resolve indoor maps (like Pokemon Centers, Gyms, Caves, multi-level buildings) to their root outdoor hubs (the main city or route). The current `getOutdoorMapId` in `src/engine/mapGraph/gen2Graph.ts` only resolves a single level of `prnt`. We need an exported `resolveOutdoorMapId` function that handles recursive parent resolution for multi-level indoor maps.
+
+## Requirements
+- Modify `src/engine/mapGraph/gen2Graph.ts`.
+- Rename or replace `getOutdoorMapId` with an exported `resolveOutdoorMapId` function.
+- `resolveOutdoorMapId(allLocations: UnifiedLocation[], mapId: number): number` must iteratively or recursively traverse the `prnt` property of locations until it finds a location without a `prnt` (the root outdoor hub), and return that ID.
+- Update `getDistanceToMap` to use the new `resolveOutdoorMapId` function.
+- Ensure the O(1) location cache strategy is maintained or improved.
+- Make similar updates to `gen1Graph.ts` to keep the APIs consistent, if it exists and uses the same pattern.
+
+## Acceptance Criteria
+- [ ] `resolveOutdoorMapId` is implemented and exported in `gen2Graph.ts`.
+- [ ] It correctly resolves multi-level indoor maps to their root outdoor parent.
+- [ ] `getDistanceToMap` uses the new function.
+- [ ] Existing tests pass, and new tests are added for `resolveOutdoorMapId` covering multi-level indoor maps.

--- a/.foundry/tasks/task-044-081-qa-indoor-outdoor-resolution.md
+++ b/.foundry/tasks/task-044-081-qa-indoor-outdoor-resolution.md
@@ -1,0 +1,42 @@
+---
+id: task-044-081-qa-indoor-outdoor-resolution
+type: TASK
+title: QA - Gen 2 Indoor to Outdoor Map Resolution
+status: PENDING
+owner_persona: qa
+created_at: '2026-05-11'
+updated_at: '2026-05-11'
+depends_on:
+  - .foundry/tasks/task-044-080-implement-indoor-outdoor-resolution.md
+jules_session_id: null
+pr_number: null
+parent: story-028-044-indoor-outdoor-resolution
+tags:
+  - gen2
+  - expansion
+  - map-graph
+  - qa
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Gen 2 Indoor to Outdoor Map Resolution
+
+## Context
+The coder has implemented `resolveOutdoorMapId` in `src/engine/mapGraph/gen2Graph.ts` (and possibly `gen1Graph.ts`) to handle multi-level indoor map resolution to their root outdoor hubs. As per the Intelligent Verification Protocol, this core graph routing logic requires dedicated QA verification.
+
+## Requirements
+- Verify that `resolveOutdoorMapId` correctly resolves a map ID with no `prnt` to itself.
+- Verify that it correctly resolves a single-level indoor map (one `prnt` layer) to its outdoor hub.
+- Verify that it correctly resolves a multi-level indoor map (e.g., 3 levels deep via `prnt`) to its root outdoor hub.
+- Verify that circular `prnt` references (if any exist or are simulated) do not cause an infinite loop (e.g., add a max depth limit or visited set in the implementation if necessary, or just verify the tests handle valid data gracefully).
+- Run all Vitest suites for map graph logic to ensure no regressions.
+
+## Acceptance Criteria
+- [ ] Tests for `resolveOutdoorMapId` are comprehensive and cover multi-level map scenarios.
+- [ ] The implementation handles recursive/iterative `prnt` traversal correctly.
+- [ ] `pnpm test` passes successfully.
+- [ ] No performance regressions introduced by the loop.


### PR DESCRIPTION
This PR translates the Phase 3 Gen 2 Indoor to Outdoor Resolution story into technical blueprints. It creates an implementation task for the coder to implement `resolveOutdoorMapId` handling recursive `prnt` references, and a QA task to verify the graph routing logic, following the Intelligent Verification Protocol. The parent story and tech lead journal have been updated accordingly.

---
*PR created automatically by Jules for task [5795226046319427415](https://jules.google.com/task/5795226046319427415) started by @szubster*