### PR TITLE
feat: Create PRD for Emulator Auto-Sync

### DIFF
--- a/.foundry/ideas/idea-061-emulator-auto-sync.md
+++ b/.foundry/ideas/idea-061-emulator-auto-sync.md
@@ -35,4 +35,7 @@ Leverage the modern Web **File System Access API** (`showDirectoryPicker` or `sh
 This significantly reduces the friction of using the app during gameplay. It perfectly aligns with the offline-first mandate, bridging the gap between a static "save viewer" and a dynamic "live companion app" for emulated playthroughs, and serves as a crucial foundational piece for advanced features like the "Automated Nuzlocke Tracker" (IDEA-057).
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD.
+- [x] Product Manager: Convert this idea into a PRD.
+
+## Generated Nodes
+- PRD: `.foundry/prds/prd-061-033-emulator-auto-sync.md`

--- a/.foundry/prds/prd-061-033-emulator-auto-sync.md
+++ b/.foundry/prds/prd-061-033-emulator-auto-sync.md
@@ -1,0 +1,45 @@
+---
+id: prd-061-033-emulator-auto-sync
+type: PRD
+title: Emulator Auto-Sync via File System Access API
+status: READY
+owner_persona: architect
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-061-emulator-auto-sync
+tags:
+  - feature
+  - ux
+  - local-sync
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# PRD: Emulator Auto-Sync via File System Access API
+
+## Context
+Currently, DexHelper requires users to manually upload their `.sav` file every time they make progress in their game. While this offline-first, client-side approach guarantees privacy and avoids server costs, the constant drag-and-drop friction disrupts the user experience, especially during long play sessions or active team building.
+
+## Goal
+To implement a background auto-refresh mechanism utilizing the Web File System Access API. This mechanism will securely read the user's `.sav` file dynamically (after explicit user permission is granted), parsing it and updating DexHelper's UI in real-time as the emulator writes changes to the save file.
+
+## Scope
+### In Scope
+- **Web File System Access API Integration:** Use `showOpenFilePicker` (or `showDirectoryPicker`) to obtain a read-only file handle to the game's `.sav` file.
+- **File Handle Retainment:** Store the file handle in IndexedDB so that on subsequent visits, the user only needs to grant permission without re-selecting the file.
+- **Change Detection:** Implement a polling mechanism (e.g., checking `File.lastModified` periodically) or use `FileSystemObserver` (if available/polyfilled) to detect when the emulator updates the save file.
+- **Live State Updates:** Automatically trigger the application's parsing engine and state hydration when a file change is detected, providing a "live tracker" experience.
+- **UI Indicators:** Add UI components to start/stop the auto-sync, display the current sync status ("Live", "Syncing...", "Disconnected"), and handle permission requests.
+- **Error Handling:** Gracefully handle edge cases such as lost file access, permission denial, or malformed save files during the auto-sync process.
+
+### Out of Scope
+- Server-side synchronization, cloud syncing, or multi-device sync (this feature is strictly local).
+- Writing to the `.sav` file. DexHelper remains strictly read-only to prevent any risk of save file corruption.
+
+## Next Steps
+- [ ] Architect: Create an ADR evaluating the File System Access API implementation strategy (polling vs observer, handle retainment) and defining the application-level state synchronization architecture.


### PR DESCRIPTION
## Summary
Created a new Product Requirements Document (`.foundry/prds/prd-061-033-emulator-auto-sync.md`) for the "Emulator Auto-Sync via File System Access API" feature as per IDEA 061.

## Changes
- Bootstrapped PRD 033 outlining the Goal, Scope (In Scope / Out of Scope), and Next Steps for the feature.
- Followed the Foundry ID Schema: `prd-<parent_NNN>-<NNN>-<slug>` -> `prd-061-033-emulator-auto-sync`.
- Assigned the `owner_persona` to `architect`, as the next step involves architectural decision records (ADRs).
- Updated the parent `IDEA` node to check off the Acceptance Criteria and linked to the new PRD.

---
*PR created automatically by Jules for task [7365363185347511909](https://jules.google.com/task/7365363185347511909) started by @szubster*