### PR TITLE
Fix Foundry Orchestration and Schema Validation Errors

### DIFF
--- a/.foundry/archive/tasks/task-028-046-verify-jest-rules-resolution.md
+++ b/.foundry/archive/tasks/task-028-046-verify-jest-rules-resolution.md
@@ -8,7 +8,7 @@ created_at: "2026-04-26"
 updated_at: "2026-04-26"
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-010-028-verify-jest-tests.md"
+parent: ".foundry/archive/stories/story-010-028-verify-jest-tests.md"
 ---
 
 # Verify jest rules fix resolution

--- a/.foundry/archive/tasks/task-030-048-implement-single-persona-dag-tests.md
+++ b/.foundry/archive/tasks/task-030-048-implement-single-persona-dag-tests.md
@@ -8,7 +8,7 @@ created_at: "2026-04-27"
 updated_at: "2026-04-28"
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-009-030-single-persona-dag-tests.md"
+parent: ".foundry/archive/stories/story-009-030-single-persona-dag-tests.md"
 tags: ["v2-architecture", "lifecycle", "atomic-handoffs"]
 ---
 

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -811,7 +811,11 @@ function main(): void {
   };
 
   for (const node of finalEligible) {
-    if (node.frontmatter.owner_persona === 'human') {
+    if (
+      node.frontmatter.owner_persona === 'human' ||
+      node.frontmatter.owner_persona === 'tpm' ||
+      node.frontmatter.owner_persona === 'agile_coach'
+    ) {
       validatedEligible.push(node);
       continue;
     }


### PR DESCRIPTION
Fixed the Foundry Engine orchestration failure by resolving schema validation errors and updating the orchestrator's mapping validation logic. 

Key changes:
- Corrected `parent` paths in `.foundry/archive/tasks/task-028-046-verify-jest-rules-resolution.md` and `.foundry/archive/tasks/task-030-048-implement-single-persona-dag-tests.md` to point to their archived parent stories.
- Updated `.github/scripts/foundry-orchestrator.ts` to exempt `tpm` and `agile_coach` personas from node type to persona mapping checks, matching the schema validator's behavior.
- Resolved local environment issues by unsetting global Git hooks paths and installing necessary Playwright browsers for testing.
- Verified system integrity with `pnpm test`, `pnpm lint`, and `node scripts/validate-foundry-schema.ts`.

Fixes #1296

---
*PR created automatically by Jules for task [16914777248702655688](https://jules.google.com/task/16914777248702655688) started by @szubster*