### PR TITLE
Epic Planner: Gen 3 encounters breakdown

### DIFF
--- a/.foundry/epics/epic-053-024-032-gen3-encounters-implementation.md
+++ b/.foundry/epics/epic-053-024-032-gen3-encounters-implementation.md
@@ -26,6 +26,11 @@ As part of adding Gen 3 support, we must implement parsing and integrations for 
 - Create stories to switch JSON generation and loading to MsgPack.
 
 ## Acceptance Criteria
-- [ ] Stories are created to update data generation scripts for Gen 3.
-- [ ] Stories are created to integrate Gen 3 encounter data.
-- [ ] Stories are created to implement the MsgPack transition (ADR 010).
+- [x] Stories are created to update data generation scripts for Gen 3.
+- [x] Stories are created to integrate Gen 3 encounter data.
+- [x] Stories are created to implement the MsgPack transition (ADR 010).
+
+## Generated Stories
+- story-032-062-gen3-data-generation-scripts
+- story-032-063-gen3-msgpack-transition
+- story-032-064-gen3-encounter-integration

--- a/.foundry/stories/story-032-062-gen3-data-generation-scripts.md
+++ b/.foundry/stories/story-032-062-gen3-data-generation-scripts.md
@@ -1,0 +1,28 @@
+---
+id: story-032-062-gen3-data-generation-scripts
+type: STORY
+title: Update Data Generation Scripts for Gen 3
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-05-17"
+updated_at: "2026-05-17"
+depends_on: []
+jules_session_id: null
+parent: epic-053-024-032-gen3-encounters-implementation
+tags:
+  - gen3
+  - data
+  - msgpack
+notes: ""
+---
+
+# Update Data Generation Scripts for Gen 3
+
+## Description
+Modify existing data generation scripts to support fetching and formatting Gen 3 locations, encounters, and pokemon data.
+
+## Acceptance Criteria
+- [ ] Scripts can fetch Gen 3 locations from API/source.
+- [ ] Scripts can fetch Gen 3 encounters from API/source.
+- [ ] Scripts can fetch Gen 3 pokemon data from API/source.
+- [ ] Data is formatted correctly for ingestion.

--- a/.foundry/stories/story-032-063-gen3-msgpack-transition.md
+++ b/.foundry/stories/story-032-063-gen3-msgpack-transition.md
@@ -1,0 +1,28 @@
+---
+id: story-032-063-gen3-msgpack-transition
+type: STORY
+title: Implement MsgPack Transition for Data Serialization
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-05-17"
+updated_at: "2026-05-17"
+depends_on:
+  - story-032-062-gen3-data-generation-scripts
+jules_session_id: null
+parent: epic-053-024-032-gen3-encounters-implementation
+tags:
+  - gen3
+  - data
+  - msgpack
+notes: ""
+---
+
+# Implement MsgPack Transition for Data Serialization
+
+## Description
+Transition the data serialization layer from JSON to MsgPack to handle larger Gen 3 datasets efficiently, as mandated by ADR 010.
+
+## Acceptance Criteria
+- [ ] Data generation scripts output `.msgpack` files instead of `.json`.
+- [ ] Client-side loading logic is updated to fetch and decode MsgPack data using `msgpackr`.
+- [ ] Bundle size and parse time metrics are verified.

--- a/.foundry/stories/story-032-064-gen3-encounter-integration.md
+++ b/.foundry/stories/story-032-064-gen3-encounter-integration.md
@@ -1,0 +1,28 @@
+---
+id: story-032-064-gen3-encounter-integration
+type: STORY
+title: Integrate Gen 3 Encounter Data into Engine
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-05-17"
+updated_at: "2026-05-17"
+depends_on:
+  - story-032-063-gen3-msgpack-transition
+  - story-032-062-gen3-data-generation-scripts
+jules_session_id: null
+parent: epic-053-024-032-gen3-encounters-implementation
+tags:
+  - gen3
+  - data
+  - msgpack
+notes: ""
+---
+
+# Integrate Gen 3 Encounter Data into Engine
+
+## Description
+Integrate the newly parsed Gen 3 encounter data into the suggestion engine and map graph.
+
+## Acceptance Criteria
+- [ ] Suggestion engine correctly utilizes Gen 3 encounter data.
+- [ ] Location and encounter routing is aware of Gen 3 specific mechanics.


### PR DESCRIPTION
### Summary
This PR fulfills the Epic Planner duty by breaking down the "Gen 3 Encounters Implementation" epic into three distinct, sequentially dependent stories:
1. Data generation scraping (Story 062)
2. Msgpack transition per ADR 010 (Story 063)
3. Data integration (Story 064)

The parent epic's markdown body has been updated correctly without modifying the YAML frontmatter. No test regressions occurred.

---
*PR created automatically by Jules for task [9704321539613106993](https://jules.google.com/task/9704321539613106993) started by @szubster*