### PR TITLE
QA Validation: Gen3 Bounds Checking

### DIFF
--- a/.foundry/tasks/task-060-109-gen3-bounds-checking-qa.md
+++ b/.foundry/tasks/task-060-109-gen3-bounds-checking-qa.md
@@ -26,5 +26,5 @@ notes: ''
 Validate that bounds checking in Gen3 data parsing logic gracefully handles out-of-bounds reads.
 
 ## Acceptance Criteria
-- [ ] Verify that `RangeError` from `DataView` operations are caught.
-- [ ] Verify that validation errors are gracefully propagated (e.g., "Corrupted Save File") when bounds are exceeded, per ADR-010.
+- [x] Verify that `RangeError` from `DataView` operations are caught.
+- [x] Verify that validation errors are gracefully propagated (e.g., "Corrupted Save File") when bounds are exceeded, per ADR-010.


### PR DESCRIPTION
Validated that the bounds checking implementation for Gen3 save parsing correctly catches `RangeError` from `DataView` operations and gracefully propagates the error as a "Corrupted Save File" message, adhering to ADR-010. Checked off acceptance criteria in the QA task node.

---
*PR created automatically by Jules for task [696123691291157229](https://jules.google.com/task/696123691291157229) started by @szubster*