### PR TITLE
fix(foundry): correct owner_persona mapping for Gen3 epics

### DIFF
--- a/.foundry/epics/epic-022-032-gen3-data-parsing.md
+++ b/.foundry/epics/epic-022-032-gen3-data-parsing.md
@@ -3,7 +3,7 @@ id: epic-022-032-gen3-data-parsing
 type: EPIC
 title: "Gen3 Data Parsing Implementation"
 status: PENDING
-owner_persona: "planner"
+owner_persona: epic_planner
 created_at: "2026-05-17"
 updated_at: "2026-05-17"
 depends_on: []

--- a/.foundry/epics/epic-053-032-gen3-map-graph-routing.md
+++ b/.foundry/epics/epic-053-032-gen3-map-graph-routing.md
@@ -3,7 +3,7 @@ id: epic-053-032-gen3-map-graph-routing
 type: EPIC
 title: 'Gen 3 Map Graph Routing'
 status: PENDING
-owner_persona: planner
+owner_persona: epic_planner
 created_at: '2026-05-17'
 updated_at: '2026-05-17'
 depends_on: []


### PR DESCRIPTION
Corrected `owner_persona` from `planner` to `epic_planner` in Gen3 EPIC nodes to resolve orchestrator validation warnings. The `planner` persona is not a valid mapping for EPIC type nodes according to the Foundry schema.

Modified files:
- `.foundry/epics/epic-022-032-gen3-data-parsing.md`
- `.foundry/epics/epic-053-032-gen3-map-graph-routing.md`

Fixes #1401

---
*PR created automatically by Jules for task [8998392829631842918](https://jules.google.com/task/8998392829631842918) started by @szubster*