### PR TITLE
🛡️ Nurse: [type improvement] Refactor Suggestion to discriminated union

### DIFF
--- a/src/components/assistant/AssistantSuggestionCard.tsx
+++ b/src/components/assistant/AssistantSuggestionCard.tsx
@@ -109,7 +109,7 @@ export function AssistantSuggestionCard({
             {s.category === 'Catch' ? (
               Object.entries(
                 (s.pokemonIds || []).reduce<Record<string, { pid: number; enc: EncounterDetail }[]>>((acc, pid) => {
-                  const encs = s.encounterInfo?.[pid];
+                  const encs = s.category === 'Catch' ? s.encounterInfo?.[pid] : undefined;
                   if (!encs) return acc;
                   const mainEnc = [...encs].sort((a, b) => b.chance - a.chance)[0];
                   if (!mainEnc) return acc;

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -592,8 +592,16 @@ describe('generateSuggestions', () => {
     const result2 = generateSuggestions(localSaveData, false, 'gold', localApiData, localStrategy);
     const catch2 = result2.suggestions.find((s) => s.category === 'Catch' && s.id.startsWith('catch-nearby'));
     expect(catch2).toBeDefined(); // Included since badges aren't needed
-    expect(catch2?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'headbutt')).toBe(true);
-    expect(catch2?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'rock-smash')).toBe(true);
+    expect(
+      (catch2?.category === 'Catch' ? catch2 : undefined)?.encounterInfo?.[missingPid]?.some(
+        (e: EncounterDetail) => e.method === 'headbutt',
+      ),
+    ).toBe(true);
+    expect(
+      (catch2?.category === 'Catch' ? catch2 : undefined)?.encounterInfo?.[missingPid]?.some(
+        (e: EncounterDetail) => e.method === 'rock-smash',
+      ),
+    ).toBe(true);
 
     // 3. Missing item but a Pokemon knows the move
     localSaveData.inventory = [];
@@ -609,8 +617,16 @@ describe('generateSuggestions', () => {
     const result3 = generateSuggestions(localSaveData, false, 'gold', localApiData, localStrategy);
     const catch3 = result3.suggestions.find((s) => s.category === 'Catch' && s.id.startsWith('catch-nearby'));
     expect(catch3).toBeDefined(); // Included because of known moves
-    expect(catch3?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'headbutt')).toBe(true);
-    expect(catch3?.encounterInfo?.[missingPid]?.some((e: EncounterDetail) => e.method === 'rock-smash')).toBe(true);
+    expect(
+      (catch3?.category === 'Catch' ? catch3 : undefined)?.encounterInfo?.[missingPid]?.some(
+        (e: EncounterDetail) => e.method === 'headbutt',
+      ),
+    ).toBe(true);
+    expect(
+      (catch3?.category === 'Catch' ? catch3 : undefined)?.encounterInfo?.[missingPid]?.some(
+        (e: EncounterDetail) => e.method === 'rock-smash',
+      ),
+    ).toBe(true);
   });
   it('should generate stat-based evolution suggestions for Tyrogue (Atk > Def, Atk < Def, Atk = Def)', () => {
     const mockApiData: AssistantApiData = {

--- a/src/engine/assistant/strategies/types.ts
+++ b/src/engine/assistant/strategies/types.ts
@@ -12,21 +12,30 @@ export interface EncounterDetail {
   time?: number | undefined;
 }
 
-export interface Suggestion {
+export interface BaseSuggestion {
   id: string;
-  category: SuggestionCategory;
   title: string;
   description: string;
+  priority: number;
   pokemonId?: number;
   pokemonIds?: number[];
-  priority: number;
-  encounterInfo?: Record<number, EncounterDetail[]>;
   warning?: string;
   debugInfo?: {
     priorityScore: number;
     reasoning?: string;
   };
 }
+
+export interface CatchSuggestion extends BaseSuggestion {
+  category: 'Catch';
+  encounterInfo?: Record<number, EncounterDetail[]>;
+}
+
+export interface StandardSuggestion extends BaseSuggestion {
+  category: Exclude<SuggestionCategory, 'Catch'>;
+}
+
+export type Suggestion = CatchSuggestion | StandardSuggestion;
 
 export interface RejectedSuggestion {
   pokemonId: number;


### PR DESCRIPTION
🛡️ Nurse: [type improvement]

**What was unsafe:**
The `Suggestion` interface in `src/engine/assistant/strategies/types.ts` was a loose object shape where `encounterInfo?: Record<number, EncounterDetail[]>;` could be defined on any suggestion type, even if the category was `'Evolve'` or `'Trade'`. This loose typing required `as` casting or could lead to invalid states.

**How it was fixed:**
Refactored `Suggestion` into a discriminated union (`CatchSuggestion` and `StandardSuggestion`) tagged by the `category` property. `encounterInfo` is now safely restricted only to the `'Catch'` category.

**What the compiler now catches:**
The TypeScript compiler now guarantees that `encounterInfo` can only be accessed or assigned when the `Suggestion`'s `category` is specifically checked and narrowed to `'Catch'`. This eliminates potential invalid states and allows the removal of unsafe property accesses without explicit assertions.

---
*PR created automatically by Jules for task [15397087238346693268](https://jules.google.com/task/15397087238346693268) started by @szubster*