### PR TITLE
🔐 [security fix] Resolve ws uninitialized memory disclosure via pnpm.overrides

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -41,3 +41,4 @@ Overrode the `@tanstack/history` version to `1.161.6` in `package.json`. While t
 
 ## Sanitize Error Logging (CWE-209)
 **Pattern:** While application code requires generic error logs to prevent CWE-209, build scripts and CI GitHub actions (`scripts/` and `.github/scripts/`) MUST retain raw error objects (e.g. `console.error(e)`) as they are essential for debugging CI failures.
+**Pattern:** When mitigating vulnerable sub-dependencies flagged by `pnpm audit` (like `ws`), use the `pnpm.overrides` field in `package.json` to securely enforce the patched version down the dependency tree. Also, to fix CWE-285 vulnerabilities (incomplete URL substring matching) flagged by CodeQL, use `.endsWith()` or `.startsWith()` instead of `.includes()` when inspecting URLs.

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     },
     "overrides": {
       "@tanstack/history": "1.161.6",
-      "serialize-javascript": ">=7.0.5"
+      "serialize-javascript": ">=7.0.5",
+      "ws": ">=8.20.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@tanstack/history': 1.161.6
   serialize-javascript: '>=7.0.5'
+  ws: '>=8.20.1'
 
 importers:
 
@@ -4376,8 +4377,8 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6188,7 +6189,7 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.0
       vitest: 4.1.6(@types/node@25.8.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(vite@8.0.13(@types/node@25.8.0)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -8720,7 +8721,7 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   wsl-utils@0.3.1:
     dependencies:


### PR DESCRIPTION
🎯 What: Updated `pnpm.overrides` in `package.json` to enforce `ws` dependency version to `>=8.20.1` and ran `pnpm install`.
⚠️ Risk: The `ws` dependency had an Uninitialized memory disclosure vulnerability that could lead to sensitive information leakage.
🛡️ Solution: Applied a `pnpm.overrides` directive to upgrade `ws` across the dependency tree safely and resolve the `pnpm audit` warning.

---
*PR created automatically by Jules for task [9727100452723208702](https://jules.google.com/task/9727100452723208702) started by @szubster*