### PR TITLE
chore(foundry): blueprint for gen 2 interaction logic fix

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -122,3 +122,7 @@ When drafting technical blueprints from stories that contain multiple independen
 
 ## 2026-05-18: Handling QA Task FAILED with Unfulfilled Acceptance Criteria
 When processing `story-029-057-interaction-logic`, I observed the child QA task (`task-057-095`) was FAILED due to "Merged with unfulfilled acceptance criteria", indicating the agent submitted an empty PR without checking its boxes or writing the tests. I unchecked the Acceptance Criteria checkboxes in the parent story (without modifying YAML frontmatter) to keep it alive, and appended a note to the QA task's markdown body instructing the `qa` persona to write the missing tests and check their boxes.
+
+## 2026-05-19: Gen 2 TM vs Move Checks (Headbutt/Rock Smash)
+*   **Learning:** In Gen 2 (Gold/Silver/Crystal), Headbutt and Rock Smash are single-use TMs (TM02 and TM08), not HMs. Furthermore, they do not require any gym badges to be used in the field. Because they disappear from the inventory when taught, our suggestion engine logic cannot solely rely on TM inventory checks to see if the player has access to these field mechanics.
+*   **Action:** We must cross-reference if any Pokémon in the player's party or PC (`allInstances`) actually knows the move (Headbutt ID: 29, Rock Smash ID: 249) instead of just checking the TM pocket, and we must remove the gym badge requirements for these specific interactions.

--- a/.foundry/stories/story-029-057-interaction-logic.md
+++ b/.foundry/stories/story-029-057-interaction-logic.md
@@ -35,3 +35,5 @@ Handle Headbutt and Rock Smash encounters in the suggestion engine, cross-refere
 ### Tasks
 - [.foundry/tasks/task-057-094-implement-headbutt-rocksmash-logic.md](.foundry/tasks/task-057-094-implement-headbutt-rocksmash-logic.md)
 - [.foundry/tasks/task-057-095-qa-headbutt-rocksmash-logic.md](.foundry/tasks/task-057-095-qa-headbutt-rocksmash-logic.md)
+- [.foundry/tasks/task-057-120-fix-headbutt-rocksmash-moves.md](.foundry/tasks/task-057-120-fix-headbutt-rocksmash-moves.md)
+- [.foundry/tasks/task-057-121-qa-headbutt-rocksmash-moves.md](.foundry/tasks/task-057-121-qa-headbutt-rocksmash-moves.md)

--- a/.foundry/tasks/task-057-120-fix-headbutt-rocksmash-moves.md
+++ b/.foundry/tasks/task-057-120-fix-headbutt-rocksmash-moves.md
@@ -1,0 +1,43 @@
+---
+id: task-057-120-fix-headbutt-rocksmash-moves
+type: TASK
+title: Fix Headbutt and Rock Smash Move Checks
+status: READY
+owner_persona: coder
+created_at: '2026-05-19'
+updated_at: '2026-05-19'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/stories/story-029-057-interaction-logic.md
+tags:
+  - gen2
+  - expansion
+  - suggestion-engine
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Fix Headbutt and Rock Smash Move Checks
+
+## Description
+The current implementation for Headbutt and Rock Smash in the suggestion engine relies solely on checking the player's inventory for the TM items (TM02 and TM08) and checks for Johto gym badges. In Gen 2, these are single-use TMs (not HMs), meaning they disappear from inventory once used. Additionally, they do not require gym badges to be used in the field. The suggestion engine must check if any Pokémon in the player's Party or PC knows the moves instead of just relying on the TM inventory, and the badge checks should be removed.
+
+## Technical Blueprint
+
+1. **Update `gen2Strategy.ts` and `suggestionEngine.ts`**
+   - Headbutt move ID is 29. Rock Smash move ID is 249.
+   - Remove the gym badge checks for both moves (Johto badge bits 1 and 2).
+   - In `suggestionEngine.ts`, update the `hasHeadbutt` and `hasRockSmash` checks to evaluate if any `PokemonInstance` in `allInstances` has move ID 29 (Headbutt) or 249 (Rock Smash) in their `moves` array, OR if the TM is in the inventory.
+   - Do the same in `gen2Strategy.ts`. The strategy only has `saveData`, so use `[...(saveData.partyDetails || []), ...(saveData.pcDetails || [])]` to get the instances.
+
+2. **Update Tests**
+   - Update `generateSuggestions.test.ts` (and any other relevant tests) to verify the new move-based logic and the removal of the badge requirements.
+
+## Acceptance Criteria
+- [ ] `gen2Strategy.ts` checks for Headbutt (Move 29) and Rock Smash (Move 249) on Pokémon instances or TMs in inventory, without badge checks.
+- [ ] `suggestionEngine.ts` checks for Headbutt (Move 29) and Rock Smash (Move 249) on Pokémon instances or TMs in inventory, without badge checks.
+- [ ] Tests verify the updated known-moves logic and lack of badge restrictions.

--- a/.foundry/tasks/task-057-121-qa-headbutt-rocksmash-moves.md
+++ b/.foundry/tasks/task-057-121-qa-headbutt-rocksmash-moves.md
@@ -1,0 +1,40 @@
+---
+id: task-057-121-qa-headbutt-rocksmash-moves
+type: TASK
+title: 'QA: Fix Headbutt and Rock Smash Move Checks'
+status: READY
+owner_persona: qa
+created_at: '2026-05-19'
+updated_at: '2026-05-19'
+depends_on:
+  - .foundry/tasks/task-057-120-fix-headbutt-rocksmash-moves.md
+jules_session_id: null
+pr_number: null
+parent: .foundry/stories/story-029-057-interaction-logic.md
+tags:
+  - gen2
+  - expansion
+  - suggestion-engine
+  - qa
+research_references:
+  - .foundry/docs/knowledge_base/development/gen2_implementation_plan.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA: Fix Headbutt and Rock Smash Move Checks
+
+## Description
+Validate the implementation of the Headbutt and Rock Smash move check logic in the suggestion engine. This node verifies the work done in `task-057-120-fix-headbutt-rocksmash-moves`.
+
+## Verification Steps
+1. Verify the suggestion engine correctly identifies Headbutt capabilities based on Pokémon known moves (ID 29) or TM inventory, without requiring badges.
+2. Verify the suggestion engine correctly identifies Rock Smash capabilities based on Pokémon known moves (ID 249) or TM inventory, without requiring badges.
+3. Verify comprehensive unit test coverage exists for the new logic.
+4. Execute `pnpm lint` and `pnpm test` to ensure overall project health.
+
+## Acceptance Criteria
+- [ ] Code meets all architectural and quality guidelines.
+- [ ] Tests successfully pass and cover Headbutt and Rock Smash known-moves logic and lack of badge restrictions.
+- [ ] Linter reports zero warnings or errors.


### PR DESCRIPTION
As the Tech Lead, I investigated the Headbutt and Rock Smash interaction logic in `gen2Strategy.ts` and `suggestionEngine.ts`. I discovered that they incorrectly relied solely on TM inventory checks (TM02 and TM08) and gym badges, which contradicts Gen 2 mechanics where these TMs are single-use, disappear when taught, and do not require badges in the field. 

I drafted technical blueprints (`task-057-120-fix-headbutt-rocksmash-moves` and `task-057-121-qa-headbutt-rocksmash-moves`) to correct this by checking if any Pokémon in the player's party or PC actually knows the moves (Headbutt ID: 29, Rock Smash ID: 249) and removing the badge checks. I updated the parent story and recorded the domain knowledge constraint in the `tech_lead.md` journal.

---
*PR created automatically by Jules for task [17311497327450493483](https://jules.google.com/task/17311497327450493483) started by @szubster*