### PR TITLE
QA: Reject task-051-087-implement-core-graph-visualizer due to aesthetic violation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -60,3 +60,9 @@ Verified the changes made in `task-050-083-enforce-acceptance-criteria.md`. Wrot
 
 ## 2026-05-14
 - Verified that `foundry-heartbeat.test.ts` and `foundry-orchestrator.test.ts` contain the appropriate tests to enforce acceptance criteria as per ADR 007. The orchestrator logic tasks for `task-050-083-enforce-acceptance-criteria.md` were successfully implemented. The target artifact already exists and is complete. Applied Empty PR policy and logged the decision.
+
+## 2026-05-14 - Task FAILED: QA Verification for Graph Component
+
+**Task**: task-051-087-implement-core-graph-visualizer
+**Outcome**: FAILED
+**Notes**: The implementation violated the aesthetic constraints defined in ADR 008. The `DagNode` component passes a className with `rounded-t` to `TelemetryDecoration`, which violates the strict `rounded-none` requirement. The task has been marked as `FAILED` with a detailed rejection reason.

--- a/.foundry/tasks/task-051-087-implement-core-graph-visualizer.md
+++ b/.foundry/tasks/task-051-087-implement-core-graph-visualizer.md
@@ -2,7 +2,7 @@
 id: task-051-087-implement-core-graph-visualizer
 type: TASK
 title: Implement Core Graph Visualizer Component
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-05-14'
 updated_at: '2026-05-14'
@@ -16,7 +16,10 @@ tags:
   - ui
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: >-
+  Implementation violates ADR 008 tactical aesthetic constraints. The DagNode
+  component passes a className with "rounded-t" to TelemetryDecoration, which
+  violates the strict "rounded-none" requirement.
 notes: ''
 ---
 


### PR DESCRIPTION
Rejected `task-051-087-implement-core-graph-visualizer` because the `DagNode` component passes a className with `rounded-t` to `TelemetryDecoration`, which violates the strict `rounded-none` constraint specified in ADR 008.

Updated the target task's frontmatter to `FAILED` with a descriptive `rejection_reason` using a `gray-matter` script to preserve the exact formatting. Added a corresponding entry to the `qa.md` journal.

---
*PR created automatically by Jules for task [12703591998739364943](https://jules.google.com/task/12703591998739364943) started by @szubster*