### PR TITLE
feat: decompose epic-032-042 into granular stories

### DIFF
--- a/.foundry/epics/epic-032-042-generation-pipeline-keys.md
+++ b/.foundry/epics/epic-032-042-generation-pipeline-keys.md
@@ -26,5 +26,9 @@ Refactor the data generation pipeline (`scripts/generate-pokedata.ts`) to output
 - Completion of the ADR 015 documenting the global data contract changes.
 
 ## Acceptance Criteria
-- [ ] The generated output from `scripts/generate-pokedata.ts` uses verbose keys like `name` and `captureRate`.
-- [ ] Enum-to-number optimizations are preserved.
+- [x] The generated output from `scripts/generate-pokedata.ts` uses verbose keys like `name` and `captureRate`.
+- [x] Enum-to-number optimizations are preserved.
+
+## Child Nodes
+- .foundry/stories/story-042-080-refactor-generation-exports.md
+- .foundry/stories/story-042-081-preserve-enum-optimizations.md

--- a/.foundry/stories/story-042-080-refactor-generation-exports.md
+++ b/.foundry/stories/story-042-080-refactor-generation-exports.md
@@ -1,0 +1,22 @@
+---
+id: story-042-080-refactor-generation-exports
+type: STORY
+title: Refactor Data Generation Pipeline to Verbose Keys
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on: []
+jules_session_id: null
+parent: epic-032-042-generation-pipeline-keys
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Refactor Data Generation Pipeline to Verbose Keys
+
+## Objective
+Refactor the data generation pipeline (`scripts/generate-pokedata.ts`) to output verbose keys instead of shortened properties to improve DX, aligning with the MsgPack `useRecords` optimization format.
+
+## Acceptance Criteria
+- [ ] The generated output from `scripts/generate-pokedata.ts` uses verbose keys like `name` and `captureRate`.

--- a/.foundry/stories/story-042-081-preserve-enum-optimizations.md
+++ b/.foundry/stories/story-042-081-preserve-enum-optimizations.md
@@ -1,0 +1,22 @@
+---
+id: story-042-081-preserve-enum-optimizations
+type: STORY
+title: Preserve Enum-to-Number Optimizations in Generation Pipeline
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on: []
+jules_session_id: null
+parent: epic-032-042-generation-pipeline-keys
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Preserve Enum-to-Number Optimizations in Generation Pipeline
+
+## Objective
+Ensure that the enum-to-number mapping logic (like `EVO_TRIGGER`, `ENCOUNTER_METHOD`) in the data generation pipeline (`scripts/generate-pokedata.ts`) is preserved when transitioning to verbose keys, to retain existing deduplication benefits.
+
+## Acceptance Criteria
+- [ ] Enum-to-number optimizations are preserved.


### PR DESCRIPTION
Decomposed `epic-032-042-generation-pipeline-keys` into two specific stories:
- `story-042-080-refactor-generation-exports.md` for refactoring the data generation exports
- `story-042-081-preserve-enum-optimizations.md` for ensuring enum-to-number mappings are retained

Updated the parent epic by appending the new child stories to the body and checking off the relevant acceptance criteria, all while ensuring its YAML frontmatter was not manipulated.

---
*PR created automatically by Jules for task [11165125192578189367](https://jules.google.com/task/11165125192578189367) started by @szubster*