### PR TITLE
🎨 Palette: Add ARIA labels to DAG filters

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -72,3 +72,4 @@
 ## 2026-05-19 - Added ARIA attributes to DAG filter buttons
 **Learning:** Filter buttons that act as toggle groups visually indicate state through color changes, but screen readers are unaware. Adding `aria-pressed={isActive}` to individual buttons and wrapping the group in `role="group"` with `aria-label` effectively communicates this interactivity.
 **Action:** Replaced `src/components/dag/DagFilterPanel.tsx` to add `aria-pressed` properties to type and status filter buttons, and wrapped the filter areas with `role="group"` and descriptive `aria-label` attributes.
+- Added `aria-label` and `title` to dynamic filter buttons in `DagFilterPanel.tsx` for improved accessibility and tooltip support.

--- a/src/components/dag/DagFilterPanel.tsx
+++ b/src/components/dag/DagFilterPanel.tsx
@@ -24,6 +24,8 @@ export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onSt
                 key={type}
                 type="button"
                 aria-pressed={isActive}
+                aria-label={`Toggle ${type} type filter`}
+                title={`Toggle ${type} type filter`}
                 onClick={() => onTypeToggle(type)}
                 className={cn(
                   'rounded-none border border-dashed px-2 py-1 transition-colors hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
@@ -69,6 +71,8 @@ export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onSt
                 key={status}
                 type="button"
                 aria-pressed={isActive}
+                aria-label={`Toggle ${status} status filter`}
+                title={`Toggle ${status} status filter`}
                 onClick={() => onStatusToggle(status)}
                 className={cn(
                   'rounded-none border border-dashed px-2 py-1 transition-colors hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',


### PR DESCRIPTION
Added descriptive `aria-label` and `title` attributes to the dynamically generated "type" and "status" filter buttons in `DagFilterPanel.tsx` to improve screen reader accessibility and provide native hover tooltips.

---
*PR created automatically by Jules for task [16721075808558883343](https://jules.google.com/task/16721075808558883343) started by @szubster*