### PR TITLE
feat(orchestrator): enforce acceptance criteria checkboxes

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -67,3 +67,7 @@ Resolved an issue where TASK nodes owned by the 'architect' persona were being f
 - Synchronized `scripts/validate-foundry-schema.ts` with these mapping changes.
 - Proactively added 'RESEARCH' node support to the schema validator.
 - Added a regression test in `.github/scripts/foundry-orchestrator.test.ts` to verify the new mapping.
+
+## 2026-05-12: Enforcing Acceptance Criteria Checkboxes in Orchestrator Preflight
+- The DAG must accurately distinguish between generation (late-binding parent) nodes and execution (leaf) nodes.
+- Leaf nodes with `hasUncheckedTasks === true` should NOT be kept perpetually in `PENDING` during the `bypassDispatch` state (when target artifacts exist). Instead, they are considered an invalid completion attempt and are failed directly using `promoteNodeToFailedWithReason(node, 'Merged with unfulfilled acceptance criteria');`.

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -32,7 +32,7 @@ function todayISO(): string {
 const TERMINAL_STATES = ['FAILED', 'COMPLETED'];
 
 /** Surgical mutation to FAILED */
-export async function transitionNodeToFailed(node: any, repoRoot: string): Promise<void> {
+export async function transitionNodeToFailed(node: any, repoRoot: string, rejectionReason?: string): Promise<void> {
   const dateStr = todayISO();
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
@@ -40,6 +40,10 @@ export async function transitionNodeToFailed(node: any, repoRoot: string): Promi
   parsed.data.status = 'FAILED';
   parsed.data.jules_session_id = null;
   parsed.data.updated_at = dateStr;
+
+  if (rejectionReason) {
+    parsed.data.rejection_reason = rejectionReason;
+  }
 
   const newContent = matter.stringify(parsed.content, parsed.data);
 

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -657,8 +657,15 @@ function main(): void {
 
       if (bypassDispatch) {
         if (hasUncheckedTasks) {
-          info(`Preflight success: Valid target artifacts exist and are completed, but ${node.repoPath} still has unchecked tasks. Promoting to READY.`);
-          eligible.push(node);
+          const type = node.frontmatter.type;
+          const isLateBindingParent = children.length > 0 || ['IDEA', 'PRD', 'EPIC', 'STORY'].includes(type);
+          if (isLateBindingParent) {
+            info(`Preflight success: Valid target artifacts exist and are completed, but ${node.repoPath} still has unchecked tasks. Promoting to READY.`);
+            eligible.push(node);
+          } else {
+            info(`Preflight failure: Leaf task ${node.repoPath} has completed target artifacts but contains unchecked boxes.`);
+            promoteNodeToFailedWithReason(node, 'Merged with unfulfilled acceptance criteria');
+          }
         } else {
           info(`Preflight success: Valid target artifacts exist and are completed. Bypassing dispatch for ${node.repoPath}`);
           promoteNodeStatus(node, 'PENDING', 'COMPLETED');


### PR DESCRIPTION
This PR addresses the issue of enforcing acceptance criteria checkboxes across the DAG orchestrator.
In the orchestrator preflight phase, leaf tasks with unchecked boxes (`- [ ]`) will no longer be permanently suspended in `PENDING` when their target artifacts are completed. Instead, they are correctly failed with `promoteNodeToFailedWithReason(node, 'Merged with unfulfilled acceptance criteria')`.
Late-binding parent nodes are correctly allowed to remain in `PENDING` status to allow for new child generation.
Additionally, the `transitionNodeToFailed` function in `foundry-heartbeat.ts` has been updated to explicitly accept and save a `rejection_reason` to the frontmatter.

---
*PR created automatically by Jules for task [5038847838152667655](https://jules.google.com/task/5038847838152667655) started by @szubster*