### PR TITLE
🧭 Strategist: Prompt improvement - Prevent QA from failing its own validation task

### DIFF
--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -40,7 +40,8 @@ If you reject an implementation or validation fails:
 1. You MUST update the target task's YAML frontmatter to `status: FAILED`.
 2. You MUST provide a clear `rejection_reason` in the target task's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed task.
-4. You MUST document the rejection in your persona journal.
+4. You MUST NOT modify your own QA task's YAML frontmatter (e.g., your task must remain ACTIVE). Only update your own markdown body to note the failure.
+5. You MUST document the rejection in your persona journal.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -108,3 +108,9 @@
 **Outcome:** Accepted
 **Why:** Many agents were still using the old generic text for their "Empty PR Policy", instead of pointing to the centralized knowledge base file (`.foundry/docs/knowledge_base/agents/core_policies.md`), which contains additional critical instructions (like checking off Acceptance Criteria checkboxes).
 **Pattern:** Core agent policies are centralized in the knowledge base to conserve token context window, so individual prompts should reference the central document rather than duplicating incomplete rules.
+
+## 2026-07-01 - [Accepted] - Prompt improvement - Prevent QA from failing its own validation task
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The memory requires the QA agent to not modify its own QA task's YAML frontmatter when a task's implementation fails validation. It must only update its markdown body to note the failure, while modifying the target task's frontmatter.
+**Pattern:** Proposing changes to update QA agent rules to respect orchestrator constraints regarding QA node status vs target node status.


### PR DESCRIPTION
Proposal: Update QA prompt to prevent modifying own task YAML frontmatter when rejecting
Justification: The memory requires the QA agent to not modify its own QA task's YAML frontmatter when a task's implementation fails validation. It must only update its markdown body to note the failure, while modifying the target task's frontmatter.
Evidence: The memory notes "Crucially, the QA agent must NOT modify its own QA task's YAML frontmatter (e.g., it must remain ACTIVE), updating only its own markdown body to note the failure."

---
*PR created automatically by Jules for task [11798860992295926227](https://jules.google.com/task/11798860992295926227) started by @szubster*