### PR TITLE
QA: Reject missing Gen 3 Map Graph implementation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -82,3 +82,9 @@ No YAML changes were made per standard Foundry architecture rules.
 
 ## 2026-05-16
 - Verified `task-052-090-implement-graph-filtering`. React Flow components (like `Controls` and `MiniMap`) can be successfully styled to match the tactical hardware aesthetic using strict Tailwind overrides (e.g., `!rounded-none !border-dashed`), proving the library selection from ADR 008 is effective for custom aesthetic requirements.
+
+## 2026-05-18 - Task FAILED: Implement Gen3 Map Graph Structure
+
+**Task**: task-059-098-gen3-map-graph-structure-impl
+**Outcome**: FAILED
+**Notes**: The coder failed to implement `gen3Graph.ts` in `src/engine/mapGraph/` as required. Validation for `task-059-099-gen3-map-graph-structure-qa` could not be completed.

--- a/.foundry/tasks/task-059-098-gen3-map-graph-structure-impl.md
+++ b/.foundry/tasks/task-059-098-gen3-map-graph-structure-impl.md
@@ -2,7 +2,7 @@
 id: task-059-098-gen3-map-graph-structure-impl
 type: TASK
 title: Implement Gen3 Map Graph Structure
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-05-18'
 updated_at: '2026-05-17'
@@ -15,7 +15,7 @@ tags:
   - map-graph
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'The coder did not implement gen3Graph.ts.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-059-099-gen3-map-graph-structure-qa.md
+++ b/.foundry/tasks/task-059-099-gen3-map-graph-structure-qa.md
@@ -33,3 +33,5 @@ Write unit tests to validate the `gen3Graph.ts` implementation.
 ## Acceptance Criteria
 - [ ] Unit tests for `getDistanceToMap` are implemented and pass.
 - [ ] Unit tests for `resolveOutdoorMapId` are implemented and pass.
+
+**QA Update:** Validation could not be completed because `gen3Graph.ts` is missing. The implementation task (`task-059-098-gen3-map-graph-structure-impl`) has been rejected.


### PR DESCRIPTION
Validation could not be completed because `gen3Graph.ts` is completely missing from the codebase. The implementer failed to create the file and satisfy the objective of the target task.

The target task `task-059-098-gen3-map-graph-structure-impl` has been properly failed and updated with a rejection reason.
The markdown body of the current QA task `task-059-099-gen3-map-graph-structure-qa` has been updated to note the lack of implementation to validate, ensuring strict adherence to the constraint prohibiting modifying the QA task's YAML frontmatter.
The rejection has been properly documented in `.foundry/journals/qa.md`.

---
*PR created automatically by Jules for task [16352232706776436645](https://jules.google.com/task/16352232706776436645) started by @szubster*