### PR TITLE
fix: ignore FAILED_PRECONDITION errors from Jules to prevent noisy issues

### DIFF
--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -109,7 +109,7 @@ jobs:
           fi
 
       - name: Report Orchestrate Failure
-        if: failure()
+        if: failure() && env.SKIP_FAILURE_ISSUE != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.MY_ISSUES_PAT }}
         run: |
@@ -225,6 +225,13 @@ jobs:
             # 4. Extract and verify session ID
             session_id=$(echo "$response" | jq -r '.id')
             
+            error_status=$(echo "$response" | jq -r '.error.status // empty')
+            if [[ "$error_status" == "FAILED_PRECONDITION" ]]; then
+              echo "::warning::Jules session failed due to quota/precondition (FAILED_PRECONDITION). Skipping issue creation."
+              echo "SKIP_FAILURE_ISSUE=true" >> $GITHUB_ENV
+              exit 1
+            fi
+
             if [[ -z "$session_id" || "$session_id" == "null" ]]; then
               echo "::error::Failed to capture Jules session ID"
               echo "Response: $response"
@@ -250,7 +257,7 @@ jobs:
           git push origin main 2>&1 | tee -a commit.log
 
       - name: Report Execution Failure
-        if: failure()
+        if: failure() && env.SKIP_FAILURE_ISSUE != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.MY_ISSUES_PAT }}
         run: |


### PR DESCRIPTION
Jules sessions sometimes fail due to 'FAILED_PRECONDITION' (quota/rate limits). This change safely captures the JSON error status and prevents the subsequent creation of a noisy GitHub issue when this specific error occurs, allowing the system to retry or ignore it organically.

---
*PR created automatically by Jules for task [5942221891315639970](https://jules.google.com/task/5942221891315639970) started by @szubster*