### PR TITLE
feat: add idea node for DAG Kanban/Scrum board view

### DIFF
--- a/.foundry/ideas/idea-051-dag-kanban-board-view.md
+++ b/.foundry/ideas/idea-051-dag-kanban-board-view.md
@@ -1,0 +1,35 @@
+---
+id: idea-051-dag-kanban-board-view
+type: IDEA
+title: DAG Kanban/Scrum Board View
+status: "PENDING"
+owner_persona: product_manager
+created_at: "2026-05-14"
+updated_at: "2026-05-14"
+depends_on: [".foundry/ideas/idea-017-dag-dashboard.md"]
+jules_session_id: null
+parent: null
+tags:
+  - foundry
+  - dag
+  - visualization
+  - board
+notes: ''
+---
+
+# Idea: DAG Kanban/Scrum Board View
+
+## Context
+The current DAG graph visualization (`idea-017-dag-dashboard`) is useful for tracing complex dependency chains, but as the number of nodes grows, the graph becomes excessively wide and difficult to read. It fails to provide an immediate, digestible overview of the project's current operational state (e.g., "what's active right now?", "what's blocked?").
+
+## Proposal
+Introduce a Kanban/Scrum-style board view as an alternative or complementary visualization to the DAG diagram. This board would reorganize the nodes to prioritize operational status over structural relationships.
+
+**Key Features:**
+1. **Columns by Status:** Nodes are organized into columns based on their operational state: `PENDING`, `ACTIVE`, `BLOCKED`, `COMPLETED`, `FAILED`, `CANCELLED`.
+2. **Swimlanes by Persona or Type:** Allow grouping rows by either `owner_persona` (e.g., `coder`, `qa`, `architect`) or node `type` (e.g., `IDEA`, `EPIC`, `TASK`).
+3. **Dependency Indicators:** Since it's a flat board, nodes should feature visual badges indicating upstream/downstream dependencies. Clicking a badge could momentarily highlight related cards across the board.
+4. **Roll-up Metrics:** Display counts for nodes within each column/swimlane intersection to provide an immediate summary of the workload.
+
+## Next Steps
+- [ ] Convert this idea into a detailed PRD defining the board layout, interactions, and integration with the existing DAG Dashboard data structures.


### PR DESCRIPTION
Proposes a new board view for the Foundry DAG to handle large node counts better than the wide graph visualization. Includes columns by status, swimlanes by persona/type, dependency badges, and roll-up metrics. Makes it dependent on the base dag-dashboard idea.

---
*PR created automatically by Jules for task [606517216555633442](https://jules.google.com/task/606517216555633442) started by @szubster*