### PR TITLE
🧹 Remove deprecated addListener from mocks

### DIFF
--- a/src/node-setup.ts
+++ b/src/node-setup.ts
@@ -34,8 +34,6 @@ Object.defineProperty(globalThis, 'matchMedia', {
         matches: false,
         media: query,
         onchange: null,
-        addListener: vi.fn<() => void>(), // deprecated
-        removeListener: vi.fn<() => void>(), // deprecated
         addEventListener: vi.fn<() => void>(),
         removeEventListener: vi.fn<() => void>(),
         dispatchEvent: vi.fn<() => void>(),

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -10,8 +10,6 @@ Object.defineProperty(window, 'matchMedia', {
         matches: false,
         media: query,
         onchange: null,
-        addListener: vi.fn<() => void>(), // deprecated
-        removeListener: vi.fn<() => void>(), // deprecated
         addEventListener: vi.fn<() => void>(),
         removeEventListener: vi.fn<() => void>(),
         dispatchEvent: vi.fn<() => void>(),


### PR DESCRIPTION
🎯 **What:** Removed deprecated `addListener` and `removeListener` methods from the `matchMedia` mocks in `src/node-setup.ts` and `src/test-setup.ts`.
💡 **Why:** Usage of `addListener` and `removeListener` in `MediaQueryList` is deprecated in favor of the standard `addEventListener` and `removeEventListener`. Removing them from test mocks encourages usage of the modern standard across the codebase and prevents new tests from relying on outdated APIs. This improves overall code health and maintainability.
✅ **Verification:** Ran `git diff` to verify only the intended code was removed. Re-ran the full test suite and linters locally (`pnpm lint` and `pnpm test`), confirming that no application logic was dependent on these deprecated mock functions and the test suite passes successfully.
✨ **Result:** A cleaner test setup with standard event listener mocks.

---
*PR created automatically by Jules for task [11562624977129462404](https://jules.google.com/task/11562624977129462404) started by @szubster*