### PR TITLE
fix: Correct STORY node owner_persona mapping and existing assignments

### DIFF
--- a/.foundry/stories/story-012-026-evaluate-cloudflare-storage.md
+++ b/.foundry/stories/story-012-026-evaluate-cloudflare-storage.md
@@ -3,7 +3,7 @@ id: story-012-026-evaluate-cloudflare-storage
 type: STORY
 title: "Evaluate Cloudflare Storage Mechanisms"
 status: "COMPLETED"
-owner_persona: coder
+owner_persona: tech_lead
 created_at: "2026-04-26"
 updated_at: "2026-04-26"
 depends_on: []

--- a/.foundry/stories/story-012-027-design-sync-mechanism.md
+++ b/.foundry/stories/story-012-027-design-sync-mechanism.md
@@ -3,7 +3,7 @@ id: story-012-027-design-sync-mechanism
 type: STORY
 title: "Design State Sync Mechanism"
 status: "COMPLETED"
-owner_persona: coder
+owner_persona: tech_lead
 created_at: "2026-04-26"
 updated_at: "2026-04-26"
 depends_on:

--- a/.foundry/stories/story-024-037-orchestrator-late-binding-completion.md
+++ b/.foundry/stories/story-024-037-orchestrator-late-binding-completion.md
@@ -3,7 +3,7 @@ id: story-024-037-orchestrator-late-binding-completion
 type: STORY
 title: 'Story: Handle Late-Binding Parent Completion'
 status: "COMPLETED"
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-04'
 updated_at: "2026-05-04"
 depends_on: []

--- a/.foundry/stories/story-038-074-cloudflare-auth-infrastructure.md
+++ b/.foundry/stories/story-038-074-cloudflare-auth-infrastructure.md
@@ -3,7 +3,7 @@ id: story-038-074-cloudflare-auth-infrastructure
 type: STORY
 title: Cloudflare Backend Infrastructure and Build Config
 status: COMPLETED
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-21'
 updated_at: '2026-05-21'
 depends_on: []

--- a/.foundry/stories/story-038-075-google-sso-integration.md
+++ b/.foundry/stories/story-038-075-google-sso-integration.md
@@ -3,7 +3,7 @@ id: story-038-075-google-sso-integration
 type: STORY
 title: Google SSO Integration and Single User Restriction
 status: ACTIVE
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-21'
 updated_at: '2026-05-21'
 depends_on:

--- a/.foundry/stories/story-038-076-offline-auth-state.md
+++ b/.foundry/stories/story-038-076-offline-auth-state.md
@@ -3,7 +3,7 @@ id: story-038-076-offline-auth-state
 type: STORY
 title: Client-side Offline Auth State Management
 status: PENDING
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-21'
 updated_at: '2026-05-21'
 depends_on:

--- a/.foundry/stories/story-040-074-orchestrator-verifying-state.md
+++ b/.foundry/stories/story-040-074-orchestrator-verifying-state.md
@@ -3,7 +3,7 @@ id: story-040-074-orchestrator-verifying-state
 type: STORY
 title: Orchestrator VERIFYING State and Matrix Dispatch
 status: ACTIVE
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-21'
 updated_at: '2026-05-21'
 depends_on: []

--- a/.foundry/stories/story-040-075-heartbeat-verifying-logic.md
+++ b/.foundry/stories/story-040-075-heartbeat-verifying-logic.md
@@ -3,7 +3,7 @@ id: story-040-075-heartbeat-verifying-logic
 type: STORY
 title: Heartbeat State Transition and Zombie Recovery
 status: PENDING
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-21'
 updated_at: '2026-05-21'
 depends_on:

--- a/.foundry/stories/story-041-077-file-system-access-idb.md
+++ b/.foundry/stories/story-041-077-file-system-access-idb.md
@@ -3,7 +3,7 @@ id: story-041-077-file-system-access-idb
 type: STORY
 title: File System Access & IndexedDB Retainment
 status: ACTIVE
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-21'
 updated_at: '2026-05-21'
 depends_on: []

--- a/.foundry/stories/story-041-078-background-polling-loop.md
+++ b/.foundry/stories/story-041-078-background-polling-loop.md
@@ -3,7 +3,7 @@ id: story-041-078-background-polling-loop
 type: STORY
 title: "Background Polling Loop & State Hydration"
 status: PENDING
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-21'
 updated_at: '2026-05-21'
 depends_on:

--- a/.foundry/stories/story-041-079-ui-sync-status.md
+++ b/.foundry/stories/story-041-079-ui-sync-status.md
@@ -3,7 +3,7 @@ id: story-041-079-ui-sync-status
 type: STORY
 title: "UI Sync Status & Permissions"
 status: PENDING
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-21'
 updated_at: '2026-05-21'
 depends_on:

--- a/.foundry/stories/story-042-080-refactor-generation-exports.md
+++ b/.foundry/stories/story-042-080-refactor-generation-exports.md
@@ -3,7 +3,7 @@ id: story-042-080-refactor-generation-exports
 type: STORY
 title: Refactor Data Generation Pipeline to Verbose Keys
 status: ACTIVE
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-21'
 updated_at: '2026-05-22'
 depends_on: []

--- a/.foundry/stories/story-042-081-preserve-enum-optimizations.md
+++ b/.foundry/stories/story-042-081-preserve-enum-optimizations.md
@@ -3,7 +3,7 @@ id: story-042-081-preserve-enum-optimizations
 type: STORY
 title: Preserve Enum-to-Number Optimizations in Generation Pipeline
 status: ACTIVE
-owner_persona: coder
+owner_persona: tech_lead
 created_at: '2026-05-21'
 updated_at: '2026-05-21'
 depends_on: []

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -22,7 +22,7 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 
 **NODE GENERATION RULES:**
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
-- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
+- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `tech_lead` for STORY nodes, `coder` for TASKs), not yourself.
 - Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
 - The strict pipeline order and persona handoff for Foundry nodes is: IDEA (PM) -> PRD (PM) -> ADR (Architect) -> EPIC (Planner) -> STORY -> TASK.
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -15,7 +15,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 **NODE GENERATION RULES:**
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
 - When a target Foundry artifact (such as a downstream PRD or generated node file) unexpectedly exists prior to the session, create a small journal entry detailing the anomaly for the Agile Coach to review later.
-- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
+- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `tech_lead` for STORY nodes, `coder` for TASKs), not yourself.
 - Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
 - The strict pipeline order and persona handoff for Foundry nodes is: IDEA (PM) -> PRD (PM) -> ADR (Architect) -> EPIC (Planner) -> STORY -> TASK.
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -19,7 +19,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 **NODE GENERATION RULES:**
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
-- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
+- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `tech_lead` for STORY nodes, `coder` for TASKs), not yourself.
 - Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
 - The strict pipeline order and persona handoff for Foundry nodes is: IDEA (PM) -> PRD (PM) -> ADR (Architect) -> EPIC (Planner) -> STORY -> TASK.
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -28,7 +28,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 **NODE GENERATION RULES:**
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
-- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `coder` for TASKs), not yourself.
+- Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `tech_lead` for STORY nodes, `coder` for TASKs), not yourself.
 - Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -871,7 +871,7 @@ function main(): void {
     IDEA: ['product_manager'],
     PRD: ['epic_planner', 'story_owner'],
     EPIC: ['story_owner', 'epic_planner'],
-    STORY: ['tech_lead', 'story_owner', 'coder'],
+    STORY: ['tech_lead', 'story_owner'],
     TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
   };


### PR DESCRIPTION
This PR fixes an issue where `STORY` nodes were being incorrectly assigned to the `coder` persona, instead of the `tech_lead`.

**Changes included:**
- Removed `coder` from the `STORY` node's valid mappings array in `.github/scripts/foundry-orchestrator.ts`.
- Updated all existing `.foundry/stories/*.md` nodes that were assigned to `coder` to now use `tech_lead`.
- Updated agent prompts (`product_manager.md`, `epic_planner.md`, `story_owner.md`, `tech_lead.md`) to explicitly state that the next pipeline step for `STORY` nodes is `tech_lead`.

All tests and lint checks have passed.

---
*PR created automatically by Jules for task [13087364061767144155](https://jules.google.com/task/13087364061767144155) started by @szubster*