### PR TITLE
ci: set git user in sync script

### DIFF
--- a/scripts/sync-pokedata.sh
+++ b/scripts/sync-pokedata.sh
@@ -18,6 +18,9 @@ BRANCH_NAME="chore/sync-pokeapi-${UPSTREAM_SHA:0:7}"
 
 echo "Detected changes. Creating PR on branch ${BRANCH_NAME}..."
 
+git config --global user.email "github-actions[bot]@users.noreply.github.com"
+git config --global user.name "github-actions[bot]"
+
 git checkout -b "$BRANCH_NAME"
 git add data/db
 git commit -m "chore: sync PokéAPI data to ${UPSTREAM_SHA:0:7}"


### PR DESCRIPTION
The Pokeapi sync CI job is failing because it attempts to create a commit but has no git user identity set. This PR fixes the issue by setting the global git user name and email to the github-actions[bot] identity in scripts/sync-pokedata.sh.

---
*PR created automatically by Jules for task [4072602592067676096](https://jules.google.com/task/4072602592067676096) started by @szubster*