### PR TITLE
refactor: replace role="group" div with fieldset and legend

### DIFF
--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -52,13 +52,8 @@ export function SearchAndFilters() {
         </TacticalInput>
 
         {/* Tactical Filter Toggles */}
-        {/* oxlint-disable jsx-a11y/prefer-tag-over-role */}
-        {/* biome-ignore lint/a11y/useSemanticElements: We use role="group" instead of <fieldset> for better screen reader compatibility with aria-label without a <legend> */}
-        <div
-          role="group"
-          className="no-scrollbar m-0 mt-2 flex min-w-0 gap-2 overflow-x-auto border-none p-0 px-1 pb-2"
-          aria-label="Filter Pokémon"
-        >
+        <fieldset className="no-scrollbar m-0 mt-2 flex min-w-0 gap-2 overflow-x-auto border-none p-0 px-1 pb-2">
+          <legend className="sr-only">Filter Pokémon</legend>
           <TacticalButton
             type="button"
             onClick={() => setFilters([])}
@@ -82,7 +77,7 @@ export function SearchAndFilters() {
               {f === 'secured' ? 'Secured' : f === 'missing' ? 'Missing' : 'Dex Only'}
             </TacticalButton>
           ))}
-        </div>
+        </fieldset>
       </div>
     </div>
   );

--- a/src/components/dag/DagFilterPanel.tsx
+++ b/src/components/dag/DagFilterPanel.tsx
@@ -13,9 +13,8 @@ const ALL_STATUSES = ['PENDING', 'READY', 'ACTIVE', 'COMPLETED', 'FAILED', 'BLOC
 export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onStatusToggle }: DagFilterPanelProps) {
   return (
     <div className="absolute top-4 left-4 z-10 flex flex-col gap-4 border border-zinc-800 border-dashed bg-zinc-950/90 p-4 font-mono text-xs text-zinc-400 backdrop-blur-sm">
-      {/* oxlint-disable jsx-a11y/prefer-tag-over-role */}
-      {/* biome-ignore lint/a11y/useSemanticElements: We use role="group" instead of <fieldset> for better screen reader compatibility with aria-label without a <legend> */}
-      <div role="group" aria-label="Filter by type">
+      <fieldset>
+        <legend className="sr-only">Filter by type</legend>
         <div className="mb-2 font-bold tracking-widest">[ SYSTEM.FILTER_TYPE ]</div>
         <div className="flex flex-wrap gap-2">
           {ALL_TYPES.map((type) => {
@@ -38,11 +37,10 @@ export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onSt
             );
           })}
         </div>
-      </div>
+      </fieldset>
 
-      {/* oxlint-disable jsx-a11y/prefer-tag-over-role */}
-      {/* biome-ignore lint/a11y/useSemanticElements: We use role="group" instead of <fieldset> for better screen reader compatibility with aria-label without a <legend> */}
-      <div role="group" aria-label="Filter by status">
+      <fieldset>
+        <legend className="sr-only">Filter by status</legend>
         <div className="mb-2 font-bold tracking-widest">[ SYSTEM.FILTER_STATUS ]</div>
         <div className="flex flex-wrap gap-2">
           {ALL_STATUSES.map((status) => {
@@ -82,7 +80,7 @@ export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onSt
             );
           })}
         </div>
-      </div>
+      </fieldset>
     </div>
   );
 }


### PR DESCRIPTION
Replaces `<div role="group">` elements that use an `aria-label` with standard `<fieldset>` elements containing a `<legend className="sr-only">`. This provides better semantic accessibility while remaining visually hidden, resolving the associated Biome lint warnings regarding the use of semantic elements.

---
*PR created automatically by Jules for task [6657574403324958176](https://jules.google.com/task/6657574403324958176) started by @szubster*