### PR TITLE
Allow architect persona to own TASK nodes

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -28,7 +28,7 @@ A custom orchestrator (`.github/scripts/foundry-orchestrator.ts`) parses the `de
 | `.foundry/prds/` | `PRD` | `product_manager` | Structured Product Requirements Documents. |
 | `.foundry/epics/` | `EPIC` | `epic_planner` | Macroscopic functional chunks derived from PRDs. |
 | `.foundry/stories/` | `STORY` | `story_owner` | Incremental, sequentially-planned delivery steps. Stories are late-binding: Story N+1 is only written after Story N completes so lessons are incorporated. |
-| `.foundry/tasks/` | `TASK` | `coder` | Concrete engineering blueprints. The Tech Lead writes them; the Coder implements; QA validates. |
+| `.foundry/tasks/` | `TASK` | `coder`, `architect` | Concrete engineering blueprints. The Tech Lead writes them; the Coder implements; QA validates. |
 | `.foundry/journals/` | — | `tpm` | Persistent agent learning logs. Each persona decides its own structure (single file, subdirectory, multiple files by domain, etc.). The `tpm` is responsible for archiving stale journal content. |
 | `.foundry/docs/adrs/` | ADR | `tech_lead` | Architecture Decision Records. The Tech Lead reads these before writing any Task to ensure consistency. |
 | `.foundry/docs/style_guides/` | Style Guide | `designer` | Global UX/UI constraints injected into designer tasks. |

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1208,4 +1208,23 @@ expect(fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-004-005.md'), 'utf
     const ideaContent = fs.readFileSync(path.join(tmpDir, '.foundry/ideas/idea-001.md'), 'utf-8');
     expect(ideaContent).toContain('status: READY');
   });
+
+  test('Mapping Validation: allows architect to own TASK nodes', () => {
+    createValidTestNode(tmpDir, '.foundry/tasks/task-architect.md', {
+      id: "task-architect",
+      type: "TASK",
+      title: "Architect Task",
+      status: "PENDING",
+      owner_persona: "architect",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-architect.md'), 'utf-8');
+    expect(result).toContain('status: READY');
+  });
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -793,7 +793,7 @@ function main(): void {
     PRD: ['epic_planner', 'architect', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
-    TASK: ['coder', 'qa', 'tech_lead'],
+    TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };
 

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -66,7 +66,7 @@ function validateSchema() {
     PRD: ['epic_planner', 'architect', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
-    TASK: ['coder', 'qa', 'tech_lead'],
+    TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };
 


### PR DESCRIPTION
The Foundry Engine failed during orchestration because a TASK node was owned by the 'architect' persona, which was not allowed by the schema validation script. I have updated both the validation script and the orchestrator logic to allow 'architect' to own 'TASK' nodes. I also updated the documentation and added a test case to ensure this mapping is supported and correctly handled.

Fixes #1214

---
*PR created automatically by Jules for task [12609516143575622176](https://jules.google.com/task/12609516143575622176) started by @szubster*