### PR TITLE
Create Story 085 for Rejection Count Parsing

### DIFF
--- a/.foundry/epics/epic-034-046-dag-data-parsing-rejection-count.md
+++ b/.foundry/epics/epic-034-046-dag-data-parsing-rejection-count.md
@@ -31,5 +31,8 @@ As per ADR 017 and PRD `prd-063-034-permanent-failure-dashboard`, we need a "Per
 3. **Context Broadcasting**: Ensure the extracted `rejection_count` is broadcasted via the shared React Context to all connected dashboard views.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Create a Story to implement the parser updates and context broadcasting for `rejection_count`.
-- [ ] Story Owner: Verify the newly created Story follows the correct dependency chain and schema.
+- [x] Story Owner: Create a Story to implement the parser updates and context broadcasting for `rejection_count`.
+- [x] Story Owner: Verify the newly created Story follows the correct dependency chain and schema.
+
+## Child Nodes
+- .foundry/stories/story-046-085-extract-broadcast-rejection-count.md

--- a/.foundry/stories/story-046-085-extract-broadcast-rejection-count.md
+++ b/.foundry/stories/story-046-085-extract-broadcast-rejection-count.md
@@ -1,0 +1,38 @@
+---
+id: story-046-085-extract-broadcast-rejection-count
+type: STORY
+title: Extract and Broadcast Rejection Count in DAG Data Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-23'
+updated_at: '2026-05-23'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-034-046-dag-data-parsing-rejection-count
+tags:
+  - foundry
+  - ui
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extract and Broadcast Rejection Count in DAG Data Parsing
+
+## Objective
+Update the existing DAG data parser to read and extract the `rejection_count` property from the YAML frontmatter of `.foundry` files. Update associated frontend models to include this data and ensure it's exposed through the React Context layer for the DAG Dashboard UI.
+
+## Context
+In order to display permanent failures on the DAG dashboard, we need to surface the `rejection_count` of each node in the UI.
+
+## Requirements
+1. Update parsing logic to capture `rejection_count`.
+2. Update the `FoundryNode` TypeScript types.
+3. Verify that the React context layer correctly exposes the property.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Create TASKs for updating parser and data models.
+- [ ] Tech Lead: Ensure DAG data model typing is consistent with ADR 017.


### PR DESCRIPTION
Creates a new STORY node `story-046-085-extract-broadcast-rejection-count` based on Epic 046 to implement the parser updates and context broadcasting for the `rejection_count` parameter, as required by ADR 017. Updates the parent Epic's markdown body to check off acceptance criteria and link the child node.

---
*PR created automatically by Jules for task [10493826956005819662](https://jules.google.com/task/10493826956005819662) started by @szubster*