### PR TITLE
Implement Death Tracking and Graveyard Logic

### DIFF
--- a/.foundry/tasks/task-070-126-implement-death-tracking-retry.md
+++ b/.foundry/tasks/task-070-126-implement-death-tracking-retry.md
@@ -27,6 +27,6 @@ notes: ''
 Detect fainted Pokémon in the party and implement logic to designate a PC Box as the Graveyard for permanently dead Pokémon.
 
 ## Acceptance Criteria
-- [ ] Implement logic to detect 0 HP Pokémon in the party as dead.
-- [ ] Implement logic to designate a PC Box as the Graveyard.
-- [ ] Pokémon in the Graveyard box are permanently marked as dead.
+- [x] Implement logic to detect 0 HP Pokémon in the party as dead.
+- [x] Implement logic to designate a PC Box as the Graveyard.
+- [x] Pokémon in the Graveyard box are permanently marked as dead.

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -20,12 +20,16 @@ export function SettingsModal() {
   const setIsLivingDex = useStore((s) => s.setIsLivingDex);
   const globalPokeball = useStore((s) => s.globalPokeball);
   const setGlobalPokeball = useStore((s) => s.setGlobalPokeball);
+  const nuzlockeGraveyardBox = useStore((s) => s.nuzlockeGraveyardBox);
+  const setNuzlockeGraveyardBox = useStore((s) => s.setNuzlockeGraveyardBox);
 
   const effectiveVersion = manualVersion || saveData?.gameVersion || 'unknown';
 
   if (!isSettingsOpen) return null;
 
   const genConfig = saveData ? getGenerationConfig(saveData.generation) : null;
+
+  const storageLocations = genConfig ? Array.from({ length: genConfig.boxCount }, (_, i) => `Box ${i + 1}`) : [];
 
   const filteredPokeballs = (genConfig?.pokeballs ?? ['poke', 'great', 'ultra'])
     .filter((pb) => pb !== 'safari') // Safari Ball cannot be a default
@@ -72,6 +76,9 @@ export function SettingsModal() {
           setGlobalPokeball={setGlobalPokeball}
           filteredPokeballs={filteredPokeballs}
           genConfig={genConfig}
+          nuzlockeGraveyardBox={nuzlockeGraveyardBox}
+          setNuzlockeGraveyardBox={setNuzlockeGraveyardBox}
+          storageLocations={storageLocations}
         />
         <ClearStorageButton
           onClear={async () => {

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from '@tanstack/react-router';
-import { Sparkles } from 'lucide-react';
+import { Skull, Sparkles } from 'lucide-react';
 import React from 'react';
 import type { PokemonInstance } from '../engine/saveParser/index';
 import { useStore } from '../store';
@@ -16,17 +16,21 @@ const StorageCard = React.memo(
     location,
     generation,
     onNavigate,
+    isDead,
   }: {
     p: PokemonInstance;
     pokemon: { id: number; name: string };
     location: string;
     generation: number;
     onNavigate: (id: number) => void;
+    isDead?: boolean;
   }) => {
     const handleClick = React.useCallback(() => onNavigate(pokemon.id), [onNavigate, pokemon.id]);
 
     let variant: 'storage-default' | 'storage-emerald' | 'storage-amber' | 'storage-red' = 'storage-default';
-    if (p.isShiny) {
+    if (isDead) {
+      variant = 'storage-red';
+    } else if (p.isShiny) {
       variant = 'storage-amber';
     } else if (location === 'Party') {
       variant = 'storage-red';
@@ -56,8 +60,14 @@ const StorageCard = React.memo(
             generation={generation}
             isShiny={p.isShiny}
             alt={pokemon.name}
-            className="h-full w-full object-contain drop-shadow-xl"
+            className={`h-full w-full object-contain drop-shadow-xl ${isDead ? 'opacity-50 grayscale' : ''}`}
           />
+          {isDead && (
+            <Skull
+              size={48}
+              className="pointer-events-none absolute inset-0 z-20 m-auto text-red-500/50 drop-shadow-md"
+            />
+          )}
         </div>
         <div className="w-full truncate px-1 text-center font-bold text-[10px] text-zinc-100 uppercase tracking-wider">
           {pokemon.name}
@@ -69,6 +79,7 @@ const StorageCard = React.memo(
 
 export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: string }[] }) {
   const saveData = useStore((s) => s.saveData);
+  const nuzlockeGraveyardBox = useStore((s) => s.nuzlockeGraveyardBox);
   const navigate = useNavigate();
   const handleNavigate = React.useCallback(
     (id: number) => {
@@ -164,6 +175,7 @@ export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: 
                       location={location}
                       generation={saveData?.generation ?? 1}
                       onNavigate={handleNavigate}
+                      isDead={location === nuzlockeGraveyardBox || (location === 'Party' && p.currentHp === 0)}
                     />
                   );
                 })

--- a/src/components/settings/SettingsControls.tsx
+++ b/src/components/settings/SettingsControls.tsx
@@ -1,4 +1,4 @@
-import { Archive, CircleDot, Settings2 } from 'lucide-react';
+import { Archive, CircleDot, Settings2, Skull } from 'lucide-react';
 import type { GameVersion, PokeballType } from '../../store';
 import type { GenerationConfig } from '../../utils/generationConfig';
 import { getGenerationConfig } from '../../utils/generationConfig';
@@ -13,6 +13,9 @@ interface SettingsControlsProps {
   setGlobalPokeball: (v: PokeballType) => void;
   filteredPokeballs: { value: PokeballType; label: string }[];
   genConfig: GenerationConfig | null;
+  nuzlockeGraveyardBox: string | null;
+  setNuzlockeGraveyardBox: (v: string | null) => void;
+  storageLocations: string[];
 }
 
 export function SettingsControls({
@@ -24,6 +27,9 @@ export function SettingsControls({
   setGlobalPokeball,
   filteredPokeballs,
   genConfig,
+  nuzlockeGraveyardBox,
+  setNuzlockeGraveyardBox,
+  storageLocations,
 }: SettingsControlsProps) {
   const versions = [
     { id: 'unknown', label: 'AUTO' },
@@ -128,6 +134,25 @@ export function SettingsControls({
             </button>
           ))}
         </div>
+      </SettingsRow>
+
+      <SettingsRow
+        icon={<Skull size={18} className="text-red-500" />}
+        iconColorClass="border-red-500/20 bg-red-500/10"
+        label="Graveyard"
+      >
+        <select
+          value={nuzlockeGraveyardBox || ''}
+          onChange={(e) => setNuzlockeGraveyardBox(e.target.value === '' ? null : e.target.value)}
+          className="w-full appearance-none rounded-none border border-zinc-800 border-dashed bg-zinc-950 px-3 py-2 font-black font-mono text-[9px] text-zinc-500 uppercase tracking-widest transition-all hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+        >
+          <option value="">[ NONE ]</option>
+          {storageLocations.map((loc) => (
+            <option key={loc} value={loc}>
+              [ {loc.toUpperCase()} ]
+            </option>
+          ))}
+        </select>
       </SettingsRow>
     </div>
   );

--- a/src/components/settings/__tests__/SettingsControls.test.tsx
+++ b/src/components/settings/__tests__/SettingsControls.test.tsx
@@ -20,6 +20,9 @@ describe('SettingsControls', () => {
         setGlobalPokeball={setGlobalPokeball}
         filteredPokeballs={[{ value: 'poke', label: 'Poke Ball' }]}
         genConfig={null}
+        nuzlockeGraveyardBox={null}
+        setNuzlockeGraveyardBox={vi.fn<(v: string | null) => void>()}
+        storageLocations={['Box 1', 'Box 2']}
       />,
     );
 
@@ -59,6 +62,9 @@ describe('SettingsControls', () => {
           fallbackSpriteUrl: () => '',
           versions: [{ id: 'red', label: 'Red', dotColor: 'bg-red-500', themeClass: 'theme-red' }],
         }}
+        nuzlockeGraveyardBox={null}
+        setNuzlockeGraveyardBox={vi.fn<(v: string | null) => void>()}
+        storageLocations={['Box 1', 'Box 2']}
       />,
     );
 
@@ -84,6 +90,9 @@ describe('SettingsControls', () => {
         setGlobalPokeball={setGlobalPokeball}
         filteredPokeballs={[{ value: 'poke', label: 'Poke Ball' }]}
         genConfig={null}
+        nuzlockeGraveyardBox={null}
+        setNuzlockeGraveyardBox={vi.fn<(v: string | null) => void>()}
+        storageLocations={['Box 1', 'Box 2']}
       />,
     );
 
@@ -116,6 +125,9 @@ describe('SettingsControls', () => {
           { value: 'love', label: 'Love Ball' },
         ]}
         genConfig={null}
+        nuzlockeGraveyardBox={null}
+        setNuzlockeGraveyardBox={vi.fn<(v: string | null) => void>()}
+        storageLocations={['Box 1', 'Box 2']}
       />,
     );
 

--- a/src/components/settings/__tests__/SettingsControls.test.tsx
+++ b/src/components/settings/__tests__/SettingsControls.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
 import type { GameVersion, PokeballType } from '../../../store';
 import { SettingsControls } from '../SettingsControls';
@@ -29,6 +29,37 @@ describe('SettingsControls', () => {
     await expect.element(page.getByText('Version')).toBeInTheDocument();
     await expect.element(page.getByText('Living Dex', { exact: true })).toBeInTheDocument();
     await expect.element(page.getByText('Ball Style')).toBeInTheDocument();
+  });
+
+  it('handles graveyard box change', async () => {
+    const setManualVersion = vi.fn<(v: GameVersion | null) => void>();
+    const setIsLivingDex = vi.fn<(v: boolean) => void>();
+    const setGlobalPokeball = vi.fn<(v: PokeballType) => void>();
+    const setNuzlockeGraveyardBox = vi.fn<(v: string | null) => void>();
+
+    await render(
+      <SettingsControls
+        effectiveVersion="unknown"
+        setManualVersion={setManualVersion}
+        isLivingDex={false}
+        setIsLivingDex={setIsLivingDex}
+        globalPokeball="poke"
+        setGlobalPokeball={setGlobalPokeball}
+        filteredPokeballs={[{ value: 'poke', label: 'Poke Ball' }]}
+        genConfig={null}
+        nuzlockeGraveyardBox={null}
+        setNuzlockeGraveyardBox={setNuzlockeGraveyardBox}
+        storageLocations={['Box 1', 'Box 2']}
+      />,
+    );
+
+    const select = page.getByRole('combobox');
+
+    await userEvent.selectOptions(select.element(), 'Box 1');
+    expect(setNuzlockeGraveyardBox).toHaveBeenCalledWith('Box 1');
+
+    await userEvent.selectOptions(select.element(), '');
+    expect(setNuzlockeGraveyardBox).toHaveBeenCalledWith(null);
   });
 
   it('handles version change', async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -54,6 +54,8 @@ interface AppStore {
   isLivingDex: boolean;
   /** Global visual preference for which Pokéball to use in the UI. */
   globalPokeball: PokeballType;
+  /** Designated PC box for dead Pokemon in Nuzlocke mode. */
+  nuzlockeGraveyardBox: string | null;
   /** Toggles a specific UI filter type in the `filters` array. */
   toggleFilter: (f: FilterType) => void;
   /** Overwrites the entire array of active UI filters. */
@@ -64,6 +66,8 @@ interface AppStore {
   setIsLivingDex: (v: boolean) => void;
   /** Sets the global visual Pokéball preference. */
   setGlobalPokeball: (v: PokeballType) => void;
+  /** Sets the Nuzlocke graveyard box. */
+  setNuzlockeGraveyardBox: (box: string | null) => void;
 
   // Transient UI state (not persisted)
   /** Current search query for filtering Pokémon lists. */
@@ -116,6 +120,7 @@ export const useStore = create<AppStore>()(
       manualVersion: null,
       isLivingDex: false,
       globalPokeball: 'poke',
+      nuzlockeGraveyardBox: null,
 
       toggleFilter: (f) => {
         const current = get().filters;
@@ -129,6 +134,7 @@ export const useStore = create<AppStore>()(
       setManualVersion: (v) => set({ manualVersion: v }),
       setIsLivingDex: (v) => set({ isLivingDex: v }),
       setGlobalPokeball: (v) => set({ globalPokeball: v }),
+      setNuzlockeGraveyardBox: (v) => set({ nuzlockeGraveyardBox: v }),
 
       // Transient UI
       searchTerm: '',
@@ -166,6 +172,7 @@ export const useStore = create<AppStore>()(
         manualVersion: state.manualVersion,
         isLivingDex: state.isLivingDex,
         globalPokeball: state.globalPokeball,
+        nuzlockeGraveyardBox: state.nuzlockeGraveyardBox,
       }),
     },
   ),


### PR DESCRIPTION
Resolves the Nuzlocke graveyard tracking implementation. 

Added the capability to designate a specific PC Box as the graveyard via the settings menu. Modified the storage grid and cards to display a visual "dead" state (grayscale sprite, skull icon, red border) for any Pokémon located in the designated graveyard box, as well as for any Pokémon in the party whose current HP is 0. Updated tests to cover the new settings properties. Checked off the acceptance criteria in the corresponding task node.

---
*PR created automatically by Jules for task [734693888859395226](https://jules.google.com/task/734693888859395226) started by @szubster*