### PR TITLE
Fix unresolvable dependency in Foundry DAG epic-031-036

### DIFF
--- a/.foundry/epics/epic-031-036-progression-tracking.md
+++ b/.foundry/epics/epic-031-036-progression-tracking.md
@@ -5,9 +5,9 @@ title: "Progression Tracking & Multiple Saves"
 status: PENDING
 owner_persona: story_owner
 created_at: "2026-05-20"
-updated_at: "2026-05-20"
+updated_at: "2026-05-21"
 depends_on:
-  - "epic-030-035-cloudflare-auth-sync"
+  - "prd-055-030-cloudflare-auth-sync"
 jules_session_id: null
 pr_number: null
 parent: prd-055-031-future-progression-trading


### PR DESCRIPTION
The Foundry DAG orchestrator was failing due to an unresolvable dependency in `epic-031-036-progression-tracking.md`. This PR updates the dependency to point to the correct PRD node `prd-055-030-cloudflare-auth-sync`.

Fixes #1661

---
*PR created automatically by Jules for task [17280309605637733608](https://jules.google.com/task/17280309605637733608) started by @szubster*