### PR TITLE
feat: implement gen3 dataview parsing scaffolding

### DIFF
--- a/.foundry/tasks/task-059-096-gen3-dataview-scaffolding-impl.md
+++ b/.foundry/tasks/task-059-096-gen3-dataview-scaffolding-impl.md
@@ -31,5 +31,5 @@ Set up the core TypeScript files and handler functions to parse Gen3 save files 
 - Leave the implementations empty (return false/throw error) as this is just the scaffolding.
 
 ## Acceptance Criteria
-- [ ] `isGen3Save` and `parseGen3` are defined and exported.
-- [ ] `parseSaveFile` delegates correctly to Gen3 logic.
+- [x] `isGen3Save` and `parseGen3` are defined and exported.
+- [x] `parseSaveFile` delegates correctly to Gen3 logic.

--- a/src/engine/saveParser/index.ts
+++ b/src/engine/saveParser/index.ts
@@ -1,6 +1,7 @@
 import type { GameVersion, PokemonInstance, SaveData } from './parsers/common';
 import { isGen1Save, parseGen1 } from './parsers/gen1';
 import { isGen2Save, parseGen2 } from './parsers/gen2';
+import { isGen3Save, parseGen3 } from './parsers/gen3';
 
 export type { GameVersion, PokemonInstance, SaveData };
 
@@ -57,6 +58,8 @@ export function parseSaveFile(buffer: ArrayBuffer, forcedVersion?: GameVersion):
         return parseGen2(view, true);
       } else if (isGen2Save(view, false)) {
         return parseGen2(view, false);
+      } else if (isGen3Save(view)) {
+        return parseGen3(view, forcedVersion);
       }
       throw new Error(
         'Could not detect a valid Pokémon Red/Blue/Yellow or Gold/Silver/Crystal save file. Please ensure you are uploading a .sav file from a Gen 1 or Gen 2 game.',

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -1,4 +1,16 @@
-export type GameVersion = 'red' | 'blue' | 'yellow' | 'gold' | 'silver' | 'crystal' | 'unknown';
+export type GameVersion =
+  | 'red'
+  | 'blue'
+  | 'yellow'
+  | 'gold'
+  | 'silver'
+  | 'crystal'
+  | 'ruby'
+  | 'sapphire'
+  | 'emerald'
+  | 'firered'
+  | 'leafgreen'
+  | 'unknown';
 type Generation = number;
 
 /**

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isGen3Save, parseGen3 } from './gen3';
+
+describe('gen3 parser scaffolding', () => {
+  it('isGen3Save should return false', () => {
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer);
+    expect(isGen3Save(view)).toBe(false);
+  });
+
+  it('parseGen3 should throw an error', () => {
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer);
+    expect(() => parseGen3(view)).toThrowError('Gen 3 parsing not implemented yet');
+  });
+});

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -1,0 +1,25 @@
+import type { GameVersion, SaveData } from './common';
+
+/**
+ * Performs a structural check to verify if the binary data is a valid Generation 3 save.
+ * Placeholder implementation for scaffolding.
+ *
+ * @param _view - The raw save file DataView.
+ * @returns True if the structure looks like a valid Gen 3 save.
+ */
+export function isGen3Save(_view: DataView): boolean {
+  return false;
+}
+
+/**
+ * Extracts all relevant game data from a Gen 3 save.
+ * Placeholder implementation for scaffolding.
+ *
+ * @param _view - The raw save file DataView.
+ * @param _forcedVersion - An optional game version override.
+ * @returns The fully parsed and structured SaveData object.
+ * @throws Error - Gen 3 parsing not implemented yet.
+ */
+export function parseGen3(_view: DataView, _forcedVersion?: GameVersion): SaveData {
+  throw new Error('Gen 3 parsing not implemented yet');
+}


### PR DESCRIPTION
Implements `isGen3Save` and `parseGen3` scaffolding using the `DataView` API to support Gen 3 data parsing, and updates the task file to mark completion.

---
*PR created automatically by Jules for task [2084376792101242795](https://jules.google.com/task/2084376792101242795) started by @szubster*