### PR TITLE
feat: Generate PRD for Hierarchical Verification Timing

### DIFF
--- a/.foundry/ideas/idea-065-epic-verification-timing.md
+++ b/.foundry/ideas/idea-065-epic-verification-timing.md
@@ -36,3 +36,7 @@ Potential solutions:
 
 ## Goal
 Establish a mechanism or process to ensure Epics are only marked `COMPLETED` when their functional requirements are actually implemented in the codebase.
+
+
+## Spawned Nodes
+- [prd-065-035-epic-verification-timing](../prds/prd-065-035-epic-verification-timing.md)

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -1,1 +1,8 @@
 # Product Manager Journal
+
+## Macro-Level Node Completion Timing (2026-05-23)
+**Observation:**
+Currently, macroscopic Foundry nodes (such as Epics and Stories) transition to the `VERIFYING` (and subsequently `COMPLETED`) status prematurely once their immediate Acceptance Criteria (usually just creating child nodes) are met, even though the actual implementation tasks have not been merged into the codebase.
+
+**Architectural Constraint:**
+This violates the spirit of the dependency graph. An Epic represents a "macroscopic functional chunk" of work. If it completes before its functional requirements are implemented, it provides a false sense of progress and can cause downstream nodes dependent on the Epic to be dispatched before the codebase is ready for them. The orchestrator must be updated to enforce strict hierarchical completion timing, preventing parent nodes from completing until all of their spawned descendant nodes are fully completed. This ensures that "Epic implementation is done" is semantically accurate across the DAG.

--- a/.foundry/prds/prd-065-035-epic-verification-timing.md
+++ b/.foundry/prds/prd-065-035-epic-verification-timing.md
@@ -1,0 +1,52 @@
+---
+id: prd-065-035-epic-verification-timing
+type: PRD
+title: Enforce Hierarchical Verification Timing for Macro Nodes
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-05-23'
+updated_at: '2026-05-23'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-065-epic-verification-timing
+tags:
+  - foundry
+  - process
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Enforce Hierarchical Verification Timing for Macro Nodes
+
+## Context
+Currently, macroscopic Foundry nodes like `EPIC` and `STORY` nodes can transition to the `VERIFYING` (and subsequently `COMPLETED`) status prematurely. A parent node is often marked complete once its immediate functional requirement—usually just the creation of child nodes—is met. This happens even though the actual implementation tasks have not been executed and merged into the codebase.
+
+Because the orchestrator treats these as standalone completions, it creates a false sense of progress and can cause downstream nodes (which depend on the Epic or Story) to be dispatched before the underlying codebase is actually ready.
+
+## Goal
+The Foundry Orchestrator must be updated to enforce strict hierarchical completion timing. A parent node (e.g., an Epic or Story) MUST NOT transition to `COMPLETED` or `VERIFYING` until all of its descendant nodes (the entire spawned sub-tree) are completely verified and in the `COMPLETED` state.
+
+This ensures that "Epic implementation is done" is semantically accurate.
+
+## Requirements
+
+1. **Implicit Dependency Enforcement:**
+   - The Orchestrator's DAG resolution algorithm in `.github/scripts/foundry-orchestrator.ts` must be updated to infer that any parent node implicitly depends on all of its recursive descendants.
+   - A node cannot be considered for `READY` (and thereby cannot transition to `COMPLETED`) if any node in its descendant tree is in any state other than `COMPLETED`.
+
+2. **Late-Binding Accommodation:**
+   - The system already accommodates late-binding parents (e.g., a node kept `PENDING` because it contains unchecked boxes or is explicitly spawning children). The new hierarchical check must integrate seamlessly with this logic. A parent that has generated children must wait for those children to finish, even if its own checkboxes are ticked.
+
+3. **Backwards Compatibility:**
+   - Existing DAG logic for explicit `depends_on` arrays remains unchanged. This PRD focuses purely on inferring the parent-child relationship to block parent completion.
+   - The solution must avoid circular dependency deadlocks (where a parent blocks a child and the child blocks the parent) by ensuring parents only wait on descendants, not vice-versa, for their final completion state.
+
+## Acceptance Criteria
+- [ ] The `foundry-orchestrator.ts` script is updated to block parent nodes from transitioning to `COMPLETED` or `VERIFYING` if any descendant child node is incomplete.
+- [ ] Unit tests in `.github/scripts/foundry-orchestrator.test.ts` are updated or added to verify that a parent node remains pending/active while its spawned children are being executed.
+- [ ] The DAG remains deadlock-free; children are still dispatched normally, but the parent waits.
+- [ ] The TPM or Agile Coach journal is updated to reflect this new process change.


### PR DESCRIPTION
This PR transforms IDEA `idea-065-epic-verification-timing` into a PRD (`prd-065-035-epic-verification-timing.md`).

- Created PRD with requirements to enforce hierarchical blockades in the orchestrator DAG.
- Updated `idea-065-epic-verification-timing.md` to reference the spawned PRD.
- Updated `product_manager.md` journal with the new architectural constraint regarding macro-level node completion timing.

---
*PR created automatically by Jules for task [10016164574320936708](https://jules.google.com/task/10016164574320936708) started by @szubster*