### PR TITLE
Update task blueprints for PR-less completion logging

### DIFF
--- a/.foundry/tasks/task-068-117-implement-heartbeat-tpm-logging.md
+++ b/.foundry/tasks/task-068-117-implement-heartbeat-tpm-logging.md
@@ -29,4 +29,8 @@ Update the `foundry-heartbeat.ts` script to log appropriate messages to the TPM 
 When a PR-less session is handled and a state transition occurs (e.g., to `COMPLETED` or `FAILED`), these events must be audited. We log them into `.foundry/journals/tpm.md`.
 
 ## Acceptance Criteria
-- [ ] Write tech lead blueprint for logging PR-less completions to TPM journal.
+- [x] Write tech lead blueprint for logging PR-less completions to TPM journal.
+
+## Downstream Nodes
+- TASK: .foundry/tasks/task-068-118-implement-heartbeat-tpm-logging.md
+- TASK: .foundry/tasks/task-068-119-qa-heartbeat-tpm-logging.md

--- a/.foundry/tasks/task-068-118-implement-heartbeat-tpm-logging.md
+++ b/.foundry/tasks/task-068-118-implement-heartbeat-tpm-logging.md
@@ -6,8 +6,7 @@ status: PENDING
 owner_persona: coder
 created_at: '2026-05-18'
 updated_at: '2026-05-18'
-depends_on:
-  - .foundry/tasks/task-068-117-implement-heartbeat-tpm-logging.md
+depends_on: []
 jules_session_id: null
 pr_number: null
 parent: story-033-068-heartbeat-tpm-logging
@@ -30,4 +29,5 @@ Update the `foundry-heartbeat.ts` script to log appropriate messages to the TPM 
 When a PR-less session is handled and a state transition occurs (e.g., to `COMPLETED` or `FAILED`), these events must be audited. We log them into `.foundry/journals/tpm.md`.
 
 ## Acceptance Criteria
-- [ ] Appropriate logs are written to `.foundry/journals/tpm.md` whenever a PR-less session results in a state transition.
+- [ ] Update `transitionNodeToCompleted` in `.github/scripts/foundry-heartbeat.ts` to log appropriately when a PR-less completion occurs (`prNumber === null`).
+- [ ] Ensure the log message distinguishes between PR merged and Empty PR session completion.

--- a/.foundry/tasks/task-068-119-qa-heartbeat-tpm-logging.md
+++ b/.foundry/tasks/task-068-119-qa-heartbeat-tpm-logging.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-05-18'
 updated_at: '2026-05-18'
 depends_on:
-  - .foundry/tasks/task-068-118-implement-heartbeat-tpm-logging.md
+  - task-068-118-implement-heartbeat-tpm-logging
 jules_session_id: null
 pr_number: null
 parent: story-033-068-heartbeat-tpm-logging
@@ -24,11 +24,11 @@ notes: ''
 # TASK: QA TPM Logging for PR-less Completions
 
 ## Objective
-Verify the changes made in `.foundry/tasks/task-068-118-implement-heartbeat-tpm-logging.md`.
+Verify the changes made in `task-068-118-implement-heartbeat-tpm-logging`.
 
 ## Context
 When a PR-less session is handled and a state transition occurs (e.g., to `COMPLETED` or `FAILED`), these events must be audited. We log them into `.foundry/journals/tpm.md`.
 
 ## Acceptance Criteria
-- [ ] Verify that appropriate logs are written to `.foundry/journals/tpm.md` whenever a PR-less session results in a state transition.
+- [ ] Verify that `transitionNodeToCompleted` in `.github/scripts/foundry-heartbeat.ts` logs correctly for empty PRs.
 - [ ] Run test suite with `cd .github/scripts && pnpm install && npx vitest run`.


### PR DESCRIPTION
Update task blueprints for PR-less completion logging

Added explicit contract details to task-068-118 (Coder) to log to `.foundry/journals/tpm.md` inside `transitionNodeToCompleted`. Updated task-068-119 (QA) to explicitly verify this with tests.
Checked off the acceptance criteria on the parent node (task-068-117) without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [1799873409026325558](https://jules.google.com/task/1799873409026325558) started by @szubster*