### PR TITLE
chore: Update PM journal for pre-existing PRD-019 (Empty PR Policy)

### DIFF
--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -61,3 +61,8 @@ During the session for transforming IDEA-019 (Automated Branch Cleanup) into a P
 Date: 2026-05-12
 
 During the session for transforming IDEA-019 (Automated Branch Cleanup) into a PRD, the target PRD node (`.foundry/prds/prd-019-019-automated-branch-cleanup.md`) was already found existing in the repository and is marked as COMPLETED. Following the Empty PR Policy, no dummy changes will be made to the PRD. The acceptance criteria in `idea-019-automated-branch-cleanup.md` will not be checked off because they correspond to implementation logic that falls outside the Product Manager persona's responsibility. This PR will be submitted as an empty PR (or with only this journal update) to allow the DAG to progress.
+
+## Issue with IDEA-019 PRD Generation (Empty PR Policy)
+Date: 2026-05-15
+
+During the session for transforming IDEA-019 (Automated Branch Cleanup) into a PRD, the target PRD node (`.foundry/prds/prd-019-019-automated-branch-cleanup.md`) was already found existing in the repository and appears complete. As per the Empty PR Policy, no changes will be made to the PRD or the parent Idea node (`idea-019-automated-branch-cleanup.md`). The acceptance criteria in the parent node are partially unchecked but relate to implementation details not under the Product Manager's purview. I am submitting this empty PR (with only this journal update) to allow the DAG to progress.


### PR DESCRIPTION
During the session for transforming IDEA-019 (Automated Branch Cleanup) into a PRD, the target PRD node (`.foundry/prds/prd-019-019-automated-branch-cleanup.md`) was already found to exist in the repository and appears complete.

As per the Empty PR Policy, no changes were made to the PRD or the parent Idea node (`idea-019-automated-branch-cleanup.md`). The acceptance criteria in the parent node are partially unchecked but relate to implementation details not under the Product Manager's purview. This PR submits only the journal update to document the anomaly and allow the DAG to progress.

---
*PR created automatically by Jules for task [1917859140826213208](https://jules.google.com/task/1917859140826213208) started by @szubster*