### PR TITLE
🧱 Mason: TacticalRadioGroup extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -66,3 +66,11 @@
 - **Key Learnings**:
   - Separating `labelClassName` and `valueClassName` allows for necessary typographic variations (like alignment or colors) while still leveraging the base structural pattern.
   - Always manually verify existing files using tools like `grep` before attempting substitutions, as files may have drifted from expected state.
+
+## TacticalRadioGroup Extraction
+- **What**: Extracted the repeating custom segmented control/radio group pattern (used for Game Version, Living Dex Mode, Ball Style, Target Status, etc.) into a reusable `TacticalRadioGroup` and `TacticalRadioGroupItem` pair using React Context.
+- **Why**: Reduced duplicated JSX and highly repetitive Tailwind tactical styling variants (blue, emerald, amber, primary, zinc). Crucially, this standardized and fixed accessibility by ensuring `role="radiogroup"` and `role="radio"` and the use of `aria-checked` instead of `aria-pressed`.
+- **Key Learnings**:
+  - When standardizing compound components like radio groups that need to pass state/handlers to children, React Context (`createContext`) is effective to prevent prop drilling and keep the child item usage clean.
+  - Omit native DOM properties that clash with custom interface types using TypeScript utility types (e.g., `Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>`).
+  - When mapping custom layout variants in Tailwind (e.g., grid vs flex layouts in segmented controls), it's important to not only pass layout props but abstract the structural CSS completely, so consumers do not need to understand the grid gap or flex border styling requirements.

--- a/src/components/TacticalRadioGroup.tsx
+++ b/src/components/TacticalRadioGroup.tsx
@@ -1,0 +1,126 @@
+import type React from 'react';
+import { createContext, useContext } from 'react';
+import { cn } from '../utils/cn';
+
+interface RadioGroupContextType {
+  value: string;
+  onChange: (value: string) => void;
+  variant: 'emerald' | 'blue' | 'amber' | 'primary' | 'zinc';
+  layout: 'grid' | 'flex';
+}
+
+const RadioGroupContext = createContext<RadioGroupContextType | null>(null);
+
+function useRadioGroupContext() {
+  const context = useContext(RadioGroupContext);
+  if (!context) {
+    throw new Error('TacticalRadioGroupItem must be used within a TacticalRadioGroup');
+  }
+  return context;
+}
+
+export interface TacticalRadioGroupProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  value: string;
+  onChange: (value: string) => void;
+  variant?: 'emerald' | 'blue' | 'amber' | 'primary' | 'zinc';
+  layout?: 'grid' | 'flex';
+  columns?: number;
+  'aria-label': string;
+}
+
+export function TacticalRadioGroup({
+  value,
+  onChange,
+  variant = 'emerald',
+  layout = 'grid',
+  columns = 3,
+  className,
+  children,
+  'aria-label': ariaLabel,
+  ...props
+}: TacticalRadioGroupProps) {
+  return (
+    <RadioGroupContext.Provider value={{ value, onChange, variant, layout }}>
+      <div
+        role="radiogroup"
+        aria-label={ariaLabel}
+        className={cn(
+          layout === 'flex' ? 'flex border border-zinc-800 border-dashed' : 'grid gap-2',
+          layout === 'grid' && {
+            'grid-cols-2': columns === 2,
+            'grid-cols-3': columns === 3,
+            'grid-cols-4': columns === 4,
+          },
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </RadioGroupContext.Provider>
+  );
+}
+
+export interface TacticalRadioGroupItemProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'value' | 'onChange'> {
+  value: string;
+  className?: string;
+  activeClassName?: string;
+}
+
+export function TacticalRadioGroupItem({
+  value,
+  className,
+  activeClassName,
+  children,
+  ...props
+}: TacticalRadioGroupItemProps) {
+  const { value: selectedValue, onChange, variant, layout } = useRadioGroupContext();
+  const isActive = selectedValue === value;
+
+  const baseItemClasses = cn(
+    'font-black font-mono text-[9px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+    {
+      'flex-1 border-zinc-800 border-l border-dashed px-2 py-2 first:border-l-0': layout === 'flex',
+      'rounded-none border border-dashed px-3 py-3': layout === 'grid',
+      'focus-visible:ring-emerald-500': variant === 'emerald',
+      'focus-visible:ring-blue-500': variant === 'blue',
+      'focus-visible:ring-amber-500': variant === 'amber',
+      'focus-visible:ring-[var(--theme-primary)]': variant === 'primary',
+      'focus-visible:ring-zinc-500': variant === 'zinc',
+    },
+  );
+
+  const activeStyles = cn(
+    {
+      'border-emerald-400 bg-emerald-500 text-zinc-950 shadow-[0_0_15px_rgba(16,185,129,0.4)]': variant === 'emerald',
+      'border-blue-500 bg-blue-500/20 text-blue-400 shadow-[0_0_10px_rgba(59,130,246,0.3)]': variant === 'blue',
+      'border-amber-500 bg-amber-500/20 text-amber-400 shadow-[0_0_10px_rgba(245,158,11,0.3)]': variant === 'amber',
+      'border-[var(--theme-primary)] bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[0_0_10px_rgba(var(--theme-primary-rgb),0.3)]':
+        variant === 'primary',
+      'border-zinc-500 bg-zinc-500/20 text-zinc-400 shadow-[0_0_10px_rgba(113,113,122,0.3)]': variant === 'zinc',
+    },
+    activeClassName,
+  );
+
+  const inactiveStyles = cn({
+    'bg-zinc-950 text-zinc-600 hover:bg-zinc-900/50 hover:text-zinc-400': layout === 'flex',
+    'border-zinc-800 bg-zinc-950 text-zinc-500 hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300':
+      layout === 'grid',
+  });
+
+  return (
+    // oxlint-disable jsx-a11y/prefer-tag-over-role
+    // biome-ignore lint/a11y/useSemanticElements: custom radio segmented control needs proper styling
+    <button
+      role="radio"
+      type="button"
+      aria-checked={isActive}
+      onClick={() => onChange(value)}
+      className={cn(baseItemClasses, isActive ? activeStyles : inactiveStyles, className)}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/pokemon/details/PokemonCatchProbability.tsx
+++ b/src/components/pokemon/details/PokemonCatchProbability.tsx
@@ -4,6 +4,7 @@ import type { PokeballType } from '../../../store';
 import { cn } from '../../../utils/cn';
 import { DataPoint } from '../../DataPoint';
 import { TacticalPanel } from '../../TacticalPanel';
+import { TacticalRadioGroup, TacticalRadioGroupItem } from '../../TacticalRadioGroup';
 
 interface PokemonCatchProbabilityProps {
   catchRate: number;
@@ -68,27 +69,25 @@ export function PokemonCatchProbability({ catchRate, effectivePokeball }: Pokemo
           </div>
         </div>
 
-        <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Target Status">
+        <TacticalRadioGroup
+          value={status}
+          onChange={(val) => setStatus(val as StatusType)}
+          variant="emerald"
+          layout="grid"
+          columns={3}
+          aria-label="Target Status"
+        >
           {STATUS_OPTIONS.map((item) => (
-            // oxlint-disable jsx-a11y/prefer-tag-over-role
-            // biome-ignore lint/a11y/useSemanticElements: custom radio segmented control needs proper styling
-            <button
-              type="button"
-              role="radio"
+            <TacticalRadioGroupItem
               key={item.id}
-              aria-checked={status === item.id}
-              onClick={() => setStatus(item.id)}
-              className={cn(
-                'rounded-none border border-dashed py-3 font-black text-[9px] uppercase tracking-widest outline-none transition-all focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-95',
-                status === item.id
-                  ? 'border-emerald-400 bg-emerald-500 text-zinc-950 shadow-[0_5px_15px_rgba(16,185,129,0.3)]'
-                  : 'border-white/10 bg-black/40 text-emerald-500/50 hover:border-emerald-500/40 hover:bg-emerald-500/10',
-              )}
+              value={item.id}
+              className="active:scale-95"
+              activeClassName="border-emerald-400 bg-emerald-500 text-zinc-950 shadow-[0_5px_15px_rgba(16,185,129,0.3)]"
             >
               {item.label}
-            </button>
+            </TacticalRadioGroupItem>
           ))}
-        </div>
+        </TacticalRadioGroup>
       </div>
 
       <div className="flex flex-col gap-2 border-emerald-500/10 border-t pt-8">

--- a/src/components/settings/SettingsControls.tsx
+++ b/src/components/settings/SettingsControls.tsx
@@ -3,6 +3,7 @@ import type { GameVersion, PokeballType } from '../../store';
 import type { GenerationConfig } from '../../utils/generationConfig';
 import { getGenerationConfig } from '../../utils/generationConfig';
 import { SettingsRow } from '../SettingsRow';
+import { TacticalRadioGroup, TacticalRadioGroupItem } from '../TacticalRadioGroup';
 
 interface SettingsControlsProps {
   effectiveVersion: string;
@@ -43,23 +44,20 @@ export function SettingsControls({
         iconColorClass="border-blue-500/20 bg-blue-500/10"
         label="Version"
       >
-        <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Game Version">
+        <TacticalRadioGroup
+          value={effectiveVersion}
+          onChange={(val) => setManualVersion(val === 'unknown' ? null : (val as GameVersion))}
+          variant="blue"
+          layout="grid"
+          columns={3}
+          aria-label="Game Version"
+        >
           {versions.map((v) => (
-            <button
-              key={v.id}
-              type="button"
-              onClick={() => setManualVersion(v.id === 'unknown' ? null : v.id)}
-              className={`rounded-none border border-dashed px-3 py-2 font-black font-mono text-[9px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
-                effectiveVersion === v.id || (v.id === 'unknown' && effectiveVersion === 'unknown')
-                  ? 'border-blue-500 bg-blue-500/20 text-blue-400 shadow-[0_0_10px_rgba(59,130,246,0.3)]'
-                  : 'border-zinc-800 bg-zinc-950 text-zinc-500 hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300'
-              }`}
-              aria-pressed={effectiveVersion === v.id || (v.id === 'unknown' && effectiveVersion === 'unknown')}
-            >
+            <TacticalRadioGroupItem key={v.id} value={v.id} className="py-2">
               {v.label}
-            </button>
+            </TacticalRadioGroupItem>
           ))}
-        </div>
+        </TacticalRadioGroup>
       </SettingsRow>
 
       <SettingsRow
@@ -67,38 +65,21 @@ export function SettingsControls({
         iconColorClass="border-purple-500/20 bg-purple-500/10"
         label="Living Dex"
       >
-        <div className="flex border border-zinc-800 border-dashed" role="radiogroup" aria-label="Living Dex Mode">
-          {/* oxlint-disable jsx-a11y/prefer-tag-over-role */}
-          {/* biome-ignore lint/a11y/useSemanticElements: segmented control needs proper styling */}
-          <button
-            role="radio"
-            type="button"
-            onClick={() => setIsLivingDex(false)}
-            aria-checked={!isLivingDex}
-            className={`flex-1 px-2 py-2 font-black font-mono text-[9px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
-              !isLivingDex
-                ? 'bg-zinc-800 text-white'
-                : 'bg-zinc-950 text-zinc-600 hover:bg-zinc-900/50 hover:text-zinc-400'
-            }`}
+        <TacticalRadioGroup
+          value={isLivingDex ? 'true' : 'false'}
+          onChange={(val) => setIsLivingDex(val === 'true')}
+          variant="emerald"
+          layout="flex"
+          aria-label="Living Dex Mode"
+        >
+          <TacticalRadioGroupItem
+            value="false"
+            activeClassName="bg-zinc-800 text-white shadow-none border-none focus-visible:ring-emerald-500"
           >
             [ STANDARD ]
-          </button>
-          {/* oxlint-disable jsx-a11y/prefer-tag-over-role */}
-          {/* biome-ignore lint/a11y/useSemanticElements: segmented control needs proper styling */}
-          <button
-            role="radio"
-            type="button"
-            onClick={() => setIsLivingDex(true)}
-            aria-checked={isLivingDex}
-            className={`flex-1 border-zinc-800 border-l border-dashed px-2 py-2 font-black font-mono text-[9px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
-              isLivingDex
-                ? 'bg-emerald-500 text-zinc-950 shadow-[0_0_15px_rgba(16,185,129,0.4)]'
-                : 'bg-zinc-950 text-zinc-600 hover:bg-zinc-900/50 hover:text-zinc-400'
-            }`}
-          >
-            [ LIVING DEX ]
-          </button>
-        </div>
+          </TacticalRadioGroupItem>
+          <TacticalRadioGroupItem value="true">[ LIVING DEX ]</TacticalRadioGroupItem>
+        </TacticalRadioGroup>
       </SettingsRow>
 
       <SettingsRow
@@ -106,18 +87,19 @@ export function SettingsControls({
         iconColorClass="border-amber-500/20 bg-amber-500/10"
         label="Ball Style"
       >
-        <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Ball Style">
+        <TacticalRadioGroup
+          value={globalPokeball}
+          onChange={(val) => setGlobalPokeball(val as PokeballType)}
+          variant="amber"
+          layout="grid"
+          columns={3}
+          aria-label="Ball Style"
+        >
           {filteredPokeballs.map((pb) => (
-            <button
+            <TacticalRadioGroupItem
               key={pb.value}
-              type="button"
-              onClick={() => setGlobalPokeball(pb.value as PokeballType)}
-              className={`flex flex-col items-center justify-center gap-1.5 rounded-none border border-dashed py-3 font-black font-mono text-[9px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
-                globalPokeball === pb.value
-                  ? 'border-amber-500 bg-amber-500/20 text-amber-400 shadow-[0_0_10px_rgba(245,158,11,0.3)]'
-                  : 'border-zinc-800 bg-zinc-950 text-zinc-500 hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300'
-              }`}
-              aria-pressed={globalPokeball === pb.value}
+              value={pb.value}
+              className="flex flex-col items-center justify-center gap-1.5 py-3"
             >
               <div
                 className={`h-4 w-4 rounded-none border ${
@@ -133,9 +115,9 @@ export function SettingsControls({
                 }`}
               />
               {pb.label}
-            </button>
+            </TacticalRadioGroupItem>
           ))}
-        </div>
+        </TacticalRadioGroup>
       </SettingsRow>
 
       <SettingsRow


### PR DESCRIPTION
🎯 What
Extracted a reusable `TacticalRadioGroup` and `TacticalRadioGroupItem` component pair to replace repeating segmented control patterns across the app.

💡 Why
Groups of buttons acting as radio selections were repeatedly implemented in `SettingsControls` and `PokemonCatchProbability`. They duplicated massive amounts of tactical Tailwind styling for variants like blue, emerald, amber, primary, and zinc. More importantly, several of these implementations were missing `role="radio"` and using `aria-pressed` instead of `aria-checked`, which is bad for accessibility. This abstraction centralizes styling, state, and a11y attributes.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` locally without errors. All e2e tests continue to pass. Verified via automated Code Review.

✨ Result
Massive reduction in boilerplate inside settings and probability panels, along with improved typing and ARIA standards compliance.

---
*PR created automatically by Jules for task [12965171447189010797](https://jules.google.com/task/12965171447189010797) started by @szubster*