### PR TITLE
Fix heredoc EOF indentation in foundry-engine workflow

### DIFF
--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -228,7 +228,7 @@ jobs:
 
                         const list = Array.from(researchPaths).map(p => `- ${p}`).join('\n');
                         console.log(list);
-                        JS_EOF
+            JS_EOF
 
             TARGET_NODE_PATH="${{ matrix.node.repo_path }}"
             export TARGET_NODE_PATH


### PR DESCRIPTION
The `cat << 'JS_EOF'` delimiter was previously overly indented causing bash to throw `wanted 'JS_EOF'` error. Indentation is now exactly 12 spaces to match the YAML block scalar base indentation, allowing bash to correctly terminate the document without breaking the YAML schema.

---
*PR created automatically by Jules for task [16502285171246974205](https://jules.google.com/task/16502285171246974205) started by @szubster*