### PR TITLE
chore(foundry): spawn research and retry tasks for failed gen 3 location fetch

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -91,3 +91,9 @@ No YAML changes were made per standard Foundry architecture rules.
 
 - Learned that task implementation can be marked completed while entirely missing the logic to fetch Gen 3 data from pret/pokeemerald. Always explicitly check scripts for target repositories.
 - 2026-05-18: Validated Headbutt and Rock Smash logic. The initial implementation checked for items (TM02 and TM08) but failed to check for the required badges (Hive and Plain badges respectively) to use these moves in the field. Added the badge checks to `saveData.johtoBadges` where bit 1 is the Hive Badge and bit 2 is the Plain Badge. Note for future: always double check both item and badge requirements for field moves.
+
+## 2026-05-19 - Implementation Task FAILED: Gen 3 Locations Fetch Script
+
+**Task**: task-062-101-gen3-locations-script-qa
+**Outcome**: FAILED
+**Notes**: The coder failed to implement the Gen 3 location fetching logic from `pret/pokeemerald` in `scripts/generateMapLocations.ts`. The implementation task (`task-062-100-gen3-locations-script-impl`) repeatedly failed and reached its maximum rejection count. Following the system rules, I spawned a `RESEARCH` node (`research-062-120-gen3-locations-investigation`) to investigate the root cause, followed by a new set of implementation and QA tasks that explicitly depend on the `RESEARCH` node. These new nodes have been appended to the parent STORY node. This ensures the DAG can continue progression by addressing the fundamental issues blocking the implementation.

--- a/.foundry/research/research-062-120-gen3-locations-investigation.md
+++ b/.foundry/research/research-062-120-gen3-locations-investigation.md
@@ -1,0 +1,22 @@
+---
+id: research-062-120-gen3-locations-investigation
+type: RESEARCH
+title: Investigate Gen 3 Locations Fetch Script Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-05-19'
+updated_at: '2026-05-19'
+depends_on: []
+jules_session_id: null
+parent: story-032-062-gen3-data-generation-scripts
+---
+
+# Investigate Gen 3 Locations Fetch Script Failure
+
+## Description
+Investigate why the `generateMapLocations.ts` script failed to correctly fetch Gen 3 locations from `pret/pokeemerald`. The implementation in `task-062-100-gen3-locations-script-impl` repeatedly failed and reached the maximum rejection count.
+
+## Objectives
+- Determine the correct file paths and formats in the `pret/pokeemerald` repository for extracting map locations and group information.
+- Provide a technical approach for parsing this data within the `generateMapLocations.ts` script.
+- Ensure the approach adheres to the ADR 010 Gen 3 map graph design if applicable, specifically the bitwise shifting requirements for unique namespacing `(3 << 16) | (group << 8) | id`.

--- a/.foundry/stories/story-032-062-gen3-data-generation-scripts.md
+++ b/.foundry/stories/story-032-062-gen3-data-generation-scripts.md
@@ -36,3 +36,6 @@ Modify existing data generation scripts to support fetching and formatting Gen 3
 - task-062-105-gen3-pokemon-script-qa
 - task-062-110-gen3-data-formatting-msgpack-impl
 - task-062-111-gen3-data-formatting-msgpack-qa
+- research-062-120-gen3-locations-investigation
+- task-062-121-gen3-locations-script-impl-retry
+- task-062-122-gen3-locations-script-qa-retry

--- a/.foundry/tasks/task-062-100-gen3-locations-script-impl.md
+++ b/.foundry/tasks/task-062-100-gen3-locations-script-impl.md
@@ -10,7 +10,7 @@ depends_on: []
 jules_session_id: null
 parent: story-032-062-gen3-data-generation-scripts
 rejection_count: 3
-rejection_reason: Max rejection count reached
+rejection_reason: Failed to fetch from pret/pokeemerald
 ---
 
 # Implement Gen 3 Locations Fetch Script

--- a/.foundry/tasks/task-062-101-gen3-locations-script-qa.md
+++ b/.foundry/tasks/task-062-101-gen3-locations-script-qa.md
@@ -24,3 +24,5 @@ QA validate the script that fetches Generation 3 locations data.
 
 ## QA Notes
 - Validation failed: Missing Gen 3 location fetching logic from pret/pokeemerald in scripts/generateMapLocations.ts
+- The implementation task `task-062-100-gen3-locations-script-impl` permanently failed (reached maximum rejection count).
+- Spawned `research-062-120-gen3-locations-investigation` to investigate the root cause, followed by a new set of implementation and QA tasks.

--- a/.foundry/tasks/task-062-121-gen3-locations-script-impl-retry.md
+++ b/.foundry/tasks/task-062-121-gen3-locations-script-impl-retry.md
@@ -1,0 +1,22 @@
+---
+id: task-062-121-gen3-locations-script-impl-retry
+type: TASK
+title: Retry Gen 3 Locations Fetch Script Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-19'
+updated_at: '2026-05-19'
+depends_on:
+  - research-062-120-gen3-locations-investigation
+jules_session_id: null
+parent: story-032-062-gen3-data-generation-scripts
+---
+
+# Retry Gen 3 Locations Fetch Script Implementation
+
+## Description
+Implement the `generateMapLocations.ts` script logic to fetch and format Generation 3 locations data from `pret/pokeemerald`, based on the findings from the research node.
+
+## Acceptance Criteria
+- [ ] Script successfully fetches Gen 3 locations from `pret/pokeemerald`.
+- [ ] Data is correctly formatted and namespaced, utilizing bitwise shifting `(3 << 16) | (group << 8) | id` to prevent collisions.

--- a/.foundry/tasks/task-062-122-gen3-locations-script-qa-retry.md
+++ b/.foundry/tasks/task-062-122-gen3-locations-script-qa-retry.md
@@ -1,0 +1,22 @@
+---
+id: task-062-122-gen3-locations-script-qa-retry
+type: TASK
+title: QA Gen 3 Locations Fetch Script Implementation Retry
+status: PENDING
+owner_persona: qa
+created_at: '2026-05-19'
+updated_at: '2026-05-19'
+depends_on:
+  - task-062-121-gen3-locations-script-impl-retry
+jules_session_id: null
+parent: story-032-062-gen3-data-generation-scripts
+---
+
+# QA Gen 3 Locations Fetch Script Implementation Retry
+
+## Description
+QA validate the retry of the script implementation that fetches Generation 3 locations data.
+
+## Acceptance Criteria
+- [ ] QA verifies the script fetches accurate Gen 3 locations from `pret/pokeemerald`.
+- [ ] QA verifies that Gen 3 map IDs are correctly namespaced using bitwise shifting to prevent collisions.


### PR DESCRIPTION
This PR processes the permanently failed Gen 3 Location Fetch Script implementation. The underlying task (`task-062-100-gen3-locations-script-impl`) failed repeatedly because it was missing the correct extraction logic for `pret/pokeemerald`. 

To resolve this, the PR:
1. Updates the failed implementation task with the proper rejection reason.
2. Spawns a `RESEARCH` node to investigate the technical blockers.
3. Spawns granular retry `TASK` nodes for implementation and QA that depend on the research.
4. Appends the new nodes to the parent story and documents the failure in the QA task markdown and QA journal.

This allows the Orchestrator DAG to progress past the blocked implementation correctly.

---
*PR created automatically by Jules for task [4357736207550241874](https://jules.google.com/task/4357736207550241874) started by @szubster*