### PR TITLE
fix(agile-coach): close empty PR loophole on rejected tasks

### DIFF
--- a/.foundry/ideas/idea-050-orchestrator-leaf-failure-validation.md
+++ b/.foundry/ideas/idea-050-orchestrator-leaf-failure-validation.md
@@ -1,0 +1,32 @@
+---
+id: idea-050-orchestrator-leaf-failure-validation
+type: IDEA
+title: 'DAG Feature: Enforce Acceptance Criteria on Empty PRs'
+status: "READY"
+owner_persona: product_manager
+created_at: '2026-05-12'
+updated_at: "2026-05-12"
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - validation
+notes: ''
+---
+
+# Idea: Enforce Acceptance Criteria on Empty PRs
+
+## Context
+Currently, the Empty PR policy automatically merges any PR with 0 file changes, advancing the node's status to `COMPLETED`. We recently discovered a bug where if a leaf node (like a Task) has unchecked acceptance criteria boxes but an agent submits an empty PR anyway, the orchestrator auto-merges it. This incorrectly advances a failed/incomplete task to `COMPLETED`, unblocking downstream nodes. ADR-007 states that leaf nodes with unchecked boxes should be marked `FAILED`, not `PENDING`.
+
+## Proposal
+Enhance the DAG Orchestrator so that before an empty PR is auto-merged, it actively checks the target artifact's markdown body. If the node contains unchecked acceptance criteria (`- [ ]`) and it is a leaf node (no children), the orchestrator must reject the empty PR, prevent auto-merge, and update the node's status to `FAILED`.
+
+## Impact
+Prevents incomplete tasks from slipping through via the Empty PR policy loop hole, enforcing stricter completion requirements and improving system reliability.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea to a PRD.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -44,3 +44,9 @@ While analyzing recent failures, I noted that `task-042-068-extract-hall-of-fame
 ### Action Taken
 1. Created `.foundry/docs/knowledge_base/engine/save_parsing/gen2_hall_of_fame.md` to explicitly document the relative offset for the Hall of Fame count, providing the Coder with grounded context to successfully complete task-042.
 2. Autonomously generated `idea-020-enforce-acceptance-criteria-completion.md` to propose a new orchestration rule that enforces all checkboxes in the Acceptance Criteria block must be checked before a node is permitted to transition to `COMPLETED`.
+
+## 2026-05-12 - Prevent Empty PR Loophole on Rejections
+Observed that the QA agent rejected a task (`task-047-078`) in its journal but failed to update the task's YAML frontmatter to `status: FAILED`. Because no files were changed, the Empty PR policy auto-merged the PR, improperly advancing the node. To fix this:
+1. Updated `qa.md` with explicit instructions on handling rejections (setting `status: FAILED` and `rejection_reason`).
+2. Added the 'WARNING: The Empty PR policy...' text to all execution/planning agents (`coder.md`, `story_owner.md`, `tech_lead.md`, `epic_planner.md`, `product_manager.md`, `qa.md`).
+3. Created `idea-050-orchestrator-leaf-failure-validation.md` to have the Orchestrator validate empty PRs against unchecked acceptance criteria.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -32,3 +32,5 @@ When modifying central systems like the DAG Orchestrator (`.github/scripts/found
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/coder.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -38,3 +38,5 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/epic_planner.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -31,3 +31,5 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/product_manager.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -41,3 +41,12 @@ When verifying orchestrator logic tasks, ensure you explicitly run the specific 
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/qa.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
+
+### Handling Rejections
+If you reject an implementation or validation fails:
+1. You MUST update the target task's YAML frontmatter to `status: FAILED`.
+2. You MUST provide a clear `rejection_reason` in the target task's YAML frontmatter.
+3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed task.
+4. You MUST document the rejection in your persona journal.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -36,3 +36,5 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/story_owner.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -44,3 +44,5 @@ If `pnpm install` hangs or fails during `lefthook install` or git hook setup, ru
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/tech_lead.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
+
+- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.


### PR DESCRIPTION
This PR addresses a critical bug in the Foundry Orchestrator where failed leaf tasks were improperly advancing to `COMPLETED` due to the Empty PR policy loop hole. When agents like QA encountered failures, they sometimes submitted empty PRs without updating the YAML frontmatter to `status: FAILED`. The orchestrator auto-merged these PRs, masking the failures. 

Changes:
1. Updated `.github/agents/qa.md` with explicit, strict instructions on handling rejections (must update YAML frontmatter).
2. Appended warnings to all relevant persona prompts prohibiting empty PRs for failed/cancelled tasks.
3. Authored a new `IDEA` node to permanently patch the Orchestrator to validate unchecked acceptance criteria before auto-merging empty PRs.
4. Logged findings and patterns in the Agile Coach's persistent journal.

---
*PR created automatically by Jules for task [15606263130672263989](https://jules.google.com/task/15606263130672263989) started by @szubster*