### PR TITLE
🛠️ Agile Coach: Instruct agents to submit Empty PRs to prevent zombie sessions

### DIFF
--- a/.foundry/ideas/idea-054-robust-session-completion.md
+++ b/.foundry/ideas/idea-054-robust-session-completion.md
@@ -1,0 +1,39 @@
+---
+id: idea-054-robust-session-completion
+type: IDEA
+title: 'Robust Handling of Session Completion in Heartbeat'
+status: "PENDING"
+owner_persona: product_manager
+created_at: '2026-05-18'
+updated_at: "2026-05-18"
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - heartbeat
+notes: ''
+---
+
+# Idea: Robust Handling of Session Completion in Heartbeat
+
+## Context
+Currently, the `foundry-heartbeat.ts` script checks the status of Jules sessions via the Jules API. If the API reports a state of `COMPLETED`, but no GitHub pull request is found in the session outputs or via GitHub search, the heartbeat script treats this as a zombie or crashed session and transitions the corresponding task node to `FAILED` with the reason "Session terminated with state: COMPLETED".
+
+This incorrectly punishes agents who successfully complete their execution but, for legitimate reasons (e.g. following the Empty PR policy), do not generate a file diff. Often, Jules will simply complete the run without a PR if no edits are made and `submit` wasn't explicitly invoked with a branch.
+
+## Proposal
+We need to make the orchestrator's heartbeat script more robust when handling `COMPLETED` sessions without a Pull Request.
+
+1. **Verify Empty Run Success**: If a session is `COMPLETED` but no PR exists, the heartbeat should differentiate between a silent crash and a deliberate Empty PR action.
+2. **Auto-Complete Empty Runs**: Since the task might have been marked as needing an Empty PR (where zero files were changed because the target was already valid), the orchestrator should gracefully allow these tasks to be marked `COMPLETED` instead of `FAILED`, provided they don't violate the acceptance criteria rule (ADR 007/009).
+
+## Impact
+- Prevents agents from getting caught in endless Resurrection Loops for tasks that have actually succeeded but required no code changes.
+- Reduces manual TPM/CEO intervention for false-positive FAILED nodes.
+- Makes the empty PR workflow smoother.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea to a PRD.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -96,3 +96,11 @@ I noticed that `task-051-087-implement-core-graph-visualizer` was rejected by QA
 ### Action Taken
 1. Updated `.github/agents/coder.md` to explicitly list the UI Aesthetic Constraints (ADR 008), strongly instructing the agent to use `rounded-none` and explicitly avoid `rounded-t`, `rounded-b`, or `rounded-sm`.
 2. Created a new task `.foundry/tasks/task-051-089-fix-core-graph-visualizer-aesthetic.md` to cleanly delegate the specific UI fixes (`src/components/dag/DagNode.tsx` and `src/components/TelemetryDecoration.tsx`) back to the coder rather than attempting to modify application source code myself.
+
+## 2026-05-18 - Robust Empty PR Handling
+### Observation
+Noticed that `task-053-092-implement-dependency-highlighting.md` failed with the rejection reason 'Session terminated with state: COMPLETED'. The orchestrator heartbeat was incorrectly flagging sessions that finished successfully without creating a PR as crashed zombies. This negatively impacted agents following the Empty PR policy by creating endless Resurrection Loops.
+
+### Action Taken
+1. Added `CRITICAL INSTRUCTION FOR EMPTY PRs` to all execution and planning agent prompts (`coder.md`, `qa.md`, `tech_lead.md`, `story_owner.md`, `epic_planner.md`, `product_manager.md`). This explicitly instructs agents to use the `submit` tool to create a Pull Request even if zero files were changed to avoid the session being marked as a zombie.
+2. Generated `idea-054-robust-session-completion.md` to propose an update to the heartbeat script to properly differentiate between a crashed session and a legitimate empty run.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -47,4 +47,6 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
 
+**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
+
 **CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -45,4 +45,6 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
 
+**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
+
 **CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -38,4 +38,6 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
 
+**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
+
 **CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -57,4 +57,6 @@ If you reject an implementation or validation fails:
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
 
+**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
+
 **CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -43,4 +43,6 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
 
+**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
+
 **CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -51,4 +51,6 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
 
+**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
+
 **CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.


### PR DESCRIPTION
🛠️ Agile Coach: Instruct agents to submit Empty PRs to prevent zombie sessions

- Noticed `task-053-092` failed due to orchestrator marking it as a zombie because the agent finished execution without changing files and didn't submit a PR.
- Updated all planning and execution persona prompts (`coder.md`, `qa.md`, `tech_lead.md`, `story_owner.md`, `epic_planner.md`, `product_manager.md`) to instruct agents to explicitly use the `submit` tool even if 0 files changed.
- Generated `idea-054-robust-session-completion.md` to propose updating the heartbeat script to properly handle empty sessions.
- Logged findings to the `agile_coach.md` journal.

---
*PR created automatically by Jules for task [3691508589820407692](https://jules.google.com/task/3691508589820407692) started by @szubster*