### PR TITLE
Agile Coach: Prompt deduplication and TPM archiving refinement

### DIFF
--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -113,3 +113,11 @@ I noticed that `task-053-092-implement-dependency-highlighting.md` failed with t
 1. Directly modified `.github/scripts/foundry-heartbeat.ts` to differentiate between a successful Empty PR (`sessionStatus === 'COMPLETED'`) and a crashed zombie session (`NOT_FOUND` or other terminal states).
 2. Created `.foundry/docs/knowledge_base/agents/core_policies.md` to centralize Empty PR and Environment Troubleshooting policies.
 3. Updated all `.github/agents/*.md` prompt files to reference this centralized core policies document, removing duplicate instructions to improve agent prompt context efficiency.
+
+## 2026-05-18 - Deduplication of Agent Prompt Policies & TPM Archiving Refinement
+### Observation
+I noticed that the extensive rules surrounding the "Empty PR Policy" (both the main instruction and the warning about failure handling) were still duplicated across all individual `.github/agents/*.md` files. This is redundant and wastes token context window, since I had previously established `.foundry/docs/knowledge_base/agents/core_policies.md` precisely to centralize these instructions. Additionally, CEO feedback clarified that while manual LLM archiving of journals by the TPM is token-heavy, it is explicitly preferred over automated archiving because old journal entries are not necessarily stale and may contain context worth remembering.
+
+### Action Taken
+1. Executed a workspace-wide deduplication by removing the redundant "Empty PR Policy" text blocks directly from the prompts of `coder`, `qa`, `tech_lead`, `story_owner`, `epic_planner`, `product_manager`, `architect`, and `tpm`. These agents will now strictly rely on the centralized `core_policies.md` reference.
+2. Updated `.github/agents/tpm.md` to explicitly instruct the TPM to be conservative when archiving, carefully evaluating whether an old entry still holds valuable system context before removing it.

--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -25,8 +25,6 @@ You are the Agile Coach of The Foundry. You run on a daily or weekly schedule as
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
-- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
-- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
 **NODE CREATION GUIDELINES:**
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -23,8 +23,6 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
-- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
-- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
 ## Journal
 

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -16,7 +16,6 @@ When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.t
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
-- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 
 ## UI Aesthetic Constraints (ADR 008)
 When implementing UI components, you MUST adhere strictly to the "tactical hardware/snooping" aesthetic outlined in ADR 008.
@@ -36,7 +35,6 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/coder.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -29,13 +29,11 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
 
-- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/epic_planner.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -21,13 +21,11 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
-- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/product_manager.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -34,7 +34,6 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/qa.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
 ### Handling Rejections
 If you reject an implementation or validation fails:

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -26,13 +26,11 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
 
-- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/story_owner.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -34,13 +34,11 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
 
-- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
 
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/tech_lead.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -6,7 +6,7 @@ You are the TPM (Technical Program Manager) agent for The Foundry.
 - You run **hourly**.
 - **Archive COMPLETED nodes:** Move nodes that have reached the COMPLETED state into the appropriate archive locations. Identify and archive at least one `COMPLETED` test node when present. Be conservative when archiving: prioritize retention over aggressive removal. Even if a node is marked `COMPLETED`, if you determine it might still be relevant or needed, retain it. It's better to leave more nodes unarchived than to aggressively remove nodes that might still have value.
 - **Resolve Minor Deadlocks:** Detect and resolve minor graph deadlocks in the DAG orchestrator.
-- **Manage Journals:** Archive stale journal content across the `.foundry/journals/` directory to keep the workspace clean.
+- **Manage Journals:** Archive stale journal content across the `.foundry/journals/` directory to keep the workspace clean. **CRITICAL:** Old journal entries do not necessarily mean they are stale. Carefully evaluate whether an old entry still holds valuable system context or learnings before archiving it. Prioritize retention over aggressive archiving.
 
 ## Mandatory Initialization Step
 When you begin your session, you **must explicitly read** all documents under the following directories to establish your context:
@@ -24,8 +24,6 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - Do not archive a parent node (e.g., an EPIC) if any of its child nodes (e.g., STORY, TASK) are still active or pending.
 - When archiving completed nodes to `.foundry/archive/`, you MUST update all active files that reference them via the 'parent' field, 'depends_on' list, or inline markdown links to use the new archived path to prevent DAG orchestrator deadlocks.
 
-- If the target artifact already exists and is complete, DO NOT make trivial formatting changes or dummy updates just to force a git diff. Document this in your persona journal, state there is no work to do, and submit the PR. Empty PRs (0 files changed) will be automatically merged to allow the Foundry DAG to progress.
-- WARNING: The Empty PR policy is ONLY for successfully completed, pre-existing artifacts. If a task/feature is cancelled, invalid, or validation fails, you MUST NOT submit an empty PR. Instead, update the YAML frontmatter to `status: FAILED` (or `status: CANCELLED`) and include a `rejection_reason` so the DAG can handle the failure properly.
 
 ## Journal
 


### PR DESCRIPTION
This PR implements proactive system improvements driven by Agile Coach analysis and CEO feedback:

1. **Prompt Context Optimization:** Deduplicated the lengthy "Empty PR Policy" and failure handling instructions across all 8 core agent prompt files. Since all agents are already instructed to read the centralized `.foundry/docs/knowledge_base/agents/core_policies.md`, removing this duplicated text saves significant token context window.
2. **TPM Archiving Refinement:** Following CEO feedback, the proposed automated journal archiving idea was reverted. Instead, the TPM agent (`.github/agents/tpm.md`) has been explicitly instructed to be conservative when archiving journals. It must now carefully evaluate whether an old entry still holds valuable system context, prioritizing retention over aggressive removal.
3. **Agile Coach Journaling:** Updated the Agile Coach journal to persistently document these observations and actions.

---
*PR created automatically by Jules for task [11655716881767045952](https://jules.google.com/task/11655716881767045952) started by @szubster*