### PR TITLE
chore(foundry): QA heartbeat tpm logging empty PR completion

### DIFF
--- a/.foundry/tasks/task-068-119-qa-heartbeat-tpm-logging.md
+++ b/.foundry/tasks/task-068-119-qa-heartbeat-tpm-logging.md
@@ -30,5 +30,5 @@ Verify the changes made in `task-068-118-implement-heartbeat-tpm-logging`.
 When a PR-less session is handled and a state transition occurs (e.g., to `COMPLETED` or `FAILED`), these events must be audited. We log them into `.foundry/journals/tpm.md`.
 
 ## Acceptance Criteria
-- [ ] Verify that `transitionNodeToCompleted` in `.github/scripts/foundry-heartbeat.ts` logs correctly for empty PRs.
-- [ ] Run test suite with `cd .github/scripts && pnpm install && npx vitest run`.
+- [x] Verify that `transitionNodeToCompleted` in `.github/scripts/foundry-heartbeat.ts` logs correctly for empty PRs.
+- [x] Run test suite with `cd .github/scripts && pnpm install && npx vitest run`.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "msgpackr": "^1.11.12",
     "@tanstack/react-query": "^5.100.11",
     "@tanstack/react-router": "^1.170.4",
     "@tanstack/react-router-devtools": "^1.167.0",
@@ -40,6 +39,7 @@
     "dataloader": "^2.2.3",
     "idb": "^8.0.3",
     "lucide-react": "^1.16.0",
+    "msgpackr": "^1.11.12",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "tailwind-merge": "^3.6.0",


### PR DESCRIPTION
QA validation for `task-068-118-implement-heartbeat-tpm-logging`.

- Ran the test suite for orchestrator/heartbeat changes, confirming `transitionNodeToCompleted` logic correctly branches and logs empty PR completions to `tpm.md`.
- No new code added as the target artifacts are completely verified.
- Checked off acceptance criteria in the corresponding task file to resolve the issue constraint.

---
*PR created automatically by Jules for task [8753532656802273642](https://jules.google.com/task/8753532656802273642) started by @szubster*