### PR TITLE
🧭 Strategist: Prompt improvement - Ensure Architect updates schemas and respects node boundaries

### DIFF
--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -6,7 +6,7 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 
 1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/docs/adrs/`. This is non-negotiable and establishes your context. Ensure you are completely aware of the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
 2.  **Maintain ADRs**: Ensure Architecture Decision Records (ADRs) are properly managed, updated, and adhered to.
-3.  **Maintain Schemas**: Ensure data schemas, communication protocols, and other structural definitions are kept up-to-date and consistent with the implementation.
+3.  **Maintain Schemas**: Ensure data schemas, communication protocols, and other structural definitions are kept up-to-date and consistent with the implementation. When an architectural decision involves global data contract changes, you MUST update the system's central schema document (`.foundry/docs/schema.md`) to reflect the new structure or property mappings, alongside publishing the ADR.
 4.  **Enforce Technical Integrity**: Review plans, code, and documentation to ensure they align with the established architectural guidelines.
 
 ## Workflow
@@ -18,7 +18,7 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 5.  Commit your work to the repository.
 
 **NODE CREATION GUIDELINES:**
-While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
+While the system generally allows node creation, as the Architect you are strictly responsible for architectural blueprinting. You MUST NOT create functional execution nodes like `EPIC`, `STORY`, or `TASK`. Breaking down work is the responsibility of other personas (Epic Planner, Story Owner, Tech Lead) via late binding. If you encounter larger architectural changes, find technical debt, or lack context, you may create an `IDEA`, `RESEARCH`, or `ADR` node. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -132,3 +132,9 @@
 **Outcome:** Merged
 **Why:** The TPM journal showed the TPM was successfully moving files but incorrectly updating YAML frontmatter `depends_on` lists and `parent` fields to point to the new `.foundry/archive/` paths. This violated the strict system constraint that these fields must only use Node IDs. The TPM prompt instructed it to update references via the 'parent' field and 'depends_on' list.
 **Pattern:** Codify system memory constraints regarding Node IDs vs file paths in YAML frontmatter into the relevant agent prompts (like the TPM archiving rules) to prevent DAG orchestrator deadlocks and schema corruption.
+
+## 2026-05-22 - [Accepted] - Prompt improvement - Ensure Architect updates schemas and respects node boundaries
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The architect's journal showed it was reprimanded for creating functional execution nodes (`EPIC`, `STORY`, `TASK`) and reminded that its role is strictly architectural blueprinting (ADRs). Furthermore, system memory dictates that when global data contracts change (e.g., ADR 010), the Architect must update `.foundry/docs/schema.md`.
+**Pattern:** Codify role constraints (e.g., node creation boundaries) and secondary responsibilities (e.g., schema updates alongside ADRs) directly into agent prompts to prevent role drift and maintain system documentation.


### PR DESCRIPTION
**Proposal**: Update the Architect schedule prompt (`.github/agents/architect.md`) to restrict the persona from creating functional execution nodes (`EPIC`, `STORY`, `TASK`) and require updates to the central schema document (`.foundry/docs/schema.md`) when global data contracts change.

**Justification**: The Architect's primary function is blueprinting via ADRs and schema definitions. Generating implementation nodes directly skips the required late-binding planner stages (like the Tech Lead or Epic Planner), disrupting the orchestrator's structured transition. Furthermore, ADRs that introduce data changes (like ADR 010) often fail to get mapped to the actual schema unless explicitly enforced.

**Evidence**: 
- **Node Boundaries**: The Architect's journal (`.foundry/journals/architect.md`, 2026-05-19) indicates: "Received CEO feedback: 'As architect you should prepare adrs. Leave rest to other personas and late binding. Improve your prompt now...' Learning: My role is strictly architectural blueprinting... I should not proactively create downstream execution nodes."
- **Schema Updates**: The architect journal (2026-05-17) explicitly logs creating ADR 010 to migrate data formatting, but the orchestrator relies heavily on the `schema.md` for validity. Ensuring the Architect updates both documents concurrently guarantees system safety.

---
*PR created automatically by Jules for task [761103332447632549](https://jules.google.com/task/761103332447632549) started by @szubster*