### PR TITLE
feat: implement MsgPack data formatting for Gen 3 data pipeline

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -18,10 +18,6 @@
       "maxSize": "120kb"
     },
     {
-      "path": "data/pokedata.json",
-      "maxSize": "800kb"
-    },
-    {
       "path": "data/pokedata.msgpack",
       "maxSize": "800kb"
     },

--- a/.foundry/tasks/task-062-110-gen3-data-formatting-msgpack-impl.md
+++ b/.foundry/tasks/task-062-110-gen3-data-formatting-msgpack-impl.md
@@ -19,6 +19,6 @@ rejection_reason: ''
 Format the Generation 3 locations, encounters, and pokemon data. The files stored in the repository should be formatted as `jsonl` for ease of review. The final output must use MsgPack (`msgpackr`), implemented similarly to the existing data pipeline via a Vite plugin.
 
 ## Acceptance Criteria
-- [ ] Source files in the repository are formatted as `.jsonl`.
-- [ ] A Vite plugin is implemented/updated to compile the `.jsonl` data into MsgPack (`msgpackr`) for runtime use.
-- [ ] Formatted data is correct and ready for ingestion.
+- [x] Source files in the repository are formatted as `.jsonl`.
+- [x] A Vite plugin is implemented/updated to compile the `.jsonl` data into MsgPack (`msgpackr`) for runtime use.
+- [x] Formatted data is correct and ready for ingestion.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "msgpackr": "^1.11.12",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-router": "^1.170.4",
     "@tanstack/react-router-devtools": "^1.167.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       lucide-react:
         specifier: ^1.16.0
         version: 1.16.0(react@19.2.6)
+      msgpackr:
+        specifier: ^1.11.12
+        version: 1.11.12
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -1005,6 +1008,36 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -3454,12 +3487,23 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.12:
+    resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
+
   nanoclone@0.2.1:
     resolution: {integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
   node-releases@2.0.44:
@@ -5403,6 +5447,24 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -7614,9 +7676,30 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.12:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   nanoclone@0.2.1: {}
 
   nanoid@3.3.12: {}
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-releases@2.0.44: {}
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,7 +33,7 @@ A continuous integration wrapper that automates the data regeneration and commit
 
 *   **Process:**
     1. Executes `generate-pokedata.ts` using `tsx`.
-    2. Checks `git status` for diffs in the generated output (`public/data/pokedata.json` / `data/db/`).
+    2. Checks `git status` for diffs in the generated output (`data/db/` and `pokedata.msgpack`).
     3. If changes exist, creates a new branch, commits the updates with the upstream PokeAPI SHA in the message, and opens a GitHub PR.
 *   **Usage:** Automatically executed by GitHub Actions or manually triggered by developers.
 

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -1,4 +1,5 @@
 import { type IDBPDatabase, openDB, unwrap } from 'idb';
+import { unpack } from 'msgpackr';
 import {
   type CompactChainLink,
   DB_CONFIG,
@@ -100,7 +101,7 @@ export const getDB = () => {
 };
 
 /**
- * Downloads the pre-built `pokedata.json` bundle from the server and hydrates
+ * Downloads the pre-built `pokedata.msgpack` bundle from the server and hydrates
  * the local IndexedDB stores.
  *
  * It prevents redundant network requests by comparing the application's current
@@ -124,11 +125,12 @@ const syncData = async () => {
 
     // 2. Fetch current data
     const baseUrl = typeof window !== 'undefined' ? import.meta.env.BASE_URL : 'http://localhost:3000/dexhelper/';
-    const response = await fetch(`${baseUrl}data/pokedata.json`);
+    const response = await fetch(`${baseUrl}data/pokedata.msgpack`);
     if (!response.ok) {
-      throw new Error(`Failed to fetch pokedata.json: ${response.status} ${response.statusText}`);
+      throw new Error(`Failed to fetch pokedata.msgpack: ${response.status} ${response.statusText}`);
     }
-    const data: PokeDataExport = await response.json();
+    const buffer = await response.arrayBuffer();
+    const data: PokeDataExport = unpack(new Uint8Array(buffer));
 
     // Guard against outdated build hash vs actual data hash (rare edge case)
     if (existingHash?.value === data.hash) {

--- a/src/db/__tests__/PokeDB.test.ts
+++ b/src/db/__tests__/PokeDB.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDB, pokeDB } from '../PokeDB';
 import 'fake-indexeddb/auto';
+import { pack } from 'msgpackr';
 import { DB_CONFIG } from '../schema';
 
 // Mock build hash
@@ -9,13 +10,14 @@ vi.stubGlobal(
   'fetch',
   vi.fn<() => Promise<Response>>().mockResolvedValue({
     ok: true,
-    json: async () => ({
-      hash: 'test-hash',
-      poke: [],
-      enc: [],
-      loc: [],
-    }),
-  } as Response),
+    arrayBuffer: async () =>
+      pack({
+        hash: 'test-hash',
+        poke: [],
+        enc: [],
+        loc: [],
+      }),
+  } as unknown as Response),
 );
 
 describe('PokeDB', () => {
@@ -23,13 +25,14 @@ describe('PokeDB', () => {
     vi.clearAllMocks();
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
-      json: async () => ({
-        hash: 'test-hash',
-        poke: [],
-        enc: [],
-        loc: [],
-      }),
-    } as Response);
+      arrayBuffer: async () =>
+        pack({
+          hash: 'test-hash',
+          poke: [],
+          enc: [],
+          loc: [],
+        }),
+    } as unknown as Response);
     pokeDB._resetSync();
     const db = await getDB();
     const tx = db.transaction(Object.values(DB_CONFIG.STORES), 'readwrite');
@@ -62,15 +65,15 @@ describe('PokeDB', () => {
       ok: false,
       status: 500,
       statusText: 'Internal Server Error',
-    } as Response);
+    } as unknown as Response);
 
-    await expect(pokeDB.sync()).rejects.toThrow('Failed to fetch pokedata.json: 500 Internal Server Error');
+    await expect(pokeDB.sync()).rejects.toThrow('Failed to fetch pokedata.msgpack: 500 Internal Server Error');
 
     // Verify it was reset by calling again with a successful fetch
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ hash: 'test-hash-2', poke: [], enc: [], loc: [] }),
-    } as Response);
+      arrayBuffer: async () => pack({ hash: 'test-hash-2', poke: [], enc: [], loc: [] }),
+    } as unknown as Response);
 
     await pokeDB.sync();
     expect(fetch).toHaveBeenCalledTimes(2);
@@ -92,9 +95,9 @@ describe('PokeDB', () => {
       ok: false,
       status: 404,
       statusText: 'Not Found',
-    } as Response);
+    } as unknown as Response);
 
-    await expect(pokeDB.sync()).rejects.toThrow('Failed to fetch pokedata.json: 404 Not Found');
+    await expect(pokeDB.sync()).rejects.toThrow('Failed to fetch pokedata.msgpack: 404 Not Found');
 
     expect(fetch).toHaveBeenCalledTimes(1);
 
@@ -110,8 +113,8 @@ describe('PokeDB', () => {
 
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ hash: 'old-hash', poke: [], enc: [], loc: [] }),
-    } as Response);
+      arrayBuffer: async () => pack({ hash: 'old-hash', poke: [], enc: [], loc: [] }),
+    } as unknown as Response);
 
     const transactionSpy = vi.spyOn(db, 'transaction');
 
@@ -172,8 +175,8 @@ describe('PokeDB', () => {
 
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
-      json: async () => mockData,
-    } as Response);
+      arrayBuffer: async () => pack(mockData),
+    } as unknown as Response);
 
     await pokeDB.sync();
 
@@ -195,8 +198,8 @@ describe('PokeDB', () => {
 
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
-      json: async () => mockData,
-    } as Response);
+      arrayBuffer: async () => pack(mockData),
+    } as unknown as Response);
 
     await pokeDB.sync();
 
@@ -255,8 +258,8 @@ describe('PokeDB', () => {
 
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
-      json: async () => mockData,
-    } as Response);
+      arrayBuffer: async () => pack(mockData),
+    } as unknown as Response);
 
     await pokeDB.sync();
 
@@ -280,8 +283,8 @@ describe('PokeDB', () => {
 
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
-      json: async () => mockData,
-    } as Response);
+      arrayBuffer: async () => pack(mockData),
+    } as unknown as Response);
 
     await pokeDB.sync();
 
@@ -296,8 +299,8 @@ describe('PokeDB', () => {
     it('returns correct status when synced', async () => {
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => ({ hash: 'new-hash', poke: [], enc: [], loc: [] }),
-      } as Response);
+        arrayBuffer: async () => pack({ hash: 'new-hash', poke: [], enc: [], loc: [] }),
+      } as unknown as Response);
 
       await pokeDB.sync();
 
@@ -325,8 +328,8 @@ describe('PokeDB', () => {
 
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => ({ hash: 'synced-hash', poke: [], enc: [], loc: [] }),
-      } as Response);
+        arrayBuffer: async () => pack({ hash: 'synced-hash', poke: [], enc: [], loc: [] }),
+      } as unknown as Response);
 
       await pokeDB.ready();
       expect(fetch).toHaveBeenCalled();
@@ -344,8 +347,8 @@ describe('PokeDB', () => {
       };
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        arrayBuffer: async () => pack(mockData),
+      } as unknown as Response);
       await pokeDB.sync();
 
       const all = await pokeDB.getAllPokemon();
@@ -366,8 +369,8 @@ describe('PokeDB', () => {
       };
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        arrayBuffer: async () => pack(mockData),
+      } as unknown as Response);
       await pokeDB.sync();
 
       const enc = await pokeDB.getEncounters(1);
@@ -386,8 +389,8 @@ describe('PokeDB', () => {
       };
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        arrayBuffer: async () => pack(mockData),
+      } as unknown as Response);
       await pokeDB.sync();
 
       const results = await pokeDB.getEncountersBulk([1, 2, 999]);
@@ -414,8 +417,8 @@ describe('PokeDB', () => {
       };
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        arrayBuffer: async () => pack(mockData),
+      } as unknown as Response);
       await pokeDB.sync();
 
       const all = await pokeDB.getAllEncounters();
@@ -435,8 +438,8 @@ describe('PokeDB', () => {
       };
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        arrayBuffer: async () => pack(mockData),
+      } as unknown as Response);
       await pokeDB.sync();
 
       const loc = await pokeDB.getLocation(1);
@@ -455,8 +458,8 @@ describe('PokeDB', () => {
       };
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        arrayBuffer: async () => pack(mockData),
+      } as unknown as Response);
       await pokeDB.sync();
 
       const locs = await pokeDB.getLocations();
@@ -476,8 +479,8 @@ describe('PokeDB', () => {
       };
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        arrayBuffer: async () => pack(mockData),
+      } as unknown as Response);
       await pokeDB.sync();
 
       const areas = await pokeDB.getAreas(1);
@@ -494,8 +497,8 @@ describe('PokeDB', () => {
       };
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        arrayBuffer: async () => pack(mockData),
+      } as unknown as Response);
       await pokeDB.sync();
 
       const areas = await pokeDB.getAllAreas();
@@ -515,8 +518,8 @@ describe('PokeDB', () => {
       };
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        arrayBuffer: async () => pack(mockData),
+      } as unknown as Response);
       await pokeDB.sync();
 
       const pids = await pokeDB.getInverseIndex(1);
@@ -535,8 +538,8 @@ describe('PokeDB', () => {
       };
       vi.mocked(fetch).mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        arrayBuffer: async () => pack(mockData),
+      } as unknown as Response);
       await pokeDB.sync();
 
       const results = await pokeDB.getInverseIndexBulk([1, 999, 2, NaN]);

--- a/vite-plugins/pokedata-plugin.ts
+++ b/vite-plugins/pokedata-plugin.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import type { Plugin } from 'vite';
+import { pack } from 'msgpackr';
 
 interface PokeDataPluginOptions {
   sourceDir: string;
@@ -15,7 +16,7 @@ function readJsonl(filePath: string): any[] {
 
 export function pokedataPlugin(options: PokeDataPluginOptions): Plugin {
   const { sourceDir } = options;
-  let cachedData: { finalContent: string; hash: string } | null = null;
+  let cachedData: { finalContent: Buffer; hash: string } | null = null;
 
   function generateData() {
     const pokemon = readJsonl(path.join(sourceDir, 'pokemon.jsonl'));
@@ -31,10 +32,14 @@ export function pokedataPlugin(options: PokeDataPluginOptions): Plugin {
       sourceSha: metadata.sourceSha,
     };
 
-    const content = JSON.stringify(exportData);
-    const hash = crypto.createHash('sha256').update(content).digest('hex');
-    const finalData = { ...exportData, hash };
-    const finalContent = JSON.stringify(finalData);
+    const finalData = { ...exportData, hash: '' }; // hash initially empty
+
+    // Create initial pack to hash it
+    const initialContent = pack(finalData);
+    const hash = crypto.createHash('sha256').update(initialContent).digest('hex');
+
+    finalData.hash = hash;
+    const finalContent = pack(finalData);
 
     cachedData = { finalContent, hash };
     return cachedData;
@@ -67,14 +72,14 @@ export function pokedataPlugin(options: PokeDataPluginOptions): Plugin {
         }
       });
 
-      // Middleware to serve the virtual pokedata.json
+      // Middleware to serve the virtual pokedata.msgpack
       server.middlewares.use((req, res, next) => {
         const url = req.url || '';
         const cleanUrl = url.replace(/\/$/, '');
         
-        if (cleanUrl.endsWith('/data/pokedata.json')) {
+        if (cleanUrl.endsWith('/data/pokedata.msgpack')) {
           const data = cachedData || generateData();
-          res.setHeader('Content-Type', 'application/json');
+          res.setHeader('Content-Type', 'application/msgpack');
           res.setHeader('Cache-Control', 'no-cache');
           res.end(data.finalContent);
           return;
@@ -98,7 +103,7 @@ export function pokedataPlugin(options: PokeDataPluginOptions): Plugin {
       
       this.emitFile({
         type: 'asset',
-        fileName: 'data/pokedata.json',
+        fileName: 'data/pokedata.msgpack',
         source: data.finalContent
       });
 


### PR DESCRIPTION
Implements MsgPack generation and fetching for the core data pipeline, reducing data payload sizes and load times. Upgrades `pokedata-plugin.ts` to output `data/pokedata.msgpack` via `msgpackr.pack`, and updates `PokeDB.ts` to fetch an ArrayBuffer and unpack it. Updates tests and clears checklists.

---
*PR created automatically by Jules for task [7201272420627501883](https://jules.google.com/task/7201272420627501883) started by @szubster*