### PR TITLE
feat: implement Nuzlocke death tracking and graveyard logic

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -126,3 +126,6 @@ For Playwright E2E tests failing due to missing browser binaries or system depen
 Invoked Empty PR Policy for task-060-114-gen3-indoor-resolution-impl because resolveOutdoorMapId was already implemented in src/engine/mapGraph/gen3Graph.ts.
 ## 2026-05-18 - Gen 3 Locations
 - The Gen 3 maps define their region mapping string representation inside `region_map_sections.json` within the decomp repo, mapped sequentially. Use this to construct proper lookup lists.
+
+- For Gen 2 Current HP, the offset starts at 34 (`offset + 34`) and is 16-bit big-endian. Reading at `offset + 35` reads the low byte of Current HP and high byte of Max HP.
+- When creating UI components, strictly follow ADR 008 "tactical hardware/snooping" constraints (e.g. `rounded-none`, dashed borders, `font-mono`).

--- a/.foundry/tasks/task-070-116-implement-death-tracking.md
+++ b/.foundry/tasks/task-070-116-implement-death-tracking.md
@@ -26,6 +26,6 @@ notes: ''
 Detect fainted Pokémon in the party and implement logic to designate a PC Box as the Graveyard for permanently dead Pokémon.
 
 ## Acceptance Criteria
-- [ ] Implement logic to detect 0 HP Pokémon in the party as dead.
-- [ ] Implement logic to designate a PC Box as the Graveyard.
-- [ ] Pokémon in the Graveyard box are permanently marked as dead.
+- [x] Implement logic to detect 0 HP Pokémon in the party as dead.
+- [x] Implement logic to designate a PC Box as the Graveyard.
+- [x] Pokémon in the Graveyard box are permanently marked as dead.

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -20,6 +20,8 @@ export function SettingsModal() {
   const setIsLivingDex = useStore((s) => s.setIsLivingDex);
   const globalPokeball = useStore((s) => s.globalPokeball);
   const setGlobalPokeball = useStore((s) => s.setGlobalPokeball);
+  const graveyardBoxId = useStore((s) => s.graveyardBoxId);
+  const setGraveyardBoxId = useStore((s) => s.setGraveyardBoxId);
 
   const effectiveVersion = manualVersion || saveData?.gameVersion || 'unknown';
 
@@ -72,6 +74,9 @@ export function SettingsModal() {
           setGlobalPokeball={setGlobalPokeball}
           filteredPokeballs={filteredPokeballs}
           genConfig={genConfig}
+          graveyardBoxId={graveyardBoxId}
+          setGraveyardBoxId={setGraveyardBoxId}
+          saveData={saveData}
         />
         <ClearStorageButton
           onClear={async () => {

--- a/src/components/settings/SettingsControls.tsx
+++ b/src/components/settings/SettingsControls.tsx
@@ -1,4 +1,5 @@
-import { Archive, CircleDot, Settings2 } from 'lucide-react';
+import { Archive, CircleDot, Settings2, Skull } from 'lucide-react';
+import type { SaveData } from '../../engine/saveParser';
 import type { GameVersion, PokeballType } from '../../store';
 import type { GenerationConfig } from '../../utils/generationConfig';
 import { getGenerationConfig } from '../../utils/generationConfig';
@@ -13,6 +14,9 @@ interface SettingsControlsProps {
   setGlobalPokeball: (v: PokeballType) => void;
   filteredPokeballs: { value: PokeballType; label: string }[];
   genConfig: GenerationConfig | null;
+  graveyardBoxId?: number | null;
+  setGraveyardBoxId?: (id: number | null) => void;
+  saveData?: SaveData | null;
 }
 
 export function SettingsControls({
@@ -24,6 +28,9 @@ export function SettingsControls({
   setGlobalPokeball,
   filteredPokeballs,
   genConfig,
+  graveyardBoxId = null,
+  setGraveyardBoxId,
+  saveData = null,
 }: SettingsControlsProps) {
   return (
     <div className="space-y-4">
@@ -83,6 +90,31 @@ export function SettingsControls({
           {filteredPokeballs.map((pb) => (
             <option key={pb.value} value={pb.value}>
               {pb.label}
+            </option>
+          ))}
+        </select>
+      </SettingsRow>
+
+      <SettingsRow
+        icon={<Skull size={18} className="text-rose-500" />}
+        iconColorClass="border-rose-500/20 bg-rose-500/10"
+        label="Graveyard Box"
+      >
+        <select
+          value={graveyardBoxId === null ? 'none' : graveyardBoxId.toString()}
+          onChange={(e) => {
+            if (setGraveyardBoxId) {
+              const val = e.target.value;
+              setGraveyardBoxId(val === 'none' ? null : parseInt(val, 10));
+            }
+          }}
+          aria-label="Select Nuzlocke Graveyard Box"
+          className="rounded-none border border-zinc-800 border-dashed bg-zinc-950 px-4 py-2 font-bold font-mono text-xs text-zinc-200 transition-colors hover:border-zinc-600 focus-visible:border-rose-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+        >
+          <option value="none">None</option>
+          {Array.from({ length: saveData?.currentBoxCount || 14 }, (_, i) => i + 1).map((boxNum) => (
+            <option key={boxNum} value={boxNum.toString()}>
+              Box {boxNum}
             </option>
           ))}
         </select>

--- a/src/engine/assistant/__tests__/checkFlagBehavior.test.ts
+++ b/src/engine/assistant/__tests__/checkFlagBehavior.test.ts
@@ -31,7 +31,7 @@ describe('suggestionEngine - checkFlag Edge Cases', () => {
       allLocations: [],
     } as unknown as AssistantApiData;
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy, null);
     const giftSuggestion = suggestions.find((s) => s.id === 'gift-131');
     expect(giftSuggestion).toBeDefined();
   });
@@ -62,7 +62,7 @@ describe('suggestionEngine - checkFlag Edge Cases', () => {
       allLocations: [],
     } as unknown as AssistantApiData;
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy, null);
     const giftSuggestion = suggestions.find((s) => s.id === 'gift-131');
     expect(giftSuggestion).toBeDefined();
   });

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -62,7 +62,7 @@ describe('generateSuggestions', () => {
       generation: 2,
     };
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'gold', mockApiData, mockStrategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'gold', mockApiData, mockStrategy, null);
     const suggestion = suggestions.find((s) => s.id === 'evo-trade-held-208');
     expect(suggestion).toBeDefined();
     expect(suggestion?.title).toBe('Ready to Trade Evolve: #208!');
@@ -106,7 +106,7 @@ describe('generateSuggestions', () => {
       allLocations: [{ id: 1, n: 'Pallet Town', r: 'Kanto', a: [{ id: 1, n: 'Pallet Town Area' }] }],
     } as unknown as AssistantApiData;
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy, null);
 
     const localSuggestion = suggestions.find((s) => s.id === 'catch-local');
     expect(localSuggestion).toBeDefined();
@@ -164,7 +164,7 @@ describe('generateSuggestions', () => {
       },
     };
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, mockStrategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, mockStrategy, null);
 
     const nearbySuggestion = suggestions.find((s) => s.id === 'catch-nearby-19');
     expect(nearbySuggestion).toBeDefined();
@@ -203,7 +203,7 @@ describe('generateSuggestions', () => {
       allLocations: [],
     } as unknown as AssistantApiData;
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy, null);
 
     const giftSuggestion = suggestions.find((s) => s.id === 'gift-131');
     expect(giftSuggestion).toBeDefined();
@@ -239,7 +239,7 @@ describe('generateSuggestions', () => {
       allLocations: [],
     } as unknown as AssistantApiData;
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy, null);
 
     const giftSuggestion = suggestions.find((s) => s.id === 'gift-131');
     expect(giftSuggestion).toBeUndefined();
@@ -278,7 +278,7 @@ describe('generateSuggestions', () => {
       allLocations: [],
     } as unknown as AssistantApiData;
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy, null);
 
     const giftSuggestion = suggestions.find((s) => s.id === 'gift-131');
     expect(giftSuggestion).toBeUndefined();
@@ -309,7 +309,7 @@ describe('generateSuggestions', () => {
       allLocations: [],
     } as unknown as AssistantApiData;
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy, null);
 
     const tradeSuggestion = suggestions.find((s) => s.id === 'npc-trade-122');
     expect(tradeSuggestion).toBeUndefined();
@@ -386,7 +386,7 @@ describe('generateSuggestions', () => {
       generation: 2, // Must be 2 for Gen2 logic
     };
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, mockStrategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, mockStrategy, null);
 
     const breedSuggestion = suggestions.find((s) => s.id === 'breed-152');
     expect(breedSuggestion).toBeDefined();
@@ -503,7 +503,7 @@ describe('generateSuggestions', () => {
       generation: 2,
     };
 
-    const { suggestions } = generateSuggestions(mockSaveData, false, 'gold', mockApiData, mockStrategy);
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'gold', mockApiData, mockStrategy, null);
 
     const evoSuggestion = suggestions.find((s) => s.id === 'evo-lvl-any-196');
     expect(evoSuggestion).toBeDefined();
@@ -567,7 +567,7 @@ describe('generateSuggestions', () => {
     // 1. Missing item
     localSaveData.generation = 2;
     localSaveData.inventory = [];
-    const result1 = generateSuggestions(localSaveData, false, 'gold', localApiData, localStrategy);
+    const result1 = generateSuggestions(localSaveData, false, 'gold', localApiData, localStrategy, null);
     const catch1 = result1.suggestions.find((s) => s.category === 'Catch' && s.id.startsWith('catch-nearby'));
     expect(catch1).toBeUndefined(); // Filtered out
 
@@ -576,7 +576,7 @@ describe('generateSuggestions', () => {
       { id: 192, quantity: 1 },
       { id: 198, quantity: 1 },
     ];
-    const result2 = generateSuggestions(localSaveData, false, 'gold', localApiData, localStrategy);
+    const result2 = generateSuggestions(localSaveData, false, 'gold', localApiData, localStrategy, null);
     const catch2 = result2.suggestions.find((s) => s.category === 'Catch' && s.id.startsWith('catch-nearby'));
     expect(catch2).toBeDefined(); // Included
     expect(catch2?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'headbutt')).toBe(true);

--- a/src/engine/assistant/__tests__/test-coverage.test.ts
+++ b/src/engine/assistant/__tests__/test-coverage.test.ts
@@ -100,7 +100,7 @@ test('coverage for suggestionEngine new lines', () => {
     allAreas: [],
   } as unknown as AssistantApiData;
 
-  const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, gen1Strategy);
+  const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, gen1Strategy, null);
 
   const espeon = suggestions.find((s) => s.pokemonId === 196);
   expect(espeon).toBeDefined();
@@ -179,7 +179,7 @@ test('coverage for suggestionEngine edge cases', () => {
     allAreas: [],
   } as unknown as AssistantApiData;
 
-  const { suggestions } = generateSuggestions(mockSaveData, false, 'gold', mockApiData, gen1Strategy);
+  const { suggestions } = generateSuggestions(mockSaveData, false, 'gold', mockApiData, gen1Strategy, null);
   const jolteon = suggestions.find((s) => s.pokemonId === 135);
   expect(jolteon).toBeDefined();
   expect(jolteon?.title).toContain('Item Needed');
@@ -218,7 +218,7 @@ test('coverage for gen 2 breeding edge case without valid base pokemon', () => {
     allAreas: [],
   } as unknown as AssistantApiData;
 
-  const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, gen1Strategy);
+  const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, gen1Strategy, null);
 
   const pichu = suggestions.find((s) => s.pokemonId === 50);
   expect(pichu).toBeDefined();
@@ -252,7 +252,7 @@ test('coverage for missing target id in pokemonMetadata for Gen 2 breeding', () 
     allAreas: [],
   } as unknown as AssistantApiData;
 
-  const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, gen1Strategy);
+  const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, gen1Strategy, null);
   const diglett = suggestions.find((s) => s.pokemonId === 50);
   expect(diglett).toBeUndefined();
 });
@@ -290,7 +290,7 @@ test('coverage for generateSuggestions with missing parent / target id / empty d
     allAreas: [],
   } as unknown as AssistantApiData;
 
-  const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, gen1Strategy);
+  const { suggestions } = generateSuggestions(mockSaveData, false, 'crystal', mockApiData, gen1Strategy, null);
   const diglett = suggestions.find((s) => s.pokemonId === 50);
   expect(diglett).toBeUndefined();
 });
@@ -320,7 +320,7 @@ test('coverage for missing target metadata entirely in evo logic', () => {
     allAreas: [],
   } as unknown as AssistantApiData;
 
-  const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy);
+  const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, gen1Strategy, null);
   const invalidEvo = suggestions.find((s) => s.category === 'Evolve');
   expect(invalidEvo).toBeUndefined();
 });
@@ -358,7 +358,7 @@ test('coverage for suggestionEngine getGameItemId unknown generation', () => {
     allAreas: [],
   } as unknown as AssistantApiData;
 
-  expect(() => generateSuggestions(mockSaveData, false, 'ruby', mockApiData, gen1Strategy)).toThrow(
+  expect(() => generateSuggestions(mockSaveData, false, 'ruby', mockApiData, gen1Strategy, null)).toThrow(
     'Unknown generation',
   );
 });
@@ -399,7 +399,7 @@ test('coverage for recursive missing exclusive logic', () => {
     getUnobtainableReason: (pid: number) => (pid === 6 ? 'Needs Link Cable' : null),
   } as unknown as import('../strategies/types').AssistantStrategy;
 
-  const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, mockStrategy);
+  const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, mockStrategy, null);
   const exclusiveSuggestion = suggestions.find((s) => s.id === 'exclusive-6');
   expect(exclusiveSuggestion).toBeUndefined();
 });

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -751,6 +751,7 @@ export function generateSuggestions(
   manualVersion: string | null | undefined,
   apiData: AssistantApiData | null,
   strategy: AssistantStrategy,
+  graveyardBoxId: number | null = null,
 ): { suggestions: Suggestion[]; debug: { rejected: RejectedSuggestion[] } } {
   const suggestions: Suggestion[] = [];
   const rejected: RejectedSuggestion[] = [];
@@ -761,11 +762,21 @@ export function generateSuggestions(
   // ⚡ Bolt: Optimize O(n) array includes to O(1) Set has for missingIds and localPids
   const missingIds = new Set<number>();
 
+  const graveyardLocation = graveyardBoxId !== null ? `Box ${graveyardBoxId}` : null;
+  const isDead = (p: PokemonInstance) => {
+    if (p.storageLocation === 'Party' && p.currentHp === 0) return true;
+    if (graveyardLocation && p.storageLocation === graveyardLocation) return true;
+    return false;
+  };
+
+  const validPartyDetails = (saveData.partyDetails || []).filter((p) => !isDead(p));
+  const validPcDetails = (saveData.pcDetails || []).filter((p) => !isDead(p));
+
   const ownedSet = isLivingDex
-    ? new Set([...(saveData.party || []), ...(saveData.pc || [])])
+    ? new Set([...validPartyDetails.map((p) => p.speciesId), ...validPcDetails.map((p) => p.speciesId)])
     : saveData.owned || new Set<number>();
 
-  const allInstances = [...(saveData.partyDetails || []), ...(saveData.pcDetails || [])];
+  const allInstances = [...validPartyDetails, ...validPcDetails];
   // ⚡ Bolt: Removed .filter().map() chain to prevent intermediate array allocations (O(N) -> O(1) memory overhead)
   const myOtIds = new Set<number>();
   for (let i = 0; i < allInstances.length; i++) {

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -37,6 +37,7 @@ export interface PokemonInstance {
   storageLocation: string;
   /** The 1-indexed position of the Pokémon within its storage container. */
   slot?: number | undefined;
+  currentHp?: number | undefined;
 }
 
 /**

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -381,6 +381,7 @@ function parseGen1Pokemon(
   const dvs = parseDVs(view.getUint16(offset + 27, false));
   const isShiny = checkShiny(dvs);
   const otName = decodeGen12String(view, otOffset);
+  const currentHp = isParty ? view.getUint16(offset + 1, false) : undefined;
 
   return {
     speciesId,
@@ -390,6 +391,7 @@ function parseGen1Pokemon(
     otName,
     storageLocation,
     slot,
+    currentHp,
   };
 }
 

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -71,6 +71,7 @@ function parseGen2PokemonInstance(
   const pokerus = view.getUint8(offset + 28);
   const level = view.getUint8(offset + 31);
   const caughtData = isCrystal ? parseCaughtData(view, offset) : undefined;
+  const currentHp = storageLocation === 'Party' ? view.getUint16(offset + 34, false) : undefined;
 
   // OT names in daycare are immediately after the data block
   const otName = storageLocation === 'Daycare' ? decodeGen12String(view, offset + 32) : undefined;
@@ -87,6 +88,7 @@ function parseGen2PokemonInstance(
     otName,
     storageLocation,
     slot,
+    currentHp,
   };
 }
 

--- a/src/hooks/useAssistant.ts
+++ b/src/hooks/useAssistant.ts
@@ -3,8 +3,6 @@ import { useMemo } from 'react';
 import { getStrategy } from '../engine/assistant/strategies/index';
 import { fetchAssistantApiData, generateSuggestions } from '../engine/assistant/suggestionEngine';
 import type { SaveData } from '../engine/saveParser/index';
-import { getGenerationConfig } from '../utils/generationConfig';
-
 /**
  * A React hook that orchestrates the Pokémon suggestion engine.
  * It identifies missing Pokémon, fetches necessary encounter data from IndexedDB,
@@ -18,7 +16,11 @@ import { getGenerationConfig } from '../utils/generationConfig';
  * @example
  * const { suggestions, isLoading } = useAssistant(saveData, false, 'red');
  */
+import { useStore } from '../store';
+import { getGenerationConfig } from '../utils/generationConfig';
+
 export function useAssistant(saveData: SaveData | null, isLivingDex: boolean, manualVersion?: string | null) {
+  const graveyardBoxId = useStore((s) => s.graveyardBoxId);
   // ⚡ Bolt: Memoized expensive missing ID and owned set calculations to prevent redundant work on every render
   const queryTargetsSlice = useMemo(() => {
     const maxDex = saveData ? getGenerationConfig(saveData.generation).maxDex : 0;
@@ -62,8 +64,8 @@ export function useAssistant(saveData: SaveData | null, isLivingDex: boolean, ma
   const strategy = useMemo(() => getStrategy(saveData?.generation || 1), [saveData?.generation]);
   // ⚡ Bolt: Memoize expensive synchronous suggestion generation to prevent blocking the main thread on every re-render
   const { suggestions, debug } = useMemo(() => {
-    return generateSuggestions(saveData, isLivingDex, manualVersion, apiData ?? null, strategy);
-  }, [saveData, isLivingDex, manualVersion, apiData, strategy]);
+    return generateSuggestions(saveData, isLivingDex, manualVersion, apiData ?? null, strategy, graveyardBoxId);
+  }, [saveData, isLivingDex, manualVersion, apiData, strategy, graveyardBoxId]);
   return {
     suggestions,
     debug,

--- a/src/store.ts
+++ b/src/store.ts
@@ -54,6 +54,8 @@ interface AppStore {
   isLivingDex: boolean;
   /** Global visual preference for which Pokéball to use in the UI. */
   globalPokeball: PokeballType;
+  /** Graveyard PC Box ID for Nuzlocke. */
+  graveyardBoxId: number | null;
   /** Toggles a specific UI filter type in the `filters` array. */
   toggleFilter: (f: FilterType) => void;
   /** Overwrites the entire array of active UI filters. */
@@ -64,6 +66,8 @@ interface AppStore {
   setIsLivingDex: (v: boolean) => void;
   /** Sets the global visual Pokéball preference. */
   setGlobalPokeball: (v: PokeballType) => void;
+  /** Sets the graveyard box ID for Nuzlocke. */
+  setGraveyardBoxId: (id: number | null) => void;
 
   // Transient UI state (not persisted)
   /** Current search query for filtering Pokémon lists. */
@@ -116,6 +120,7 @@ export const useStore = create<AppStore>()(
       manualVersion: null,
       isLivingDex: false,
       globalPokeball: 'poke',
+      graveyardBoxId: null,
 
       toggleFilter: (f) => {
         const current = get().filters;
@@ -129,6 +134,7 @@ export const useStore = create<AppStore>()(
       setManualVersion: (v) => set({ manualVersion: v }),
       setIsLivingDex: (v) => set({ isLivingDex: v }),
       setGlobalPokeball: (v) => set({ globalPokeball: v }),
+      setGraveyardBoxId: (id) => set({ graveyardBoxId: id }),
 
       // Transient UI
       searchTerm: '',
@@ -166,6 +172,7 @@ export const useStore = create<AppStore>()(
         manualVersion: state.manualVersion,
         isLivingDex: state.isLivingDex,
         globalPokeball: state.globalPokeball,
+        graveyardBoxId: state.graveyardBoxId,
       }),
     },
   ),


### PR DESCRIPTION
Detects fainted Pokémon (0 HP) in the party and implements logic to designate a PC Box as the Graveyard for permanently dead Pokémon.

- Adds `currentHp` extracting to Gen 1 and Gen 2 save parsers.
- Adds `graveyardBoxId` to Zustand store.
- Adds Nuzlocke Graveyard Box setting in UI using ADR 008 aesthetics (`rounded-none`).
- Updates Assistant Suggestion Engine to filter out fainted and graveyard Pokémon from suggestions.

---
*PR created automatically by Jules for task [1833448674963849102](https://jules.google.com/task/1833448674963849102) started by @szubster*