### PR TITLE
feat: implement nuzlocke multiple encounter detection

### DIFF
--- a/.foundry/tasks/task-069-118-detect-violations-impl.md
+++ b/.foundry/tasks/task-069-118-detect-violations-impl.md
@@ -26,6 +26,6 @@ notes: ''
 Implement the logic to identify Nuzlocke violations when multiple Pokémon share the same `met_location`.
 
 ## Acceptance Criteria
-- [ ] Logic detects if more than one Pokémon is caught at the same `met_location`.
-- [ ] Flags violations accordingly.
-- [ ] Includes tests to verify correct violation detection.
+- [x] Logic detects if more than one Pokémon is caught at the same `met_location`.
+- [x] Flags violations accordingly.
+- [x] Includes tests to verify correct violation detection.

--- a/src/engine/nuzlocke/tracker.test.ts
+++ b/src/engine/nuzlocke/tracker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { PokemonInstance, SaveData } from '../saveParser/parsers/common';
-import { aggregateEncountersByLocation } from './tracker';
+import { aggregateEncountersByLocation, detectNuzlockeViolations } from './tracker';
 
 describe('aggregateEncountersByLocation', () => {
   it('should aggregate encounters by location correctly', () => {
@@ -41,5 +41,55 @@ describe('aggregateEncountersByLocation', () => {
     expect(route2).toBeDefined();
     expect(route2?.encounters).toHaveLength(1);
     expect(route2?.encounters[0]?.speciesId).toBe(3);
+  });
+});
+
+describe('detectNuzlockeViolations', () => {
+  it('should return empty array if there are no violations', () => {
+    const saveData: Partial<SaveData> = {
+      partyDetails: [
+        {
+          speciesId: 1,
+          caughtData: { location: 1, locationName: 'Route 1', level: 5, time: 'Day' },
+        } as PokemonInstance,
+      ],
+      pcDetails: [
+        {
+          speciesId: 3,
+          caughtData: { location: 2, locationName: 'Route 2', level: 7, time: 'Day' },
+        } as PokemonInstance,
+      ],
+    };
+
+    const result = detectNuzlockeViolations(saveData as SaveData);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should return violations if multiple encounters share the same location', () => {
+    const saveData: Partial<SaveData> = {
+      partyDetails: [
+        {
+          speciesId: 1,
+          caughtData: { location: 1, locationName: 'Route 1', level: 5, time: 'Day' },
+        } as PokemonInstance,
+      ],
+      pcDetails: [
+        {
+          speciesId: 2,
+          caughtData: { location: 1, locationName: 'Route 1', level: 6, time: 'Day' },
+        } as PokemonInstance,
+        {
+          speciesId: 3,
+          caughtData: { location: 2, locationName: 'Route 2', level: 7, time: 'Day' },
+        } as PokemonInstance,
+      ],
+    };
+
+    const result = detectNuzlockeViolations(saveData as SaveData);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.locationId).toBe(1);
+    expect(result[0]?.encounters).toHaveLength(2);
+    expect(result[0]?.encounters[0]?.speciesId).toBe(1);
+    expect(result[0]?.encounters[1]?.speciesId).toBe(2);
   });
 });

--- a/src/engine/nuzlocke/tracker.ts
+++ b/src/engine/nuzlocke/tracker.ts
@@ -30,3 +30,7 @@ export function aggregateEncountersByLocation(saveData: SaveData): LocationEncou
 
   return Array.from(locationMap.values());
 }
+
+export function detectNuzlockeViolations(saveData: SaveData): LocationEncounters[] {
+  return aggregateEncountersByLocation(saveData).filter((location) => location.encounters.length > 1);
+}


### PR DESCRIPTION
Implements the logic to detect Nuzlocke violations when multiple Pokémon share the same `met_location`, as per ADR 012 and Task 069-118. Tests have been written and all QA checks are passing.

---
*PR created automatically by Jules for task [12321926426266647865](https://jules.google.com/task/12321926426266647865) started by @szubster*