### PR TITLE
chore(foundry): Validate death tracking and graveyard logic

### DIFF
--- a/.foundry/tasks/task-070-127-qa-death-tracking-retry.md
+++ b/.foundry/tasks/task-070-127-qa-death-tracking-retry.md
@@ -27,6 +27,6 @@ notes: ''
 Validate the death tracking and graveyard logic implementation.
 
 ## Acceptance Criteria
-- [ ] Run `pnpm test` and ensure tests pass.
-- [ ] Validate fainted Pokémon in the party are detected as dead.
-- [ ] Validate Pokémon in the designated Graveyard PC Box are permanently marked as dead.
+- [x] Run `pnpm test` and ensure tests pass.
+- [x] Validate fainted Pokémon in the party are detected as dead.
+- [x] Validate Pokémon in the designated Graveyard PC Box are permanently marked as dead.


### PR DESCRIPTION
I have verified the death tracking and graveyard logic implementation. The task acceptance criteria have been checked off in the markdown body without modifying the YAML frontmatter. `pnpm lint` and `pnpm test` pass.

---
*PR created automatically by Jules for task [403907949014164523](https://jules.google.com/task/403907949014164523) started by @szubster*