### PR TITLE
qa: reject dashboard alive team implementation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -14,3 +14,7 @@ During the validation of `task-072-128-implement-dag-cancellation`, I discovered
 
 ## Missing Integration Failures
 When an implementation task only creates standalone UI components but fails to integrate or render them anywhere in the main application (making them inaccessible to the user), the task MUST be rejected. The purpose of implementation isn't just to write code that passes isolated unit tests; it is to deliver accessible features.
+
+## 2026-05-24: Component Integration Policy Enforcement
+During the verification of `task-071-134-run-dashboard-ui-impl`, I found that the `AliveTeamView` component was fully implemented with corresponding tests, but it was completely unlinked and omitted from the application's view hierarchy (specifically, no Run Dashboard routes or integration existed).
+**Lesson**: Following the "Component Integration Policy", standalone UI components that are not integrated into the application making them inaccessible MUST result in a rejected implementation task, regardless of how well written the isolated unit tests are. The purpose of implementation is to deliver accessible features, not just code.

--- a/.foundry/tasks/task-071-134-run-dashboard-ui-impl.md
+++ b/.foundry/tasks/task-071-134-run-dashboard-ui-impl.md
@@ -2,7 +2,7 @@
 id: task-071-134-run-dashboard-ui-impl
 type: TASK
 title: Implement Dashboard Alive Team View
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-05-22'
 updated_at: '2026-05-23'
@@ -15,7 +15,11 @@ tags:
   - nuzlocke
   - verification
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: >-
+  Component Integration Policy Violation: The AliveTeamView component was
+  created but never integrated into the application view hierarchy (e.g., Run
+  Dashboard routes are missing/unlinked), making it unrenderable and
+  inaccessible to users.
 notes: ''
 ---
 

--- a/.foundry/tasks/task-071-135-run-dashboard-ui-qa.md
+++ b/.foundry/tasks/task-071-135-run-dashboard-ui-qa.md
@@ -28,3 +28,7 @@ QA the "Alive" team view for the Run Dashboard UI.
 ## Acceptance Criteria
 - [ ] Verify the "Alive" team view displays correctly.
 - [ ] Verify the UI meets all requirements for the Nuzlocke Tracker mode.
+
+
+## QA Notes
+- Validation FAILED: The `AliveTeamView` component was implemented, but it is not linked or integrated into the actual Run Dashboard UI (or any accessible route). This violates the Component Integration Policy. Rejecting the implementation task.


### PR DESCRIPTION
The `AliveTeamView` implementation task (`task-071-134-run-dashboard-ui-impl`) failed to integrate the new component into the application view hierarchy (e.g., Run Dashboard routes are missing). This violates the Component Integration Policy.

The implementation task has been marked as `FAILED` and returned to the Resurrection Loop for correction. The QA task and journal have been updated to reflect the rejection reason.

---
*PR created automatically by Jules for task [2397427065791103767](https://jules.google.com/task/2397427065791103767) started by @szubster*