### PR TITLE
🛠️ Infras: replace jest oxlint rules with vitest

### DIFF
--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -59,3 +59,6 @@ Critical learnings:
 
 ## 2026-05-13 - Optimized Lefthook Pre-Commit
 **Learning:** Found that `type-check` hook in `lefthook.yml` was running `pnpm lint`, which sequentially ran `type-check`, `check:biome`, `oxlint`, `knip`, and `lint:package-json` across the *entire project*. Because `lefthook` already has separate commands for `biome-check`, `oxlint`, and `sort-package-json` on `{staged_files}`, this caused redundant full-project checks on every commit, significantly slowing down DX. Replaced `run: pnpm lint` with `run: pnpm type-check` for the `type-check` command to maintain the full-project type safety requested by the user while avoiding redundant linter execution.
+
+## 2026-05-15 - Switched jest rules to vitest rules in oxlint
+**Learning:** Found that `.oxlintrc.json` had rules configured for `jest` plugin (`jest/no-disabled-tests`, `jest/no-standalone-expect`) but the project uses Vitest and explicitly registered the `"vitest"` plugin. Replaced the `jest` prefix with `vitest` to properly apply the rules to Vitest files.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -15,8 +15,8 @@
     "vitest/require-mock-type-parameters": "error",
     "react-hooks/exhaustive-deps": "off",
     "vitest/expect-expect": "error",
-    "jest/no-disabled-tests": "error",
-    "jest/no-standalone-expect": [
+    "vitest/no-disabled-tests": "error",
+    "vitest/no-standalone-expect": [
       "error",
       {
         "additionalTestBlockFunctions": [


### PR DESCRIPTION
Replaced `jest` prefixed rules in `.oxlintrc.json` with `vitest` equivalents as the project uses Vitest for testing. This resolves a misconfiguration where `oxlint` was checking for Jest rules rather than Vitest ones.

---
*PR created automatically by Jules for task [2764479069861892721](https://jules.google.com/task/2764479069861892721) started by @szubster*