### PR TITLE
test: increase coverage for tracker violations

### DIFF
--- a/.foundry/tasks/task-069-119-detect-violations-qa.md
+++ b/.foundry/tasks/task-069-119-detect-violations-qa.md
@@ -26,5 +26,5 @@ notes: ''
 Validate the implementation of Nuzlocke violation detection logic for multiple encounters at the same `met_location`.
 
 ## Acceptance Criteria
-- [ ] Run test suites to verify that Nuzlocke violation logic functions as expected.
-- [ ] Verify test coverage is sufficient.
+- [x] Run test suites to verify that Nuzlocke violation logic functions as expected.
+- [x] Verify test coverage is sufficient.

--- a/src/engine/nuzlocke/tracker.test.ts
+++ b/src/engine/nuzlocke/tracker.test.ts
@@ -42,6 +42,26 @@ describe('aggregateEncountersByLocation', () => {
     expect(route2?.encounters).toHaveLength(1);
     expect(route2?.encounters[0]?.speciesId).toBe(3);
   });
+
+  it('should handle missing partyDetails and pcDetails', () => {
+    const saveData: Partial<SaveData> = {};
+    const result = aggregateEncountersByLocation(saveData as SaveData);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should fallback to Location {id} if locationName is missing', () => {
+    const saveData: Partial<SaveData> = {
+      partyDetails: [
+        {
+          speciesId: 1,
+          caughtData: { location: 99, level: 5, time: 'Day' },
+        } as PokemonInstance,
+      ],
+    };
+    const result = aggregateEncountersByLocation(saveData as SaveData);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.locationName).toBe('Location 99');
+  });
 });
 
 describe('detectNuzlockeViolations', () => {


### PR DESCRIPTION
Validate Nuzlocke violation detection for multiple encounters per location and ensure 100% test coverage. Checked off task Acceptance Criteria without modifying YAML frontmatter.

---
*PR created automatically by Jules for task [10005381711679967905](https://jules.google.com/task/10005381711679967905) started by @szubster*