### PR TITLE
fix: downgrade github actions versions from @v6 to @v4

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Biome
         uses: biomejs/setup-biome@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"
@@ -43,15 +43,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"
@@ -63,12 +63,12 @@ jobs:
         run: pnpm test --coverage
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v5
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -76,15 +76,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"
@@ -97,15 +97,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,15 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"
@@ -42,7 +42,7 @@ jobs:
         run: pnpm build
         
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@v5
         
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -21,17 +21,17 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24' # Required for --strip-types
           cache: "pnpm"
@@ -146,18 +146,18 @@ jobs:
         node: ${{ fromJson(needs.orchestrate.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: main
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: "pnpm"
@@ -190,45 +190,45 @@ jobs:
 
             # 1.5 Extract research_references from parent chain safely
             cat << 'JS_EOF' > extract-research.cjs
-const fs = require('fs');
-const path = require('path');
-const matter = require('gray-matter');
+          const fs = require('fs');
+          const path = require('path');
+          const matter = require('gray-matter');
 
-const targetNodePath = process.env.TARGET_NODE_PATH;
-const researchPaths = new Set();
-const visitedPaths = new Set();
-let currentPath = targetNodePath;
+          const targetNodePath = process.env.TARGET_NODE_PATH;
+          const researchPaths = new Set();
+          const visitedPaths = new Set();
+          let currentPath = targetNodePath;
 
-while (currentPath && !visitedPaths.has(currentPath)) {
-  visitedPaths.add(currentPath);
-  if (!fs.existsSync(currentPath)) break;
-  try {
-    const raw = fs.readFileSync(currentPath, 'utf-8');
-    const parsed = matter(raw);
-    const fm = parsed.data || {};
+          while (currentPath && !visitedPaths.has(currentPath)) {
+            visitedPaths.add(currentPath);
+            if (!fs.existsSync(currentPath)) break;
+            try {
+              const raw = fs.readFileSync(currentPath, 'utf-8');
+              const parsed = matter(raw);
+              const fm = parsed.data || {};
 
-    if (Array.isArray(fm.research_references)) {
-      fm.research_references.forEach(ref => {
-        if (typeof ref === 'string' && ref.endsWith('.md')) {
-          researchPaths.add(ref);
-        }
-      });
-    }
+              if (Array.isArray(fm.research_references)) {
+                fm.research_references.forEach(ref => {
+                  if (typeof ref === 'string' && ref.endsWith('.md')) {
+                    researchPaths.add(ref);
+                  }
+                });
+              }
 
-    const parent = fm.parent;
-    if (typeof parent === 'string' && parent.endsWith('.md') && parent !== currentPath) {
-      currentPath = parent;
-    } else {
-      break;
-    }
-  } catch (e) {
-    break;
-  }
-}
+              const parent = fm.parent;
+              if (typeof parent === 'string' && parent.endsWith('.md') && parent !== currentPath) {
+                currentPath = parent;
+              } else {
+                break;
+              }
+            } catch (e) {
+              break;
+            }
+          }
 
-const list = Array.from(researchPaths).map(p => `- ${p}`).join('\n');
-console.log(list);
-JS_EOF
+          const list = Array.from(researchPaths).map(p => `- ${p}`).join('\n');
+          console.log(list);
+          JS_EOF
 
             TARGET_NODE_PATH="${{ matrix.node.repo_path }}"
             export TARGET_NODE_PATH

--- a/.github/workflows/foundry-scheduled-agent.yml
+++ b/.github/workflows/foundry-scheduled-agent.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/jules-agents.yml
+++ b/.github/workflows/jules-agents.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       agents: ${{ steps.list.outputs.agents }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .jules/schedules
 
@@ -32,7 +32,7 @@ jobs:
       matrix:
         agent: ${{ fromJSON(needs.discover.outputs.agents) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .jules/schedules
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,13 +17,13 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@v4
       with:
         run_install: false
 
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v4
       with:
         node-version: 24
         cache: "pnpm"

--- a/.github/workflows/sync-pokedata.yml
+++ b/.github/workflows/sync-pokedata.yml
@@ -12,17 +12,17 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 


### PR DESCRIPTION
GitHub Actions does not have `@v6` versions for common actions like `actions/checkout` or `actions/setup-node`. I downgraded them to `@v4` (or `@v5` where appropriate) across all `.github/workflows/*.yml` files.

I also fixed an indentation parsing issue with `knip` inside `.github/workflows/foundry-engine.yml`.

---
*PR created automatically by Jules for task [5986710520641473457](https://jules.google.com/task/5986710520641473457) started by @szubster*