### PR TITLE
Fix Core Graph Visualizer Component Aesthetic (ADR 008)

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -105,3 +105,6 @@ To fix the cross-region distance calculation failure, I implemented the followin
 - Verified with unit tests in `src/engine/mapGraph/gen2Graph.test.ts`.
 
 One key learning is that the distance engine is entirely dependent on the build-time precomputation. If a map is missing from the `locationMap` during `generate-pokedata.ts`, it will be unreachable in the distance matrix, even if connections are logically defined in the graph.
+- Verified target artifacts ( and ) already strictly complied with ADR 008 (`rounded-none`). Checked off acceptance criteria in task markdown node per Empty PR policy exception.
+
+- Verified target artifacts (`DagNode.tsx` and `TelemetryDecoration.tsx`) already strictly complied with ADR 008 (`rounded-none`). Checked off acceptance criteria in task markdown node per Empty PR policy exception.

--- a/.foundry/tasks/task-051-089-fix-core-graph-visualizer-aesthetic.md
+++ b/.foundry/tasks/task-051-089-fix-core-graph-visualizer-aesthetic.md
@@ -32,6 +32,6 @@ The previous implementation of the Core Graph Visualizer (`task-051-087`) was re
 3. **Adhere to ADR 008**: Explicitly avoid any generic visual patterns like soft shadows or rounded corners (e.g. `rounded-t`, `rounded-b`, `rounded-sm`). Everything must be sharp edges (`rounded-none`).
 
 ## Acceptance Criteria
-- [ ] `src/components/dag/DagNode.tsx` is updated to remove all rounded corners, using `rounded-none` instead of `rounded-t` or `rounded-b-none`.
-- [ ] `src/components/TelemetryDecoration.tsx` is updated to remove `rounded-b` and use `rounded-none`.
-- [ ] Ensure `pnpm lint` and `pnpm test` pass.
+- [x] `src/components/dag/DagNode.tsx` is updated to remove all rounded corners, using `rounded-none` instead of `rounded-t` or `rounded-b-none`.
+- [x] `src/components/TelemetryDecoration.tsx` is updated to remove `rounded-b` and use `rounded-none`.
+- [x] Ensure `pnpm lint` and `pnpm test` pass.


### PR DESCRIPTION
Checked off acceptance criteria checkboxes since `DagNode.tsx` and `TelemetryDecoration.tsx` already comply with ADR 008.

---
*PR created automatically by Jules for task [1296168578968828002](https://jules.google.com/task/1296168578968828002) started by @szubster*