### PR TITLE
Fix Foundry Orchestration Failures

### DIFF
--- a/.foundry/tasks/task-062-112-gen3-locations-script-retry-impl.md
+++ b/.foundry/tasks/task-062-112-gen3-locations-script-retry-impl.md
@@ -11,6 +11,7 @@ depends_on:
 research_references:
   - .foundry/research/research-062-001-gen3-location-fetching.md
 jules_session_id: null
+rejection_reason: ''
 parent: story-032-062-gen3-data-generation-scripts
 ---
 

--- a/.foundry/tasks/task-062-113-gen3-locations-script-retry-qa.md
+++ b/.foundry/tasks/task-062-113-gen3-locations-script-retry-qa.md
@@ -9,6 +9,7 @@ updated_at: '2026-05-19'
 depends_on:
   - task-062-112-gen3-locations-script-retry-impl
 jules_session_id: null
+rejection_reason: ''
 parent: story-032-062-gen3-data-generation-scripts
 ---
 

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -12,6 +12,7 @@ function resolveNodeIdToPath(nodeId: string): string {
     epic: 'epics',
     story: 'stories',
     task: 'tasks',
+    research: 'research',
     adr: 'docs/adrs'
   };
   if (!type) return nodeId;


### PR DESCRIPTION
This PR addresses two CI failures in the Foundry orchestration phase:
1. The `link-checker` failed to resolve `research-` node IDs because the `RESEARCH` node type was missing from the folder mapping in `scripts/check-links.ts`.
2. The `validate-foundry-schema` script issued warnings about the missing `rejection_reason` field in recently created task nodes.

Changes:
- Updated `scripts/check-links.ts` to map `research` IDs to the `.foundry/research/` directory.
- Added `rejection_reason: ''` to `.foundry/tasks/task-062-112-gen3-locations-script-retry-impl.md` and `.foundry/tasks/task-062-113-gen3-locations-script-retry-qa.md`.
- Verified fixes by running the validation scripts manually and ensuring `pnpm lint && pnpm test` passes.

Fixes #1618

---
*PR created automatically by Jules for task [10130769409636014191](https://jules.google.com/task/10130769409636014191) started by @szubster*