### PR TITLE
chore(bundlemon): adjust config to automatically track new files

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -24,6 +24,14 @@
     {
       "path": "data/pokedata.msgpack",
       "maxSize": "800kb"
+    },
+    {
+      "path": "workbox-<hash>.js",
+      "maxSize": "50kb"
+    },
+    {
+      "path": "**/*",
+      "maxSize": "500kb"
     }
   ],
   "reportOutput": [


### PR DESCRIPTION
Appends a fallback `**/*` pattern to the `files` array in `.bundlemonrc.json` so that Bundlemon automatically tracks the size of any unrecognized/new build outputs not captured by previous explicitly defined paths. Also explicitly added tracking for the newly discovered `workbox-<hash>.js` artifact.

---
*PR created automatically by Jules for task [703511394162018225](https://jules.google.com/task/703511394162018225) started by @szubster*