### PR TITLE
📝 Epic Planner: Automated Nuzlocke Tracker Breakdown

### DIFF
--- a/.foundry/epics/epic-026-034-automated-nuzlocke-tracker.md
+++ b/.foundry/epics/epic-026-034-automated-nuzlocke-tracker.md
@@ -23,3 +23,8 @@ notes: ''
 
 ## Description
 Break down the Automated Nuzlocke Tracker feature into stories and tasks. Refer to ADR 012 for the architectural decisions.
+
+### STORIES
+- [ ] .foundry/stories/story-034-069-automated-route-tracking.md
+- [ ] .foundry/stories/story-034-070-death-tracking-and-graveyard.md
+- [ ] .foundry/stories/story-034-071-run-dashboard-ui.md

--- a/.foundry/stories/story-034-069-automated-route-tracking.md
+++ b/.foundry/stories/story-034-069-automated-route-tracking.md
@@ -1,0 +1,25 @@
+---
+id: story-034-069-automated-route-tracking
+type: STORY
+title: Automated Route Tracking Implementation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-026-034-automated-nuzlocke-tracker
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Automated Route Tracking Implementation
+
+## Description
+Implement the underlying logic to aggregate caught Pokémon by `met_location` and identify first encounters. Detect violations if multiple Pokémon share the same location.

--- a/.foundry/stories/story-034-070-death-tracking-and-graveyard.md
+++ b/.foundry/stories/story-034-070-death-tracking-and-graveyard.md
@@ -1,0 +1,25 @@
+---
+id: story-034-070-death-tracking-and-graveyard
+type: STORY
+title: Death Tracking and Graveyard Logic
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-026-034-automated-nuzlocke-tracker
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Death Tracking and Graveyard Logic
+
+## Description
+Detect fainted Pokémon in the party and implement logic to designate a PC Box as the Graveyard for permanently dead Pokémon.

--- a/.foundry/stories/story-034-071-run-dashboard-ui.md
+++ b/.foundry/stories/story-034-071-run-dashboard-ui.md
@@ -1,0 +1,27 @@
+---
+id: story-034-071-run-dashboard-ui
+type: STORY
+title: Run Dashboard UI Integration
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on:
+  - story-034-069-automated-route-tracking
+  - story-034-070-death-tracking-and-graveyard
+jules_session_id: null
+pr_number: null
+parent: epic-026-034-automated-nuzlocke-tracker
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Run Dashboard UI Integration
+
+## Description
+Build the UI components for the Nuzlocke Tracker mode, including the "Alive" team view, visited routes checklist, unvisited routes, and the Graveyard.


### PR DESCRIPTION
As the Epic Planner, I have successfully transformed PRD-057-026 into a detailed EPIC breakdown for the Automated Nuzlocke Verification and Run Tracker feature.

I created three distinct, granular STORY nodes:
1. `story-034-069-automated-route-tracking`: Implements the underlying location logic.
2. `story-034-070-death-tracking-and-graveyard`: Implements death detection and PC Box graveyard logic.
3. `story-034-071-run-dashboard-ui`: Implements the user interface, correctly establishing a DAG dependency on the two underlying logic stories (`story-034-069` and `story-034-070`).

The parent EPIC (`epic-026-034-automated-nuzlocke-tracker.md`) has had its markdown body updated to reference these newly created stories, while strictly adhering to the critical rule of not mutating its YAML frontmatter. All tests and linting passed successfully.

---
*PR created automatically by Jules for task [5047072212288242463](https://jules.google.com/task/5047072212288242463) started by @szubster*