### PR TITLE
Tech Lead: Resurrect Gen 2 Cross-Region Distance Task

### DIFF
--- a/.foundry/stories/story-028-045-cross-region-distance.md
+++ b/.foundry/stories/story-028-045-cross-region-distance.md
@@ -36,5 +36,5 @@ Implement `getDistanceToMap` algorithms adapted for Gen 2 transition points.
 - [.foundry/tasks/task-045-086-qa-cross-region-distance.md](.foundry/tasks/task-045-086-qa-cross-region-distance.md)
 
 ## Acceptance Criteria
-- [ ] Create implementation task.
-- [ ] Create QA task.
+- [x] Create implementation task.
+- [x] Create QA task.

--- a/.foundry/tasks/task-045-085-implement-cross-region-distance.md
+++ b/.foundry/tasks/task-045-085-implement-cross-region-distance.md
@@ -31,8 +31,8 @@ Implement `getDistanceToMap` algorithms adapted for Gen 2 transition points.
 - Ensure the logic accurately computes pathing between Johto and Kanto.
 
 ## Acceptance Criteria
-- [x] `getDistanceToMap` handles calculating distances across the Johto/Kanto region boundary.
-- [x] Transition points (Magnet Train, S.S. Aqua, Route 27) are accounted for in the algorithm.
+- [ ] `getDistanceToMap` handles calculating distances across the Johto/Kanto region boundary.
+- [ ] Transition points (Magnet Train, S.S. Aqua, Route 27) are accounted for in the algorithm.
 
 ## Validation Failure Note
 The initial implementation task failed validation. The Tech Lead (myself) must ensure that the `coder` has explicitly reviewed the `locationMap` generation step (`scripts/generate-pokedata.ts`) and verified that cross-region hub maps (like Route 26, Saffron City, and Vermilion City) are correctly injected into the map graph's `locationMap` so that the Floyd-Warshall pathfinding precomputes routes through them successfully. It seems that the problem might lie not in `gen2Graph.ts` itself, but in whether these maps are actually included in the matrix pre-computation.

--- a/data/db/metadata.json
+++ b/data/db/metadata.json
@@ -1,4 +1,4 @@
 {
   "sourceSha": "",
-  "generatedAt": "2026-05-16T15:16:58.396Z"
+  "generatedAt": "2026-05-16T19:03:16.423Z"
 }


### PR DESCRIPTION
When processing \`story-028-045-cross-region-distance\`, I noticed the \`rejection_reason\` indicated that the implementation task \`task-045-085\` failed validation. The Tech Lead must pass along the feedback to the \`coder\` instead of incorrectly marking the story as FAILED or applying the Empty PR Policy. I unchecked the Acceptance Criteria checkboxes in the implementation task (\`task-045-085\`) without modifying any YAML frontmatter to route the task back into the DAG so the \`coder\` and \`qa\` can address the issue. I also checked the checkboxes in the parent story (\`story-028-045\`) to complete my assignment. All tests including e2e passed.

---
*PR created automatically by Jules for task [9632571989311329990](https://jules.google.com/task/9632571989311329990) started by @szubster*