### PR TITLE
Epic Breakdown: Gen3 Data Parsing Implementation

### DIFF
--- a/.foundry/epics/epic-022-032-gen3-data-parsing.md
+++ b/.foundry/epics/epic-022-032-gen3-data-parsing.md
@@ -28,3 +28,7 @@ Implement data parsers to handle Gen3 format while ensuring backwards compatibil
 - Setup parsing handlers using `DataView` API for Gen3 formats.
 - Add bounds checking that correctly handles out-of-bounds reads gracefully as per ADR-010.
 - Verify backwards compatibility for legacy interfaces.
+
+- [x] [story-032-059-gen3-dataview-scaffolding](.foundry/stories/story-032-059-gen3-dataview-scaffolding.md)
+- [x] [story-032-060-gen3-bounds-checking](.foundry/stories/story-032-060-gen3-bounds-checking.md)
+- [x] [story-032-061-gen3-legacy-compatibility](.foundry/stories/story-032-061-gen3-legacy-compatibility.md)

--- a/.foundry/stories/story-032-059-gen3-dataview-scaffolding.md
+++ b/.foundry/stories/story-032-059-gen3-dataview-scaffolding.md
@@ -1,0 +1,29 @@
+---
+id: story-032-059-gen3-dataview-scaffolding
+type: STORY
+title: Gen3 DataView Parser Scaffolding
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-17'
+updated_at: '2026-05-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-022-032-gen3-data-parsing
+tags:
+  - gen3
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: Story for setting up Gen3 data parsing handlers using DataView.
+---
+
+# Story: Gen3 DataView Parser Scaffolding
+
+## Objective
+Set up the initial parsing handlers for the Gen3 save format using the native `DataView` API.
+
+## Acceptance Criteria
+- [ ] Implement initial Gen3 `DataView` parsing scaffolding.
+- [ ] Ensure that new functions and handlers strictly follow the native API pattern.

--- a/.foundry/stories/story-032-060-gen3-bounds-checking.md
+++ b/.foundry/stories/story-032-060-gen3-bounds-checking.md
@@ -1,0 +1,30 @@
+---
+id: story-032-060-gen3-bounds-checking
+type: STORY
+title: Gen3 Bounds Checking Implementation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-17'
+updated_at: '2026-05-17'
+depends_on:
+  - .foundry/stories/story-032-059-gen3-dataview-scaffolding.md
+jules_session_id: null
+pr_number: null
+parent: epic-022-032-gen3-data-parsing
+tags:
+  - gen3
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: Story for adding bounds checking to Gen3 parsing.
+---
+
+# Story: Gen3 Bounds Checking Implementation
+
+## Objective
+Add bounds checking to the Gen3 data parsing logic to gracefully handle out-of-bounds reads.
+
+## Acceptance Criteria
+- [ ] Implement `try...catch` blocks or appropriate mechanisms to catch `RangeError` from `DataView` operations.
+- [ ] Propagate validation errors gracefully (e.g., "Corrupted Save File") when bounds are exceeded as per ADR-010.

--- a/.foundry/stories/story-032-061-gen3-legacy-compatibility.md
+++ b/.foundry/stories/story-032-061-gen3-legacy-compatibility.md
@@ -1,0 +1,30 @@
+---
+id: story-032-061-gen3-legacy-compatibility
+type: STORY
+title: Gen3 Data Parsing Legacy Compatibility Verification
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-17'
+updated_at: '2026-05-17'
+depends_on:
+  - .foundry/stories/story-032-060-gen3-bounds-checking.md
+jules_session_id: null
+pr_number: null
+parent: epic-022-032-gen3-data-parsing
+tags:
+  - gen3
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: Story for verifying Gen 1 and Gen 2 legacy interfaces.
+---
+
+# Story: Gen3 Data Parsing Legacy Compatibility Verification
+
+## Objective
+Ensure that the newly implemented Gen3 data parsing logic does not break existing Gen 1 and Gen 2 parsing functionality.
+
+## Acceptance Criteria
+- [ ] Verify that Gen 1 and Gen 2 parsing interfaces continue to function normally.
+- [ ] Implement or update integration tests to confirm legacy backwards compatibility.


### PR DESCRIPTION
- Created 3 granular Story nodes (`story-032-059`, `story-032-060`, `story-032-061`) for Gen3 DataView scaffolding, bounds checking, and legacy compatibility.
- Set up sequential `depends_on` chains across the new stories.
- Updated the parent Epic `epic-022-032-gen3-data-parsing.md` by appending the new stories as checked-off Acceptance Criteria without altering its YAML frontmatter.

---
*PR created automatically by Jules for task [13818327627020265328](https://jules.google.com/task/13818327627020265328) started by @szubster*