### PR TITLE
🧭 Strategist: Prompt improvement - Standardize Empty PR Policy across all agents

### DIFF
--- a/.github/agents/archivist.md
+++ b/.github/agents/archivist.md
@@ -63,5 +63,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 If no stale or problematic knowledge can be identified, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/bolt.md
+++ b/.github/agents/bolt.md
@@ -52,5 +52,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 If no clear performance win can be identified, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/canvas.md
+++ b/.github/agents/canvas.md
@@ -70,5 +70,5 @@ Entry format:
 If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no design opportunity exists, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/infras.md
+++ b/.github/agents/infras.md
@@ -49,5 +49,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 If no clear tooling improvement can be identified, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/mason.md
+++ b/.github/agents/mason.md
@@ -44,5 +44,5 @@ Log critical learnings: recurring patterns, extraction challenges, or reusable l
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/mason.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/nurse.md
+++ b/.github/agents/nurse.md
@@ -51,5 +51,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 If no meaningful type-safety issue can be identified, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/oak.md
+++ b/.github/agents/oak.md
@@ -58,5 +58,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 If no data discrepancy can be identified, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/palette.md
+++ b/.github/agents/palette.md
@@ -51,5 +51,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 If no clear UX win can be identified, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/scribe.md
+++ b/.github/agents/scribe.md
@@ -50,5 +50,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 If no meaningful documentation gap can be identified, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/sentinel.md
+++ b/.github/agents/sentinel.md
@@ -56,5 +56,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 If no meaningful coverage gap can be identified, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/shield.md
+++ b/.github/agents/shield.md
@@ -46,5 +46,5 @@ Only log **critical** learnings: recurring vulnerability patterns or complex sec
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/shield.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/strategist.md
+++ b/.github/agents/strategist.md
@@ -80,5 +80,5 @@ Entry format:
 If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no meaningful roster or prompt change can be justified, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/sweeper.md
+++ b/.github/agents/sweeper.md
@@ -43,5 +43,5 @@ Only log **critical** learnings: unexpected entanglements or patterns to watch o
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/sweeper.md`). Do not add journal entries of the form 'I did X' unless they contain a meaningful learning or pattern for the future. Meaningless journal updates waste tokens. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/trainer.md
+++ b/.github/agents/trainer.md
@@ -50,5 +50,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 If no clear assistant improvement can be identified, do not create a PR.
 
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.github/agents/visionary.md
+++ b/.github/agents/visionary.md
@@ -47,5 +47,5 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 If no high-value idea can be formulated, do not create a PR.
 
-## Empty PR Policy
-Completely empty PRs should be fine and automerged by GitHub actions (there is an action for that already).
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -102,3 +102,9 @@
 **Outcome:** Accepted
 **Why:** Agents were incorrectly restricted or implicitly discouraged from creating dynamic nodes (like RESEARCH, IDEA, ADR) when discovering new tasks, lacking context, or uncovering architectural concerns. Scheduled agents were also not explicitly empowered to create Foundry nodes.
 **Pattern:** Prompts should empower agents to spawn their own tasks (`IDEA`, `RESEARCH`, `ADR`) directly into `.foundry/` if they discover work that needs to be done.
+
+## 2026-05-18 - [Accepted] - Prompt improvement - Standardize Empty PR Policy across all agents
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** Many agents were still using the old generic text for their "Empty PR Policy", instead of pointing to the centralized knowledge base file (`.foundry/docs/knowledge_base/agents/core_policies.md`), which contains additional critical instructions (like checking off Acceptance Criteria checkboxes).
+**Pattern:** Core agent policies are centralized in the knowledge base to conserve token context window, so individual prompts should reference the central document rather than duplicating incomplete rules.


### PR DESCRIPTION
Replaces the generic Empty PR Policy in old agents with a reference to the centralized Core Policies knowledge base file.

---
*PR created automatically by Jules for task [740671927088573523](https://jules.google.com/task/740671927088573523) started by @szubster*