### PR TITLE
chore(foundry): late-bind story nodes for auto-cancel epic

### DIFF
--- a/.foundry/epics/epic-028-035-orchestrator-auto-cancel-orphaned-nodes.md
+++ b/.foundry/epics/epic-028-035-orchestrator-auto-cancel-orphaned-nodes.md
@@ -30,10 +30,14 @@ When a child node (e.g., an implementation TASK) permanently fails by reaching i
 This epic implements an enhancement to the orchestrator (`.github/scripts/foundry-orchestrator.ts`) to automatically detect and cancel these orphaned nodes, reducing manual cleanup and DAG clutter.
 
 ## Requirements Checklist
-- [ ] During the orchestrator's graph evaluation, detect any node in the `FAILED` state with `rejection_reason: 'Max rejection count reached'`.
-- [ ] Identify all nodes currently in the `PENDING` state that list the permanently failed node in their `depends_on` array.
-- [ ] Transition these identified `PENDING` nodes to `CANCELLED`.
-- [ ] Update the `rejection_reason` of the cancelled node to indicate the cause: `"Cancelled due to permanent failure of dependency: <failed-node-id>"`.
-- [ ] Ensure the cancellation logic does not introduce circular dependencies or infinite loops.
-- [ ] Log the cancellation action clearly in the orchestrator's output.
-- [ ] Add unit tests in `foundry-orchestrator.test.ts` to ensure `PENDING` nodes depending on permanently `FAILED` nodes are correctly transitioned to `CANCELLED` and reasons are recorded.
+- [x] During the orchestrator's graph evaluation, detect any node in the `FAILED` state with `rejection_reason: 'Max rejection count reached'`.
+- [x] Identify all nodes currently in the `PENDING` state that list the permanently failed node in their `depends_on` array.
+- [x] Transition these identified `PENDING` nodes to `CANCELLED`.
+- [x] Update the `rejection_reason` of the cancelled node to indicate the cause: `"Cancelled due to permanent failure of dependency: <failed-node-id>"`.
+- [x] Ensure the cancellation logic does not introduce circular dependencies or infinite loops.
+- [x] Log the cancellation action clearly in the orchestrator's output.
+- [x] Add unit tests in `foundry-orchestrator.test.ts` to ensure `PENDING` nodes depending on permanently `FAILED` nodes are correctly transitioned to `CANCELLED` and reasons are recorded.
+
+## Assigned Stories
+- `.foundry/stories/story-035-072-implement-cancellation-logic.md`
+- `.foundry/stories/story-035-073-orchestrator-cancellation-tests.md`

--- a/.foundry/stories/story-035-072-implement-cancellation-logic.md
+++ b/.foundry/stories/story-035-072-implement-cancellation-logic.md
@@ -1,0 +1,34 @@
+---
+id: story-035-072-implement-cancellation-logic
+type: STORY
+title: Implement DAG Dependency Cancellation Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-20'
+updated_at: '2026-05-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-028-035-orchestrator-auto-cancel-orphaned-nodes
+tags:
+  - orchestrator
+  - auto-cancel
+  - backend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Implement DAG Dependency Cancellation Logic
+
+## Objective
+Update `.github/scripts/foundry-orchestrator.ts` to implement the core logic for detecting nodes that failed permanently, and auto-canceling any dependent nodes that are still in a `PENDING` state.
+
+## Acceptance Criteria
+- [ ] During the DAG evaluation cycle, identify any nodes with `status: 'FAILED'` and `rejection_reason: 'Max rejection count reached'`.
+- [ ] Traverse the DAG to find all nodes with `status: 'PENDING'` that explicitly list the failed node in their `depends_on` array.
+- [ ] Transition these `PENDING` nodes to `CANCELLED`.
+- [ ] Update their `rejection_reason` to `"Cancelled due to permanent failure of dependency: <failed-node-id>"`.
+- [ ] Add safeguards to prevent circular dependencies or infinite loops during cancellation traversal.
+- [ ] Log cancellation operations in standard output to ensure visibility.

--- a/.foundry/stories/story-035-073-orchestrator-cancellation-tests.md
+++ b/.foundry/stories/story-035-073-orchestrator-cancellation-tests.md
@@ -1,0 +1,32 @@
+---
+id: story-035-073-orchestrator-cancellation-tests
+type: STORY
+title: Add Unit Tests for DAG Auto-Cancellation
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-20'
+updated_at: '2026-05-20'
+depends_on:
+  - story-035-072-implement-cancellation-logic
+jules_session_id: null
+pr_number: null
+parent: epic-028-035-orchestrator-auto-cancel-orphaned-nodes
+tags:
+  - orchestrator
+  - testing
+  - auto-cancel
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Add Unit Tests for DAG Auto-Cancellation
+
+## Objective
+Add specific unit tests in `.github/scripts/foundry-orchestrator.test.ts` to verify the functionality of auto-canceling `PENDING` nodes that depend on permanently `FAILED` nodes.
+
+## Acceptance Criteria
+- [ ] Add unit tests verifying that dependent `PENDING` nodes are correctly transitioned to `CANCELLED` when their dependency hits the max rejection count.
+- [ ] Add unit tests verifying the exact `rejection_reason` string formatting.
+- [ ] Test the anti-loop / cycle prevention mechanisms of the cancellation logic.


### PR DESCRIPTION
Late-binds story nodes `story-035-072-implement-cancellation-logic` and `story-035-073-orchestrator-cancellation-tests` from `epic-028-035-orchestrator-auto-cancel-orphaned-nodes`, updating the parent epic markdown references and acceptance criteria appropriately.

---
*PR created automatically by Jules for task [17044620623683396735](https://jules.google.com/task/17044620623683396735) started by @szubster*