### PR TITLE
🧹 chore: remove unused import in PokemonDetails (Empty PR)

### DIFF
--- a/.foundry/ideas/idea-019-automated-branch-cleanup.md
+++ b/.foundry/ideas/idea-019-automated-branch-cleanup.md
@@ -7,7 +7,7 @@ owner_persona: product_manager
 created_at: '2026-05-08'
 updated_at: '2026-05-12'
 depends_on: []
-jules_session_id: '1917859140826213208'
+jules_session_id: '11456327573075628019'
 pr_number: null
 parent: null
 tags: []

--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -71,3 +71,8 @@ Resolved an issue where TASK nodes owned by the 'architect' persona were being f
 ## 2026-05-12: Enforcing Acceptance Criteria Checkboxes in Orchestrator Preflight
 - The DAG must accurately distinguish between generation (late-binding parent) nodes and execution (leaf) nodes.
 - Leaf nodes with `hasUncheckedTasks === true` should NOT be kept perpetually in `PENDING` during the `bypassDispatch` state (when target artifacts exist). Instead, they are considered an invalid completion attempt and are failed directly using `promoteNodeToFailedWithReason(node, 'Merged with unfulfilled acceptance criteria');`.
+
+## Anomaly Report: Code Health Task - Unused Import
+- **Issue**: Remove the unused import `CompactChainLink` from `src/components/PokemonDetails.tsx`.
+- **Finding**: Exploring the file `src/components/PokemonDetails.tsx` shows the text `CompactChainLink` no longer exists, and `pnpm lint` returned zero errors.
+- **Action**: Following the Empty PR policy for target artifacts that already exist and are complete, I am documenting this anomaly and submitting an empty PR with zero file changes, as the issue has already been resolved by previous work. No trivial formatting changes were made.

--- a/.foundry/journals/tpm.md
+++ b/.foundry/journals/tpm.md
@@ -107,3 +107,15 @@
 - **2026-05-12**: PR #1246 merged. `story-031-050-enforce-acceptance-criteria-completion` is now COMPLETED.
 
 - **2026-05-12**: Heartbeat detected zombie session for `task-048-081-integrate-graph-library`. Transitioned to FAILED.
+
+- **2026-05-12**: PR #1249 merged. `idea-019-automated-branch-cleanup` is now PENDING.
+
+- **2026-05-12**: PR #1248 merged. `prd-019-019-orchestrator-test-factories` is now PENDING.
+
+- **2026-05-12**: PR #1250 merged. `prd-050-021-orchestrator-leaf-failure-validation` is now COMPLETED.
+
+- **2026-05-12**: PR #1247 merged. `story-028-044-indoor-outdoor-resolution` is now PENDING.
+
+- **2026-05-12**: PR #1251 merged with unchecked tasks. `task-050-083-enforce-acceptance-criteria` is now FAILED.
+
+- **2026-05-12**: Resurrection Loop triggered for `task-048-081-integrate-graph-library`. Reason: Retry from FAILED status.. Transitioned back to READY.

--- a/.foundry/prds/prd-019-019-orchestrator-test-factories.md
+++ b/.foundry/prds/prd-019-019-orchestrator-test-factories.md
@@ -7,7 +7,7 @@ owner_persona: epic_planner
 created_at: '2026-05-08'
 updated_at: '2026-05-12'
 depends_on: []
-jules_session_id: '2573853909337821732'
+jules_session_id: '4808464681406745507'
 pr_number: null
 parent: idea-019-orchestrator-test-factories
 tags: []

--- a/.foundry/prds/prd-050-021-orchestrator-leaf-failure-validation.md
+++ b/.foundry/prds/prd-050-021-orchestrator-leaf-failure-validation.md
@@ -2,12 +2,12 @@
 id: prd-050-021-orchestrator-leaf-failure-validation
 type: PRD
 title: Enforce Acceptance Criteria on Empty PRs
-status: ACTIVE
+status: COMPLETED
 owner_persona: architect
 created_at: '2026-05-12'
 updated_at: '2026-05-12'
 depends_on: []
-jules_session_id: '3960445590362236818'
+jules_session_id: null
 parent: idea-050-orchestrator-leaf-failure-validation
 tags:
   - foundry

--- a/.foundry/stories/story-028-044-indoor-outdoor-resolution.md
+++ b/.foundry/stories/story-028-044-indoor-outdoor-resolution.md
@@ -8,7 +8,7 @@ created_at: '2026-05-08'
 updated_at: '2026-05-12'
 depends_on:
   - .foundry/stories/story-028-043-gen2-map-graph.md
-jules_session_id: '155572791073751177'
+jules_session_id: '17052536337448432789'
 pr_number: null
 parent: .foundry/epics/epic-017-028-map-graph-routing.md
 tags:

--- a/.foundry/stories/story-031-050-enforce-acceptance-criteria-completion.md
+++ b/.foundry/stories/story-031-050-enforce-acceptance-criteria-completion.md
@@ -2,7 +2,7 @@
 id: story-031-050-enforce-acceptance-criteria-completion
 type: STORY
 title: Enforce Acceptance Criteria Completion Logic in Heartbeat and Orchestrator
-status: COMPLETED
+status: ACTIVE
 owner_persona: tech_lead
 created_at: '2026-05-11'
 updated_at: '2026-05-12'

--- a/.foundry/tasks/task-048-081-integrate-graph-library.md
+++ b/.foundry/tasks/task-048-081-integrate-graph-library.md
@@ -2,18 +2,18 @@
 id: task-048-081-integrate-graph-library
 type: TASK
 title: Integrate Selected Graph Library into DAG Dashboard
-status: FAILED
+status: ACTIVE
 owner_persona: coder
 created_at: '2026-05-11'
 updated_at: '2026-05-12'
 depends_on:
   - .foundry/tasks/task-048-080-evaluate-graph-libraries.md
-jules_session_id: null
+jules_session_id: '8644465375958592083'
 pr_number: null
 parent: story-029-048-evaluate-graph-libraries
 tags: []
 research_references: []
-rejection_count: 0
+rejection_count: 1
 rejection_reason: ''
 notes: ''
 ---

--- a/.foundry/tasks/task-050-083-enforce-acceptance-criteria.md
+++ b/.foundry/tasks/task-050-083-enforce-acceptance-criteria.md
@@ -2,18 +2,18 @@
 id: task-050-083-enforce-acceptance-criteria
 type: TASK
 title: Enforce Acceptance Criteria in Heartbeat and Orchestrator
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-05-12'
 updated_at: '2026-05-12'
 depends_on: []
-jules_session_id: '5038847838152667655'
+jules_session_id: null
 pr_number: null
 parent: story-031-050-enforce-acceptance-criteria-completion
 tags: []
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: Merged with unfulfilled acceptance criteria
 notes: ''
 ---
 


### PR DESCRIPTION
🎯 **What:** The issue reported an unused import (`CompactChainLink`) in `src/components/PokemonDetails.tsx`. Exploring the file revealed that the text no longer existed, and `pnpm lint` returned zero errors.
💡 **Why:** This is a zero-file-change PR (modifying only `.foundry/journals/coder.md` to note the finding) following the Empty PR policy, as the target artifact exists and is complete (the issue has already been resolved in prior work).
✅ **Verification:** Verified by checking the file (`cat src/components/PokemonDetails.tsx`), confirming via `grep`, and running `pnpm lint` and `pnpm test` successfully.
✨ **Result:** Anomaly documented in the coder journal and empty PR submitted to progress the DAG.

---
*PR created automatically by Jules for task [7456142938146418401](https://jules.google.com/task/7456142938146418401) started by @szubster*