### PR TITLE
Foundry: Retry Gen3 Locations Generation

### DIFF
--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -76,3 +76,5 @@ Note that generation 3 data formatting and serialization uses MsgPack (`msgpackr
 ## 2026-05-18: Gen3 Data Formats Update
 Note that generation 3 data formatting uses `.jsonl` for source files in the repository for ease of review, which is then compiled into MsgPack via a Vite plugin for runtime use.
 - Sibling dependencies must strictly use node IDs (e.g., task-123-slug) instead of relative file paths to satisfy memory constraints.
+## 2026-05-19: Handling Failed Leaf Tasks
+- **Pattern Insight:** When a leaf task (e.g. a `coder` or `qa` TASK) fails permanently by reaching its Max Rejection Count, the best course of action is to spawn a `RESEARCH` node to investigate the root cause, followed by a new set of implementation and QA tasks that explicitly depend on the `RESEARCH` node. This isolates the unknown factor and ensures the new attempt is informed. Append these new nodes to the parent node.

--- a/.foundry/research/research-062-001-pokeemerald-locations.md
+++ b/.foundry/research/research-062-001-pokeemerald-locations.md
@@ -1,0 +1,28 @@
+---
+id: research-062-001-pokeemerald-locations
+type: RESEARCH
+title: Investigate pret/pokeemerald Locations Data Structure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-05-19'
+updated_at: '2026-05-19'
+depends_on: []
+jules_session_id: null
+parent: story-032-062-gen3-data-generation-scripts
+tags:
+  - gen3
+  - data
+  - msgpack
+  - research
+notes: ''
+---
+
+# Investigate pret/pokeemerald Locations Data Structure
+
+## Description
+Investigate the `pret/pokeemerald` repository to determine how map locations and internal location IDs are structured. This is required to fix the Gen 3 locations generation script, which previously failed because it was missing this logic. Identify the correct files to parse in order to build the Gen 3 map graph data.
+
+## Acceptance Criteria
+- [ ] Determine the files in `pret/pokeemerald` that contain map location mappings.
+- [ ] Document the data structure and how to parse it.
+- [ ] Provide clear recommendations for `task-062-120-gen3-locations-script-retry-impl`.

--- a/.foundry/stories/story-032-062-gen3-data-generation-scripts.md
+++ b/.foundry/stories/story-032-062-gen3-data-generation-scripts.md
@@ -36,3 +36,6 @@ Modify existing data generation scripts to support fetching and formatting Gen 3
 - task-062-105-gen3-pokemon-script-qa
 - task-062-110-gen3-data-formatting-msgpack-impl
 - task-062-111-gen3-data-formatting-msgpack-qa
+- research-062-001-pokeemerald-locations
+- task-062-120-gen3-locations-script-retry-impl
+- task-062-121-gen3-locations-script-retry-qa

--- a/.foundry/tasks/task-062-120-gen3-locations-script-retry-impl.md
+++ b/.foundry/tasks/task-062-120-gen3-locations-script-retry-impl.md
@@ -1,0 +1,30 @@
+---
+id: task-062-120-gen3-locations-script-retry-impl
+type: TASK
+title: Retry Implementing Gen 3 Locations Fetch Script
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-19'
+updated_at: '2026-05-19'
+depends_on:
+  - research-062-001-pokeemerald-locations
+jules_session_id: null
+parent: story-032-062-gen3-data-generation-scripts
+tags:
+  - gen3
+  - data
+  - msgpack
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Retry Implementing Gen 3 Locations Fetch Script
+
+## Description
+Based on the findings from `research-062-001-pokeemerald-locations`, implement the script to fetch and format Generation 3 locations data.
+
+## Acceptance Criteria
+- [ ] Script successfully fetches Gen 3 locations from `pret/pokeemerald`.
+- [ ] Data is correctly formatted.
+- [ ] The script writes the data properly for msgpack encoding.

--- a/.foundry/tasks/task-062-121-gen3-locations-script-retry-qa.md
+++ b/.foundry/tasks/task-062-121-gen3-locations-script-retry-qa.md
@@ -1,0 +1,29 @@
+---
+id: task-062-121-gen3-locations-script-retry-qa
+type: TASK
+title: QA Retry Implementing Gen 3 Locations Fetch Script
+status: PENDING
+owner_persona: qa
+created_at: '2026-05-19'
+updated_at: '2026-05-19'
+depends_on:
+  - task-062-120-gen3-locations-script-retry-impl
+jules_session_id: null
+parent: story-032-062-gen3-data-generation-scripts
+tags:
+  - gen3
+  - data
+  - msgpack
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Retry Implementing Gen 3 Locations Fetch Script
+
+## Description
+QA validate the script that fetches Generation 3 locations data, specifically ensuring it properly parses `pret/pokeemerald`.
+
+## Acceptance Criteria
+- [ ] QA verifies the script fetches accurate Gen 3 locations from `pret/pokeemerald`.
+- [ ] QA verifies the output format matches expectations.


### PR DESCRIPTION
After investigating the failure of `task-062-100-gen3-locations-script-impl` (which hit max rejection count due to missing pret/pokeemerald parsing logic), I have generated a `RESEARCH` node to isolate and investigate the root cause. Subsequently, I have spawned `task-062-120` and `task-062-121` to retry the implementation and QA, and appended them to the parent story `story-032-062-gen3-data-generation-scripts`. 

Additionally, I recorded this workflow pattern into the `story_owner` journal for future reference.

---
*PR created automatically by Jules for task [1565881621887393412](https://jules.google.com/task/1565881621887393412) started by @szubster*