### PR TITLE
fix: Headbutt and Rock Smash move checks for Gen 2

### DIFF
--- a/.foundry/tasks/task-057-120-fix-headbutt-rocksmash-moves.md
+++ b/.foundry/tasks/task-057-120-fix-headbutt-rocksmash-moves.md
@@ -38,6 +38,6 @@ The current implementation for Headbutt and Rock Smash in the suggestion engine 
    - Update `generateSuggestions.test.ts` (and any other relevant tests) to verify the new move-based logic and the removal of the badge requirements.
 
 ## Acceptance Criteria
-- [ ] `gen2Strategy.ts` checks for Headbutt (Move 29) and Rock Smash (Move 249) on Pokémon instances or TMs in inventory, without badge checks.
-- [ ] `suggestionEngine.ts` checks for Headbutt (Move 29) and Rock Smash (Move 249) on Pokémon instances or TMs in inventory, without badge checks.
-- [ ] Tests verify the updated known-moves logic and lack of badge restrictions.
+- [x] `gen2Strategy.ts` checks for Headbutt (Move 29) and Rock Smash (Move 249) on Pokémon instances or TMs in inventory, without badge checks.
+- [x] `suggestionEngine.ts` checks for Headbutt (Move 29) and Rock Smash (Move 249) on Pokémon instances or TMs in inventory, without badge checks.
+- [x] Tests verify the updated known-moves logic and lack of badge restrictions.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "msgpackr": "^1.11.12",
     "@tanstack/react-query": "^5.100.11",
     "@tanstack/react-router": "^1.170.4",
     "@tanstack/react-router-devtools": "^1.167.0",
@@ -40,6 +39,7 @@
     "dataloader": "^2.2.3",
     "idb": "^8.0.3",
     "lucide-react": "^1.16.0",
+    "msgpackr": "^1.11.12",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "tailwind-merge": "^3.6.0",

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -103,7 +103,14 @@ describe('generateSuggestions', () => {
       pokemonMetadata: {},
       ancestralEncounters: {},
       areaNames: { 1: 'Pallet Town' },
-      allLocations: [{ id: 1, n: 'Pallet Town', r: 'Kanto', a: [{ id: 1, n: 'Pallet Town Area' }] }],
+      allLocations: [
+        {
+          id: 1,
+          n: 'Pallet Town',
+          r: 'Kanto',
+          a: [{ id: 1, n: 'Pallet Town Area' }],
+        },
+      ],
     } as unknown as AssistantApiData;
 
     const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
@@ -150,7 +157,12 @@ describe('generateSuggestions', () => {
       ancestralEncounters: {},
       areaNames: { 1: 'Pallet Town', 2: 'Route 1' },
       allLocations: [
-        { id: 1, n: 'Pallet Town', r: 'Kanto', a: [{ id: 1, n: 'Pallet Town Area' }] },
+        {
+          id: 1,
+          n: 'Pallet Town',
+          r: 'Kanto',
+          a: [{ id: 1, n: 'Pallet Town Area' }],
+        },
         { id: 2, n: 'Route 1', r: 'Kanto', a: [{ id: 2, n: 'Route 1 Area' }] },
       ],
     } as unknown as AssistantApiData;
@@ -571,7 +583,7 @@ describe('generateSuggestions', () => {
     const catch1 = result1.suggestions.find((s) => s.category === 'Catch' && s.id.startsWith('catch-nearby'));
     expect(catch1).toBeUndefined(); // Filtered out
 
-    // 2. Has item but no badges
+    // 2. Has item (badges no longer required)
     localSaveData.inventory = [
       { id: 192, quantity: 1 },
       { id: 198, quantity: 1 },
@@ -579,13 +591,24 @@ describe('generateSuggestions', () => {
     localSaveData.johtoBadges = 0;
     const result2 = generateSuggestions(localSaveData, false, 'gold', localApiData, localStrategy);
     const catch2 = result2.suggestions.find((s) => s.category === 'Catch' && s.id.startsWith('catch-nearby'));
-    expect(catch2).toBeUndefined(); // Filtered out
+    expect(catch2).toBeDefined(); // Included since badges aren't needed
+    expect(catch2?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'headbutt')).toBe(true);
+    expect(catch2?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'rock-smash')).toBe(true);
 
-    // 3. Has item and badges
-    localSaveData.johtoBadges = (1 << 1) | (1 << 2); // Hive and Plain badges
+    // 3. Missing item but a Pokemon knows the move
+    localSaveData.inventory = [];
+    localSaveData.partyDetails = [
+      {
+        speciesId: 1,
+        level: 10,
+        isShiny: false,
+        moves: [29, 249], // Headbutt and Rock Smash
+        storageLocation: 'Party',
+      },
+    ];
     const result3 = generateSuggestions(localSaveData, false, 'gold', localApiData, localStrategy);
     const catch3 = result3.suggestions.find((s) => s.category === 'Catch' && s.id.startsWith('catch-nearby'));
-    expect(catch3).toBeDefined(); // Included
+    expect(catch3).toBeDefined(); // Included because of known moves
     expect(catch3?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'headbutt')).toBe(true);
     expect(catch3?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'rock-smash')).toBe(true);
   });

--- a/src/engine/assistant/strategies/gen2Strategy.ts
+++ b/src/engine/assistant/strategies/gen2Strategy.ts
@@ -56,10 +56,13 @@ export const gen2Strategy: AssistantStrategy = {
     // TM08 (Rock Smash) is Item ID 198 (0xC6), TM02 (Headbutt) is Item ID 192 (0xC0)
     // Actually, TMs are stored in TM pocket directly in Gen 2 parsed inventory as item IDs
     // Headbutt = TM02 = Item ID 192, Rock Smash = TM08 = Item ID 198
+    // In Gen 2, these are single-use and do not require badges to use in the field.
+    const allInstances = [...(saveData.partyDetails || []), ...(saveData.pcDetails || [])];
     const hasHeadbutt =
-      saveData.inventory.some((i) => i.id === 192 && i.quantity > 0) && ((saveData.johtoBadges || 0) & (1 << 1)) !== 0; // Hive badge is bit 1
+      saveData.inventory.some((i) => i.id === 192 && i.quantity > 0) || allInstances.some((p) => p.moves?.includes(29));
     const hasRockSmash =
-      saveData.inventory.some((i) => i.id === 198 && i.quantity > 0) && ((saveData.johtoBadges || 0) & (1 << 2)) !== 0; // Plain badge is bit 2
+      saveData.inventory.some((i) => i.id === 198 && i.quantity > 0) ||
+      allInstances.some((p) => p.moves?.includes(249));
 
     if (hasHeadbutt) {
       suggestions.push({

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -821,7 +821,11 @@ export function generateSuggestions(
   for (let i = 1; i <= maxDex; i++) {
     if (!ownedSet.has(i)) {
       if (saveData.generation === 1 && i === 150 && (saveData.hallOfFameCount || 0) === 0) {
-        rejected.push({ pokemonId: i, reason: 'Hall of Fame count is 0. Mewtwo is locked.', code: 'HOF_LOCKED' });
+        rejected.push({
+          pokemonId: i,
+          reason: 'Hall of Fame count is 0. Mewtwo is locked.',
+          code: 'HOF_LOCKED',
+        });
         continue;
       }
       missingIds.add(i);
@@ -840,9 +844,9 @@ export function generateSuggestions(
   const localPids = new Set<number>();
 
   const hasHeadbutt =
-    saveData.inventory.some((i) => i.id === 192 && i.quantity > 0) && ((saveData.johtoBadges || 0) & (1 << 1)) !== 0; // Hive badge is bit 1
+    saveData.inventory.some((i) => i.id === 192 && i.quantity > 0) || allInstances.some((p) => p.moves?.includes(29));
   const hasRockSmash =
-    saveData.inventory.some((i) => i.id === 198 && i.quantity > 0) && ((saveData.johtoBadges || 0) & (1 << 2)) !== 0; // Plain badge is bit 2
+    saveData.inventory.some((i) => i.id === 198 && i.quantity > 0) || allInstances.some((p) => p.moves?.includes(249));
 
   generateCatchSuggestions(
     apiData,


### PR DESCRIPTION
Implements the fix for Headbutt and Rock Smash suggestion logic in Gen 2.

Previously, the logic only checked the inventory for TM02 and TM08 and verified Johto gym badges. Because these TMs are single-use in Gen 2 and don't require badges, this logic has been updated. Now, it checks if any Pokémon in the player's Party or PC knows the moves (Headbutt ID 29, Rock Smash ID 249) in addition to checking the TM inventory, while safely removing the gym badge check. Tests have been updated to test this new functionality.

---
*PR created automatically by Jules for task [3746718345755201302](https://jules.google.com/task/3746718345755201302) started by @szubster*