### PR TITLE
Implement DAG Dependency Cancellation Logic

### DIFF
--- a/.foundry/tasks/task-072-128-implement-dag-cancellation.md
+++ b/.foundry/tasks/task-072-128-implement-dag-cancellation.md
@@ -36,9 +36,9 @@ As requested in `story-035-072-implement-cancellation-logic`, the orchestrator n
 - Log cancellation details to the console output.
 
 ## Acceptance Criteria
-- [ ] Implement detection of permanently failed nodes (`status === 'FAILED'` and `rejection_reason === 'Max rejection count reached'`) during the DAG evaluation cycle in `.github/scripts/foundry-orchestrator.ts`.
-- [ ] Traverse the DAG to identify all `PENDING` nodes that rely directly or indirectly on the failed node via their `depends_on` array.
-- [ ] Transition identified `PENDING` nodes to `CANCELLED`.
-- [ ] Set `rejection_reason` for the newly cancelled nodes to `"Cancelled due to permanent failure of dependency: <failed-node-id>"`.
-- [ ] Include loop detection/safeguards to prevent infinite traversals if circular dependencies exist.
-- [ ] Output console logs for the cancellation operations.
+- [x] Implement detection of permanently failed nodes (`status === 'FAILED'` and `rejection_reason === 'Max rejection count reached'`) during the DAG evaluation cycle in `.github/scripts/foundry-orchestrator.ts`.
+- [x] Traverse the DAG to identify all `PENDING` nodes that rely directly or indirectly on the failed node via their `depends_on` array.
+- [x] Transition identified `PENDING` nodes to `CANCELLED`.
+- [x] Set `rejection_reason` for the newly cancelled nodes to `"Cancelled due to permanent failure of dependency: <failed-node-id>"`.
+- [x] Include loop detection/safeguards to prevent infinite traversals if circular dependencies exist.
+- [x] Output console logs for the cancellation operations.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -982,6 +982,135 @@ describe('foundry-orchestrator', () => {
     expect(result).toContain('status: READY');
   });
 
+  test('Impossible Loop: Auto-cancels PENDING nodes depending indirectly on permanently failed node', () => {
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-impossible.md', {
+      id: "task-impossible",
+      type: "TASK",
+      title: "Impossible Task",
+      status: "FAILED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: ".foundry/stories/story-001.md",
+      depends_on: [".foundry/stories/story-001.md"],
+      jules_session_id: null,
+      rejection_reason: "Max rejection count reached",
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-orphaned-qa.md', {
+      id: "task-orphaned-qa",
+      type: "TASK",
+      title: "Orphaned QA Task",
+      status: "PENDING",
+      owner_persona: "qa",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: ".foundry/stories/story-001.md",
+      depends_on: [".foundry/tasks/task-impossible.md"],
+      jules_session_id: null,
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-orphaned-auditor.md', {
+      id: "task-orphaned-auditor",
+      type: "TASK",
+      title: "Orphaned Auditor Task",
+      status: "PENDING",
+      owner_persona: "auditor",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: ".foundry/stories/story-001.md",
+      depends_on: [".foundry/tasks/task-orphaned-qa.md"],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const parentResult = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-001.md'), 'utf-8');
+    expect(parentResult).toContain('status: READY');
+
+    const qaResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-orphaned-qa.md'), 'utf-8');
+    expect(qaResult).toContain('status: CANCELLED');
+    expect(qaResult).toContain("rejection_reason: 'Cancelled due to permanent failure of dependency: task-impossible'");
+
+    const auditorResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-orphaned-auditor.md'), 'utf-8');
+    expect(auditorResult).toContain('status: CANCELLED');
+    expect(auditorResult).toContain("rejection_reason: 'Cancelled due to permanent failure of dependency: task-impossible'");
+  });
+
+  test('Impossible Loop: Auto-cancels without infinite loop on circular dependency', () => {
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-impossible.md', {
+      id: "task-impossible",
+      type: "TASK",
+      title: "Impossible Task",
+      status: "FAILED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: ".foundry/stories/story-001.md",
+      depends_on: [".foundry/stories/story-001.md"],
+      jules_session_id: null,
+      rejection_reason: "Max rejection count reached",
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-orphaned-qa.md', {
+      id: "task-orphaned-qa",
+      type: "TASK",
+      title: "Orphaned QA Task",
+      status: "PENDING",
+      owner_persona: "qa",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: ".foundry/stories/story-001.md",
+      depends_on: [".foundry/tasks/task-impossible.md", ".foundry/tasks/task-orphaned-auditor.md"],
+      jules_session_id: null,
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-orphaned-auditor.md', {
+      id: "task-orphaned-auditor",
+      type: "TASK",
+      title: "Orphaned Auditor Task",
+      status: "PENDING",
+      owner_persona: "auditor",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: ".foundry/stories/story-001.md",
+      depends_on: [".foundry/tasks/task-orphaned-qa.md"],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const qaResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-orphaned-qa.md'), 'utf-8');
+    expect(qaResult).toContain('status: CANCELLED');
+
+    const auditorResult = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-orphaned-auditor.md'), 'utf-8');
+    expect(auditorResult).toContain('status: CANCELLED');
+  });
+
   test('Impossible Loop: Auto-cancels orphaned PENDING nodes depending on permanently failed node', () => {
     createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
       id: "story-001",

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -544,15 +544,39 @@ function main(): void {
   info('Phase 3.6: Checking for Impossible Loop conditions...');
   for (const node of nodes) {
     if (node.frontmatter.status === 'FAILED' && node.frontmatter.rejection_reason === 'Max rejection count reached') {
-      // Auto-cancel orphaned PENDING nodes depending on this permanently failed node
-      for (const otherNode of nodes) {
-        if (otherNode.frontmatter.status === 'PENDING') {
-          const dependsOnPaths = (otherNode.frontmatter.depends_on || []).map(resolveNodePath).filter(Boolean);
-          if (dependsOnPaths.includes(node.repoPath)) {
-            promoteNodeToCancelledWithReason(otherNode, `Cancelled due to permanent failure of dependency: ${node.frontmatter.id}`);
-            // Also add to cancelledNodes to ensure any of ITS children get cancelled by cascade logic
-            cancelledNodes.add(otherNode.repoPath);
-            cascadeCancel(otherNode.repoPath);
+      // Auto-cancel orphaned PENDING nodes depending directly or indirectly on this permanently failed node
+
+      // Build a reverse dependency graph
+      const dependents = new Map<string, string[]>();
+      for (const n of nodes) {
+        const deps = (n.frontmatter.depends_on || []).map(resolveNodePath).filter(Boolean) as string[];
+        for (const d of deps) {
+          if (!dependents.has(d)) {
+            dependents.set(d, []);
+          }
+          dependents.get(d)!.push(n.repoPath);
+        }
+      }
+
+      const visited = new Set<string>();
+      const queue = [node.repoPath];
+      visited.add(node.repoPath);
+
+      while (queue.length > 0) {
+        const currentPath = queue.shift()!;
+        const currentDependents = dependents.get(currentPath) || [];
+
+        for (const depPath of currentDependents) {
+          if (!visited.has(depPath)) {
+            visited.add(depPath);
+            queue.push(depPath);
+
+            const dependentNode = nodeMap.get(depPath);
+            if (dependentNode && dependentNode.frontmatter.status === 'PENDING') {
+              promoteNodeToCancelledWithReason(dependentNode, `Cancelled due to permanent failure of dependency: ${node.frontmatter.id}`);
+              cancelledNodes.add(dependentNode.repoPath);
+              cascadeCancel(dependentNode.repoPath);
+            }
           }
         }
       }


### PR DESCRIPTION
Implement the cancellation logic outlined in task-072-128 to ensure all nodes depending (directly or indirectly) on a permanently failed node are automatically cancelled, and avoid infinite loops from circular dependencies.

---
*PR created automatically by Jules for task [17785404989167924302](https://jules.google.com/task/17785404989167924302) started by @szubster*