### PR TITLE
⚡ Bolt: Eliminate Array.from().slice() array allocation overhead

### DIFF
--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -866,7 +866,12 @@ export function generateSuggestions(
   const effectiveVersion = manualVersion || saveData.gameVersion;
   const displayVersion = effectiveVersion === 'unknown' ? genConfig.defaultVersion : effectiveVersion;
   const displayVersionId = POKE_VERSION_MAP[displayVersion] || 1;
-  const queryTargets = Array.from(missingIds).slice(0, 100);
+  // ⚡ Bolt: Use a manual loop instead of Array.from().slice() to eliminate intermediate array allocations
+  const queryTargets: number[] = [];
+  for (const pid of missingIds) {
+    if (queryTargets.length >= 100) break;
+    queryTargets.push(pid);
+  }
 
   // Special Strategy-Specific Suggestions (e.g. Box full warning)
   const specialSuggestions = strategy.getSpecialSuggestions(saveData, Array.from(missingIds));


### PR DESCRIPTION
💡 What: Replaced `Array.from(missingIds).slice(0, 100)` with a manual `for...of` loop to build `queryTargets` in `suggestionEngine.ts`.
🎯 Why: `missingIds` is a `Set`. Using `Array.from(missingIds).slice(0, 100)` iterates over the entire set, creates a full-sized array of all missing IDs in memory, and then allocates a second, smaller array via `.slice()`. By manually looping and breaking early, we avoid creating the full intermediate array, which provides an O(N) -> O(K) (where K=100) performance improvement in terms of array allocations during every `generateSuggestions` execution.
📊 Measured Improvement: Reduces memory allocation operations.
How to Verify: Run `pnpm test` and `pnpm test:e2e` to verify suggestions are identical to the previous approach.

---
*PR created automatically by Jules for task [661038680370995875](https://jules.google.com/task/661038680370995875) started by @szubster*