### PR TITLE
QA Gen3 Bounds Checking

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -91,3 +91,8 @@ No YAML changes were made per standard Foundry architecture rules.
 
 - Learned that task implementation can be marked completed while entirely missing the logic to fetch Gen 3 data from pret/pokeemerald. Always explicitly check scripts for target repositories.
 - 2026-05-18: Validated Headbutt and Rock Smash logic. The initial implementation checked for items (TM02 and TM08) but failed to check for the required badges (Hive and Plain badges respectively) to use these moves in the field. Added the badge checks to `saveData.johtoBadges` where bit 1 is the Hive Badge and bit 2 is the Plain Badge. Note for future: always double check both item and badge requirements for field moves.
+
+## 2026-05-19 - Task COMPLETED: QA Gen3 Bounds Checking
+**Task**: task-060-117-gen3-bounds-checking-qa
+**Outcome**: COMPLETED (Empty PR)
+**Notes**: Verified that the coder successfully implemented bounds checking for Gen3 save parsing using the `DataView` API in `src/engine/saveParser/parsers/gen3.ts`. The implementation properly catches `RangeError` from out-of-bounds `DataView` operations and gracefully propagates a "Corrupted Save File" validation error as required by ADR-010. Confirmed that `gen3.test.ts` thoroughly covers these bounds checking scenarios. All static checks and unit tests passed via `pnpm lint && pnpm test`. The acceptance criteria in the markdown body were already checked off by the coder, so submitting an empty PR to unblock the DAG.


### PR DESCRIPTION
Submitting Empty PR for task-060-117-gen3-bounds-checking-qa. The coder has correctly implemented `RangeError` catching and error propagation in `gen3.ts` using the `DataView` API as required by ADR 010. Tests exist and `pnpm lint && pnpm test` pass. The acceptance criteria in the markdown body are already checked off. Added notes to the QA journal.

---
*PR created automatically by Jules for task [18131936938088083433](https://jules.google.com/task/18131936938088083433) started by @szubster*