### PR TITLE
Create STORY for Enforce Acceptance Criteria Completion Epic

### DIFF
--- a/.foundry/epics/epic-020-031-enforce-acceptance-criteria-completion.md
+++ b/.foundry/epics/epic-020-031-enforce-acceptance-criteria-completion.md
@@ -29,6 +29,9 @@ According to ADR 007, standard leaf tasks that are merged with unchecked accepta
 3. Update `foundry-orchestrator.ts` preflight and idempotent checks to ensure they don't improperly promote nodes with unchecked boxes to `READY` if they aren't supposed to be.
 
 ## Tasks Required
-- [ ] Investigate how `foundry-heartbeat.ts` can reliably determine if a node is a late-binding parent versus a leaf task.
-- [ ] Implement the `FAILED` fallback state for leaf tasks with unchecked boxes in `foundry-heartbeat.ts`.
-- [ ] Add unit tests in `foundry-heartbeat.test.ts` to verify the different handling of leaf tasks versus parent nodes with unchecked boxes.
+- [x] Investigate how `foundry-heartbeat.ts` can reliably determine if a node is a late-binding parent versus a leaf task.
+- [x] Implement the `FAILED` fallback state for leaf tasks with unchecked boxes in `foundry-heartbeat.ts`.
+- [x] Add unit tests in `foundry-heartbeat.test.ts` to verify the different handling of leaf tasks versus parent nodes with unchecked boxes.
+
+### Child Nodes
+- [ ] .foundry/stories/story-031-050-enforce-acceptance-criteria-completion.md

--- a/.foundry/stories/story-031-050-enforce-acceptance-criteria-completion.md
+++ b/.foundry/stories/story-031-050-enforce-acceptance-criteria-completion.md
@@ -1,0 +1,31 @@
+---
+id: story-031-050-enforce-acceptance-criteria-completion
+type: STORY
+title: Enforce Acceptance Criteria Completion Logic in Heartbeat and Orchestrator
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-11'
+updated_at: '2026-05-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-020-031-enforce-acceptance-criteria-completion
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Enforce Acceptance Criteria Completion Logic in Heartbeat and Orchestrator
+
+## Description
+According to ADR 007, standard leaf tasks that are merged with unchecked acceptance criteria checkboxes are currently demoted to `PENDING` by the `foundry-heartbeat.ts` script. This leads to them being stuck indefinitely since they do not generate child nodes. We need to explicitly differentiate between a late-binding parent (which stays `PENDING`) and a regular task (which should fail).
+
+This story focuses on updating `foundry-heartbeat.ts` to differentiate between parent nodes and leaf nodes when unchecked tasks are found. It also updates `foundry-orchestrator.ts` preflight checks to prevent promoting nodes to `READY` if they are leaf tasks with unchecked boxes.
+
+## Acceptance Criteria
+- [ ] Update `foundry-heartbeat.ts` to check if a node has children via orchestrator mapping before deciding to keep it in `PENDING` due to unchecked tasks.
+- [ ] If it is a leaf task without children but contains unchecked boxes, transition it to `FAILED` with an appropriate journal message indicating that the PR was merged with unfulfilled acceptance criteria.
+- [ ] Update `foundry-orchestrator.ts` preflight logic to prevent improperly promoting nodes with unchecked boxes to `READY`.
+- [ ] Add unit tests in `foundry-heartbeat.test.ts` to verify the different handling of leaf tasks versus parent nodes with unchecked boxes.


### PR DESCRIPTION
Creates the next late-binding STORY node for the Enforce Acceptance Criteria Checkbox Completion Epic, outlining the implementation to differentiate between parent nodes and leaf nodes when checking for unchecked tasks in the heartbeat and orchestrator. It also checks off the corresponding acceptance criteria in the parent EPIC.

---
*PR created automatically by Jules for task [6888304931338879002](https://jules.google.com/task/6888304931338879002) started by @szubster*