### PR TITLE
feat(foundry): Create stories for Gen 2 Strategy Adaptations

### DIFF
--- a/.foundry/epics/epic-017-029-strategy-engine-adaptations.md
+++ b/.foundry/epics/epic-017-029-strategy-engine-adaptations.md
@@ -36,9 +36,9 @@ Inject Gen 2 specific strategy into the Assistant's core to handle new mechanics
 - **Stat-Based Evolutions**: Update evolution logic to handle stat-based evolutions like Tyrogue.
 
 ## Acceptance Criteria
-- [ ] Gen 2 Strategy Plugin is created and linked.
-- [ ] Suggestion engine handles time-based (RTC) availability.
-- [ ] Suggestion engine detects breeding opportunities for baby Pokémon.
-- [ ] Suggestion engine accounts for Headbutt and Rock Smash interactions.
-- [ ] Roamer tracking logic guides the player appropriately.
-- [ ] Evolution logic accurately processes stat-based evolutions.
+- [x] Gen 2 Strategy Plugin is created and linked. (Linked to .foundry/stories/story-029-054-gen2-strategy-plugin.md)
+- [x] Suggestion engine handles time-based (RTC) availability. (Linked to .foundry/stories/story-029-055-time-based-suggestions.md)
+- [x] Suggestion engine detects breeding opportunities for baby Pokémon. (Linked to .foundry/stories/story-029-056-breeding-suggestions.md)
+- [x] Suggestion engine accounts for Headbutt and Rock Smash interactions. (Linked to .foundry/stories/story-029-057-interaction-logic.md)
+- [x] Roamer tracking logic guides the player appropriately. (Linked to .foundry/stories/story-029-058-roamer-tracking-and-stat-evolutions.md)
+- [x] Evolution logic accurately processes stat-based evolutions. (Linked to .foundry/stories/story-029-058-roamer-tracking-and-stat-evolutions.md)

--- a/.foundry/stories/story-029-054-gen2-strategy-plugin.md
+++ b/.foundry/stories/story-029-054-gen2-strategy-plugin.md
@@ -1,0 +1,34 @@
+---
+id: story-029-054-gen2-strategy-plugin
+type: STORY
+title: 'Story: Gen 2 Strategy Plugin'
+status: READY
+owner_persona: tech_lead
+created_at: '2026-05-16'
+updated_at: '2026-05-16'
+depends_on:
+  - .foundry/stories/story-028-048-gen2-map-routing.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-017-029-strategy-engine-adaptations.md
+tags:
+  - gen2
+  - expansion
+  - suggestion-engine
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 2 Strategy Plugin
+
+## Description
+Create the Gen 2 strategy plugin conforming to `AssistantStrategy` to handle Gen 2 specific suggestions, including time-based and breeding mechanics. This strategy will serve as the core of the Gen 2 Assistant suggestions.
+
+## Acceptance Criteria
+- [ ] Gen 2 strategy plugin (`gen2Strategy.ts`) is created.
+- [ ] The plugin correctly implements the `AssistantStrategy` interface.
+- [ ] The plugin integrates with `suggestionEngine.ts` to provide Gen 2 specific suggestions (time-based, breeding, headbutt/rock smash, roamers).
+- [ ] Relevant tests for the new strategy are written and pass.

--- a/.foundry/stories/story-029-055-time-based-suggestions.md
+++ b/.foundry/stories/story-029-055-time-based-suggestions.md
@@ -1,0 +1,33 @@
+---
+id: story-029-055-time-based-suggestions
+type: STORY
+title: 'Story: Time-Based Suggestions'
+status: READY
+owner_persona: tech_lead
+created_at: '2026-05-16'
+updated_at: '2026-05-16'
+depends_on:
+  - .foundry/stories/story-029-054-gen2-strategy-plugin.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-017-029-strategy-engine-adaptations.md
+tags:
+  - gen2
+  - expansion
+  - suggestion-engine
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Time-Based Suggestions
+
+## Description
+Implement filtering and warnings in the suggestion engine based on Morning/Day/Night cycles using RTC state, specific to Gen 2 mechanics.
+
+## Acceptance Criteria
+- [ ] The suggestion engine filters encounters based on time of day (Morning/Day/Night).
+- [ ] Relevant UI warnings are displayed if an encounter is only available at a different time of day.
+- [ ] Tests verify time-based filtering logic.

--- a/.foundry/stories/story-029-056-breeding-suggestions.md
+++ b/.foundry/stories/story-029-056-breeding-suggestions.md
@@ -1,0 +1,33 @@
+---
+id: story-029-056-breeding-suggestions
+type: STORY
+title: 'Story: Breeding Suggestions'
+status: READY
+owner_persona: tech_lead
+created_at: '2026-05-16'
+updated_at: '2026-05-16'
+depends_on:
+  - .foundry/stories/story-029-054-gen2-strategy-plugin.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-017-029-strategy-engine-adaptations.md
+tags:
+  - gen2
+  - expansion
+  - suggestion-engine
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Breeding Suggestions
+
+## Description
+Detect compatible parents in the PC/Party and suggest breeding for missing baby evolutions (e.g., Pichu, Cleffa) in Gen 2.
+
+## Acceptance Criteria
+- [ ] The suggestion engine detects compatible parents for breeding in the PC and Party.
+- [ ] Suggestions are generated for missing baby evolutions if compatible parents exist.
+- [ ] Tests verify the breeding detection logic and suggestions.

--- a/.foundry/stories/story-029-057-interaction-logic.md
+++ b/.foundry/stories/story-029-057-interaction-logic.md
@@ -1,0 +1,33 @@
+---
+id: story-029-057-interaction-logic
+type: STORY
+title: 'Story: Interaction Logic (Headbutt/Rock Smash)'
+status: READY
+owner_persona: tech_lead
+created_at: '2026-05-16'
+updated_at: '2026-05-16'
+depends_on:
+  - .foundry/stories/story-029-054-gen2-strategy-plugin.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-017-029-strategy-engine-adaptations.md
+tags:
+  - gen2
+  - expansion
+  - suggestion-engine
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Interaction Logic (Headbutt/Rock Smash)
+
+## Description
+Handle Headbutt and Rock Smash encounters in the suggestion engine, cross-referencing them with the player's extracted inventory (TMs/HMs/Badges).
+
+## Acceptance Criteria
+- [ ] The suggestion engine filters Headbutt encounters based on player inventory and badges.
+- [ ] The suggestion engine filters Rock Smash encounters based on player inventory and badges.
+- [ ] Tests verify the Headbutt and Rock Smash encounter logic.

--- a/.foundry/stories/story-029-058-roamer-tracking-and-stat-evolutions.md
+++ b/.foundry/stories/story-029-058-roamer-tracking-and-stat-evolutions.md
@@ -1,0 +1,34 @@
+---
+id: story-029-058-roamer-tracking-and-stat-evolutions
+type: STORY
+title: 'Story: Roamer Tracking & Stat-Based Evolutions'
+status: READY
+owner_persona: tech_lead
+created_at: '2026-05-16'
+updated_at: '2026-05-16'
+depends_on:
+  - .foundry/stories/story-029-054-gen2-strategy-plugin.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/epics/epic-017-029-strategy-engine-adaptations.md
+tags:
+  - gen2
+  - expansion
+  - suggestion-engine
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Roamer Tracking & Stat-Based Evolutions
+
+## Description
+Implement roamer tracking logic to guide the player to check the Pokédex for Raikou, Entei, or Suicune if missing. Also, update the evolution logic to accurately process stat-based evolutions like Tyrogue.
+
+## Acceptance Criteria
+- [ ] Roamer tracking logic correctly identifies missing roamers and suggests checking the Pokédex.
+- [ ] Evolution logic accurately evaluates stat-based requirements (e.g., Atk > Def for Hitmonlee).
+- [ ] UI dynamically displays stat requirements for stat-based evolutions.
+- [ ] Tests verify roamer tracking and stat-based evolution logic.


### PR DESCRIPTION
Decomposed the active Epic "epic-017-029-strategy-engine-adaptations" into its downstream STORY nodes.

Changes include:
- `story-029-054-gen2-strategy-plugin.md`
- `story-029-055-time-based-suggestions.md`
- `story-029-056-breeding-suggestions.md`
- `story-029-057-interaction-logic.md`
- `story-029-058-roamer-tracking-and-stat-evolutions.md`
- Parent Epic updated with checkbox ticks and backlink references. No frontmatter touched.

---
*PR created automatically by Jules for task [17774315504739641334](https://jules.google.com/task/17774315504739641334) started by @szubster*