### PR TITLE
🧪 Sentinel: [engine] Add Gen 3 fallback coverage to parseSaveFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -94,3 +94,4 @@ When creating `SaveData` mocks for Vitest engine tests, ensure required fields l
 
 ### TypeScript Mock Types in Vitest
 When replacing store values using `vi.mock()` or mocking data that implements complex interfaces, avoid `as any`. Instead, use `as unknown as ReturnType<...>` to safely cast the object without disabling type checking in strict Biome environments.
+Mocking module exports in Vitest using vi.mock is safer than vi.spyOn for ensuring coverage logic falls through correctly

--- a/src/engine/saveParser/index.test.ts
+++ b/src/engine/saveParser/index.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { parseSaveFile } from './index';
+import * as gen3Module from './parsers/gen3';
+
+vi.mock('./parsers/gen3', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./parsers/gen3')>();
+  return {
+    ...actual,
+  };
+});
 
 describe('saveParser - Dynamic Offset Shift Detection', () => {
   const HEADER_SIZE = 32768;
@@ -230,5 +238,24 @@ describe('saveParser - Error Handling and Fallbacks', () => {
     } finally {
       global.DataView = originalDataView;
     }
+  });
+
+  it('should fallback to gen3 if checksum invalid but structurally valid for gen3', () => {
+    const buffer = new Uint8Array(HEADER_SIZE);
+
+    // Clear gen1/gen2 checks
+    buffer[0x2f2d] = 0x00;
+    buffer[0x2865] = 0x01;
+    buffer[0x2866] = 0x00;
+    buffer[0x288a] = 0x01;
+    buffer[0x288b] = 0x00;
+
+    // Mock isGen3Save to return true
+    const isGen3Spy = vi.spyOn(gen3Module, 'isGen3Save').mockReturnValue(true);
+
+    // Should call parseGen3, which throws 'Gen 3 parsing not implemented yet'
+    expect(() => parseSaveFile(buffer.buffer)).toThrow('Gen 3 parsing not implemented yet');
+
+    isGen3Spy.mockRestore();
   });
 });


### PR DESCRIPTION
🎯 **What**
Added test coverage to `src/engine/saveParser/index.ts` to verify the fallback logic when a save file mimics a Gen 3 structure but fails Gen 1 and Gen 2 validation.

📊 **Coverage**
Improved branch coverage inside the `parseSaveFile` module by testing the conditional `else if (isGen3Save(view))` block.

✨ **Result**
Ensures the save parser correctly delegates to `parseGen3` when `isGen3Save` passes, throwing the expected unimplemented error safely.

---
*PR created automatically by Jules for task [5014502395714420877](https://jules.google.com/task/5014502395714420877) started by @szubster*