### PR TITLE
Foundry: QA State Transition Logic for PR-less Completions

### DIFF
--- a/.foundry/tasks/task-067-116-qa-heartbeat-state-transitions.md
+++ b/.foundry/tasks/task-067-116-qa-heartbeat-state-transitions.md
@@ -36,7 +36,7 @@ Once a PR-less `COMPLETED` session is detected (handled in Story 066), the heart
 4. Verify completely checked boxes cause `COMPLETED` transition.
 
 ## Acceptance Criteria
-- [ ] Ensure that PR-less `COMPLETED` sessions for leaf tasks with unchecked boxes are marked `FAILED` with a rejection reason.
-- [ ] Ensure that PR-less `COMPLETED` sessions for valid parents with unchecked boxes are transitioned correctly to `PENDING`.
-- [ ] Ensure that PR-less `COMPLETED` sessions with all boxes checked (or no boxes) are marked `COMPLETED`.
-- [ ] Run test suite with `cd .github/scripts && pnpm install && npx vitest run`.
+- [x] Ensure that PR-less `COMPLETED` sessions for leaf tasks with unchecked boxes are marked `FAILED` with a rejection reason.
+- [x] Ensure that PR-less `COMPLETED` sessions for valid parents with unchecked boxes are transitioned correctly to `PENDING`.
+- [x] Ensure that PR-less `COMPLETED` sessions with all boxes checked (or no boxes) are marked `COMPLETED`.
+- [x] Run test suite with `cd .github/scripts && pnpm install && npx vitest run`.


### PR DESCRIPTION
QA verification of task-067-115.

Verified that PR-less COMPLETED sessions check unchecked boxes, setting FAILED for leaves, PENDING for parents, and COMPLETED for all checked. Updated the checkboxes for the task node.

---
*PR created automatically by Jules for task [2990801578998814903](https://jules.google.com/task/2990801578998814903) started by @szubster*