### PR TITLE
🛠️ Infras: Fix Biome version mismatch

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: "2.4.14"
+          version: "2.4.15"
 
       - name: Run Biome
         run: biome ci --error-on-warnings .

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -66,3 +66,6 @@ Critical learnings:
 ## 2026-05-18 - Added madge for circular dependency checking
 **Learning:** Integrated `madge` to statically analyze and prevent circular dependencies in the codebase. Added `lint:circular` to the `lint` pipeline to ensure PRs fail if circular dependencies are introduced.
 * The project uses Vite 8 with Rolldown. When configuring `manualChunks` in `vite.config.ts`'s `rollupOptions.output`, it must be defined as a function (e.g., `manualChunks(id) { ... }`) rather than an object to avoid build errors like 'Expected Function but received Object'.
+
+## 2026-05-20 - Fixed Biome Schema Version Mismatch Again
+**Learning:** The Biome CLI version (2.4.15) in `package.json` and `biome.jsonc` was bumped but the version in `.github/workflows/biome.yml` was left at `2.4.14`, meaning CI wasn't using the same version as local. Updated the workflow to match.


### PR DESCRIPTION
**What:**
Updated `.github/workflows/biome.yml` to specify Biome version `2.4.15` instead of `2.4.14`.

**Why:**
The project's `package.json` and `biome.jsonc` have been bumped to `2.4.15`, but the GitHub Actions workflow was left on the old version. This caused CI to run with a different version of Biome than local development, potentially leading to schema warnings or differing lint results.

**Impact on DX/CI:**
Ensures CI consistency and correctness. Local `pnpm lint` and CI `biome check` will now be perfectly aligned and use the same schemas and rulesets, avoiding 'it works on my machine' scenarios.

**Setup notes:**
No special setup required. Tests and lint checks pass perfectly.

---
*PR created automatically by Jules for task [582720217703406608](https://jules.google.com/task/582720217703406608) started by @szubster*