### PR TITLE
🎨 Palette: Add focus-visible states to DAG filter buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -66,3 +66,5 @@
 
 - Added `aria-current="page"` to active links in navigation for screen reader accessibility.
 - Used `aria-expanded` on interactive buttons controlling menus/modals (e.g. settings button).
+- **Playwright Frontend Verification:** When writing Playwright scripts to verify frontend changes locally against the development server (`npm run dev`), use `http://localhost:3000` instead of Vite's default port 5173, as specified in `package.json`.
+- **Scheduled Node Creation:** Scheduled or foundry agents can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory to document technical debt, architectural changes, or gaps in context. Appropriate `owner_persona` must be set for new nodes (e.g., `researcher` for RESEARCH, `architect` for ADRs).

--- a/src/components/dag/DagFilterPanel.tsx
+++ b/src/components/dag/DagFilterPanel.tsx
@@ -24,7 +24,7 @@ export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onSt
                 type="button"
                 onClick={() => onTypeToggle(type)}
                 className={cn(
-                  'rounded-none border border-dashed px-2 py-1 transition-colors hover:bg-zinc-800',
+                  'rounded-none border border-dashed px-2 py-1 transition-colors hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
                   isActive
                     ? 'border-[var(--theme-primary)] text-[var(--theme-primary)]'
                     : 'border-zinc-800 text-zinc-500',
@@ -67,7 +67,7 @@ export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onSt
                 type="button"
                 onClick={() => onStatusToggle(status)}
                 className={cn(
-                  'rounded-none border border-dashed px-2 py-1 transition-colors hover:bg-zinc-800',
+                  'rounded-none border border-dashed px-2 py-1 transition-colors hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
                   isActive ? activeColorClass : 'border-zinc-800 text-zinc-500',
                 )}
               >


### PR DESCRIPTION
Added missing `focus-visible` Tailwind classes to the Type and Status filter buttons in the `DagFilterPanel` component. This addresses a keyboard accessibility gap by ensuring clear visual feedback when navigating via keyboard (tab order).

---
*PR created automatically by Jules for task [5541401279415240286](https://jules.google.com/task/5541401279415240286) started by @szubster*