### PR TITLE
🧠 Trainer: [improvement] Evo path selection deduplication and clarity

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -36,3 +36,15 @@
 ## 2024-05-19 - Assistant Daycare Breeding Partner Requirement
 **Learning:** Gen 2 breeding suggestions previously suggested "Leave your #evolutionIdToBreed at the Daycare to get an Egg!" even if the player already had the Pokémon in the Daycare but it was alone, which incorrectly suggested to the user that breeding was in progress or ready. We need to explicitly check if `saveData.daycare.length === 2` to determine if breeding is actually occurring.
 **Action:** When evaluating `EVO_TRIGGER.BREED` (or general breeding recommendations), check `isInDaycare`. If true and `length === 1`, suggest "Need Partner" and advise leaving a compatible partner (like Ditto). If false, explicitly advise leaving the target AND a compatible partner.
+## 2024-05-20 - Multi-stage Evolution Deduplication
+**Learning:** The suggestion engine previously generated redundant suggestions for multi-stage evolutions if multiple subsequent stages were missing (e.g., both Charmeleon and Charizard missing from Pokedex would generate two "Evolve Charmander" suggestions).
+**Action:** When iterating over , skip generation if  AND the intermediate  is also present in . This allows the engine to naturally generate a single "Path to" suggestion for the intermediate stage without flooding the UI.
+## 2024-05-20 - Intermediate Evolution Suggestion Clarity
+**Learning:** For multi-stage evolutions where an intermediate stage is required (e.g. "Path to #Charizard" needing a Charmeleon), the previous title ("Level Up Evolution") and description were misleading, implying the immediate evolution would yield the final target.
+**Action:** Dynamically rewrite the title (e.g., `Path to #${targetId}`) and description (e.g., `into #${immediateEvoTargetId} to progress towards #${targetId}`) when  to clarify the intermediate progression step.
+## 2024-05-20 - Multi-stage Evolution Deduplication
+**Learning:** The suggestion engine previously generated redundant suggestions for multi-stage evolutions if multiple subsequent stages were missing (e.g., both Charmeleon and Charizard missing from Pokedex would generate two "Evolve Charmander" suggestions).
+**Action:** When iterating over `immediateEvoTarget.det`, skip generation if `immediateEvoTargetId !== targetId` AND the intermediate `immediateEvoTargetId` is also present in `missingIds`. This allows the engine to naturally generate a single "Path to" suggestion for the intermediate stage without flooding the UI.
+## 2024-05-20 - Intermediate Evolution Suggestion Clarity
+**Learning:** For multi-stage evolutions where an intermediate stage is required (e.g. "Path to #Charizard" needing a Charmeleon), the previous title ("Level Up Evolution") and description were misleading, implying the immediate evolution would yield the final target.
+**Action:** Dynamically rewrite the title (e.g., `Path to #${targetId}`) and description (e.g., `into #${immediateEvoTargetId} to progress towards #${targetId}`) when `immediateEvoTargetId !== targetId` to clarify the intermediate progression step.

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -588,6 +588,7 @@ function generateEvolutionSuggestions(
   instancesBySpecies: Map<number, PokemonInstance[]>,
   suggestions: Suggestion[],
   displayVersion: string,
+  missingIds: Set<number>,
 ) {
   // E. Evolutions
   // Evaluates the player's current boxes and party to find pre-evolutions.
@@ -619,6 +620,15 @@ function generateEvolutionSuggestions(
     const immediateEvoTarget = apiData.pokemonMetadata?.[immediateEvoTargetId];
     if (!immediateEvoTarget) return;
 
+    // If we're looking at a multi-stage evolution (e.g., target is Charizard, immediate is Charmeleon)
+    // AND the intermediate stage (Charmeleon) is ALSO missing from the Pokedex,
+    // we should skip generating the suggestion for the final stage (Charizard) because
+    // the engine will already generate an identical "Evolve Charmander -> Charmeleon" suggestion
+    // when it evaluates Charmeleon as a target. This prevents redundant duplicates.
+    if (immediateEvoTargetId !== targetId && missingIds.has(immediateEvoTargetId)) {
+      return;
+    }
+
     const details = immediateEvoTarget.det;
     if (!details || details.length === 0) return;
 
@@ -647,6 +657,10 @@ function generateEvolutionSuggestions(
       } else {
         bestInstance = evolvableInstances.reduce((prev, current) => (prev.level > current.level ? prev : current));
       }
+
+      const isIntermediate = immediateEvoTargetId !== targetId;
+      const pathTitlePrefix = isIntermediate ? `Path to #${targetId}` : 'Evolution';
+      const evolveTargetText = isIntermediate ? ` into #${immediateEvoTargetId} to progress towards #${targetId}` : '';
 
       if (tr === EVO_TRIGGER.LEVEL_UP) {
         if (min_l) {
@@ -684,10 +698,10 @@ function generateEvolutionSuggestions(
           suggestions.push({
             id: `evo-lvl-${targetId}`,
             category: 'Evolve',
-            title: `Level Up Evolution: #${targetId}`,
+            title: isIntermediate ? pathTitlePrefix : `Level Up Evolution: #${targetId}`,
             description: isActuallyReady
-              ? `Your Lv. ${bestInstance.level} pre-evolution is ready to evolve ${specificReq}!`
-              : `Your Lv. ${bestInstance.level} pre-evolution evolves at Lv. ${min_l} ${specificReq}.`,
+              ? `Your Lv. ${bestInstance.level} pre-evolution is ready to evolve${evolveTargetText} ${specificReq}!`
+              : `Your Lv. ${bestInstance.level} pre-evolution evolves at Lv. ${min_l}${evolveTargetText} ${specificReq}.`,
             pokemonId: targetId,
             priority: isActuallyReady ? 90 : 75,
           });
@@ -700,10 +714,14 @@ function generateEvolutionSuggestions(
           suggestions.push({
             id: `evo-happy-${targetId}`,
             category: 'Evolve',
-            title: isFriendlyEnough ? `Ready to Evolve: #${targetId}!` : `Happiness Evolution: #${targetId}`,
+            title: isIntermediate
+              ? pathTitlePrefix
+              : isFriendlyEnough
+                ? `Ready to Evolve: #${targetId}!`
+                : `Happiness Evolution: #${targetId}`,
             description: isFriendlyEnough
-              ? `Your pre-evolution is friendly enough${friendshipStatus}! Level it up${todMsg} to evolve.`
-              : `Level up your pre-evolution with high happiness${friendshipStatus} to evolve${todMsg}!`,
+              ? `Your pre-evolution is friendly enough${friendshipStatus}! Level it up${todMsg} to evolve${evolveTargetText}.`
+              : `Level up your pre-evolution with high happiness${friendshipStatus} to evolve${todMsg}${evolveTargetText}!`,
             pokemonId: targetId,
             priority: isFriendlyEnough ? 90 : 80,
           });
@@ -712,8 +730,8 @@ function generateEvolutionSuggestions(
           suggestions.push({
             id: `evo-lvl-any-${targetId}`,
             category: 'Evolve',
-            title: `Level Up Evolution: #${targetId}`,
-            description: `Level up your pre-evolution${todMsg} to evolve!`,
+            title: isIntermediate ? pathTitlePrefix : `Level Up Evolution: #${targetId}`,
+            description: `Level up your pre-evolution${todMsg} to evolve${evolveTargetText}!`,
             pokemonId: targetId,
             priority: 70,
           });
@@ -725,8 +743,14 @@ function generateEvolutionSuggestions(
         suggestions.push({
           id: `evo-item-${targetId}-${item}`,
           category: 'Evolve',
-          title: hasStone ? `Ready to Evolve: #${targetId}!` : `Item Needed: #${targetId}`,
-          description: hasStone ? `Use your ${itemName} to evolve it!` : `Find a ${itemName} to evolve it.`,
+          title: isIntermediate
+            ? pathTitlePrefix
+            : hasStone
+              ? `Ready to Evolve: #${targetId}!`
+              : `Item Needed: #${targetId}`,
+          description: hasStone
+            ? `Use your ${itemName} to evolve it${evolveTargetText}!`
+            : `Find a ${itemName} to evolve it${evolveTargetText}.`,
           pokemonId: targetId,
           priority: hasStone ? 95 : 40,
         });
@@ -740,17 +764,21 @@ function generateEvolutionSuggestions(
           const hasHeldItem = hasHeldItemInBag || !!holdingInstance;
           const itemName = EVO_ITEM_NAMES[held] || 'item';
 
-          let description = `Find a ${itemName}, have your pre-evolution hold it, and trade to evolve.`;
+          let description = `Find a ${itemName}, have your pre-evolution hold it, and trade to evolve${evolveTargetText}.`;
           if (holdingInstance) {
-            description = `Your pre-evolution is already holding the ${itemName}! Trade it to evolve!`;
+            description = `Your pre-evolution is already holding the ${itemName}! Trade it to evolve${evolveTargetText}!`;
           } else if (hasHeldItemInBag) {
-            description = `Have your pre-evolution hold the ${itemName} and trade it to evolve!`;
+            description = `Have your pre-evolution hold the ${itemName} and trade it to evolve${evolveTargetText}!`;
           }
 
           suggestions.push({
             id: `evo-trade-held-${targetId}`,
             category: 'Evolve',
-            title: hasHeldItem ? `Ready to Trade Evolve: #${targetId}!` : `Item Needed for Trade: #${targetId}`,
+            title: isIntermediate
+              ? pathTitlePrefix
+              : hasHeldItem
+                ? `Ready to Trade Evolve: #${targetId}!`
+                : `Item Needed for Trade: #${targetId}`,
             description,
             pokemonId: targetId,
             priority: hasHeldItem ? 90 : 45,
@@ -759,8 +787,8 @@ function generateEvolutionSuggestions(
           suggestions.push({
             id: `evo-trade-${targetId}`,
             category: 'Evolve',
-            title: `Trade Evolution: #${targetId}`,
-            description: `Trade your pre-evolution to evolve it!`,
+            title: isIntermediate ? pathTitlePrefix : `Trade Evolution: #${targetId}`,
+            description: `Trade your pre-evolution to evolve it${evolveTargetText}!`,
             pokemonId: targetId,
             priority: 85,
           });
@@ -936,7 +964,15 @@ export function generateSuggestions(
 
   generateBreedingSuggestions(queryTargets, saveData, apiData, instancesBySpecies, suggestions);
 
-  generateEvolutionSuggestions(queryTargets, saveData, apiData, instancesBySpecies, suggestions, displayVersion);
+  generateEvolutionSuggestions(
+    queryTargets,
+    saveData,
+    apiData,
+    instancesBySpecies,
+    suggestions,
+    displayVersion,
+    missingIds,
+  );
 
   // ⚡ Bolt: Eliminate O(N) array tuple allocation during suggestion deduplication
   const uniqueMap = new Map<string, Suggestion>();


### PR DESCRIPTION
What:
The PR deduplicates multi-stage evolution suggestions by skipping redundant steps when an intermediate stage is already correctly evaluated as a missing target in its own right. It also heavily improves the verbiage of the suggestions when the player *does* need to evolve into an intermediate stage to work towards a final target they are missing (e.g., changing "Level Up Evolution" to "Path to #Charizard").

Why:
The assistant previously spammed users with multiple identical "Level Up Evolution" warnings for the same base Pokémon if the user was missing both stage 1 and stage 2 evolutions. It also didn't clearly communicate that an evolution was merely a stepping stone toward a separate target.

Impact on recommendation quality:
Removes redundant entries, freeing up slots for other actionable advice. Considerably improves clarity for multi-stage evolutionary lines by explicitly stating what the immediate target is and why the player is being asked to evolve it.

Test coverage:
Passes all existing `suggestionEngine.ts` unit tests and end-to-end recommendation flow tests. Added strict condition checks against `immediateEvoTargetId` vs `targetId` and `missingIds` presence.

---
*PR created automatically by Jules for task [8976216404442418419](https://jules.google.com/task/8976216404442418419) started by @szubster*