### PR TITLE
Fix Foundry DAG Resolution Warnings: Invalid Owner Mapping

### DIFF
--- a/.foundry/prds/prd-063-034-permanent-failure-dashboard.md
+++ b/.foundry/prds/prd-063-034-permanent-failure-dashboard.md
@@ -2,8 +2,8 @@
 id: prd-063-034-permanent-failure-dashboard
 type: PRD
 title: Permanent Failure Dashboard View
-status: FAILED
-owner_persona: architect
+status: PENDING
+owner_persona: epic_planner
 created_at: '2026-05-22'
 updated_at: '2026-05-22'
 depends_on: []
@@ -16,7 +16,7 @@ tags:
   - dashboard
 research_references: []
 rejection_count: 0
-rejection_reason: Invalid owner_persona mapping
+rejection_reason: ''
 notes: ''
 ---
 
@@ -31,4 +31,4 @@ Create a dedicated "Permanent Failures" view or filter within the DAG Dashboard.
 - This will allow the Tech Lead or Product Manager to quickly identify deadlocks and spawn the necessary `RESEARCH` nodes to resolve them.
 
 ## Next Steps
-- [ ] Architect: Create an ADR evaluating the permanent failure dashboard implementation strategy and define the application-level state synchronization architecture.
+- [ ] Epic Planner: Create Epics for the permanent failure dashboard feature.


### PR DESCRIPTION
This PR resolves the DAG resolution warnings reported by the Foundry Engine. 

The orchestrator flagged `.foundry/prds/prd-063-034-permanent-failure-dashboard.md` as FAILED due to an "Invalid owner_persona mapping". Per the Foundry schema and orchestrator validation rules, PRD nodes cannot be owned by the `architect` persona. 

I have:
1. Updated the node's `owner_persona` to `epic_planner`.
2. Reset its `status` from `FAILED` to `PENDING`.
3. Cleared the `rejection_reason`.
4. Updated the markdown body to assign the next steps to the Epic Planner.

Verification:
- Ran the orchestrator in dry-run mode: `npx tsx .github/scripts/foundry-orchestrator.ts --dry-run --strict`. It successfully promoted the node to READY without warnings.
- Ran orchestrator unit tests: `npx vitest foundry-orchestrator.test.ts`. All tests passed.

Fixes #1727

---
*PR created automatically by Jules for task [16965017195343436944](https://jules.google.com/task/16965017195343436944) started by @szubster*