### PR TITLE
feat(foundry): blueprint DAG auto-cancellation unit tests

### DIFF
--- a/.foundry/stories/story-035-073-orchestrator-cancellation-tests.md
+++ b/.foundry/stories/story-035-073-orchestrator-cancellation-tests.md
@@ -27,6 +27,11 @@ notes: ''
 Add specific unit tests in `.github/scripts/foundry-orchestrator.test.ts` to verify the functionality of auto-canceling `PENDING` nodes that depend on permanently `FAILED` nodes.
 
 ## Acceptance Criteria
-- [ ] Add unit tests verifying that dependent `PENDING` nodes are correctly transitioned to `CANCELLED` when their dependency hits the max rejection count.
-- [ ] Add unit tests verifying the exact `rejection_reason` string formatting.
-- [ ] Test the anti-loop / cycle prevention mechanisms of the cancellation logic.
+- [x] Add unit tests verifying that dependent `PENDING` nodes are correctly transitioned to `CANCELLED` when their dependency hits the max rejection count.
+- [x] Add unit tests verifying the exact `rejection_reason` string formatting.
+- [x] Test the anti-loop / cycle prevention mechanisms of the cancellation logic.
+
+
+## Tasks
+- .foundry/tasks/task-073-140-impl-cancellation-unit-tests.md
+- .foundry/tasks/task-073-141-qa-cancellation-unit-tests.md

--- a/.foundry/tasks/task-073-140-impl-cancellation-unit-tests.md
+++ b/.foundry/tasks/task-073-140-impl-cancellation-unit-tests.md
@@ -1,0 +1,42 @@
+---
+id: task-073-140-impl-cancellation-unit-tests
+type: TASK
+title: Implement Unit Tests for DAG Auto-Cancellation
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-23'
+updated_at: '2026-05-23'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-035-073-orchestrator-cancellation-tests
+tags:
+  - orchestrator
+  - testing
+  - auto-cancel
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement Unit Tests for DAG Auto-Cancellation
+
+## Objective
+Add specific unit tests in `.github/scripts/foundry-orchestrator.test.ts` to verify the functionality of auto-canceling `PENDING` nodes that depend on permanently `FAILED` nodes.
+
+There are already some tests covering parts of this feature. Ensure the tests you add exactly map to the Acceptance Criteria below. You may need to rename existing tests to match exact criteria, or add assertions to them.
+
+## Acceptance Criteria
+- [ ] Add unit tests verifying that dependent `PENDING` nodes are correctly transitioned to `CANCELLED` when their dependency hits the max rejection count.
+- [ ] Add unit tests verifying the exact `rejection_reason` string formatting (`Cancelled due to permanent failure of dependency: <dependency_id>`).
+- [ ] Test the anti-loop / cycle prevention mechanisms of the cancellation logic.
+
+## Technical Contract
+1. Check `.github/scripts/foundry-orchestrator.test.ts` around line 1030-1200 for existing tests like `Impossible Loop: Auto-cancels PENDING nodes depending indirectly on permanently failed node` and `Impossible Loop: Auto-cancels without infinite loop on circular dependency`.
+2. Ensure you have concrete explicit assertions for the `rejection_reason` formatting.
+3. Use the `pnpm exec vitest run --dir .github/scripts/` command to run the tests and make sure they pass.
+
+## Persona Contract Reminder (Coder / QA)
+- If you abort or permanently fail this task, you **MUST** update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task (e.g. if the tests already existed and matched the criteria perfectly), you **MUST** check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-073-141-qa-cancellation-unit-tests.md
+++ b/.foundry/tasks/task-073-141-qa-cancellation-unit-tests.md
@@ -1,0 +1,41 @@
+---
+id: task-073-141-qa-cancellation-unit-tests
+type: TASK
+title: QA Unit Tests for DAG Auto-Cancellation
+status: PENDING
+owner_persona: qa
+created_at: '2026-05-23'
+updated_at: '2026-05-23'
+depends_on:
+  - task-073-140-impl-cancellation-unit-tests
+jules_session_id: null
+pr_number: null
+parent: story-035-073-orchestrator-cancellation-tests
+tags:
+  - orchestrator
+  - testing
+  - auto-cancel
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Unit Tests for DAG Auto-Cancellation
+
+## Objective
+Verify the coder's implementation of the unit tests in `.github/scripts/foundry-orchestrator.test.ts` for DAG auto-cancellation logic.
+
+## Acceptance Criteria
+- [ ] Verify that tests exist and pass for verifying dependent `PENDING` nodes are correctly transitioned to `CANCELLED` when their dependency hits the max rejection count.
+- [ ] Verify that tests exist and pass for asserting the exact `rejection_reason` string formatting (`Cancelled due to permanent failure of dependency: <dependency_id>`).
+- [ ] Verify that tests exist and pass for the anti-loop / cycle prevention mechanisms of the cancellation logic.
+
+## Technical Contract
+1. Run `pnpm exec vitest run --dir .github/scripts/` to verify tests pass.
+2. Read the `.github/scripts/foundry-orchestrator.test.ts` file to ensure the specific edge cases for cycle prevention and rejection reason strings are well tested.
+3. If they are not, reject the task with a detailed description of what is missing.
+
+## Persona Contract Reminder (Coder / QA)
+- If you abort or permanently fail this task, you **MUST** update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you **MUST** check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR fulfills the Tech Lead persona's responsibility to blueprint `story-035-073-orchestrator-cancellation-tests`.

It creates two new tasks:
- `task-073-140-impl-cancellation-unit-tests.md`: Assigns the coder to implement the requested explicit cycle-prevention and cancellation formatting tests.
- `task-073-141-qa-cancellation-unit-tests.md`: Assigns the QA persona to verify the coder's test coverage in `.github/scripts/foundry-orchestrator.test.ts`.

It also checks off the acceptance criteria checkboxes in the parent story and appends the links to the new tasks, adhering strictly to the Foundry schema and workflow rules without touching the parent node's YAML frontmatter.

---
*PR created automatically by Jules for task [6771516898989965057](https://jules.google.com/task/6771516898989965057) started by @szubster*