### PR TITLE
docs(foundry): clarify empty PR policy for agents

### DIFF
--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -32,3 +32,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/agile_coach.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -34,3 +34,7 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/architect.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -32,3 +32,7 @@ When modifying central systems like the DAG Orchestrator (`.github/scripts/found
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/coder.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -38,3 +38,7 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/epic_planner.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -31,3 +31,7 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/product_manager.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -41,3 +41,7 @@ When verifying orchestrator logic tasks, ensure you explicitly run the specific 
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/qa.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -36,3 +36,7 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/story_owner.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -44,3 +44,7 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/tech_lead.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -36,3 +36,7 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/tpm.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/archivist.md
+++ b/.jules/schedules/archivist.md
@@ -58,3 +58,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ---
 
 If no stale or problematic knowledge can be identified, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/bolt.md
+++ b/.jules/schedules/bolt.md
@@ -47,3 +47,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ---
 
 If no clear performance win can be identified, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/canvas.md
+++ b/.jules/schedules/canvas.md
@@ -65,3 +65,7 @@ Entry format:
 ---
 
 If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no design opportunity exists, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/infras.md
+++ b/.jules/schedules/infras.md
@@ -44,3 +44,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ---
 
 If no clear tooling improvement can be identified, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/mason.md
+++ b/.jules/schedules/mason.md
@@ -39,3 +39,7 @@ Read `.jules/mason.md` before starting (create if missing).
 Log critical learnings: recurring patterns, extraction challenges, or reusable logic wins.
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/mason.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/nurse.md
+++ b/.jules/schedules/nurse.md
@@ -46,3 +46,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ---
 
 If no meaningful type-safety issue can be identified, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/oak.md
+++ b/.jules/schedules/oak.md
@@ -53,3 +53,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ---
 
 If no data discrepancy can be identified, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/palette.md
+++ b/.jules/schedules/palette.md
@@ -46,3 +46,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ---
 
 If no clear UX win can be identified, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/researcher.md
+++ b/.jules/schedules/researcher.md
@@ -48,3 +48,7 @@ If the `RESEARCH` node's questions have already been answered or the required kn
 
 ## Journal Instructions
 Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/scribe.md
+++ b/.jules/schedules/scribe.md
@@ -45,3 +45,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ---
 
 If no meaningful documentation gap can be identified, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/sentinel.md
+++ b/.jules/schedules/sentinel.md
@@ -51,3 +51,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ---
 
 If no meaningful coverage gap can be identified, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/shield.md
+++ b/.jules/schedules/shield.md
@@ -41,3 +41,7 @@ Read `.jules/shield.md` before starting (create if missing).
 Only log **critical** learnings: recurring vulnerability patterns or complex security rationales.
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/shield.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/strategist.md
+++ b/.jules/schedules/strategist.md
@@ -75,3 +75,7 @@ Entry format:
 ---
 
 If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no meaningful roster or prompt change can be justified, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/sweeper.md
+++ b/.jules/schedules/sweeper.md
@@ -38,3 +38,7 @@ Read `.jules/sweeper.md` before starting (create if missing).
 Only log **critical** learnings: unexpected entanglements or patterns to watch out for.
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/sweeper.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/schedules/trainer.md
+++ b/.jules/schedules/trainer.md
@@ -45,3 +45,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ---
 
 If no clear assistant improvement can be identified, do not create a PR.
+
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).


### PR DESCRIPTION
Appended explicit instructions to all Foundry agent profiles and Jules
schedule definitions indicating that completely empty PRs are
acceptable and will be automatically merged by GitHub Actions. This
ensures all agents properly utilize the Empty PR policy to advance the
DAG when no further file modifications are required.

---
*PR created automatically by Jules for task [15428383526260873023](https://jules.google.com/task/15428383526260873023) started by @szubster*