### PR TITLE
Enforce schema validation for research references

### DIFF
--- a/.foundry/ideas/idea-052-strict-research-references-validation.md
+++ b/.foundry/ideas/idea-052-strict-research-references-validation.md
@@ -1,0 +1,32 @@
+---
+id: idea-052-strict-research-references-validation
+type: IDEA
+title: Strict Schema Validations for Research References
+status: COMPLETED
+owner_persona: agile_coach
+created_at: '2026-05-14'
+updated_at: '2026-05-14'
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - foundry
+  - schema
+  - validation
+notes: 'Created autonomously by agile_coach to enforce stricter schema validation for research references'
+---
+
+# Idea: Strict Schema Validations for Research References
+
+## Context
+Following the implementation of `idea-051-strict-schema-validations`, which added validation for `depends_on` and `parent` fields, it was discovered that `research_references` paths were still not being validated by the pre-commit schema hook (`scripts/validate-foundry-schema.ts`). If an agent provided a bad path, it would fail silently and deprive downstream agents of the necessary contextual research, undermining the intent of ADR-004.
+
+## Proposal
+Enhance the pre-commit schema validation hook (`scripts/validate-foundry-schema.ts`):
+1. **Validate Research References Paths**: Iterate through `research_references` and verify that each file actually exists using `fs.existsSync`.
+
+## Implementation Status
+This has been implemented directly by the Agile Coach persona. The schema validation script has been updated to iterate over `data['research_references']` and enforce file existence. This node serves as a historical record of the improvement.
+
+## Acceptance Criteria
+- [x] Schema validation script checks that files listed in `research_references` exist on the filesystem.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -71,6 +71,15 @@ Additionally, some nodes (`idea-021-unified-scheduled-agent-policies.md` and `ta
 3. Created `idea-051-strict-schema-validations.md` as an architectural improvement record.
 4. Populated `rejection_reason` with 'Resolved: Validated by human/agent' for the problematic `ACTIVE` nodes to satisfy the strict schema during any potential future state transitions.
 5. Enhanced `scripts/validate-foundry-schema.ts` to issue a warning for ANY node missing the `rejection_reason` field, even if not `FAILED`, to improve diagnostic visibility.
+
+## 2026-05-14: Enforce Schema Validation for Research References
+### Observation
+I noticed that while `validate-foundry-schema.ts` validated `depends_on` and `parent` paths, it completely lacked validation for `research_references`. This omission could lead to agents adding invalid or non-existent file paths to `research_references`, which would fail silently and deprive downstream agents of necessary context.
+
+### Action Taken
+1. Modified `scripts/validate-foundry-schema.ts` to strictly validate `research_references`. It now iterates over any provided references and uses `fs.existsSync` to ensure the target files exist, emitting an error and failing validation if they do not.
+2. Autonomously generated `idea-052-strict-research-references-validation.md` to document this architectural improvement.
+
 ## 2026-05-13: System-Wide Empty PR Exception Synchronization
 ### Observation
 I noted that `task-050-083-enforce-acceptance-criteria.md` failed with the rejection reason "Merged with unfulfilled acceptance criteria". The `coder` had successfully implemented the code updates to the orchestrator and heartbeat but failed to check the acceptance criteria boxes in the task node before submitting their empty PR. The orchestrator properly caught this due to ADR 007. I also noticed that the `CRITICAL EXCEPTION TO EMPTY PR POLICY` paragraph was missing from the prompts for several meta-agents (`architect`, `tpm`, `agile_coach`), leading to potential future contradictions if these agents attempt empty PRs.

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -147,6 +147,17 @@ function validateSchema() {
       }
     }
 
+    if (data['research_references'] && Array.isArray(data['research_references'])) {
+      for (const ref of data['research_references']) {
+        if (typeof ref === 'string' && ref.includes('/')) {
+          if (!fs.existsSync(ref)) {
+            console.error(`Error: Research reference path does not exist: '${ref}' in file ${file}`);
+            hasError = true;
+          }
+        }
+      }
+    }
+
     if (data['parent']) {
       // Parent might be an ID or a path. If it looks like a path (contains '/'), verify it exists.
       if (typeof data['parent'] === 'string' && data['parent'].includes('/')) {


### PR DESCRIPTION
This PR addresses a missing validation check in the Foundry schema validation hook (`validate-foundry-schema.ts`). Previously, `depends_on` and `parent` fields were validated, but `research_references` paths were not. This allowed agents to add invalid paths silently, depriving downstream agents of important context. 

Changes include:
- Updating `scripts/validate-foundry-schema.ts` to strictly validate the existence of file paths in `research_references`.
- Adding an entry to `.foundry/journals/agile_coach.md` noting the observation and action taken.
- Creating an `IDEA` node `.foundry/ideas/idea-052-strict-research-references-validation.md` to document the change.

---
*PR created automatically by Jules for task [17225267037111680168](https://jules.google.com/task/17225267037111680168) started by @szubster*