### PR TITLE
Agile Coach: Fix Empty PR Bug & Unify Agent Policies

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -1,0 +1,12 @@
+# Core Agent Policies
+
+## Environment Troubleshooting
+If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
+If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
+
+## Empty PR Policy
+Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+
+**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
+
+**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -104,3 +104,12 @@ Noticed that `task-053-092-implement-dependency-highlighting.md` failed with the
 ### Action Taken
 1. Added `CRITICAL INSTRUCTION FOR EMPTY PRs` to all execution and planning agent prompts (`coder.md`, `qa.md`, `tech_lead.md`, `story_owner.md`, `epic_planner.md`, `product_manager.md`). This explicitly instructs agents to use the `submit` tool to create a Pull Request even if zero files were changed to avoid the session being marked as a zombie.
 2. Generated `idea-054-robust-session-completion.md` to propose an update to the heartbeat script to properly differentiate between a crashed session and a legitimate empty run.
+
+## 2026-05-18 - Fix Empty PR Termination Bug & Proactive Architecture Improvements
+### Observation
+I noticed that `task-053-092-implement-dependency-highlighting.md` failed with the rejection reason 'Session terminated with state: COMPLETED'. The orchestrator heartbeat was incorrectly flagging sessions that finished successfully without creating a PR as crashed zombies. This negatively impacted agents following the Empty PR policy by creating endless Resurrection Loops. Also noted that many duplicate core policies exist across all `.github/agents/*.md`.
+
+### Action Taken
+1. Directly modified `.github/scripts/foundry-heartbeat.ts` to differentiate between a successful Empty PR (`sessionStatus === 'COMPLETED'`) and a crashed zombie session (`NOT_FOUND` or other terminal states).
+2. Created `.foundry/docs/knowledge_base/agents/core_policies.md` to centralize Empty PR and Environment Troubleshooting policies.
+3. Updated all `.github/agents/*.md` prompt files to reference this centralized core policies document, removing duplicate instructions to improve agent prompt context efficiency.

--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -22,7 +22,6 @@ You are the Agile Coach of The Foundry. You run on a daily or weekly schedule as
 6.  Autonomously generate new `IDEA` or `TASK` nodes to represent larger architectural or process improvements derived from observed friction.
 7.  Submit a PR with your proposed improvements and any newly generated nodes, clearly detailing the "why" based on your analysis or creative insight.
 
-
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
@@ -36,8 +35,6 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/agile_coach.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
-
-**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -17,7 +17,6 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 4.  Produce architectural reviews, updated schemas, or new ADRs as required.
 5.  Commit your work to the repository.
 
-
 **NODE CREATION GUIDELINES:**
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
 
@@ -27,16 +26,10 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 - WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
-## Environment Troubleshooting
-If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
-If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/architect.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
-
-**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -10,12 +10,6 @@ When you begin your session, you **must explicitly read** all documents under th
 
 Ensure you are fully aware of and adhere to the rules outlined in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
 
-
-
-## Environment Troubleshooting
-If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
-If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
-
 ## Foundry Orchestrator Updates
 When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.ts`), ensure that any test fixtures in `.github/scripts/foundry-orchestrator.test.ts` are updated with valid `owner_persona` mappings (e.g., `IDEA` -> `product_manager`, `TASK` -> `coder`) to pass the Phase 4.8 Mapping Validation checks.
 
@@ -44,9 +38,6 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 - WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
-**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
-
-**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -17,7 +17,6 @@ Produce clean, well-structured markdown files for each Epic, ensuring they align
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
-
 **NODE CREATION GUIDELINES:**
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
 
@@ -32,19 +31,12 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 
 - If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 
-## Environment Troubleshooting
-If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
-If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/epic_planner.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 - WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
-**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
-
-**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -6,13 +6,11 @@ When you begin your session, you must explicitly read all documents under `.foun
 
 You must strictly adhere to the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
 
-
 **NODE CREATION GUIDELINES:**
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
-
 
 **NODE GENERATION RULES:**
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
@@ -25,19 +23,12 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
 - If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 
-## Environment Troubleshooting
-If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
-If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/product_manager.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 - WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
-**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
-
-**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -22,17 +22,6 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/001-the-f
 3. **Approval/Rejection**: If the implementation is valid, approve it. If not, detail what is missing or incorrect according to the contract and architecture.
 4. **Specify Results**: Explicitly specify the results of your validation work. Depending on the scope and need for further analysis, this output can include new tests, documentation updates, or the creation of new tasks, stories, PRDs, or ideas.
 
-
-
-## Environment Troubleshooting
-If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
-If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
-
-**CRITICAL CONTEXT GATHERING INSTRUCTION:**
-When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
-
-- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
-
 ## Quality Assurance
 Before approving a task, you MUST run `pnpm lint && pnpm test` to ensure project health and verify that no regressions are introduced by the implementer.
 To automatically fix code formatting errors flagged by Biome during lint checks, run `pnpm check:fix` or `pnpm format:biome`.
@@ -54,9 +43,6 @@ If you reject an implementation or validation fails:
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed task.
 4. You MUST document the rejection in your persona journal.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
-**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
-
-**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/researcher.md
+++ b/.github/agents/researcher.md
@@ -17,21 +17,10 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/004-resea
 - **Context Synthesis**: Organize your findings into clear, structured, and actionable research reports.
 - **Knowledge Base Contribution**: When your findings establish new, lasting facts or patterns about the project, update or create relevant documentation in `.foundry/docs/knowledge_base/`.
 
-## Environment Troubleshooting
-If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
-If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
-
-**CRITICAL CONTEXT GATHERING INSTRUCTION:**
-When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
-
-**NODE CREATION GUIDELINES:**
-While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/researcher.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
-**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -11,13 +11,11 @@ As the Story Owner, your role is to monitor active epics and write STORY nodes d
 You must be thoroughly aware of and strictly adhere to the rules outlined in:
 `.foundry/docs/adrs/001-the-foundry-architecture.md`
 
-
 **NODE CREATION GUIDELINES:**
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
-
 
 **NODE GENERATION RULES:**
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
@@ -30,19 +28,12 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 - If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 
-## Environment Troubleshooting
-If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
-If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/story_owner.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 - WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
-**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
-
-**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -20,13 +20,11 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 3.  Draft one or more TASK nodes that implement the story, deciding via the Intelligent Verification Protocol whether a separate QA TASK is required.
 4.  Commit the new TASK nodes to the repository.
 
-
 **NODE CREATION GUIDELINES:**
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
-
 
 **NODE GENERATION RULES:**
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
@@ -38,19 +36,12 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 - If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 
-## Environment Troubleshooting
-If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
-If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/tech_lead.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 - WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
-**CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
-
-**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -17,10 +17,8 @@ When you begin your session, you **must explicitly read** all documents under th
 Ensure you are completely aware of the rules defined in:
 - `.foundry/docs/adrs/001-the-foundry-architecture.md`
 
-
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
-
 
 **ARCHIVING RULES:**
 - Do not archive a parent node (e.g., an EPIC) if any of its child nodes (e.g., STORY, TASK) are still active or pending.
@@ -29,19 +27,10 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 - WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
-## Environment Troubleshooting
-If `pnpm install` fails due to an unsupported Node engine version mismatch (e.g., `wanted: {"node":">=24.0.0"}`), temporarily disable the strict check using `pnpm config set engine-strict false` before installing.
-If `pnpm install` hangs or fails during `lefthook install` or git hook setup, run `git config --unset-all --global core.hooksPath` before retrying the installation.
-
-**NODE CREATION GUIDELINES:**
-While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/tpm.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
-
-**CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -55,7 +55,7 @@ export async function transitionNodeToFailed(node: any, repoRoot: string, reject
 }
 
 /** Surgical mutation to COMPLETED or PENDING depending on tasks */
-export async function transitionNodeToCompleted(node: any, repoRoot: string, prNumber: number): Promise<void> {
+export async function transitionNodeToCompleted(node: any, repoRoot: string, prNumber: number | null): Promise<void> {
   const dateStr = todayISO();
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
@@ -68,7 +68,7 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
 
   let targetStatus = "COMPLETED";
   let rejectionReason = "";
-  let message = `PR #${prNumber} merged.`;
+  let message = prNumber !== null ? `PR #${prNumber} merged.` : `Empty PR session successfully completed.`;
 
   if (hasUncheckedTasks) {
     // Determine if it's a late-binding parent
@@ -109,7 +109,7 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
     fs.writeFileSync(node.filePath, newContent, 'utf-8');
     logToJournal(repoRoot, `\n- **${dateStr}**: ${message} \`${node.frontmatter.id}\` is now ${targetStatus}.\n`);
   }
-  info(`${dryTag}Transitioned ACTIVE → ${targetStatus}: ${node.repoPath} (PR #${prNumber})`);
+  info(`${dryTag}Transitioned ACTIVE → ${targetStatus}: ${node.repoPath} ${prNumber !== null ? `(PR #${prNumber})` : `(Empty PR)`}`);
 }
 
 /** Surgical mutation back to READY (Resurrection) */
@@ -310,7 +310,10 @@ export async function main() {
 
     // B. Terminal State check (Zombie detection)
     if (!isHuman) {
-      if (sessionStatus === 'NOT_FOUND' || (sessionStatus && TERMINAL_STATES.includes(sessionStatus))) {
+      if (sessionStatus === 'COMPLETED') {
+        info(`Session ${sessionId} successfully COMPLETED without a PR. Processing as Empty PR.`);
+        await transitionNodeToCompleted(node, repoRoot, null);
+      } else if (sessionStatus === 'NOT_FOUND' || (sessionStatus && TERMINAL_STATES.includes(sessionStatus))) {
         info(`Session ${sessionId} (Status: ${sessionStatus}) terminated without PR. Failing.`);
         await transitionNodeToFailed(node, repoRoot, `Session terminated with state: ${sessionStatus || 'NOT_FOUND'}`);
       } else if (updateTime) {


### PR DESCRIPTION
As the Agile Coach, I analyzed recent rejected tasks (`task-053-092`) and noticed that successful sessions making no file changes (Empty PR policy) were incorrectly flagged as crashed zombies by `foundry-heartbeat.ts`. I have directly modified `foundry-heartbeat.ts` to fix this bug.

I also observed duplicated policies across all agent prompts. To improve consistency, I created `.foundry/docs/knowledge_base/agents/core_policies.md` and updated all `.github/agents/*.md` files to reference it instead of duplicating text.

---
*PR created automatically by Jules for task [621690366591923634](https://jules.google.com/task/621690366591923634) started by @szubster*