### PR TITLE
feat: implement Gen 2 static data for gifts and NPC trades

### DIFF
--- a/.foundry/tasks/task-049-082-implement-gen2-assistant-data.md
+++ b/.foundry/tasks/task-049-082-implement-gen2-assistant-data.md
@@ -57,6 +57,6 @@ Include the following Gen 2 in-game trades:
 **Coder Self-Verification**: As this is purely static data addition without complex logic, the Coder should self-verify the data accuracy and ensure it passes type checks and linting. No separate QA task is required.
 
 ## Acceptance Criteria
-- [ ] Create `src/engine/data/gen2/assistantData.ts`.
-- [ ] Define `STATIC_GIFT_DATA` for Gen 2 (Togepi Egg, Eevee from Bill, Shuckle in Cianwood, Dratini, Tyrogue).
-- [ ] Define `STATIC_NPC_TRADE_DATA` (e.g., trading Bellsprout for Onix `Rocky`, Drowzee for Machop `Muscle`).
+- [x] Create `src/engine/data/gen2/assistantData.ts`.
+- [x] Define `STATIC_GIFT_DATA` for Gen 2 (Togepi Egg, Eevee from Bill, Shuckle in Cianwood, Dratini, Tyrogue).
+- [x] Define `STATIC_NPC_TRADE_DATA` (e.g., trading Bellsprout for Onix `Rocky`, Drowzee for Machop `Muscle`).

--- a/src/engine/data/gen1/assistantData.ts
+++ b/src/engine/data/gen1/assistantData.ts
@@ -71,24 +71,6 @@ export const STATIC_GIFT_DATA: Record<
   145: { name: 'Zapdos', location: 'Power Plant', reason: 'Static', gen: 1, eventFlag: 0x227, requiredBadges: 3 }, // Need Surf (from Safari Zone/Koga so usually 4, but let's say 3+)
   146: { name: 'Moltres', location: 'Victory Road', reason: 'Static', gen: 1, eventFlag: 0x230, requiredBadges: 8 }, // Need all 8 badges to reach Victory Road
   150: { name: 'Mewtwo', location: 'Cerulean Cave', reason: 'Static', gen: 1, eventFlag: 0x231, requiredBadges: 8 }, // Need to beat E4
-
-  // Gen 2 (Placeholder: event flags for Gen 2 are at different offsets and not yet mapped)
-  152: { name: 'Chikorita', location: 'New Bark Town', reason: 'Starter', gen: 2 },
-  155: { name: 'Cyndaquil', location: 'New Bark Town', reason: 'Starter', gen: 2 },
-  158: { name: 'Totodile', location: 'New Bark Town', reason: 'Starter', gen: 2 },
-  185: {
-    name: 'Sudowoodo',
-    location: 'Route 36',
-    reason: 'Static (Requires SquirtBottle)',
-    gen: 2,
-  },
-  130: { name: 'Gyarados', location: 'Lake of Rage', reason: 'Static (Shiny)', gen: 2 },
-  249: { name: 'Lugia', location: 'Whirl Islands', reason: 'Static', gen: 2 },
-  250: { name: 'Ho-oh', location: 'Tin Tower', reason: 'Static', gen: 2 },
-  245: { name: 'Suicune', location: 'Tin Tower', reason: 'Static (Crystal)', gen: 2 },
-  213: { name: 'Shuckle', location: 'Cianwood City', reason: 'Gift from NPC', gen: 2 },
-  236: { name: 'Tyrogue', location: 'Mt. Mortar', reason: 'Gift from Kiyo', gen: 2 },
-  147: { name: 'Dratini', location: "Dragon's Den", reason: 'Gift from Dragon Elder', gen: 2 },
 };
 
 /**
@@ -100,7 +82,7 @@ export const STATIC_GIFT_DATA: Record<
  * `receivedOtName` — the OT name the game assigns to the received pokémon (used to detect if claimed)
  * `gen`          — generation the trade belongs to
  */
-interface NpcTradeEntry {
+export interface NpcTradeEntry {
   receivedId: number;
   offeredId: number;
   location: string;
@@ -232,41 +214,5 @@ export const STATIC_NPC_TRADE_DATA: NpcTradeEntry[] = [
     gen: 1,
     versions: ['yellow'],
     tradeIndex: 10,
-  },
-
-  // ── Gen 2 ────────────────────────────────────────────────────────────────
-  // Machop for Drowzee — Goldenrod City (trade house) — Gold/Silver/Crystal
-  {
-    receivedId: 66,
-    offeredId: 96,
-    location: 'Goldenrod City (trade house)',
-    receivedOtName: 'KYLE',
-    gen: 2,
-  },
-  // Onix for Bellsprout — Violet City (trade house) — Gold/Silver/Crystal
-  {
-    receivedId: 95,
-    offeredId: 69,
-    location: 'Violet City (trade house)',
-    receivedOtName: 'KYLE',
-    gen: 2,
-  },
-  // Haunter for Drowzee — Sprout Tower? No — actually Goldenrod trade house has Abra trade too
-  // Abra for Drowzee — Goldenrod City (2F of trade house) — Gold/Silver/Crystal
-  {
-    receivedId: 63,
-    offeredId: 96,
-    location: 'Goldenrod City (trade center, 2F)',
-    receivedOtName: 'NOB',
-    gen: 2,
-  },
-  // Voltorb for Krabby — New Bark Town neighbor — Crystal only
-  {
-    receivedId: 100,
-    offeredId: 98,
-    location: "Fisher's house (Route 30 area)",
-    receivedOtName: 'TOM',
-    gen: 2,
-    versions: ['crystal'],
   },
 ];

--- a/src/engine/data/gen2/__tests__/assistantData.test.ts
+++ b/src/engine/data/gen2/__tests__/assistantData.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { STATIC_GIFT_DATA, STATIC_NPC_TRADE_DATA } from '../assistantData';
+
+describe('STATIC_GIFT_DATA', () => {
+  it('should have basic valid structure for all entries', () => {
+    Object.values(STATIC_GIFT_DATA).forEach((gift) => {
+      expect(typeof gift.name).toBe('string');
+      expect(gift.name.length).toBeGreaterThan(0);
+      expect(typeof gift.location).toBe('string');
+      expect(gift.location.length).toBeGreaterThan(0);
+      expect(typeof gift.reason).toBe('string');
+      expect(gift.reason.length).toBeGreaterThan(0);
+      expect(gift.gen).toBe(2);
+    });
+  });
+
+  it('should correctly define Togepi (ID 175)', () => {
+    const togepi = STATIC_GIFT_DATA[175];
+    expect(togepi).toBeDefined();
+    expect(togepi?.name).toBe('Togepi');
+    expect(togepi?.location).toBe('Violet City');
+    expect(togepi?.reason).toBe('Gift from Aide');
+    expect(togepi?.gen).toBe(2);
+  });
+});
+
+describe('STATIC_NPC_TRADE_DATA', () => {
+  it('should correctly define Onix for Bellsprout (ROCKY)', () => {
+    const trade = STATIC_NPC_TRADE_DATA.find((t) => t.receivedOtName === 'ROCKY');
+    expect(trade).toBeDefined();
+    expect(trade?.offeredId).toBe(69); // Bellsprout
+    expect(trade?.receivedId).toBe(95); // Onix
+    expect(trade?.gen).toBe(2);
+  });
+
+  it('should correctly define Machop for Drowzee (MUSCLE)', () => {
+    const trade = STATIC_NPC_TRADE_DATA.find((t) => t.receivedOtName === 'MUSCLE');
+    expect(trade).toBeDefined();
+    expect(trade?.offeredId).toBe(96); // Drowzee
+    expect(trade?.receivedId).toBe(66); // Machop
+    expect(trade?.gen).toBe(2);
+  });
+});

--- a/src/engine/data/gen2/assistantData.ts
+++ b/src/engine/data/gen2/assistantData.ts
@@ -1,0 +1,58 @@
+import type { NpcTradeEntry } from '../gen1/assistantData';
+
+export const STATIC_GIFT_DATA: Record<
+  number,
+  { name: string; location: string; reason: string; gen?: number; eventFlag?: number; requiredBadges?: number }
+> = {
+  175: { name: 'Togepi', location: 'Violet City', reason: 'Gift from Aide', gen: 2 },
+  133: { name: 'Eevee', location: 'Goldenrod City', reason: 'Gift from Bill', gen: 2 },
+  213: { name: 'Shuckle', location: 'Cianwood City', reason: 'Gift from Kirk', gen: 2 },
+  147: { name: 'Dratini', location: "Dragon's Den", reason: 'Gift from Dragon Elder', gen: 2 },
+  236: { name: 'Tyrogue', location: 'Mt. Mortar', reason: 'Gift from Kiyo', gen: 2 },
+
+  152: { name: 'Chikorita', location: 'New Bark Town', reason: 'Starter', gen: 2 },
+  155: { name: 'Cyndaquil', location: 'New Bark Town', reason: 'Starter', gen: 2 },
+  158: { name: 'Totodile', location: 'New Bark Town', reason: 'Starter', gen: 2 },
+  185: {
+    name: 'Sudowoodo',
+    location: 'Route 36',
+    reason: 'Static (Requires SquirtBottle)',
+    gen: 2,
+  },
+  130: { name: 'Gyarados', location: 'Lake of Rage', reason: 'Static (Shiny)', gen: 2 },
+  249: { name: 'Lugia', location: 'Whirl Islands', reason: 'Static', gen: 2 },
+  250: { name: 'Ho-oh', location: 'Tin Tower', reason: 'Static', gen: 2 },
+  245: { name: 'Suicune', location: 'Tin Tower', reason: 'Static (Crystal)', gen: 2 },
+};
+
+export const STATIC_NPC_TRADE_DATA: NpcTradeEntry[] = [
+  {
+    receivedId: 66,
+    offeredId: 96,
+    location: 'Goldenrod City (trade house)',
+    receivedOtName: 'MUSCLE',
+    gen: 2,
+  },
+  {
+    receivedId: 95,
+    offeredId: 69,
+    location: 'Violet City (trade house)',
+    receivedOtName: 'ROCKY',
+    gen: 2,
+  },
+  {
+    receivedId: 63,
+    offeredId: 96,
+    location: 'Goldenrod City (trade center, 2F)',
+    receivedOtName: 'NOB',
+    gen: 2,
+  },
+  {
+    receivedId: 100,
+    offeredId: 98,
+    location: "Fisher's house (Route 30 area)",
+    receivedOtName: 'TOM',
+    gen: 2,
+    versions: ['crystal'],
+  },
+];


### PR DESCRIPTION
This PR implements Gen 2 static data for Assistant suggestions (gifts and NPC trades) as specified in `task-049-082-implement-gen2-assistant-data.md`.

- Extracted Gen 2 data and placeholders from `gen1/assistantData.ts`.
- Exported the `NpcTradeEntry` interface from `gen1` to be reused in `gen2`.
- Created `src/engine/data/gen2/assistantData.ts` containing `STATIC_GIFT_DATA` and `STATIC_NPC_TRADE_DATA` with the precise IDs, locations, and data specified in the task.
- Enforced type-only imports for `NpcTradeEntry` as required by `verbatimModuleSyntax`.
- Addressed Biome lint warnings.
- Checked off all task Acceptance Criteria.

---
*PR created automatically by Jules for task [8560448346395680046](https://jules.google.com/task/8560448346395680046) started by @szubster*