### PR TITLE
🧠 Trainer: Suppress breeding suggestions for intermediate evolutions

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -48,3 +48,6 @@
 ## 2024-05-20 - Intermediate Evolution Suggestion Clarity
 **Learning:** For multi-stage evolutions where an intermediate stage is required (e.g. "Path to #Charizard" needing a Charmeleon), the previous title ("Level Up Evolution") and description were misleading, implying the immediate evolution would yield the final target.
 **Action:** Dynamically rewrite the title (e.g., `Path to #${targetId}`) and description (e.g., `into #${immediateEvoTargetId} to progress towards #${targetId}`) when `immediateEvoTargetId !== targetId` to clarify the intermediate progression step.
+## 2024-05-21 - Breeding Intermediate Evolution Suggestion Fix
+**Learning:** In Pokémon Gen 2, eggs always hatch into the lowest evolutionary stage. The assistant's `generateBreedingSuggestions` previously suggested breeding intermediate evolutions (like Charizard) to obtain other intermediate evolutions (like Charmeleon), which is mechanically impossible.
+**Action:** Update the breeding logic to verify that the target Pokémon is actually a base or baby stage (by checking `p.efrm === undefined || p.efrm.length === 0`) before evaluating its ancestors for breeding suggestions.

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type { PokemonMetadata } from '../../../db/schema';
 import type { SaveData } from '../../saveParser/index';
+import type { PokemonInstance } from '../../saveParser/parsers/common';
+import { getStrategy } from '../strategies';
 import { gen1Strategy } from '../strategies/gen1Strategy';
 import type { EncounterDetail } from '../strategies/types';
 import type { AssistantApiData } from '../suggestionEngine';
@@ -695,5 +697,81 @@ describe('generateSuggestions', () => {
     expect(evoLeeNotReady?.title).toBe('Level Up Evolution: #106');
     expect(evoLeeNotReady?.description).toBe('Your Lv. 20 pre-evolution evolves at Lv. 20 (needs Lv. 20, Atk > Def).');
     expect(evoLeeNotReady?.priority).toBe(75); // Lower priority because it's not actually ready
+  });
+
+  it('should suppress breeding suggestions for intermediate evolutions (e.g. Charmeleon)', () => {
+    const mockApiData = {
+      localAid: 1,
+      localEncounters: [],
+      missingEncounters: {},
+      pokemonMetadata: {
+        4: { id: 4, baby: false, efrm: [], eto: [{ id: 5, eto: [{ id: 6 }] }] } as unknown as PokemonMetadata,
+        5: { id: 5, baby: false, efrm: [4], eto: [{ id: 6, eto: [] }] } as unknown as PokemonMetadata, // Charmeleon
+        6: { id: 6, baby: false, efrm: [5, 4], eto: [] } as unknown as PokemonMetadata, // Charizard
+      },
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const mockSaveData: SaveData = {
+      generation: 2,
+      gameVersion: 'gold',
+      owned: new Set([4, 6]), // Owns Charmander and Charizard, missing Charmeleon (5)
+      seen: new Set(),
+      party: [],
+      inventory: [],
+      currentMapId: 0,
+      partyDetails: [],
+      pcDetails: [{ speciesId: 6, level: 40, storageLocation: 'Box 1', otName: 'TEST' } as PokemonInstance],
+      trainerName: 'TEST',
+    } as unknown as SaveData;
+
+    const strategy = getStrategy(2);
+    if (!strategy) throw new Error('Strategy not found');
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'gold', mockApiData, strategy);
+
+    const breedSugg = suggestions.find((s) => s.category === 'Breed' && s.pokemonId === 5);
+    expect(breedSugg).toBeUndefined(); // It should be undefined because Charizard egg hatches to Charmander
+  });
+
+  it('should generate breeding suggestions for base/baby pokemon (e.g. Pichu)', () => {
+    const mockApiData = {
+      localAid: 1,
+      localEncounters: [],
+      missingEncounters: {},
+      pokemonMetadata: {
+        172: { id: 172, baby: true, efrm: [], eto: [{ id: 25, eto: [] }] } as unknown as PokemonMetadata, // Pichu
+        25: { id: 25, baby: false, efrm: [172], eto: [{ id: 26, eto: [] }] } as unknown as PokemonMetadata, // Pikachu
+        26: { id: 26, baby: false, efrm: [25, 172], eto: [] } as unknown as PokemonMetadata, // Raichu
+      },
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const fullOwnedSet = new Set(Array.from({ length: 251 }, (_, i) => i + 1));
+    fullOwnedSet.delete(172);
+
+    const mockSaveData: SaveData = {
+      generation: 2,
+      gameVersion: 'gold',
+      owned: fullOwnedSet, // Owns Pikachu, missing Pichu
+      seen: new Set(),
+      party: [],
+      inventory: [],
+      currentMapId: 0,
+      partyDetails: [{ speciesId: 25, level: 40, storageLocation: 'Box 1', otName: 'TEST' } as PokemonInstance],
+      pcDetails: [],
+      trainerName: 'TEST',
+    } as unknown as SaveData;
+
+    const strategy = getStrategy(2);
+    if (!strategy) throw new Error('Strategy not found');
+    const { suggestions } = generateSuggestions(mockSaveData, false, 'gold', mockApiData, strategy);
+
+    const breedSugg = suggestions.find((s) => s.category === 'Breed' && s.pokemonId === 172);
+    expect(breedSugg).toBeDefined();
+    expect(breedSugg?.title).toBe('Breed: #172');
   });
 });

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -517,20 +517,23 @@ function generateBreedingSuggestions(
       let canBreed = false;
       let evolutionIdToBreed: number | null = null;
 
-      // Look at all evolutions of the target (recursive)
-      const stack = [...(p.eto || [])];
-      while (stack.length > 0) {
-        const evo = stack.pop();
-        if (
-          evo &&
-          (instancesBySpecies.has(evo.id) || (saveData.daycare?.some((d) => d.speciesId === evo.id) ?? false))
-        ) {
-          canBreed = true;
-          evolutionIdToBreed = evo.id;
-          break;
-        }
-        if (evo?.eto && evo.eto.length > 0) {
-          stack.push(...evo.eto);
+      // Only base Pokemon can be hatched from an egg
+      if (p.efrm === undefined || p.efrm.length === 0) {
+        // Look at all evolutions of the target (recursive)
+        const stack = [...(p.eto || [])];
+        while (stack.length > 0) {
+          const evo = stack.pop();
+          if (
+            evo &&
+            (instancesBySpecies.has(evo.id) || (saveData.daycare?.some((d) => d.speciesId === evo.id) ?? false))
+          ) {
+            canBreed = true;
+            evolutionIdToBreed = evo.id;
+            break;
+          }
+          if (evo?.eto && evo.eto.length > 0) {
+            stack.push(...evo.eto);
+          }
         }
       }
 


### PR DESCRIPTION
### What
This PR fixes a logical flaw in the Assistant's breeding recommendation engine. Previously, it could suggest breeding a fully-evolved Pokémon (like Charizard) to obtain an intermediate missing Pokédex entry (like Charmeleon). This is mechanically impossible because eggs always hatch into the lowest evolutionary stage.

### Why
To ensure the Assistant only provides valid, actionable advice that accurately reflects Pokémon breeding mechanics (base forms only).

### Impact on recommendation quality
Removes misleading and technically impossible breeding suggestions from the Assistant panel, improving trust and accuracy.

### Test coverage
Added unit tests explicitly asserting that breeding suggestions:
1. Are correctly suppressed for intermediate evolutions.
2. Are correctly generated for baby/base Pokémon (e.g., Pichu).
Tested against the real `crystal.sav` fixture and verified logic via the e2e testing suite.

---
*PR created automatically by Jules for task [14957428450447355768](https://jules.google.com/task/14957428450447355768) started by @szubster*