### PR TITLE
docs(foundry): Create ADR 015 to revert data format optimizations

### DIFF
--- a/.foundry/docs/adrs/015-revert-data-optimizations.md
+++ b/.foundry/docs/adrs/015-revert-data-optimizations.md
@@ -1,0 +1,20 @@
+# ADR 015: Revert Data Format Optimizations (Short Property Names)
+
+## Date
+2026-05-21
+
+## Status
+Accepted
+
+## Context
+With the transition to MsgPack (`msgpackr`) and the configuration of highly-efficient decoding options (specifically `useRecords: true` and `bundleStrings: true`), our previous optimizations around making JSON as compact as possible may be obsolete and negatively impacting developer experience (DX).
+
+MsgPack's `useRecords` extension extracts object structures/keys and passes them as an extension rather than stringifying them repetitively. This makes short property names largely redundant in terms of size optimization. A recent benchmark confirmed that long property strings differ by only 52 bytes per 1,000 objects.
+
+## Decision
+We will revert the short property names back to their full, readable names across the application (`PokeDB.ts`, `schema.ts`, `scripts/generate-pokedata.ts`, etc.) to improve Developer Experience (DX) while maintaining enum-to-number optimizations (which still provide significant size reductions as strings cannot be perfectly deduplicated).
+
+## Consequences
+- **Positive:** Improved readability and DX. Developers will no longer need to map obscure short keys (e.g., `n` to `name`, `cr` to `captureRate`) back to their logical meanings.
+- **Negative:** Negligible increase in serialized payload size, estimated at ~52 bytes per 1,000 objects.
+- **Constraints:** The data generation pipeline and runtime hydration interfaces must be refactored to use the verbose keys. The application must still work correctly with MsgPack `useRecords: true`. Enum-to-number optimizations must be preserved.

--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -250,3 +250,41 @@ Paths are **always relative to the repository root**, starting with `.foundry/`.
 
 ## 11. EMPTY PR POLICY
 If a target artifact already exists and matches the required state, personas must submit an empty PR (0 files changed). The system will automatically merge these PRs to progress the node to `COMPLETED`. Personas should document the reasoning in their journals.
+
+---
+
+## 12. PokeData Property Naming Schema (Application Data)
+
+As defined in ADR 015, with the transition to MsgPack (`msgpackr`) and the configuration of `useRecords: true`, the application's runtime data structures (`PokeData`) now use full, readable property names rather than minified strings. This improves Developer Experience (DX) without significantly increasing payload sizes, because the serialization library deduplicates structural keys.
+
+*   `name` (formerly `n`)
+*   `captureRate` (formerly `cr`)
+*   `genderRate` (formerly `gr`)
+*   `evolvesTo` (formerly `eto`)
+*   `evolvesFrom` (formerly `efrm`)
+*   `evolutionDetails` (formerly `det`)
+*   `chance` (formerly `c`)
+*   `method` (formerly `m`)
+*   `minLevel` (formerly `min` or `ml`)
+*   `maxLevel` (formerly `max`)
+*   `timeOfDay` (formerly `t` or `time`)
+*   `areaId` (formerly `aid`)
+*   `versionId` (formerly `v`)
+*   `details` (formerly `d`)
+*   `pokemonId` (formerly `pid`)
+*   `encounters` (formerly `enc`)
+*   `parentId` (formerly `prnt`)
+*   `connections` (formerly `conn`)
+*   `pokemonIds` (formerly `pids`)
+*   `distances` (formerly `dist`)
+*   `trigger` (formerly `tr`)
+*   `minHappiness` (formerly `mh`)
+*   `itemId` (formerly `item`)
+*   `heldItemId` (formerly `held`)
+*   `relativePhysicalStats` (formerly `rps`)
+*   `evolvesFromId` (formerly `ef`)
+*   `pokemon` (formerly `poke`)
+*   `locations` (formerly `loc`)
+*   `hash` (remains `hash`)
+
+Enum-to-number optimizations (e.g., mapping encounter methods or string triggers to integer values) are preserved.

--- a/.foundry/journals/architect.md
+++ b/.foundry/journals/architect.md
@@ -17,3 +17,6 @@ Architects frequently perform evaluation tasks (e.g., assessing graph libraries,
 ## 2026-05-19: Late Binding Correction
 Received CEO feedback: "As architect you should prepare adrs. Leave rest to other personas and late binding. Improve your prompt now, if it was not obvious."
 Learning: My role is strictly architectural blueprinting (creating ADRs, schemas). Breaking down work into EPICs, STORYs, and TASKs is the responsibility of other personas (epic_planner, story_owner, tech_lead) via late binding. I should not proactively create downstream execution nodes.
+
+### 2026-05-21: Re-evaluating Data Deduplication Optimizations
+When utilizing advanced serializers with object structure deduplication (like `msgpackr` with `useRecords`), stripping property names down to minified keys (e.g., `n` instead of `name`) for size reduction becomes an anti-pattern. The serialization library already extracts these keys into extensions, making the short names redundant. Moving forward, we should prioritize readable, verbose property names to preserve Developer Experience (DX) rather than prematurely optimizing property lengths, as the size gains are negligible (e.g., ~52 bytes per 1,000 objects). Enum-to-integer optimizations remain valid as strings cannot be perfectly deduplicated.

--- a/.foundry/prds/prd-005-032-revert-data-optimizations.md
+++ b/.foundry/prds/prd-005-032-revert-data-optimizations.md
@@ -62,5 +62,5 @@ The exact list of properties to rename across the application (`PokeDB.ts`, `sch
 - Ensure the application still works correctly with MsgPack `useRecords: true`.
 
 ## Acceptance Criteria
-- [ ] Determine how to propagate this into an ADR (Architecture Decision Record) since we are changing data contracts globally.
-- [ ] Ensure that an ADR is created to record this decision before creating Epics/Stories.
+- [x] Determine how to propagate this into an ADR (Architecture Decision Record) since we are changing data contracts globally.
+- [x] Ensure that an ADR is created to record this decision before creating Epics/Stories.


### PR DESCRIPTION
Creates the Architecture Decision Record (ADR 015) to formally revert the minified property keys (e.g., `n` to `name`) in the PokeData structure back to their full, readable names. This improves Developer Experience (DX) because our migration to MsgPack (`msgpackr`) with `useRecords` makes short keys structurally redundant and obsolete. 

I also updated the system schema (`schema.md`) to document the specific verbose property mappings to maintain the data contract globally.

---
*PR created automatically by Jules for task [1284796857659478516](https://jules.google.com/task/1284796857659478516) started by @szubster*