### PR TITLE
🛡️ Nurse: [type improvement]

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -57,3 +57,8 @@ The compiler statically guarantees that the `StatusType` union and the `STATUS_O
 - When testing React Flow (`@xyflow/react`) interactions in Vitest browser mode, clicking the background pane requires targeting the `.react-flow__pane` element specifically, as generic background clicks may not register correctly.
 - To view Vitest coverage summaries directly in the terminal (especially in CI environments where coverage files might not be readily accessible), use the `text` or `text-summary` reporter (e.g., `npx vitest run --coverage.reporter=text-summary`).
 - When testing React Flow (`@xyflow/react`) interactions in Vitest browser mode, clicking the background pane requires targeting the `.react-flow__pane` element specifically. Furthermore, use native DOM events like `dispatchEvent(new MouseEvent('click', { bubbles: true }))` rather than `.click()` on the pane element to ensure events register reliably in test environments.
+
+## 2025-05-20 - Type Narrowing `ArrayBuffer`
+
+- **Context:** The `parseSaveFile` function was typed to only accept `ArrayBuffer`, forcing the caller to explicitly cast `buffer.buffer as ArrayBuffer` since IndexedDB fetches return `Uint8Array` whose `.buffer` property resolves to `ArrayBufferLike`.
+- **Learning:** When accepting binary buffers that will be parsed via `DataView`, type the parameter as `ArrayBufferLike` rather than strictly `ArrayBuffer`. `DataView` inherently supports `ArrayBufferLike` (which encompasses `ArrayBuffer`, `SharedArrayBuffer`, etc.), preventing the need for explicit type overrides at the call site.

--- a/src/engine/saveParser/index.ts
+++ b/src/engine/saveParser/index.ts
@@ -15,7 +15,7 @@ export type { GameVersion, PokemonInstance, SaveData };
  * @returns The structured SaveData object representing the player's progress and Pokémon.
  * @throws An Error if the file size is invalid or if neither Gen 1 nor Gen 2 structures could be matched.
  */
-export function parseSaveFile(buffer: ArrayBuffer, forcedVersion?: GameVersion): SaveData {
+export function parseSaveFile(buffer: ArrayBufferLike, forcedVersion?: GameVersion): SaveData {
   const view = new DataView(buffer);
 
   if (buffer.byteLength < 32768) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -150,7 +150,7 @@ export const useStore = create<AppStore>()(
           const buffer = await saveDB.getSave('last_save_file');
           if (buffer) {
             const { manualVersion } = get();
-            const data = parseSaveFile(buffer.buffer as ArrayBuffer, manualVersion || undefined);
+            const data = parseSaveFile(buffer.buffer, manualVersion || undefined);
             set({ saveData: data });
           }
         } catch {


### PR DESCRIPTION
**What was unsafe:**
The `parseSaveFile` function was strictly typed to accept `ArrayBuffer`, which forced `src/store.ts` to perform an unsafe `buffer.buffer as ArrayBuffer` cast when pulling the `Uint8Array` save block out of IndexedDB, since the `.buffer` property resolves to `ArrayBufferLike`.

**How it was fixed:**
I updated the parameter type of `buffer` in `parseSaveFile` (`src/engine/saveParser/index.ts`) from `ArrayBuffer` to `ArrayBufferLike`.

**What the compiler now catches:**
The compiler now accurately maps the interface allowed by `DataView`, eliminating the explicit type coercion and guaranteeing that any implementation modifications safely adhere to the broader generic bound of Javascript TypedArray internal buffers.

---
*PR created automatically by Jules for task [5644982353177841375](https://jules.google.com/task/5644982353177841375) started by @szubster*