### PR TITLE
Fix broken link in story-029-054 metadata

### DIFF
--- a/.foundry/stories/story-029-054-gen2-strategy-plugin.md
+++ b/.foundry/stories/story-029-054-gen2-strategy-plugin.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-05-16'
 updated_at: '2026-05-16'
 depends_on:
-  - .foundry/stories/story-028-048-gen2-map-routing.md
+  - .foundry/stories/story-028-045-cross-region-distance.md
 jules_session_id: null
 pr_number: null
 parent: .foundry/epics/epic-017-029-strategy-engine-adaptations.md


### PR DESCRIPTION
Fixed a broken file reference in the metadata of the Gen 2 Strategy Plugin story. The original reference pointed to a non-existent file, causing pre-commit hooks to fail. Updated it to point to the correct existing dependency. Verified with link-checker and schema validation scripts.

Fixes #1380

---
*PR created automatically by Jules for task [2556721312415884017](https://jules.google.com/task/2556721312415884017) started by @szubster*