### PR TITLE
Draft ADR 010 for Gen 3 Map Graph Design and breakdown PRD into epic

### DIFF
--- a/.foundry/docs/adrs/010-gen3-map-graph-design.md
+++ b/.foundry/docs/adrs/010-gen3-map-graph-design.md
@@ -1,0 +1,22 @@
+# ADR 010: Gen 3 Map Graph Design
+
+## Date
+2026-05-17
+
+## Status
+Accepted
+
+## Context
+Generation 3 encompasses games set in two different regions: Hoenn (Ruby, Sapphire, Emerald) and Kanto (FireRed, LeafGreen). To provide accurate traversal, location resolution, and distance calculations for Gen 3 encounters, we must design a unified map graph architecture that supports both regions while maintaining compatibility with the existing `getDistanceToMap` and `resolveOutdoorMapId` patterns established in `gen1Graph.ts` and `gen2Graph.ts`.
+
+## Decision
+We will create a unified `gen3Graph.ts` file within `src/engine/mapGraph/`.
+This module will:
+1.  **Implement `getDistanceToMap`**: This function will take a `startMapId` and `targetAid`. It will use a precomputed Floyd-Warshall distance lookup stored on the `UnifiedLocation` objects (via the `dist` array), ensuring O(1) performance during strategy evaluation.
+2.  **Implement `resolveOutdoorMapId`**: This function will map indoor locations (like houses or caves) to their outdoor parent hubs by recursively traversing the `prnt` property on the location objects, just as in previous generations.
+3.  **Define Map Connectivity Constants**: We will export structural definitions (e.g., `gen3HoennMapGraph` and `gen3KantoMapGraph` if needed) that define the logical connections between map nodes (routes, cities, landmarks) for both the Hoenn region and the revamped Kanto region (including the Sevii Islands if applicable). Note that the real-time pathfinding is skipped in favor of the build-time distance matrix, but these definitions are critical for visual dashboard rendering and fallback resolution logic.
+
+## Consequences
+-   **Positive**: Adheres to the established architecture for O(1) distance lookups, keeping the suggestion engine performant.
+-   **Positive**: Consolidates Gen 3 map logic into a single cohesive module, simplifying strategy development for RSE and FRLG.
+-   **Negative**: FRLG uses a different Kanto map layout (with Sevii Islands) than Gen 1 (RBY) or Gen 2 (GSC), meaning the Kanto graph definition within Gen 3 will be distinct from the others, slightly increasing the maintenance overhead of map topologies.

--- a/.foundry/epics/epic-053-032-gen3-map-graph-routing.md
+++ b/.foundry/epics/epic-053-032-gen3-map-graph-routing.md
@@ -1,0 +1,38 @@
+---
+id: epic-053-032-gen3-map-graph-routing
+type: EPIC
+title: 'Gen 3 Map Graph Routing'
+status: PENDING
+owner_persona: planner
+created_at: '2026-05-17'
+updated_at: '2026-05-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-053-023-gen3-map-graph
+tags:
+  - gen3
+  - map-graph
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: 'Created by architect.'
+---
+
+# Epic: Gen 3 Map Graph Routing
+
+## Objective
+Implement the map graph for Generation 3, supporting routing and distance calculation for both Hoenn (Ruby, Sapphire, Emerald) and Kanto (FireRed, LeafGreen).
+
+## Requirements
+- **Gen 3 Map Graph**: Create a unified map graph structure in `src/engine/mapGraph/gen3Graph.ts` covering Hoenn and Kanto.
+- **Indoor to Outdoor Resolution**: Implement `resolveOutdoorMapId` mapped to Gen 3 map ID structures.
+- **Cross-Region/Distance Lookup**: Implement `getDistanceToMap` algorithms leveraging the precomputed Floyd-Warshall distance lookup matrix for Gen 3.
+
+## Acceptance Criteria
+- [ ] `gen3Graph.ts` is implemented and unit tested.
+- [ ] `resolveOutdoorMapId` accurately determines the outdoor parent map ID for both Hoenn and Kanto Gen 3 internal structures.
+- [ ] `getDistanceToMap` yields accurate distances to target areas.
+
+## Created Stories
+<!-- Planner will add stories here -->

--- a/.foundry/prds/prd-053-023-gen3-map-graph.md
+++ b/.foundry/prds/prd-053-023-gen3-map-graph.md
@@ -23,3 +23,6 @@ Generation 3 (Ruby, Sapphire, Emerald, FireRed, LeafGreen) requires new map grap
 ## Requirements
 - Design the map graph for Gen 3.
 - Implement map generation/resolution for Gen 3.
+
+## Created Epics
+- [.foundry/epics/epic-053-032-gen3-map-graph-routing.md](.foundry/epics/epic-053-032-gen3-map-graph-routing.md)


### PR DESCRIPTION
This PR addresses the Gen3 Map Graph Design PRD.

As the architect, I have:
1. Created `ADR 010` outlining the strategy for the Gen 3 Map Graph, detailing how `getDistanceToMap` and `resolveOutdoorMapId` should be implemented to unify Hoenn and Kanto routing within a single `gen3Graph.ts` file, leveraging the precomputed Floyd-Warshall distance lookup matrix for O(1) performance.
2. Created a new Epic (`epic-053-032-gen3-map-graph-routing.md`) assigned to the `planner` persona to break down the implementation tasks.
3. Updated the PRD node (`prd-053-023-gen3-map-graph.md`) to link to the newly created Epic without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [14274109464458264933](https://jules.google.com/task/14274109464458264933) started by @szubster*