### PR TITLE
QA Validation: Gen 2 Indoor to Outdoor Map Resolution

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -45,3 +45,6 @@ The QA check failed because the coder did not implement the `cleanupRemoteBranch
 - Verified offsets used match the knowledge base instructions (e.g. `0xA8` relative to Johto badges for Hall of Fame count).
 - Confirmed unit tests and fixture tests pass successfully (`pnpm test`).
 - Updated task node markdown body with checked acceptance criteria. Submitting an empty PR to allow DAG progression.
+
+### 2026-05-12 - Gen 2 Map Resolution
+Successfully verified `resolveOutdoorMapId` logic in `gen1Graph.ts` and `gen2Graph.ts`. Added comprehensive tests to ensure multi-level graph routing works, and verified the implementation correctly handles protection against circular prnt references by using a `Set`.

--- a/.foundry/tasks/task-044-081-qa-indoor-outdoor-resolution.md
+++ b/.foundry/tasks/task-044-081-qa-indoor-outdoor-resolution.md
@@ -36,7 +36,7 @@ The coder has implemented `resolveOutdoorMapId` in `src/engine/mapGraph/gen2Grap
 - Run all Vitest suites for map graph logic to ensure no regressions.
 
 ## Acceptance Criteria
-- [ ] Tests for `resolveOutdoorMapId` are comprehensive and cover multi-level map scenarios.
-- [ ] The implementation handles recursive/iterative `prnt` traversal correctly.
-- [ ] `pnpm test` passes successfully.
-- [ ] No performance regressions introduced by the loop.
+- [x] Tests for `resolveOutdoorMapId` are comprehensive and cover multi-level map scenarios.
+- [x] The implementation handles recursive/iterative `prnt` traversal correctly.
+- [x] `pnpm test` passes successfully.
+- [x] No performance regressions introduced by the loop.

--- a/src/engine/mapGraph/gen1Graph.test.ts
+++ b/src/engine/mapGraph/gen1Graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { UnifiedLocation } from '../../db/schema';
-import { getDistanceToMap } from './gen1Graph';
+import { getDistanceToMap, resolveOutdoorMapId } from './gen1Graph';
 
 const mockLocations: UnifiedLocation[] = [
   { id: 0x00, n: 'Pallet Town', conn: [0x01], dist: { 0x00: 0, 0x01: 1, 0x02: 2 } },
@@ -74,5 +74,39 @@ describe('getDistanceToMap', () => {
     ];
     const result = getDistanceToMap(locationsWithoutDist, 0x00, 0x01);
     expect(result).toBeNull();
+  });
+});
+
+describe('resolveOutdoorMapId', () => {
+  it('correctly resolves a map ID with no prnt to itself', () => {
+    // Pallet Town (0x00) has no prnt
+    const result = resolveOutdoorMapId(mockLocations, 0x00);
+    expect(result).toBe(0x00);
+  });
+
+  it('correctly resolves a single-level indoor map to its outdoor hub', () => {
+    // Player's House (0x25) -> Pallet Town (0x00)
+    const result = resolveOutdoorMapId(mockLocations, 0x25);
+    expect(result).toBe(0x00);
+  });
+
+  it('correctly resolves a multi-level indoor map to its root outdoor hub', () => {
+    // Player's House 2F (0x26) -> Player's House (0x25) -> Pallet Town (0x00)
+    const result = resolveOutdoorMapId(mockLocations, 0x26);
+    expect(result).toBe(0x00);
+  });
+
+  it('handles circular prnt references gracefully', () => {
+    // Create a circular mock: 0x90 -> 0x91 -> 0x90
+    const circularLocations = [
+      ...mockLocations,
+      { id: 0x90, n: 'Loop A', prnt: 0x91, conn: [], dist: {} },
+      { id: 0x91, n: 'Loop B', prnt: 0x90, conn: [], dist: {} },
+    ];
+    // It should stop at the first revisited node
+    const result = resolveOutdoorMapId(circularLocations, 0x90);
+    // Since 0x90 -> 0x91 -> 0x90, 0x90 is visited, then 0x91 is visited, then 0x90 is already visited
+    // so it breaks loop when currentMapId becomes 0x90 again, returning 0x90.
+    expect(result).toBe(0x90);
   });
 });

--- a/src/engine/mapGraph/gen2Graph.test.ts
+++ b/src/engine/mapGraph/gen2Graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { UnifiedLocation } from '../../db/schema';
-import { getDistanceToMap } from './gen2Graph';
+import { getDistanceToMap, resolveOutdoorMapId } from './gen2Graph';
 
 const mockLocations: UnifiedLocation[] = [
   // Start locations (simulate Johto/Kanto structure)
@@ -66,5 +66,39 @@ describe('getDistanceToMap (Gen 2)', () => {
     ];
     const result = getDistanceToMap(locationsWithoutDist, 0x0306, 0x1111);
     expect(result).toBeNull();
+  });
+});
+
+describe('resolveOutdoorMapId', () => {
+  it('correctly resolves a map ID with no prnt to itself', () => {
+    // Goldenrod City (0x0306) has no prnt
+    const result = resolveOutdoorMapId(mockLocations, 0x0306);
+    expect(result).toBe(0x0306);
+  });
+
+  it('correctly resolves a single-level indoor map to its outdoor hub', () => {
+    // Goldenrod Pokecenter (0x25) -> Goldenrod City (0x0306)
+    const result = resolveOutdoorMapId(mockLocations, 0x25);
+    expect(result).toBe(0x0306);
+  });
+
+  it('correctly resolves a multi-level indoor map to its root outdoor hub', () => {
+    // Goldenrod Pokecenter 2F (0x26) -> Goldenrod Pokecenter (0x25) -> Goldenrod City (0x0306)
+    const result = resolveOutdoorMapId(mockLocations, 0x26);
+    expect(result).toBe(0x0306);
+  });
+
+  it('handles circular prnt references gracefully', () => {
+    // Create a circular mock: 0x90 -> 0x91 -> 0x90
+    const circularLocations = [
+      ...mockLocations,
+      { id: 0x90, n: 'Loop A', prnt: 0x91, conn: [], dist: {} },
+      { id: 0x91, n: 'Loop B', prnt: 0x90, conn: [], dist: {} },
+    ];
+    // It should stop at the first revisited node
+    const result = resolveOutdoorMapId(circularLocations, 0x90);
+    // Since 0x90 -> 0x91 -> 0x90, 0x90 is visited, then 0x91 is visited, then 0x90 is already visited
+    // so it breaks loop when currentMapId becomes 0x90 again, returning 0x90.
+    expect(result).toBe(0x90);
   });
 });


### PR DESCRIPTION
QA validation for task-044-081-qa-indoor-outdoor-resolution. Added Vitest unit tests in `gen1Graph.test.ts` and `gen2Graph.test.ts` to ensure multi-level map graph routing correctly resolves to outdoor parent nodes without running into infinite loops for cyclical `prnt` links. Verified `pnpm lint` and `pnpm test` pass. Approved Acceptance Criteria in task markdown body and updated QA journal.

---
*PR created automatically by Jules for task [1087004501897425540](https://jules.google.com/task/1087004501897425540) started by @szubster*