### PR TITLE
💡 Visionary: Add IDEA node for Cloudflare syncing and progression

### DIFF
--- a/.foundry/ideas/idea-055-cloudflare-sync-and-future-features.md
+++ b/.foundry/ideas/idea-055-cloudflare-sync-and-future-features.md
@@ -1,0 +1,48 @@
+---
+id: idea-055-cloudflare-sync-and-future-features
+type: IDEA
+title: Cloudflare Backend for Offline-First Save Syncing and Future Progression Features
+status: ACTIVE
+owner_persona: product_manager
+created_at: '2024-05-18'
+updated_at: '2024-05-18'
+depends_on: []
+jules_session_id: 'unknown'
+parent: null
+tags:
+  - backend
+  - sync
+  - cloudflare
+  - authentication
+  - progression
+notes: ''
+rejection_reason: ''
+rejection_count: 0
+---
+
+# Idea: Cloudflare Backend for Offline-First Save Syncing and Future Progression Features
+
+## Context
+Currently, our application relies completely on client-side state and browser storage. While this adheres strictly to our offline-first mandate, users cannot easily access their game states across multiple devices or browsers. To solve this, we want to introduce a server-side component utilizing the Cloudflare stack.
+
+The primary requirement is that the application **must remain client and offline-first**. The GitHub Pages deployment (or standard static deployment) must continue functioning purely as a browser-side application with zero server dependency.
+
+## Phase 1: Authentication & Basic Sync (No Cost)
+We want to introduce basic server functionality focusing initially on minimal infrastructure costs.
+- **SSO Login:** Implement Single Sign-On (SSO) starting with Google Authentication. This will be restricted to a single user initially to establish the foundation.
+- **Save Syncing:** Store user save files in Cloudflare (e.g., using Workers KV, R2, or D1 depending on research) to enable synchronization.
+- **Cross-Device Sync:** When a user logs in from another browser or device, the application should pull their save data from the Cloudflare server, ensuring consistency across devices.
+- **Extensive Research Required:** We need to carefully research which Cloudflare products fit our "no cost" initial requirement while seamlessly integrating with our offline-first architecture. Downstream RESEARCH nodes should be created to determine the best approach.
+
+## Phase 2: Future Roadmap
+Once Phase 1 is stable, we plan to tackle the following features. The current architecture should be designed with these in mind:
+- **Progression Tracking:** Support multiple save files per playthrough, allowing users to track their progression over time.
+- **Multiple Playthroughs:** Support for concurrently managing states across different games (e.g., Pokémon Red, Diamond, Emerald).
+- **Pokémon Trading (Inter-Save):** Allow users to transfer Pokémon between their different playthroughs (similar to PKHeX), enforcing all necessary game and generation rules.
+
+## Approach
+This is a long-term architectural shift. There is no rush.
+We should prioritize extensive research, utilize late binding to spin off specific `RESEARCH` nodes for Cloudflare services and offline-sync conflict resolution, and iteratively design the system to accommodate the Phase 2 roadmap.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD.


### PR DESCRIPTION
Creates an IDEA node outlining the long-term plan to introduce Cloudflare-backed syncing and SSO authentication while maintaining the offline-first/client-heavy architecture. Details the free-tier phase 1 and the complex future phase 2 (progression tracking, inter-game trading) and emphasizes an un-rushed, research-first approach using late-binding.

---
*PR created automatically by Jules for task [5042370126648742446](https://jules.google.com/task/5042370126648742446) started by @szubster*