### PR TITLE
🧠 Trainer: Parse PC Items for accurate Assistant suggestions

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -51,3 +51,6 @@
 ## 2024-05-21 - Breeding Intermediate Evolution Suggestion Fix
 **Learning:** In Pokémon Gen 2, eggs always hatch into the lowest evolutionary stage. The assistant's `generateBreedingSuggestions` previously suggested breeding intermediate evolutions (like Charizard) to obtain other intermediate evolutions (like Charmeleon), which is mechanically impossible.
 **Action:** Update the breeding logic to verify that the target Pokémon is actually a base or baby stage (by checking `p.efrm === undefined || p.efrm.length === 0`) before evaluating its ancestors for breeding suggestions.
+## 2024-05-22 - Assistant PC Item Checking
+**Learning:** The suggestion engine previously only checked the player's active `inventory` for items (like evolution stones, trade held items, rods, and TMs). However, Gen 1 and Gen 2 games allow players to store up to 50 items in the PC. If a required item was stored in the PC, the assistant would incorrectly suggest the player still needed to find one.
+**Action:** Updated both Gen 1 and Gen 2 save parsers to extract `pcItems`. The suggestion engine (`EVO_TRIGGER.USE_ITEM`, `EVO_TRIGGER.TRADE`, etc.) now safely checks `saveData.pcItems` alongside `saveData.inventory` using optional chaining (`?.`) and nullish coalescing (`?? false`).

--- a/src/components/assistant/AssistantSuggestionCard.tsx
+++ b/src/components/assistant/AssistantSuggestionCard.tsx
@@ -135,7 +135,9 @@ export function AssistantSuggestionCard({
                       : method.includes('good')
                         ? rodIds.GOOD
                         : rodIds.SUPER;
-                    isOwned = saveData.inventory.some((i) => i.id === rodId);
+                    isOwned =
+                      saveData.inventory.some((i) => i.id === rodId) ||
+                      (saveData.pcItems?.some((i) => i.id === rodId) ?? false);
                   }
                 }
                 const Icon = isRod ? Fish : isSurf ? Waves : isGrass ? Trees : Target;

--- a/src/engine/assistant/strategies/gen2Strategy.ts
+++ b/src/engine/assistant/strategies/gen2Strategy.ts
@@ -59,9 +59,12 @@ export const gen2Strategy: AssistantStrategy = {
     // In Gen 2, these are single-use and do not require badges to use in the field.
     const allInstances = [...(saveData.partyDetails || []), ...(saveData.pcDetails || [])];
     const hasHeadbutt =
-      saveData.inventory.some((i) => i.id === 192 && i.quantity > 0) || allInstances.some((p) => p.moves?.includes(29));
+      saveData.inventory.some((i) => i.id === 192 && i.quantity > 0) ||
+      (saveData.pcItems?.some((i) => i.id === 192 && i.quantity > 0) ?? false) ||
+      allInstances.some((p) => p.moves?.includes(29));
     const hasRockSmash =
       saveData.inventory.some((i) => i.id === 198 && i.quantity > 0) ||
+      (saveData.pcItems?.some((i) => i.id === 198 && i.quantity > 0) ?? false) ||
       allInstances.some((p) => p.moves?.includes(249));
 
     if (hasHeadbutt) {

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -741,7 +741,9 @@ function generateEvolutionSuggestions(
         }
       } else if (tr === EVO_TRIGGER.USE_ITEM && item) {
         const gameItemId = getGameItemId(item, saveData.generation);
-        const hasStone = saveData.inventory.some((i) => i.id === gameItemId && i.quantity > 0);
+        const hasStone =
+          saveData.inventory.some((i) => i.id === gameItemId && i.quantity > 0) ||
+          (saveData.pcItems?.some((i) => i.id === gameItemId && i.quantity > 0) ?? false);
         const itemName = EVO_ITEM_NAMES[item] || 'item';
         suggestions.push({
           id: `evo-item-${targetId}-${item}`,
@@ -760,7 +762,9 @@ function generateEvolutionSuggestions(
       } else if (tr === EVO_TRIGGER.TRADE) {
         if (held) {
           const gameHeldId = getGameItemId(held, saveData.generation);
-          const hasHeldItemInBag = saveData.inventory.some((i) => i.id === gameHeldId && i.quantity > 0);
+          const hasHeldItemInBag =
+            saveData.inventory.some((i) => i.id === gameHeldId && i.quantity > 0) ||
+            (saveData.pcItems?.some((i) => i.id === gameHeldId && i.quantity > 0) ?? false);
           const holdingInstance =
             evolvableInstances.find((inst) => inst.item === gameHeldId) ||
             ownedInstances.find((inst) => inst.item === gameHeldId);
@@ -875,9 +879,13 @@ export function generateSuggestions(
   const localPids = new Set<number>();
 
   const hasHeadbutt =
-    saveData.inventory.some((i) => i.id === 192 && i.quantity > 0) || allInstances.some((p) => p.moves?.includes(29));
+    saveData.inventory.some((i) => i.id === 192 && i.quantity > 0) ||
+    (saveData.pcItems?.some((i) => i.id === 192 && i.quantity > 0) ?? false) ||
+    allInstances.some((p) => p.moves?.includes(29));
   const hasRockSmash =
-    saveData.inventory.some((i) => i.id === 198 && i.quantity > 0) || allInstances.some((p) => p.moves?.includes(249));
+    saveData.inventory.some((i) => i.id === 198 && i.quantity > 0) ||
+    (saveData.pcItems?.some((i) => i.id === 198 && i.quantity > 0) ?? false) ||
+    allInstances.some((p) => p.moves?.includes(249));
 
   generateCatchSuggestions(
     apiData,

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -64,6 +64,7 @@ export interface SaveData {
   johtoBadges?: number;
   kantoBadges?: number;
   inventory: { id: number; quantity: number }[];
+  pcItems?: { id: number; quantity: number }[];
   currentBoxCount: number;
   hallOfFameCount: number;
   eventFlags?: Uint8Array;

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -582,6 +582,13 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
     inventory.push({ id: view.getUint8(itemOffset), quantity: view.getUint8(itemOffset + 1) });
   }
 
+  const pcItems: { id: number; quantity: number }[] = [];
+  const pcItemCount = view.getUint8(0x27e6 + offsetShift);
+  for (let i = 0; i < Math.min(pcItemCount, 50); i++) {
+    const itemOffset = 0x27e7 + offsetShift + i * 2;
+    pcItems.push({ id: view.getUint8(itemOffset), quantity: view.getUint8(itemOffset + 1) });
+  }
+
   const hallOfFameRaw = view.getUint8(0x25b3 + offsetShift);
   const eventFlagsOffset = 0x29e6 + offsetShift;
   const eventFlags = new Uint8Array(view.buffer, eventFlagsOffset, 0x118);
@@ -602,6 +609,7 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
     currentMapId,
     currentMapName,
     inventory,
+    pcItems,
     currentBoxCount,
     hallOfFameCount: hallOfFameRaw === 0xff ? 0 : hallOfFameRaw,
     eventFlags,

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -528,6 +528,18 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
 
   const inventory = parseInventory(view, isCrystal);
 
+  const pcItems: { id: number; quantity: number }[] = [];
+  const pcItemsPocket = isCrystal ? 0x2460 : 0x247e;
+  const pcItemsCount = view.getUint8(pcItemsPocket);
+  if (pcItemsCount > 0 && pcItemsCount <= 50) {
+    for (let i = 0; i < pcItemsCount; i++) {
+      const offset = pcItemsPocket + 1 + i * 2;
+      const id = view.getUint8(offset);
+      const quantity = view.getUint8(offset + 1);
+      pcItems.push({ id, quantity });
+    }
+  }
+
   const hallOfFameOffset = johtoBadgesOffset + 0xa8;
   const hallOfFameCount = view.getUint8(hallOfFameOffset);
 
@@ -551,6 +563,7 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
     currentMapName,
     mapGroup,
     inventory,
+    pcItems,
     daycare,
     daycareHasEgg,
     currentBoxCount: 0,


### PR DESCRIPTION
### What
Updated the Assistant suggestion engine to check PC Item Storage for required items (Evolution stones, trade-held items, Headbutt/Rock Smash TMs, and fishing rods) in Gen 1 and Gen 2 saves.

### Why
Gen 1 and Gen 2 have limited bag space, meaning players frequently store evolution stones and unused TMs in their PC. The assistant was incorrectly suggesting that players needed to "Find a Moon Stone" even if they already had 5 sitting in their PC. By parsing `pcItems`, the assistant can now correctly identify these owned items and provide accurate "Ready to Evolve" suggestions.

### Impact on recommendation quality
High. Eliminates false-positive "Item Needed" suggestions for players who responsibly manage their limited Gen 1/2 bag space. 

### Test coverage
Verified with existing unit and E2E tests, which all pass. Fallback handling (`?.` and `?? false`) ensures backward compatibility with save parsers that do not populate `pcItems`.

---
*PR created automatically by Jules for task [7244319511828290330](https://jules.google.com/task/7244319511828290330) started by @szubster*