### PR TITLE
Epic planner empty PR for orchestrator-test-factories

### DIFF
--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -45,3 +45,7 @@ Outcome: The generated epics (epic-007-atomic-handoff-schema.md, epic-008-atomic
 >> **Task:** PRD-019-019-orchestrator-test-factories -> Epic epic-019-030-orchestrator-test-factories
 >> **Decision:** The target artifact Epic `epic-019-030-orchestrator-test-factories.md` already exists and is completed. The parent `prd-019-019-orchestrator-test-factories.md` already correctly spawned it.
 >> **Action:** Per the Empty PR Policy, submitted PR with 0 files changed.
+
+>> **Task:** PRD-019-019-orchestrator-test-factories -> Epic epic-019-030-orchestrator-test-factories
+>> **Decision:** The target artifact Epic `epic-019-030-orchestrator-test-factories.md` already exists and is completed.
+>> **Action:** Per the Empty PR Policy, I did not make dummy updates or trivial formatting changes to force a git diff. Submitted PR directly.


### PR DESCRIPTION
Epic planner empty PR for orchestrator-test-factories

---
*PR created automatically by Jules for task [2573853909337821732](https://jules.google.com/task/2573853909337821732) started by @szubster*