### PR TITLE
🛡️ Agile Coach: Fix Empty PR policy contradiction with ADR 007

### DIFF
--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -50,3 +50,11 @@ Observed that the QA agent rejected a task (`task-047-078`) in its journal but f
 1. Updated `qa.md` with explicit instructions on handling rejections (setting `status: FAILED` and `rejection_reason`).
 2. Added the 'WARNING: The Empty PR policy...' text to all execution/planning agents (`coder.md`, `story_owner.md`, `tech_lead.md`, `epic_planner.md`, `product_manager.md`, `qa.md`).
 3. Created `idea-050-orchestrator-leaf-failure-validation.md` to have the Orchestrator validate empty PRs against unchecked acceptance criteria.
+
+## 2026-05-12 - Fix Empty PR Policy Contradiction with ADR 007/009
+### Observation
+Noticed that `task-050-083-enforce-acceptance-criteria.md` failed with the rejection reason "Merged with unfulfilled acceptance criteria" despite its objective already being implemented in the code. The agent correctly realized the work was done and followed the Empty PR policy to "NOT make trivial formatting changes". However, ADR 007 and ADR 009 strictly mandate that leaf tasks with unchecked acceptance criteria checkboxes MUST be failed. This created a contradiction where agents were punished for following the Empty PR policy while leaving boxes unchecked.
+
+### Action Taken
+1. Added a `CRITICAL EXCEPTION TO EMPTY PR POLICY` section to all core execution and planning agent prompts (`coder.md`, `qa.md`, `tech_lead.md`, `story_owner.md`, `epic_planner.md`, `product_manager.md`).
+2. This exception explicitly instructs agents that if a target artifact is complete but checkboxes are unchecked, checking those boxes (`- [x]`) is a mandatory contractual obligation, not a trivial formatting change, and failure to do so will result in immediate rejection by the orchestrator.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -37,3 +37,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+
+**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -43,3 +43,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+
+**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -36,3 +36,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+
+**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -53,3 +53,5 @@ If you reject an implementation or validation fails:
 
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+
+**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -41,3 +41,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+
+**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -49,3 +49,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+
+**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.


### PR DESCRIPTION
## Context
`task-050-083-enforce-acceptance-criteria.md` failed with the rejection reason "Merged with unfulfilled acceptance criteria" despite its objective already being implemented in the code. The agent correctly realized the work was done and followed the Empty PR policy to "NOT make trivial formatting changes". However, ADR 007 and ADR 009 strictly mandate that leaf tasks with unchecked acceptance criteria checkboxes MUST be failed. This created a contradiction where agents were punished for following the Empty PR policy while leaving boxes unchecked.

## Actions Taken
Added a `CRITICAL EXCEPTION TO EMPTY PR POLICY` section to all core execution and planning agent prompts (`coder.md`, `qa.md`, `tech_lead.md`, `story_owner.md`, `epic_planner.md`, `product_manager.md`). This exception explicitly instructs agents that if a target artifact is complete but checkboxes are unchecked, checking those boxes (`- [x]`) is a mandatory contractual obligation, not a trivial formatting change, and failure to do so will result in immediate rejection by the orchestrator.

---
*PR created automatically by Jules for task [17571009451024126904](https://jules.google.com/task/17571009451024126904) started by @szubster*