### PR TITLE
chore: mark task 068-118 complete

### DIFF
--- a/.foundry/tasks/task-068-118-implement-heartbeat-tpm-logging.md
+++ b/.foundry/tasks/task-068-118-implement-heartbeat-tpm-logging.md
@@ -29,5 +29,5 @@ Update the `foundry-heartbeat.ts` script to log appropriate messages to the TPM 
 When a PR-less session is handled and a state transition occurs (e.g., to `COMPLETED` or `FAILED`), these events must be audited. We log them into `.foundry/journals/tpm.md`.
 
 ## Acceptance Criteria
-- [ ] Update `transitionNodeToCompleted` in `.github/scripts/foundry-heartbeat.ts` to log appropriately when a PR-less completion occurs (`prNumber === null`).
-- [ ] Ensure the log message distinguishes between PR merged and Empty PR session completion.
+- [x] Update `transitionNodeToCompleted` in `.github/scripts/foundry-heartbeat.ts` to log appropriately when a PR-less completion occurs (`prNumber === null`).
+- [x] Ensure the log message distinguishes between PR merged and Empty PR session completion.


### PR DESCRIPTION
This PR fulfills task-068-118. The underlying code in `foundry-heartbeat.ts` was already properly implemented (perhaps by another agent's partial work or overlapping task) to log appropriately to the TPM journal, distinguishing between Empty PR and Merged PR sessions. The acceptance criteria checkboxes in `.foundry/tasks/task-068-118-implement-heartbeat-tpm-logging.md` have been checked.

---
*PR created automatically by Jules for task [12594713208631760441](https://jules.google.com/task/12594713208631760441) started by @szubster*