### PR TITLE
Preserve Enum-to-Number Optimizations in Generation Pipeline

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -55,3 +55,6 @@ The CEO/Architect has specified that Cloudflare Pages are already deployed using
 
 ## 2026-05-21: Purpose of Wrangler in a Pull-Based Deployment Model
 Even though the project uses Cloudflare's GitHub integration for deployments (Inversion of Control, where Cloudflare polls the repo), the `wrangler` CLI is still a required devDependency. It provides the local emulation environment (`workerd`) necessary to test Cloudflare Workers, Pages, and bindings (like KV or D1) locally during development before committing.
+
+## Data Key Renaming
+When structural data keys are renamed (e.g., transitioning from short keys like `m` to verbose keys like `method` for MsgPack optimizations), data compaction logic must also be updated to support the new keys to prevent silent loss of deduplication benefits.

--- a/.foundry/stories/story-042-081-preserve-enum-optimizations.md
+++ b/.foundry/stories/story-042-081-preserve-enum-optimizations.md
@@ -19,4 +19,4 @@ notes: ''
 Ensure that the enum-to-number mapping logic (like `EVO_TRIGGER`, `ENCOUNTER_METHOD`) in the data generation pipeline (`scripts/generate-pokedata.ts`) is preserved when transitioning to verbose keys, to retain existing deduplication benefits.
 
 ## Acceptance Criteria
-- [ ] Enum-to-number optimizations are preserved.
+- [x] Enum-to-number optimizations are preserved.

--- a/scripts/generate-pokedata.ts
+++ b/scripts/generate-pokedata.ts
@@ -571,18 +571,18 @@ function compact(obj: any): any {
       // Omit baby: false
       if (key === 'baby' && value === false) continue;
       // Omit m: 1 (WALK)
-      if (key === 'm' && value === 1) continue;
+      if ((key === 'm' || key === 'method') && value === 1) continue;
       // Omit empty objects (dist: {})
       if (value !== null && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0) continue;
       
       // Omit gr: 4 (gender_rate default)
-      if (key === 'gr' && value === 4) continue;
+      if ((key === 'gr' || key === 'genderRate') && value === 4) continue;
       // Omit tr: 1 (EVO_TRIGGER.LEVEL_UP default)
-      if (key === 'tr' && value === 1) continue;
+      if ((key === 'tr' || key === 'trigger') && value === 1) continue;
       // Omit mh: 160 (min_happiness default)
-      if (key === 'mh' && value === 160) continue;
+      if ((key === 'mh' || key === 'minHappiness') && value === 160) continue;
       // Omit max if same as min (encounter levels)
-      if (key === 'max' && value === obj.min) continue;
+      if ((key === 'max' || key === 'maxLevel') && (value === obj.min || value === obj.minLevel)) continue;
 
       result[key] = compact(value);
     }


### PR DESCRIPTION
This PR preserves the deduplication benefits of the data generation pipeline when transitioning from short keys to verbose keys.

Changes made:
1. Updated the `compact` function in `scripts/generate-pokedata.ts` to recognize and omit default values for verbose keys (`method`, `trigger`, `genderRate`, `minHappiness`, `maxLevel`) in addition to their existing short keys.
2. Checked off the acceptance criteria box in `.foundry/stories/story-042-081-preserve-enum-optimizations.md`.
3. Added a learning note to `.foundry/journals/coder.md` about updating compaction logic when data keys are renamed.

---
*PR created automatically by Jules for task [907090582626826679](https://jules.google.com/task/907090582626826679) started by @szubster*