### PR TITLE
Implement Gen 2 Assistant Strategy

### DIFF
--- a/src/engine/assistant/strategies/gen2Strategy.test.ts
+++ b/src/engine/assistant/strategies/gen2Strategy.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import type { UnifiedLocation } from '../../../db/schema';
+import type { SaveData } from '../../saveParser/index';
+import { gen2Strategy } from './gen2Strategy';
+
+const mockLocations: UnifiedLocation[] = [
+  // Johto Hubs
+  { id: 0x0306, n: 'Goldenrod City', conn: [0x0a], dist: { 0x0a: 1, 0x05: 2, 0x0307: 3 } },
+  { id: 0x0307, n: 'Olivine City', conn: [0x05], dist: { 0x05: 1, 0x0a: 2, 0x0306: 3 } },
+  // Kanto Hubs
+  { id: 0x0a, n: 'Saffron City', conn: [0x0306, 0x05], dist: { 0x0306: 1, 0x05: 1, 0x0307: 2 } },
+  { id: 0x05, n: 'Vermilion City', conn: [0x0a, 0x0307], dist: { 0x0a: 1, 0x0307: 1, 0x0306: 2 } },
+  // Indoor
+  { id: 0x25, n: 'Goldenrod Pokecenter', prnt: 0x0306, conn: [], dist: {} },
+];
+
+const mockSaveData = (currentMapId: number): SaveData => ({
+  generation: 2,
+  gameVersion: 'gold',
+  trainerName: 'GOLD',
+  badges: 0,
+  currentMapId,
+  currentMapName: 'Mock Map',
+  inventory: [],
+  owned: new Set(),
+  seen: new Set(),
+  party: [],
+  pc: [],
+  partyDetails: [],
+  pcDetails: [],
+  trainerId: 12345,
+  currentBoxCount: 0,
+  hallOfFameCount: 0,
+});
+
+describe('gen2Strategy', () => {
+  describe('resolveMapAid', () => {
+    it('resolves outdoor map directly', () => {
+      const saveData = mockSaveData(0x0306);
+      const result = gen2Strategy.resolveMapAid(saveData, mockLocations);
+      expect(result).toBe(0x0306);
+    });
+
+    it('resolves indoor map to outdoor parent', () => {
+      const saveData = mockSaveData(0x25);
+      const result = gen2Strategy.resolveMapAid(saveData, mockLocations);
+      expect(result).toBe(0x0306);
+    });
+  });
+
+  describe('getMapDistance', () => {
+    it('calculates distance between Johto and Kanto (Magnet Train)', () => {
+      // Goldenrod (Johto) to Saffron (Kanto)
+      const result = gen2Strategy.getMapDistance(0x0306, 0x0a, mockLocations);
+      expect(result).toEqual({ distance: 1, name: 'Saffron City' });
+    });
+
+    it('calculates distance between Johto and Kanto (S.S. Aqua)', () => {
+      // Olivine (Johto) to Vermilion (Kanto)
+      const result = gen2Strategy.getMapDistance(0x0307, 0x05, mockLocations);
+      expect(result).toEqual({ distance: 1, name: 'Vermilion City' });
+    });
+
+    it('returns null for unreachable maps', () => {
+      const result = gen2Strategy.getMapDistance(0x0306, 0x999, mockLocations);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getUnobtainableReason', () => {
+    it('returns reason for version exclusives', () => {
+      // Vulpix (ID 37) is silver exclusive
+      const result = gen2Strategy.getUnobtainableReason(37, 'gold', 0, new Set());
+      expect(result).toContain('not available in Gold');
+    });
+
+    it('returns null for obtainable pokemon', () => {
+      // Pidgey (ID 16) is in all versions
+      const result = gen2Strategy.getUnobtainableReason(16, 'gold', 0, new Set());
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getSpecialSuggestions', () => {
+    it('adds box full warning when box is almost full', () => {
+      const saveData = { ...mockSaveData(0x0306), currentBoxCount: 19 };
+      const result = gen2Strategy.getSpecialSuggestions(saveData, []);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe('box-full-warning');
+    });
+
+    it('does not add warning when box has space', () => {
+      const saveData = { ...mockSaveData(0x0306), currentBoxCount: 5 };
+      const result = gen2Strategy.getSpecialSuggestions(saveData, []);
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/src/engine/assistant/strategies/gen2Strategy.ts
+++ b/src/engine/assistant/strategies/gen2Strategy.ts
@@ -1,0 +1,47 @@
+import type { UnifiedLocation } from '../../../db/schema';
+import { getGenerationConfig } from '../../../utils/generationConfig';
+import { getGen2UnobtainableReason } from '../../exclusives/gen2Exclusives';
+import { getDistanceToMap, resolveOutdoorMapId } from '../../mapGraph/gen2Graph';
+import type { SaveData } from '../../saveParser/index';
+import type { AssistantStrategy, Suggestion } from './types';
+
+export const gen2Strategy: AssistantStrategy = {
+  generation: 2,
+
+  resolveMapAid(saveData: SaveData, allLocations: UnifiedLocation[]): number | null {
+    const mapId = saveData.currentMapId;
+    return resolveOutdoorMapId(allLocations, mapId);
+  },
+
+  getMapDistance(currentMapId: number, targetAid: number, allLocations: UnifiedLocation[]) {
+    return getDistanceToMap(allLocations, currentMapId, targetAid);
+  },
+
+  getUnobtainableReason(pokemonId: number, version: string, ownedCount: number, ownedSet: Set<number>) {
+    return getGen2UnobtainableReason(pokemonId, version, ownedCount, ownedSet);
+  },
+
+  getSpecialSuggestions(saveData: SaveData, _missingIds: number[]): Suggestion[] {
+    const suggestions: Suggestion[] = [];
+    const genConfig = getGenerationConfig(2);
+
+    // Box full warning
+    if (saveData.currentBoxCount >= genConfig.boxWarningThreshold) {
+      suggestions.push({
+        id: 'box-full-warning',
+        pokemonId: 0,
+        title: 'Current Box Almost Full',
+        category: 'Event',
+        priority: 1000,
+        description: `Your current box has ${saveData.currentBoxCount}/${genConfig.boxCapacity} Pokémon. Switch boxes at a Pokémon Center PC or you won't be able to catch more!`,
+      });
+    }
+
+    return suggestions;
+  },
+
+  isInternallyObtainable(_baseId: number, _version: string): boolean {
+    // Gen 2 has breeding, so most base forms are obtainable if you have an evolution.
+    return true;
+  },
+};

--- a/src/engine/assistant/strategies/index.ts
+++ b/src/engine/assistant/strategies/index.ts
@@ -1,4 +1,5 @@
 import { gen1Strategy } from './gen1Strategy';
+import { gen2Strategy } from './gen2Strategy';
 import type { AssistantStrategy } from './types';
 
 const fallbackStrategy: AssistantStrategy = {
@@ -12,7 +13,7 @@ const fallbackStrategy: AssistantStrategy = {
 
 const STRATEGIES: Record<number, AssistantStrategy> = {
   1: gen1Strategy,
-  // Future: 2: gen2Strategy, 3: gen3Strategy, etc.
+  2: gen2Strategy,
 };
 
 /**


### PR DESCRIPTION
Implemented the Gen 2 strategy for the assistant recommendation engine. 
- Created `src/engine/assistant/strategies/gen2Strategy.ts` to handle Gen 2 specific logic.
- Registered the new strategy in `src/engine/assistant/strategies/index.ts`.
- Added comprehensive unit tests in `src/engine/assistant/strategies/gen2Strategy.test.ts`, including verification of cross-region distances (Magnet Train and S.S. Aqua).
- Ensured no data regressions by reverting unintended changes to precomputed JSONL files.

Fixes #1337

---
*PR created automatically by Jules for task [15867732655385813686](https://jules.google.com/task/15867732655385813686) started by @szubster*