### PR TITLE
Improve Impossible Loop Handling & Propose Auto-Cancellation of Orphaned Nodes

### DIFF
--- a/.foundry/ideas/idea-059-orchestrator-auto-cancel-orphaned-nodes.md
+++ b/.foundry/ideas/idea-059-orchestrator-auto-cancel-orphaned-nodes.md
@@ -1,0 +1,37 @@
+---
+id: idea-059-orchestrator-auto-cancel-orphaned-nodes
+type: IDEA
+title: Auto-Cancel Orphaned PENDING Nodes in Orchestrator
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-05-20'
+updated_at: '2026-05-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - cancellation
+research_references: []
+notes: ''
+---
+
+# Auto-Cancel Orphaned PENDING Nodes in Orchestrator
+
+## Description
+Currently, when a child node (like an implementation TASK) permanently fails by reaching its Max Rejection Count, the Orchestrator's "Impossible Loop" wakes up the parent node (e.g., STORY). The parent must then spawn a RESEARCH node and new implementation tasks.
+
+However, any sibling QA tasks that depended on the permanently failed implementation task become "orphaned" in a `PENDING` state. Manually finding and updating the markdown of these orphaned QA nodes places an unnecessary burden on the planning personas (`tech_lead` and `story_owner`) and clutters the DAG.
+
+We should enhance the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.ts`) to automatically detect these orphaned `PENDING` nodes.
+
+## Proposed Solution
+If a node enters the `FAILED` state with `rejection_reason: 'Max rejection count reached'`, the orchestrator should automatically transition any `PENDING` node that lists the failed node in its `depends_on` array to `CANCELLED`. This cascading cancellation should log an appropriate reason (e.g., "Cancelled due to permanent failure of dependency").
+
+## Acceptance Criteria
+- [ ] Orchestrator detects `PENDING` nodes depending on a permanently failed node (`Max rejection count reached`).
+- [ ] Orchestrator automatically transitions these orphaned nodes to `CANCELLED`.
+- [ ] The `foundry-orchestrator.test.ts` includes a unit test for this behavior.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -121,3 +121,11 @@ I noticed that the extensive rules surrounding the "Empty PR Policy" (both the m
 ### Action Taken
 1. Executed a workspace-wide deduplication by removing the redundant "Empty PR Policy" text blocks directly from the prompts of `coder`, `qa`, `tech_lead`, `story_owner`, `epic_planner`, `product_manager`, `architect`, and `tpm`. These agents will now strictly rely on the centralized `core_policies.md` reference.
 2. Updated `.github/agents/tpm.md` to explicitly instruct the TPM to be conservative when archiving, carefully evaluating whether an old entry still holds valuable system context before removing it.
+
+## 2026-05-20 - Handling the Impossible Loop & Orphaned QA Nodes
+### Observation
+I noticed that `task-062-100-gen3-locations-script-impl.md` failed with `rejection_reason: Max rejection count reached`. This correctly triggered the Orchestrator's "Impossible Loop" to wake up its parent. However, the system lacked explicit instructions for the planning personas (`tech_lead` and `story_owner`) on how to handle these permanent failures—specifically, the need to spawn a `RESEARCH` node to investigate the root cause, and how to deal with the sibling `QA` task (`task-062-101`) that was left orphaned in a `PENDING` state.
+
+### Action Taken
+1. Updated `.github/agents/tech_lead.md` and `.github/agents/story_owner.md` to explicitly include a "HANDLING PERMANENT CHILD FAILURES (THE IMPOSSIBLE LOOP)" section. This instructs them to spawn a `RESEARCH` node, generate replacement tasks, and critically, update the orphaned QA node's Markdown body (without touching its YAML) to indicate it is CANCELLED.
+2. Realized that manually managing orphaned QA nodes is an unnecessary burden on the planning personas. Created `idea-059-orchestrator-auto-cancel-orphaned-nodes.md` to propose an architectural enhancement where the Orchestrator automatically transitions any `PENDING` node depending on a permanently failed node to `CANCELLED`.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -26,6 +26,13 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
 
+**HANDLING PERMANENT CHILD FAILURES (THE IMPOSSIBLE LOOP):**
+If you are woken up by the Orchestrator because a child node reached its Max Rejection Count (e.g., a TASK failed permanently), you MUST:
+1. Spawn a `RESEARCH` node to investigate the root cause of the failure.
+2. Create a new set of replacement nodes (e.g., tasks) that explicitly depend on the `RESEARCH` node being completed.
+3. Append these new nodes to your own markdown body.
+4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending nodes (like `QA` task nodes) associated with the failed implementation. Instead, update the orphaned node's Markdown body indicating that it is CANCELLED and replaced by the new tasks.
+
 
 ## Journal
 
@@ -34,4 +41,3 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
-

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -34,6 +34,13 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
 
+**HANDLING PERMANENT CHILD FAILURES (THE IMPOSSIBLE LOOP):**
+If you are woken up by the Orchestrator because a child node reached its Max Rejection Count (e.g., a `coder` TASK failed permanently), you MUST:
+1. Spawn a `RESEARCH` node to investigate the root cause of the failure.
+2. Create a new set of replacement implementation and/or QA tasks that explicitly depend on the `RESEARCH` node being completed.
+3. Append these new nodes to your own markdown body.
+4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending `QA` task nodes associated with the failed implementation. Instead, update the orphaned QA task's Markdown body indicating that it is CANCELLED and replaced by the new tasks.
+
 
 ## Journal
 
@@ -42,4 +49,3 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
-


### PR DESCRIPTION
This PR addresses the "Impossible Loop" scenario where a child task permanently fails (reaches Max Rejection Count), leaving sibling tasks (like QA) orphaned in a PENDING state.

1. **Process Improvement**: Updated the `.github/agents/tech_lead.md` and `.github/agents/story_owner.md` prompts to explicitly instruct them on how to manually handle these permanent failures (spawning RESEARCH nodes, creating replacement tasks, and updating the markdown of orphaned QA nodes to indicate cancellation).
2. **Systemic Improvement**: Autonomously generated `idea-059-orchestrator-auto-cancel-orphaned-nodes.md` to propose enhancing the Orchestrator to automatically cascade a `CANCELLED` state to these orphaned nodes, reducing the manual burden on planning personas.
3. **Journaling**: Recorded these observations and actions in `.foundry/journals/agile_coach.md`.

---
*PR created automatically by Jules for task [7290908584598436923](https://jules.google.com/task/7290908584598436923) started by @szubster*