### PR TITLE
Fix pnpm version conflict in sync-pokedata workflow

### DIFF
--- a/.github/workflows/sync-pokedata.yml
+++ b/.github/workflows/sync-pokedata.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10
+          run_install: false
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
Removed the hardcoded `version: 10` from the `pnpm/action-setup` step in `.github/workflows/sync-pokedata.yml` and replaced it with `run_install: false`. This allows the action to infer the correct pnpm version from the `packageManager` field in `package.json`, resolving the "Multiple versions of pnpm specified" error.

---
*PR created automatically by Jules for task [17646308676681825188](https://jules.google.com/task/17646308676681825188) started by @szubster*