### PR TITLE
Foundry: Break down Smart Route Radar PRD

### DIFF
--- a/.foundry/epics/epic-035-048-smart-radar-data-unification.md
+++ b/.foundry/epics/epic-035-048-smart-radar-data-unification.md
@@ -1,0 +1,35 @@
+---
+id: epic-035-048-smart-radar-data-unification
+type: EPIC
+title: Smart Radar Data Unification
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-23'
+updated_at: '2026-05-23'
+depends_on:
+  - task-035-142-smart-radar-adr
+jules_session_id: null
+pr_number: null
+parent: prd-064-035-smart-route-radar
+tags:
+  - feature
+  - ux
+  - map
+  - data
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Smart Radar Data Unification
+
+## Context
+As defined in PRD `prd-064-035-smart-route-radar`, we need to integrate dynamic suggestions from `suggestionEngine` with frontend map visualizations.
+
+## Scope
+Unify the data structures used by the suggestion engine and the map rendering components (as will be defined by the ADR produced in `task-035-142-smart-radar-adr`).
+
+## Acceptance Criteria
+- [ ] Write stories to implement data unification according to the ADR.
+- [ ] Complete child stories/tasks for data unification.

--- a/.foundry/epics/epic-035-049-smart-radar-heatmap-generation.md
+++ b/.foundry/epics/epic-035-049-smart-radar-heatmap-generation.md
@@ -1,0 +1,35 @@
+---
+id: epic-035-049-smart-radar-heatmap-generation
+type: EPIC
+title: Smart Radar Heatmap Generation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-23'
+updated_at: '2026-05-23'
+depends_on:
+  - epic-035-048-smart-radar-data-unification
+jules_session_id: null
+pr_number: null
+parent: prd-064-035-smart-route-radar
+tags:
+  - feature
+  - ux
+  - map
+  - visualization
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Smart Radar Heatmap Generation
+
+## Context
+As defined in PRD `prd-064-035-smart-route-radar`, we need to generate a visual heatmap overlay indicating the density of missing encounters.
+
+## Scope
+Implement the logic and UI layer to overlay heatmap data onto the map graph based on the unified data from `epic-035-048-smart-radar-data-unification`.
+
+## Acceptance Criteria
+- [ ] Write stories to implement the heatmap generation and overlay.
+- [ ] Complete child stories/tasks for heatmap generation.

--- a/.foundry/epics/epic-035-050-smart-radar-interactive-ui.md
+++ b/.foundry/epics/epic-035-050-smart-radar-interactive-ui.md
@@ -1,0 +1,35 @@
+---
+id: epic-035-050-smart-radar-interactive-ui
+type: EPIC
+title: Smart Radar Interactive UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-23'
+updated_at: '2026-05-23'
+depends_on:
+  - epic-035-049-smart-radar-heatmap-generation
+jules_session_id: null
+pr_number: null
+parent: prd-064-035-smart-route-radar
+tags:
+  - feature
+  - ux
+  - map
+  - interactive
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Smart Radar Interactive UI
+
+## Context
+As defined in PRD `prd-064-035-smart-route-radar`, users should be able to click on map nodes to see missing encounters and requirements.
+
+## Scope
+Make map nodes interactive and build the detail views to display missing encounter rates and specific requirements dynamically.
+
+## Acceptance Criteria
+- [ ] Write stories to implement interactive map nodes and detail views.
+- [ ] Complete child stories/tasks for the interactive UI.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -1,2 +1,5 @@
 Learning: For Gen 3 which encompasses games set in two different regions (Hoenn and Kanto), it's important to design a unified map graph architecture that supports both regions within a single module (gen3Graph.ts). This ensures consistency and simplifies strategy development across RSE and FRLG.
 When extracting Stories from an Epic that specifies acceptance criteria corresponding directly to the resulting tasks, we can map Epic criteria directly to Story completion criteria, ensuring they are explicitly checked off in the Epic but implemented down the chain.
+
+## Smart Route Radar (2026-05-23)
+When creating Epic breakdowns that involve significant new architecture, such as combining dynamic save states with static map rendering logic (as seen in the Smart Route Radar feature), it is necessary to schedule an architectural TASK (assigned to `architect`) alongside the EPICS. The subsequent implementation EPICS (e.g., Data Unification) MUST explicitly declare a `depends_on` on the architect's TASK to ensure the ADR is written before the implementation stories are planned. This prevents the `story_owner` from starting work without an approved system design.

--- a/.foundry/prds/prd-064-035-smart-route-radar.md
+++ b/.foundry/prds/prd-064-035-smart-route-radar.md
@@ -43,4 +43,11 @@ Visualizing the assistant's data geographically shifts DexHelper from being just
 3.  **Interactive Nodes**: The map nodes must be clickable, triggering a detail view that shows the specific missing encounters, similar to the existing static map views but filtered by the user's save state.
 
 ## Next Steps
-- [ ] Architect: Convert this PRD into an ADR detailing the system design for joining static encounter data with dynamic save state in the UI.
+- [x] Architect: Convert this PRD into an ADR detailing the system design for joining static encounter data with dynamic save state in the UI.
+
+
+## Generated Tasks
+- [x] [task-035-142-smart-radar-adr](.foundry/tasks/task-035-142-smart-radar-adr.md)
+- [x] [epic-035-048-smart-radar-data-unification](.foundry/epics/epic-035-048-smart-radar-data-unification.md)
+- [x] [epic-035-049-smart-radar-heatmap-generation](.foundry/epics/epic-035-049-smart-radar-heatmap-generation.md)
+- [x] [epic-035-050-smart-radar-interactive-ui](.foundry/epics/epic-035-050-smart-radar-interactive-ui.md)

--- a/.foundry/tasks/task-035-142-smart-radar-adr.md
+++ b/.foundry/tasks/task-035-142-smart-radar-adr.md
@@ -1,0 +1,33 @@
+---
+id: task-035-142-smart-radar-adr
+type: TASK
+title: Smart Route Radar ADR
+status: PENDING
+owner_persona: architect
+created_at: '2026-05-23'
+updated_at: '2026-05-23'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-064-035-smart-route-radar
+tags:
+  - feature
+  - ux
+  - map
+  - exploration
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Smart Route Radar Architecture Decision Record
+
+## Objective
+Convert PRD `prd-064-035-smart-route-radar` into an ADR detailing the system design for joining static encounter data with dynamic save state in the UI.
+
+## Acceptance Criteria
+- [ ] Create an ADR in `.foundry/docs/adrs/` detailing how to unify static encounter data with dynamic save state for the Smart Route Radar map UI.
+- [ ] Document the data structures and flow for the heatmap UI layer.
+- [ ] Define how interactive map nodes will resolve specific encounters (rates, conditions).


### PR DESCRIPTION
Transformed PRD `prd-064-035-smart-route-radar` into a technical task for the architect to write an ADR, and three implementation epics for the data unification, heatmap generation, and interactive UI. Updated the PRD body with checkboxes for the newly created tasks. Added a journal entry explaining the dependency relationship for architecture tasks.

---
*PR created automatically by Jules for task [11786613801179700586](https://jules.google.com/task/11786613801179700586) started by @szubster*