### PR TITLE
Allow architect to own TASK nodes

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -793,7 +793,7 @@ function main(): void {
     PRD: ['epic_planner', 'architect', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
-    TASK: ['coder', 'qa', 'tech_lead'],
+    TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };
 

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -66,7 +66,7 @@ function validateSchema() {
     PRD: ['epic_planner', 'architect', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
-    TASK: ['coder', 'qa', 'tech_lead'],
+    TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };
 


### PR DESCRIPTION
The Foundry Engine was failing during orchestration because TASK nodes could not be owned by the 'architect' persona. This change updates the valid mapping configuration in both the orchestrator and the schema validation script to allow 'architect' to own TASKs, which is necessary for tasks involving high-level research and architectural evaluation.

Fixes #1210

---
*PR created automatically by Jules for task [3717816843582793672](https://jules.google.com/task/3717816843582793672) started by @szubster*