### PR TITLE
feat(foundry): convert idea 055 into multiple PRDs and RESEARCH nodes

### DIFF
--- a/.foundry/ideas/idea-055-cloudflare-sync-and-future-features.md
+++ b/.foundry/ideas/idea-055-cloudflare-sync-and-future-features.md
@@ -47,4 +47,8 @@ This is a long-term architectural shift. There is no rush.
 We should prioritize extensive research, utilize late binding to spin off specific `RESEARCH` nodes for Cloudflare services and offline-sync conflict resolution, and iteratively design the system to accommodate the Phase 2 roadmap.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD.
+- [x] Product Manager: Convert this idea into a PRD.
+
+## Generated PRDs
+- `.foundry/prds/prd-055-030-cloudflare-auth-sync.md`
+- `.foundry/prds/prd-055-031-future-progression-trading.md`

--- a/.foundry/prds/prd-055-030-cloudflare-auth-sync.md
+++ b/.foundry/prds/prd-055-030-cloudflare-auth-sync.md
@@ -1,0 +1,44 @@
+---
+id: prd-055-030-cloudflare-auth-sync
+type: PRD
+title: Cloudflare Authentication and Save Syncing (Phase 1)
+status: PENDING
+owner_persona: "epic_planner"
+created_at: "2026-05-20"
+updated_at: "2026-05-20"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-055-cloudflare-sync-and-future-features
+tags: ["backend", "sync", "cloudflare", "authentication", "phase1"]
+research_references: []
+rejection_reason: ""
+notes: "Derived from Idea 055"
+---
+
+# PRD: Cloudflare Authentication and Save Syncing (Phase 1)
+
+## Context
+Our application currently relies entirely on client-side state and browser storage, which makes cross-device syncing difficult. Phase 1 of our backend integration requires introducing basic server functionality using Cloudflare. Importantly, the core application **must remain client and offline-first**, continuing to function purely as a browser-side application.
+
+## Requirements
+
+### 1. Authentication
+- Implement Single Sign-On (SSO) using Google Authentication.
+- Restrict login to a single user initially to establish the foundation securely.
+
+### 2. Save Syncing
+- Establish a backend mechanism to store user save files.
+- Ensure cross-device synchronization: when a user logs in from another device, their save data is pulled from the backend to maintain consistency.
+
+## Open Questions / Research Needs
+- Which Cloudflare product (Workers KV, R2, D1) best fits the "no cost" requirement and aligns with our offline-first architecture for save syncing?
+- How to handle conflict resolution when the user has offline changes and the server has different data?
+
+## Acceptance Criteria
+- [ ] Epic Planner: Break this PRD down into Epics.
+
+## References
+- Parent Idea: `.foundry/ideas/idea-055-cloudflare-sync-and-future-features.md`
+
+- Child Research Node: `.foundry/research/research-030-004-cloudflare-storage-evaluation.md`

--- a/.foundry/prds/prd-055-031-future-progression-trading.md
+++ b/.foundry/prds/prd-055-031-future-progression-trading.md
@@ -1,0 +1,42 @@
+---
+id: prd-055-031-future-progression-trading
+type: PRD
+title: Future Progression Features and Trading (Phase 2)
+status: PENDING
+owner_persona: "epic_planner"
+created_at: "2026-05-20"
+updated_at: "2026-05-20"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-055-cloudflare-sync-and-future-features
+tags: ["backend", "sync", "progression", "trading", "phase2"]
+research_references: []
+rejection_reason: ""
+notes: "Derived from Idea 055"
+---
+
+# PRD: Future Progression Features and Trading (Phase 2)
+
+## Context
+Following the implementation of Phase 1 (basic authentication and save syncing), we need to expand the backend's capability to track multiple concurrent states and allow cross-save interactions. This PRD details Phase 2 features.
+
+## Requirements
+
+### 1. Progression Tracking & Multiple Saves
+- Support storing and tracking multiple save files per playthrough, enabling progression tracking over time.
+- Support managing states across different games concurrently (e.g., Pokémon Red, Diamond, Emerald).
+
+### 2. Pokémon Trading (Inter-Save)
+- Implement a mechanism to transfer Pokémon between a user's different playthroughs.
+- Enforce game and generation transfer rules during the trading process (e.g., similar to PKHeX validations).
+
+## Constraints
+- Must build upon the Cloudflare architecture established in Phase 1.
+- Offline-first mandate remains; features must degrade gracefully when disconnected.
+
+## Acceptance Criteria
+- [ ] Epic Planner: Break this PRD down into Epics.
+
+## References
+- Parent Idea: `.foundry/ideas/idea-055-cloudflare-sync-and-future-features.md`

--- a/.foundry/research/research-030-004-cloudflare-storage-evaluation.md
+++ b/.foundry/research/research-030-004-cloudflare-storage-evaluation.md
@@ -1,0 +1,42 @@
+---
+id: research-030-004-cloudflare-storage-evaluation
+type: RESEARCH
+title: Cloudflare Storage Evaluation for Save Syncing
+status: PENDING
+owner_persona: "researcher"
+created_at: "2026-05-20"
+updated_at: "2026-05-20"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-055-030-cloudflare-auth-sync
+tags: ["backend", "sync", "cloudflare", "research"]
+research_references: []
+rejection_reason: ""
+notes: ""
+---
+
+# Research: Cloudflare Storage Evaluation for Save Syncing
+
+## Objective
+Evaluate which Cloudflare product is the best fit for our offline-first save syncing requirement with a "no cost" initial setup.
+
+## Context
+We are implementing Phase 1 of backend sync. We need to store user save files in the Cloudflare stack. We want to evaluate the following options based on the constraint of starting with "no cost" (free tier) and supporting an offline-first browser architecture.
+
+## Options to Evaluate
+1. **Cloudflare Workers KV**
+   - Pros/Cons?
+   - Eventual consistency limitations?
+2. **Cloudflare R2**
+   - Object storage. Cost for operations?
+3. **Cloudflare D1**
+   - Relational DB. Is it overkill or necessary for file blobs?
+
+## Questions to Answer
+- Which product provides the best free tier limits for our use case (frequent save states)?
+- How does each option integrate with offline-first synchronization logic (e.g. handling conflicts)?
+- Provide a recommendation for the MVP implementation.
+
+## Acceptance Criteria
+- [ ] Researcher: Update this markdown body with findings and a clear technical recommendation.


### PR DESCRIPTION
This PR fulfills the transformation of Idea 055 (Cloudflare Backend for Offline-First Save Syncing) into structured PRDs.

It introduces two granular PRD nodes assigned to the `epic_planner` for further breakdown, avoiding a monolithic design. It also directly spawns a `RESEARCH` node to evaluate Workers KV, R2, and D1 for offline sync compatibility, as explicitly requested in the parent Idea.

The original Idea node was safely updated to mark the Product Manager task as complete without modifying its YAML frontmatter.

All tests and linting passed successfully.

---
*PR created automatically by Jules for task [9067926089594367538](https://jules.google.com/task/9067926089594367538) started by @szubster*