### PR TITLE
🧭 Strategist: prompt improvement - Update Archivist to clean Foundry journals

### DIFF
--- a/.github/agents/archivist.md
+++ b/.github/agents/archivist.md
@@ -11,6 +11,7 @@ The following knowledge stores are in scope:
 | `.serena/memories/` (maps to `.foundry/docs/knowledge_base/`) | Serena memories — architecture decisions, patterns, status tracking | Markdown, organized by topic |
 | `.jules/*.md` | Jules agent journals — critical learnings from scheduled agents (bolt, palette, etc.) | Markdown, date-stamped entries |
 | `.Jules/*.md` | Legacy Jules journals (case-sensitivity artifact) — may duplicate `.jules/` | Markdown |
+| `.foundry/journals/*.md` | Foundry persona journals — critical learnings from Foundry agents (coder, qa, tpm, etc.) | Markdown, date-stamped entries |
 | `.agents/rules/` | Agent instructions — coding standards and rules for AI agents | Markdown |
 | `.github/agents/` | Schedule prompts — do NOT modify these (they are maintained manually) | — |
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -120,3 +120,9 @@
 **Outcome:** Accepted
 **Why:** The memory requires agents to ignore false negatives from `request_code_review` when executing the Empty PR Policy (checking off boxes). This needed to be codified in the central `core_policies.md` since agent prompts shouldn't duplicate empty PR rules.
 **Pattern:** Codify memory constraints into the central knowledge base when they apply to all agents.
+
+## 2026-07-06 - [Accepted] - Prompt improvement - Update Archivist to clean Foundry journals
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The memory requires agents to log only critical learnings, but Foundry journals (like `tpm.md`, `coder.md`, `qa.md`) were accumulating routine "I did X" entries, task verifications, and orchestrator state changes. The archivist prompt only included `.jules/*.md` and `.serena/memories/` in its scope, missing `.foundry/journals/*.md`. Adding this allows the archivist to automatically purge noisy status updates that provide no value to future runs, conserving context.
+**Pattern:** Ensure cleanup/maintenance agents have scope over all relevant directories when file structures evolve (e.g. addition of `.foundry/journals/`).


### PR DESCRIPTION
**Proposal**: Add `.foundry/journals/*.md` to the scope of the Archivist agent in `.github/agents/archivist.md`.
**Justification**: The Foundry persona journals (like `coder.md`, `qa.md`, `tpm.md`) have been accumulating routine "I did X" entries, task verifications, and orchestrator state changes, creating noise and bloating context windows. The archivist prompt previously only included `.jules/*.md` and `.serena/memories/` in its scope. Expanding the scope allows the Archivist to purge noisy status updates in `.foundry/journals/` automatically.
**Evidence**: Observed bloat in `.foundry/journals/tpm.md` and `.foundry/journals/coder.md` with routine PR merges, empty PR logs, and task completions, contradicting the strict instruction to only log critical learnings.

---
*PR created automatically by Jules for task [144199237434070246](https://jules.google.com/task/144199237434070246) started by @szubster*