### PR TITLE
QA Reject: Visited Routes Checklist Implementation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -11,3 +11,6 @@ Rejected `task-072-128-implement-dag-cancellation` because it violated the archi
 During the validation of `task-072-128-implement-dag-cancellation`, I discovered a critical invariant violation in the DAG orchestrator. The Wait and Wake phase (Phase 3.5) was incorrectly transitioning `COMPLETED` nodes to `PENDING` if they had incomplete dependencies. This violates the core orchestrator principle that `COMPLETED` nodes are immutable, and caused those nodes to be erroneously swept up by downstream cascade cancellation logic.
 
 **Lesson**: When checking nodes for suspension based on incomplete dependencies, the orchestrator MUST strictly ignore nodes that are already in terminal states (`COMPLETED` or `CANCELLED`). Terminal state immutability is essential to prevent infinite loops and incorrect cascading status updates.
+
+## Missing Integration Failures
+When an implementation task only creates standalone UI components but fails to integrate or render them anywhere in the main application (making them inaccessible to the user), the task MUST be rejected. The purpose of implementation isn't just to write code that passes isolated unit tests; it is to deliver accessible features.

--- a/.foundry/tasks/task-071-136-visited-routes-checklist-impl.md
+++ b/.foundry/tasks/task-071-136-visited-routes-checklist-impl.md
@@ -2,7 +2,7 @@
 id: task-071-136-visited-routes-checklist-impl
 type: TASK
 title: Implement Visited Routes Checklist
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-05-22'
 updated_at: '2026-05-23'
@@ -14,8 +14,10 @@ tags:
   - feature
   - nuzlocke
   - verification
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: >-
+  Component is implemented but never rendered or integrated anywhere in the app
+  (e.g. no Run Dashboard exists to show it).
 notes: ''
 ---
 

--- a/.foundry/tasks/task-071-137-visited-routes-checklist-qa.md
+++ b/.foundry/tasks/task-071-137-visited-routes-checklist-qa.md
@@ -28,3 +28,5 @@ QA the visited and unvisited routes checklist for the Run Dashboard UI.
 ## Acceptance Criteria
 - [ ] Verify the visited routes checklist UI functions correctly.
 - [ ] Verify the unvisited routes checklist UI functions correctly.
+
+**QA Failure Note:** The implementation task was failed. While the `VisitedRoutesChecklist` component was created, it is completely unlinked and not rendered anywhere in the application. There is no Run Dashboard UI that is accessible to verify this component against a real user journey.


### PR DESCRIPTION
QA review of the Visited Routes Checklist implementation. The implementation was rejected because while the `VisitedRoutesChecklist` UI component was created and verified with unit tests, it was never actually linked, rendered, or made accessible within the application (e.g., there is no Run Dashboard to view it).

The implementation task was marked as FAILED, the QA task was updated to reflect this, and a lesson was appended to the QA journal.

---
*PR created automatically by Jules for task [17745401163861383763](https://jules.google.com/task/17745401163861383763) started by @szubster*