### PR TITLE
feat(auth): implement cloudflare access google sso flow

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -46,3 +46,6 @@ The CEO/Architect has specified that Cloudflare Pages are already deployed using
 
 ## 2026-05-21: Purpose of Wrangler in a Pull-Based Deployment Model
 Even though the project uses Cloudflare's GitHub integration for deployments (Inversion of Control, where Cloudflare polls the repo), the `wrangler` CLI is still a required devDependency. It provides the local emulation environment (`workerd`) necessary to test Cloudflare Workers, Pages, and bindings (like KV or D1) locally during development before committing.
+
+## 2026-05-22: Cloudflare Access Plugin Usage
+When using `@cloudflare/pages-plugin-cloudflare-access`, remember that the verified JWT payload is injected into `context.data.cloudflareAccess.JWT.payload`. The `JWT` key is completely uppercase, not lowercase.

--- a/functions/api/auth/_middleware.ts
+++ b/functions/api/auth/_middleware.ts
@@ -1,0 +1,8 @@
+import cloudflareAccessPlugin from "@cloudflare/pages-plugin-cloudflare-access";
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  return cloudflareAccessPlugin({
+    domain: context.env.CLOUDFLARE_ACCESS_DOMAIN as `https://${string}.cloudflareaccess.com`,
+    aud: context.env.CLOUDFLARE_ACCESS_AUD,
+  })(context);
+};

--- a/functions/api/auth/me.ts
+++ b/functions/api/auth/me.ts
@@ -1,0 +1,17 @@
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  // @cloudflare/pages-plugin-cloudflare-access injects the verified payload into context.data.cloudflareAccess
+  const accessData = context.data["cloudflareAccess"] as { JWT: { payload: unknown } } | undefined;
+
+  if (!accessData || !accessData.JWT) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  // The payload typically includes identity information from Cloudflare Access.
+  return new Response(JSON.stringify({ user: accessData.JWT.payload }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" }
+  });
+};

--- a/functions/env.d.ts
+++ b/functions/env.d.ts
@@ -1,0 +1,4 @@
+interface Env {
+  CLOUDFLARE_ACCESS_DOMAIN: string;
+  CLOUDFLARE_ACCESS_AUD: string;
+}

--- a/knip.json
+++ b/knip.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignoreExportsUsedInFile": true,
-  "ignoreDependencies": ["wrangler"],
+  "ignoreDependencies": ["wrangler", "@cloudflare/pages-plugin-cloudflare-access"],
   "ignore": [
     "src/test-setup.ts",
     "scripts/validate-foundry-schema.ts",
     ".github/scripts/extract-research.ts",
-    "scripts/gen3-fetch-locations.ts"
+    "scripts/gen3-fetch-locations.ts",
+    "functions/**/*.ts"
   ],
   "rules": {
     "files": "warn",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@cloudflare/pages-plugin-cloudflare-access": "^1.0.5",
     "@tanstack/react-query": "^5.100.11",
     "@tanstack/react-router": "^1.170.7",
     "@tanstack/react-router-devtools": "^1.167.0",
@@ -48,6 +49,7 @@
   "devDependencies": {
     "@argos-ci/playwright": "^7.0.2",
     "@biomejs/biome": "^2.4.15",
+    "@cloudflare/workers-types": "^4.20260523.1",
     "@codecov/vite-plugin": "^2.0.1",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "0.5.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@cloudflare/pages-plugin-cloudflare-access':
+        specifier: ^1.0.5
+        version: 1.0.5
       '@tanstack/react-query':
         specifier: ^5.100.11
         version: 5.100.11(react@19.2.6)
@@ -57,6 +60,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.15
         version: 2.4.15
+      '@cloudflare/workers-types':
+        specifier: ^4.20260523.1
+        version: 4.20260523.1
       '@codecov/vite-plugin':
         specifier: ^2.0.1
         version: 2.0.1(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
@@ -167,7 +173,7 @@ importers:
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.7)
       wrangler:
         specifier: ^4.93.1
-        version: 4.93.1
+        version: 4.93.1(@cloudflare/workers-types@4.20260523.1)
 
   .github/scripts:
     dependencies:
@@ -809,6 +815,9 @@ packages:
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
     engines: {node: '>=22.0.0'}
 
+  '@cloudflare/pages-plugin-cloudflare-access@1.0.5':
+    resolution: {integrity: sha512-EGVSaUoFLxKfds2tgLWGzIk/xXLO2RqwZDUKsH/olXdNOckOMr4ShR8Pt1AJpZrakCDNiDVXmfLDJYTufxuQRw==}
+
   '@cloudflare/unenv-preset@2.16.1':
     resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
     peerDependencies:
@@ -847,6 +856,9 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workers-types@4.20260523.1':
+    resolution: {integrity: sha512-Kr66Jip2K3t0srdoLLImzblTTx2T409Zk2J6AHANmlB950rlHr2henMQx7+cdQOLm2p1CttuBcYB1UVjdiFN8Q==}
 
   '@codecov/bundler-plugin-core@2.0.1':
     resolution: {integrity: sha512-TkdKn/rEwZQ723M7DDUmHe5r0IJa23rUT4TAx5jXmg12wGZGAHGWWU7LKeQsYCsKdLMxK7bLaGk9M++4wSRD5w==}
@@ -5583,6 +5595,8 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
+  '@cloudflare/pages-plugin-cloudflare-access@1.0.5': {}
+
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260520.1)':
     dependencies:
       unenv: 2.0.0-rc.24
@@ -5603,6 +5617,8 @@ snapshots:
 
   '@cloudflare/workerd-windows-64@1.20260520.1':
     optional: true
+
+  '@cloudflare/workers-types@4.20260523.1': {}
 
   '@codecov/bundler-plugin-core@2.0.1':
     dependencies:
@@ -9290,7 +9306,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260520.1
       '@cloudflare/workerd-windows-64': 1.20260520.1
 
-  wrangler@4.93.1:
+  wrangler@4.93.1(@cloudflare/workers-types@4.20260523.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260520.1)
@@ -9301,6 +9317,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260520.1
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260523.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "paths": {
       "@/*": ["./*"]
     },
+    "types": ["@cloudflare/workers-types"],
     "incremental": true
   },
   "exclude": [".github/scripts"]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,7 @@
 name = "dexhelper"
 compatibility_date = "2026-05-21"
 pages_build_output_dir = "dist"
+
+[vars]
+CLOUDFLARE_ACCESS_DOMAIN = "https://<your-team>.cloudflareaccess.com"
+CLOUDFLARE_ACCESS_AUD = "<your-access-aud-string>"


### PR DESCRIPTION
Implemented the Google SSO login flow securely within the Cloudflare backend using Cloudflare Access (as requested in the story requirements) rather than a custom OAuth flow.

The `@cloudflare/pages-plugin-cloudflare-access` handles the authentication natively. It automatically redirects unauthenticated users, validates JWT signatures via Cloudflare's JWKS endpoint, and injects the payload into the context.

I've also:
- Added `functions/api/auth/_middleware.ts` to attach the plugin to all `/api/auth/*` requests.
- Added `functions/api/auth/me.ts` to return the verified `JWT.payload` to the frontend.
- Added the necessary variable placeholders in `wrangler.toml` (`CLOUDFLARE_ACCESS_DOMAIN` and `CLOUDFLARE_ACCESS_AUD`).
- Checked off the Acceptance Criteria.

---
*PR created automatically by Jules for task [12228321687548243571](https://jules.google.com/task/12228321687548243571) started by @szubster*