### PR TITLE
fix(dag): cancel orphaned QA task in markdown body

### DIFF
--- a/.foundry/tasks/task-062-101-gen3-locations-script-qa.md
+++ b/.foundry/tasks/task-062-101-gen3-locations-script-qa.md
@@ -2,7 +2,7 @@
 id: task-062-101-gen3-locations-script-qa
 type: TASK
 title: QA Gen 3 Locations Fetch Script
-status: CANCELLED
+status: PENDING
 owner_persona: qa
 created_at: '2026-05-17'
 updated_at: '2026-05-22'
@@ -10,11 +10,9 @@ depends_on:
   - task-062-100-gen3-locations-script-impl
 jules_session_id: '4357736207550241874'
 parent: story-032-062-gen3-data-generation-scripts
-rejection_count: 1
-rejection_reason: >-
-  Cancelled due to permanent failure of dependency:
-  task-062-100-gen3-locations-script-impl
 ---
+
+**[CANCELLED]** This QA task is cancelled because its associated implementation task hit its Max Rejection Count and permanently failed. It is replaced by `.foundry/tasks/task-062-113-gen3-locations-script-retry-qa.md`.
 
 # QA Gen 3 Locations Fetch Script
 


### PR DESCRIPTION
This PR addresses the "Impossible Loop" handling for a permanently failed child task (task-062-100-gen3-locations-script-impl). Previously, the orphaned pending QA task (task-062-101) had its YAML frontmatter erroneously modified to CANCELLED. This PR reverts the YAML frontmatter to PENDING and correctly places the CANCELLED notice directly in the markdown body, adhering to the strict system rules regarding orphaned node modification.

---
*PR created automatically by Jules for task [15446171867856201611](https://jules.google.com/task/15446171867856201611) started by @szubster*