### PR TITLE
feat: add tests for Tyrogue stat-based evolutions

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -132,3 +132,6 @@ Invoked Empty PR Policy for task-060-114-gen3-indoor-resolution-impl because res
 * The Empty PR Policy dictates that we must check off the acceptance criteria in the Markdown body WITHOUT modifying the YAML frontmatter, then use the `submit` tool to create the Pull Request anyway.
 * Do not leave the session without calling `submit`, as this will cause the Orchestrator to flag the session as a FAILED "crashed zombie".
 * Be aware that the `request_code_review` tool might flag Empty PR implementations as incorrect (generating a false negative) because it does not see code changes. This is expected under the Empty PR Policy; ignore the automated assessment and proceed with `submit`.
+
+## 2026-05-19: Biome Iterable Callback Return Error
+When passing a callback to iteration methods like `forEach`, do not use an implicit return (e.g. `arr.forEach(x => set.delete(x))`). This violates Biome's `lint/suspicious/useIterableCallbackReturn` rule. Use a block statement instead: `arr.forEach(x => { set.delete(x); })`.

--- a/.foundry/tasks/task-058-094-implement-roamer-and-stat-evolutions.md
+++ b/.foundry/tasks/task-058-094-implement-roamer-and-stat-evolutions.md
@@ -41,7 +41,7 @@ Implement roamer tracking logic to guide the player to check the Pokédex for Ra
    - Write or update tests to verify the roamer tracking logic and the stat-based evolution suggestions.
 
 ## Acceptance Criteria
-- [ ] Roamer tracking logic correctly identifies missing roamers and suggests checking the Pokédex.
-- [ ] Evolution logic accurately evaluates stat-based requirements (e.g., Atk > Def for Hitmonlee).
-- [ ] UI dynamically displays stat requirements for stat-based evolutions.
-- [ ] Tests verify roamer tracking and stat-based evolution logic.
+- [x] Roamer tracking logic correctly identifies missing roamers and suggests checking the Pokédex.
+- [x] Evolution logic accurately evaluates stat-based requirements (e.g., Atk > Def for Hitmonlee).
+- [x] UI dynamically displays stat requirements for stat-based evolutions.
+- [x] Tests verify roamer tracking and stat-based evolution logic.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "msgpackr": "^1.11.12",
     "@tanstack/react-query": "^5.100.11",
     "@tanstack/react-router": "^1.170.4",
     "@tanstack/react-router-devtools": "^1.167.0",
@@ -40,6 +39,7 @@
     "dataloader": "^2.2.3",
     "idb": "^8.0.3",
     "lucide-react": "^1.16.0",
+    "msgpackr": "^1.11.12",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "tailwind-merge": "^3.6.0",

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -589,4 +589,88 @@ describe('generateSuggestions', () => {
     expect(catch3?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'headbutt')).toBe(true);
     expect(catch3?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'rock-smash')).toBe(true);
   });
+  it('should generate stat-based evolution suggestions for Tyrogue (Atk > Def, Atk < Def, Atk = Def)', () => {
+    const mockApiData: AssistantApiData = {
+      localAid: 1,
+      localEncounters: [],
+      missingEncounters: {},
+      pokemonMetadata: {
+        106: { id: 106, efrm: [236], det: [{ tr: 1, ml: 20, rps: 1 }] } as unknown as PokemonMetadata, // Hitmonlee
+        107: { id: 107, efrm: [236], det: [{ tr: 1, ml: 20, rps: -1 }] } as unknown as PokemonMetadata, // Hitmonchan
+        237: { id: 237, efrm: [236], det: [{ tr: 1, ml: 20, rps: 0 }] } as unknown as PokemonMetadata, // Hitmontop
+      },
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const mockStrategy = {
+      ...gen1Strategy,
+      generation: 2,
+    };
+
+    // Helper to create mock save data with a specific Tyrogue
+    const createSaveDataWithTyrogue = (dvs: { atk: number; def: number }, missingIds: number[]) => {
+      const ownedSet = new Set(Array.from({ length: 251 }, (_, i) => i + 1));
+      missingIds.forEach((id) => {
+        ownedSet.delete(id);
+      });
+      return {
+        generation: 2,
+        gameVersion: 'gold',
+        owned: ownedSet,
+        seen: new Set(),
+        party: [],
+        inventory: [],
+        currentMapId: 0,
+        eventFlags: new Uint8Array(300),
+        partyDetails: [],
+        pcDetails: [
+          {
+            speciesId: 236, // Tyrogue
+            level: 20,
+            dvs,
+            statExp: { hp: 0, atk: 0, def: 0, spd: 0, spc: 0 },
+            isShiny: false,
+            moves: [],
+            storageLocation: 'Box 1',
+          },
+        ],
+        trainerName: 'GOLD',
+      } as unknown as SaveData;
+    };
+
+    // Case 1: Atk > Def (Hitmonlee - 106)
+    const dataAtkGtr = createSaveDataWithTyrogue({ atk: 15, def: 0 }, [106]);
+    const { suggestions: suggs1 } = generateSuggestions(dataAtkGtr, false, 'gold', mockApiData, mockStrategy);
+    const evoLee = suggs1.find((s) => s.id === 'evo-lvl-106');
+    expect(evoLee).toBeDefined();
+    expect(evoLee?.title).toBe('Level Up Evolution: #106');
+    expect(evoLee?.description).toBe('Your Lv. 20 pre-evolution is ready to evolve (needs Lv. 20, Atk > Def)!');
+
+    // Case 2: Atk < Def (Hitmonchan - 107)
+    const dataAtkLsr = createSaveDataWithTyrogue({ atk: 0, def: 15 }, [107]);
+    const { suggestions: suggs2 } = generateSuggestions(dataAtkLsr, false, 'gold', mockApiData, mockStrategy);
+    const evoChan = suggs2.find((s) => s.id === 'evo-lvl-107');
+    expect(evoChan).toBeDefined();
+    expect(evoChan?.title).toBe('Level Up Evolution: #107');
+    expect(evoChan?.description).toBe('Your Lv. 20 pre-evolution is ready to evolve (needs Lv. 20, Atk < Def)!');
+
+    // Case 3: Atk = Def (Hitmontop - 237)
+    const dataAtkEq = createSaveDataWithTyrogue({ atk: 10, def: 10 }, [237]);
+    const { suggestions: suggs3 } = generateSuggestions(dataAtkEq, false, 'gold', mockApiData, mockStrategy);
+    const evoTop = suggs3.find((s) => s.id === 'evo-lvl-237');
+    expect(evoTop).toBeDefined();
+    expect(evoTop?.title).toBe('Level Up Evolution: #237');
+    expect(evoTop?.description).toBe('Your Lv. 20 pre-evolution is ready to evolve (needs Lv. 20, Atk = Def)!');
+
+    // Case 4: Not matching Atk > Def for Hitmonlee
+    const dataAtkNotGtr = createSaveDataWithTyrogue({ atk: 0, def: 15 }, [106]);
+    const { suggestions: suggs4 } = generateSuggestions(dataAtkNotGtr, false, 'gold', mockApiData, mockStrategy);
+    const evoLeeNotReady = suggs4.find((s) => s.id === 'evo-lvl-106');
+    expect(evoLeeNotReady).toBeDefined();
+    expect(evoLeeNotReady?.title).toBe('Level Up Evolution: #106');
+    expect(evoLeeNotReady?.description).toBe('Your Lv. 20 pre-evolution evolves at Lv. 20 (needs Lv. 20, Atk > Def).');
+    expect(evoLeeNotReady?.priority).toBe(75); // Lower priority because it's not actually ready
+  });
 });


### PR DESCRIPTION
Adds test coverage verifying the `Atk > Def`, `Atk < Def`, and `Atk = Def` stat-based evolution logic for Tyrogue in `suggestionEngine.ts`. Additionally, checks off the relevant acceptance criteria in the target Foundry task node. Fixed a Biome linting error.

---
*PR created automatically by Jules for task [17819367781035889427](https://jules.google.com/task/17819367781035889427) started by @szubster*