### PR TITLE
docs(foundry): log further observation on macro node verification in auditor journal

### DIFF
--- a/.foundry/ideas/idea-065-epic-verification-timing.md
+++ b/.foundry/ideas/idea-065-epic-verification-timing.md
@@ -39,4 +39,4 @@ Establish a mechanism or process to ensure Epics are only marked `COMPLETED` whe
 
 
 ## Spawned Nodes
-- [prd-065-035-epic-verification-timing](../prds/prd-065-035-epic-verification-timing.md)
+- [x] [prd-065-035-epic-verification-timing](../prds/prd-065-035-epic-verification-timing.md)

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -8,3 +8,5 @@ This violates the spirit of the dependency graph. An Epic represents a "macrosco
 
 **Recommendation/Learnings:**
 The system needs a clearer distinction between "Epic planning is done" and "Epic implementation is done". Perhaps Epics should implicitly depend on all their child nodes, or the `story_owner` needs to wait until all child stories are `COMPLETED` before submitting the empty PR to transition the Epic to `VERIFYING`. Currently, submitting the Epic when only the planning is done leads to failed audits.
+## 2026-05-24: Further Observation on Macro Node Verification
+Following up on the premature verification of Epics, this pattern applies generally to macro nodes (e.g., Story nodes as well). The system requires strict hierarchical completion enforcement. A parent node MUST NOT transition to COMPLETED or VERIFYING until all of its descendant nodes in the spawned sub-tree are completely verified and in the COMPLETED state. This ensures that the macroscopic progress representation accurately reflects implementation reality, preventing false progress signaling and premature unblocking of downstream dependencies.


### PR DESCRIPTION
This PR logs a further observation regarding the premature verification of macro nodes (like Epics and Stories) to the Auditor journal, building upon the initial observation about Epics.

The system requires strict hierarchical completion enforcement to accurately reflect implementation reality and prevent false progress signaling.

The node `idea-065-epic-verification-timing` is verified and completed.

---
*PR created automatically by Jules for task [12636791878054878917](https://jules.google.com/task/12636791878054878917) started by @szubster*