### PR TITLE
🧭 Strategist: Prompt improvement - Read Foundry journals to assess persona prompts

### DIFF
--- a/.github/agents/strategist.md
+++ b/.github/agents/strategist.md
@@ -4,7 +4,7 @@ Review the current Jules agent roster, the quality of existing prompts, and the 
 
 ## Context
 
-The current agent roster lives in `.github/agents/`. Before proposing anything, **read every existing schedule** to understand what's already covered. Also review agent journals (e.g., `.jules/bolt.md`, `.jules/canvas.md`) to assess whether their prompts are producing good results based on their recorded successes and failures.
+The current agent roster lives in `.github/agents/`. Before proposing anything, **read every existing schedule** to understand what's already covered. Also review agent journals (e.g., `.jules/bolt.md`, `.foundry/journals/coder.md`) to assess whether their prompts are producing good results based on their recorded successes and failures.
 
 ## Focus Areas
 
@@ -20,7 +20,7 @@ The current agent roster lives in `.github/agents/`. Before proposing anything, 
 - Read your journal before starting — it's your only memory
 - Include a journal entry for the current change in every PR you open. Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability.
 - Read all files in `.github/agents/` before proposing anything
-- Review agent journals (`.jules/*.md`) to assess prompt effectiveness instead of searching git or PR history
+- Review agent journals (`.jules/*.md`, `.foundry/journals/*.md`) to assess prompt effectiveness instead of searching git or PR history
 - Study the current codebase structure, agent journals, and open issues for context
 - Propose in a clear format with justification and evidence
 - **Commit your precise file changes** to the repository (creating, mutating, or deleting the files inside `.github/agents/`).

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -138,3 +138,9 @@
 **Outcome:** Merged
 **Why:** The architect's journal showed it was reprimanded for creating functional execution nodes (`EPIC`, `STORY`, `TASK`) and reminded that its role is strictly architectural blueprinting (ADRs). Furthermore, system memory dictates that when global data contracts change (e.g., ADR 010), the Architect must update `.foundry/docs/schema.md`.
 **Pattern:** Codify role constraints (e.g., node creation boundaries) and secondary responsibilities (e.g., schema updates alongside ADRs) directly into agent prompts to prevent role drift and maintain system documentation.
+
+## 2026-07-08 - [Accepted] - Prompt improvement - Read Foundry journals to assess persona prompts
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The Strategist was only instructed to read `.jules/*.md` to assess agent prompt quality, missing all Foundry execution personas which log their learnings to `.foundry/journals/*.md` (e.g., coder, qa, tech_lead). This gap prevented the Strategist from identifying prompt quality issues for the most active execution agents.
+**Pattern:** Update prompts to ensure they have access to the correct and complete set of journals for all personas, specifically including both `.jules/` and `.foundry/journals/` when reading logs to identify issues.


### PR DESCRIPTION
**Proposal**: Modified `.github/agents/strategist.md` to explicitly instruct the Strategist persona to review `.foundry/journals/*.md` alongside `.jules/*.md` when evaluating prompt quality.

**Justification**: The existing Strategist prompt restricted it to reading only `.jules/*.md` files for its journal analysis. This meant the Strategist was entirely blind to the execution history, recurring failures, and prompt friction experienced by the primary Foundry personas (e.g., coder, qa, tech_lead, tpm), as their journals are located in `.foundry/journals/`. By lacking visibility into the execution layer, the Strategist could not identify when those specific prompts needed structural improvements.

**Evidence**: 
- The Strategist's own prompt instructed it to: `- Review agent journals (\`.jules/*.md\`) to assess prompt effectiveness instead of searching git or PR history`.
- All Foundry execution personas (Coder, QA, Tech Lead, TPM) explicitly log to `.foundry/journals/*.md` according to their prompts (e.g. `cat .github/agents/coder.md`).
- A previous Strategist run successfully updated the Archivist prompt to also clean up `.foundry/journals/` because it suffered from the same blind spot, proving that the directory split exists and needs to be accounted for by meta-agents.

---
*PR created automatically by Jules for task [3708871997644293156](https://jules.google.com/task/3708871997644293156) started by @szubster*