### PR TITLE
fix(ci): Update PokeAPI sync action to use MY_ISSUES_PAT

### DIFF
--- a/.github/workflows/sync-pokedata.yml
+++ b/.github/workflows/sync-pokedata.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Sync Data
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.MY_ISSUES_PAT }}
         run: |
           chmod +x scripts/sync-pokedata.sh
           ./scripts/sync-pokedata.sh


### PR DESCRIPTION
This changes `.github/workflows/sync-pokedata.yml` to use `secrets.MY_ISSUES_PAT` instead of `github.token` to allow the sync action to successfully create pull requests.

---
*PR created automatically by Jules for task [5759182992948252820](https://jules.google.com/task/5759182992948252820) started by @szubster*