### PR TITLE
🔐 [Fix] Prevent information leakage in sync controller (CWE-209)

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -41,3 +41,10 @@ Overrode the `@tanstack/history` version to `1.161.6` in `package.json`. While t
 **Pattern:** When mitigating vulnerable sub-dependencies flagged by `pnpm audit` (like `ws`), use the `pnpm.overrides` field in `package.json` to securely enforce the patched version down the dependency tree. Also, to fix CWE-285 vulnerabilities (incomplete URL substring matching) flagged by CodeQL, use `.endsWith()` or `.startsWith()` instead of `.includes()` when inspecting URLs.
 ## 2026-06-03 - [Mitigated CWE-209] - Prevented information leakage in AppLayout.tsx
 **Pattern:** When fixing CWE-209 by replacing `err.message` with generic strings, ensure that any variable previously capturing the error object in a try-catch block (e.g., `catch (err)`) is either removed or prefixed with an underscore (e.g., `catch (_err)`) to avoid unused variable warnings from the linter.
+
+## Sanitize Error Logging (CWE-209)
+**Pattern:** When addressing CWE-209 by removing raw error objects from `console.error` logs, replace the output with descriptive, contextual static strings (e.g., `console.error('Failed to parse live save file')`) rather than generic homogenous fallbacks like `'System: sync failed'`. This preserves frontend debuggability without leaking sensitive object properties.
+**Pattern:** When the error object is completely unused in the `catch` block after removing it from the `console.error` logs, use modern ES2019 optional catch binding (`catch { ... }`) rather than prefixing it (`catch (_err)`). The project's linter will flag *any* caught but unused variable, even if prefixed with an underscore.
+
+## Incomplete URL Substring Matching (CWE-285)
+**Pattern:** While `.includes()` should be avoided for validating URLs (favoring `.startsWith()` or URL parsing), do NOT blindly apply this rule to `ErrorEvent.message` property checks (e.g., catching Vite chunk load errors). Browsers often prepend prefixes like `TypeError: ` to error messages, so `.startsWith()` will fail to match dynamically imported module errors, causing major application regressions. Use `.includes()` for generic error string matching.

--- a/src/hooks/useFileSyncController.ts
+++ b/src/hooks/useFileSyncController.ts
@@ -34,8 +34,8 @@ export function useFileSyncController() {
         await saveDB.putSave('last_save_file', new Uint8Array(buffer));
         setStatus('live');
         setErrorMsg(null);
-      } catch (err) {
-        console.error(err);
+      } catch {
+        console.error('Failed to parse live save file.');
         setStatus('error');
         setErrorMsg('Failed to parse live save file.');
       }
@@ -72,7 +72,7 @@ export function useFileSyncController() {
       lastModifiedRef.current = file.lastModified;
       await processFile(file);
     } catch (err) {
-      console.error('User cancelled or error:', err);
+      console.error('User cancelled or error');
       // Don't set error status if user just cancelled
       if (err instanceof Error && err.name !== 'AbortError') {
         setStatus('error');
@@ -103,8 +103,8 @@ export function useFileSyncController() {
             setStatus('disconnected');
           }
         }
-      } catch (e) {
-        console.error('Failed to restore handle', e);
+      } catch {
+        console.error('Failed to restore handle');
       }
     }
     void restoreHandle();
@@ -124,8 +124,8 @@ export function useFileSyncController() {
           await processFile(file);
         }
       }
-    } catch (err) {
-      console.error('Failed to resume sync', err);
+    } catch {
+      console.error('Failed to resume sync');
       setStatus('error');
     }
   }, [processFile]);
@@ -143,8 +143,8 @@ export function useFileSyncController() {
           lastModifiedRef.current = file.lastModified;
           await processFile(file);
         }
-      } catch (err) {
-        console.error('Polling error:', err);
+      } catch {
+        console.error('Polling error');
         // We might have lost permission or file was deleted
         setStatus('disconnected');
       }


### PR DESCRIPTION
🎯 What
This PR updates the error handling in `useFileSyncController.ts` by removing raw error objects from generic `console.error` calls and replacing them with descriptive static strings. It also drops unused catch variables using ES2019 syntax to satisfy linter rules.

⚠️ Risk
Low. The functionality remains entirely unchanged, only the console error text is modified. The static text is descriptive enough to maintain debuggability.

🛡️ Solution
Replaced `console.error(err)` with descriptive string literals such as `console.error('Failed to parse live save file.')` and removed the caught parameter (`err` or `e`) unless used elsewhere in the block.

---
*PR created automatically by Jules for task [13752233474237476422](https://jules.google.com/task/13752233474237476422) started by @szubster*