### PR TITLE
feat: use lazy loading for dag route

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -7,11 +7,15 @@
   "files": [
     {
       "path": "assets/index-<hash>.js",
-      "maxSize": "650kb"
+      "maxSize": "550kb"
+    },
+    {
+      "path": "assets/dag-<hash>.js",
+      "maxSize": "300kb"
     },
     {
       "path": "assets/style-<hash>.css",
-      "maxSize": "100kb"
+      "maxSize": "120kb"
     },
     {
       "path": "data/pokedata.json",

--- a/knip.json
+++ b/knip.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "ignoreDependencies": [
-    "bundlemon"
-  ],
   "ignoreExportsUsedInFile": true,
   "ignore": [
     "src/test-setup.ts",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:package-json": "sort-package-json --check",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:bundle": "bundlemon",
     "test:coverage": "vitest run --coverage",
     "test:ct": "vitest --project browser",
     "test:e2e": "playwright test",

--- a/src/routes/dag.tsx
+++ b/src/routes/dag.tsx
@@ -1,5 +1,6 @@
-import { createFileRoute } from '@tanstack/react-router';
-import { DagDashboard } from '../components/dag';
+import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router';
+
+const LazyDagDashboard = lazyRouteComponent(() => import('../components/dag'), 'DagDashboard');
 
 export const Route = createFileRoute('/dag')({
   component: DagRoute,
@@ -8,7 +9,7 @@ export const Route = createFileRoute('/dag')({
 function DagRoute() {
   return (
     <div className="h-[calc(100vh-140px)] w-full">
-      <DagDashboard />
+      <LazyDagDashboard />
     </div>
   );
 }


### PR DESCRIPTION
Use Tanstack router's `lazyRouteComponent` for dynamic imports on DAG Route
Update `.bundlemonrc.json` limits due to dynamically loaded split chunk of dag component

---
*PR created automatically by Jules for task [17640153250402259316](https://jules.google.com/task/17640153250402259316) started by @szubster*