### PR TITLE
Architect: Define Gen3 Data Parsing ADR

### DIFF
--- a/.foundry/docs/adrs/010-gen3-data-parsing.md
+++ b/.foundry/docs/adrs/010-gen3-data-parsing.md
@@ -1,0 +1,17 @@
+# ADR 010: Gen3 Data Parsing Strategy
+
+## Status
+Accepted
+
+## Context
+As part of the Gen3 support expansion (Ruby, Sapphire, Emerald, FireRed, LeafGreen), we need to handle parsing save files that have different internal structures compared to Gen 1 and Gen 2. Previous generations recently migrated from `Uint8Array` to `DataView` for robustness and native bounds checking (as documented in `save_parser/dataview_migration.md`). The Gen3 data parsing must align with this architectural pattern to maintain system-wide consistency, safety against corrupted files, and long-term maintainability.
+
+## Decision
+1. **Mandate `DataView` API**: All new Gen3 save parsing logic MUST exclusively use the native `DataView` API (e.g., `getUint8`, `getUint16`, `getUint32`) rather than raw `Uint8Array` manipulations.
+2. **Bounds Checking & Graceful Failures**: The parser must rely on `DataView` to throw `RangeError` on out-of-bounds reads. These must be caught explicitly by the parser engine, and gracefully propagated up as specific validation errors (e.g., "Corrupted Save File"), rather than crashing the application or returning malformed data.
+3. **Backwards Compatibility**: Implement the Gen3 parsing handlers alongside the existing Gen 1 and Gen 2 handlers without altering the legacy parsing interfaces. This ensures the backwards compatibility mandated by PRD 053-022.
+
+## Consequences
+- **Positive**: Prevents silent failures and corrupted data rendering when parsing truncated or malformed Gen3 save files.
+- **Positive**: Maintains architectural consistency with the rest of the parsing engine, reducing technical debt.
+- **Negative**: The `DataView` API can be slightly more verbose to write than raw array access, but this is an acceptable trade-off for safety.

--- a/.foundry/prd-053-022-gen3-data-parsing.md
+++ b/.foundry/prd-053-022-gen3-data-parsing.md
@@ -1,0 +1,30 @@
+---
+id: prd-053-022-gen3-data-parsing
+type: PRD
+title: Gen3 Data Parsing
+status: READY
+owner_persona: architect
+created_at: '2026-05-17'
+updated_at: '2026-05-17'
+depends_on: []
+jules_session_id: null
+parent: idea-053-gen3-support
+tags:
+  - gen3
+  - feature
+notes: Spawned from Idea 053
+---
+
+# PRD: Gen3 Data Parsing
+
+## Context
+As part of adding Gen3 support, we need to adapt our data parsing strategy to handle the Gen3 format.
+
+## Requirements
+- Implement data parsers to handle Gen3 format.
+- Ensure backwards compatibility with Gen 1 and Gen 2 logic.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md
+
+- [.foundry/docs/adrs/010-gen3-data-parsing.md](.foundry/docs/adrs/010-gen3-data-parsing.md)


### PR DESCRIPTION
As the Architect, I created ADR 010 to document the technical strategy for parsing Gen3 save files. 
The strategy requires the use of the `DataView` API for safe binary parsing, error handling practices, and backward compatibility. 
I linked this new ADR to the assigned PRD without modifying any YAML frontmatter, according to the system rules.

---
*PR created automatically by Jules for task [1288261935948782707](https://jules.google.com/task/1288261935948782707) started by @szubster*