### PR TITLE
Create stories for emulator auto-sync

### DIFF
--- a/.foundry/epics/epic-033-041-emulator-auto-sync.md
+++ b/.foundry/epics/epic-033-041-emulator-auto-sync.md
@@ -32,4 +32,9 @@ DexHelper needs to support dynamic background refresh of the user's `.sav` file 
 - Expose sync status (Live, Syncing, Disconnected) in the UI.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Break this Epic down into Stories.
+- [x] Story Owner: Break this Epic down into Stories.
+
+### Stories
+- story-041-077-file-system-access-idb
+- story-041-078-background-polling-loop
+- story-041-079-ui-sync-status

--- a/.foundry/stories/story-041-077-file-system-access-idb.md
+++ b/.foundry/stories/story-041-077-file-system-access-idb.md
@@ -1,0 +1,24 @@
+---
+id: story-041-077-file-system-access-idb
+type: STORY
+title: "File System Access & IndexedDB Retainment"
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-033-041-emulator-auto-sync
+tags: [feature, local-sync]
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: File System Access & IndexedDB Retainment
+
+## Requirements
+- Obtain a read-only `FileSystemFileHandle` using `showOpenFilePicker`.
+- Retain the file handle across sessions by serializing it to IndexedDB.
+- Attempt to restore the handle on subsequent visits, potentially re-requesting permission.

--- a/.foundry/stories/story-041-078-background-polling-loop.md
+++ b/.foundry/stories/story-041-078-background-polling-loop.md
@@ -1,0 +1,26 @@
+---
+id: story-041-078-background-polling-loop
+type: STORY
+title: "Background Polling Loop & State Hydration"
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on:
+  - story-041-077-file-system-access-idb
+jules_session_id: null
+pr_number: null
+parent: epic-033-041-emulator-auto-sync
+tags: [feature, background-sync]
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Background Polling Loop & State Hydration
+
+## Requirements
+- Set up a background polling loop (checking `lastModified` on the file) to detect file changes from the emulator at a sensible interval.
+- When a change is detected, read the file as an `ArrayBuffer`.
+- Pass the raw `ArrayBuffer` to DexHelper's existing parsing engine.
+- Hydrate the global application state to provide a "Live Tracker" experience.

--- a/.foundry/stories/story-041-079-ui-sync-status.md
+++ b/.foundry/stories/story-041-079-ui-sync-status.md
@@ -1,0 +1,25 @@
+---
+id: story-041-079-ui-sync-status
+type: STORY
+title: "UI Sync Status & Permissions"
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on:
+  - story-041-078-background-polling-loop
+jules_session_id: null
+pr_number: null
+parent: epic-033-041-emulator-auto-sync
+tags: [feature, ui]
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: UI Sync Status & Permissions
+
+## Requirements
+- Display current sync status in the UI (e.g., Live, Syncing, Disconnected).
+- Gracefully handle unsupported browsers (fallback to manual drag-and-drop upload).
+- Implement a UI gesture (like a "Resume Sync" button) if the browser needs a user interaction to re-grant permission.


### PR DESCRIPTION
Created stories `story-041-077`, `story-041-078`, and `story-041-079` to break down the Emulator Auto-Sync Integration epic. Appended references to the parent epic and checked off acceptance criteria.

---
*PR created automatically by Jules for task [1198321773349573506](https://jules.google.com/task/1198321773349573506) started by @szubster*