### PR TITLE
feat(foundry): generate epics for permanent failure dashboard

### DIFF
--- a/.foundry/epics/epic-034-046-dag-data-parsing-rejection-count.md
+++ b/.foundry/epics/epic-034-046-dag-data-parsing-rejection-count.md
@@ -1,0 +1,35 @@
+---
+id: epic-034-046-dag-data-parsing-rejection-count
+type: EPIC
+title: Extract and Broadcast Rejection Count in DAG Data Parsing
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-05-22"
+updated_at: "2026-05-22"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-063-034-permanent-failure-dashboard
+tags:
+  - foundry
+  - ui
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Extract and Broadcast Rejection Count in DAG Data Parsing
+
+## Context
+As per ADR 017 and PRD `prd-063-034-permanent-failure-dashboard`, we need a "Permanent Failures" view in the DAG Dashboard. To enable this without introducing new persistent state stores, we must update the DAG data parsing layer to extract the `rejection_count` field from the markdown frontmatter of `.foundry` files.
+
+## High-Level Requirements
+1. **Parser Update**: Modify the existing DAG data parser to read and extract the `rejection_count` property from the YAML frontmatter of each parsed node.
+2. **Data Model Update**: Update any associated TypeScript interfaces/types representing a Foundry DAG node to include `rejection_count: number`.
+3. **Context Broadcasting**: Ensure the extracted `rejection_count` is broadcasted via the shared React Context to all connected dashboard views.
+
+## Acceptance Criteria
+- [ ] Story Owner: Create a Story to implement the parser updates and context broadcasting for `rejection_count`.
+- [ ] Story Owner: Verify the newly created Story follows the correct dependency chain and schema.

--- a/.foundry/epics/epic-034-047-permanent-failure-dashboard-ui.md
+++ b/.foundry/epics/epic-034-047-permanent-failure-dashboard-ui.md
@@ -1,0 +1,36 @@
+---
+id: epic-034-047-permanent-failure-dashboard-ui
+type: EPIC
+title: Implement Permanent Failure Dashboard UI
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-05-22"
+updated_at: "2026-05-22"
+depends_on:
+  - .foundry/epics/epic-034-046-dag-data-parsing-rejection-count.md
+jules_session_id: null
+pr_number: null
+parent: prd-063-034-permanent-failure-dashboard
+tags:
+  - foundry
+  - ui
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement Permanent Failure Dashboard UI
+
+## Context
+As per ADR 017 and PRD `prd-063-034-permanent-failure-dashboard`, we need a "Permanent Failures" view in the DAG Dashboard. This epic handles the UI implementation, which relies on the `rejection_count` data exposed by `epic-034-046-dag-data-parsing-rejection-count`.
+
+## High-Level Requirements
+1. **View/Filter Integration**: Add a new view mode or filter to the existing DAG Dashboard UI (built on React Flow / Kanban Board).
+2. **Filtering Logic**: The UI should filter nodes based on the shared context, selecting those with `status: FAILED` and `rejection_count >= MAX_REJECTION_THRESHOLD`.
+3. **Visual Highlighting**: Ensure permanently failed nodes are visually distinct to allow the Tech Lead or Product Manager to quickly identify deadlocks.
+
+## Acceptance Criteria
+- [ ] Story Owner: Create a Story to implement the UI for the permanent failure view/filter.
+- [ ] Story Owner: Ensure the new UI correctly consumes the `rejection_count` property from the shared React Context.

--- a/.foundry/prds/prd-063-034-permanent-failure-dashboard.md
+++ b/.foundry/prds/prd-063-034-permanent-failure-dashboard.md
@@ -31,4 +31,8 @@ Create a dedicated "Permanent Failures" view or filter within the DAG Dashboard.
 - This will allow the Tech Lead or Product Manager to quickly identify deadlocks and spawn the necessary `RESEARCH` nodes to resolve them.
 
 ## Next Steps
-- [ ] Epic Planner: Create Epics for the permanent failure dashboard feature.
+- [x] Epic Planner: Create Epics for the permanent failure dashboard feature.
+
+### Downstream Epics
+- `.foundry/epics/epic-034-046-dag-data-parsing-rejection-count.md`
+- `.foundry/epics/epic-034-047-permanent-failure-dashboard-ui.md`


### PR DESCRIPTION
This PR implements the breakdown of PRD `prd-063-034-permanent-failure-dashboard.md` into actionable Epics.

### Changes
1. Created `epic-034-046-dag-data-parsing-rejection-count.md` to extract the `rejection_count` field from the markdown frontmatter of `.foundry` files in the DAG data parsing layer, as dictated by ADR 017.
2. Created `epic-034-047-permanent-failure-dashboard-ui.md` to implement the UI for the permanent failure view/filter, depending on the data parsing Epic.
3. Updated the Acceptance Criteria inside `prd-063-034-permanent-failure-dashboard.md` to mark the Epic Planner task as complete and appended the child node references to the bottom of the document without altering the YAML frontmatter.

The orchestrator was verified locally in dry-run mode, and all tests pass. All dependencies follow the schema rules and avoid cyclic definitions.

---
*PR created automatically by Jules for task [5284350698219197104](https://jules.google.com/task/5284350698219197104) started by @szubster*