### PR TITLE
Fix Foundry Orchestration Failure and Sync Schema Validator

### DIFF
--- a/.foundry/epics/epic-003-actions-engine.md
+++ b/.foundry/epics/epic-003-actions-engine.md
@@ -1,14 +1,16 @@
 ---
 id: epic-003-actions-engine
 type: EPIC
-title: "GitHub Actions Orchestration Engine"
+title: GitHub Actions Orchestration Engine
 status: COMPLETED
 owner_persona: epic_planner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
-parent: ".foundry/ideas/idea-001-the-foundry.md"
+created_at: '2026-04-20'
+updated_at: '2026-04-20'
+parent: .foundry/ideas/idea-001-the-foundry.md
 depends_on: []
 jules_session_id: null
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # GitHub Actions Orchestration Engine

--- a/.foundry/epics/epic-004-distributed-id-schema.md
+++ b/.foundry/epics/epic-004-distributed-id-schema.md
@@ -1,17 +1,20 @@
 ---
 id: epic-004-distributed-id-schema
 type: EPIC
-title: "Collision-Free ID Schema Implementation"
-status: "COMPLETED"
+title: Collision-Free ID Schema Implementation
+status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-21"
-updated_at: "2026-04-22"
+created_at: '2026-04-21'
+updated_at: '2026-04-22'
 depends_on: []
 jules_session_id: null
 parent: .foundry/prds/prd-001-distributed-ids.md
-tags: ["schema", "distributed-ids"]
+tags:
+  - schema
+  - distributed-ids
 rejection_count: 1
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Epic: Collision-Free ID Schema Implementation

--- a/.foundry/epics/epic-004-generic-agent-scheduling.md
+++ b/.foundry/epics/epic-004-generic-agent-scheduling.md
@@ -1,17 +1,19 @@
 ---
-id: "epic-004-generic-agent-scheduling"
-type: "EPIC"
-title: "Generic Agent Scheduling"
-status: "COMPLETED"
-owner_persona: "story_owner"
-created_at: "2026-04-21"
-updated_at: "2026-04-22"
+id: epic-004-generic-agent-scheduling
+type: EPIC
+title: Generic Agent Scheduling
+status: COMPLETED
+owner_persona: story_owner
+created_at: '2026-04-21'
+updated_at: '2026-04-22'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/prds/prd-001-agent-scheduling.md"
-tags: ["infrastructure"]
+parent: .foundry/prds/prd-001-agent-scheduling.md
+tags:
+  - infrastructure
 rejection_count: 0
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Generic Agent Scheduling

--- a/.foundry/epics/epic-005-shadow-dispatch-prevention.md
+++ b/.foundry/epics/epic-005-shadow-dispatch-prevention.md
@@ -1,17 +1,20 @@
 ---
 id: epic-005-shadow-dispatch-prevention
 type: EPIC
-title: "Shadow Dispatch Prevention & Cross-Branch Locks"
-status: "COMPLETED"
+title: Shadow Dispatch Prevention & Cross-Branch Locks
+status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-21"
-updated_at: "2026-04-22"
+created_at: '2026-04-21'
+updated_at: '2026-04-22'
 depends_on: []
 jules_session_id: null
 parent: .foundry/prds/prd-001-distributed-ids.md
-tags: ["orchestrator", "concurrency"]
+tags:
+  - orchestrator
+  - concurrency
 rejection_count: 1
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Epic: Shadow Dispatch Prevention & Cross-Branch Locks

--- a/.foundry/epics/epic-005-tpm-agent-scheduling.md
+++ b/.foundry/epics/epic-005-tpm-agent-scheduling.md
@@ -1,18 +1,20 @@
 ---
-id: "epic-005-tpm-agent-scheduling"
-type: "EPIC"
-title: "TPM Agent Scheduling"
-status: "COMPLETED"
-owner_persona: "story_owner"
-created_at: "2026-04-21"
-updated_at: "2026-04-23"
+id: epic-005-tpm-agent-scheduling
+type: EPIC
+title: TPM Agent Scheduling
+status: COMPLETED
+owner_persona: story_owner
+created_at: '2026-04-21'
+updated_at: '2026-04-23'
 depends_on:
-  - ".foundry/epics/epic-004-generic-agent-scheduling.md"
+  - .foundry/epics/epic-004-generic-agent-scheduling.md
 jules_session_id: null
-parent: ".foundry/prds/prd-001-agent-scheduling.md"
-tags: ["infrastructure"]
+parent: .foundry/prds/prd-001-agent-scheduling.md
+tags:
+  - infrastructure
 rejection_count: 1
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # TPM Agent Scheduling

--- a/.foundry/epics/epic-006-id-pre-commit-hooks.md
+++ b/.foundry/epics/epic-006-id-pre-commit-hooks.md
@@ -1,18 +1,21 @@
 ---
 id: epic-006-id-pre-commit-hooks
 type: EPIC
-title: "ID Integrity Pre-Commit Validation"
-status: "COMPLETED"
+title: ID Integrity Pre-Commit Validation
+status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-21"
-updated_at: "2026-04-25"
+created_at: '2026-04-21'
+updated_at: '2026-04-25'
 depends_on:
   - .foundry/epics/epic-004-distributed-id-schema.md
 jules_session_id: null
 parent: .foundry/prds/prd-001-distributed-ids.md
-tags: ["ci", "pre-commit"]
+tags:
+  - ci
+  - pre-commit
 rejection_count: 0
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Epic: ID Integrity Pre-Commit Validation

--- a/.foundry/epics/epic-007-atomic-handoff-schema.md
+++ b/.foundry/epics/epic-007-atomic-handoff-schema.md
@@ -1,15 +1,20 @@
 ---
-id: "epic-007-atomic-handoff-schema"
-type: "EPIC"
-title: "Epic: Atomic Handoff Schema & Documentation"
-status: "COMPLETED"
-owner_persona: "story_owner"
-created_at: "2026-04-22"
-updated_at: "2026-04-23"
+id: epic-007-atomic-handoff-schema
+type: EPIC
+title: 'Epic: Atomic Handoff Schema & Documentation'
+status: COMPLETED
+owner_persona: story_owner
+created_at: '2026-04-22'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/prds/prd-001-v2-lifecycle.md"
-tags: ["v2-architecture", "lifecycle", "atomic-handoffs"]
+parent: .foundry/prds/prd-001-v2-lifecycle.md
+tags:
+  - v2-architecture
+  - lifecycle
+  - atomic-handoffs
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Epic: Atomic Handoff Schema & Documentation

--- a/.foundry/epics/epic-008-atomic-handoff-orchestrator.md
+++ b/.foundry/epics/epic-008-atomic-handoff-orchestrator.md
@@ -1,16 +1,21 @@
 ---
-id: "epic-008-atomic-handoff-orchestrator"
-type: "EPIC"
-title: "Epic: Orchestrator Script Refactor for Atomic Handoffs"
-status: "COMPLETED"
-owner_persona: "story_owner"
-created_at: "2026-04-22"
-updated_at: "2026-04-26"
+id: epic-008-atomic-handoff-orchestrator
+type: EPIC
+title: 'Epic: Orchestrator Script Refactor for Atomic Handoffs'
+status: COMPLETED
+owner_persona: story_owner
+created_at: '2026-04-22'
+updated_at: '2026-04-26'
 depends_on:
   - .foundry/epics/epic-007-atomic-handoff-schema.md
 jules_session_id: null
-parent: ".foundry/prds/prd-001-v2-lifecycle.md"
-tags: ["v2-architecture", "lifecycle", "atomic-handoffs"]
+parent: .foundry/prds/prd-001-v2-lifecycle.md
+tags:
+  - v2-architecture
+  - lifecycle
+  - atomic-handoffs
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Epic: Orchestrator Script Refactor for Atomic Handoffs

--- a/.foundry/epics/epic-009-020-relax-node-engine.md
+++ b/.foundry/epics/epic-009-020-relax-node-engine.md
@@ -1,17 +1,20 @@
 ---
 id: epic-009-020-relax-node-engine
 type: EPIC
-title: "Relax Node engine requirement in package.json to >=22.0.0"
-status: "COMPLETED"
-owner_persona: "story_owner"
-created_at: "2026-05-01"
-updated_at: "2026-05-01"
+title: Relax Node engine requirement in package.json to >=22.0.0
+status: COMPLETED
+owner_persona: story_owner
+created_at: '2026-05-01'
+updated_at: '2026-05-01'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: ".foundry/prds/prd-011-009-relax-node-engine.md"
-tags: ["infrastructure"]
-notes: ""
+parent: .foundry/prds/prd-011-009-relax-node-engine.md
+tags:
+  - infrastructure
+notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Relax Node engine requirement in package.json to >=22.0.0

--- a/.foundry/epics/epic-009-atomic-handoff-testing.md
+++ b/.foundry/epics/epic-009-atomic-handoff-testing.md
@@ -1,19 +1,24 @@
 ---
-id: "epic-009-atomic-handoff-testing"
-type: "EPIC"
-title: "Epic: Atomic Handoff Testing Expansion"
+id: epic-009-atomic-handoff-testing
+type: EPIC
+title: 'Epic: Atomic Handoff Testing Expansion'
 status: PENDING
-owner_persona: "story_owner"
-created_at: "2026-04-22"
-updated_at: "2026-04-27"
+owner_persona: story_owner
+created_at: '2026-04-22'
+updated_at: '2026-04-27'
 depends_on:
   - .foundry/epics/epic-008-atomic-handoff-orchestrator.md
   - .foundry/archive/stories/story-009-032-lifecycle-integration-tests.md
   - .foundry/stories/story-009-031-deadlock-prevention-tests.md
   - .foundry/archive/stories/story-009-030-single-persona-dag-tests.md
 jules_session_id: null
-parent: ".foundry/prds/prd-001-v2-lifecycle.md"
-tags: ["v2-architecture", "lifecycle", "atomic-handoffs"]
+parent: .foundry/prds/prd-001-v2-lifecycle.md
+tags:
+  - v2-architecture
+  - lifecycle
+  - atomic-handoffs
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Epic: Atomic Handoff Testing Expansion

--- a/.foundry/epics/epic-010-human-schema.md
+++ b/.foundry/epics/epic-010-human-schema.md
@@ -1,17 +1,19 @@
 ---
 id: epic-010-human-schema
 type: EPIC
-title: "Update Foundry Schema for Human Persona"
-status: "COMPLETED"
+title: Update Foundry Schema for Human Persona
+status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/prds/prd-004-human-in-the-loop.md"
+parent: .foundry/prds/prd-004-human-in-the-loop.md
 tags:
-  - "human-in-the-loop"
-  - "schema"
+  - human-in-the-loop
+  - schema
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Epic 010: Update Foundry Schema for Human Persona

--- a/.foundry/epics/epic-010-oxlint-config.md
+++ b/.foundry/epics/epic-010-oxlint-config.md
@@ -1,11 +1,11 @@
 ---
-id: "epic-010-oxlint-config"
-type: "EPIC"
-title: "Tighten oxlint configuration and enable plugins"
-status: "COMPLETED"
-owner_persona: "story_owner"
-created_at: "2026-04-23"
-updated_at: "2026-05-01"
+id: epic-010-oxlint-config
+type: EPIC
+title: Tighten oxlint configuration and enable plugins
+status: COMPLETED
+owner_persona: story_owner
+created_at: '2026-04-23'
+updated_at: '2026-05-01'
 parent: null
 depends_on:
   - .foundry/archive/stories/story-010-028-verify-jest-tests.md
@@ -14,6 +14,8 @@ depends_on:
   - .foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
   - .foundry/stories/story-010-014-implement-oxlint-config.md
 jules_session_id: null
+rejection_reason: ''
+rejection_count: 0
 ---
 
 ## Summary

--- a/.foundry/epics/epic-010-persona-permissions.md
+++ b/.foundry/epics/epic-010-persona-permissions.md
@@ -1,18 +1,20 @@
 ---
 id: epic-010-persona-permissions
 type: EPIC
-title: "Persona Permissions Matrix for Late Binding"
-status: "COMPLETED"
+title: Persona Permissions Matrix for Late Binding
+status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-23"
-updated_at: "2026-04-23"
+created_at: '2026-04-23'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/prds/prd-005-010-late-binding-orchestrator.md"
+parent: .foundry/prds/prd-005-010-late-binding-orchestrator.md
 tags:
   - foundry-v2
   - architecture
   - orchestration
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Persona Permissions Matrix for Late Binding

--- a/.foundry/epics/epic-011-022-implement-gray-matter.md
+++ b/.foundry/epics/epic-011-022-implement-gray-matter.md
@@ -1,17 +1,23 @@
 ---
 id: epic-011-022-implement-gray-matter
 type: EPIC
-title: "Epic: Implement Gray-Matter parsing system-wide"
-status: "COMPLETED"
-owner_persona: "epic_planner"
-created_at: "2026-05-02"
-updated_at: "2026-05-03"
+title: 'Epic: Implement Gray-Matter parsing system-wide'
+status: COMPLETED
+owner_persona: epic_planner
+created_at: '2026-05-02'
+updated_at: '2026-05-03'
 depends_on:
   - .foundry/prds/prd-012-011-gray-matter-parsing.md
 jules_session_id: null
-parent: ".foundry/prds/prd-012-011-gray-matter-parsing.md"
-tags: ["foundry", "parsing", "gray-matter", "maintenance"]
-notes: "Derived from PRD prd-012-011-gray-matter-parsing. Enforces ADR-006."
+parent: .foundry/prds/prd-012-011-gray-matter-parsing.md
+tags:
+  - foundry
+  - parsing
+  - gray-matter
+  - maintenance
+notes: Derived from PRD prd-012-011-gray-matter-parsing. Enforces ADR-006.
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Epic: Implement Gray-Matter parsing system-wide

--- a/.foundry/epics/epic-011-human-orchestrator.md
+++ b/.foundry/epics/epic-011-human-orchestrator.md
@@ -1,18 +1,20 @@
 ---
 id: epic-011-human-orchestrator
 type: EPIC
-title: "Bypass Jules Dispatch for Human Tasks in Orchestrator"
-status: "COMPLETED"
+title: Bypass Jules Dispatch for Human Tasks in Orchestrator
+status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-23"
-updated_at: "2026-04-23"
+created_at: '2026-04-23'
+updated_at: '2026-04-23'
 depends_on:
-  - ".foundry/epics/epic-010-human-schema.md"
+  - .foundry/epics/epic-010-human-schema.md
 jules_session_id: null
-parent: ".foundry/prds/prd-004-human-in-the-loop.md"
+parent: .foundry/prds/prd-004-human-in-the-loop.md
 tags:
-  - "human-in-the-loop"
-  - "orchestrator"
+  - human-in-the-loop
+  - orchestrator
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Epic 011: Bypass Jules Dispatch for Human Tasks in Orchestrator

--- a/.foundry/epics/epic-011-wait-and-wake-protocol.md
+++ b/.foundry/epics/epic-011-wait-and-wake-protocol.md
@@ -1,19 +1,21 @@
 ---
 id: epic-011-wait-and-wake-protocol
 type: EPIC
-title: "Wait & Wake Protocol and Impossible Loop"
-status: "COMPLETED"
+title: Wait & Wake Protocol and Impossible Loop
+status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-23"
-updated_at: "2026-04-25"
+created_at: '2026-04-23'
+updated_at: '2026-04-25'
 depends_on:
   - .foundry/epics/epic-010-persona-permissions.md
 jules_session_id: null
-parent: ".foundry/prds/prd-005-010-late-binding-orchestrator.md"
+parent: .foundry/prds/prd-005-010-late-binding-orchestrator.md
 tags:
   - foundry-v2
   - architecture
   - orchestration
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Wait & Wake Protocol and Impossible Loop

--- a/.foundry/epics/epic-012-gastown-orchestrator.md
+++ b/.foundry/epics/epic-012-gastown-orchestrator.md
@@ -1,22 +1,24 @@
 ---
 id: epic-012-gastown-orchestrator
 type: EPIC
-title: "Gastown Cloudflare Worker Migration Evaluation"
-status: "COMPLETED"
+title: Gastown Cloudflare Worker Migration Evaluation
+status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-23"
-updated_at: "2026-05-01"
+created_at: '2026-04-23'
+updated_at: '2026-05-01'
 depends_on:
   - .foundry/epics/epic-011-wait-and-wake-protocol.md
   - .foundry/stories/story-012-029-document-gastown-migration-decision.md
   - .foundry/stories/story-012-027-design-sync-mechanism.md
   - .foundry/stories/story-012-026-evaluate-cloudflare-storage.md
 jules_session_id: null
-parent: ".foundry/prds/prd-005-010-late-binding-orchestrator.md"
+parent: .foundry/prds/prd-005-010-late-binding-orchestrator.md
 tags:
   - foundry-v2
   - architecture
   - orchestration
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Gastown Cloudflare Worker Migration Evaluation

--- a/.foundry/epics/epic-012-human-heartbeat.md
+++ b/.foundry/epics/epic-012-human-heartbeat.md
@@ -1,18 +1,20 @@
 ---
 id: epic-012-human-heartbeat
 type: EPIC
-title: "Modify Heartbeat Script for Human Tasks"
-status: "COMPLETED"
+title: Modify Heartbeat Script for Human Tasks
+status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-23"
-updated_at: "2026-04-23"
+created_at: '2026-04-23'
+updated_at: '2026-04-23'
 depends_on:
-  - ".foundry/epics/epic-010-human-schema.md"
+  - .foundry/epics/epic-010-human-schema.md
 jules_session_id: null
-parent: ".foundry/prds/prd-004-human-in-the-loop.md"
+parent: .foundry/prds/prd-004-human-in-the-loop.md
 tags:
-  - "human-in-the-loop"
-  - "heartbeat"
+  - human-in-the-loop
+  - heartbeat
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Epic 012: Modify Heartbeat Script for Human Tasks

--- a/.foundry/epics/epic-013-023-orchestrator-cascade-cancellation.md
+++ b/.foundry/epics/epic-013-023-orchestrator-cascade-cancellation.md
@@ -2,10 +2,10 @@
 id: epic-013-023-orchestrator-cascade-cancellation
 type: EPIC
 title: 'Epic: Implement Cascading Cancellation in Orchestrator'
-status: "COMPLETED"
+status: COMPLETED
 owner_persona: story_owner
 created_at: '2026-05-03'
-updated_at: "2026-05-04"
+updated_at: '2026-05-04'
 depends_on: []
 jules_session_id: null
 pr_number: null
@@ -16,6 +16,8 @@ tags:
   - orchestrator
   - cancellation
 notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Epic: Implement Cascading Cancellation in Orchestrator

--- a/.foundry/epics/epic-030-038-cloudflare-google-sso.md
+++ b/.foundry/epics/epic-030-038-cloudflare-google-sso.md
@@ -21,6 +21,7 @@ rejection_reason: ''
 notes: >-
   Derived from PRD 055-030. Establishes the secure foundation for single-user
   login before save syncing.
+rejection_count: 0
 ---
 
 # Epic: Cloudflare Single Sign-On (SSO) Authentication

--- a/.foundry/epics/epic-030-039-cloudflare-r2-save-sync.md
+++ b/.foundry/epics/epic-030-039-cloudflare-r2-save-sync.md
@@ -20,7 +20,10 @@ tags:
 research_references:
   - .foundry/research/research-030-004-cloudflare-storage-evaluation.md
 rejection_reason: ''
-notes: Derived from PRD 055-030 and Research 030-004. Uses Cloudflare R2 for strong consistency and file blob storage.
+notes: >-
+  Derived from PRD 055-030 and Research 030-004. Uses Cloudflare R2 for strong
+  consistency and file blob storage.
+rejection_count: 0
 ---
 
 # Epic: Cloudflare R2 Offline-First Save Syncing

--- a/.foundry/epics/epic-032-042-generation-pipeline-keys.md
+++ b/.foundry/epics/epic-032-042-generation-pipeline-keys.md
@@ -11,6 +11,7 @@ jules_session_id: null
 parent: prd-005-032-revert-data-optimizations
 rejection_reason: ''
 notes: ''
+rejection_count: 0
 ---
 
 # Epic: Update Data Generation Pipeline to Verbose Keys

--- a/.foundry/epics/epic-032-043-runtime-interfaces-keys.md
+++ b/.foundry/epics/epic-032-043-runtime-interfaces-keys.md
@@ -12,6 +12,7 @@ jules_session_id: null
 parent: prd-005-032-revert-data-optimizations
 rejection_reason: ''
 notes: ''
+rejection_count: 0
 ---
 
 # Epic: Update Runtime Interfaces to Verbose Keys

--- a/.foundry/epics/epic-053-024-032-gen3-encounters-implementation.md
+++ b/.foundry/epics/epic-053-024-032-gen3-encounters-implementation.md
@@ -14,6 +14,8 @@ tags:
   - feature
   - encounters
 notes: Spawned from PRD 053-024 to implement Gen 3 encounter data
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Epic: Gen 3 Encounters Implementation

--- a/.foundry/stories/story-001-matrix-runner.md
+++ b/.foundry/stories/story-001-matrix-runner.md
@@ -1,14 +1,16 @@
 ---
 id: story-001-matrix-runner
 type: STORY
-title: "Matrix-based Parallel Dispatcher"
+title: Matrix-based Parallel Dispatcher
 status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
+created_at: '2026-04-20'
+updated_at: '2026-04-20'
 depends_on:
   - .foundry/epics/epic-003-actions-engine.md
 jules_session_id: null
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Matrix-based Parallel Dispatcher

--- a/.foundry/stories/story-002-personas.md
+++ b/.foundry/stories/story-002-personas.md
@@ -1,15 +1,16 @@
 ---
 id: story-002-personas
 type: STORY
-title: "Persona-aware Prompt Injection"
+title: Persona-aware Prompt Injection
 status: COMPLETED
 rejection_count: 3
 owner_persona: story_owner
-created_at: "2026-04-20"
-updated_at: "2026-04-21"
+created_at: '2026-04-20'
+updated_at: '2026-04-21'
 depends_on:
   - .foundry/epics/epic-003-actions-engine.md
 jules_session_id: null
+rejection_reason: ''
 ---
 
 # Persona-aware Prompt Injection

--- a/.foundry/stories/story-003-dynamic-verification.md
+++ b/.foundry/stories/story-003-dynamic-verification.md
@@ -1,15 +1,17 @@
 ---
 id: story-003-dynamic-verification
 type: STORY
-title: "Intelligent Verification & Evolution"
-status: "COMPLETED"
+title: Intelligent Verification & Evolution
+status: COMPLETED
 owner_persona: story_owner
-created_at: "2026-04-21"
-updated_at: "2026-04-23"
+created_at: '2026-04-21'
+updated_at: '2026-04-23'
 depends_on:
   - .foundry/docs/adrs/001-the-foundry-architecture.md
   - .foundry/stories/story-002-personas.md
 jules_session_id: null
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Intelligent Verification & Evolution

--- a/.foundry/stories/story-004-generic-scheduling-workflow.md
+++ b/.foundry/stories/story-004-generic-scheduling-workflow.md
@@ -1,14 +1,16 @@
 ---
 id: story-004-generic-scheduling-workflow
 type: STORY
-title: "Generic Scheduling Mechanism Workflow"
-status: "COMPLETED"
+title: Generic Scheduling Mechanism Workflow
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-22"
-updated_at: "2026-04-22"
+created_at: '2026-04-22'
+updated_at: '2026-04-22'
 depends_on: []
 jules_session_id: null
 parent: .foundry/epics/epic-004-generic-agent-scheduling.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Generic Scheduling Mechanism Workflow

--- a/.foundry/stories/story-004-id-schema-decision.md
+++ b/.foundry/stories/story-004-id-schema-decision.md
@@ -1,14 +1,16 @@
 ---
 id: story-004-id-schema-decision
 type: STORY
-title: "Decide ID Schema and Update Documentation"
-status: "COMPLETED"
+title: Decide ID Schema and Update Documentation
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-22"
-updated_at: "2026-04-23"
+created_at: '2026-04-22'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
 parent: .foundry/epics/epic-004-distributed-id-schema.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Story: Decide ID Schema and Update Documentation

--- a/.foundry/stories/story-004-shadow-dispatch-verification.md
+++ b/.foundry/stories/story-004-shadow-dispatch-verification.md
@@ -1,17 +1,21 @@
 ---
 id: story-004-shadow-dispatch-verification
 type: STORY
-title: "Shadow Dispatch Verification Phase"
-status: "COMPLETED"
+title: Shadow Dispatch Verification Phase
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-22"
-updated_at: "2026-04-23"
+created_at: '2026-04-22'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
 parent: .foundry/epics/epic-005-shadow-dispatch-prevention.md
-tags: ["orchestrator", "concurrency", "investigation"]
+tags:
+  - orchestrator
+  - concurrency
+  - investigation
 rejection_count: 0
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Story: Shadow Dispatch Verification Phase

--- a/.foundry/stories/story-005-012-configure-tpm-schedule.md
+++ b/.foundry/stories/story-005-012-configure-tpm-schedule.md
@@ -1,17 +1,19 @@
 ---
 id: story-005-012-configure-tpm-schedule
 type: STORY
-title: "Configure TPM Schedule"
-status: "COMPLETED"
+title: Configure TPM Schedule
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
 parent: .foundry/epics/epic-005-tpm-agent-scheduling.md
-tags: ["infrastructure"]
+tags:
+  - infrastructure
 rejection_count: 0
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Configure TPM Schedule

--- a/.foundry/stories/story-005-013-tpm-archiving-logic.md
+++ b/.foundry/stories/story-005-013-tpm-archiving-logic.md
@@ -1,17 +1,19 @@
 ---
 id: story-005-013-tpm-archiving-logic
 type: STORY
-title: "TPM Archiving Logic"
-status: "COMPLETED"
+title: TPM Archiving Logic
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
 parent: .foundry/epics/epic-005-tpm-agent-scheduling.md
-tags: ["infrastructure"]
+tags:
+  - infrastructure
 rejection_count: 0
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # TPM Archiving Logic

--- a/.foundry/stories/story-005-empty-state-handling.md
+++ b/.foundry/stories/story-005-empty-state-handling.md
@@ -1,15 +1,17 @@
 ---
 id: story-005-empty-state-handling
 type: STORY
-title: "Graceful Empty State Handling"
-status: "COMPLETED"
+title: Graceful Empty State Handling
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-22"
-updated_at: "2026-04-22"
+created_at: '2026-04-22'
+updated_at: '2026-04-22'
 depends_on:
   - .foundry/stories/story-004-generic-scheduling-workflow.md
 jules_session_id: null
 parent: .foundry/epics/epic-004-generic-agent-scheduling.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Graceful Empty State Handling

--- a/.foundry/stories/story-005-id-schema-templates.md
+++ b/.foundry/stories/story-005-id-schema-templates.md
@@ -1,15 +1,17 @@
 ---
 id: story-005-id-schema-templates
 type: STORY
-title: "Update Templates and Generation Scripts"
-status: "COMPLETED"
+title: Update Templates and Generation Scripts
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-22"
-updated_at: "2026-04-24"
+created_at: '2026-04-22'
+updated_at: '2026-04-24'
 depends_on:
   - .foundry/stories/story-004-id-schema-decision.md
 jules_session_id: null
 parent: .foundry/epics/epic-004-distributed-id-schema.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Story: Update Templates and Generation Scripts

--- a/.foundry/stories/story-006-015-implement-link-checker.md
+++ b/.foundry/stories/story-006-015-implement-link-checker.md
@@ -1,17 +1,20 @@
 ---
 id: story-006-015-implement-link-checker
 type: STORY
-title: "Implement Link Checker Pre-commit Hook"
-status: "COMPLETED"
+title: Implement Link Checker Pre-commit Hook
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-24"
-updated_at: "2026-04-25"
+created_at: '2026-04-24'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
 parent: .foundry/prds/prd-007-006-automated-link-checker.md
-tags: ["infras", "verification"]
+tags:
+  - infras
+  - verification
 rejection_count: 1
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Story: Implement Automated Link Checker Pre-commit Hook

--- a/.foundry/stories/story-006-022-implement-id-validation-hook.md
+++ b/.foundry/stories/story-006-022-implement-id-validation-hook.md
@@ -1,14 +1,16 @@
 ---
 id: story-006-022-implement-id-validation-hook
 type: STORY
-title: "Implement ID Validation Pre-commit Hook"
-status: "COMPLETED"
+title: Implement ID Validation Pre-commit Hook
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
 parent: .foundry/epics/epic-006-id-pre-commit-hooks.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Implement ID Validation Pre-commit Hook

--- a/.foundry/stories/story-006-scheduling-configuration.md
+++ b/.foundry/stories/story-006-scheduling-configuration.md
@@ -1,15 +1,17 @@
 ---
 id: story-006-scheduling-configuration
 type: STORY
-title: "Scheduling Configuration"
-status: "COMPLETED"
+title: Scheduling Configuration
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-22"
-updated_at: "2026-04-22"
+created_at: '2026-04-22'
+updated_at: '2026-04-22'
 depends_on:
   - .foundry/stories/story-004-generic-scheduling-workflow.md
 jules_session_id: null
 parent: .foundry/epics/epic-004-generic-agent-scheduling.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Scheduling Configuration

--- a/.foundry/stories/story-007-schema-invariant.md
+++ b/.foundry/stories/story-007-schema-invariant.md
@@ -1,14 +1,16 @@
 ---
-id: "story-007-schema-invariant"
-type: "STORY"
-title: "Update Schema Invariants for Atomic Handoffs"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+id: story-007-schema-invariant
+type: STORY
+title: Update Schema Invariants for Atomic Handoffs
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-007-atomic-handoff-schema.md"
+parent: .foundry/epics/epic-007-atomic-handoff-schema.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update Schema Invariants for Atomic Handoffs

--- a/.foundry/stories/story-008-023-validate-single-owner.md
+++ b/.foundry/stories/story-008-023-validate-single-owner.md
@@ -1,14 +1,16 @@
 ---
-id: "story-008-023-validate-single-owner"
-type: "STORY"
-title: "Validate Single Owner Persona in Orchestrator"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+id: story-008-023-validate-single-owner
+type: STORY
+title: Validate Single Owner Persona in Orchestrator
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-008-atomic-handoff-orchestrator.md"
+parent: .foundry/epics/epic-008-atomic-handoff-orchestrator.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Validate Single Owner Persona in Orchestrator

--- a/.foundry/stories/story-008-024-update-status-on-merge.md
+++ b/.foundry/stories/story-008-024-update-status-on-merge.md
@@ -1,14 +1,16 @@
 ---
-id: "story-008-024-update-status-on-merge"
-type: "STORY"
-title: "Update Node Status on PR Merge"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+id: story-008-024-update-status-on-merge
+type: STORY
+title: Update Node Status on PR Merge
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-008-atomic-handoff-orchestrator.md"
+parent: .foundry/epics/epic-008-atomic-handoff-orchestrator.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update Node Status on PR Merge

--- a/.foundry/stories/story-008-025-verify-dag-resolution.md
+++ b/.foundry/stories/story-008-025-verify-dag-resolution.md
@@ -1,16 +1,18 @@
 ---
-id: "story-008-025-verify-dag-resolution"
-type: "STORY"
-title: "Verify DAG Resolution with Atomic Files"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+id: story-008-025-verify-dag-resolution
+type: STORY
+title: Verify DAG Resolution with Atomic Files
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on:
-  - ".foundry/stories/story-008-023-validate-single-owner.md"
-  - ".foundry/stories/story-008-024-update-status-on-merge.md"
+  - .foundry/stories/story-008-023-validate-single-owner.md
+  - .foundry/stories/story-008-024-update-status-on-merge.md
 jules_session_id: null
-parent: ".foundry/epics/epic-008-atomic-handoff-orchestrator.md"
+parent: .foundry/epics/epic-008-atomic-handoff-orchestrator.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Verify DAG Resolution with Atomic Files

--- a/.foundry/stories/story-008-schema-examples.md
+++ b/.foundry/stories/story-008-schema-examples.md
@@ -1,15 +1,17 @@
 ---
-id: "story-008-schema-examples"
-type: "STORY"
-title: "Update Documentation Examples for Atomic Files"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-04-23"
-updated_at: "2026-04-25"
+id: story-008-schema-examples
+type: STORY
+title: Update Documentation Examples for Atomic Files
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-04-23'
+updated_at: '2026-04-25'
 depends_on:
-  - ".foundry/stories/story-007-schema-invariant.md"
+  - .foundry/stories/story-007-schema-invariant.md
 jules_session_id: null
-parent: ".foundry/epics/epic-007-atomic-handoff-schema.md"
+parent: .foundry/epics/epic-007-atomic-handoff-schema.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update Documentation Examples for Atomic Files

--- a/.foundry/stories/story-009-031-deadlock-prevention-tests.md
+++ b/.foundry/stories/story-009-031-deadlock-prevention-tests.md
@@ -1,16 +1,21 @@
 ---
-id: "story-009-031-deadlock-prevention-tests"
-type: "STORY"
-title: "Story: Deadlock Prevention Mechanism Unit Tests"
+id: story-009-031-deadlock-prevention-tests
+type: STORY
+title: 'Story: Deadlock Prevention Mechanism Unit Tests'
 status: PENDING
-owner_persona: "tech_lead"
-created_at: "2026-04-27"
-updated_at: "2026-04-27"
+owner_persona: tech_lead
+created_at: '2026-04-27'
+updated_at: '2026-04-27'
 depends_on:
   - .foundry/tasks/task-031-048-implement-deadlock-tests.md
 jules_session_id: null
-parent: ".foundry/epics/epic-009-atomic-handoff-testing.md"
-tags: ["v2-architecture", "lifecycle", "atomic-handoffs"]
+parent: .foundry/epics/epic-009-atomic-handoff-testing.md
+tags:
+  - v2-architecture
+  - lifecycle
+  - atomic-handoffs
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Story: Deadlock Prevention Mechanism Unit Tests

--- a/.foundry/stories/story-009-composite-deprecation.md
+++ b/.foundry/stories/story-009-composite-deprecation.md
@@ -1,15 +1,17 @@
 ---
-id: "story-009-composite-deprecation"
-type: "STORY"
-title: "Deprecate Composite Nodes in Schema"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-04-23"
-updated_at: "2026-04-25"
+id: story-009-composite-deprecation
+type: STORY
+title: Deprecate Composite Nodes in Schema
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-04-23'
+updated_at: '2026-04-25'
 depends_on:
-  - ".foundry/stories/story-007-schema-invariant.md"
+  - .foundry/stories/story-007-schema-invariant.md
 jules_session_id: null
-parent: ".foundry/epics/epic-007-atomic-handoff-schema.md"
+parent: .foundry/epics/epic-007-atomic-handoff-schema.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Deprecate Composite Nodes in Schema

--- a/.foundry/stories/story-010-012-schema-human-persona.md
+++ b/.foundry/stories/story-010-012-schema-human-persona.md
@@ -1,17 +1,19 @@
 ---
 id: story-010-012-schema-human-persona
 type: STORY
-title: "Update Foundry Schema for Human Persona"
-status: "COMPLETED"
+title: Update Foundry Schema for Human Persona
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-010-human-schema.md"
+parent: .foundry/epics/epic-010-human-schema.md
 tags:
-  - "human-in-the-loop"
-  - "schema"
+  - human-in-the-loop
+  - schema
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Story 012: Update Foundry Schema for Human Persona

--- a/.foundry/stories/story-010-014-implement-oxlint-config.md
+++ b/.foundry/stories/story-010-014-implement-oxlint-config.md
@@ -1,14 +1,16 @@
 ---
-id: "story-010-014-implement-oxlint-config"
-type: "STORY"
-title: "Implement strict oxlint configuration"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+id: story-010-014-implement-oxlint-config
+type: STORY
+title: Implement strict oxlint configuration
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-010-oxlint-config.md"
+parent: .foundry/epics/epic-010-oxlint-config.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Implement strict oxlint configuration

--- a/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
+++ b/.foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
@@ -1,15 +1,17 @@
 ---
-id: "story-010-015-enforce-strict-oxlint-rules"
-type: "STORY"
-title: "Fix disabled oxlint rules across the codebase"
-status: "COMPLETED"
-owner_persona: "story_owner"
-created_at: "2026-04-24"
-updated_at: "2026-04-25"
+id: story-010-015-enforce-strict-oxlint-rules
+type: STORY
+title: Fix disabled oxlint rules across the codebase
+status: COMPLETED
+owner_persona: story_owner
+created_at: '2026-04-24'
+updated_at: '2026-04-25'
 depends_on:
-  - ".foundry/tasks/task-014-027-configure-oxlint-json.md"
-parent: ".foundry/epics/epic-010-oxlint-config.md"
+  - .foundry/tasks/task-014-027-configure-oxlint-json.md
+parent: .foundry/epics/epic-010-oxlint-config.md
 jules_session_id: null
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Fix disabled oxlint rules across the codebase

--- a/.foundry/stories/story-010-016-enable-expensive-oxlint-checks.md
+++ b/.foundry/stories/story-010-016-enable-expensive-oxlint-checks.md
@@ -1,16 +1,18 @@
 ---
-id: "story-010-016-enable-expensive-oxlint-checks"
-type: "STORY"
-title: "Enable expensive and strict oxlint checks"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-04-26"
-updated_at: "2026-05-01"
+id: story-010-016-enable-expensive-oxlint-checks
+type: STORY
+title: Enable expensive and strict oxlint checks
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-04-26'
+updated_at: '2026-05-01'
 depends_on:
   - .foundry/tasks/task-016-040-oxlint-import-promise-plugins.md
   - .foundry/tasks/task-016-039-oxlint-type-aware.md
 jules_session_id: null
-parent: ".foundry/epics/epic-010-oxlint-config.md"
+parent: .foundry/epics/epic-010-oxlint-config.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Enable expensive and strict oxlint checks

--- a/.foundry/stories/story-010-017-fix-jest-rules.md
+++ b/.foundry/stories/story-010-017-fix-jest-rules.md
@@ -1,14 +1,16 @@
 ---
-id: "story-010-017-fix-jest-rules"
-type: "STORY"
-title: "Fix jest rules reported by oxlint"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-04-26"
-updated_at: "2026-04-27"
+id: story-010-017-fix-jest-rules
+type: STORY
+title: Fix jest rules reported by oxlint
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-04-26'
+updated_at: '2026-04-27'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-010-oxlint-config.md"
+parent: .foundry/epics/epic-010-oxlint-config.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Fix jest rules reported by oxlint

--- a/.foundry/stories/story-010-orchestrator-human-bypass.md
+++ b/.foundry/stories/story-010-orchestrator-human-bypass.md
@@ -1,17 +1,19 @@
 ---
 id: story-010-orchestrator-human-bypass
 type: STORY
-title: "Implement Human Task Bypass in Orchestrator"
-status: "COMPLETED"
+title: Implement Human Task Bypass in Orchestrator
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-23"
-updated_at: "2026-04-23"
+created_at: '2026-04-23'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-011-human-orchestrator.md"
+parent: .foundry/epics/epic-011-human-orchestrator.md
 tags:
-  - "human-in-the-loop"
-  - "orchestrator"
+  - human-in-the-loop
+  - orchestrator
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Story 010: Implement Human Task Bypass in Orchestrator

--- a/.foundry/stories/story-010-persona-permissions-matrix.md
+++ b/.foundry/stories/story-010-persona-permissions-matrix.md
@@ -1,18 +1,20 @@
 ---
 id: story-010-persona-permissions-matrix
 type: STORY
-title: "Implement Persona Node Creation Permissions Matrix"
-status: "COMPLETED"
+title: Implement Persona Node Creation Permissions Matrix
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-010-persona-permissions.md"
+parent: .foundry/epics/epic-010-persona-permissions.md
 tags:
   - foundry-v2
   - architecture
   - orchestration
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Implement Persona Node Creation Permissions Matrix

--- a/.foundry/stories/story-011-016-wait-wake-implementation.md
+++ b/.foundry/stories/story-011-016-wait-wake-implementation.md
@@ -1,18 +1,20 @@
 ---
 id: story-011-016-wait-wake-implementation
 type: STORY
-title: "Wait & Wake Protocol Orchestrator Implementation"
-status: "COMPLETED"
+title: Wait & Wake Protocol Orchestrator Implementation
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-24"
-updated_at: "2026-04-25"
+created_at: '2026-04-24'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-011-wait-and-wake-protocol.md"
+parent: .foundry/epics/epic-011-wait-and-wake-protocol.md
 tags:
   - foundry-v2
   - architecture
   - orchestration
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Wait & Wake Protocol Orchestrator Implementation

--- a/.foundry/stories/story-011-017-impossible-loop.md
+++ b/.foundry/stories/story-011-017-impossible-loop.md
@@ -1,18 +1,20 @@
 ---
 id: story-011-017-impossible-loop
 type: STORY
-title: "Impossible Loop Implementation"
-status: "COMPLETED"
+title: Impossible Loop Implementation
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-24"
-updated_at: "2026-04-25"
+created_at: '2026-04-24'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-011-wait-and-wake-protocol.md"
+parent: .foundry/epics/epic-011-wait-and-wake-protocol.md
 tags:
   - foundry-v2
   - architecture
   - orchestration
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Impossible Loop Implementation

--- a/.foundry/stories/story-011-human-heartbeat-script.md
+++ b/.foundry/stories/story-011-human-heartbeat-script.md
@@ -1,17 +1,19 @@
 ---
 id: story-011-human-heartbeat-script
 type: STORY
-title: "Update heartbeat script to support human tasks"
-status: "COMPLETED"
+title: Update heartbeat script to support human tasks
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-23"
-updated_at: "2026-04-23"
+created_at: '2026-04-23'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/epics/epic-012-human-heartbeat.md"
+parent: .foundry/epics/epic-012-human-heartbeat.md
 tags:
-  - "human-in-the-loop"
-  - "heartbeat"
+  - human-in-the-loop
+  - heartbeat
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Story 011: Update heartbeat script to support human tasks

--- a/.foundry/stories/story-012-026-evaluate-cloudflare-storage.md
+++ b/.foundry/stories/story-012-026-evaluate-cloudflare-storage.md
@@ -1,20 +1,21 @@
 ---
 id: story-012-026-evaluate-cloudflare-storage
 type: STORY
-title: "Evaluate Cloudflare Storage Mechanisms"
-status: "COMPLETED"
+title: Evaluate Cloudflare Storage Mechanisms
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-26"
-updated_at: "2026-04-26"
+created_at: '2026-04-26'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: ".foundry/epics/epic-012-gastown-orchestrator.md"
+parent: .foundry/epics/epic-012-gastown-orchestrator.md
 tags:
   - foundry-v2
   - architecture
   - orchestration
 rejection_count: 1
+rejection_reason: ''
 ---
 
 # Evaluate Cloudflare Storage Mechanisms

--- a/.foundry/stories/story-012-027-design-sync-mechanism.md
+++ b/.foundry/stories/story-012-027-design-sync-mechanism.md
@@ -1,21 +1,22 @@
 ---
 id: story-012-027-design-sync-mechanism
 type: STORY
-title: "Design State Sync Mechanism"
-status: "COMPLETED"
+title: Design State Sync Mechanism
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-26"
-updated_at: "2026-04-26"
+created_at: '2026-04-26'
+updated_at: '2026-04-26'
 depends_on:
   - .foundry/stories/story-012-026-evaluate-cloudflare-storage.md
 jules_session_id: null
 pr_number: null
-parent: ".foundry/epics/epic-012-gastown-orchestrator.md"
+parent: .foundry/epics/epic-012-gastown-orchestrator.md
 tags:
   - foundry-v2
   - architecture
   - orchestration
 rejection_count: 0
+rejection_reason: ''
 ---
 
 # Design State Sync Mechanism

--- a/.foundry/stories/story-012-029-document-gastown-migration-decision.md
+++ b/.foundry/stories/story-012-029-document-gastown-migration-decision.md
@@ -1,11 +1,11 @@
 ---
 id: story-012-029-document-gastown-migration-decision
 type: STORY
-title: "Document Gastown Migration Decision"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-04-26"
-updated_at: "2026-04-29"
+title: Document Gastown Migration Decision
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-04-26'
+updated_at: '2026-04-29'
 depends_on:
   - .foundry/stories/story-012-027-design-sync-mechanism.md
   - .foundry/tasks/task-029-047-write-gastown-adr.md
@@ -17,6 +17,7 @@ tags:
   - architecture
   - orchestration
 rejection_count: 12
+rejection_reason: ''
 ---
 
 # Document Gastown Migration Decision

--- a/.foundry/stories/story-020-035-relax-node-engine.md
+++ b/.foundry/stories/story-020-035-relax-node-engine.md
@@ -1,17 +1,20 @@
 ---
 id: story-020-035-relax-node-engine
 type: STORY
-title: "Update package.json Node engine"
-status: "COMPLETED"
-owner_persona: "tech_lead"
-created_at: "2026-05-01"
-updated_at: "2026-05-01"
+title: Update package.json Node engine
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-05-01'
+updated_at: '2026-05-01'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: ".foundry/epics/epic-009-020-relax-node-engine.md"
-tags: ["infrastructure"]
-notes: ""
+parent: .foundry/epics/epic-009-020-relax-node-engine.md
+tags:
+  - infrastructure
+notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update package.json Node engine

--- a/.foundry/stories/story-023-036-implement-cascade-cancellation.md
+++ b/.foundry/stories/story-023-036-implement-cascade-cancellation.md
@@ -2,10 +2,10 @@
 id: story-023-036-implement-cascade-cancellation
 type: STORY
 title: 'Story: Implement Cascading Cancellation in Orchestrator'
-status: "COMPLETED"
+status: COMPLETED
 owner_persona: tech_lead
 created_at: '2026-05-03'
-updated_at: "2026-05-04"
+updated_at: '2026-05-04'
 depends_on: []
 jules_session_id: null
 pr_number: null
@@ -16,6 +16,8 @@ tags:
   - orchestrator
   - cancellation
 notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Story: Implement Cascading Cancellation in Orchestrator

--- a/.foundry/stories/story-032-063-gen3-msgpack-transition.md
+++ b/.foundry/stories/story-032-063-gen3-msgpack-transition.md
@@ -3,9 +3,9 @@ id: story-032-063-gen3-msgpack-transition
 type: STORY
 title: Implement MsgPack Transition for Data Serialization
 status: PENDING
-owner_persona: "story_owner"
-created_at: "2026-05-17"
-updated_at: "2026-05-17"
+owner_persona: story_owner
+created_at: '2026-05-17'
+updated_at: '2026-05-17'
 depends_on:
   - story-032-062-gen3-data-generation-scripts
 jules_session_id: null
@@ -14,7 +14,9 @@ tags:
   - gen3
   - data
   - msgpack
-notes: ""
+notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Implement MsgPack Transition for Data Serialization

--- a/.foundry/stories/story-032-064-gen3-encounter-integration.md
+++ b/.foundry/stories/story-032-064-gen3-encounter-integration.md
@@ -3,9 +3,9 @@ id: story-032-064-gen3-encounter-integration
 type: STORY
 title: Integrate Gen 3 Encounter Data into Engine
 status: PENDING
-owner_persona: "story_owner"
-created_at: "2026-05-17"
-updated_at: "2026-05-17"
+owner_persona: story_owner
+created_at: '2026-05-17'
+updated_at: '2026-05-17'
 depends_on:
   - story-032-063-gen3-msgpack-transition
   - story-032-062-gen3-data-generation-scripts
@@ -15,7 +15,9 @@ tags:
   - gen3
   - data
   - msgpack
-notes: ""
+notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Integrate Gen 3 Encounter Data into Engine

--- a/.foundry/tasks/task-000-028-handle-pre-existing-artifacts.md
+++ b/.foundry/tasks/task-000-028-handle-pre-existing-artifacts.md
@@ -1,14 +1,16 @@
 ---
 id: task-000-028-handle-pre-existing-artifacts
 type: TASK
-title: "Handle Pre-existing Artifacts Rule"
+title: Handle Pre-existing Artifacts Rule
 status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-25"
-updated_at: "2026-04-25"
+created_at: '2026-04-25'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
 parent: null
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Handle Pre-existing Artifacts Rule

--- a/.foundry/tasks/task-001-create-engine-yaml.md
+++ b/.foundry/tasks/task-001-create-engine-yaml.md
@@ -1,14 +1,16 @@
 ---
 id: task-001-create-engine-yaml
 type: TASK
-title: "Core Foundry Orchestration Engine"
+title: Core Foundry Orchestration Engine
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-20"
+created_at: '2026-04-20'
+updated_at: '2026-04-20'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-001-matrix-runner.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Core Foundry Orchestration Engine

--- a/.foundry/tasks/task-002-create-heartbeat.md
+++ b/.foundry/tasks/task-002-create-heartbeat.md
@@ -1,15 +1,17 @@
 ---
 id: task-002-create-heartbeat
 type: TASK
-title: "Session Heartbeat & Stale Node Detection"
+title: Session Heartbeat & Stale Node Detection
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-21"
+created_at: '2026-04-20'
+updated_at: '2026-04-21'
 depends_on:
   - .foundry/tasks/task-001-create-engine-yaml.md
-jules_session_id: "4392356162765776613"
+jules_session_id: '4392356162765776613'
 parent: .foundry/stories/story-001-matrix-runner.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Session Heartbeat & Stale Node Detection

--- a/.foundry/tasks/task-003-resurrection-loop.md
+++ b/.foundry/tasks/task-003-resurrection-loop.md
@@ -1,16 +1,17 @@
 ---
 id: task-003-resurrection-loop
 type: TASK
-title: "Resurrection Loop & Rejection Handling"
+title: Resurrection Loop & Rejection Handling
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-20"
-updated_at: "2026-04-21"
+created_at: '2026-04-20'
+updated_at: '2026-04-21'
 depends_on:
   - .foundry/tasks/task-002-create-heartbeat.md
 jules_session_id: null
 rejection_count: 0
 parent: .foundry/stories/story-001-matrix-runner.md
+rejection_reason: ''
 ---
 
 # Resurrection Loop & Rejection Handling

--- a/.foundry/tasks/task-004-scaffold-pm.md
+++ b/.foundry/tasks/task-004-scaffold-pm.md
@@ -1,15 +1,17 @@
 ---
 id: task-004-scaffold-pm
 type: TASK
-title: "Scaffold Product Manager Persona"
+title: Scaffold Product Manager Persona
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-21"
+created_at: '2026-04-21'
+updated_at: '2026-04-21'
 depends_on: []
 jules_session_id: null
 pr_number: null
 parent: .foundry/stories/story-002-personas.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Scaffold Product Manager Persona

--- a/.foundry/tasks/task-005-024-update-id-templates.md
+++ b/.foundry/tasks/task-005-024-update-id-templates.md
@@ -1,14 +1,16 @@
 ---
 id: task-005-024-update-id-templates
 type: TASK
-title: "Update Generation Templates to Parent-Linked ID Schema"
-status: "COMPLETED"
+title: Update Generation Templates to Parent-Linked ID Schema
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-005-id-schema-templates.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Task: Update Generation Templates to Parent-Linked ID Schema

--- a/.foundry/tasks/task-005-025-update-orchestrator-validation.md
+++ b/.foundry/tasks/task-005-025-update-orchestrator-validation.md
@@ -1,14 +1,16 @@
 ---
 id: task-005-025-update-orchestrator-validation
 type: TASK
-title: "Update Orchestrator Validation for Parent-Linked ID Schema"
-status: "COMPLETED"
+title: Update Orchestrator Validation for Parent-Linked ID Schema
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-23"
-updated_at: "2026-04-25"
+created_at: '2026-04-23'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-005-id-schema-templates.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Task: Update Orchestrator Validation for Parent-Linked ID Schema

--- a/.foundry/tasks/task-005-026-qa-orchestrator-validation.md
+++ b/.foundry/tasks/task-005-026-qa-orchestrator-validation.md
@@ -1,15 +1,17 @@
 ---
 id: task-005-026-qa-orchestrator-validation
 type: TASK
-title: "QA Verification: Orchestrator Validation for Parent-Linked ID Schema"
-status: "COMPLETED"
+title: 'QA Verification: Orchestrator Validation for Parent-Linked ID Schema'
+status: COMPLETED
 owner_persona: qa
-created_at: "2026-04-23"
-updated_at: "2026-04-25"
+created_at: '2026-04-23'
+updated_at: '2026-04-25'
 depends_on:
   - .foundry/tasks/task-005-025-update-orchestrator-validation.md
 jules_session_id: null
 parent: .foundry/stories/story-005-id-schema-templates.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # QA Task: Verify Orchestrator Validation for Parent-Linked ID Schema

--- a/.foundry/tasks/task-005-modify-action-runner.md
+++ b/.foundry/tasks/task-005-modify-action-runner.md
@@ -1,15 +1,17 @@
 ---
 id: task-005-modify-action-runner
 type: TASK
-title: "Modify Action Runner"
+title: Modify Action Runner
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-21"
+created_at: '2026-04-21'
+updated_at: '2026-04-21'
 depends_on: []
 jules_session_id: null
 pr_number: null
 parent: .foundry/stories/story-002-personas.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Modify Action Runner

--- a/.foundry/tasks/task-006-migrate-memory-system.md
+++ b/.foundry/tasks/task-006-migrate-memory-system.md
@@ -1,16 +1,17 @@
 ---
 id: task-006-migrate-memory-system
 type: TASK
-title: "Migrate Memory System to The Foundry"
-status: "COMPLETED"
+title: Migrate Memory System to The Foundry
+status: COMPLETED
 rejection_count: 1
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-21"
+created_at: '2026-04-21'
+updated_at: '2026-04-21'
 depends_on: []
 jules_session_id: null
 pr_number: null
 parent: .foundry/stories/story-002-personas.md
+rejection_reason: ''
 ---
 
 # Migrate Memory System to The Foundry

--- a/.foundry/tasks/task-007-024-update-schema-owner-invariant.md
+++ b/.foundry/tasks/task-007-024-update-schema-owner-invariant.md
@@ -1,14 +1,16 @@
 ---
-id: "task-007-024-update-schema-owner-invariant"
-type: "TASK"
-title: "Update schema.md to enforce single owner invariant"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+id: task-007-024-update-schema-owner-invariant
+type: TASK
+title: Update schema.md to enforce single owner invariant
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-007-schema-invariant.md"
+parent: .foundry/stories/story-007-schema-invariant.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update schema.md to enforce single owner invariant

--- a/.foundry/tasks/task-007-scaffold-epic-planner.md
+++ b/.foundry/tasks/task-007-scaffold-epic-planner.md
@@ -1,15 +1,17 @@
 ---
 id: task-007-scaffold-epic-planner
 type: TASK
-title: "Scaffold Epic Planner Persona"
+title: Scaffold Epic Planner Persona
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-21"
+created_at: '2026-04-21'
+updated_at: '2026-04-21'
 depends_on: []
 jules_session_id: null
 pr_number: null
 parent: .foundry/stories/story-002-personas.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Scaffold Epic Planner Persona

--- a/.foundry/tasks/task-008-028-update-schema-examples.md
+++ b/.foundry/tasks/task-008-028-update-schema-examples.md
@@ -1,14 +1,16 @@
 ---
-id: "task-008-028-update-schema-examples"
-type: "TASK"
-title: "Update Documentation Examples for Atomic Files"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-24"
-updated_at: "2026-04-25"
+id: task-008-028-update-schema-examples
+type: TASK
+title: Update Documentation Examples for Atomic Files
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-24'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-008-schema-examples.md"
+parent: .foundry/stories/story-008-schema-examples.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update Documentation Examples for Atomic Files

--- a/.foundry/tasks/task-008-scaffold-story-owner.md
+++ b/.foundry/tasks/task-008-scaffold-story-owner.md
@@ -1,15 +1,17 @@
 ---
 id: task-008-scaffold-story-owner
 type: TASK
-title: "Scaffold Story Owner Persona"
+title: Scaffold Story Owner Persona
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-21"
+created_at: '2026-04-21'
+updated_at: '2026-04-21'
 depends_on: []
 jules_session_id: null
 pr_number: null
 parent: .foundry/stories/story-002-personas.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Scaffold Story Owner Persona

--- a/.foundry/tasks/task-009-028-deprecate-composite-nodes.md
+++ b/.foundry/tasks/task-009-028-deprecate-composite-nodes.md
@@ -1,17 +1,18 @@
 ---
 id: task-009-028-deprecate-composite-nodes
 type: TASK
-title: "Deprecate Composite Nodes in Schema"
-status: "COMPLETED"
+title: Deprecate Composite Nodes in Schema
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-24"
-updated_at: "2026-04-25"
+created_at: '2026-04-24'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-009-composite-deprecation.md
 tags: []
 rejection_count: 0
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Deprecate Composite Nodes in Schema

--- a/.foundry/tasks/task-009-scaffold-tech-lead.md
+++ b/.foundry/tasks/task-009-scaffold-tech-lead.md
@@ -1,15 +1,17 @@
 ---
 id: task-009-scaffold-tech-lead
 type: TASK
-title: "Scaffold Tech Lead Persona"
+title: Scaffold Tech Lead Persona
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-21"
+created_at: '2026-04-21'
+updated_at: '2026-04-21'
 depends_on: []
 jules_session_id: null
 pr_number: null
 parent: .foundry/stories/story-002-personas.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Scaffold Tech Lead Persona

--- a/.foundry/tasks/task-010-024-update-persona-prompts.md
+++ b/.foundry/tasks/task-010-024-update-persona-prompts.md
@@ -1,11 +1,11 @@
 ---
 id: task-010-024-update-persona-prompts
 type: TASK
-title: "Update Agent Prompts for Node Creation Guidelines"
-status: "COMPLETED"
+title: Update Agent Prompts for Node Creation Guidelines
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-010-persona-permissions-matrix.md
@@ -14,7 +14,8 @@ tags:
   - architecture
   - orchestration
 rejection_count: 0
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Update Agent Prompts for Node Creation Guidelines

--- a/.foundry/tasks/task-010-scaffold-coder.md
+++ b/.foundry/tasks/task-010-scaffold-coder.md
@@ -1,15 +1,17 @@
 ---
 id: task-010-scaffold-coder
 type: TASK
-title: "Scaffold Coder Persona"
+title: Scaffold Coder Persona
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-21"
+created_at: '2026-04-21'
+updated_at: '2026-04-21'
 depends_on: []
 jules_session_id: null
 pr_number: null
 parent: .foundry/stories/story-002-personas.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Scaffold Coder Persona

--- a/.foundry/tasks/task-011-scaffold-qa.md
+++ b/.foundry/tasks/task-011-scaffold-qa.md
@@ -1,15 +1,17 @@
 ---
 id: task-011-scaffold-qa
 type: TASK
-title: "Scaffold QA Persona"
+title: Scaffold QA Persona
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-21"
+created_at: '2026-04-21'
+updated_at: '2026-04-21'
 depends_on: []
 jules_session_id: null
 pr_number: null
 parent: .foundry/stories/story-002-personas.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Scaffold QA Persona

--- a/.foundry/tasks/task-012-024-configure-tpm-workflow.md
+++ b/.foundry/tasks/task-012-024-configure-tpm-workflow.md
@@ -1,17 +1,19 @@
 ---
 id: task-012-024-configure-tpm-workflow
 type: TASK
-title: "Configure TPM Schedule Workflow"
-status: "COMPLETED"
+title: Configure TPM Schedule Workflow
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-005-012-configure-tpm-schedule.md
-tags: ["infrastructure"]
+tags:
+  - infrastructure
 rejection_count: 0
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Configure TPM Schedule Workflow

--- a/.foundry/tasks/task-012-024-update-human-schema.md
+++ b/.foundry/tasks/task-012-024-update-human-schema.md
@@ -1,17 +1,19 @@
 ---
 id: task-012-024-update-human-schema
 type: TASK
-title: "Update Foundry Schema for Human Persona"
-status: "COMPLETED"
+title: Update Foundry Schema for Human Persona
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-24"
-updated_at: "2026-04-25"
+created_at: '2026-04-24'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-010-012-schema-human-persona.md"
+parent: .foundry/stories/story-010-012-schema-human-persona.md
 tags:
-  - "human-in-the-loop"
-  - "schema"
+  - human-in-the-loop
+  - schema
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Task: Update Foundry Schema for Human Persona

--- a/.foundry/tasks/task-012-scaffold-tpm.md
+++ b/.foundry/tasks/task-012-scaffold-tpm.md
@@ -1,15 +1,17 @@
 ---
 id: task-012-scaffold-tpm
 type: TASK
-title: "Scaffold TPM Persona"
+title: Scaffold TPM Persona
 status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-21"
+created_at: '2026-04-21'
+updated_at: '2026-04-21'
 depends_on: []
 jules_session_id: null
 pr_number: null
 parent: .foundry/stories/story-002-personas.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Scaffold TPM Persona

--- a/.foundry/tasks/task-013-024-update-tpm-prompt.md
+++ b/.foundry/tasks/task-013-024-update-tpm-prompt.md
@@ -1,17 +1,21 @@
 ---
 id: task-013-024-update-tpm-prompt
 type: TASK
-title: "Update TPM Prompt for Archiving Logic"
-status: "COMPLETED"
+title: Update TPM Prompt for Archiving Logic
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-005-013-tpm-archiving-logic.md
-tags: ["infrastructure"]
+tags:
+  - infrastructure
 rejection_count: 0
-notes: "Self-verification by coder is sufficient as this is a simple text prompt change."
+notes: >-
+  Self-verification by coder is sufficient as this is a simple text prompt
+  change.
+rejection_reason: ''
 ---
 
 # Update TPM Prompt for Archiving Logic

--- a/.foundry/tasks/task-013-scaffold-agile-coach.md
+++ b/.foundry/tasks/task-013-scaffold-agile-coach.md
@@ -1,16 +1,17 @@
 ---
 id: task-013-scaffold-agile-coach
 type: TASK
-title: "Scaffold Agile Coach Persona"
-status: "COMPLETED"
+title: Scaffold Agile Coach Persona
+status: COMPLETED
 rejection_count: 1
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-21"
+created_at: '2026-04-21'
+updated_at: '2026-04-21'
 depends_on: []
 jules_session_id: null
 pr_number: null
 parent: .foundry/stories/story-002-personas.md
+rejection_reason: ''
 ---
 
 # Scaffold Agile Coach Persona

--- a/.foundry/tasks/task-014-027-configure-oxlint-json.md
+++ b/.foundry/tasks/task-014-027-configure-oxlint-json.md
@@ -1,14 +1,16 @@
 ---
-id: "task-014-027-configure-oxlint-json"
-type: "TASK"
-title: "Configure .oxlintrc.json with strict rules and plugins"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-24"
-updated_at: "2026-04-25"
+id: task-014-027-configure-oxlint-json
+type: TASK
+title: Configure .oxlintrc.json with strict rules and plugins
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-24'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-010-014-implement-oxlint-config.md"
+parent: .foundry/stories/story-010-014-implement-oxlint-config.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Configure .oxlintrc.json with strict rules and plugins

--- a/.foundry/tasks/task-014-scaffold-architect.md
+++ b/.foundry/tasks/task-014-scaffold-architect.md
@@ -1,14 +1,16 @@
 ---
 id: task-014-scaffold-architect
 type: TASK
-title: "Scaffold Architect Persona"
-status: "COMPLETED"
+title: Scaffold Architect Persona
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-24"
+created_at: '2026-04-21'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-003-dynamic-verification.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Scaffold Architect Persona

--- a/.foundry/tasks/task-015-028-implement-link-checker.md
+++ b/.foundry/tasks/task-015-028-implement-link-checker.md
@@ -1,17 +1,20 @@
 ---
 id: task-015-028-implement-link-checker
 type: TASK
-title: "Implement Link Checker Pre-commit Hook Script"
-status: "COMPLETED"
+title: Implement Link Checker Pre-commit Hook Script
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-25"
-updated_at: "2026-04-25"
+created_at: '2026-04-25'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-006-015-implement-link-checker.md
-tags: ["infras", "verification"]
+tags:
+  - infras
+  - verification
 rejection_count: 0
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Task: Implement Link Checker Pre-commit Hook Script

--- a/.foundry/tasks/task-015-029-qa-link-checker.md
+++ b/.foundry/tasks/task-015-029-qa-link-checker.md
@@ -1,18 +1,21 @@
 ---
 id: task-015-029-qa-link-checker
 type: TASK
-title: "QA Validation: Link Checker Pre-commit Hook Script"
-status: "COMPLETED"
+title: 'QA Validation: Link Checker Pre-commit Hook Script'
+status: COMPLETED
 owner_persona: qa
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on:
   - .foundry/tasks/task-015-028-implement-link-checker.md
 jules_session_id: null
 parent: .foundry/stories/story-006-015-implement-link-checker.md
-tags: ["infras", "verification"]
+tags:
+  - infras
+  - verification
 rejection_count: 0
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # QA Task: Validate Link Checker Pre-commit Hook

--- a/.foundry/tasks/task-015-033-oxlint-require-mock-type-parameters.md
+++ b/.foundry/tasks/task-015-033-oxlint-require-mock-type-parameters.md
@@ -1,14 +1,16 @@
 ---
-id: "task-015-033-oxlint-require-mock-type-parameters"
-type: "TASK"
-title: "Enable oxlint vitest/require-mock-type-parameters"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+id: task-015-033-oxlint-require-mock-type-parameters
+type: TASK
+title: Enable oxlint vitest/require-mock-type-parameters
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-010-015-enforce-strict-oxlint-rules.md"
+parent: .foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Enable oxlint vitest/require-mock-type-parameters

--- a/.foundry/tasks/task-015-034-oxlint-expect-expect.md
+++ b/.foundry/tasks/task-015-034-oxlint-expect-expect.md
@@ -1,14 +1,16 @@
 ---
-id: "task-015-034-oxlint-expect-expect"
-type: "TASK"
-title: "Enable oxlint vitest/expect-expect"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+id: task-015-034-oxlint-expect-expect
+type: TASK
+title: Enable oxlint vitest/expect-expect
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-010-015-enforce-strict-oxlint-rules.md"
+parent: .foundry/stories/story-010-015-enforce-strict-oxlint-rules.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Enable oxlint vitest/expect-expect

--- a/.foundry/tasks/task-015-update-tech-lead-protocol.md
+++ b/.foundry/tasks/task-015-update-tech-lead-protocol.md
@@ -1,14 +1,16 @@
 ---
 id: task-015-update-tech-lead-protocol
 type: TASK
-title: "Update Tech Lead Persona with Intelligent Verification Protocol"
-status: "COMPLETED"
+title: Update Tech Lead Persona with Intelligent Verification Protocol
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-24"
+created_at: '2026-04-21'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-003-dynamic-verification.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update Tech Lead Persona with Intelligent Verification Protocol

--- a/.foundry/tasks/task-016-030-implement-wait-wake.md
+++ b/.foundry/tasks/task-016-030-implement-wait-wake.md
@@ -1,15 +1,17 @@
 ---
 id: task-016-030-implement-wait-wake
 type: TASK
-title: "Implement Wait & Wake logic in Orchestrator"
-status: "COMPLETED"
+title: Implement Wait & Wake logic in Orchestrator
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-25"
-updated_at: "2026-04-25"
+created_at: '2026-04-25'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: ".foundry/stories/story-011-016-wait-wake-implementation.md"
+parent: .foundry/stories/story-011-016-wait-wake-implementation.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Implement Wait & Wake logic in Orchestrator

--- a/.foundry/tasks/task-016-031-qa-wait-wake.md
+++ b/.foundry/tasks/task-016-031-qa-wait-wake.md
@@ -1,16 +1,18 @@
 ---
 id: task-016-031-qa-wait-wake
 type: TASK
-title: "QA Wait & Wake logic in Orchestrator"
-status: "COMPLETED"
+title: QA Wait & Wake logic in Orchestrator
+status: COMPLETED
 owner_persona: qa
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on:
   - .foundry/tasks/task-016-030-implement-wait-wake.md
 jules_session_id: null
 pr_number: null
-parent: ".foundry/stories/story-011-016-wait-wake-implementation.md"
+parent: .foundry/stories/story-011-016-wait-wake-implementation.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # QA Wait & Wake logic in Orchestrator

--- a/.foundry/tasks/task-016-039-oxlint-type-aware.md
+++ b/.foundry/tasks/task-016-039-oxlint-type-aware.md
@@ -1,14 +1,16 @@
 ---
-id: "task-016-039-oxlint-type-aware"
-type: "TASK"
-title: "Enable oxlint type-aware and type-check options"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-26"
-updated_at: "2026-04-29"
+id: task-016-039-oxlint-type-aware
+type: TASK
+title: Enable oxlint type-aware and type-check options
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-26'
+updated_at: '2026-04-29'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-010-016-enable-expensive-oxlint-checks.md"
+parent: .foundry/stories/story-010-016-enable-expensive-oxlint-checks.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Enable oxlint type-aware and type-check options

--- a/.foundry/tasks/task-016-040-oxlint-import-promise-plugins.md
+++ b/.foundry/tasks/task-016-040-oxlint-import-promise-plugins.md
@@ -1,14 +1,16 @@
 ---
-id: "task-016-040-oxlint-import-promise-plugins"
-type: "TASK"
-title: "Enable oxlint import and promise plugins"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-26"
-updated_at: "2026-04-26"
+id: task-016-040-oxlint-import-promise-plugins
+type: TASK
+title: Enable oxlint import and promise plugins
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-26'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-010-016-enable-expensive-oxlint-checks.md"
+parent: .foundry/stories/story-010-016-enable-expensive-oxlint-checks.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Enable oxlint import and promise plugins

--- a/.foundry/tasks/task-016-update-agile-coach-evolution.md
+++ b/.foundry/tasks/task-016-update-agile-coach-evolution.md
@@ -1,14 +1,16 @@
 ---
 id: task-016-update-agile-coach-evolution
 type: TASK
-title: "Update Agile Coach Persona with Evolution Protocol"
-status: "COMPLETED"
+title: Update Agile Coach Persona with Evolution Protocol
+status: COMPLETED
 owner_persona: tech_lead
-created_at: "2026-04-21"
-updated_at: "2026-04-23"
+created_at: '2026-04-21'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-003-dynamic-verification.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update Agile Coach Persona with Evolution Protocol

--- a/.foundry/tasks/task-017-030-update-schema-rejection-reason.md
+++ b/.foundry/tasks/task-017-030-update-schema-rejection-reason.md
@@ -1,14 +1,16 @@
 ---
 id: task-017-030-update-schema-rejection-reason
 type: TASK
-title: "Update Schema for rejection_reason"
-status: "COMPLETED"
+title: Update Schema for rejection_reason
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-25"
-updated_at: "2026-04-25"
+created_at: '2026-04-25'
+updated_at: '2026-04-25'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-011-017-impossible-loop.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update Schema for rejection_reason

--- a/.foundry/tasks/task-017-031-implement-impossible-loop.md
+++ b/.foundry/tasks/task-017-031-implement-impossible-loop.md
@@ -1,15 +1,17 @@
 ---
 id: task-017-031-implement-impossible-loop
 type: TASK
-title: "Implement Impossible Loop in Orchestrator"
-status: "COMPLETED"
+title: Implement Impossible Loop in Orchestrator
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on:
   - .foundry/tasks/task-017-030-update-schema-rejection-reason.md
 jules_session_id: null
 parent: .foundry/stories/story-011-017-impossible-loop.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Implement Impossible Loop in Orchestrator

--- a/.foundry/tasks/task-017-032-qa-impossible-loop.md
+++ b/.foundry/tasks/task-017-032-qa-impossible-loop.md
@@ -1,15 +1,17 @@
 ---
 id: task-017-032-qa-impossible-loop
 type: TASK
-title: "QA Impossible Loop Orchestrator Logic"
-status: "COMPLETED"
+title: QA Impossible Loop Orchestrator Logic
+status: COMPLETED
 owner_persona: qa
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on:
   - .foundry/tasks/task-017-031-implement-impossible-loop.md
 jules_session_id: null
 parent: .foundry/stories/story-011-017-impossible-loop.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # QA Impossible Loop Orchestrator Logic

--- a/.foundry/tasks/task-017-041-fix-jest-standalone-expect.md
+++ b/.foundry/tasks/task-017-041-fix-jest-standalone-expect.md
@@ -1,14 +1,16 @@
 ---
-id: "task-017-041-fix-jest-standalone-expect"
-type: "TASK"
-title: "Fix and enable jest/no-standalone-expect"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-26"
-updated_at: "2026-04-26"
+id: task-017-041-fix-jest-standalone-expect
+type: TASK
+title: Fix and enable jest/no-standalone-expect
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-26'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-010-017-fix-jest-rules.md"
+parent: .foundry/stories/story-010-017-fix-jest-rules.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Fix and enable jest/no-standalone-expect

--- a/.foundry/tasks/task-018-implement-scheduled-agent-registry.md
+++ b/.foundry/tasks/task-018-implement-scheduled-agent-registry.md
@@ -1,17 +1,19 @@
 ---
 id: task-018-implement-scheduled-agent-registry
 type: TASK
-title: "Implement Scheduled Agent Registry"
-status: "COMPLETED"
+title: Implement Scheduled Agent Registry
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-22"
-updated_at: "2026-04-23"
+created_at: '2026-04-22'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-006-scheduling-configuration.md
-tags: ["infrastructure"]
+tags:
+  - infrastructure
 rejection_count: 1
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Implement Scheduled Agent Registry

--- a/.foundry/tasks/task-018-scheduled-agent-empty-state.md
+++ b/.foundry/tasks/task-018-scheduled-agent-empty-state.md
@@ -1,17 +1,18 @@
 ---
 id: task-018-scheduled-agent-empty-state
 type: TASK
-title: "Scheduled Agent Workflow Empty State Support via Prompt"
-status: "COMPLETED"
+title: Scheduled Agent Workflow Empty State Support via Prompt
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-22"
-updated_at: "2026-04-23"
+created_at: '2026-04-22'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-005-empty-state-handling.md
 tags: []
 rejection_count: 1
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Scheduled Agent Workflow Empty State Support via Prompt

--- a/.foundry/tasks/task-020-auto-close-empty-prs.md
+++ b/.foundry/tasks/task-020-auto-close-empty-prs.md
@@ -1,17 +1,18 @@
 ---
 id: task-020-auto-close-empty-prs
 type: TASK
-title: "Auto-close Empty PRs"
-status: "COMPLETED"
+title: Auto-close Empty PRs
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-22"
-updated_at: "2026-04-23"
+created_at: '2026-04-22'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-005-empty-state-handling.md
 tags: []
 rejection_count: 1
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Auto-close Empty PRs

--- a/.foundry/tasks/task-021-document-id-schema.md
+++ b/.foundry/tasks/task-021-document-id-schema.md
@@ -1,14 +1,16 @@
 ---
 id: task-021-document-id-schema
 type: TASK
-title: "Finalize ID Schema and Update Documentation"
-status: "COMPLETED"
+title: Finalize ID Schema and Update Documentation
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-23"
-updated_at: "2026-04-23"
+created_at: '2026-04-23'
+updated_at: '2026-04-23'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-004-id-schema-decision.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Finalize ID Schema and Update Documentation

--- a/.foundry/tasks/task-021-investigate-shadow-dispatch.md
+++ b/.foundry/tasks/task-021-investigate-shadow-dispatch.md
@@ -1,17 +1,21 @@
 ---
 id: task-021-investigate-shadow-dispatch
 type: TASK
-title: "Document Shadow Dispatch Verification Findings"
-status: "COMPLETED"
+title: Document Shadow Dispatch Verification Findings
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-004-shadow-dispatch-verification.md
-tags: ["orchestrator", "concurrency", "investigation"]
+tags:
+  - orchestrator
+  - concurrency
+  - investigation
 rejection_count: 2
-notes: ""
+notes: ''
+rejection_reason: ''
 ---
 
 # Task: Document Shadow Dispatch Verification Findings

--- a/.foundry/tasks/task-022-039-implement-id-validation-hook.md
+++ b/.foundry/tasks/task-022-039-implement-id-validation-hook.md
@@ -1,14 +1,16 @@
 ---
 id: task-022-039-implement-id-validation-hook
 type: TASK
-title: "Implement ID Validation Pre-commit Hook"
-status: "COMPLETED"
+title: Implement ID Validation Pre-commit Hook
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
 parent: .foundry/stories/story-006-022-implement-id-validation-hook.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Implement ID Validation Pre-commit Hook

--- a/.foundry/tasks/task-022-040-qa-id-validation-hook.md
+++ b/.foundry/tasks/task-022-040-qa-id-validation-hook.md
@@ -1,15 +1,17 @@
 ---
 id: task-022-040-qa-id-validation-hook
 type: TASK
-title: "QA ID Validation Pre-commit Hook"
-status: "COMPLETED"
+title: QA ID Validation Pre-commit Hook
+status: COMPLETED
 owner_persona: qa
-created_at: "2026-04-25"
-updated_at: "2026-04-26"
+created_at: '2026-04-25'
+updated_at: '2026-04-26'
 depends_on:
   - .foundry/tasks/task-022-039-implement-id-validation-hook.md
 jules_session_id: null
 parent: .foundry/stories/story-006-022-implement-id-validation-hook.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # QA ID Validation Pre-commit Hook

--- a/.foundry/tasks/task-022-orchestrator-human-bypass.md
+++ b/.foundry/tasks/task-022-orchestrator-human-bypass.md
@@ -1,17 +1,19 @@
 ---
 id: task-022-orchestrator-human-bypass
 type: TASK
-title: "Implement Human Task Bypass in Orchestrator"
-status: "COMPLETED"
+title: Implement Human Task Bypass in Orchestrator
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-010-orchestrator-human-bypass.md"
+parent: .foundry/stories/story-010-orchestrator-human-bypass.md
 tags:
-  - "human-in-the-loop"
-  - "orchestrator"
+  - human-in-the-loop
+  - orchestrator
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Task 022: Implement Human Task Bypass in Orchestrator

--- a/.foundry/tasks/task-022-update-heartbeat-script.md
+++ b/.foundry/tasks/task-022-update-heartbeat-script.md
@@ -1,17 +1,19 @@
 ---
 id: task-022-update-heartbeat-script
 type: TASK
-title: "Update heartbeat script to support human tasks"
-status: "COMPLETED"
+title: Update heartbeat script to support human tasks
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-011-human-heartbeat-script.md"
+parent: .foundry/stories/story-011-human-heartbeat-script.md
 tags:
-  - "human-in-the-loop"
-  - "heartbeat"
+  - human-in-the-loop
+  - heartbeat
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update heartbeat script to support human tasks

--- a/.foundry/tasks/task-023-041-implement-single-owner-validation.md
+++ b/.foundry/tasks/task-023-041-implement-single-owner-validation.md
@@ -1,14 +1,16 @@
 ---
-id: "task-023-041-implement-single-owner-validation"
-type: "TASK"
-title: "Implement single owner validation in orchestrator"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-26"
-updated_at: "2026-04-26"
+id: task-023-041-implement-single-owner-validation
+type: TASK
+title: Implement single owner validation in orchestrator
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-26'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
-parent: ".foundry/stories/story-008-023-validate-single-owner.md"
+parent: .foundry/stories/story-008-023-validate-single-owner.md
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Implement single owner validation in orchestrator

--- a/.foundry/tasks/task-023-qa-orchestrator-human-bypass.md
+++ b/.foundry/tasks/task-023-qa-orchestrator-human-bypass.md
@@ -1,19 +1,21 @@
 ---
 id: task-023-qa-orchestrator-human-bypass
 type: TASK
-title: "QA Verification: Human Task Bypass in Orchestrator"
-status: "COMPLETED"
+title: 'QA Verification: Human Task Bypass in Orchestrator'
+status: COMPLETED
 owner_persona: qa
-created_at: "2026-04-23"
-updated_at: "2026-04-24"
+created_at: '2026-04-23'
+updated_at: '2026-04-24'
 depends_on:
-  - ".foundry/tasks/task-022-orchestrator-human-bypass.md"
+  - .foundry/tasks/task-022-orchestrator-human-bypass.md
 jules_session_id: null
-parent: ".foundry/stories/story-010-orchestrator-human-bypass.md"
+parent: .foundry/stories/story-010-orchestrator-human-bypass.md
 tags:
-  - "human-in-the-loop"
-  - "orchestrator"
-  - "qa"
+  - human-in-the-loop
+  - orchestrator
+  - qa
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Task 023: QA Verification for Human Task Bypass in Orchestrator

--- a/.foundry/tasks/task-024-041-update-status-on-merge.md
+++ b/.foundry/tasks/task-024-041-update-status-on-merge.md
@@ -1,16 +1,21 @@
 ---
-id: "task-024-041-update-status-on-merge"
-type: "TASK"
-title: "Update Node Status on PR Merge"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-26"
-updated_at: "2026-04-26"
+id: task-024-041-update-status-on-merge
+type: TASK
+title: Update Node Status on PR Merge
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-26'
+updated_at: '2026-04-26'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: ".foundry/stories/story-008-024-update-status-on-merge.md"
-tags: ["foundry-engine", "orchestrator", "pr-merge"]
+parent: .foundry/stories/story-008-024-update-status-on-merge.md
+tags:
+  - foundry-engine
+  - orchestrator
+  - pr-merge
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update Node Status on PR Merge

--- a/.foundry/tasks/task-024-042-qa-update-status-on-merge.md
+++ b/.foundry/tasks/task-024-042-qa-update-status-on-merge.md
@@ -1,17 +1,22 @@
 ---
-id: "task-024-042-qa-update-status-on-merge"
-type: "TASK"
-title: "QA: Update Node Status on PR Merge"
-status: "COMPLETED"
-owner_persona: "qa"
-created_at: "2026-04-26"
-updated_at: "2026-04-26"
+id: task-024-042-qa-update-status-on-merge
+type: TASK
+title: 'QA: Update Node Status on PR Merge'
+status: COMPLETED
+owner_persona: qa
+created_at: '2026-04-26'
+updated_at: '2026-04-26'
 depends_on:
-  - ".foundry/tasks/task-024-041-update-status-on-merge.md"
+  - .foundry/tasks/task-024-041-update-status-on-merge.md
 jules_session_id: null
 pr_number: null
-parent: ".foundry/stories/story-008-024-update-status-on-merge.md"
-tags: ["foundry-engine", "qa", "pr-merge"]
+parent: .foundry/stories/story-008-024-update-status-on-merge.md
+tags:
+  - foundry-engine
+  - qa
+  - pr-merge
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # QA: Update Node Status on PR Merge

--- a/.foundry/tasks/task-029-047-write-gastown-adr.md
+++ b/.foundry/tasks/task-029-047-write-gastown-adr.md
@@ -1,11 +1,11 @@
 ---
 id: task-029-047-write-gastown-adr
 type: TASK
-title: "Write Gastown Migration ADR"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-26"
-updated_at: "2026-04-28"
+title: Write Gastown Migration ADR
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-26'
+updated_at: '2026-04-28'
 depends_on: []
 jules_session_id: null
 pr_number: null
@@ -15,6 +15,7 @@ tags:
   - architecture
   - orchestration
 rejection_count: 0
+rejection_reason: ''
 ---
 
 # Write Gastown Migration ADR

--- a/.foundry/tasks/task-031-048-implement-deadlock-tests.md
+++ b/.foundry/tasks/task-031-048-implement-deadlock-tests.md
@@ -1,15 +1,20 @@
 ---
-id: "task-031-048-implement-deadlock-tests"
-type: "TASK"
-title: "Implement Deadlock Prevention Mechanism Unit Tests"
-status: "ACTIVE"
-owner_persona: "coder"
-created_at: "2026-04-27"
-updated_at: "2026-04-27"
+id: task-031-048-implement-deadlock-tests
+type: TASK
+title: Implement Deadlock Prevention Mechanism Unit Tests
+status: ACTIVE
+owner_persona: coder
+created_at: '2026-04-27'
+updated_at: '2026-04-27'
 depends_on: []
-jules_session_id: "4640549639143018851"
-parent: ".foundry/stories/story-009-031-deadlock-prevention-tests.md"
-tags: ["v2-architecture", "lifecycle", "atomic-handoffs"]
+jules_session_id: '4640549639143018851'
+parent: .foundry/stories/story-009-031-deadlock-prevention-tests.md
+tags:
+  - v2-architecture
+  - lifecycle
+  - atomic-handoffs
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Implement Deadlock Prevention Mechanism Unit Tests

--- a/.foundry/tasks/task-033-053-update-playwright-idb-injection.md
+++ b/.foundry/tasks/task-033-053-update-playwright-idb-injection.md
@@ -1,15 +1,20 @@
 ---
 id: task-033-053-update-playwright-idb-injection
 type: TASK
-title: "Update Playwright IDB Injection"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-04-27"
-updated_at: "2026-04-28"
+title: Update Playwright IDB Injection
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-04-27'
+updated_at: '2026-04-28'
 depends_on: []
 jules_session_id: null
 parent: .foundry/archive/stories/story-016-033-update-e2e-testing-for-idb.md
-tags: ["e2e", "testing", "indexeddb"]
+tags:
+  - e2e
+  - testing
+  - indexeddb
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update Playwright IDB Injection

--- a/.foundry/tasks/task-033-060-remove-localstorage-e2e.md
+++ b/.foundry/tasks/task-033-060-remove-localstorage-e2e.md
@@ -1,15 +1,20 @@
 ---
 id: task-033-060-remove-localstorage-e2e
 type: TASK
-title: "Remove localStorage fallback from E2E Testing"
-status: "COMPLETED"
-owner_persona: "coder"
-created_at: "2026-05-01"
-updated_at: "2026-05-01"
+title: Remove localStorage fallback from E2E Testing
+status: COMPLETED
+owner_persona: coder
+created_at: '2026-05-01'
+updated_at: '2026-05-01'
 depends_on: []
 jules_session_id: null
 parent: .foundry/archive/stories/story-016-033-update-e2e-testing-for-idb.md
-tags: ["e2e", "testing", "indexeddb"]
+tags:
+  - e2e
+  - testing
+  - indexeddb
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Remove localStorage fallback from E2E Testing

--- a/.foundry/tasks/task-035-061-relax-node-engine.md
+++ b/.foundry/tasks/task-035-061-relax-node-engine.md
@@ -1,17 +1,20 @@
 ---
 id: task-035-061-relax-node-engine
 type: TASK
-title: "Update engines.node in package.json"
-status: "COMPLETED"
+title: Update engines.node in package.json
+status: COMPLETED
 owner_persona: coder
-created_at: "2026-05-01"
-updated_at: "2026-05-02"
+created_at: '2026-05-01'
+updated_at: '2026-05-02'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: ".foundry/stories/story-020-035-relax-node-engine.md"
-tags: ["infrastructure"]
-notes: ""
+parent: .foundry/stories/story-020-035-relax-node-engine.md
+tags:
+  - infrastructure
+notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Update engines.node in package.json

--- a/.foundry/tasks/task-036-062-implement-cascade-cancellation.md
+++ b/.foundry/tasks/task-036-062-implement-cascade-cancellation.md
@@ -2,10 +2,10 @@
 id: task-036-062-implement-cascade-cancellation
 type: TASK
 title: Implement Cascading Cancellation in Orchestrator
-status: "COMPLETED"
+status: COMPLETED
 owner_persona: coder
 created_at: '2026-05-04'
-updated_at: "2026-05-04"
+updated_at: '2026-05-04'
 depends_on: []
 jules_session_id: null
 pr_number: null
@@ -16,6 +16,8 @@ tags:
   - orchestrator
   - cancellation
 notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Task 062: Implement Cascading Cancellation in Orchestrator

--- a/.foundry/tasks/task-036-063-qa-cascade-cancellation.md
+++ b/.foundry/tasks/task-036-063-qa-cascade-cancellation.md
@@ -2,10 +2,10 @@
 id: task-036-063-qa-cascade-cancellation
 type: TASK
 title: QA Cascading Cancellation in Orchestrator
-status: "COMPLETED"
+status: COMPLETED
 owner_persona: qa
 created_at: '2026-05-04'
-updated_at: "2026-05-04"
+updated_at: '2026-05-04'
 depends_on:
   - .foundry/tasks/task-036-062-implement-cascade-cancellation.md
 jules_session_id: null
@@ -17,6 +17,8 @@ tags:
   - orchestrator
   - cancellation
 notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Task 063: QA Cascading Cancellation in Orchestrator

--- a/.foundry/tasks/task-062-112-gen3-locations-script-retry-impl.md
+++ b/.foundry/tasks/task-062-112-gen3-locations-script-retry-impl.md
@@ -13,6 +13,7 @@ research_references:
 jules_session_id: null
 rejection_reason: ''
 parent: story-032-062-gen3-data-generation-scripts
+rejection_count: 0
 ---
 
 # Retry Implement Gen 3 Locations Fetch Script

--- a/.foundry/tasks/task-062-113-gen3-locations-script-retry-qa.md
+++ b/.foundry/tasks/task-062-113-gen3-locations-script-retry-qa.md
@@ -11,6 +11,7 @@ depends_on:
 jules_session_id: null
 rejection_reason: ''
 parent: story-032-062-gen3-data-generation-scripts
+rejection_count: 0
 ---
 
 # QA Retry Gen 3 Locations Fetch Script

--- a/.foundry/tasks/task-063-132-msgpack-transition-impl.md
+++ b/.foundry/tasks/task-063-132-msgpack-transition-impl.md
@@ -14,6 +14,8 @@ tags:
   - data
   - msgpack
 notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Implement MsgPack Transition for Data Serialization

--- a/.foundry/tasks/task-063-133-msgpack-transition-qa.md
+++ b/.foundry/tasks/task-063-133-msgpack-transition-qa.md
@@ -15,6 +15,8 @@ tags:
   - data
   - msgpack
 notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # QA MsgPack Transition for Data Serialization

--- a/.foundry/tasks/task-064-134-encounter-integration-impl.md
+++ b/.foundry/tasks/task-064-134-encounter-integration-impl.md
@@ -3,9 +3,9 @@ id: task-064-134-encounter-integration-impl
 type: TASK
 title: Integrate Gen 3 Encounter Data into Engine
 status: PENDING
-owner_persona: "tech_lead"
-created_at: "2026-05-22"
-updated_at: "2026-05-22"
+owner_persona: tech_lead
+created_at: '2026-05-22'
+updated_at: '2026-05-22'
 depends_on:
   - .foundry/tasks/task-063-132-msgpack-transition-impl.md
   - .foundry/tasks/task-063-133-msgpack-transition-qa.md
@@ -15,7 +15,9 @@ tags:
   - gen3
   - data
   - msgpack
-notes: ""
+notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # Integrate Gen 3 Encounter Data into Engine

--- a/.foundry/tasks/task-064-135-encounter-integration-qa.md
+++ b/.foundry/tasks/task-064-135-encounter-integration-qa.md
@@ -3,9 +3,9 @@ id: task-064-135-encounter-integration-qa
 type: TASK
 title: QA Integrate Gen 3 Encounter Data into Engine
 status: PENDING
-owner_persona: "tech_lead"
-created_at: "2026-05-22"
-updated_at: "2026-05-22"
+owner_persona: tech_lead
+created_at: '2026-05-22'
+updated_at: '2026-05-22'
 depends_on:
   - .foundry/tasks/task-064-134-encounter-integration-impl.md
 jules_session_id: null
@@ -14,7 +14,9 @@ tags:
   - gen3
   - data
   - msgpack
-notes: ""
+notes: ''
+rejection_reason: ''
+rejection_count: 0
 ---
 
 # QA Integrate Gen 3 Encounter Data into Engine

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -55,10 +55,10 @@ function validateSchema() {
   const otherRegex = /^(prd|epic|story|task|research)-\d{3}(-\d{3})?(-[a-z0-9-]+)?$/;
 
   const validTypes = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH'];
-  const validStatuses = ['PENDING', 'READY', 'ACTIVE', 'COMPLETED', 'FAILED', 'BLOCKED', 'CANCELLED'];
+  const validStatuses = ['PENDING', 'READY', 'ACTIVE', 'VERIFYING', 'COMPLETED', 'FAILED', 'BLOCKED', 'CANCELLED'];
   const validPersonas = [
     'product_manager', 'epic_planner', 'story_owner', 'architect',
-    'tech_lead', 'coder', 'qa', 'human', 'tpm', 'agile_coach', 'researcher'
+    'tech_lead', 'coder', 'qa', 'human', 'tpm', 'agile_coach', 'researcher', 'auditor'
   ];
 
   const validMappings: Record<string, string[]> = {
@@ -126,7 +126,7 @@ function validateSchema() {
         console.error(`Error: Missing rejection_reason for FAILED node in file ${file}`);
         hasError = true;
       }
-    } else if (status === 'ACTIVE' || status === 'COMPLETED' || status === 'READY') {
+    } else if (status === 'ACTIVE' || status === 'COMPLETED' || status === 'READY' || status === 'VERIFYING') {
       // Proactively ensure rejection_reason is populated if it exists to prevent edge-case validation failures
       // during transitions, but do not fail for non-FAILED nodes unless it's explicitly malformed.
       const reason = data['rejection_reason'];


### PR DESCRIPTION
This PR resolves the "Foundry Engine: Orchestrate Failure" by synchronizing the schema validator with the actual state machine defined in the orchestrator and heartbeat scripts. 

Key changes:
1. **Validator Synchronization**: Added the `VERIFYING` status and `auditor` persona to the allowed enums in `scripts/validate-foundry-schema.ts`.
2. **Metadata Standardization**: Executed an automated sweep across all Foundry nodes (epics, stories, and tasks) to ensure the `rejection_reason` and `rejection_count` fields are present, fulfilling schema requirements and preventing future warnings/failures.
3. **Environment Fix**: Reset global git hooks and performed a workspace-wide dependency installation to ensure `gray-matter` and other critical tools are available for the scripts.

These changes restore the health of the Foundry DAG and ensure that the newly introduced `auditor` persona and `VERIFYING` state can operate without triggering validation errors.

Fixes #1773

---
*PR created automatically by Jules for task [6801327349260725858](https://jules.google.com/task/6801327349260725858) started by @szubster*