### PR TITLE
PRD: Enforce Acceptance Criteria on Empty PRs

### DIFF
--- a/.foundry/ideas/idea-050-orchestrator-leaf-failure-validation.md
+++ b/.foundry/ideas/idea-050-orchestrator-leaf-failure-validation.md
@@ -29,4 +29,8 @@ Enhance the DAG Orchestrator so that before an empty PR is auto-merged, it activ
 Prevents incomplete tasks from slipping through via the Empty PR policy loop hole, enforcing stricter completion requirements and improving system reliability.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea to a PRD.
+- [x] Product Manager: Convert this idea to a PRD.
+
+
+## Generated Nodes
+- [PRD-050-021](.foundry/prds/prd-050-021-orchestrator-leaf-failure-validation.md)

--- a/.foundry/prds/prd-050-021-orchestrator-leaf-failure-validation.md
+++ b/.foundry/prds/prd-050-021-orchestrator-leaf-failure-validation.md
@@ -1,0 +1,48 @@
+---
+id: prd-050-021-orchestrator-leaf-failure-validation
+type: PRD
+title: 'Enforce Acceptance Criteria on Empty PRs'
+status: PENDING
+owner_persona: architect
+created_at: '2026-05-12'
+updated_at: '2026-05-12'
+depends_on: []
+jules_session_id: null
+parent: idea-050-orchestrator-leaf-failure-validation
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - validation
+notes: ''
+---
+
+# PRD: Enforce Acceptance Criteria on Empty PRs
+
+## 1. Context and Problem Statement
+According to the Foundry's Empty PR policy, if an agent determines that a target artifact already exists and is complete, it should submit an empty PR (0 files changed) which is auto-merged by GitHub Actions. However, a bug exists where agents submit empty PRs for leaf nodes (e.g., Tasks) that have unchecked acceptance criteria (`- [ ]`) in their markdown bodies. The `.github/workflows/auto-close-empty-pr.yml` currently merges these empty PRs unconditionally, falsely advancing incomplete tasks to `COMPLETED` and improperly unblocking downstream nodes.
+
+Per ADR-007, leaf nodes with unchecked boxes must be marked `FAILED`, not `PENDING` or `COMPLETED`. We need to strictly enforce this validation before allowing an empty PR to be auto-merged.
+
+## 2. Requirements
+
+### Functional Requirements
+1. **Validation Check**: Before auto-merging an empty PR, the system must validate the target node's markdown body.
+2. **Acceptance Criteria Parsing**: The system must check for the presence of unchecked acceptance criteria boxes (e.g., `- [ ]`).
+3. **Leaf Node Check**: The validation must determine if the target node is a leaf node (i.e., no other nodes reference it as a parent).
+4. **Failure Condition**: If the target artifact is a leaf node AND has unchecked acceptance criteria, the system must:
+   - Reject the empty PR.
+   - Prevent the auto-merge.
+   - Update the node's status to `FAILED`.
+   - Add a `rejection_reason` explaining the failure.
+5. **Success Condition**: If the target artifact has all boxes checked, or is not a leaf node (e.g., it is late-binding), the empty PR should be auto-merged as usual.
+
+### Non-Functional Requirements
+1. **Resilience**: The validation process must handle file reads and frontmatter parsing gracefully without crashing the pipeline.
+2. **Performance**: The check should be lightweight and fast, adding minimal overhead to the `auto-close-empty-pr` workflow.
+
+## 3. Scope
+The scope of this feature is limited to the Empty PR auto-merge pipeline and orchestrator validation rules. It will primarily involve creating or modifying validation scripts (e.g., `validate-empty-pr.js`) and updating `.github/workflows/auto-close-empty-pr.yml`.
+
+## 4. Next Steps
+- [ ] Architect: Review this PRD and create an Architecture Decision Record (ADR).


### PR DESCRIPTION
This PR fulfills the acceptance criteria of IDEA-050 by converting the idea into a proper PRD.

Changes:
- Created `.foundry/prds/prd-050-021-orchestrator-leaf-failure-validation.md`
- Updated `.foundry/ideas/idea-050-orchestrator-leaf-failure-validation.md` to check off the acceptance criteria and link the newly generated PRD.
- Added a relevant entry to the `.foundry/journals/product_manager.md` journal.

---
*PR created automatically by Jules for task [1610649360325564566](https://jules.google.com/task/1610649360325564566) started by @szubster*