### PR TITLE
feat(orchestrator): implement auto-cancel for orphaned pending nodes

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -982,6 +982,56 @@ describe('foundry-orchestrator', () => {
     expect(result).toContain('status: READY');
   });
 
+  test('Impossible Loop: Auto-cancels orphaned PENDING nodes depending on permanently failed node', () => {
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-impossible.md', {
+      id: "task-impossible",
+      type: "TASK",
+      title: "Impossible Task",
+      status: "FAILED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: ".foundry/stories/story-001.md",
+      depends_on: [".foundry/stories/story-001.md"],
+      jules_session_id: null,
+      rejection_reason: "Max rejection count reached",
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-orphaned-qa.md', {
+      id: "task-orphaned-qa",
+      type: "TASK",
+      title: "Orphaned QA Task",
+      status: "PENDING",
+      owner_persona: "qa",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: ".foundry/stories/story-001.md",
+      depends_on: [".foundry/tasks/task-impossible.md"],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const parentResult = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-001.md'), 'utf-8');
+    expect(parentResult).toContain('status: READY');
+
+    const qaResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-orphaned-qa.md'), 'utf-8');
+    expect(qaResult).toContain('status: CANCELLED');
+    expect(qaResult).toContain("rejection_reason: 'Cancelled due to permanent failure of dependency: task-impossible'");
+  });
+
   test('Impossible Loop: flags node for tpm if no parent exists', () => {
     createValidTestNode(tmpDir, '.foundry/tasks/task-impossible-no-parent.md', {
       id: "task-impossible-no-parent",

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -291,6 +291,28 @@ function promoteNodeToTpm(node: ParsedNode): void {
   info(`${dryTag}Flagged node for TPM: ${node.repoPath}`);
 }
 
+function promoteNodeToCancelledWithReason(node: ParsedNode, reason: string): void {
+  const dateStr = todayISO();
+  const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
+
+  const newData = { ...node.frontmatter, status: 'CANCELLED' as Status, rejection_reason: reason, updated_at: dateStr };
+  const newContent = matter.stringify(node.body, newData);
+
+  if (!DRY_RUN) {
+    try {
+      fs.writeFileSync(node.filePath, newContent, 'utf-8');
+    } catch (e) {
+      warn(`${dryTag}Failed to write file ${node.repoPath}: ${String(e)}`);
+      return;
+    }
+  }
+
+  node.frontmatter = newData as FoundryFrontmatter;
+  node.rawContent = newContent;
+
+  info(`${dryTag}Cancelled node ${node.repoPath} with reason: ${reason}`);
+}
+
 function promoteNodeToFailedWithReason(node: ParsedNode, reason: string): void {
   const dateStr = todayISO();
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
@@ -521,6 +543,21 @@ function main(): void {
   // ── Phase 3.6: IMPOSSIBLE LOOP ─────────────────────────────────────────────
   info('Phase 3.6: Checking for Impossible Loop conditions...');
   for (const node of nodes) {
+    if (node.frontmatter.status === 'FAILED' && node.frontmatter.rejection_reason === 'Max rejection count reached') {
+      // Auto-cancel orphaned PENDING nodes depending on this permanently failed node
+      for (const otherNode of nodes) {
+        if (otherNode.frontmatter.status === 'PENDING') {
+          const dependsOnPaths = (otherNode.frontmatter.depends_on || []).map(resolveNodePath).filter(Boolean);
+          if (dependsOnPaths.includes(node.repoPath)) {
+            promoteNodeToCancelledWithReason(otherNode, `Cancelled due to permanent failure of dependency: ${node.frontmatter.id}`);
+            // Also add to cancelledNodes to ensure any of ITS children get cancelled by cascade logic
+            cancelledNodes.add(otherNode.repoPath);
+            cascadeCancel(otherNode.repoPath);
+          }
+        }
+      }
+    }
+
     if (node.frontmatter.status === 'FAILED' && node.frontmatter.rejection_reason) {
       const parentPath = resolveNodePath(node.frontmatter.parent);
       if (parentPath) {


### PR DESCRIPTION
Implements auto-cancellation logic for orphaned pending nodes in the Foundry DAG Orchestrator, addressing the issue where failed child nodes left dependent sibling tasks stuck indefinitely.

---
*PR created automatically by Jules for task [10113099392784313108](https://jules.google.com/task/10113099392784313108) started by @szubster*