### PR TITLE
🧪 QA: Verify and fix tactical aesthetic for DagNode

### DIFF
--- a/.foundry/tasks/task-051-088-qa-core-graph-visualizer.md
+++ b/.foundry/tasks/task-051-088-qa-core-graph-visualizer.md
@@ -37,7 +37,7 @@ You need to verify the implementation of the core graph visualization component 
 4. Verify that edges are rendered to show directed dependencies.
 
 ## Acceptance Criteria
-- [ ] Confirm the implementation uses React Flow.
-- [ ] Verify the custom node component renders `id`, `type`, `status`, and `owner_persona`.
-- [ ] Verify the tactical aesthetic constraints are strictly met via Tailwind CSS (`rounded-none`, `border-dashed`, `font-mono`).
-- [ ] Confirm directed edges are rendered successfully.
+- [x] Confirm the implementation uses React Flow.
+- [x] Verify the custom node component renders `id`, `type`, `status`, and `owner_persona`.
+- [x] Verify the tactical aesthetic constraints are strictly met via Tailwind CSS (`rounded-none`, `border-dashed`, `font-mono`).
+- [x] Confirm directed edges are rendered successfully.

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -26,7 +26,7 @@ export function BottomNav() {
       {/* Telemetry decoration */}
       <TelemetryDecoration
         label="LINK_ACTIVE"
-        className="-top-[21px] left-4 rounded-t rounded-b-none border-t border-b-0 bg-zinc-950"
+        className="-top-[21px] left-4 rounded-none border-t border-b-0 bg-zinc-950"
       />
 
       <div className="relative mx-auto grid max-w-md grid-cols-5 items-center">
@@ -50,7 +50,7 @@ export function BottomNav() {
           aria-label="Pokedex"
           title="Pokedex"
           className={cn(
-            'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+            'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isDex ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
           )}
         >
@@ -69,7 +69,7 @@ export function BottomNav() {
           aria-label="Storage"
           title="Storage"
           className={cn(
-            'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+            'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isStorage ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
           )}
         >
@@ -88,7 +88,7 @@ export function BottomNav() {
           aria-label="Assistant"
           title="Assistant"
           className={cn(
-            'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+            'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isAssistant ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
           )}
         >
@@ -107,7 +107,7 @@ export function BottomNav() {
           aria-label="DAG"
           title="DAG"
           className={cn(
-            'group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+            'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isDag ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
           )}
         >
@@ -126,7 +126,7 @@ export function BottomNav() {
           onClick={() => setIsSettingsOpen(true)}
           aria-label="Open settings menu"
           title="Open settings menu"
-          className="group relative z-10 flex flex-col items-center gap-1.5 rounded-sm py-2 text-zinc-600 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+          className="group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 text-zinc-600 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
           <div className="transition-transform active:scale-90">
             <Settings2 size={20} strokeWidth={2} />

--- a/src/components/TelemetryDecoration.tsx
+++ b/src/components/TelemetryDecoration.tsx
@@ -11,7 +11,7 @@ export function TelemetryDecoration({ label, className, dotClassName, textClassN
   return (
     <div
       className={cn(
-        'absolute flex gap-1 rounded-b border border-zinc-800 border-t-0 border-dashed bg-zinc-900 px-3 py-1 font-black text-[8px] text-zinc-600 tracking-widest',
+        'absolute flex gap-1 rounded-none border border-zinc-800 border-t-0 border-dashed bg-zinc-900 px-3 py-1 font-black text-[8px] text-zinc-600 tracking-widest',
         className,
       )}
     >

--- a/src/components/dag/DagNode.tsx
+++ b/src/components/dag/DagNode.tsx
@@ -46,6 +46,7 @@ export function DagNode({ data }: { data: DagNodeData }) {
 
   return (
     <div
+      data-testid="dag-node"
       className={cn(
         'relative min-w-[200px] max-w-[300px] rounded-none border border-dashed p-3 font-mono transition-all',
         bgClass,
@@ -57,7 +58,7 @@ export function DagNode({ data }: { data: DagNodeData }) {
 
       <TelemetryDecoration
         label={data.type}
-        className="-top-[17px] left-[-1px] rounded-t rounded-b-none border-b-0 px-2 py-0.5 text-[8px]"
+        className="-top-[17px] left-[-1px] rounded-none border-b-0 px-2 py-0.5 text-[8px]"
         dotClassName={dotColor}
       />
 

--- a/src/components/dag/__tests__/DagNode.test.tsx
+++ b/src/components/dag/__tests__/DagNode.test.tsx
@@ -1,0 +1,74 @@
+import { ReactFlow } from '@xyflow/react';
+import { expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { DagNode } from '../DagNode';
+
+const nodeTypes = {
+  custom: DagNode,
+};
+
+test('DagNode renders all required fields', async () => {
+  const data = {
+    id: 'test-task-001',
+    label: 'test-task-001',
+    type: 'TASK',
+    status: 'ACTIVE',
+    owner_persona: 'coder',
+  };
+
+  const nodes = [
+    {
+      id: 'test-task-001',
+      type: 'custom',
+      data,
+      position: { x: 0, y: 0 },
+    },
+  ];
+
+  await render(
+    <div style={{ width: '500px', height: '500px' }}>
+      <ReactFlow nodes={nodes} nodeTypes={nodeTypes} />
+    </div>,
+  );
+
+  // Check if ID/Label is rendered
+  await expect.element(page.getByText('test-task-001')).toBeInTheDocument();
+  // Check if Type is rendered
+  await expect.element(page.getByText('TASK', { exact: true })).toBeInTheDocument();
+  // Check if Status is rendered
+  await expect.element(page.getByText('ACTIVE', { exact: true })).toBeInTheDocument();
+  // Check if Owner Persona is rendered
+  await expect.element(page.getByText('coder', { exact: true })).toBeInTheDocument();
+});
+
+test('DagNode adheres to tactical aesthetic classes', async () => {
+  const data = {
+    id: 'test-task-001',
+    label: 'test-task-001',
+    type: 'TASK',
+    status: 'ACTIVE',
+    owner_persona: 'coder',
+  };
+
+  const nodes = [
+    {
+      id: 'test-task-001',
+      type: 'custom',
+      data,
+      position: { x: 0, y: 0 },
+    },
+  ];
+
+  await render(
+    <div style={{ width: '500px', height: '500px' }}>
+      <ReactFlow nodes={nodes} nodeTypes={nodeTypes} />
+    </div>,
+  );
+
+  const node = page.getByTestId('dag-node');
+
+  await expect.element(node).toHaveClass('rounded-none');
+  await expect.element(node).toHaveClass('border-dashed');
+  await expect.element(node).toHaveClass('font-mono');
+});


### PR DESCRIPTION
This PR completes the QA verification and necessary fixes for the core graph visualizer component.

Key changes:
- **Strict Aesthetic Adherence**: Replaced all instances of `rounded-t`, `rounded-b`, and `rounded-sm` with `rounded-none` in `TelemetryDecoration.tsx`, `DagNode.tsx`, and `BottomNav.tsx` to strictly follow ADR 008's "tactical hardware" requirement.
- **Robust Verification**: Added `src/components/dag/__tests__/DagNode.test.tsx` using Vitest Browser to verify that the node component correctly renders its ID, type, status, and owner persona, while maintaining the required CSS classes.
- **Improved Testability**: Added `data-testid="dag-node"` to the `DagNode` component.
- **Task Completion**: Checked off all acceptance criteria in `.foundry/tasks/task-051-088-qa-core-graph-visualizer.md`.

All tests (unit, browser, e2e) and linting pass.

Fixes #1303

---
*PR created automatically by Jules for task [16247374799104312128](https://jules.google.com/task/16247374799104312128) started by @szubster*