### PR TITLE
Fix DAG Resolution Warning: Invalid owner_persona for TASK node

### DIFF
--- a/.foundry/tasks/task-048-080-evaluate-graph-libraries.md
+++ b/.foundry/tasks/task-048-080-evaluate-graph-libraries.md
@@ -3,7 +3,7 @@ id: task-048-080-evaluate-graph-libraries
 type: TASK
 title: "Evaluate Graph Rendering Libraries for DAG Dashboard"
 status: PENDING
-owner_persona: "architect"
+owner_persona: "tech_lead"
 created_at: "2026-05-11"
 updated_at: "2026-05-11"
 depends_on: []


### PR DESCRIPTION
Updated .foundry/tasks/task-048-080-evaluate-graph-libraries.md to change owner_persona from architect to tech_lead, resolving the Foundry Engine orchestrator warning.

Fixes #1204

---
*PR created automatically by Jules for task [7742471976350824831](https://jules.google.com/task/7742471976350824831) started by @szubster*