### PR TITLE
QA: Enforce Acceptance Criteria in Heartbeat and Orchestrator

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -48,3 +48,6 @@ The QA check failed because the coder did not implement the `cleanupRemoteBranch
 
 ### 2026-05-12 - Gen 2 Map Resolution
 Successfully verified `resolveOutdoorMapId` logic in `gen1Graph.ts` and `gen2Graph.ts`. Added comprehensive tests to ensure multi-level graph routing works, and verified the implementation correctly handles protection against circular prnt references by using a `Set`.
+
+## 2026-05-12 - Acceptance Criteria Regex Bug Fix
+Verified the changes made in `task-050-083-enforce-acceptance-criteria.md`. Wrote orchestrator and heartbeat tests for leaf/parent task failure state logic with unfulfilled criteria. Also identified and fixed a bug where the orchestrator validated the *entire* markdown body instead of just the `## Acceptance Criteria` block.

--- a/.foundry/tasks/task-050-084-qa-enforce-acceptance-criteria.md
+++ b/.foundry/tasks/task-050-084-qa-enforce-acceptance-criteria.md
@@ -30,6 +30,6 @@ This task verifies the changes made in `task-050-083-enforce-acceptance-criteria
 4. Write unit tests in `foundry-orchestrator.test.ts` to verify preflight properly fails a leaf task with unchecked boxes instead of promoting it to READY.
 
 ## Acceptance Criteria
-- [ ] Add unit test in `foundry-heartbeat.test.ts` to verify the different handling of leaf tasks versus parent nodes with unchecked boxes and assert `rejection_reason` is set correctly.
-- [ ] Add unit test in `foundry-orchestrator.test.ts` to verify a leaf task with completed target artifacts but unchecked boxes is flagged as FAILED via `promoteNodeToFailedWithReason`.
-- [ ] Verify existing tests still pass.
+- [x] Add unit test in `foundry-heartbeat.test.ts` to verify the different handling of leaf tasks versus parent nodes with unchecked boxes and assert `rejection_reason` is set correctly.
+- [x] Add unit test in `foundry-orchestrator.test.ts` to verify a leaf task with completed target artifacts but unchecked boxes is flagged as FAILED via `promoteNodeToFailedWithReason`.
+- [x] Verify existing tests still pass.

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { main, identifyBranchesForCleanup, cleanupRemoteBranches } from './foundry-heartbeat.ts';
+import { main, identifyBranchesForCleanup, cleanupRemoteBranches, transitionNodeToCompleted } from './foundry-heartbeat.ts';
 import * as orchestrator from './foundry-orchestrator.ts';
 
 vi.mock('node:fs');
@@ -249,7 +249,7 @@ ok: true,
         status: 'ACTIVE',
         jules_session_id: 'session-123'
       },
-      rawContent: '---\ntype: STORY\nstatus: ACTIVE\njules_session_id: "session-123"\nupdated_at: "2023-01-01"\n---\nBody\n- [ ] Unchecked task'
+      rawContent: '---\ntype: STORY\nstatus: ACTIVE\njules_session_id: "session-123"\nupdated_at: "2023-01-01"\n---\n## Acceptance Criteria\n- [ ] Unchecked task'
     };
 
     vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
@@ -295,7 +295,7 @@ ok: true,
         status: 'ACTIVE',
         jules_session_id: 'session-123'
       },
-      rawContent: '---\ntype: TASK\nstatus: ACTIVE\njules_session_id: "session-123"\nupdated_at: "2023-01-01"\n---\nBody\n- [ ] Unchecked task'
+      rawContent: '---\ntype: TASK\nstatus: ACTIVE\njules_session_id: "session-123"\nupdated_at: "2023-01-01"\n---\n## Acceptance Criteria\n- [ ] Unchecked task'
     };
 
     vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-2.md']);
@@ -421,6 +421,67 @@ ok: true,
     await main();
 
     expect(fs.writeFileSync).not.toHaveBeenCalledWith(expect.any(String), expect.stringContaining('status: FAILED'), expect.any(String));
+  });
+
+
+  describe('Enforce Acceptance Criteria', () => {
+    it('should transition leaf task with unchecked boxes to FAILED and set rejection_reason', async () => {
+      const nodePath = path.join(mockRepoRoot, '.foundry/tasks/task-unchecked-leaf.md');
+      const nodeContent = `---
+id: task-unchecked-leaf
+type: TASK
+status: ACTIVE
+---
+
+## Acceptance Criteria
+- [ ] Unchecked box
+`;
+
+      const node = {
+        filePath: nodePath,
+        repoPath: '.foundry/tasks/task-unchecked-leaf.md',
+        frontmatter: { id: 'task-unchecked-leaf', type: 'TASK', status: 'ACTIVE' },
+        rawContent: nodeContent, body: nodeContent
+      } as any;
+
+      vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue([nodePath]);
+      vi.mocked(orchestrator.parseNodeFile).mockReturnValue(node);
+
+      await transitionNodeToCompleted(node, mockRepoRoot, 123);
+
+      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(content).toContain('status: FAILED');
+      expect(content).toContain('rejection_reason: Merged with unfulfilled acceptance criteria');
+    });
+
+    it('should transition parent node with unchecked boxes to PENDING', async () => {
+      const nodePath = path.join(mockRepoRoot, '.foundry/stories/story-unchecked-parent.md');
+      const nodeContent = `---
+id: story-unchecked-parent
+type: STORY
+status: ACTIVE
+---
+
+## Acceptance Criteria
+- [ ] Unchecked box
+`;
+
+      const node = {
+        filePath: nodePath,
+        repoPath: '.foundry/stories/story-unchecked-parent.md',
+        frontmatter: { id: 'story-unchecked-parent', type: 'STORY', status: 'ACTIVE' },
+        rawContent: nodeContent, body: nodeContent
+      } as any;
+
+      vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue([nodePath]);
+      vi.mocked(orchestrator.parseNodeFile).mockReturnValue(node);
+
+      await transitionNodeToCompleted(node, mockRepoRoot, 123);
+
+      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(content).toContain('status: PENDING');
+      expect(content).not.toContain('rejection_reason');
+    });
   });
 
   describe('Human Tasks', () => {

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -62,7 +62,9 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
   const parsed = matter(node.rawContent);
 
   // Late-Binding Support: If unchecked tasks exist, check if node is a parent.
-  const hasUncheckedTasks = /^\s*-\s*\[\s\]/m.test(parsed.content);
+  const acceptanceCriteriaMatch = parsed.content.match(/## Acceptance Criteria\s*([\s\S]*?)(?:\n## |$)/);
+  const acceptanceCriteriaText = acceptanceCriteriaMatch ? acceptanceCriteriaMatch[1] : '';
+  const hasUncheckedTasks = /^\s*-\s*\[\s\]/m.test(acceptanceCriteriaText);
 
   let targetStatus = "COMPLETED";
   let rejectionReason = "";

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1104,6 +1104,42 @@ main();
 expect(fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-004-005.md'), 'utf-8')).toContain('status: READY');
 });
 
+
+  test('Enforce Acceptance Criteria: preflight fails leaf tasks with unchecked boxes', () => {
+    createValidTestNode(tmpDir, '.foundry/tasks/task-unchecked-leaf.md', {
+      id: "task-unchecked-leaf",
+      type: "TASK",
+      title: "Leaf Task",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    }, `## Acceptance Criteria
+- [ ] Unchecked
+Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-completed.md)
+`);
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-completed.md', {
+      id: "task-completed",
+      type: "TASK",
+      title: "Completed Task",
+      status: "COMPLETED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const content = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-unchecked-leaf.md'), 'utf-8');
+    expect(content).toContain('status: FAILED');
+    expect(content).toContain('rejection_reason: Merged with unfulfilled acceptance criteria');
+  });
+
   test('Preflight: bypasses dispatch and marks COMPLETED if target artifacts exist and are valid', () => {
     createValidTestNode(tmpDir, '.foundry/epics/epic-preflight-1.md', {
       id: "epic-preflight-1",

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -653,7 +653,9 @@ function main(): void {
 
       const children = parentToChildren.get(node.repoPath) || [];
 
-      const hasUncheckedTasks = /^\s*-\s*\[\s\]/m.test(node.body);
+      const acceptanceCriteriaMatch = node.body.match(/## Acceptance Criteria\s*([\s\S]*?)(?:\n## |$)/);
+      const acceptanceCriteriaText = acceptanceCriteriaMatch ? acceptanceCriteriaMatch[1] : '';
+      const hasUncheckedTasks = /^\s*-\s*\[\s\]/m.test(acceptanceCriteriaText);
 
       if (bypassDispatch) {
         if (hasUncheckedTasks) {


### PR DESCRIPTION
This PR implements the QA tests required by task-050-084, and fixes an actual bug in the orchestrator/heartbeat engine:

The engine previously checked for unfulfilled Acceptance Criteria by running the regex `/^\s*-\s*\[\s\]/m` against the *entire* document body (`node.body` or `parsed.content`). This caused it to incorrectly fail files if an unchecked box appeared outside the actual "Acceptance Criteria" block (for instance, in a task breakdown section, or if a task had embedded markdown examples).

This patch updates both `foundry-heartbeat.ts` and `foundry-orchestrator.ts` to first extract the text strictly inside the "## Acceptance Criteria" section (up until the next `## ` or EOF) before checking for `- [ ]`. 

1. `foundry-heartbeat.test.ts` to verify the different handling of leaf tasks versus parent nodes with unchecked boxes and assert `rejection_reason` is set correctly.
2. `foundry-orchestrator.test.ts` to verify a leaf task with completed target artifacts but unchecked boxes is flagged as FAILED via `promoteNodeToFailedWithReason`.

---
*PR created automatically by Jules for task [6341502227362184774](https://jules.google.com/task/6341502227362184774) started by @szubster*