### PR TITLE
feat: add no-ask-rules.md to force agents to communicate via PRs and late binding

### DIFF
--- a/.agents/rules/no_ask_rules.md
+++ b/.agents/rules/no_ask_rules.md
@@ -4,7 +4,7 @@ trigger: "@Jules"
 
 # Communication Rules for Jules
 
-You are Jules. You must NOT ask the user for permission, input, or clarification during execution unless explicitly requested by the initial prompt.
+If you are Jules, you must NOT ask the user for permission, input, or clarification during execution unless explicitly requested by the initial prompt.
 
 1. **Interact via PRs, not chat:** Your goal is to produce pull requests and code modifications autonomously.
 2. **Utilize Late Binding for Unknowns:** If you do not know something or lack context to proceed:

--- a/.agents/rules/no_ask_rules.md
+++ b/.agents/rules/no_ask_rules.md
@@ -1,10 +1,10 @@
 ---
-trigger: always_on
+trigger: "@Jules"
 ---
 
-# Communication Rules
+# Communication Rules for Jules
 
-You must NOT ask the user for permission, input, or clarification during execution unless explicitly requested by the initial prompt.
+You are Jules. You must NOT ask the user for permission, input, or clarification during execution unless explicitly requested by the initial prompt.
 
 1. **Interact via PRs, not chat:** Your goal is to produce pull requests and code modifications autonomously.
 2. **Utilize Late Binding for Unknowns:** If you do not know something or lack context to proceed:

--- a/.agents/rules/no_ask_rules.md
+++ b/.agents/rules/no_ask_rules.md
@@ -1,0 +1,14 @@
+---
+trigger: always_on
+---
+
+# Communication Rules
+
+You must NOT ask the user for permission, input, or clarification during execution unless explicitly requested by the initial prompt.
+
+1. **Interact via PRs, not chat:** Your goal is to produce pull requests and code modifications autonomously.
+2. **Utilize Late Binding for Unknowns:** If you do not know something or lack context to proceed:
+   - Do NOT ask the user.
+   - Instead, create a new Foundry node (e.g., an `IDEA`, `RESEARCH`, `ADR`, or `TASK` node depending on the scope) in `.foundry/`.
+   - Set the `owner_persona` of the new node to an appropriate persona (like `architect`, `researcher`, `story_owner`, etc.) so that the issue can be investigated and resolved via the late binding orchestration process.
+   - Ensure you follow the correct Foundry directory structure and metadata conventions when creating these nodes.


### PR DESCRIPTION
Creates `.agents/rules/no_ask_rules.md` to instruct agents that they must not
ask the user for permission or input. Instead, they must submit PRs autonomously
and handle any unknowns or blockers by dynamically creating appropriate Foundry
nodes (`IDEA`, `RESEARCH`, `ADR`, `TASK`) using the late binding architecture.

---
*PR created automatically by Jules for task [1101178674356312758](https://jules.google.com/task/1101178674356312758) started by @szubster*