### PR TITLE
QA: Fix Headbutt and Rock Smash Move Checks

### DIFF
--- a/.foundry/tasks/task-057-121-qa-headbutt-rocksmash-moves.md
+++ b/.foundry/tasks/task-057-121-qa-headbutt-rocksmash-moves.md
@@ -35,6 +35,6 @@ Validate the implementation of the Headbutt and Rock Smash move check logic in t
 4. Execute `pnpm lint` and `pnpm test` to ensure overall project health.
 
 ## Acceptance Criteria
-- [ ] Code meets all architectural and quality guidelines.
-- [ ] Tests successfully pass and cover Headbutt and Rock Smash known-moves logic and lack of badge restrictions.
-- [ ] Linter reports zero warnings or errors.
+- [x] Code meets all architectural and quality guidelines.
+- [x] Tests successfully pass and cover Headbutt and Rock Smash known-moves logic and lack of badge restrictions.
+- [x] Linter reports zero warnings or errors.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "msgpackr": "^1.11.12",
     "@tanstack/react-query": "^5.100.11",
     "@tanstack/react-router": "^1.170.4",
     "@tanstack/react-router-devtools": "^1.167.0",
@@ -40,6 +39,7 @@
     "dataloader": "^2.2.3",
     "idb": "^8.0.3",
     "lucide-react": "^1.16.0",
+    "msgpackr": "^1.11.12",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "tailwind-merge": "^3.6.0",


### PR DESCRIPTION
Verified the suggestions engine properly checks for Gen 2 moves Headbutt and Rock Smash on Pokemon and TMs instead of requiring badges. Updated the checkboxes in `task-057-121-qa-headbutt-rocksmash-moves.md` to reflect QA validation completion.

---
*PR created automatically by Jules for task [9989378815478970586](https://jules.google.com/task/9989378815478970586) started by @szubster*