### PR TITLE
feat(foundry): Convert Multi-Save Trade Planner IDEA to PRD

### DIFF
--- a/.foundry/ideas/idea-059-multi-save-trade-planner.md
+++ b/.foundry/ideas/idea-059-multi-save-trade-planner.md
@@ -38,4 +38,6 @@ Introduce a "Multi-Save Mode" in DexHelper that allows users to analyze two or m
 This feature transforms DexHelper from a single-file viewer into a comprehensive Collection Manager. It directly solves the most tedious aspect of completing the retro Pokédex by providing actionable, cross-game intelligence, significantly reducing manual tracking and planning for players managing multiple versions.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD.
+- [x] Product Manager: Convert this idea into a PRD.
+
+Generated PRD: .foundry/prds/prd-059-028-multi-save-trade-planner.md

--- a/.foundry/prds/prd-059-028-multi-save-trade-planner.md
+++ b/.foundry/prds/prd-059-028-multi-save-trade-planner.md
@@ -1,0 +1,31 @@
+---
+id: prd-059-028-multi-save-trade-planner
+type: PRD
+title: Multi-Save Trade Planner
+status: PENDING
+owner_persona: architect
+created_at: '2026-05-20'
+updated_at: '2026-05-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: .foundry/ideas/idea-059-multi-save-trade-planner.md
+tags:
+  - feature
+  - trades
+  - multi-save
+research_references: []
+notes: ''
+---
+# Multi-Save Trade Planner
+
+## Objective
+Provide intelligent tools within DexHelper to analyze multiple active save files simultaneously, identifying optimal trade opportunities and cross-save synergies to accelerate Pokédex completion.
+
+## Scope
+- Multi-save simultaneous load capability.
+- Cross-save missing dex analysis.
+- Trade evolution flagging.
+
+## Acceptance Criteria
+- [ ] Architect: Review this PRD and create an ADR detailing the system architecture needed to support simultaneous analysis of multiple save files.


### PR DESCRIPTION
Creates a new PRD for the Multi-Save Trade Planner feature, derived from `idea-059-multi-save-trade-planner.md`. 
The new node assigns the `architect` persona to author the corresponding ADR. 
The parent IDEA's markdown body has been updated to check off the acceptance criteria and link the new node, without touching the parent's YAML frontmatter.

---
*PR created automatically by Jules for task [5167819934673137068](https://jules.google.com/task/5167819934673137068) started by @szubster*