### PR TITLE
🗂️ Story Owner: Breakdown Automated Route Tracking

### DIFF
--- a/.foundry/epics/epic-026-034-automated-nuzlocke-tracker.md
+++ b/.foundry/epics/epic-026-034-automated-nuzlocke-tracker.md
@@ -25,6 +25,6 @@ notes: ''
 Break down the Automated Nuzlocke Tracker feature into stories and tasks. Refer to ADR 012 for the architectural decisions.
 
 ### STORIES
-- [ ] .foundry/stories/story-034-069-automated-route-tracking.md
+- [x] .foundry/stories/story-034-069-automated-route-tracking.md
 - [ ] .foundry/stories/story-034-070-death-tracking-and-graveyard.md
 - [ ] .foundry/stories/story-034-071-run-dashboard-ui.md

--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -71,3 +71,4 @@ Note that generation 3 data formatting and serialization uses MsgPack (`msgpackr
 
 ## 2026-05-18: Gen3 Data Formats Update
 Note that generation 3 data formatting uses `.jsonl` for source files in the repository for ease of review, which is then compiled into MsgPack via a Vite plugin for runtime use.
+- Sibling dependencies must strictly use node IDs (e.g., task-123-slug) instead of relative file paths to satisfy memory constraints.

--- a/.foundry/stories/story-034-069-automated-route-tracking.md
+++ b/.foundry/stories/story-034-069-automated-route-tracking.md
@@ -23,3 +23,9 @@ notes: ''
 
 ## Description
 Implement the underlying logic to aggregate caught Pokémon by `met_location` and identify first encounters. Detect violations if multiple Pokémon share the same location.
+
+### TASKS
+- [ ] .foundry/tasks/task-069-116-aggregate-encounters-impl.md
+- [ ] .foundry/tasks/task-069-117-aggregate-encounters-qa.md
+- [ ] .foundry/tasks/task-069-118-detect-violations-impl.md
+- [ ] .foundry/tasks/task-069-119-detect-violations-qa.md

--- a/.foundry/tasks/task-069-116-aggregate-encounters-impl.md
+++ b/.foundry/tasks/task-069-116-aggregate-encounters-impl.md
@@ -1,0 +1,30 @@
+---
+id: task-069-116-aggregate-encounters-impl
+type: TASK
+title: Aggregate encounters by met_location
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-034-069-automated-route-tracking
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Aggregate encounters by met_location
+
+## Description
+Implement the logic to aggregate caught Pokémon by their `met_location` from the save file (both Party and PC). This will be used to identify first encounters.
+
+## Acceptance Criteria
+- [ ] Logic extracts `met_location` from all caught Pokémon in the active save.
+- [ ] Encounters are aggregated by location.
+- [ ] Tests are written to ensure the aggregation works properly.

--- a/.foundry/tasks/task-069-117-aggregate-encounters-qa.md
+++ b/.foundry/tasks/task-069-117-aggregate-encounters-qa.md
@@ -1,0 +1,30 @@
+---
+id: task-069-117-aggregate-encounters-qa
+type: TASK
+title: QA Aggregate encounters by met_location
+status: PENDING
+owner_persona: qa
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on:
+  - task-069-116-aggregate-encounters-impl
+jules_session_id: null
+pr_number: null
+parent: story-034-069-automated-route-tracking
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Aggregate encounters by met_location
+
+## Description
+Validate the implementation of the logic to aggregate caught Pokémon by their `met_location`.
+
+## Acceptance Criteria
+- [ ] Run test suites to verify that `met_location` aggregation logic functions as expected.
+- [ ] Verify test coverage is sufficient.

--- a/.foundry/tasks/task-069-118-detect-violations-impl.md
+++ b/.foundry/tasks/task-069-118-detect-violations-impl.md
@@ -1,0 +1,31 @@
+---
+id: task-069-118-detect-violations-impl
+type: TASK
+title: Detect multiple encounters per location
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on:
+  - task-069-116-aggregate-encounters-impl
+jules_session_id: null
+pr_number: null
+parent: story-034-069-automated-route-tracking
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Detect multiple encounters per location
+
+## Description
+Implement the logic to identify Nuzlocke violations when multiple Pokémon share the same `met_location`.
+
+## Acceptance Criteria
+- [ ] Logic detects if more than one Pokémon is caught at the same `met_location`.
+- [ ] Flags violations accordingly.
+- [ ] Includes tests to verify correct violation detection.

--- a/.foundry/tasks/task-069-119-detect-violations-qa.md
+++ b/.foundry/tasks/task-069-119-detect-violations-qa.md
@@ -1,0 +1,30 @@
+---
+id: task-069-119-detect-violations-qa
+type: TASK
+title: QA Detect multiple encounters per location
+status: PENDING
+owner_persona: qa
+created_at: '2026-05-18'
+updated_at: '2026-05-18'
+depends_on:
+  - task-069-118-detect-violations-impl
+jules_session_id: null
+pr_number: null
+parent: story-034-069-automated-route-tracking
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Detect multiple encounters per location
+
+## Description
+Validate the implementation of Nuzlocke violation detection logic for multiple encounters at the same `met_location`.
+
+## Acceptance Criteria
+- [ ] Run test suites to verify that Nuzlocke violation logic functions as expected.
+- [ ] Verify test coverage is sufficient.


### PR DESCRIPTION
As the Story Owner, broke down STORY `story-034-069-automated-route-tracking` into four granular TASK nodes adhering to the system rules:
- `task-069-116-aggregate-encounters-impl` (coder)
- `task-069-117-aggregate-encounters-qa` (qa)
- `task-069-118-detect-violations-impl` (coder)
- `task-069-119-detect-violations-qa` (qa)

Updated the markdown body of the STORY node with references to the new tasks, and checked off the STORY in the parent EPIC `epic-026-034-automated-nuzlocke-tracker`. YAML frontmatter was left completely untouched across all parent nodes to adhere to the Empty PR and Status lifecycle policies. Added a lesson about using Node IDs in sibling dependencies to the persona journal.

---
*PR created automatically by Jules for task [1426180733376589492](https://jules.google.com/task/1426180733376589492) started by @szubster*