### PR TITLE
chore: Implement State Transition Logic for PR-less Completions

### DIFF
--- a/.foundry/tasks/task-067-115-implement-heartbeat-state-transitions.md
+++ b/.foundry/tasks/task-067-115-implement-heartbeat-state-transitions.md
@@ -37,6 +37,6 @@ Once a PR-less `COMPLETED` session is detected (handled in Story 066), the heart
 5. If all boxes checked (or no boxes exist) -> Transition to `COMPLETED`.
 
 ## Acceptance Criteria
-- [ ] PR-less `COMPLETED` sessions for leaf tasks with unchecked boxes are marked `FAILED` with a rejection reason.
-- [ ] PR-less `COMPLETED` sessions for valid parents with unchecked boxes are transitioned correctly to `PENDING`.
-- [ ] PR-less `COMPLETED` sessions with all boxes checked (or no boxes) are marked `COMPLETED`.
+- [x] PR-less `COMPLETED` sessions for leaf tasks with unchecked boxes are marked `FAILED` with a rejection reason.
+- [x] PR-less `COMPLETED` sessions for valid parents with unchecked boxes are transitioned correctly to `PENDING`.
+- [x] PR-less `COMPLETED` sessions with all boxes checked (or no boxes) are marked `COMPLETED`.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "msgpackr": "^1.11.12",
     "@tanstack/react-query": "^5.100.11",
     "@tanstack/react-router": "^1.170.4",
     "@tanstack/react-router-devtools": "^1.167.0",
@@ -40,6 +39,7 @@
     "dataloader": "^2.2.3",
     "idb": "^8.0.3",
     "lucide-react": "^1.16.0",
+    "msgpackr": "^1.11.12",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "tailwind-merge": "^3.6.0",


### PR DESCRIPTION
Implement the state transition logic for PR-less `COMPLETED` sessions in `foundry-heartbeat.ts` according to the rules defined in ADR 011 and ADR 007.

The required logic is already implemented in `transitionNodeToCompleted` inside `foundry-heartbeat.ts`, which correctly identifies if a node is a leaf task or a late-binding parent (via `hasChildren` check and evaluating unchecked tasks). It correctly marks valid parents as `PENDING` and leaf tasks as `FAILED` with a rejection reason. The unit tests are present and passing.

This is an Empty PR that checks off the Acceptance Criteria inside the Foundry Task file to fulfill the requirements of ADR 007 without changing any target artifacts since they already met the requirements.

---
*PR created automatically by Jules for task [13908356336938634058](https://jules.google.com/task/13908356336938634058) started by @szubster*