### PR TITLE
feat(foundry): break down Cloudflare SSO epic into stories

### DIFF
--- a/.foundry/epics/epic-030-038-cloudflare-google-sso.md
+++ b/.foundry/epics/epic-030-038-cloudflare-google-sso.md
@@ -37,4 +37,9 @@ As part of Phase 1 to introduce a backend while keeping the application offline-
 - Ensure graceful degradation so the application continues to function normally (offline-first) on GitHub Pages without Cloudflare integration.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Break this Epic down into Stories.
+- [x] Story Owner: Break this Epic down into Stories.
+
+### Generated Stories
+- .foundry/stories/story-038-074-cloudflare-auth-infrastructure.md
+- .foundry/stories/story-038-075-google-sso-integration.md
+- .foundry/stories/story-038-076-offline-auth-state.md

--- a/.foundry/stories/story-038-074-cloudflare-auth-infrastructure.md
+++ b/.foundry/stories/story-038-074-cloudflare-auth-infrastructure.md
@@ -1,0 +1,33 @@
+---
+id: story-038-074-cloudflare-auth-infrastructure
+type: STORY
+title: Cloudflare Backend Infrastructure and Build Config
+status: READY
+owner_persona: coder
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-030-038-cloudflare-google-sso
+tags:
+  - backend
+  - authentication
+  - sso
+  - cloudflare
+  - phase1
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Cloudflare Backend Infrastructure and Build Config
+
+## Context
+As the first step of implementing Cloudflare Google SSO (Epic 038), we need to set up the foundation for the Cloudflare backend. This involves creating the initial Cloudflare build configuration and ensuring the application can gracefully degrade to an offline-first mode when hosted on GitHub Pages without the Cloudflare backend.
+
+## Acceptance Criteria
+- [ ] Implement Cloudflare Pages/Worker configuration (e.g. `wrangler.toml`, or relevant build settings) to support a backend API.
+- [ ] Add deployment instructions or scripts for Cloudflare.
+- [ ] Ensure that the current offline-first GitHub Pages build remains fully functional when the backend environment variables or API endpoints are missing.

--- a/.foundry/stories/story-038-075-google-sso-integration.md
+++ b/.foundry/stories/story-038-075-google-sso-integration.md
@@ -1,0 +1,35 @@
+---
+id: story-038-075-google-sso-integration
+type: STORY
+title: Google SSO Integration and Single User Restriction
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on:
+  - story-038-074-cloudflare-auth-infrastructure
+jules_session_id: null
+pr_number: null
+parent: epic-030-038-cloudflare-google-sso
+tags:
+  - backend
+  - authentication
+  - sso
+  - cloudflare
+  - phase1
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Google SSO Integration and Single User Restriction
+
+## Context
+With the Cloudflare infrastructure in place, we need to implement the Google SSO flow. To ensure security and control during this initial phase, the login must be restricted to a single approved user account.
+
+## Acceptance Criteria
+- [ ] Implement Google OAuth2/SSO login flow within the Cloudflare backend.
+- [ ] Add authentication endpoints (e.g., login, callback, verify).
+- [ ] Implement logic to restrict successful authentication to a single predefined Google user email or ID.
+- [ ] Reject all other login attempts with a clear unauthorized response.

--- a/.foundry/stories/story-038-076-offline-auth-state.md
+++ b/.foundry/stories/story-038-076-offline-auth-state.md
@@ -1,0 +1,36 @@
+---
+id: story-038-076-offline-auth-state
+type: STORY
+title: Client-side Offline Auth State Management
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on:
+  - story-038-075-google-sso-integration
+jules_session_id: null
+pr_number: null
+parent: epic-030-038-cloudflare-google-sso
+tags:
+  - backend
+  - authentication
+  - sso
+  - cloudflare
+  - phase1
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Client-side Offline Auth State Management
+
+## Context
+The application is designed to be offline-first. Therefore, the client needs to gracefully handle the authentication state, persisting it securely so that the user remains authenticated even when the connection drops or the app is loaded entirely offline.
+
+## Acceptance Criteria
+- [ ] Implement client-side logic to initiate the Google SSO login flow.
+- [ ] Securely store the authentication token or session state on the client (e.g., HttpOnly cookies if applicable via Cloudflare, or secure LocalStorage/IndexedDB).
+- [ ] Ensure the UI reflects the authenticated state.
+- [ ] Ensure the authenticated state persists across page reloads and when the device goes offline.
+- [ ] Implement a logout mechanism that clears the client-side state.


### PR DESCRIPTION
This PR breaks down Epic `epic-030-038-cloudflare-google-sso` into granular Stories as requested.

The following Story nodes were created:
1. `story-038-074-cloudflare-auth-infrastructure`: Initial backend infrastructure and offline-first graceful degradation config.
2. `story-038-075-google-sso-integration`: Integration of Google SSO restricted to a single user.
3. `story-038-076-offline-auth-state`: Handling client-side state of the authentication to remain offline-first.

The parent Epic has been updated to reflect the completion of the breakdown by checking off the acceptance criteria box and appending the child references in its markdown body.

All files validate correctly against the schema, orchestrator preflight checks, and testing requirements.

---
*PR created automatically by Jules for task [2172044534811112713](https://jules.google.com/task/2172044534811112713) started by @szubster*