### PR TITLE
🧭 Strategist: Prompt improvement - Align schedules with Empty PR Policy

### DIFF
--- a/.jules/schedules/archivist.md
+++ b/.jules/schedules/archivist.md
@@ -60,7 +60,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ---
 
-If no stale or problematic knowledge can be identified, do not create a PR.
+If no stale or problematic knowledge can be identified, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/bolt.md
+++ b/.jules/schedules/bolt.md
@@ -49,7 +49,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ---
 
-If no clear performance win can be identified, do not create a PR.
+If no clear performance win can be identified, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/canvas.md
+++ b/.jules/schedules/canvas.md
@@ -67,7 +67,7 @@ Entry format:
 
 ---
 
-If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no design opportunity exists, do not create a PR.
+If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no design opportunity exists, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/infras.md
+++ b/.jules/schedules/infras.md
@@ -46,7 +46,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ---
 
-If no clear tooling improvement can be identified, do not create a PR.
+If no clear tooling improvement can be identified, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/nurse.md
+++ b/.jules/schedules/nurse.md
@@ -48,7 +48,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ---
 
-If no meaningful type-safety issue can be identified, do not create a PR.
+If no meaningful type-safety issue can be identified, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/oak.md
+++ b/.jules/schedules/oak.md
@@ -55,7 +55,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ---
 
-If no data discrepancy can be identified, do not create a PR.
+If no data discrepancy can be identified, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/palette.md
+++ b/.jules/schedules/palette.md
@@ -48,7 +48,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ---
 
-If no clear UX win can be identified, do not create a PR.
+If no clear UX win can be identified, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/scribe.md
+++ b/.jules/schedules/scribe.md
@@ -47,7 +47,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ---
 
-If no meaningful documentation gap can be identified, do not create a PR.
+If no meaningful documentation gap can be identified, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/sentinel.md
+++ b/.jules/schedules/sentinel.md
@@ -53,7 +53,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ---
 
-If no meaningful coverage gap can be identified, do not create a PR.
+If no meaningful coverage gap can be identified, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/strategist.md
+++ b/.jules/schedules/strategist.md
@@ -77,7 +77,7 @@ Entry format:
 
 ---
 
-If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no meaningful roster or prompt change can be justified, do not create a PR.
+If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no meaningful roster or prompt change can be justified, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/trainer.md
+++ b/.jules/schedules/trainer.md
@@ -47,7 +47,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ---
 
-If no clear assistant improvement can be identified, do not create a PR.
+If no clear assistant improvement can be identified, submit an empty PR.
 
 
 ## Empty PR Policy

--- a/.jules/schedules/visionary.md
+++ b/.jules/schedules/visionary.md
@@ -45,7 +45,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ---
 
-If no high-value idea can be formulated, do not create a PR.
+If no high-value idea can be formulated, submit an empty PR.
 
 ## Empty PR Policy
 Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -102,3 +102,9 @@
 **Outcome:** Accepted
 **Why:** Agents were incorrectly restricted or implicitly discouraged from creating dynamic nodes (like RESEARCH, IDEA, ADR) when discovering new tasks, lacking context, or uncovering architectural concerns. Scheduled agents were also not explicitly empowered to create Foundry nodes.
 **Pattern:** Prompts should empower agents to spawn their own tasks (`IDEA`, `RESEARCH`, `ADR`) directly into `.foundry/` if they discover work that needs to be done.
+
+## 2026-05-18 - [Accepted] - Prompt improvement - Update schedules to follow Empty PR Policy
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** System memory defines an "Empty PR Policy" where agents should submit an empty PR rather than aborting entirely when no work is found. The scheduled prompts still contained the conflicting instruction "do not create a PR".
+**Pattern:** Ensure scheduled prompt fallback instructions align with global system heartbeat/empty PR policies so the orchestrator correctly registers completion.


### PR DESCRIPTION
**Proposal:**
Updated all scheduled agent prompts in `.jules/schedules/*.md` to replace the fallback instruction "do not create a PR" with "submit an empty PR".

**Justification:**
System memory and orchestrator policies define an "Empty PR Policy" where agents should submit an empty PR rather than aborting entirely when no work is found. This ensures the DAG orchestrator successfully registers completion/heartbeats. The scheduled prompts previously contradicted this, causing silent exits.

**Evidence:**
- `.jules/strategist.md` specifies the empty PR policy rule.
- Agent schedules (`canvas.md`, `sentinel.md`, `nurse.md`, etc.) contained conflicting text instructing them to not create a PR if no changes were found.

---
*PR created automatically by Jules for task [3035499315282238281](https://jules.google.com/task/3035499315282238281) started by @szubster*