### PR TITLE
🖼️ Canvas: Tactical GlobalError Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -115,3 +115,9 @@
 **Outcome:** Rejected → journaled
 **Why:** The maintainer preferred the previous look with the navigation items integrated into the top header.
 **Pattern:** While vertical sidebars are common for dashboards, avoid moving core navigation out of the top header for desktop layouts, as it changes the structural feel too drastically for the maintainer's preference. Keep navigation integrated into `AppLayout`/`AppHeader` or `BottomNav`.
+
+## 2026-05-20 - [Accepted] - 🖼️ Canvas: Tactical GlobalError Redesign
+**What:** Redesigned the `GlobalError` component to fully embrace the tactical "snooping" aesthetic by replacing the generic styled `div` with `<TacticalPanel variant="red">`.
+**Outcome:** Accepted
+**Why:** Brings the error messaging interface in line with the heavily tactical, specialized hardware motif, solidifying the application's unique visual identity. Tactical panels automatically include dashed borders, LCD grid backgrounds, scanlines, and corner crosshairs.
+**Pattern:** Consistently utilize `TacticalPanel` and matching variants (e.g. `red` for errors) instead of building custom styles with raw elements, ensuring a unified UI language across all system notifications.

--- a/src/components/GlobalError.tsx
+++ b/src/components/GlobalError.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle } from 'lucide-react';
-import { CornerCrosshairs } from './CornerCrosshairs';
+import { TacticalPanel } from './TacticalPanel';
 
 interface GlobalErrorProps {
   error: string | null;
@@ -9,13 +9,17 @@ export function GlobalError({ error }: GlobalErrorProps) {
   if (!error) return null;
 
   return (
-    <div className="fade-in slide-in-from-top-2 relative mx-4 mt-4 mb-0 flex animate-in items-center gap-4 rounded-none border border-red-500/50 border-dashed bg-red-950/50 p-5 text-red-500">
-      <CornerCrosshairs className="h-2 w-2 border-red-500" />
-      <AlertTriangle size={24} className="flex-shrink-0" />
-      <div className="flex flex-col">
-        <span className="font-black font-mono text-[10px] uppercase tracking-tighter">[ SYSTEM.ERROR ]</span>
+    <TacticalPanel
+      variant="red"
+      className="fade-in slide-in-from-top-2 relative mx-4 mt-4 mb-0 flex animate-in items-center gap-4 border-red-500/50 p-5 text-red-500"
+    >
+      <AlertTriangle size={24} className="relative z-10 flex-shrink-0" />
+      <div className="relative z-10 flex flex-col">
+        <span className="font-black font-mono text-[10px] text-red-400 uppercase tracking-tighter">
+          [ SYSTEM.ERROR ]
+        </span>
         <span className="font-medium font-mono text-sm">{error}</span>
       </div>
-    </div>
+    </TacticalPanel>
   );
 }


### PR DESCRIPTION
This PR redesigns the `GlobalError` component to use the `TacticalPanel` (with the `red` variant) instead of relying on custom inline classes on a generic `div`. This ensures the error display correctly matches the application's strict tactical hardware / snooping aesthetic, including the LCD grid background, scanlines, and corner crosshairs.

A journal entry has been appended to `.jules/canvas.md`.

---
*PR created automatically by Jules for task [10322901463028906380](https://jules.google.com/task/10322901463028906380) started by @szubster*