### PR TITLE
Epic Planner: Empty PR for PRD-019

### DIFF
--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -41,3 +41,7 @@ Outcome: The generated epics (epic-007-atomic-handoff-schema.md, epic-008-atomic
 >> **Task:** PRD-019-019-orchestrator-test-factories -> Epic epic-019-030-orchestrator-test-factories
 >> **Decision:** The target artifact Epic `epic-019-030-orchestrator-test-factories.md` already exists and is completed.
 >> **Action:** Per the Empty PR Policy, I did not make dummy updates or trivial formatting changes to force a git diff. Submitted PR directly.
+
+>> **Task:** PRD-019-019-orchestrator-test-factories -> Epic epic-019-030-orchestrator-test-factories
+>> **Decision:** The target artifact Epic `epic-019-030-orchestrator-test-factories.md` already exists and is completed. The parent `prd-019-019-orchestrator-test-factories.md` already correctly spawned it.
+>> **Action:** Per the Empty PR Policy, submitted PR with 0 files changed.


### PR DESCRIPTION
The generated epic `epic-019-030-orchestrator-test-factories` already exists and is complete. As the Epic Planner, I have applied the Empty PR Policy, documented the occurrence in the persona journal, and refrained from making trivial formatting modifications to force a diff.

---
*PR created automatically by Jules for task [14069645523074245051](https://jules.google.com/task/14069645523074245051) started by @szubster*