### PR TITLE
chore: fix PokéAPI sync script paths and SHA extraction

### DIFF
--- a/scripts/sync-pokedata.sh
+++ b/scripts/sync-pokedata.sh
@@ -7,19 +7,19 @@ echo "--- PokéAPI Sync Script ---"
 pnpm run data:gen
 
 # 2. Check for changes
-if [[ -z $(git status -s public/data/pokedata.json) ]]; then
-  echo "No changes detected in pokedata.json. Skipping PR."
+if [[ -z $(git status -s data/db) ]]; then
+  echo "No changes detected in data/db. Skipping PR."
   exit 0
 fi
 
 # 3. Create a branch and PR
-UPSTREAM_SHA=$(node -e "console.log(JSON.parse(require('fs').readFileSync('public/data/pokedata.json', 'utf8')).sourceSha)")
+UPSTREAM_SHA=$(node -e "console.log(JSON.parse(require('fs').readFileSync('data/db/metadata.json', 'utf8')).sourceSha)")
 BRANCH_NAME="chore/sync-pokeapi-${UPSTREAM_SHA:0:7}"
 
 echo "Detected changes. Creating PR on branch ${BRANCH_NAME}..."
 
 git checkout -b "$BRANCH_NAME"
-git add public/data/pokedata.json
+git add data/db
 git commit -m "chore: sync PokéAPI data to ${UPSTREAM_SHA:0:7}"
 git push origin "$BRANCH_NAME"
 


### PR DESCRIPTION
This PR fixes a bug in `scripts/sync-pokedata.sh` where it was checking for changes against the old `public/data/pokedata.json` location instead of the new `data/db/` directory.

### Changes
- Updated `git status` path from `public/data/pokedata.json` to `data/db`
- Updated upstream SHA extraction to read from `data/db/metadata.json` instead of `public/data/pokedata.json`
- Updated `git add` path from `public/data/pokedata.json` to `data/db`

---
*PR created automatically by Jules for task [17237108264741069123](https://jules.google.com/task/17237108264741069123) started by @szubster*