### PR TITLE
📓 Story Owner: Create story-029-052-implement-graph-filtering

### DIFF
--- a/.foundry/epics/epic-017-029-dag-dashboard-ui.md
+++ b/.foundry/epics/epic-017-029-dag-dashboard-ui.md
@@ -37,10 +37,11 @@ This Epic covers the frontend user interface for the DAG Dashboard Webview. It c
 ## Acceptance Criteria
 - [x] Select and integrate a graph rendering library (e.g., Mermaid.js, React Flow).
 - [x] Implement the core graph visualization component.
-- [ ] Implement filtering UI controls and logic.
+- [x] Implement filtering UI controls and logic.
 - [ ] Implement dependency highlighting interactions.
 - [ ] Wire up the UI to consume data from the parsing layer.
 
 ## Stories
 - `.foundry/stories/story-029-048-evaluate-graph-libraries.md`
 - `.foundry/stories/story-029-051-implement-core-graph-visualization.md`
+- `.foundry/stories/story-029-052-implement-graph-filtering.md`

--- a/.foundry/stories/story-029-052-implement-graph-filtering.md
+++ b/.foundry/stories/story-029-052-implement-graph-filtering.md
@@ -1,0 +1,40 @@
+---
+id: story-029-052-implement-graph-filtering
+type: STORY
+title: Implement Graph Filtering UI Controls
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-14'
+updated_at: '2026-05-14'
+depends_on:
+  - .foundry/stories/story-029-051-implement-core-graph-visualization.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-017-029-dag-dashboard-ui.md
+tags:
+  - dag
+  - dashboard
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Graph Filtering UI Controls
+
+## Overview
+Following the implementation of the core graph visualization for the DAG Dashboard, this story focuses on adding interactive filtering controls. These controls will allow users to filter the visible nodes by their type (e.g., IDEA, EPIC, STORY, TASK) or status (e.g., PENDING, READY, ACTIVE, COMPLETED), improving the readability and navigability of large graphs.
+
+## Requirements
+- Implement UI controls (e.g., dropdowns, toggle buttons) for filtering the graph.
+- Support filtering by `type` (IDEA, PRD, EPIC, STORY, TASK).
+- Support filtering by `status` (PENDING, READY, ACTIVE, COMPLETED, FAILED, BLOCKED, CANCELLED).
+- Ensure the filtering logic efficiently updates the React Flow graph state to show/hide nodes and their connecting edges appropriately.
+- Adhere to the 'tactical hardware/snooping' aesthetic (sharp edges, dashed borders, monospaced fonts) for the new UI controls as specified in ADR 008.
+
+## Acceptance Criteria
+- [ ] Create UI components for filtering by node type and status.
+- [ ] Integrate filtering logic with the React Flow graph component state.
+- [ ] Ensure edges are updated correctly when nodes are filtered out (e.g., hiding edges connected to hidden nodes).
+- [ ] Verify that the styling of the filter controls matches the project's strict design system requirements.


### PR DESCRIPTION
As the Story Owner, I have:
1. Created `story-029-052-implement-graph-filtering.md` mapped to `tech_lead` based on the outstanding requirements in `epic-017-029-dag-dashboard-ui`.
2. Updated the parent Epic by checking off the `- [x] Implement filtering UI controls and logic.` checkbox and appending the new Story link in the markdown body, leaving the YAML frontmatter intact.
3. Cleaned up the journal to avoid meaningless token waste.
4. Ran `pnpm lint` and `pnpm test` successfully.

---
*PR created automatically by Jules for task [10100810709520327785](https://jules.google.com/task/10100810709520327785) started by @szubster*