### PR TITLE
🎨 Palette: add aria-current to BottomNav

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -63,3 +63,6 @@
 ## 2026-05-20 - Adding ARIA attributes dynamically to dialog elements
 **Learning:** The 'Palette' persona must strictly isolate its work to accessibility and micro-UX enhancements (ARIA attributes, keyboard navigation, focus states). It must NEVER modify structural CSS, design system properties (e.g., altering `rounded` classes for aesthetics), or overlap with the 'Canvas' persona's responsibilities, as this causes UI regressions like breaking loading spinners. Also, when passing ARIA properties like `aria-label` to dynamic elements (e.g., `<div role={role}>`), use `// biome-ignore lint/a11y/useAriaPropsSupportedByRole: We will fix this in future` and `{/* oxlint-disable jsx-a11y/role-supports-aria-props */}` to suppress static analysis errors if the linter cannot infer the role at compile time.
 **Action:** Added `aria-label`, `aria-labelledby`, and `aria-describedby` props to `TacticalModal` to improve screen reader descriptions, updated usages in `VersionModal`, `PokemonDetails`, and `SettingsModal` to pass these attributes, and correctly suppressed linter rules to allow these dynamic roles.
+
+- Added `aria-current="page"` to active links in navigation for screen reader accessibility.
+- Used `aria-expanded` on interactive buttons controlling menus/modals (e.g. settings button).

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -7,6 +7,7 @@ import { TelemetryDecoration } from './TelemetryDecoration';
 export function BottomNav() {
   const saveData = useStore((s) => s.saveData);
   const setIsSettingsOpen = useStore((s) => s.setIsSettingsOpen);
+  const isSettingsOpen = useStore((s) => s.isSettingsOpen);
   const location = useLocation();
 
   if (!saveData) return null;
@@ -49,6 +50,7 @@ export function BottomNav() {
           to="/"
           aria-label="Pokedex"
           title="Pokedex"
+          aria-current={isDex ? 'page' : undefined}
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isDex ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
@@ -68,6 +70,7 @@ export function BottomNav() {
           to="/storage"
           aria-label="Storage"
           title="Storage"
+          aria-current={isStorage ? 'page' : undefined}
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isStorage ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
@@ -87,6 +90,7 @@ export function BottomNav() {
           to="/assistant"
           aria-label="Assistant"
           title="Assistant"
+          aria-current={isAssistant ? 'page' : undefined}
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isAssistant ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
@@ -106,6 +110,7 @@ export function BottomNav() {
           to="/dag"
           aria-label="DAG"
           title="DAG"
+          aria-current={isDag ? 'page' : undefined}
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
             isDag ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
@@ -126,6 +131,7 @@ export function BottomNav() {
           onClick={() => setIsSettingsOpen(true)}
           aria-label="Open settings menu"
           title="Open settings menu"
+          aria-expanded={isSettingsOpen}
           className="group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 text-zinc-600 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
           <div className="transition-transform active:scale-90">


### PR DESCRIPTION
Added `aria-current="page"` to active links in navigation for screen reader accessibility. Also used `aria-expanded` on the settings button to improve the accessibility of the UI. This enhances the micro-UX and improves the overall tactical hardware aesthetic by keeping it functional and accessible.

---
*PR created automatically by Jules for task [2441095765496799385](https://jules.google.com/task/2441095765496799385) started by @szubster*