### PR TITLE
Allow Architect persona to own TASK nodes

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -793,7 +793,7 @@ function main(): void {
     PRD: ['epic_planner', 'architect', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
-    TASK: ['coder', 'qa', 'tech_lead'],
+    TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };
 

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -66,7 +66,7 @@ function validateSchema() {
     PRD: ['epic_planner', 'architect', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
-    TASK: ['coder', 'qa', 'tech_lead'],
+    TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };
 


### PR DESCRIPTION
Resolved DAG resolution warnings by permitting the 'architect' persona to own 'TASK' nodes. This ensures architectural tasks can be properly assigned and resolved within the Foundry engine.

Fixes #1209

---
*PR created automatically by Jules for task [12427662745513285077](https://jules.google.com/task/12427662745513285077) started by @szubster*