### PR TITLE
🧪 Sentinel: Add boundary test for resolveOutdoorMapId

### DIFF
--- a/src/engine/mapGraph/gen1Graph.test.ts
+++ b/src/engine/mapGraph/gen1Graph.test.ts
@@ -109,4 +109,10 @@ describe('resolveOutdoorMapId', () => {
     // so it breaks loop when currentMapId becomes 0x90 again, returning 0x90.
     expect(result).toBe(0x90);
   });
+
+  it('gracefully returns original mapId if location is not found', () => {
+    // 0x999 does not exist in mockLocations
+    const result = resolveOutdoorMapId(mockLocations, 0x999);
+    expect(result).toBe(0x999);
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added a missing boundary test for `resolveOutdoorMapId` in `Gen1Graph` to verify its behavior when an unknown location ID is provided.

📊 **Coverage:** The new test covers the specific edge case where `resolveOutdoorMapId` receives a map ID (`0x999`) that does not exist in the internal `mockLocations` or real graph. It asserts that the function gracefully returns the same original ID instead of throwing an error or hanging.

✨ **Result:** Test coverage and confidence in the graph traversal engine are improved. The boundary conditions are now explicitly guaranteed by the Vitest suite.

---
*PR created automatically by Jules for task [13836198402487073276](https://jules.google.com/task/13836198402487073276) started by @szubster*