### PR TITLE
Resolve Foundry Engine orchestration failure

### DIFF
--- a/.foundry/stories/story-028-045-cross-region-distance.md
+++ b/.foundry/stories/story-028-045-cross-region-distance.md
@@ -2,7 +2,7 @@
 id: story-028-045-cross-region-distance
 type: STORY
 title: 'Phase 3: Cross-Region Distance'
-status: ACTIVE
+status: FAILED
 owner_persona: tech_lead
 created_at: '2026-05-08'
 updated_at: '2026-05-14'
@@ -18,7 +18,7 @@ tags:
 research_references:
   - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Implementation task task-045-085 failed validation.'
 notes: ''
 ---
 


### PR DESCRIPTION
Updated `.foundry/stories/story-028-045-cross-region-distance.md` to `status: FAILED` and provided a `rejection_reason` as required by the Foundry node schema. This resolves the orchestration failure where a `FAILED` node was missing its mandatory rejection reason. The failure reflects the state of its child task `task-045-085`.

Fixes #1308

---
*PR created automatically by Jules for task [4848853107827592748](https://jules.google.com/task/4848853107827592748) started by @szubster*