### PR TITLE
feat(nuzlocke): aggregate encounters by location

### DIFF
--- a/.foundry/tasks/task-069-116-aggregate-encounters-impl.md
+++ b/.foundry/tasks/task-069-116-aggregate-encounters-impl.md
@@ -25,6 +25,6 @@ notes: ''
 Implement the logic to aggregate caught Pokémon by their `met_location` from the save file (both Party and PC). This will be used to identify first encounters.
 
 ## Acceptance Criteria
-- [ ] Logic extracts `met_location` from all caught Pokémon in the active save.
-- [ ] Encounters are aggregated by location.
-- [ ] Tests are written to ensure the aggregation works properly.
+- [x] Logic extracts `met_location` from all caught Pokémon in the active save.
+- [x] Encounters are aggregated by location.
+- [x] Tests are written to ensure the aggregation works properly.

--- a/src/engine/nuzlocke/tracker.test.ts
+++ b/src/engine/nuzlocke/tracker.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { PokemonInstance, SaveData } from '../saveParser/parsers/common';
+import { aggregateEncountersByLocation } from './tracker';
+
+describe('aggregateEncountersByLocation', () => {
+  it('should aggregate encounters by location correctly', () => {
+    const saveData: Partial<SaveData> = {
+      partyDetails: [
+        {
+          speciesId: 1,
+          caughtData: { location: 1, locationName: 'Route 1', level: 5, time: 'Day' },
+        } as PokemonInstance,
+      ],
+      pcDetails: [
+        {
+          speciesId: 2,
+          caughtData: { location: 1, locationName: 'Route 1', level: 6, time: 'Day' },
+        } as PokemonInstance,
+        {
+          speciesId: 3,
+          caughtData: { location: 2, locationName: 'Route 2', level: 7, time: 'Day' },
+        } as PokemonInstance,
+        {
+          speciesId: 4,
+          caughtData: undefined,
+        } as PokemonInstance,
+      ],
+    };
+
+    const result = aggregateEncountersByLocation(saveData as SaveData);
+
+    expect(result).toHaveLength(2);
+
+    const route1 = result.find((r) => r.locationId === 1);
+    expect(route1).toBeDefined();
+    expect(route1?.encounters).toHaveLength(2);
+    expect(route1?.encounters[0]?.speciesId).toBe(1);
+    expect(route1?.encounters[1]?.speciesId).toBe(2);
+
+    const route2 = result.find((r) => r.locationId === 2);
+    expect(route2).toBeDefined();
+    expect(route2?.encounters).toHaveLength(1);
+    expect(route2?.encounters[0]?.speciesId).toBe(3);
+  });
+});

--- a/src/engine/nuzlocke/tracker.ts
+++ b/src/engine/nuzlocke/tracker.ts
@@ -1,0 +1,32 @@
+import type { PokemonInstance, SaveData } from '../saveParser/parsers/common';
+
+export interface LocationEncounters {
+  locationId: number;
+  locationName: string;
+  encounters: PokemonInstance[];
+}
+
+export function aggregateEncountersByLocation(saveData: SaveData): LocationEncounters[] {
+  const locationMap = new Map<number, LocationEncounters>();
+
+  const allInstances = [...(saveData.partyDetails || []), ...(saveData.pcDetails || [])];
+
+  for (const instance of allInstances) {
+    if (instance.caughtData?.location) {
+      const { location, locationName } = instance.caughtData;
+
+      let entry = locationMap.get(location);
+      if (!entry) {
+        entry = {
+          locationId: location,
+          locationName: locationName || `Location ${location}`,
+          encounters: [],
+        };
+        locationMap.set(location, entry);
+      }
+      entry.encounters.push(instance);
+    }
+  }
+
+  return Array.from(locationMap.values());
+}


### PR DESCRIPTION
This PR implements the core logic for the automated Nuzlocke tracker to group encountered Pokémon by location.

It addresses `.foundry/tasks/task-069-116-aggregate-encounters-impl.md` by:
- Creating `src/engine/nuzlocke/tracker.ts` with `aggregateEncountersByLocation`.
- Adding unit tests in `src/engine/nuzlocke/tracker.test.ts`.
- Checking all acceptance criteria in the markdown file.
- Resolving type issues caused by `verbatimModuleSyntax`.

---
*PR created automatically by Jules for task [3850319207578900543](https://jules.google.com/task/3850319207578900543) started by @szubster*