### PR TITLE
🛠️ Infras: Implement manualChunks for better caching and chunk size

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -7,11 +7,23 @@
   "files": [
     {
       "path": "assets/index-<hash>.js",
-      "maxSize": "555kb"
+      "maxSize": "300kb"
     },
     {
       "path": "assets/dag-<hash>.js",
-      "maxSize": "300kb"
+      "maxSize": "100kb"
+    },
+    {
+      "path": "assets/react-<hash>.js",
+      "maxSize": "250kb"
+    },
+    {
+      "path": "assets/router-<hash>.js",
+      "maxSize": "100kb"
+    },
+    {
+      "path": "assets/xyflow-<hash>.js",
+      "maxSize": "200kb"
     },
     {
       "path": "assets/style-<hash>.css",

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -65,3 +65,4 @@ Critical learnings:
 
 ## 2026-05-18 - Added madge for circular dependency checking
 **Learning:** Integrated `madge` to statically analyze and prevent circular dependencies in the codebase. Added `lint:circular` to the `lint` pipeline to ensure PRs fail if circular dependencies are introduced.
+* The project uses Vite 8 with Rolldown. When configuring `manualChunks` in `vite.config.ts`'s `rollupOptions.output`, it must be defined as a function (e.g., `manualChunks(id) { ... }`) rather than an object to avoid build errors like 'Expected Function but received Object'.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -95,6 +95,18 @@ export default defineConfig(() => {
       reportCompressedSize: true,
       rollupOptions: {
         output: {
+          manualChunks(id) {
+            if (id.includes('node_modules/react/') || id.includes('node_modules/react-dom/')) {
+              return 'react';
+            }
+            if (id.includes('node_modules/@tanstack/react-router/')) {
+              return 'router';
+            }
+            if (id.includes('node_modules/@xyflow/')) {
+              return 'xyflow';
+            }
+            return undefined;
+          }
         },
       },
     },


### PR DESCRIPTION
This PR updates the `vite.config.ts` to use a `manualChunks` function in the Rollup output options. 
By pulling out `react`, `@tanstack/react-router`, and `@xyflow` into their own named chunks, the main `index.js` file size is reduced, allowing browsers to load and cache these less frequently changing libraries independently of the application logic.

**Impact on DX/CI:**
- Smaller core chunk sizes.
- Faster client-side updates (app code changes don't bust vendor cache).
- Keeps bundle sizes below Vite's warnings.

**Setup notes:**
Configured as a function `manualChunks(id)` per Vite 8/Rolldown requirement.

---
*PR created automatically by Jules for task [8095636454907866385](https://jules.google.com/task/8095636454907866385) started by @szubster*