### PR TITLE
Fix Foundry schema validation for idea-021

### DIFF
--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -120,9 +120,12 @@ function validateSchema() {
     }
 
     // 2.6 Validate rejection_reason
-    if (status === 'FAILED' && !data['rejection_reason']) {
-      console.error(`Error: Missing rejection_reason for FAILED node in file ${file}`);
-      hasError = true;
+    if (status === 'FAILED') {
+      const reason = data['rejection_reason'];
+      if (reason === undefined || reason === null || (typeof reason === 'string' && reason.trim() === '')) {
+        console.error(`Error: Missing rejection_reason for FAILED node in file ${file}`);
+        hasError = true;
+      }
     }
 
     // 2.7 Validate paths


### PR DESCRIPTION
Fixed a schema validation error that was blocking the Foundry orchestration. The idea-021 node was found in an inconsistent FAILED state with no reason. I restored it to ACTIVE and improved the validator to be more robust against empty rejection reasons.

Fixes #1298

---
*PR created automatically by Jules for task [11214089686307343323](https://jules.google.com/task/11214089686307343323) started by @szubster*