### PR TITLE
Allow architect to own TASK nodes

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -58,3 +58,11 @@ Task task-046-077-standardize-orchestrator-test-factories: Implemented `foundry-
 
 ## 2026-05-12 - task-042-069-extract-roamers
 The roamer location extraction logic for Gen 2 (Raikou, Entei, Suicune) is already implemented in `src/engine/saveParser/parsers/gen2.ts`, and the corresponding tests exist in `src/engine/saveParser/parsers/gen2.test.ts`. Submitting an empty PR to allow the DAG to progress.
+
+## 2026-05-11: Updated Foundry Orchestrator Persona Mappings
+
+Resolved an issue where TASK nodes owned by the 'architect' persona were being flagged as invalid.
+- Updated `.github/scripts/foundry-orchestrator.ts` to allow 'architect' to own 'TASK' nodes.
+- Synchronized `scripts/validate-foundry-schema.ts` with these mapping changes.
+- Proactively added 'RESEARCH' node support to the schema validator.
+- Added a regression test in `.github/scripts/foundry-orchestrator.test.ts` to verify the new mapping.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1002,6 +1002,7 @@ describe('foundry-orchestrator', () => {
     createValidTestNode(tmpDir, '.foundry/research/research-001.md', { id: "research-001", type: "RESEARCH", title: "Research Task", status: "PENDING", owner_persona: "researcher", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
     createValidTestNode(tmpDir, '.foundry/prds/prd-architect.md', { id: "prd-architect", type: "PRD", title: "Architect PRD", status: "PENDING", owner_persona: "architect", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
     createValidTestNode(tmpDir, '.foundry/tasks/task-tech-lead.md', { id: "task-tech-lead", type: "TASK", title: "Tech Lead Task", status: "PENDING", owner_persona: "tech_lead", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
+    createValidTestNode(tmpDir, '.foundry/tasks/task-architect.md', { id: "task-architect", type: "TASK", title: "Architect Task", status: "PENDING", owner_persona: "architect", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
 
     main();
 
@@ -1024,6 +1025,9 @@ describe('foundry-orchestrator', () => {
 
     const taskTechLeadResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-tech-lead.md'), 'utf-8');
     expect(taskTechLeadResult).toContain('status: READY');
+
+    const taskArchitectResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-architect.md'), 'utf-8');
+    expect(taskArchitectResult).toContain('status: READY');
   });
 
   test('Atomic Handoffs: resolves dependencies across single-persona atomic tasks', () => {

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -793,7 +793,7 @@ function main(): void {
     PRD: ['epic_planner', 'architect', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
-    TASK: ['coder', 'qa', 'tech_lead'],
+    TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };
 

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -52,9 +52,9 @@ function validateSchema() {
   let hasError = false;
 
   const ideaRegex = /^idea-\d{3}(-[a-z0-9-]+)?$/;
-  const otherRegex = /^(prd|epic|story|task)-\d{3}(-\d{3})?(-[a-z0-9-]+)?$/;
+  const otherRegex = /^(prd|epic|story|task|research)-\d{3}(-\d{3})?(-[a-z0-9-]+)?$/;
 
-  const validTypes = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK'];
+  const validTypes = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH'];
   const validStatuses = ['PENDING', 'READY', 'ACTIVE', 'COMPLETED', 'FAILED', 'BLOCKED', 'CANCELLED'];
   const validPersonas = [
     'product_manager', 'epic_planner', 'story_owner', 'architect',
@@ -66,7 +66,7 @@ function validateSchema() {
     PRD: ['epic_planner', 'architect', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
-    TASK: ['coder', 'qa', 'tech_lead'],
+    TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };
 


### PR DESCRIPTION
Updated the \`validMappings\` in \`foundry-orchestrator.ts\` and \`validate-foundry-schema.ts\` to include 'architect' for 'TASK' nodes. Added 'RESEARCH' to \`validTypes\` in the validator. Added a test case in \`foundry-orchestrator.test.ts\` and updated \`.foundry/journals/coder.md\`.

Fixes #1213

---
*PR created automatically by Jules for task [4647476628007251281](https://jules.google.com/task/4647476628007251281) started by @szubster*