### PR TITLE
🖼️ Canvas: Tactical BottomNav Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -122,3 +122,9 @@
 **Outcome:** Accepted
 **Why:** Brings the interactive inputs of the settings panel in line with the rest of the application's heavily tactical, specialized hardware motif, correcting the generic web UI elements previously used.
 **Pattern:** Consistently eliminate generic web UI patterns (native `<select>` dropdowns, default sliding toggles) in favor of sharp, high-contrast, terminal-like button grids or segmented controls to maintain the specialized device illusion.
+
+## 2026-06-10 - [Accepted] - 🖼️ Canvas: Tactical BottomNav Redesign
+**What:** Redesigned the `BottomNav` component (the mobile bottom navigation bar) to fully embrace the tactical "snooping" hardware aesthetic. Replaced the generic sliding background box with a sharp, dashed-border hardware frame, complete with `CornerCrosshairs` (`border-t-[3px] border-l-[3px]`), a scanning laser line (`animate-[scan_2s_linear_infinite]`), and monospaced bracketed text (e.g. `[ DEX ]`). Added LCD flicker and pulse animations to the active tab to simulate an active terminal state.
+**Outcome:** Accepted
+**Why:** Brings the mobile navigation interface tightly in line with the rest of the application's established tactical hardware motif (matching `AppLayout`, `Grid`, and `Details`), correcting the previous web-standard smooth transitions.
+**Pattern:** Ensure mobile layout structural components adhere to strict tactical aesthetics (sharp borders, corner crosshairs, scanning/flicker animations, monospace telemetry text) rather than generic app-like smoothed navigation bars, to maintain the specialized device illusion.

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -31,18 +31,21 @@ export function BottomNav() {
       />
 
       <div className="relative mx-auto grid max-w-md grid-cols-5 items-center">
-        {/* Active Indicator Brackets */}
+        {/* Active Indicator Hardware Frame */}
         {activeIndex !== -1 && (
           <div
-            className="pointer-events-none absolute z-0 h-full w-[20%] transition-transform duration-500 ease-out"
+            className="pointer-events-none absolute z-0 h-full w-[20%] transition-transform duration-300 ease-[cubic-bezier(0.2,1,0.2,1)]"
             style={{ transform: `translateX(${activeIndex * 100}%)` }}
           >
-            <div className="absolute top-0 left-2 h-2 w-2 border-[var(--theme-primary)] border-t-2 border-l-2" />
-            <div className="absolute top-0 right-2 h-2 w-2 border-[var(--theme-primary)] border-t-2 border-r-2" />
-            <div className="absolute bottom-0 left-2 h-2 w-2 border-[var(--theme-primary)] border-b-2 border-l-2" />
-            <div className="absolute right-2 bottom-0 h-2 w-2 border-[var(--theme-primary)] border-r-2 border-b-2" />
-            <div className="absolute inset-x-2 inset-y-0 bg-[var(--theme-primary)]/10" />
-            <div className="scanline-overlay absolute inset-x-2 inset-y-0 opacity-20" />
+            <div className="absolute inset-x-1 inset-y-0.5 border border-[var(--theme-primary)]/50 border-dashed bg-[var(--theme-primary)]/10" />
+            <div className="absolute top-0 left-1 h-2 w-2 border-[var(--theme-primary)] border-t-[3px] border-l-[3px]" />
+            <div className="absolute top-0 right-1 h-2 w-2 border-[var(--theme-primary)] border-t-[3px] border-r-[3px]" />
+            <div className="absolute bottom-0 left-1 h-2 w-2 border-[var(--theme-primary)] border-b-[3px] border-l-[3px]" />
+            <div className="absolute right-1 bottom-0 h-2 w-2 border-[var(--theme-primary)] border-r-[3px] border-b-[3px]" />
+
+            {/* Scanning Laser Line */}
+            <div className="absolute inset-x-1 top-0 h-[1px] animate-[scan_2s_linear_infinite] bg-[var(--theme-primary)] opacity-50 shadow-[0_0_8px_var(--theme-primary)]" />
+            <div className="scanline-overlay absolute inset-x-1 inset-y-0.5 opacity-30" />
           </div>
         )}
 
@@ -53,17 +56,18 @@ export function BottomNav() {
           aria-current={isDex ? 'page' : undefined}
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
-            isDex ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
+            isDex ? 'text-[var(--theme-primary)]' : 'text-zinc-600 hover:text-zinc-400',
           )}
         >
-          <div className="transition-transform active:scale-90">
+          {isDex && <div className="lcd-flicker absolute inset-0 bg-[var(--theme-primary)]/5" />}
+          <div className={cn('transition-transform', isDex ? 'animate-pulse' : 'active:scale-90')}>
             <LayoutGrid
               size={20}
               strokeWidth={isDex ? 2.5 : 2}
-              className={cn(isDex && 'drop-shadow-[0_0_8px_rgba(var(--theme-primary-rgb),0.8)]')}
+              className={cn(isDex && 'drop-shadow-[0_0_10px_rgba(var(--theme-primary-rgb),1)]')}
             />
           </div>
-          <span className="font-bold text-[9px] uppercase tracking-widest">SYS.DEX</span>
+          <span className="font-bold font-mono text-[9px] uppercase tracking-[0.2em]">{isDex ? '[ DEX ]' : 'DEX'}</span>
         </Link>
 
         <Link
@@ -73,17 +77,20 @@ export function BottomNav() {
           aria-current={isStorage ? 'page' : undefined}
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
-            isStorage ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
+            isStorage ? 'text-[var(--theme-primary)]' : 'text-zinc-600 hover:text-zinc-400',
           )}
         >
-          <div className="transition-transform active:scale-90">
+          {isStorage && <div className="lcd-flicker absolute inset-0 bg-[var(--theme-primary)]/5" />}
+          <div className={cn('transition-transform', isStorage ? 'animate-pulse' : 'active:scale-90')}>
             <Database
               size={20}
               strokeWidth={isStorage ? 2.5 : 2}
-              className={cn(isStorage && 'drop-shadow-[0_0_8px_rgba(var(--theme-primary-rgb),0.8)]')}
+              className={cn(isStorage && 'drop-shadow-[0_0_10px_rgba(var(--theme-primary-rgb),1)]')}
             />
           </div>
-          <span className="font-bold text-[9px] uppercase tracking-widest">SYS.STRG</span>
+          <span className="font-bold font-mono text-[9px] uppercase tracking-[0.2em]">
+            {isStorage ? '[ STRG ]' : 'STRG'}
+          </span>
         </Link>
 
         <Link
@@ -93,17 +100,20 @@ export function BottomNav() {
           aria-current={isAssistant ? 'page' : undefined}
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
-            isAssistant ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
+            isAssistant ? 'text-[var(--theme-primary)]' : 'text-zinc-600 hover:text-zinc-400',
           )}
         >
-          <div className="transition-transform active:scale-90">
+          {isAssistant && <div className="lcd-flicker absolute inset-0 bg-[var(--theme-primary)]/5" />}
+          <div className={cn('transition-transform', isAssistant ? 'animate-pulse' : 'active:scale-90')}>
             <Sparkles
               size={20}
               strokeWidth={isAssistant ? 2.5 : 2}
-              className={cn(isAssistant && 'drop-shadow-[0_0_8px_rgba(var(--theme-primary-rgb),0.8)]')}
+              className={cn(isAssistant && 'drop-shadow-[0_0_10px_rgba(var(--theme-primary-rgb),1)]')}
             />
           </div>
-          <span className="font-bold text-[9px] uppercase tracking-widest">SYS.ASST</span>
+          <span className="font-bold font-mono text-[9px] uppercase tracking-[0.2em]">
+            {isAssistant ? '[ ASST ]' : 'ASST'}
+          </span>
         </Link>
 
         <Link
@@ -113,17 +123,18 @@ export function BottomNav() {
           aria-current={isDag ? 'page' : undefined}
           className={cn(
             'group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
-            isDag ? 'text-[var(--theme-primary)]' : 'text-zinc-600',
+            isDag ? 'text-[var(--theme-primary)]' : 'text-zinc-600 hover:text-zinc-400',
           )}
         >
-          <div className="transition-transform active:scale-90">
+          {isDag && <div className="lcd-flicker absolute inset-0 bg-[var(--theme-primary)]/5" />}
+          <div className={cn('transition-transform', isDag ? 'animate-pulse' : 'active:scale-90')}>
             <GitGraph
               size={20}
               strokeWidth={isDag ? 2.5 : 2}
-              className={cn(isDag && 'drop-shadow-[0_0_8px_rgba(var(--theme-primary-rgb),0.8)]')}
+              className={cn(isDag && 'drop-shadow-[0_0_10px_rgba(var(--theme-primary-rgb),1)]')}
             />
           </div>
-          <span className="font-bold text-[9px] uppercase tracking-widest">SYS.DAG</span>
+          <span className="font-bold font-mono text-[9px] uppercase tracking-[0.2em]">{isDag ? '[ DAG ]' : 'DAG'}</span>
         </Link>
 
         <button
@@ -132,12 +143,12 @@ export function BottomNav() {
           aria-label="Open settings menu"
           title="Open settings menu"
           aria-expanded={isSettingsOpen}
-          className="group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 text-zinc-600 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+          className="group relative z-10 flex flex-col items-center gap-1.5 rounded-none py-2 text-zinc-600 transition-all duration-300 hover:text-zinc-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
           <div className="transition-transform active:scale-90">
             <Settings2 size={20} strokeWidth={2} />
           </div>
-          <span className="font-bold text-[9px] uppercase tracking-widest">SYS.MENU</span>
+          <span className="font-bold font-mono text-[9px] uppercase tracking-[0.2em]">MENU</span>
         </button>
       </div>
     </nav>

--- a/src/components/__tests__/BottomNav.test.tsx
+++ b/src/components/__tests__/BottomNav.test.tsx
@@ -66,9 +66,9 @@ describe('BottomNav', () => {
       </QueryClientProvider>,
     );
 
-    await expect.element(getByText('SYS.DEX')).toBeInTheDocument();
-    await expect.element(getByText('SYS.STRG')).toBeInTheDocument();
-    await expect.element(getByText('SYS.ASST')).toBeInTheDocument();
-    await expect.element(getByText('SYS.MENU')).toBeInTheDocument();
+    await expect.element(getByText('[ DEX ]')).toBeInTheDocument();
+    await expect.element(getByText('STRG')).toBeInTheDocument();
+    await expect.element(getByText('ASST')).toBeInTheDocument();
+    await expect.element(getByText('MENU')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Redesigned the `BottomNav` component (mobile bottom navigation bar) to fully embrace the tactical "snooping" hardware aesthetic.
- Replaced the generic sliding background box with a sharp, dashed-border hardware frame.
- Added `CornerCrosshairs` (`border-t-[3px] border-l-[3px]`).
- Added a scanning laser line (`animate-[scan_2s_linear_infinite]`).
- Updated active tab text to use monospaced brackets (e.g. `[ DEX ]`).
- Added LCD flicker (`lcd-flicker`) and pulse animations to the active tab to simulate an active terminal state.
- Updated `canvas.md` with new learnings.

---
*PR created automatically by Jules for task [3551254591572802972](https://jules.google.com/task/3551254591572802972) started by @szubster*