### PR TITLE
docs(foundry): Add research findings for auditor persona and verifying state

### DIFF
--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -3,3 +3,7 @@
 - Map IDs are structured as `(GroupIndex << 8) | MapIndex` driven from `data/maps/map_groups.json` which lists map folder names.
 - Map topology details for connection (via `connections` array) and indoor parental resolution (via `warp_events` pointing its `dest_map` property to an outdoor hub's string name) are located within each map's specific `map.json` file inside its `data/maps/` folder.
 - Map localizations are decoded from `MAPSEC_*` strings found inside the map's `map.json` property `region_map_section` against `src/data/region_map/region_map_sections.json` where `id` equals `MAPSEC_*`.
+
+## Research on Auditor Persona State Machine
+
+When implementing new pipeline states that involve temporary ownership handoffs (like the `VERIFYING` state owned by the `auditor`), it is a critical architectural constraint to **not** modify the `owner_persona` in the node's YAML frontmatter. If the frontmatter is overwritten, the system loses the history of the original implementer (e.g., `coder`). Instead, dynamic ownership should be injected only in the orchestrator's matrix JSON output during dispatch. This preserves the original owner, ensuring that if the temporary owner rejects the work (triggering the Resurrection Loop), the node will correctly route back to the original persona for rework.

--- a/.foundry/research/research-029-003-auditor-implementation-details.md
+++ b/.foundry/research/research-029-003-auditor-implementation-details.md
@@ -31,6 +31,25 @@ Figure out the exact technical details and required implementation steps to intr
 - Figure out exactly how the auditor should spawn downstream nodes dynamically, and the implications of adding this new state to the pipeline.
 
 ## Deliverables
-- [ ] Determine orchestrator script changes.
-- [ ] Draft new persona prompt.
-- [ ] Document any edge cases or implications discovered during research.
+- [x] Determine orchestrator script changes.
+- [x] Draft new persona prompt.
+- [x] Document any edge cases or implications discovered during research.
+
+## Research Findings
+
+### 1. Orchestrator Script Changes (`.github/scripts/foundry-orchestrator.ts`)
+- **VALID_STATUSES**: Add `'VERIFYING'` to the list of valid node statuses.
+- **Matrix Output Override (CRITICAL)**: In Phase 6 (Collect Phase), when formatting nodes for the JSON matrix output (used to dispatch Jules sessions), the script must check if a node is in the `VERIFYING` state. If it is, the script should dynamically set `owner_persona: 'auditor'` in the JSON object *without* modifying the actual YAML frontmatter in the file. This ensures the `.md` file retains its original owner (e.g., `coder` or `tech_lead`), allowing the Resurrection Loop to correctly re-assign the task back to the original author if the Auditor transitions the node to `FAILED`.
+- **Suspension / Incomplete Logic**: The `isHierarchicallyIncomplete` function and related `depends_on` suspension logic must treat `VERIFYING` nodes similarly to `ACTIVE` nodes; they are not `COMPLETED`, so they still block downstream nodes from transitioning to `READY`.
+
+### 2. Heartbeat Script Changes (`.github/scripts/foundry-heartbeat.ts`)
+- **Transition to `VERIFYING`**: The `transitionNodeToCompleted` function (or a new equivalent function) must be updated. When a PR is merged (and doesn't have unfulfilled late-binding tasks), instead of mutating the node state to `COMPLETED`, it should mutate the status to `VERIFYING` and clear the `jules_session_id`.
+- **Zombie Detection**: The Heartbeat script must monitor `VERIFYING` nodes in its "Pass 1" check exactly as it monitors `ACTIVE` nodes. If an auditor session crashes or times out, it should transition back to `VERIFYING` (ready for another auditor pickup) or `FAILED`, ensuring the auditor step isn't permanently blocked.
+
+### 3. Auditor Persona Prompt (`.github/agents/auditor.md`)
+- Drafted a prompt instructing the Auditor to explicitly read contextual docs, evaluate the artifacts against the original intent, extract learnings, and potentially spawn `RESEARCH`, `IDEA`, or `ADR` nodes.
+- Instructed the Auditor to submit an empty PR to transition to `COMPLETED` on success, or update the YAML status to `FAILED` with a `rejection_reason` to trigger the Resurrection Loop on failure.
+
+### Edge Cases and Implications
+- **Resurrection Loop Handoff**: By keeping the original `owner_persona` in the markdown file and only overriding it in the GitHub Actions matrix output, a `FAILED` node rejected by the auditor will automatically be re-dispatched to the original author (e.g., Coder) because the Orchestrator reads the original frontmatter during the next run.
+- **Empty PR Policy Compliance**: The Auditor must execute the Empty PR policy to signify a successful verification, which the orchestrator/heartbeat handles via the standard automerge workflow.

--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -1,0 +1,26 @@
+# Auditor Persona
+
+You are the Auditor persona in the Foundry system. Your role is to assess and verify nodes that have transitioned to the `VERIFYING` state after their primary implementation is submitted.
+
+## Initialization Rules
+
+**CRITICAL:** When you begin your session, you **must** establish context by explicitly reading the following documents individually using `read_file`:
+- All documents under `.foundry/docs/`
+- All documents under `.foundry/docs/knowledge_base/`
+- All documents under `.foundry/docs/adrs/`
+
+## Responsibilities
+
+1. **Verification**: Assess the generated artifacts against the original intent, Acceptance Criteria, and technical contracts of the node.
+2. **Analysis**: Extract learnings, identify technical debt, or find unresolved questions that arose during execution.
+3. **Node Generation**: Dynamically spawn new downstream nodes (such as `RESEARCH`, `IDEA`, or `ADR` nodes) based on these learnings to capture value that would otherwise be lost when the node is permanently archived. Do NOT add new nodes to the `depends_on` array of the node being verified; instead, spawn them as detached follow-ups or link them in the Markdown body.
+4. **Resolution**:
+   - If the verification passes and learnings are captured: Use the `submit` tool to create an empty PR. The Empty PR Policy will transition the node to `COMPLETED`.
+   - If the verification fails or requires a retry: Transition the node to `FAILED` by updating the YAML frontmatter (`status: FAILED`), providing an appropriate `rejection_reason`, and leaving the Acceptance Criteria unchanged/unchecked. Then use the `submit` tool to trigger the Resurrection Loop.
+
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
+
+## Journal
+
+When you discover recurring patterns, long-term lessons, architectural constraints, or recurring failures during audits, you MUST generate a memory by updating your persona journal (`.foundry/journals/auditor.md`). Explain *why* the lesson matters. Do not use your journal as a logbook for completed tasks or PRs merged.


### PR DESCRIPTION
Creates `.github/agents/auditor.md` with the auditor persona prompt.
Appends research findings to `research-029-003-auditor-implementation-details.md`.
Documents critical architectural constraint regarding dynamic `owner_persona` override in `researcher.md` journal.

---
*PR created automatically by Jules for task [10381410897921206741](https://jules.google.com/task/10381410897921206741) started by @szubster*