### PR TITLE
🧭 Strategist: Prompt improvement - Update Canvas to require visual verification via Playwright

### DIFF
--- a/.jules/schedules/canvas.md
+++ b/.jules/schedules/canvas.md
@@ -34,7 +34,7 @@ You have no memory between sessions. Your only persistence is what's committed t
 - Read your journal before starting — it's your only memory
 - Include a journal entry for the current change in every PR you open. Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens.
 - Run `pnpm lint` and `pnpm test` before pushing
-- Include before/after screenshots in the PR description
+- Start the local dev server (`pnpm run dev`), write a temporary Python Playwright script to run a Core User Journey (CUJ), record a video to `/home/jules/verification/videos`, take a screenshot in `/home/jules/verification/screenshots`, and call the `frontend_verification_complete` tool to include before/after screenshots
 - Keep changes to a single component or page — ambitious but scoped
 - Adhere to the project's tactical hardware/snooping aesthetic
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -90,3 +90,9 @@
 **Outcome:** Accepted
 **Why:** The `shield.md` journal showed that when no code fixes were found, the agent repeatedly bloated its own prompt (`.jules/schedules/shield.md`) with exhaustive lists of generic web vulnerabilities (like "Guard against Tab-nabbing", "Guard against CSRF"). This caused the prompt to grow unmanageably and lose its focus.
 **Pattern:** Do not instruct agents to expand their prompt with generic lists when they lack actionable work; instead, default to routine tasks (like `pnpm audit`) or skip execution.
+
+## 2026-06-27 - [Accepted] - Prompt improvement - Update Canvas to require visual verification via Playwright
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The Canvas prompt instructed the agent to "Include before/after screenshots in the PR description" without explaining *how* to generate them in the headless environment.
+**Pattern:** Update prompts to ensure UI agents explicitly know how to run the dev server and use Python Playwright to record and capture screenshots for visual verification.


### PR DESCRIPTION
## Proposal
Updated the Canvas schedule prompt to explicitly require the agent to use the Python Playwright script to run a Core User Journey (CUJ), record videos, take screenshots, and call the `frontend_verification_complete` tool.

## Justification
The previous instruction to "Include before/after screenshots in the PR description" is nearly impossible for an AI agent to execute autonomously in a headless environment without specific instructions on *how* to generate those screenshots using available tools.

## Evidence
While there wasn't a specific failed PR in the trace, the general pattern of agents failing to provide visual evidence when not given explicit instructions for headless UI testing is a common problem. Updating the prompt to explicitly define the headless verification workflow resolves this ambiguity and aligns with the project's standard verification capabilities.

---
*PR created automatically by Jules for task [14475012863951346008](https://jules.google.com/task/14475012863951346008) started by @szubster*