### PR TITLE
🎨 Palette: Refactor filter toggle group accessibility

### DIFF
--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -52,7 +52,10 @@ export function SearchAndFilters() {
         </TacticalInput>
 
         {/* Tactical Filter Toggles */}
-        <fieldset
+        {/* oxlint-disable jsx-a11y/prefer-tag-over-role */}
+        {/* biome-ignore lint/a11y/useSemanticElements: We use role="group" instead of <fieldset> for better screen reader compatibility with aria-label without a <legend> */}
+        <div
+          role="group"
           className="no-scrollbar m-0 mt-2 flex min-w-0 gap-2 overflow-x-auto border-none p-0 px-1 pb-2"
           aria-label="Filter Pokémon"
         >
@@ -79,7 +82,7 @@ export function SearchAndFilters() {
               {f === 'secured' ? 'Secured' : f === 'missing' ? 'Missing' : 'Dex Only'}
             </TacticalButton>
           ))}
-        </fieldset>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Replaced the `<fieldset>` element with a `<div role="group">` in the `SearchAndFilters` component to improve screen reader compatibility for the group of filter toggles. Added necessary linter suppressions for Biome and Oxlint.

---
*PR created automatically by Jules for task [16460936826258007106](https://jules.google.com/task/16460936826258007106) started by @szubster*