### PR TITLE
🗃️ Archivist: Correct file path for testing rules in onboarding documentation

### DIFF
--- a/.foundry/docs/knowledge_base/onboarding/style_and_conventions.md
+++ b/.foundry/docs/knowledge_base/onboarding/style_and_conventions.md
@@ -10,7 +10,7 @@
 
 ## Testing Standards
 
-Following the project's `testing_rules.md`:
+Following the project's `.agents/rules/testing_rules.md`:
 - **New Features**: Must include appropriate tests (Unit or E2E). We prioritize an **E2E-First Strategy** for all UI-facing features.
 - **Initialization**: All E2E tests must use `initializeWithSave(page)` from `tests/e2e/test-utils.ts` to ensure the application is correctly hydrated with a save file fixture.
 - **Bug Fixes**: Write a test to reproduce the bug *before* fixing it (Test-First Approach).

--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -39,3 +39,8 @@
 
 **Learning:** `.foundry/docs/knowledge_base/infrastructure/jules_agents_dispatch.md` had an outdated list of agents.
 **Action:** Updated it to properly reflect the 15 agents deployed, by adding the missing `researcher` agent to the list.
+
+## 2026-06-26 - Archivist Run Learnings
+
+**Learning:** Memory entries that reference specific external instruction files (like `testing_rules.md`) can become inaccurate or broken if the referenced file is moved to a new directory structure (like `.agents/rules/`).
+**Action:** Corrected path references in `onboarding/style_and_conventions.md` to point to `.agents/rules/testing_rules.md` to ensure onboarding rules point to actual existent files.


### PR DESCRIPTION
Updated the path from `testing_rules.md` to `.agents/rules/testing_rules.md` in `.serena/memories/onboarding/style_and_conventions.md` to accurately reflect the location of the rules. Validated with `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [11700592405169744339](https://jules.google.com/task/11700592405169744339) started by @szubster*