### PR TITLE
🛠️ Infras: Fix invalid @v6 tags for GitHub Actions

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Biome
         uses: biomejs/setup-biome@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"
@@ -43,15 +43,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"
@@ -63,12 +63,12 @@ jobs:
         run: pnpm test --coverage
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v4
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -76,15 +76,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"
@@ -97,15 +97,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,15 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"
@@ -42,7 +42,7 @@ jobs:
         run: pnpm build
         
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@v5
         
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -21,17 +21,17 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24' # Required for --strip-types
           cache: "pnpm"
@@ -146,18 +146,18 @@ jobs:
         node: ${{ fromJson(needs.orchestrate.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: main
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: "pnpm"

--- a/.github/workflows/foundry-scheduled-agent.yml
+++ b/.github/workflows/foundry-scheduled-agent.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/jules-agents.yml
+++ b/.github/workflows/jules-agents.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       agents: ${{ steps.list.outputs.agents }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .jules/schedules
 
@@ -32,7 +32,7 @@ jobs:
       matrix:
         agent: ${{ fromJSON(needs.discover.outputs.agents) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .jules/schedules
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,13 +17,13 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@v4
       with:
         run_install: false
 
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v4
       with:
         node-version: 24
         cache: "pnpm"

--- a/.github/workflows/sync-pokedata.yml
+++ b/.github/workflows/sync-pokedata.yml
@@ -12,17 +12,17 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -62,3 +62,5 @@ Critical learnings:
 
 ## 2026-05-15 - Switched jest rules to vitest rules in oxlint
 **Learning:** Found that `.oxlintrc.json` had rules configured for `jest` plugin (`jest/no-disabled-tests`, `jest/no-standalone-expect`) but the project uses Vitest and explicitly registered the `"vitest"` plugin. Replaced the `jest` prefix with `vitest` to properly apply the rules to Vitest files.
+* The 'Infras' persona identifies and implements ONE improvement to developer tooling, build pipelines, or DX without modifying app logic. It verifies changes with `pnpm lint`, `pnpm test`, and `pnpm test:e2e`, logs critical learnings to `.jules/infras.md`, formats PR titles as `🛠️ Infras: [improvement]`, and submits an empty PR if no improvement is identified.
+* The 'Completeness Rule' for execution plans requires that explicit steps to run all relevant tests (e.g., `pnpm lint`, `pnpm test`, and `pnpm test:e2e`) must be included before the pre-commit step to ensure changes have not introduced regressions.


### PR DESCRIPTION
**What:** Replaced invalid `@v6` tags with the correct `@v4` (and `@v5`) tags for GitHub actions across all `.github/workflows/*.yml` files.
**Why:** The actions being used do not have `@v6` releases, which causes all CI pipelines using these tags to instantly fail.
**Impact on DX/CI:** Fixes a critical failure in the CI/CD pipeline preventing automated builds, tests, and deployments from running successfully.
**Setup Notes:** N/A.

---
*PR created automatically by Jules for task [1066767236346313822](https://jules.google.com/task/1066767236346313822) started by @szubster*