### PR TITLE
Empty PR: Document enforce-acceptance-criteria completion

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -71,3 +71,9 @@ Resolved an issue where TASK nodes owned by the 'architect' persona were being f
 ## 2026-05-12: Enforcing Acceptance Criteria Checkboxes in Orchestrator Preflight
 - The DAG must accurately distinguish between generation (late-binding parent) nodes and execution (leaf) nodes.
 - Leaf nodes with `hasUncheckedTasks === true` should NOT be kept perpetually in `PENDING` during the `bypassDispatch` state (when target artifacts exist). Instead, they are considered an invalid completion attempt and are failed directly using `promoteNodeToFailedWithReason(node, 'Merged with unfulfilled acceptance criteria');`.
+
+## 2026-05-12: Empty PR Policy for task-050-083-enforce-acceptance-criteria
+Upon review, the required updates to enforce acceptance criteria are already implemented.
+- `foundry-heartbeat.ts` already correctly assigns `parsed.data.rejection_reason = rejectionReason;` when transitioning to `FAILED`.
+- `foundry-orchestrator.ts` already successfully differentiates between late-binding parents and leaf tasks during Phase 3.7 Preflight when `hasUncheckedTasks` is true.
+Following the Empty PR policy, I am making 0 file changes since the target artifacts exist and are complete. I am leaving the parent node unmodified.


### PR DESCRIPTION
Empty PR: Document enforce-acceptance-criteria completion

- Appended entry to `.foundry/journals/coder.md` confirming `foundry-heartbeat.ts` and `foundry-orchestrator.ts` already meet acceptance criteria.
- Target artifacts exist and are complete.
- Adhered to Empty PR policy with 0 file changes for the codebase.

---
*PR created automatically by Jules for task [1758003304253685958](https://jules.google.com/task/1758003304253685958) started by @szubster*