### PR TITLE
Epic: Implement Orchestrator Auto-Cancel for Orphaned Nodes

### DIFF
--- a/.foundry/epics/epic-028-035-orchestrator-auto-cancel-orphaned-nodes.md
+++ b/.foundry/epics/epic-028-035-orchestrator-auto-cancel-orphaned-nodes.md
@@ -1,0 +1,39 @@
+---
+id: epic-028-035-orchestrator-auto-cancel-orphaned-nodes
+type: EPIC
+title: Implement Orchestrator Auto-Cancel for Orphaned Nodes
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-20'
+updated_at: '2026-05-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-059-028-orchestrator-auto-cancel-orphaned-nodes
+tags:
+  - foundry
+  - dag
+  - orchestrator
+  - cancellation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Implement Orchestrator Auto-Cancel for Orphaned Nodes
+
+## Context
+When a child node (e.g., an implementation TASK) permanently fails by reaching its `Max rejection count reached`, the orchestrator currently wakes up the parent node to spawn new tasks. However, sibling tasks that depended on the failed task (like a QA task) are left as orphaned nodes stuck in the `PENDING` state.
+
+## Objective
+This epic implements an enhancement to the orchestrator (`.github/scripts/foundry-orchestrator.ts`) to automatically detect and cancel these orphaned nodes, reducing manual cleanup and DAG clutter.
+
+## Requirements Checklist
+- [ ] During the orchestrator's graph evaluation, detect any node in the `FAILED` state with `rejection_reason: 'Max rejection count reached'`.
+- [ ] Identify all nodes currently in the `PENDING` state that list the permanently failed node in their `depends_on` array.
+- [ ] Transition these identified `PENDING` nodes to `CANCELLED`.
+- [ ] Update the `rejection_reason` of the cancelled node to indicate the cause: `"Cancelled due to permanent failure of dependency: <failed-node-id>"`.
+- [ ] Ensure the cancellation logic does not introduce circular dependencies or infinite loops.
+- [ ] Log the cancellation action clearly in the orchestrator's output.
+- [ ] Add unit tests in `foundry-orchestrator.test.ts` to ensure `PENDING` nodes depending on permanently `FAILED` nodes are correctly transitioned to `CANCELLED` and reasons are recorded.

--- a/.foundry/prds/prd-059-028-orchestrator-auto-cancel-orphaned-nodes.md
+++ b/.foundry/prds/prd-059-028-orchestrator-auto-cancel-orphaned-nodes.md
@@ -41,3 +41,6 @@ When a child node (e.g., an implementation TASK) permanently fails by reaching i
 ## Testing Strategy
 - Unit testing in `foundry-orchestrator.test.ts` to ensure `PENDING` nodes depending on permanently `FAILED` nodes are correctly transitioned to `CANCELLED`.
 - Verification that the cancellation reason is properly recorded in the node's frontmatter.
+
+## Epics
+- .foundry/epics/epic-028-035-orchestrator-auto-cancel-orphaned-nodes.md


### PR DESCRIPTION
This PR converts the PRD `prd-059-028-orchestrator-auto-cancel-orphaned-nodes.md` into an actionable Epic (`epic-028-035-orchestrator-auto-cancel-orphaned-nodes.md`).

It assigns the newly created Epic to the `story_owner` and links it in the markdown body of the parent PRD.

---
*PR created automatically by Jules for task [8122953170807600566](https://jules.google.com/task/8122953170807600566) started by @szubster*