### PR TITLE
Architect: Empty PR for PRD 020-020

### DIFF
--- a/.foundry/journals/architect.md
+++ b/.foundry/journals/architect.md
@@ -15,3 +15,5 @@ Architects frequently perform evaluation tasks (e.g., assessing graph libraries,
 - Verified that `task-048-080` is now correctly promoted to READY by the orchestrator.
 
 - **2026-05-12**: Addressed CI audit failure caused by critical malware advisory GHSA-rmmr-r34h-pfm5 in `@tanstack/history`. Updated CI workflow to ignore this specific advisory as a temporary mitigation while using the known-stable version `1.161.6`.
+
+- **2026-05-12**: Applied the Empty PR Policy to `prd-020-020-enforce-acceptance-criteria-completion`. The required target artifact (ADR 007) and its downstream implementations (e.g., `story-031-050-enforce-acceptance-criteria-completion`) already exist. The PRD acceptance criteria were already checked off. No new architectural design or documentation was required, so no files were modified.


### PR DESCRIPTION
Applied the Empty PR Policy for `prd-020-020-enforce-acceptance-criteria-completion` because ADR 007 and related tasks already implement the required acceptance criteria. Documented this decision in `.foundry/journals/architect.md`.

---
*PR created automatically by Jules for task [18155315849651405941](https://jules.google.com/task/18155315849651405941) started by @szubster*