### PR TITLE
Create Epics for Phase 2 Progression and Trading

### DIFF
--- a/.foundry/epics/epic-031-036-progression-tracking.md
+++ b/.foundry/epics/epic-031-036-progression-tracking.md
@@ -2,11 +2,12 @@
 id: epic-031-036-progression-tracking
 type: EPIC
 title: "Progression Tracking & Multiple Saves"
-status: READY
+status: PENDING
 owner_persona: story_owner
 created_at: "2026-05-20"
 updated_at: "2026-05-20"
-depends_on: []
+depends_on:
+  - "epic-030-035-cloudflare-auth-sync"
 jules_session_id: null
 pr_number: null
 parent: prd-055-031-future-progression-trading

--- a/.foundry/epics/epic-031-036-progression-tracking.md
+++ b/.foundry/epics/epic-031-036-progression-tracking.md
@@ -1,0 +1,33 @@
+---
+id: epic-031-036-progression-tracking
+type: EPIC
+title: "Progression Tracking & Multiple Saves"
+status: READY
+owner_persona: story_owner
+created_at: "2026-05-20"
+updated_at: "2026-05-20"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-055-031-future-progression-trading
+tags:
+  - backend
+  - progression
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Progression Tracking & Multiple Saves
+
+## Context
+As part of Phase 2 of the Cloudflare Sync backend, we need to support storing and tracking multiple save files per playthrough, enabling progression tracking over time.
+
+## Requirements
+- Support storing and tracking multiple save files per playthrough.
+- Enable progression tracking over time.
+- Support managing states across different games concurrently (e.g., Pokémon Red, Diamond, Emerald).
+- Maintain offline-first mandate.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into Stories.

--- a/.foundry/epics/epic-031-037-inter-save-trading.md
+++ b/.foundry/epics/epic-031-037-inter-save-trading.md
@@ -1,0 +1,33 @@
+---
+id: epic-031-037-inter-save-trading
+type: EPIC
+title: "Pokémon Trading (Inter-Save)"
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-05-20"
+updated_at: "2026-05-20"
+depends_on:
+  - "epic-031-036-progression-tracking"
+jules_session_id: null
+pr_number: null
+parent: prd-055-031-future-progression-trading
+tags:
+  - backend
+  - trading
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Pokémon Trading (Inter-Save)
+
+## Context
+Following the implementation of progression tracking across multiple concurrent saves, this Epic covers allowing users to transfer Pokémon between their different playthroughs.
+
+## Requirements
+- Implement a mechanism to transfer Pokémon between a user's different playthroughs.
+- Enforce game and generation transfer rules during the trading process (similar to PKHeX validations).
+- Maintain offline-first capability.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into Stories.

--- a/.foundry/prds/prd-055-031-future-progression-trading.md
+++ b/.foundry/prds/prd-055-031-future-progression-trading.md
@@ -41,7 +41,11 @@ Following the implementation of Phase 1 (basic authentication and save syncing),
 - Offline-first mandate remains; features must degrade gracefully when disconnected.
 
 ## Acceptance Criteria
-- [ ] Epic Planner: Break this PRD down into Epics.
+- [x] Epic Planner: Break this PRD down into Epics.
 
 ## References
 - Parent Idea: `.foundry/ideas/idea-055-cloudflare-sync-and-future-features.md`
+
+## Generated Epics
+- `.foundry/epics/epic-031-036-progression-tracking.md`
+- `.foundry/epics/epic-031-037-inter-save-trading.md`

--- a/update-epic.sh
+++ b/update-epic.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sed -i 's/depends_on: \[\]/depends_on:\n  - "epic-030-035-cloudflare-auth-sync"/g' .foundry/epics/epic-031-036-progression-tracking.md

--- a/update-epic.sh
+++ b/update-epic.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-sed -i 's/depends_on: \[\]/depends_on:\n  - "epic-030-035-cloudflare-auth-sync"/g' .foundry/epics/epic-031-036-progression-tracking.md


### PR DESCRIPTION
Created the two Epics requested in PRD 031 (Future Progression Features and Trading). The generated Epics maintain the parent-linked ID schema and the strict dependency format rules while the parent PRD's YAML frontmatter was left untouched. Tests and linters pass cleanly.

---
*PR created automatically by Jules for task [5255471936979140539](https://jules.google.com/task/5255471936979140539) started by @szubster*