### PR TITLE
Allow `VERIFYING` to `ACTIVE` status transition for auditor sessions

### DIFF
--- a/.github/scripts/foundry-active.test.ts
+++ b/.github/scripts/foundry-active.test.ts
@@ -35,6 +35,22 @@ describe('foundry-active', () => {
     expect(result).toContain('# Body content');
   });
 
+  test('Happy Path: transitions VERIFYING to ACTIVE and sets jules_session_id', () => {
+    const relPath = '.foundry/tasks/task-verifying.md';
+    createValidTestNode(tmpDir, relPath, {
+      id: 'task-verifying',
+      status: 'VERIFYING'
+    }, '# Verification content');
+
+    transitionNodeToActive(relPath, 'sessions/verification-123', tmpDir);
+
+    const result = fs.readFileSync(path.join(tmpDir, relPath), 'utf-8');
+    expect(result).toContain('status: ACTIVE');
+    expect(result).toContain('jules_session_id: sessions/verification-123');
+    expect(result).not.toContain('status: VERIFYING');
+    expect(result).toContain('# Verification content');
+  });
+
   test('Quoted Values: handles READY in quotes correctly', () => {
     const relPath = '.foundry/tasks/task-quoted.md';
     createValidTestNode(tmpDir, relPath, {
@@ -49,14 +65,14 @@ describe('foundry-active', () => {
     expect(result).toContain('jules_session_id: run-quoted');
   });
 
-  test('Validation: fails if node is not READY', () => {
+  test('Validation: fails if node is not READY or VERIFYING', () => {
     const relPath = '.foundry/tasks/task-001.md';
     createValidTestNode(tmpDir, relPath, {
       id: 'task-001',
       status: 'PENDING'
     }, '');
 
-    expect(() => transitionNodeToActive(relPath, 'run-123', tmpDir)).toThrow('Node is not in READY status');
+    expect(() => transitionNodeToActive(relPath, 'run-123', tmpDir)).toThrow('Node is not in READY or VERIFYING status');
   });
 
   test('Strict Check: fails if unexpected field is modified', () => {

--- a/.github/scripts/foundry-active.ts
+++ b/.github/scripts/foundry-active.ts
@@ -42,8 +42,8 @@ export function transitionNodeToActive(repoPath: string, sessionId: string, repo
   const original = matter(rawContent);
 
   // 1. Pre-validation
-  if (original.data['status'] !== 'READY') {
-    throw new Error(`Node is not in READY status (current: ${original.data['status']}): ${repoPath}`);
+  if (original.data['status'] !== 'READY' && original.data['status'] !== 'VERIFYING') {
+    throw new Error(`Node is not in READY or VERIFYING status (current: ${original.data['status']}): ${repoPath}`);
   }
 
   const dateStr = todayISO();


### PR DESCRIPTION
The Foundry Engine failed because `foundry-active.ts` only permitted transitions to `ACTIVE` from the `READY` status. However, nodes awaiting verification are in the `VERIFYING` status. This PR expands the permitted initial statuses to include `VERIFYING`, allowing auditor sessions to be dispatched correctly.

Key changes:
- Updated `.github/scripts/foundry-active.ts` to allow `READY` or `VERIFYING` as initial status.
- Updated `.github/scripts/foundry-active.test.ts` with a new test case for the `VERIFYING` path.
- Verified DAG integrity and full test suite pass.

Fixes #1780

---
*PR created automatically by Jules for task [7500103813072105569](https://jules.google.com/task/7500103813072105569) started by @szubster*