### PR TITLE
tech lead: extract and broadcast rejection count tasks

### DIFF
--- a/.foundry/stories/story-046-085-extract-broadcast-rejection-count.md
+++ b/.foundry/stories/story-046-085-extract-broadcast-rejection-count.md
@@ -34,5 +34,9 @@ In order to display permanent failures on the DAG dashboard, we need to surface 
 3. Verify that the React context layer correctly exposes the property.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Create TASKs for updating parser and data models.
-- [ ] Tech Lead: Ensure DAG data model typing is consistent with ADR 017.
+- [x] Tech Lead: Create TASKs for updating parser and data models.
+- [x] Tech Lead: Ensure DAG data model typing is consistent with ADR 017.
+
+## Generated Tasks
+- [ ] .foundry/tasks/task-085-142-impl-extract-rejection-count.md
+- [ ] .foundry/tasks/task-085-143-qa-extract-rejection-count.md

--- a/.foundry/tasks/task-085-142-impl-extract-rejection-count.md
+++ b/.foundry/tasks/task-085-142-impl-extract-rejection-count.md
@@ -1,0 +1,43 @@
+---
+id: task-085-142-impl-extract-rejection-count
+type: TASK
+title: Implement DAG Data Parsing for Rejection Count
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-23'
+updated_at: '2026-05-23'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-046-085-extract-broadcast-rejection-count
+tags:
+  - foundry
+  - ui
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement DAG Data Parsing for Rejection Count
+
+## Objective
+Update the existing DAG data parser to read and extract the `rejection_count` property from the YAML frontmatter of `.foundry` files. Update associated frontend models to include this data and ensure it's exposed through the React Context layer for the DAG Dashboard UI.
+
+## Context
+In order to display permanent failures on the DAG dashboard, we need to surface the `rejection_count` of each node in the UI. We need to introduce a "Permanent Failures" view within the DAG Dashboard (ADR 017).
+
+## Requirements
+1. Update parsing logic to capture `rejection_count` from the `.foundry` markdown files YAML frontmatter.
+2. Update the `FoundryNode` TypeScript types.
+3. Verify that the React context layer correctly exposes the property to connected UI views.
+
+## Acceptance Criteria
+- [ ] Coder: Update parsing logic.
+- [ ] Coder: Update `FoundryNode` TypeScript types.
+- [ ] Coder: Ensure React context layer correctly exposes the property.
+
+## Reminders
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-085-143-qa-extract-rejection-count.md
+++ b/.foundry/tasks/task-085-143-qa-extract-rejection-count.md
@@ -1,0 +1,44 @@
+---
+id: task-085-143-qa-extract-rejection-count
+type: TASK
+title: QA DAG Data Parsing for Rejection Count
+status: PENDING
+owner_persona: qa
+created_at: '2026-05-23'
+updated_at: '2026-05-23'
+depends_on:
+  - task-085-142-impl-extract-rejection-count
+jules_session_id: null
+pr_number: null
+parent: story-046-085-extract-broadcast-rejection-count
+tags:
+  - foundry
+  - ui
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA DAG Data Parsing for Rejection Count
+
+## Objective
+Verify that the DAG data parsing logic correctly extracts the `rejection_count` property, the `FoundryNode` TypeScript types are properly updated according to ADR 017, and that the React context layer accurately broadcasts the `rejection_count` property for the DAG Dashboard UI.
+
+## Context
+This is a verification task for `task-085-142-impl-extract-rejection-count`. In order to display permanent failures on the DAG dashboard, we need to surface the `rejection_count` of each node in the UI.
+
+## Requirements
+1. Verify parser extracts `rejection_count`.
+2. Verify data models align with ADR 017.
+3. Verify context layer broadcasts `rejection_count`.
+
+## Acceptance Criteria
+- [ ] QA: Verify parser extracts `rejection_count`.
+- [ ] QA: Verify data models align with ADR 017.
+- [ ] QA: Verify context layer broadcasts `rejection_count`.
+
+## Reminders
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Created tasks for extracting and broadcasting rejection counts to the frontend, fulfilling Story 046-085.

---
*PR created automatically by Jules for task [2628118099232734747](https://jules.google.com/task/2628118099232734747) started by @szubster*