### PR TITLE
Create ADR 011 for Robust Session Completion

### DIFF
--- a/.foundry/docs/adrs/011-robust-session-completion.md
+++ b/.foundry/docs/adrs/011-robust-session-completion.md
@@ -1,0 +1,49 @@
+---
+id: adr-011-robust-session-completion
+type: ADR
+title: Robust Handling of Session Completion in Heartbeat
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - heartbeat
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# ADR 011: Robust Handling of Session Completion in Heartbeat
+
+## Date
+2026-05-18
+
+## Status
+Accepted
+
+## Context
+Under the Foundry's "Empty PR" policy (ADR 009), agents submit an empty PR if the target artifact is already complete or no work is required. These PRs are auto-merged, and the DAG advances smoothly. However, sometimes agents simply finish their session (resulting in a Jules API state of `COMPLETED`) without opening an explicit Empty PR.
+
+Currently, `foundry-heartbeat.ts` evaluates Jules sessions by checking the Jules API and attempting to find an associated PR. If the API returns `COMPLETED` but no PR exists, the script considers the session a zombie or crashed run and defaults to transitioning the task node to `FAILED`. This logic unjustly penalizes legitimate empty runs and forces nodes into the Resurrection Loop needlessly.
+
+We need to differentiate between genuine crashes and correct but PR-less empty completions, and ensure these empty runs follow the exact same Acceptance Criteria validations introduced by ADR 007.
+
+## Decision
+1. **Graceful PR-less Completion**: If the Jules session API reports a state of `COMPLETED` but no PR is found, the heartbeat script MUST NOT automatically fail the node. Instead, it must initiate a graceful completion flow.
+2. **Acceptance Criteria Verification (ADR 007 Alignment)**: Before marking the PR-less node as `COMPLETED`, the heartbeat MUST parse the node's markdown content to verify compliance with ADR 007.
+   - If the node contains unchecked markdown tasks (`- [ ]`), the heartbeat must transition the node to `FAILED` with a `rejection_reason` indicating unfulfilled acceptance criteria.
+   - If the node is a valid late-binding parent (has children or is of type `IDEA`, `PRD`, `EPIC`, `STORY`), unchecked tasks serve as a signal to keep the node in a `PENDING` state to await child generation.
+   - If all tasks are checked off (or if there are no tasks), the heartbeat transitions the node to `COMPLETED`.
+3. **Journal Logging**: The heartbeat must explicitly log these PR-less `COMPLETED` state transitions in the TPM journal to ensure system state changes are auditable.
+
+## Consequences
+- **Positive**: Correctly honors agents that complete their tasks with zero file changes, reducing false failures.
+- **Positive**: Prevents endless Resurrection Loops for successfully analyzed but unedited nodes.
+- **Negative**: Increases the complexity of `foundry-heartbeat.ts` by requiring it to conditionally evaluate the PR existence and combine it with the markdown task validation logic.

--- a/.foundry/docs/adrs/011-robust-session-completion.md
+++ b/.foundry/docs/adrs/011-robust-session-completion.md
@@ -39,7 +39,7 @@ We need to differentiate between genuine crashes and correct but PR-less empty c
 1. **Graceful PR-less Completion**: If the Jules session API reports a state of `COMPLETED` but no PR is found, the heartbeat script MUST NOT automatically fail the node. Instead, it must initiate a graceful completion flow.
 2. **Acceptance Criteria Verification (ADR 007 Alignment)**: Before marking the PR-less node as `COMPLETED`, the heartbeat MUST parse the node's markdown content to verify compliance with ADR 007.
    - If the node contains unchecked markdown tasks (`- [ ]`), the heartbeat must transition the node to `FAILED` with a `rejection_reason` indicating unfulfilled acceptance criteria.
-   - If the node is a valid late-binding parent (has children or is of type `IDEA`, `PRD`, `EPIC`, `STORY`), unchecked tasks serve as a signal to keep the node in a `PENDING` state to await child generation.
+   - If the node is a valid late-binding parent (has children or is of type `IDEA`, `PRD`, `EPIC`, `STORY`), unchecked tasks serve as a signal to keep the node in a `PENDING` state to await child generation. Note that leaf tasks (like `TASK` or `RESEARCH`) may also use late binding, so if they have children, they should also be treated as late-binding parents.
    - If all tasks are checked off (or if there are no tasks), the heartbeat transitions the node to `COMPLETED`.
 3. **Journal Logging**: The heartbeat must explicitly log these PR-less `COMPLETED` state transitions in the TPM journal to ensure system state changes are auditable.
 

--- a/.foundry/epics/epic-025-033-robust-session-completion.md
+++ b/.foundry/epics/epic-025-033-robust-session-completion.md
@@ -7,7 +7,7 @@ owner_persona: epic_planner
 created_at: '2026-05-18'
 updated_at: '2026-05-18'
 depends_on:
-  - adr-011-robust-session-completion
+  - .foundry/docs/adrs/011-robust-session-completion.md
 jules_session_id: null
 pr_number: null
 parent: prd-054-025-robust-session-completion
@@ -37,7 +37,7 @@ We need to differentiate between a silent crash and a legitimate PR-less complet
 2. If `COMPLETED` and no PR, do not automatically mark as `FAILED`.
 3. Check the node's markdown content for unchecked acceptance criteria (`- [ ]`).
 4. If it's a leaf task with unchecked boxes, transition to `FAILED` with a `rejection_reason`.
-5. If it's a valid late-binding parent (has children or is of type `IDEA`, `PRD`, `EPIC`, `STORY`) with unchecked boxes, transition to `PENDING` (or remain `READY`).
+5. If it's a valid late-binding parent (has children or is of type `IDEA`, `PRD`, `EPIC`, `STORY`, or a `TASK`/`RESEARCH` that has generated children) with unchecked boxes, transition to `PENDING` (or remain `READY`).
 6. If all boxes are checked (or no boxes exist), transition the node gracefully to `COMPLETED`.
 7. Ensure adequate logging to the TPM journal for these PR-less completions.
 

--- a/.foundry/epics/epic-025-033-robust-session-completion.md
+++ b/.foundry/epics/epic-025-033-robust-session-completion.md
@@ -1,0 +1,48 @@
+---
+id: epic-025-033-robust-session-completion
+type: EPIC
+title: Implement Robust Session Completion in Heartbeat
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on:
+  - adr-011-robust-session-completion
+jules_session_id: null
+pr_number: null
+parent: prd-054-025-robust-session-completion
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - heartbeat
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Implement Robust Session Completion in Heartbeat
+
+## Objective
+Implement the changes described in ADR 011 and PRD 054-025 to enable the `foundry-heartbeat.ts` script to properly handle Jules sessions that complete successfully without opening a Pull Request.
+
+## Context
+Under the "Empty PR" policy, agents are allowed to complete tasks without making file changes if the artifact is already correct. Sometimes, they simply finish their session (Jules API state `COMPLETED`) without opening a PR. The current heartbeat script treats these as crashed sessions and fails the node.
+
+We need to differentiate between a silent crash and a legitimate PR-less completion. When the Jules API reports `COMPLETED` but no PR exists, we should evaluate the node according to the strict acceptance criteria validations outlined in ADR 007 and ADR 011.
+
+## Requirements
+
+1. Update `foundry-heartbeat.ts` to detect when a session is in the `COMPLETED` state but has no associated PR.
+2. If `COMPLETED` and no PR, do not automatically mark as `FAILED`.
+3. Check the node's markdown content for unchecked acceptance criteria (`- [ ]`).
+4. If it's a leaf task with unchecked boxes, transition to `FAILED` with a `rejection_reason`.
+5. If it's a valid late-binding parent (has children or is of type `IDEA`, `PRD`, `EPIC`, `STORY`) with unchecked boxes, transition to `PENDING` (or remain `READY`).
+6. If all boxes are checked (or no boxes exist), transition the node gracefully to `COMPLETED`.
+7. Ensure adequate logging to the TPM journal for these PR-less completions.
+
+## Acceptance Criteria
+- [ ] Heartbeat script correctly parses Jules session state even without a PR.
+- [ ] PR-less `COMPLETED` sessions for leaf tasks with unchecked boxes are marked `FAILED`.
+- [ ] PR-less `COMPLETED` sessions for leaf tasks with all boxes checked are marked `COMPLETED`.
+- [ ] Appropriate logs are written to `.foundry/journals/tpm.md`.

--- a/.foundry/journals/architect.md
+++ b/.foundry/journals/architect.md
@@ -25,3 +25,8 @@ Architects frequently perform evaluation tasks (e.g., assessing graph libraries,
 ## 2026-05-17
 * **MsgPack Transition for Gen 3:** As part of the Gen 3 data implementation, I created ADR 010 to mandate a shift from JSON to MsgPack (`msgpackr`) for data storage and hydration. As previously researched in `data_format_strategy.md`, expanding from ~177 KB of Gen 1-2 data up to the full Gen 3 size risks ballooning the bundle and slowing down client-side parsing. By making this transition now, we optimize application efficiency.
 - When referencing other nodes in YAML frontmatter fields like `parent` or `depends_on`, strictly use the exact node ID (e.g., `prd-053-022-gen3-data-parsing`) rather than the relative file path to avoid Groundedness Rule violations.
+
+
+## 2026-05-18: Robust Session Completion
+Created ADR 011 and Epic 025-033 to handle robust session completion in the heartbeat script.
+This addresses the issue where the orchestrator falsely marks empty PR runs as failed. The heartbeat will now correctly evaluate nodes with a COMPLETED Jules session state without a PR, applying ADR 007 acceptance criteria rules before transitioning the node state.

--- a/.foundry/prds/prd-054-025-robust-session-completion.md
+++ b/.foundry/prds/prd-054-025-robust-session-completion.md
@@ -45,4 +45,9 @@ However, under the "Empty PR" policy, agents are instructed to submit an empty P
 - Agents following the Empty PR policy will see their nodes correctly progress to `COMPLETED` without being trapped in the Resurrection Loop.
 
 ## Next Steps
-- [ ] Architect: Produce an Architecture Decision Record (ADR) detailing the technical implementation of this robust empty-run completion handling.
+- [x] Architect: Produce an Architecture Decision Record (ADR) detailing the technical implementation of this robust empty-run completion handling.
+
+
+## Downstream Nodes
+- ADR: `.foundry/docs/adrs/011-robust-session-completion.md`
+- EPIC: `.foundry/epics/epic-025-033-robust-session-completion.md`

--- a/test-validate.mjs
+++ b/test-validate.mjs
@@ -1,0 +1,16 @@
+import { discoverNodeFiles, parseNodeFile } from './.github/scripts/foundry-orchestrator.ts';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const files = discoverNodeFiles(path.join(repoRoot, '.foundry'));
+const issues = [];
+for (const file of files) {
+  const node = parseNodeFile(file, repoRoot);
+  if (!node) {
+    issues.push(`Failed to parse: ${file}`);
+  } else {
+    if (!node.frontmatter.id) issues.push(`Missing ID: ${file}`);
+    if (!node.frontmatter.owner_persona) issues.push(`Missing owner: ${file}`);
+  }
+}
+console.log(issues.length ? issues : "All nodes valid!");


### PR DESCRIPTION
This PR creates ADR 011 and its corresponding EPIC to address the issue of correctly identifying legitimate empty completions versus silent crashes in the heartbeat script. It introduces a formal requirement for the heartbeat to evaluate tasks against ADR 007 even when a session completes without a PR.

---
*PR created automatically by Jules for task [323501815015825666](https://jules.google.com/task/323501815015825666) started by @szubster*