### PR TITLE
Complete QA for Gen 3 Locations Fetch Script

### DIFF
--- a/.foundry/tasks/task-062-113-gen3-locations-script-retry-qa.md
+++ b/.foundry/tasks/task-062-113-gen3-locations-script-retry-qa.md
@@ -19,4 +19,4 @@ parent: story-032-062-gen3-data-generation-scripts
 QA validate the retried script that fetches Generation 3 locations data.
 
 ## Acceptance Criteria
-- [ ] QA verifies the script fetches accurate Gen 3 locations from `pret/pokeemerald`.
+- [x] QA verifies the script fetches accurate Gen 3 locations from `pret/pokeemerald`.

--- a/knip.json
+++ b/knip.json
@@ -4,7 +4,8 @@
   "ignore": [
     "src/test-setup.ts",
     "scripts/validate-foundry-schema.ts",
-    ".github/scripts/extract-research.ts"
+    ".github/scripts/extract-research.ts",
+    "scripts/gen3-fetch-locations.ts"
   ],
   "rules": {
     "files": "warn",


### PR DESCRIPTION
This PR completes the QA task `task-062-113-gen3-locations-script-retry-qa`. 
- Verified `scripts/gen3-fetch-locations.ts` functions successfully by fetching from `pret/pokeemerald`.
- Checked off the acceptance criteria in the markdown body.
- Added `scripts/gen3-fetch-locations.ts` to `knip.json` ignore list to fix a linting error where knip incorrectly flagged it as unused.
- Ran tests and linting to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [11837493261545584940](https://jules.google.com/task/11837493261545584940) started by @szubster*