### PR TITLE
Agile Coach: Enforce Strict Schema Validations

### DIFF
--- a/.foundry/ideas/idea-051-strict-schema-validations.md
+++ b/.foundry/ideas/idea-051-strict-schema-validations.md
@@ -1,0 +1,37 @@
+---
+id: idea-051-strict-schema-validations
+type: IDEA
+title: Strict Schema Validations for FAILED Nodes and Dependency Paths
+status: COMPLETED
+owner_persona: agile_coach
+created_at: '2026-05-14'
+updated_at: '2026-05-14'
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - foundry
+  - schema
+  - validation
+notes: 'Created autonomously by agile_coach to enforce stricter schema validation'
+---
+
+# Idea: Strict Schema Validations for FAILED Nodes and Dependency Paths
+
+## Context
+While analyzing the system for potential improvements, it was noted that while the `agent-failure-reporting.md` documentation mandates a `rejection_reason` whenever `status` is set to `FAILED`, the `validate-foundry-schema.ts` pre-commit hook did not enforce this.
+Furthermore, the `depends_on` and `parent` fields contained paths that were not verified for existence during the pre-commit stage. If an agent provided a bad path, it would only be caught later when the orchestrator failed to resolve dependencies, causing delays.
+
+## Proposal
+Enhance the pre-commit schema validation hook (`scripts/validate-foundry-schema.ts`):
+1. **Enforce rejection_reason**: Ensure that if `status` is `FAILED`, `rejection_reason` is non-empty.
+2. **Validate Dependency Paths**: Iterate through `depends_on` and verify that the file actually exists using `fs.existsSync`.
+3. **Validate Parent Path**: If a `parent` is provided and it looks like a path (contains '/'), verify that it exists.
+
+## Implementation Status
+This has been implemented directly by the Agile Coach persona. The schema validation script has been updated. This node serves as a historical record of the improvement.
+
+## Acceptance Criteria
+- [x] Schema validation script enforces `rejection_reason` on `FAILED` nodes.
+- [x] Schema validation script checks that files in `depends_on` exist.
+- [x] Schema validation script checks that `parent` path exists.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -58,3 +58,12 @@ Noticed that `task-050-083-enforce-acceptance-criteria.md` failed with the rejec
 ### Action Taken
 1. Added a `CRITICAL EXCEPTION TO EMPTY PR POLICY` section to all core execution and planning agent prompts (`coder.md`, `qa.md`, `tech_lead.md`, `story_owner.md`, `epic_planner.md`, `product_manager.md`).
 2. This exception explicitly instructs agents that if a target artifact is complete but checkboxes are unchecked, checking those boxes (`- [x]`) is a mandatory contractual obligation, not a trivial formatting change, and failure to do so will result in immediate rejection by the orchestrator.
+
+## 2026-05-14 - Pre-commit Strict Schema Validations
+### Observation
+While analyzing the system for potential improvements, I noticed that `scripts/validate-foundry-schema.ts` did not enforce the `rejection_reason` requirement when a node is marked as `FAILED`. Furthermore, `depends_on` and `parent` fields contained paths that were not verified for existence during the pre-commit stage. If an agent provided a bad path, it would only be caught later when the orchestrator failed to resolve dependencies.
+
+### Action Taken
+1. Modified `scripts/validate-foundry-schema.ts` to enforce `rejection_reason` on `FAILED` nodes.
+2. Modified `scripts/validate-foundry-schema.ts` to verify the existence of all paths provided in `depends_on` and `parent` fields.
+3. Created `idea-051-strict-schema-validations.md` as an architectural improvement record.

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -119,6 +119,34 @@ function validateSchema() {
       }
     }
 
+    // 2.6 Validate rejection_reason
+    if (status === 'FAILED' && !data['rejection_reason']) {
+      console.error(`Error: Missing rejection_reason for FAILED node in file ${file}`);
+      hasError = true;
+    }
+
+    // 2.7 Validate paths
+    if (data['depends_on'] && Array.isArray(data['depends_on'])) {
+      for (const dep of data['depends_on']) {
+        if (typeof dep === 'string' && dep.includes('/')) {
+          if (!fs.existsSync(dep)) {
+            console.error(`Error: Dependency path does not exist: '${dep}' in file ${file}`);
+            hasError = true;
+          }
+        }
+      }
+    }
+
+    if (data['parent']) {
+      // Parent might be an ID or a path. If it looks like a path (contains '/'), verify it exists.
+      if (typeof data['parent'] === 'string' && data['parent'].includes('/')) {
+        if (!fs.existsSync(data['parent'])) {
+          console.error(`Error: Parent path does not exist: '${data['parent']}' in file ${file}`);
+          hasError = true;
+        }
+      }
+    }
+
     // 3. ID format & uniqueness
     if (id) {
       if (ids.has(id)) {


### PR DESCRIPTION
I have proactively added strict schema validation to the Foundry's pre-commit hook as the Agile Coach. The script now enforces that a `rejection_reason` is provided when a node is marked as `FAILED`, and verifies that file paths in the `depends_on` and `parent` arrays actually exist on the filesystem to catch broken references early.

---
*PR created automatically by Jules for task [13988712543440148604](https://jules.google.com/task/13988712543440148604) started by @szubster*