### PR TITLE
chore(dag): mark data fetching task as complete

### DIFF
--- a/.foundry/tasks/task-065-114-wire-up-data-layer-impl.md
+++ b/.foundry/tasks/task-065-114-wire-up-data-layer-impl.md
@@ -22,6 +22,6 @@ notes: ''
 This task requires checking and completing the implementation of fetching the actual `.foundry` DAG data for the React Flow DAG Dashboard.
 
 ## Acceptance Criteria
-- [ ] Confirm `src/components/dag/DagDashboard.tsx` fetches `import.meta.env.BASE_URL + "data/foundry.json"`.
-- [ ] Ensure that `buildDagGraph` from `src/utils/dag/builder.ts` correctly parses this response.
-- [ ] Map the parsed nodes and edges to the React Flow layout state.
+- [x] Confirm `src/components/dag/DagDashboard.tsx` fetches `import.meta.env.BASE_URL + "data/foundry.json"`.
+- [x] Ensure that `buildDagGraph` from `src/utils/dag/builder.ts` correctly parses this response.
+- [x] Map the parsed nodes and edges to the React Flow layout state.


### PR DESCRIPTION
The target artifacts (`src/components/dag/DagDashboard.tsx` and `src/utils/dag/builder.ts`) for DAG data fetching are already completely implemented and tested. Updated the acceptance criteria checkboxes in the task node to reflect this state under the Empty PR Policy.

---
*PR created automatically by Jules for task [6083864211428589312](https://jules.google.com/task/6083864211428589312) started by @szubster*