### PR TITLE
⚡ Bolt: Memoize queryTargetsSlice in useAssistant

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -86,3 +86,6 @@ Learned that the dex encounters DataLoader was firing individual getEncounters c
 **What:** Replaced `filtered = locations.filter(...).slice(0, 5)` with a manual `for` loop that breaks when 5 items are found.
 **Why:** The `filter()` approach scans the entire array (O(N) operation) even if we only need the first 5 matches. With potentially hundreds of locations, stopping early minimizes execution time to O(K) where K is the number of elements checked to find 5 matches.
 **Measured Improvement:** Faster response time during search input by skipping redundant string comparisons, keeping the UI thread unblocked.
+
+## 2024-XX-XX
+* When attempting micro-optimizations, remember that replacing `Map.set` deduplication with `Set.has` check logic can alter programmatic behavior: `Map` creates a 'last-wins' overwrite strategy, whereas `Set` creates a 'first-wins' skip strategy. Do not implement such replacements when array order or precedence is meaningful to the application logic.

--- a/src/hooks/useAssistant.ts
+++ b/src/hooks/useAssistant.ts
@@ -19,30 +19,33 @@ import { getGenerationConfig } from '../utils/generationConfig';
  * const { suggestions, isLoading } = useAssistant(saveData, false, 'red');
  */
 export function useAssistant(saveData: SaveData | null, isLivingDex: boolean, manualVersion?: string | null) {
-  const maxDex = saveData ? getGenerationConfig(saveData.generation).maxDex : 0;
-  const missingIds: number[] = [];
+  // ⚡ Bolt: Memoized expensive missing ID and owned set calculations to prevent redundant work on every render
+  const queryTargetsSlice = useMemo(() => {
+    const maxDex = saveData ? getGenerationConfig(saveData.generation).maxDex : 0;
+    const missingIds: number[] = [];
 
-  // If building a Living Dex, the internal Pokédex 'owned' flag isn't sufficient.
-  // We must verify the player physically possesses the Pokémon in their Party or PC.
-  const ownedSet = saveData
-    ? isLivingDex
-      ? new Set([...saveData.party, ...saveData.pc])
-      : saveData.owned
-    : new Set<number>();
+    // If building a Living Dex, the internal Pokédex 'owned' flag isn't sufficient.
+    // We must verify the player physically possesses the Pokémon in their Party or PC.
+    const ownedSet = saveData
+      ? isLivingDex
+        ? new Set([...saveData.party, ...saveData.pc])
+        : saveData.owned
+      : new Set<number>();
 
-  if (saveData) {
-    for (let i = 1; i <= maxDex; i++) {
-      if (!ownedSet.has(i)) {
-        // Mewtwo (150) is physically inaccessible in Gen 1 until the Elite Four is defeated.
-        if (saveData.generation === 1 && i === 150 && (saveData.hallOfFameCount || 0) === 0) continue;
-        missingIds.push(i);
+    if (saveData) {
+      for (let i = 1; i <= maxDex; i++) {
+        if (!ownedSet.has(i)) {
+          // Mewtwo (150) is physically inaccessible in Gen 1 until the Elite Four is defeated.
+          if (saveData.generation === 1 && i === 150 && (saveData.hallOfFameCount || 0) === 0) continue;
+          missingIds.push(i);
+        }
       }
     }
-  }
 
-  // Limit the synchronous engine to evaluating the first 30 missing Pokémon at a time.
-  // This prevents massive batched queries to IndexedDB and keeps the UI responsive.
-  const queryTargetsSlice = missingIds.slice(0, 30);
+    // Limit the synchronous engine to evaluating the first 30 missing Pokémon at a time.
+    // This prevents massive batched queries to IndexedDB and keeps the UI responsive.
+    return missingIds.slice(0, 30);
+  }, [saveData, isLivingDex]);
 
   const { data: apiData, isLoading: isLoadingEncounters } = useQuery({
     queryKey: [


### PR DESCRIPTION
💡 **What**: Wrapped the expensive synchronous calculations for `queryTargetsSlice`, `missingIds`, and `ownedSet` inside a `useMemo` block in `src/hooks/useAssistant.ts`.

🎯 **Why**: Previously, these operations (iterating over arrays, creating Sets, pushing up to 1025 missing IDs in a loop) ran synchronously on the main thread during every render of any component using `useAssistant`. This caused unnecessary performance overhead.

📊 **Measured Improvement**: The calculation is now safely cached between renders, re-evaluating only when `saveData` or `isLivingDex` change, avoiding O(N) array loops and memory allocations on re-renders, while strictly preserving application state and logic.

**How to Verify**:
Run `pnpm lint` and `pnpm test` to ensure there are no regressions. Behavior remains unchanged while rendering efficiency increases.

---
*PR created automatically by Jules for task [9459860713422127420](https://jules.google.com/task/9459860713422127420) started by @szubster*