### PR TITLE
feat(nuzlocke): Implement death tracking and graveyard logic

### DIFF
--- a/.foundry/tasks/task-070-116-implement-death-tracking.md
+++ b/.foundry/tasks/task-070-116-implement-death-tracking.md
@@ -26,6 +26,6 @@ notes: ''
 Detect fainted Pokémon in the party and implement logic to designate a PC Box as the Graveyard for permanently dead Pokémon.
 
 ## Acceptance Criteria
-- [ ] Implement logic to detect 0 HP Pokémon in the party as dead.
-- [ ] Implement logic to designate a PC Box as the Graveyard.
-- [ ] Pokémon in the Graveyard box are permanently marked as dead.
+- [x] Implement logic to detect 0 HP Pokémon in the party as dead.
+- [x] Implement logic to designate a PC Box as the Graveyard.
+- [x] Pokémon in the Graveyard box are permanently marked as dead.

--- a/src/engine/nuzlocke/tracker.test.ts
+++ b/src/engine/nuzlocke/tracker.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { PokemonInstance, SaveData } from '../saveParser/parsers/common';
-import { aggregateEncountersByLocation, detectNuzlockeViolations } from './tracker';
+import {
+  aggregateEncountersByLocation,
+  detectNuzlockeViolations,
+  getDeadPokemon,
+  getGraveyardPokemon,
+} from './tracker';
 
 describe('aggregateEncountersByLocation', () => {
   it('should aggregate encounters by location correctly', () => {
@@ -111,5 +116,76 @@ describe('detectNuzlockeViolations', () => {
     expect(result[0]?.encounters).toHaveLength(2);
     expect(result[0]?.encounters[0]?.speciesId).toBe(1);
     expect(result[0]?.encounters[1]?.speciesId).toBe(2);
+  });
+});
+
+describe('getDeadPokemon', () => {
+  it('should return pokemon in the party with 0 HP', () => {
+    const saveData: Partial<SaveData> = {
+      partyDetails: [
+        { speciesId: 1, currentHp: 10 } as PokemonInstance,
+        { speciesId: 2, currentHp: 0 } as PokemonInstance,
+        { speciesId: 3, currentHp: undefined } as PokemonInstance,
+        { speciesId: 4, currentHp: 0 } as PokemonInstance,
+      ],
+    };
+
+    const result = getDeadPokemon(saveData as SaveData);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.speciesId).toBe(2);
+    expect(result[1]?.speciesId).toBe(4);
+  });
+
+  it('should return empty array if no pokemon have 0 HP', () => {
+    const saveData: Partial<SaveData> = {
+      partyDetails: [
+        { speciesId: 1, currentHp: 10 } as PokemonInstance,
+        { speciesId: 3, currentHp: undefined } as PokemonInstance,
+      ],
+    };
+
+    const result = getDeadPokemon(saveData as SaveData);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle undefined partyDetails gracefully', () => {
+    const saveData: Partial<SaveData> = {};
+    const result = getDeadPokemon(saveData as SaveData);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('getGraveyardPokemon', () => {
+  it('should return pokemon stored in the designated graveyard box', () => {
+    const saveData: Partial<SaveData> = {
+      pcDetails: [
+        { speciesId: 1, storageLocation: 'Box 1' } as PokemonInstance,
+        { speciesId: 2, storageLocation: 'Box 14' } as PokemonInstance,
+        { speciesId: 3, storageLocation: 'Box 14' } as PokemonInstance,
+      ],
+    };
+
+    const result = getGraveyardPokemon(saveData as SaveData, 'Box 14');
+    expect(result).toHaveLength(2);
+    expect(result[0]?.speciesId).toBe(2);
+    expect(result[1]?.speciesId).toBe(3);
+  });
+
+  it('should return empty array if no pokemon are in the graveyard box', () => {
+    const saveData: Partial<SaveData> = {
+      pcDetails: [
+        { speciesId: 1, storageLocation: 'Box 1' } as PokemonInstance,
+        { speciesId: 2, storageLocation: 'Box 2' } as PokemonInstance,
+      ],
+    };
+
+    const result = getGraveyardPokemon(saveData as SaveData, 'Box 14');
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle undefined pcDetails gracefully', () => {
+    const saveData: Partial<SaveData> = {};
+    const result = getGraveyardPokemon(saveData as SaveData, 'Box 14');
+    expect(result).toHaveLength(0);
   });
 });

--- a/src/engine/nuzlocke/tracker.ts
+++ b/src/engine/nuzlocke/tracker.ts
@@ -34,3 +34,11 @@ export function aggregateEncountersByLocation(saveData: SaveData): LocationEncou
 export function detectNuzlockeViolations(saveData: SaveData): LocationEncounters[] {
   return aggregateEncountersByLocation(saveData).filter((location) => location.encounters.length > 1);
 }
+
+export function getDeadPokemon(saveData: SaveData): PokemonInstance[] {
+  return (saveData.partyDetails || []).filter((p) => p.currentHp === 0);
+}
+
+export function getGraveyardPokemon(saveData: SaveData, graveyardBox: string): PokemonInstance[] {
+  return (saveData.pcDetails || []).filter((p) => p.storageLocation === graveyardBox);
+}

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -25,6 +25,7 @@ export interface PokemonInstance {
   moves: number[];
   friendship?: number | undefined;
   pokerus?: number | undefined;
+  currentHp?: number | undefined;
   dvs?: { hp: number; atk: number; def: number; spd: number; spc: number };
   statExp?: { hp: number; atk: number; def: number; spd: number; spc: number };
   caughtData?:

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -408,6 +408,8 @@ function parseGen1Pokemon(
   const speciesId = INTERNAL_ID_TO_DEX[internalId];
   if (!speciesId) return null;
 
+  const currentHp = isParty ? view.getUint16(offset + 1, false) : undefined;
+
   // Party has stats, so level is at offset + 33. PC has no stats, level is at offset + 3.
   const level = view.getUint8(isParty ? offset + 33 : offset + 3);
   const moves: number[] = [];
@@ -421,6 +423,7 @@ function parseGen1Pokemon(
 
   return {
     speciesId,
+    currentHp,
     level,
     isShiny,
     moves,

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -70,6 +70,7 @@ function parseGen2PokemonInstance(
   const friendship = view.getUint8(offset + 27);
   const pokerus = view.getUint8(offset + 28);
   const level = view.getUint8(offset + 31);
+  const currentHp = storageLocation === 'Party' ? view.getUint16(offset + 34, false) : undefined;
   const caughtData = isCrystal ? parseCaughtData(view, offset) : undefined;
 
   // OT names in daycare are immediately after the data block
@@ -77,6 +78,7 @@ function parseGen2PokemonInstance(
 
   return {
     speciesId,
+    currentHp,
     level,
     isShiny,
     item,


### PR DESCRIPTION
Detects fainted Pokémon in the party and implements logic to designate a PC Box as the Graveyard for permanently dead Pokémon in the Nuzlocke Tracker. This implements the `task-070-116-implement-death-tracking.md` requirements.

---
*PR created automatically by Jules for task [10073151515836431590](https://jules.google.com/task/10073151515836431590) started by @szubster*