### PR TITLE
Fix Impossible Loop QA test in foundry orchestrator

### DIFF
--- a/.foundry/tasks/task-072-128-implement-dag-cancellation.md
+++ b/.foundry/tasks/task-072-128-implement-dag-cancellation.md
@@ -38,9 +38,9 @@ As requested in `story-035-072-implement-cancellation-logic`, the orchestrator n
 - Log cancellation details to the console output.
 
 ## Acceptance Criteria
-- [ ] Implement detection of permanently failed nodes (`status === 'FAILED'` and `rejection_reason === 'Max rejection count reached'`) during the DAG evaluation cycle in `.github/scripts/foundry-orchestrator.ts`.
-- [ ] Traverse the DAG to identify all `PENDING` nodes that rely directly or indirectly on the failed node via their `depends_on` array.
-- [ ] Transition identified `PENDING` nodes to `CANCELLED`.
-- [ ] Set `rejection_reason` for the newly cancelled nodes to `"Cancelled due to permanent failure of dependency: <failed-node-id>"`.
-- [ ] Include loop detection/safeguards to prevent infinite traversals if circular dependencies exist.
-- [ ] Output console logs for the cancellation operations.
+- [x] Implement detection of permanently failed nodes (`status === 'FAILED'` and `rejection_reason === 'Max rejection count reached'`) during the DAG evaluation cycle in `.github/scripts/foundry-orchestrator.ts`.
+- [x] Traverse the DAG to identify all `PENDING` nodes that rely directly or indirectly on the failed node via their `depends_on` array.
+- [x] Transition identified `PENDING` nodes to `CANCELLED`.
+- [x] Set `rejection_reason` for the newly cancelled nodes to `"Cancelled due to permanent failure of dependency: <failed-node-id>"`.
+- [x] Include loop detection/safeguards to prevent infinite traversals if circular dependencies exist.
+- [x] Output console logs for the cancellation operations.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -983,7 +983,7 @@ describe('foundry-orchestrator', () => {
   });
 
 
-  test.fails('Impossible Loop: ignores COMPLETED nodes during permanent failure cancellation cascade', () => {
+  test('Impossible Loop: ignores COMPLETED nodes during permanent failure cancellation cascade', () => {
     createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
       id: "story-001",
       type: "STORY",


### PR DESCRIPTION
This commit removes `test.fails` from the "Impossible Loop: ignores COMPLETED nodes during permanent failure cancellation cascade" test in `.github/scripts/foundry-orchestrator.test.ts`. The implementation already ignores `COMPLETED` nodes appropriately and does not incorrectly sweep them up in cascade cancellation, contrary to what the QA persona suggested. The task acceptance criteria in `.foundry/tasks/task-072-128-implement-dag-cancellation.md` were also updated.

---
*PR created automatically by Jules for task [18176954015458791470](https://jules.google.com/task/18176954015458791470) started by @szubster*