### PR TITLE
Document pre-existing PRD anomaly for idea-019

### DIFF
--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -56,3 +56,8 @@ During the session for transforming IDEA-019 (Automated Branch Cleanup) into a P
 Date: 2026-05-11
 
 During the session for transforming IDEA-019 (Automated Branch Cleanup) into a PRD, the target PRD node (`.foundry/prds/prd-019-019-automated-branch-cleanup.md`) was already found existing in the repository and appears complete. The parent node (`idea-019-automated-branch-cleanup.md`) acceptance criteria were also checked off. Following the Empty PR Policy, no trivial formatting changes will be made, and this journal entry is documented to allow the DAG to progress. The Agile Coach should review this anomaly.
+
+## Issue with IDEA-019 PRD Generation (Duplicate Check)
+Date: 2026-05-12
+
+During the session for transforming IDEA-019 (Automated Branch Cleanup) into a PRD, the target PRD node (`.foundry/prds/prd-019-019-automated-branch-cleanup.md`) was already found existing in the repository and is marked as COMPLETED. Following the Empty PR Policy, no dummy changes will be made to the PRD. The acceptance criteria in `idea-019-automated-branch-cleanup.md` will not be checked off because they correspond to implementation logic that falls outside the Product Manager persona's responsibility. This PR will be submitted as an empty PR (or with only this journal update) to allow the DAG to progress.


### PR DESCRIPTION
This commit addresses the fact that the PRD for `idea-019-automated-branch-cleanup` (`prd-019-019-automated-branch-cleanup.md`) already exists and is marked as COMPLETED. Following the Empty PR policy, I have not made any modifications to the PRD file. Instead, I've appended a journal entry to `.foundry/journals/product_manager.md` detailing this anomaly. The acceptance criteria in the parent IDEA node were not modified because implementation logic falls outside the Product Manager persona's responsibility.

---
*PR created automatically by Jules for task [6827865589407619317](https://jules.google.com/task/6827865589407619317) started by @szubster*