### PR TITLE
story_owner: Create story for core graph visualization component

### DIFF
--- a/.foundry/epics/epic-017-029-dag-dashboard-ui.md
+++ b/.foundry/epics/epic-017-029-dag-dashboard-ui.md
@@ -36,10 +36,11 @@ This Epic covers the frontend user interface for the DAG Dashboard Webview. It c
 
 ## Acceptance Criteria
 - [x] Select and integrate a graph rendering library (e.g., Mermaid.js, React Flow).
-- [ ] Implement the core graph visualization component.
+- [x] Implement the core graph visualization component.
 - [ ] Implement filtering UI controls and logic.
 - [ ] Implement dependency highlighting interactions.
 - [ ] Wire up the UI to consume data from the parsing layer.
 
 ## Stories
 - `.foundry/stories/story-029-048-evaluate-graph-libraries.md`
+- `.foundry/stories/story-029-051-implement-core-graph-visualization.md`

--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -50,3 +50,4 @@ All acceptance criteria in .foundry/epics/epic-014-025-enforce-persona-pipeline-
 - Target STORY node `.foundry/stories/story-030-046-standardize-orchestrator-test-factories.md` already exists and is `COMPLETED`.
 - Parent Epic's acceptance criteria have been checked off.
 - Applying Empty PR Policy.
+- **2026-05-XX Pattern Insight:** When implementing sequential stories (e.g., in `epic-017-029-dag-dashboard-ui`), sibling dependencies should be correctly linked using `depends_on`. For instance, `story-029-051-implement-core-graph-visualization` correctly blocks on `story-029-048-evaluate-graph-libraries`. I also made sure to append the newly spawned story to the parent epic's markdown and tick the checkbox, without modifying its YAML frontmatter.

--- a/.foundry/stories/story-029-051-implement-core-graph-visualization.md
+++ b/.foundry/stories/story-029-051-implement-core-graph-visualization.md
@@ -1,0 +1,40 @@
+---
+id: story-029-051-implement-core-graph-visualization
+type: STORY
+title: Implement Core Graph Visualization Component
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-12'
+updated_at: '2026-05-12'
+depends_on:
+  - .foundry/stories/story-029-048-evaluate-graph-libraries.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-017-029-dag-dashboard-ui.md
+tags:
+  - dag
+  - dashboard
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Core Graph Visualization Component
+
+## Overview
+Following the selection and integration of the graph rendering library (React Flow / Mermaid.js), this story focuses on implementing the core graph visualization component for the DAG Dashboard. It should render the nodes and edges representing the Foundry DAG.
+
+## Requirements
+- Render a directed graph visualization of the Foundry nodes.
+- Display `id`, `type`, `status`, and `owner_persona` within or alongside each node representation.
+- Ensure the layout is readable for moderate node counts.
+
+## Acceptance Criteria
+- [ ] Create a core graph component using the selected graph rendering library.
+- [ ] Render node elements displaying `id`, `type`, `status`, and `owner_persona`.
+- [ ] Render directed edges between nodes based on their `depends_on` relationships.
+- [ ] Apply basic styling to nodes based on their status or type.
+
+### Generated Tasks


### PR DESCRIPTION
Created the next sequential STORY node (`story-029-051-implement-core-graph-visualization`) for the DAG Dashboard Visualization epic, ensuring proper sibling dependencies and updating the parent Epic appropriately.

---
*PR created automatically by Jules for task [5316928527286581993](https://jules.google.com/task/5316928527286581993) started by @szubster*