### PR TITLE
docs: check off QA acceptance criteria for task-053-125

### DIFF
--- a/.foundry/tasks/task-053-125-qa-retry-dependency-highlighting.md
+++ b/.foundry/tasks/task-053-125-qa-retry-dependency-highlighting.md
@@ -54,8 +54,8 @@ This task replaces the orphaned QA task `task-053-093-qa-dependency-highlighting
    - Run `pnpm test`, `pnpm test:e2e`, and `pnpm lint` to ensure no regressions were introduced.
 
 ## Acceptance Criteria
-- [ ] Verify interaction accurately triggers and clears highlighting state.
-- [ ] Verify traversal logic correctly highlights direct upstream and downstream nodes.
-- [ ] Verify visual styling correctly dims unrelated elements and adheres to ADR 008.
-- [ ] Verify unit tests are present and passing.
-- [ ] Ensure `pnpm lint` and all test suites pass.
+- [x] Verify interaction accurately triggers and clears highlighting state.
+- [x] Verify traversal logic correctly highlights direct upstream and downstream nodes.
+- [x] Verify visual styling correctly dims unrelated elements and adheres to ADR 008.
+- [x] Verify unit tests are present and passing.
+- [x] Ensure `pnpm lint` and all test suites pass.


### PR DESCRIPTION
Checked off QA acceptance criteria for task-053-125 according to the empty PR policy, acknowledging that task-053-124 correctly implements the dependency highlighting requirements.

---
*PR created automatically by Jules for task [17391810933143797011](https://jules.google.com/task/17391810933143797011) started by @szubster*