### PR TITLE
fix: fix pokeapi sync script and workflow

### DIFF
--- a/.github/workflows/sync-pokedata.yml
+++ b/.github/workflows/sync-pokedata.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/scripts/sync-pokedata.sh
+++ b/scripts/sync-pokedata.sh
@@ -4,7 +4,7 @@ set -e
 echo "--- PokéAPI Sync Script ---"
 
 # 1. Run generation
-pnpm tsx scripts/generate-pokedata.ts
+pnpm run data:gen
 
 # 2. Check for changes
 if [[ -z $(git status -s public/data/pokedata.json) ]]; then


### PR DESCRIPTION
This PR fixes the failing pokeapi sync workflow.

It does this by:
1. Updating the `sync-pokedata.yml` workflow to use Node 24 instead of Node 20. This satisfies the `>=22.0.0` engine requirement in `package.json` that was causing `pnpm` to throw a warning. Node 24 is also already used in the main CI workflow.
2. Updating `scripts/sync-pokedata.sh` to use `pnpm run data:gen` instead of `pnpm tsx scripts/generate-pokedata.ts`. The repository doesn't have `tsx` installed globally or locally as a direct command that `pnpm tsx` can resolve, and package.json already defines `data:gen` to use Node's native strip-types (`node --experimental-strip-types scripts/generate-pokedata.ts`).

---
*PR created automatically by Jules for task [5871367951114336936](https://jules.google.com/task/5871367951114336936) started by @szubster*