### PR TITLE
🛠️ Fix Orchestration Failure: Enforce Rejection Reason & Correct Parent Promotion

### DIFF
--- a/.foundry/stories/story-028-045-cross-region-distance.md
+++ b/.foundry/stories/story-028-045-cross-region-distance.md
@@ -2,7 +2,7 @@
 id: story-028-045-cross-region-distance
 type: STORY
 title: 'Phase 3: Cross-Region Distance'
-status: ACTIVE
+status: READY
 owner_persona: tech_lead
 created_at: '2026-05-08'
 updated_at: '2026-05-14'

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -32,7 +32,7 @@ function todayISO(): string {
 const TERMINAL_STATES = ['FAILED', 'COMPLETED'];
 
 /** Surgical mutation to FAILED */
-export async function transitionNodeToFailed(node: any, repoRoot: string, rejectionReason?: string): Promise<void> {
+export async function transitionNodeToFailed(node: any, repoRoot: string, rejectionReason: string): Promise<void> {
   const dateStr = todayISO();
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
@@ -40,18 +40,15 @@ export async function transitionNodeToFailed(node: any, repoRoot: string, reject
   parsed.data.status = 'FAILED';
   parsed.data.jules_session_id = null;
   parsed.data.updated_at = dateStr;
-
-  if (rejectionReason) {
-    parsed.data.rejection_reason = rejectionReason;
-  }
+  parsed.data.rejection_reason = rejectionReason;
 
   const newContent = matter.stringify(parsed.content, parsed.data);
 
   if (!DRY_RUN) {
     fs.writeFileSync(node.filePath, newContent, 'utf-8');
-    logToJournal(repoRoot, `\n- **${dateStr}**: Heartbeat detected zombie session for \`${node.frontmatter.id}\`. Transitioned to FAILED.\n`);
+    logToJournal(repoRoot, `\n- **${dateStr}**: Heartbeat detected failure for \`${node.frontmatter.id}\`. Reason: ${rejectionReason}. Transitioned to FAILED.\n`);
   }
-  info(`${dryTag}Transitioned ACTIVE → FAILED: ${node.repoPath}`);
+  info(`${dryTag}Transitioned ACTIVE → FAILED: ${node.repoPath} (${rejectionReason})`);
 }
 
 /** Surgical mutation to COMPLETED or PENDING depending on tasks */
@@ -241,7 +238,7 @@ export async function main() {
 
     if (!isHuman && (!sessionId || sessionId === 'null')) {
       warn(`Node ${node.repoPath} is ACTIVE but missing session ID. Failing.`);
-      await transitionNodeToFailed(node, repoRoot);
+      await transitionNodeToFailed(node, repoRoot, "Active node missing session ID (zombie node)");
       continue;
     }
 
@@ -299,16 +296,18 @@ export async function main() {
     // B. Terminal State check (Zombie detection)
     if (!isHuman) {
       if (sessionStatus === 'NOT_FOUND' || (sessionStatus && TERMINAL_STATES.includes(sessionStatus))) {
-        info(`Session ${sessionId} (Status: ${sessionStatus}) terminated without PR. Failing.`);
-        await transitionNodeToFailed(node, repoRoot);
+        const reason = `Session ${sessionId} terminated without PR (Status: ${sessionStatus})`;
+        info(`${reason}. Failing.`);
+        await transitionNodeToFailed(node, repoRoot, reason);
       } else if (updateTime) {
         const lastUpdate = new Date(updateTime).getTime();
         const now = Date.now();
         const hoursElapsed = (now - lastUpdate) / (1000 * 60 * 60);
 
         if (hoursElapsed > 24) {
-          info(`Session ${sessionId} has been IN_PROGRESS for >24h. Assuming dead. Failing.`);
-          await transitionNodeToFailed(node, repoRoot);
+          const reason = `Session ${sessionId} has been IN_PROGRESS for >24h. Assuming dead.`;
+          info(`${reason}. Failing.`);
+          await transitionNodeToFailed(node, repoRoot, reason);
         }
       }
     }

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -526,7 +526,8 @@ function main(): void {
         const parentNode = nodeMap.get(parentPath);
         if (parentNode && parentNode.frontmatter.status !== 'ACTIVE') {
           info(`Impossible Loop: waking up parent ${parentNode.repoPath}`);
-          promoteNodeStatus(parentNode, parentNode.frontmatter.status, 'ACTIVE');
+          const targetStatus = parentNode.frontmatter.owner_persona === 'human' ? 'ACTIVE' : 'READY';
+          promoteNodeStatus(parentNode, parentNode.frontmatter.status, targetStatus);
         }
       } else if (node.frontmatter.owner_persona !== 'tpm') {
         info(`Impossible Loop: flagging node without parent for TPM: ${node.repoPath}`);


### PR DESCRIPTION
This PR fixes a validation error in the Foundry Engine orchestration phase. The root cause was that the heartbeat script transitioned nodes to `FAILED` without providing the required `rejection_reason` field, violating the schema enforced in the pre-commit hook. 

Additionally, the 'Impossible Loop' logic in the orchestrator was waking up parent nodes as `ACTIVE` even if they were automation-owned (like `tech_lead`), leading to 'zombie' nodes that lacked session IDs and were subsequently failed by the heartbeat.

Key changes:
1.  **Robust Failure Transitions:** Modified `foundry-heartbeat.ts` to make `rejection_reason` a mandatory parameter in `transitionNodeToFailed`. Updated all automated failure detections (session timeout, zombie detection) to provide clear justifications.
2.  **Correct Lifecycle Transitions:** Updated `foundry-orchestrator.ts` Phase 3.6 to promote non-human parents to `READY` instead of `ACTIVE` during an Impossible Loop. This ensures they go through the dispatcher and receive a valid Jules session.
3.  **State Recovery:** Manually corrected `.foundry/stories/story-028-045-cross-region-distance.md` back to `READY` status. It had been incorrectly set to `ACTIVE` by the previous orchestrator run and then failed by the heartbeat without a reason.

Verified with `pnpm lint`, `pnpm test`, and `node --experimental-strip-types scripts/validate-foundry-schema.ts`.

Fixes #1313

---
*PR created automatically by Jules for task [59310822731853379](https://jules.google.com/task/59310822731853379) started by @szubster*