### PR TITLE
QA: Validate Gen3 bounds checking

### DIFF
--- a/.foundry/tasks/task-060-116-gen3-bounds-checking-impl.md
+++ b/.foundry/tasks/task-060-116-gen3-bounds-checking-impl.md
@@ -25,5 +25,5 @@ notes: ''
 Implement `try...catch` blocks or appropriate mechanisms to catch `RangeError` from `DataView` operations in Gen3 parsing logic.
 
 ## Acceptance Criteria
-- [ ] Ensure `DataView` operations catch `RangeError`.
-- [ ] Propagate validation errors gracefully (e.g., "Corrupted Save File").
+- [x] Ensure `DataView` operations catch `RangeError`.
+- [x] Propagate validation errors gracefully (e.g., "Corrupted Save File").

--- a/.foundry/tasks/task-060-117-gen3-bounds-checking-qa.md
+++ b/.foundry/tasks/task-060-117-gen3-bounds-checking-qa.md
@@ -26,5 +26,5 @@ notes: ''
 Validate that bounds checking in Gen3 data parsing logic gracefully handles out-of-bounds reads.
 
 ## Acceptance Criteria
-- [ ] Verify that `RangeError` from `DataView` operations are caught.
-- [ ] Verify that validation errors are gracefully propagated (e.g., "Corrupted Save File") when bounds are exceeded, per ADR-010.
+- [x] Verify that `RangeError` from `DataView` operations are caught.
+- [x] Verify that validation errors are gracefully propagated (e.g., "Corrupted Save File") when bounds are exceeded, per ADR-010.


### PR DESCRIPTION
Checked acceptance criteria checkboxes for task-060-116-gen3-bounds-checking-impl.md and task-060-117-gen3-bounds-checking-qa.md after verifying the correct RangeError exception handling is implemented in Gen3 save parsers per ADR-010. No YAML frontmatter was modified.

---
*PR created automatically by Jules for task [13769339573001013819](https://jules.google.com/task/13769339573001013819) started by @szubster*