### PR TITLE
chore(foundry): mark task-061-114-gen3-distance-lookup-impl as completed

### DIFF
--- a/.foundry/tasks/task-061-114-gen3-distance-lookup-impl.md
+++ b/.foundry/tasks/task-061-114-gen3-distance-lookup-impl.md
@@ -31,5 +31,5 @@ Implement `getDistanceToMap` with precomputed distance matrix logic for Gen 3.
 - Implement this in `src/engine/mapGraph/gen3Graph.ts`.
 
 ## Acceptance Criteria
-- [ ] `getDistanceToMap` is implemented and exports the required signature.
-- [ ] `getDistanceToMap` correctly utilizes the `dist` array from `UnifiedLocation` for O(1) lookups.
+- [x] `getDistanceToMap` is implemented and exports the required signature.
+- [x] `getDistanceToMap` correctly utilizes the `dist` array from `UnifiedLocation` for O(1) lookups.


### PR DESCRIPTION
The target artifact `src/engine/mapGraph/gen3Graph.ts` already contains the requested precomputed distance matrix logic for Gen 3. The markdown file's checkboxes have been checked to satisfy the Empty PR Policy and ADR 007 completeness contract.

---
*PR created automatically by Jules for task [5721693481387319392](https://jules.google.com/task/5721693481387319392) started by @szubster*