### PR TITLE
⚡ Bolt: Cache locations query to prevent redundant IndexedDB hits on keystrokes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,8 @@ Learned that the dex encounters DataLoader was firing individual getEncounters c
 - **Learnings:** When filtering and mapping arrays derived from large state objects, always look for opportunities to combine the operations into a single pass and memoize the result.
 
 - **Memoization of Heavy Synchronous Work:** In React, heavy synchronous functions like `generateSuggestions` (which iterates arrays and allocates new objects) must be wrapped in `useMemo` if they are placed inside a custom hook that gets re-rendered often. Otherwise, they block the main thread unnecessarily on every state update in the parent component.
+
+## Optimization Pattern: Caching DB Lookups in frequent UI Hooks
+
+*   **Problem:** Using `setTimeout` debouncing inside `useEffect` with manual `await db.get(...)` calls still triggers redundant IndexedDB disk reads on every final keystroke.
+*   **Solution:** Use `@tanstack/react-query` (`useQuery` with `staleTime: Infinity`) at the component level to cache static database data. Reference this cached data in the `useEffect` instead of firing manual queries, effectively reducing DB reads from O(K) (where K = debounced keystrokes) to O(1) for static lookup data.

--- a/src/components/LocationSuggestions.tsx
+++ b/src/components/LocationSuggestions.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import { MapPin, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { pokeDB } from '../db/PokeDB';
@@ -14,6 +15,13 @@ export function LocationSuggestions() {
   const [suggestions, setSuggestions] = useState<(GenericLocation & { count: number })[]>([]);
   const [isOpen, setIsOpen] = useState(false);
 
+  // ⚡ Bolt: Cache locations query to prevent redundant IndexedDB hits on every keystroke debounce
+  const { data: locations = [] } = useQuery({
+    queryKey: ['locations'],
+    queryFn: () => pokeDB.getLocations(),
+    staleTime: Infinity,
+  });
+
   useEffect(() => {
     if (!searchTerm || searchTerm.length < 2 || selectedLocationId) {
       setSuggestions([]);
@@ -22,8 +30,6 @@ export function LocationSuggestions() {
     }
 
     const timeoutId = setTimeout(async () => {
-      const locations = await pokeDB.getLocations();
-
       const term = searchTerm.toLowerCase();
       const filtered = locations.filter((l) => l.n.toLowerCase().includes(term)).slice(0, 5);
 
@@ -36,7 +42,7 @@ export function LocationSuggestions() {
     }, 250);
 
     return () => clearTimeout(timeoutId);
-  }, [searchTerm, selectedLocationId]);
+  }, [searchTerm, selectedLocationId, locations]);
 
   if (!isOpen && !selectedLocationId) return null;
 


### PR DESCRIPTION
💡 What
Replaced a redundant manual `await pokeDB.getLocations()` call inside a debounced `useEffect` with a top-level `@tanstack/react-query` `useQuery` cache in `src/components/LocationSuggestions.tsx`.

🎯 Why
On every keystroke in the search bar, the UI waits for the 250ms debounce and then executes a full read of the IndexedDB `locations` store. Since locations are a static data set, fetching it repeatedly blocks the main thread unnecessarily and incurs constant I/O latency. 

📊 Measured Improvement
IndexedDB hits for the `locations` table dropped from O(k) (k = number of debounced search inputs) to O(1) per session. The `locations` array is now reliably cached in-memory and instantly accessible when filtering.

How to Verify
1. Run `pnpm test` and `pnpm lint`.
2. Launch the app and search for locations in the terminal search. Monitor the network/storage tabs to verify IndexedDB is not repeatedly queried for `locations`.

---
*PR created automatically by Jules for task [14366231621415427909](https://jules.google.com/task/14366231621415427909) started by @szubster*