### PR TITLE
fix: correctly process pr-less completed sessions in heartbeat

### DIFF
--- a/.foundry/tasks/task-066-106-implement-prless-detection.md
+++ b/.foundry/tasks/task-066-106-implement-prless-detection.md
@@ -29,5 +29,5 @@ Update the `foundry-heartbeat.ts` script to correctly parse the Jules API sessio
 As part of making the session completion robust for the "Empty PR" policy (ADR 011), the heartbeat script needs to stop blindly failing sessions that are `COMPLETED` according to the API but lack a PR.
 
 ## Acceptance Criteria
-- [ ] Heartbeat script correctly parses Jules session state even without a PR.
-- [ ] When API state is `COMPLETED` and PR is missing, the script identifies this as a "PR-less completion" instead of a crash.
+- [x] Heartbeat script correctly parses Jules session state even without a PR.
+- [x] When API state is `COMPLETED` and PR is missing, the script identifies this as a "PR-less completion" instead of a crash.

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -480,6 +480,90 @@ Body`;
   });
 
   describe('Enforce Acceptance Criteria', () => {
+
+  it('should process PR-less COMPLETED session as Empty PR', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: 'session-pr-less'
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: "session-pr-less"\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    // @ts-expect-error - Mock signature mismatch
+    globalFetch.mockImplementation((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : (url as URL).toString();
+      if (urlStr.startsWith('https://jules.googleapis.com/')) {
+        return Promise.resolve({
+            ok: true,
+            status: 200,
+          json: async () => ({
+              state: 'COMPLETED',
+              outputs: {}
+            })
+          });
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+    });
+
+    await main();
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(writeCall[1]).toContain('status: COMPLETED');
+  });
+
+  it('should process PR-less COMPLETED session with unchecked tasks as FAILED with correct message', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        type: 'TASK',
+        status: 'ACTIVE',
+        jules_session_id: 'session-pr-less'
+      },
+      rawContent: '---\ntype: TASK\nstatus: ACTIVE\njules_session_id: "session-pr-less"\nupdated_at: "2023-01-01"\n---\n## Acceptance Criteria\n- [ ] Unchecked box'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    // @ts-expect-error - Mock signature mismatch
+    globalFetch.mockImplementation((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : (url as URL).toString();
+      if (urlStr.startsWith('https://jules.googleapis.com/')) {
+        return Promise.resolve({
+            ok: true,
+            status: 200,
+          json: async () => ({
+              state: 'COMPLETED',
+              outputs: {}
+            })
+          });
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+    });
+
+    await transitionNodeToCompleted(mockNode, '/mock/repo', null);
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(writeCall[1]).toContain('status: FAILED');
+
+    // Also check the logToJournal call to make sure the message is correct
+    const appendCall = vi.mocked(fs.appendFileSync).mock.calls.find(call =>
+      typeof call[1] === 'string' && call[1].includes('Empty PR session completed with unchecked tasks.')
+    );
+    expect(appendCall).toBeTruthy();
+  });
+
     it('should transition leaf task with unchecked boxes to FAILED and set rejection_reason', async () => {
       const nodePath = path.join(mockRepoRoot, '.foundry/tasks/task-unchecked-leaf.md');
       const nodeContent = `---

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -91,7 +91,7 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
     } else {
        targetStatus = "FAILED";
        rejectionReason = "Merged with unfulfilled acceptance criteria";
-       message = `PR #${prNumber} merged with unchecked tasks.`;
+       message = prNumber !== null ? `PR #${prNumber} merged with unchecked tasks.` : `Empty PR session completed with unchecked tasks.`;
     }
   }
 
@@ -167,7 +167,13 @@ async function findPRForSession(
       sessionStatus = data.state || null;
       updateTime = data.updateTime;
       
-      const prUrl = data.outputs?.find((o: any) => o.pullRequest?.url)?.pullRequest.url;
+      let prUrl;
+      if (Array.isArray(data.outputs)) {
+        prUrl = data.outputs.find((o: any) => o.pullRequest?.url)?.pullRequest.url;
+      } else if (data.outputs && typeof data.outputs === 'object') {
+        const key = Object.keys(data.outputs).find(k => data.outputs[k]?.pullRequest?.url);
+        if (key) prUrl = data.outputs[key].pullRequest.url;
+      }
       if (prUrl) {
         const match = prUrl.match(/pull\/(\d+)$/);
         if (match) {


### PR DESCRIPTION
This PR fixes the `foundry-heartbeat.ts` script to correctly parse Jules session status when it completes without an associated pull request (an "Empty PR"). Previously, when checking the API for a PR state, if the session outputs lacked a Pull Request URL, the script would crash or throw a TypeError, causing the session tracking to incorrectly register a crashed run and initiate the Resurrection Loop instead of processing it correctly according to ADR 011. The script has been updated to robustly traverse the Jules outputs map/array and appropriately flag Empty PR completion correctly.

---
*PR created automatically by Jules for task [6927802644815842427](https://jules.google.com/task/6927802644815842427) started by @szubster*