### PR TITLE
Architect: Create ADR 009 for Enforce Acceptance Criteria on Empty PRs

### DIFF
--- a/.foundry/docs/adrs/009-enforce-acceptance-criteria-empty-prs.md
+++ b/.foundry/docs/adrs/009-enforce-acceptance-criteria-empty-prs.md
@@ -1,0 +1,22 @@
+# ADR 009: Enforce Acceptance Criteria Checkboxes Before Empty PR Auto-Merge
+
+## Date
+2026-05-12
+
+## Status
+Accepted
+
+## Context
+According to the Foundry's Empty PR policy, if an agent determines that a target artifact already exists and is complete, it submits an empty PR (0 files changed) which is auto-merged by GitHub Actions. However, agents were submitting empty PRs for leaf nodes (e.g., Tasks) that still had unchecked acceptance criteria (`- [ ]`) in their markdown bodies. The `.github/workflows/auto-close-empty-pr.yml` merged these empty PRs unconditionally, falsely advancing incomplete tasks to `COMPLETED` and improperly unblocking downstream nodes.
+
+This violates ADR 007, which mandates that leaf nodes with unchecked boxes must be marked `FAILED`, rather than `PENDING` or `COMPLETED`. We need to strictly enforce this validation during the empty PR / preflight checks in the orchestrator and heartbeat.
+
+## Decision
+1. **Preflight Failure for Leaf Tasks**: During the orchestrator's preflight check (`foundry-orchestrator.ts`), if a leaf task (a node without children) is evaluated for bypass because its target artifacts already exist, it MUST NOT be bypassed if it contains unchecked acceptance criteria (`- [ ]`). Instead, the preflight check must transition the node to `FAILED` and assign a `rejection_reason`.
+2. **Heartbeat Failure for Empty PRs**: The `foundry-heartbeat.ts` script, which processes PR merges, must properly record the `rejection_reason` in the YAML frontmatter when transitioning a leaf node to `FAILED` due to unfulfilled acceptance criteria.
+3. **Late-Binding Parents Excluded**: If a node is a late-binding parent (e.g., it has children or is a generation node like `IDEA`, `PRD`, `EPIC`, `STORY`), unchecked boxes continue to act as an intentional signal to keep the node in `READY` or `PENDING` states so new child nodes can be generated.
+
+## Consequences
+- **Positive**: Strict adherence to the `COMPLETED` contract ensures that leaf tasks are fully implemented and validated before progressing in the DAG.
+- **Positive**: Eradicates false-positive auto-merges for tasks that have not fully met their acceptance criteria, reducing technical debt.
+- **Negative**: Adds conditional logic to the orchestrator preflight to accurately distinguish between valid late-binding parent nodes and invalid leaf tasks.

--- a/.foundry/journals/architect.md
+++ b/.foundry/journals/architect.md
@@ -17,3 +17,7 @@ Architects frequently perform evaluation tasks (e.g., assessing graph libraries,
 - **2026-05-12**: Addressed CI audit failure caused by critical malware advisory GHSA-rmmr-r34h-pfm5 in `@tanstack/history`. Updated CI workflow to ignore this specific advisory as a temporary mitigation while using the known-stable version `1.161.6`.
 
 - **2026-05-12**: Applied the Empty PR Policy to `prd-020-020-enforce-acceptance-criteria-completion`. The required target artifact (ADR 007) and its downstream implementations (e.g., `story-031-050-enforce-acceptance-criteria-completion`) already exist. The PRD acceptance criteria were already checked off. No new architectural design or documentation was required, so no files were modified.
+
+## 2026-05-12: Enforce Acceptance Criteria on Empty PRs
+- **Pattern**: A bug allowed leaf node tasks with unchecked acceptance criteria boxes to be bypassed as "completed" simply because their target artifacts already existed, submitting empty PRs that auto-merged.
+- **Action**: Created ADR 009 to formally document that during empty PR evaluation (both preflight in orchestrator and heartbeat for merges), leaf nodes MUST fail and set `rejection_reason` if they contain unchecked boxes. Late-binding parent nodes are exempt from this failure state.

--- a/.foundry/prds/prd-050-021-orchestrator-leaf-failure-validation.md
+++ b/.foundry/prds/prd-050-021-orchestrator-leaf-failure-validation.md
@@ -45,4 +45,4 @@ Per ADR-007, leaf nodes with unchecked boxes must be marked `FAILED`, not `PENDI
 The scope of this feature is limited to the Empty PR auto-merge pipeline and orchestrator validation rules. It will primarily involve creating or modifying validation scripts (e.g., `validate-empty-pr.js`) and updating `.github/workflows/auto-close-empty-pr.yml`.
 
 ## 4. Next Steps
-- [ ] Architect: Review this PRD and create an Architecture Decision Record (ADR).
+- [x] Architect: Review this PRD and create an Architecture Decision Record (ADR).


### PR DESCRIPTION
Creates ADR 009 to formally document that leaf node tasks must fail if they are submitted as empty PRs with unchecked acceptance criteria, while late-binding parent nodes are exempt. This is to prevent falsely advancing incomplete tasks to COMPLETED. Updates Architect journal and PRD.

---
*PR created automatically by Jules for task [3960445590362236818](https://jules.google.com/task/3960445590362236818) started by @szubster*