### PR TITLE
chore: spawn stories for auditor persona implementation

### DIFF
--- a/.foundry/epics/epic-029-040-auditor-implementation.md
+++ b/.foundry/epics/epic-029-040-auditor-implementation.md
@@ -47,5 +47,7 @@ We will create two specific stories for this epic:
    - Update `foundry-heartbeat.ts` PR merge state transition logic and zombie timeout recovery for the `VERIFYING` state.
 
 ## Acceptance Criteria
-- [ ] Story spawned for Orchestrator updates.
-- [ ] Story spawned for Heartbeat updates.
+- [x] Story spawned for Orchestrator updates.
+- [x] Story spawned for Heartbeat updates.
+
+Spawned .foundry/stories/story-040-074-orchestrator-verifying-state.md and .foundry/stories/story-040-075-heartbeat-verifying-logic.md

--- a/.foundry/stories/story-040-074-orchestrator-verifying-state.md
+++ b/.foundry/stories/story-040-074-orchestrator-verifying-state.md
@@ -1,0 +1,33 @@
+---
+id: story-040-074-orchestrator-verifying-state
+type: STORY
+title: Orchestrator VERIFYING State and Matrix Dispatch
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-029-040-auditor-implementation
+tags:
+  - process
+  - orchestrator
+rejection_count: 0
+rejection_reason: ''
+---
+
+# Story: Orchestrator VERIFYING State and Matrix Dispatch
+
+## Objective
+Implement updates to `foundry-orchestrator.ts` type definitions and matrix JSON formulation logic for the new VERIFYING state.
+
+## Implementation Details
+- Add `'VERIFYING'` to the list of valid node statuses (`VALID_STATUSES`).
+- In Phase 6 (Collect Phase) of matrix output formulation, check if a node is in the `VERIFYING` state. If it is, dynamically set `owner_persona: 'auditor'` in the JSON object *without* modifying the actual YAML frontmatter in the file.
+- Update `isHierarchicallyIncomplete` function and related `depends_on` suspension logic to treat `VERIFYING` nodes similarly to `ACTIVE` nodes; they are not `COMPLETED`, so they still block downstream nodes from transitioning to `READY`.
+
+## Acceptance Criteria
+- [ ] Added `VERIFYING` to valid statuses.
+- [ ] Matrix logic overrides persona to auditor for VERIFYING nodes.
+- [ ] Dependencies check treats VERIFYING nodes as blocking.

--- a/.foundry/stories/story-040-075-heartbeat-verifying-logic.md
+++ b/.foundry/stories/story-040-075-heartbeat-verifying-logic.md
@@ -1,0 +1,32 @@
+---
+id: story-040-075-heartbeat-verifying-logic
+type: STORY
+title: Heartbeat State Transition and Zombie Recovery
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on:
+  - story-040-074-orchestrator-verifying-state
+jules_session_id: null
+pr_number: null
+parent: epic-029-040-auditor-implementation
+tags:
+  - process
+  - orchestrator
+rejection_count: 0
+rejection_reason: ''
+---
+
+# Story: Heartbeat State Transition and Zombie Recovery
+
+## Objective
+Update `foundry-heartbeat.ts` PR merge state transition logic and zombie timeout recovery for the VERIFYING state.
+
+## Implementation Details
+- The `transitionNodeToCompleted` function (or a new equivalent function) must be updated. When a PR is merged (and doesn't have unfulfilled late-binding tasks), instead of mutating the node state to `COMPLETED`, it should mutate the status to `VERIFYING` and clear the `jules_session_id`.
+- The Heartbeat script must monitor `VERIFYING` nodes in its "Pass 1" check exactly as it monitors `ACTIVE` nodes. If an auditor session crashes or times out, it should transition back to `VERIFYING` (ready for another auditor pickup) or `FAILED`, ensuring the auditor step isn't permanently blocked.
+
+## Acceptance Criteria
+- [ ] PR merge transitions node to VERIFYING instead of COMPLETED.
+- [ ] Zombie detection extended to VERIFYING nodes.


### PR DESCRIPTION
Spawned stories `story-040-074-orchestrator-verifying-state` and `story-040-075-heartbeat-verifying-logic` to implement the `VERIFYING` state. Checked off acceptance criteria in `epic-029-040-auditor-implementation`.

---
*PR created automatically by Jules for task [13900461799508436084](https://jules.google.com/task/13900461799508436084) started by @szubster*