### PR TITLE
Allow architect to own TASK nodes in Foundry Engine

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -28,7 +28,7 @@ A custom orchestrator (`.github/scripts/foundry-orchestrator.ts`) parses the `de
 | `.foundry/prds/` | `PRD` | `product_manager` | Structured Product Requirements Documents. |
 | `.foundry/epics/` | `EPIC` | `epic_planner` | Macroscopic functional chunks derived from PRDs. |
 | `.foundry/stories/` | `STORY` | `story_owner` | Incremental, sequentially-planned delivery steps. Stories are late-binding: Story N+1 is only written after Story N completes so lessons are incorporated. |
-| `.foundry/tasks/` | `TASK` | `coder` | Concrete engineering blueprints. The Tech Lead writes them; the Coder implements; QA validates. |
+| `.foundry/tasks/` | `TASK` | `coder` | Concrete engineering blueprints. The Tech Lead or Architect writes them; the Coder implements; QA validates. |
 | `.foundry/journals/` | — | `tpm` | Persistent agent learning logs. Each persona decides its own structure (single file, subdirectory, multiple files by domain, etc.). The `tpm` is responsible for archiving stale journal content. |
 | `.foundry/docs/adrs/` | ADR | `tech_lead` | Architecture Decision Records. The Tech Lead reads these before writing any Task to ensure consistency. |
 | `.foundry/docs/style_guides/` | Style Guide | `designer` | Global UX/UI constraints injected into designer tasks. |

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1208,4 +1208,24 @@ expect(fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-004-005.md'), 'utf
     const ideaContent = fs.readFileSync(path.join(tmpDir, '.foundry/ideas/idea-001.md'), 'utf-8');
     expect(ideaContent).toContain('status: READY');
   });
+
+  test('Mapping Validation: allows architect to own TASK nodes', () => {
+    createValidTestNode(tmpDir, '.foundry/tasks/task-architect.md', {
+      id: "task-architect",
+      type: "TASK",
+      title: "Architect Task",
+      status: "PENDING",
+      owner_persona: "architect",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-architect.md'), 'utf-8');
+    expect(result).toContain('status: READY');
+    expect(result).toContain('owner_persona: architect');
+  });
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -793,7 +793,7 @@ function main(): void {
     PRD: ['epic_planner', 'architect', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
-    TASK: ['coder', 'qa', 'tech_lead'],
+    TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };
 

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -54,7 +54,7 @@ function validateSchema() {
   const ideaRegex = /^idea-\d{3}(-[a-z0-9-]+)?$/;
   const otherRegex = /^(prd|epic|story|task)-\d{3}(-\d{3})?(-[a-z0-9-]+)?$/;
 
-  const validTypes = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK'];
+  const validTypes = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH'];
   const validStatuses = ['PENDING', 'READY', 'ACTIVE', 'COMPLETED', 'FAILED', 'BLOCKED', 'CANCELLED'];
   const validPersonas = [
     'product_manager', 'epic_planner', 'story_owner', 'architect',
@@ -66,7 +66,7 @@ function validateSchema() {
     PRD: ['epic_planner', 'architect', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
-    TASK: ['coder', 'qa', 'tech_lead'],
+    TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };
 


### PR DESCRIPTION
The Foundry Engine orchestration failed because a TASK node was assigned to the 'architect' persona, which was not allowed by the validation and orchestration logic. This PR updates the valid mappings to allow 'architect' to own 'TASK' nodes, ensuring architectural tasks can be processed by the engine. It also fixes a discrepancy where 'RESEARCH' nodes were missing from the validation script's list of valid types. Documentation and tests are updated accordingly.

Fixes #1205

---
*PR created automatically by Jules for task [5991441457341983076](https://jules.google.com/task/5991441457341983076) started by @szubster*