### PR TITLE
QA Task Completion: Aggregate Encounters By met_location

### DIFF
--- a/.foundry/tasks/task-069-117-aggregate-encounters-qa.md
+++ b/.foundry/tasks/task-069-117-aggregate-encounters-qa.md
@@ -26,5 +26,5 @@ notes: ''
 Validate the implementation of the logic to aggregate caught Pokémon by their `met_location`.
 
 ## Acceptance Criteria
-- [ ] Run test suites to verify that `met_location` aggregation logic functions as expected.
-- [ ] Verify test coverage is sufficient.
+- [x] Run test suites to verify that `met_location` aggregation logic functions as expected.
+- [x] Verify test coverage is sufficient.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "msgpackr": "^1.11.12",
     "@tanstack/react-query": "^5.100.11",
     "@tanstack/react-router": "^1.170.4",
     "@tanstack/react-router-devtools": "^1.167.0",
@@ -40,6 +39,7 @@
     "dataloader": "^2.2.3",
     "idb": "^8.0.3",
     "lucide-react": "^1.16.0",
+    "msgpackr": "^1.11.12",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "tailwind-merge": "^3.6.0",


### PR DESCRIPTION
Empty PR created per the Foundry Empty PR policy to check off the acceptance criteria for the QA task of aggregating encounters by met_location. No further logic changes were required since all codebase tests pass successfully and all coverage looks sufficient.

---
*PR created automatically by Jules for task [4254429246730265544](https://jules.google.com/task/4254429246730265544) started by @szubster*