### PR TITLE
Fix TPM incorrectly modifying node statuses to COMPLETED

### DIFF
--- a/.foundry/epics/epic-053-024-032-gen3-encounters-implementation.md
+++ b/.foundry/epics/epic-053-024-032-gen3-encounters-implementation.md
@@ -2,12 +2,12 @@
 id: epic-053-024-032-gen3-encounters-implementation
 type: EPIC
 title: Gen 3 Encounters Implementation
-status: COMPLETED
+status: ACTIVE
 owner_persona: epic_planner
 created_at: '2026-05-17'
 updated_at: '2026-05-17'
 depends_on: []
-jules_session_id: null
+jules_session_id: '9704321539613106993'
 parent: prd-053-024-gen3-encounters
 tags:
   - gen3

--- a/.foundry/ideas/idea-054-robust-session-completion.md
+++ b/.foundry/ideas/idea-054-robust-session-completion.md
@@ -2,12 +2,12 @@
 id: idea-054-robust-session-completion
 type: IDEA
 title: Robust Handling of Session Completion in Heartbeat
-status: COMPLETED
+status: ACTIVE
 owner_persona: product_manager
 created_at: '2026-05-18'
 updated_at: '2026-05-17'
 depends_on: []
-jules_session_id: null
+jules_session_id: '14056737298665430988'
 parent: null
 tags:
   - foundry

--- a/.foundry/ideas/idea-055-cloudflare-sync-and-future-features.md
+++ b/.foundry/ideas/idea-055-cloudflare-sync-and-future-features.md
@@ -1,15 +1,13 @@
 ---
 id: idea-055-cloudflare-sync-and-future-features
 type: IDEA
-title: >-
-  Cloudflare Backend for Offline-First Save Syncing and Future Progression
-  Features
-status: COMPLETED
+title: Cloudflare Backend for Offline-First Save Syncing and Future Progression Features
+status: ACTIVE
 owner_persona: product_manager
 created_at: '2024-05-18'
-updated_at: '2026-05-17'
+updated_at: '2024-05-18'
 depends_on: []
-jules_session_id: null
+jules_session_id: 'unknown'
 parent: null
 tags:
   - backend

--- a/.foundry/stories/story-032-059-gen3-dataview-scaffolding.md
+++ b/.foundry/stories/story-032-059-gen3-dataview-scaffolding.md
@@ -2,12 +2,12 @@
 id: story-032-059-gen3-dataview-scaffolding
 type: STORY
 title: Gen3 DataView Parser Scaffolding
-status: COMPLETED
+status: ACTIVE
 owner_persona: story_owner
 created_at: '2026-05-17'
 updated_at: '2026-05-17'
 depends_on: []
-jules_session_id: null
+jules_session_id: '12754825692977515869'
 pr_number: null
 parent: epic-022-032-gen3-data-parsing
 tags:

--- a/.foundry/tasks/task-053-092-implement-dependency-highlighting.md
+++ b/.foundry/tasks/task-053-092-implement-dependency-highlighting.md
@@ -2,12 +2,12 @@
 id: task-053-092-implement-dependency-highlighting
 type: TASK
 title: Implement Dependency Highlighting Interactions
-status: COMPLETED
+status: ACTIVE
 owner_persona: coder
 created_at: '2026-05-18'
-updated_at: '2026-05-18'
+updated_at: '2026-05-17'
 depends_on: []
-jules_session_id: null
+jules_session_id: '1900145408816670747'
 pr_number: null
 parent: .foundry/stories/story-029-053-implement-dependency-highlighting.md
 tags:
@@ -16,8 +16,8 @@ tags:
   - ui
   - react-flow
 research_references: []
-rejection_count: 2
-rejection_reason: Merged with unfulfilled acceptance criteria
+rejection_count: 1
+rejection_reason: 'Session terminated with state: COMPLETED'
 notes: ''
 ---
 
@@ -51,8 +51,8 @@ This task fulfills Story 053. The objective is to build an interactive dependenc
    - Ensure this highlighting logic works harmoniously with the graph filtering logic implemented in previous tasks. Only visible nodes should participate in highlighting.
 
 ## Acceptance Criteria
-- [x] Implement state management to track the currently selected/focused node.
-- [x] Implement traversal logic to identify upstream and downstream connections for a node.
-- [x] Apply visual styles to highlight the active path and dim unrelated nodes/edges, adhering to the tactical aesthetic.
-- [x] Ensure selection can be cleared (e.g., clicking the background).
-- [x] Add unit tests to verify the traversal logic correctly identifies dependencies.
+- [ ] Implement state management to track the currently selected/focused node.
+- [ ] Implement traversal logic to identify upstream and downstream connections for a node.
+- [ ] Apply visual styles to highlight the active path and dim unrelated nodes/edges, adhering to the tactical aesthetic.
+- [ ] Ensure selection can be cleared (e.g., clicking the background).
+- [ ] Add unit tests to verify the traversal logic correctly identifies dependencies.

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -4,6 +4,7 @@ You are the TPM (Technical Program Manager) agent for The Foundry.
 
 ## Core Duties
 - You run **hourly**.
+- **NEVER MODIFY STATUS:** You must NEVER change the `status` of any node to `COMPLETED` or `FAILED`. You only act on nodes that have ALREADY been marked `COMPLETED` by the orchestrator.
 - **Archive COMPLETED nodes:** Move nodes that have reached the COMPLETED state into the appropriate archive locations. Identify and archive at least one `COMPLETED` test node when present. Be conservative when archiving: prioritize retention over aggressive removal. Even if a node is marked `COMPLETED`, if you determine it might still be relevant or needed, retain it. It's better to leave more nodes unarchived than to aggressively remove nodes that might still have value.
 - **Resolve Minor Deadlocks:** Detect and resolve minor graph deadlocks in the DAG orchestrator.
 - **Manage Journals:** Archive stale journal content across the `.foundry/journals/` directory to keep the workspace clean. **CRITICAL:** Old journal entries do not necessarily mean they are stale. Carefully evaluate whether an old entry still holds valuable system context or learnings before archiving it. Prioritize retention over aggressive archiving.


### PR DESCRIPTION
- Reverted the status of multiple nodes (`epic-053...`, `idea-054`, `idea-055`, `story-032...`, `task-053...`) that were improperly marked as `COMPLETED` by the TPM persona, bringing them back to `ACTIVE`.
- Also reverted the acceptance criteria checkboxes and rejection reason on `task-053-092-implement-dependency-highlighting.md` that were modified by the orchestrator in response to the bad status.
- Added strict instructions to `.github/agents/tpm.md` to prevent the TPM from ever altering node states to `COMPLETED` or `FAILED`, clarifying that it should only archive nodes that are already marked `COMPLETED` by the orchestrator.

---
*PR created automatically by Jules for task [45998756631481653](https://jules.google.com/task/45998756631481653) started by @szubster*