### PR TITLE
Fix Orchestrator mapping to prevent architect from owning PRDs

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -152,7 +152,7 @@ No persona should ever manually set `status: READY`. The orchestrator calculates
 | `product_manager` | Transforms `IDEA` → `PRD`. |
 | `epic_planner` | Transforms `PRD` → `EPIC` breakdown. |
 | `story_owner` | Monitors active epics; writes `STORY` nodes dynamically (late-binding). |
-| `architect` | Master of the Blueprint. Maintains ADRs, schemas, and defines global App/Foundry architecture. |
+| `architect` | Master of the Blueprint. Maintains ADRs, schemas, and defines global App/Foundry architecture. Cannot own `PRD` nodes; if an ADR is needed, the `product_manager` spawns a `TASK` for the `architect` alongside a `PRD` for the `epic_planner`. |
 | `tech_lead` | Transforms `STORY` → `TASK` (technical implementation plans). |
 | `coder` | Implements individual `TASK` nodes. |
 | `qa` | Validates `TASK` implementation against technical contracts. |

--- a/.foundry/prds/prd-005-032-revert-data-optimizations.md
+++ b/.foundry/prds/prd-005-032-revert-data-optimizations.md
@@ -2,12 +2,12 @@
 id: prd-005-032-revert-data-optimizations
 type: PRD
 title: Revert Data Format Optimizations (Short Property Names)
-status: ACTIVE
-owner_persona: architect
+status: PENDING
+owner_persona: epic_planner
 created_at: '2026-05-21'
 updated_at: '2026-05-21'
 depends_on: []
-jules_session_id: '1284796857659478516'
+jules_session_id: null
 parent: idea-005-revert-data-optimizations
 rejection_reason: ''
 ---

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1079,7 +1079,8 @@ describe('foundry-orchestrator', () => {
     expect(researchResult).toContain('status: READY');
 
     const prdArchitectResult = fs.readFileSync(path.join(tmpDir, '.foundry/prds/prd-architect.md'), 'utf-8');
-    expect(prdArchitectResult).toContain('status: READY');
+    expect(prdArchitectResult).toContain('status: FAILED');
+    expect(prdArchitectResult).toContain('rejection_reason: Invalid owner_persona mapping');
 
     const taskTechLeadResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-tech-lead.md'), 'utf-8');
     expect(taskTechLeadResult).toContain('status: READY');

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -845,7 +845,7 @@ function main(): void {
   const validatedEligible: ParsedNode[] = [];
   const validMappings: Record<string, string[]> = {
     IDEA: ['product_manager'],
-    PRD: ['epic_planner', 'architect', 'story_owner'],
+    PRD: ['epic_planner', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
     STORY: ['tech_lead', 'story_owner', 'coder'],
     TASK: ['coder', 'qa', 'tech_lead', 'architect'],


### PR DESCRIPTION
This PR updates the `owner_persona` mapping in the Foundry Orchestrator, removing `architect` as a valid persona for `PRD` nodes. It also updates the schema to clarify that `product_manager` should assign `architect` to `TASK` nodes for writing ADRs alongside `PRD`s given to `epic_planner`. Finally, it repairs a stalled PRD (`prd-005-032-revert-data-optimizations.md`) that got stuck as `ACTIVE` under an `architect` by resetting it to `PENDING` and unassigning it from the completed Jules session.

---
*PR created automatically by Jules for task [7760329033196981798](https://jules.google.com/task/7760329033196981798) started by @szubster*