### PR TITLE
chore: apply empty PR policy for already completed tasks

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -65,3 +65,8 @@ All sibling tasks were explicitly linked via `depends_on` to ensure execution se
 
 ## 2026-05-12 - Graph Rendering Library Evaluation
 Evaluated graph rendering libraries for the DAG Dashboard. Selected React Flow over Mermaid.js and Cytoscape.js. React Flow offers the best balance of seamless integration with our React/Tailwind ecosystem (critical for enforcing the strict tactical hardware aesthetic with custom DOM nodes) and out-of-the-box interactivity features. Documented in ADR 008.
+
+## 2026-05-12: Artifacts Already Exist
+- **Task:** Phase 3: Indoor to Outdoor Resolution (story-028-044-indoor-outdoor-resolution)
+- **Observation:** The generated artifacts (`task-044-080-implement-indoor-outdoor-resolution.md` and `task-044-081-qa-indoor-outdoor-resolution.md`) already exist and are marked as COMPLETED.
+- **Action:** Executing Empty PR Policy. Since the requested target nodes already exist and are complete, I will not modify any parent node checkboxes or files to force a git diff. There is no work to do, submitting an empty PR.


### PR DESCRIPTION
The required artifacts (`task-044-080` and `task-044-081`) for `story-028-044-indoor-outdoor-resolution` already exist and are marked as COMPLETED. Applying the Empty PR Policy by updating the persona journal and leaving the parent node unmodified to progress the DAG.

---
*PR created automatically by Jules for task [9446970082799389609](https://jules.google.com/task/9446970082799389609) started by @szubster*