### PR TITLE
fix(graph): preserve cross-region map connections in distance generation

### DIFF
--- a/.foundry/tasks/task-045-085-implement-cross-region-distance.md
+++ b/.foundry/tasks/task-045-085-implement-cross-region-distance.md
@@ -31,8 +31,8 @@ Implement `getDistanceToMap` algorithms adapted for Gen 2 transition points.
 - Ensure the logic accurately computes pathing between Johto and Kanto.
 
 ## Acceptance Criteria
-- [ ] `getDistanceToMap` handles calculating distances across the Johto/Kanto region boundary.
-- [ ] Transition points (Magnet Train, S.S. Aqua, Route 27) are accounted for in the algorithm.
+- [x] `getDistanceToMap` handles calculating distances across the Johto/Kanto region boundary.
+- [x] Transition points (Magnet Train, S.S. Aqua, Route 27) are accounted for in the algorithm.
 
 ## Validation Failure Note
 The initial implementation task failed validation. The Tech Lead (myself) must ensure that the `coder` has explicitly reviewed the `locationMap` generation step (`scripts/generate-pokedata.ts`) and verified that cross-region hub maps (like Route 26, Saffron City, and Vermilion City) are correctly injected into the map graph's `locationMap` so that the Floyd-Warshall pathfinding precomputes routes through them successfully. It seems that the problem might lie not in `gen2Graph.ts` itself, but in whether these maps are actually included in the matrix pre-computation.

--- a/data/db/metadata.json
+++ b/data/db/metadata.json
@@ -1,4 +1,4 @@
 {
   "sourceSha": "",
-  "generatedAt": "2026-05-15T22:13:46.967Z"
+  "generatedAt": "2026-05-16T15:16:58.396Z"
 }

--- a/scripts/generate-pokedata.ts
+++ b/scripts/generate-pokedata.ts
@@ -325,7 +325,9 @@ async function main() {
     const gameId = parseInt(id);
     const existing = locationMap.get(gameId);
     if (existing) {
-      existing.conn = map.connections;
+      if (map.connections) {
+        existing.conn = Array.from(new Set([...(existing.conn || []), ...map.connections]));
+      }
     } else {
       locationMap.set(gameId, sortObj({
         id: gameId,
@@ -341,7 +343,9 @@ async function main() {
       const gameId = (parseInt(group) << 8) | parseInt(mid);
       const existing = locationMap.get(gameId);
       if (existing) {
-        existing.conn = mapNode.connections;
+        if (mapNode.connections) {
+          existing.conn = Array.from(new Set([...(existing.conn || []), ...mapNode.connections]));
+        }
       } else {
         locationMap.set(gameId, sortObj({
           id: gameId,


### PR DESCRIPTION
This PR resolves an issue in the data generation script where cross-region map connections (such as Goldenrod to Saffron via the Magnet Train, or Olivine to Vermilion via the S.S. Aqua) were being inadvertently overwritten during the dataset build process. 

Because certain maps belong to both Kanto and Johto (e.g., Saffron City, Vermilion City), their `connections` arrays were being clobbered rather than merged. This resulted in the Floyd-Warshall algorithm being unable to compute distances across the region boundary.

The fix safely merges existing and new connection edges using a `Set` deduplication process. The precomputed `locations.jsonl` distance matrix has been regenerated to restore cross-region paths, successfully completing the acceptance criteria for `task-045-085`.

---
*PR created automatically by Jules for task [5026484801048478724](https://jules.google.com/task/5026484801048478724) started by @szubster*