### PR TITLE
Architect: Nuzlocke Tracker ADR and Epic Creation

### DIFF
--- a/.foundry/docs/adrs/012-automated-nuzlocke-tracker.md
+++ b/.foundry/docs/adrs/012-automated-nuzlocke-tracker.md
@@ -1,0 +1,40 @@
+---
+id: adr-012-automated-nuzlocke-tracker
+type: ADR
+title: Automated Nuzlocke Tracker Architecture
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# ADR 012: Automated Nuzlocke Tracker Architecture
+
+## Status
+Accepted
+
+## Context
+We need to implement an Automated Nuzlocke Tracker within DexHelper to automate the tracking of encounters and deaths for players doing Nuzlocke challenge runs.
+
+## Decision
+1. **Automated Route Tracking**: We will aggregate caught Pokémon in the save file (both Party and PC) by their `met_location`.
+2. **First Encounter Identification**: We will identify the first catch for every distinct location.
+3. **Violation Flagging**: We will flag a violation if multiple Pokémon share the same `met_location` (excluding in-game gifts or static encounters if applicable).
+4. **Death Tracking**: Pokémon in the party with 0 HP will be considered "dead". Additionally, we will introduce a UI setting to designate a specific PC Box as the "Graveyard". Any Pokémon in this box will be permanently marked as dead.
+5. **Run Dashboard UI**: A dashboard view will show the alive team, visited routes, unvisited routes, and the graveyard.
+6. **Out of Scope**: In-game rule enforcement, Species Clause, and Randomizer tracking are excluded for v1.
+
+## Consequences
+- **Positive**: Automates manual entry for Nuzlocke players.
+- **Negative**: Relies entirely on save data post-catch, meaning players must check the app to see if they've already encountered something on a route.

--- a/.foundry/epics/epic-026-034-automated-nuzlocke-tracker.md
+++ b/.foundry/epics/epic-026-034-automated-nuzlocke-tracker.md
@@ -1,0 +1,25 @@
+---
+id: epic-026-034-automated-nuzlocke-tracker
+type: EPIC
+title: Automated Nuzlocke Verification and Run Tracker
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/prds/prd-057-026-automated-nuzlocke-tracker.md
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Automated Nuzlocke Verification and Run Tracker
+
+## Description
+Break down the Automated Nuzlocke Tracker feature into stories and tasks. Refer to ADR 012 for the architectural decisions.

--- a/.foundry/journals/architect.md
+++ b/.foundry/journals/architect.md
@@ -30,3 +30,5 @@ Architects frequently perform evaluation tasks (e.g., assessing graph libraries,
 ## 2026-05-18: Robust Session Completion
 Created ADR 011 and Epic 025-033 to handle robust session completion in the heartbeat script.
 This addresses the issue where the orchestrator falsely marks empty PR runs as failed. The heartbeat will now correctly evaluate nodes with a COMPLETED Jules session state without a PR, applying ADR 007 acceptance criteria rules before transitioning the node state.
+
+- 2026-05-18: Decided that Nuzlocke death tracking requires a UI setting to designate a specific PC box as a Graveyard to persist state without mutating the game ROM.

--- a/.foundry/prds/prd-057-026-automated-nuzlocke-tracker.md
+++ b/.foundry/prds/prd-057-026-automated-nuzlocke-tracker.md
@@ -55,4 +55,7 @@ Currently, players track this information manually using spreadsheets or third-p
 - Randomizer tracking (assuming vanilla game routes).
 
 ## Next Steps
-- [ ] Architect: Produce an Architecture Decision Record (ADR) detailing the technical implementation of this feature.
+- [x] Architect: Produce an Architecture Decision Record (ADR) detailing the technical implementation of this feature.
+- ADR: .foundry/docs/adrs/012-automated-nuzlocke-tracker.md
+
+- Epic: .foundry/epics/epic-026-034-automated-nuzlocke-tracker.md


### PR DESCRIPTION
This PR fulfills the Architect persona task for the Automated Nuzlocke Tracker PRD.
It creates ADR 012 to define the architectural decisions (save data aggregation, PC box graveyards, out-of-scope in-game enforcement), checks off the required Acceptance Criteria, and spawns the downstream Epic for the planner to begin breakdown.

---
*PR created automatically by Jules for task [5609625980820891931](https://jules.google.com/task/5609625980820891931) started by @szubster*