### PR TITLE
🧭 Strategist: Prompt improvement - Fix TPM archiving rules to use Node IDs

### DIFF
--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -23,7 +23,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 **ARCHIVING RULES:**
 - Do not archive a parent node (e.g., an EPIC) if any of its child nodes (e.g., STORY, TASK) are still active or pending.
-- When archiving completed nodes to `.foundry/archive/`, you MUST update all active files that reference them via the 'parent' field, 'depends_on' list, or inline markdown links to use the new archived path to prevent DAG orchestrator deadlocks.
+- When archiving completed nodes to `.foundry/archive/`, you MUST update all active files that reference them in inline markdown links to use the new archived path. **CRITICAL:** Do NOT modify the 'parent' field or 'depends_on' list in the YAML frontmatter to use file paths; they must strictly remain as Node IDs to prevent DAG orchestrator deadlocks.
 
 
 ## Journal

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -126,3 +126,9 @@
 **Outcome:** Accepted
 **Why:** The memory requires agents to log only critical learnings, but Foundry journals (like `tpm.md`, `coder.md`, `qa.md`) were accumulating routine "I did X" entries, task verifications, and orchestrator state changes. The archivist prompt only included `.jules/*.md` and `.serena/memories/` in its scope, missing `.foundry/journals/*.md`. Adding this allows the archivist to automatically purge noisy status updates that provide no value to future runs, conserving context.
 **Pattern:** Ensure cleanup/maintenance agents have scope over all relevant directories when file structures evolve (e.g. addition of `.foundry/journals/`).
+
+## 2026-07-07 - [Accepted] - Prompt improvement - Fix TPM archiving rules to use Node IDs
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The TPM journal showed the TPM was successfully moving files but incorrectly updating YAML frontmatter `depends_on` lists and `parent` fields to point to the new `.foundry/archive/` paths. This violated the strict system constraint that these fields must only use Node IDs. The TPM prompt instructed it to update references via the 'parent' field and 'depends_on' list.
+**Pattern:** Codify system memory constraints regarding Node IDs vs file paths in YAML frontmatter into the relevant agent prompts (like the TPM archiving rules) to prevent DAG orchestrator deadlocks and schema corruption.


### PR DESCRIPTION
Updates the TPM archiving prompt to prevent orchestration deadlocks by ensuring `parent` and `depends_on` frontmatter properties remain as Node IDs instead of file paths. Adds an accompanying `strategist.md` journal entry logging this prompt improvement.

---
*PR created automatically by Jules for task [9604131572092666501](https://jules.google.com/task/9604131572092666501) started by @szubster*