### PR TITLE
chore(foundry): Auditor verification for smart route radar

### DIFF
--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -8,3 +8,11 @@ This violates the spirit of the dependency graph. An Epic represents a "macrosco
 
 **Recommendation/Learnings:**
 The system needs a clearer distinction between "Epic planning is done" and "Epic implementation is done". Perhaps Epics should implicitly depend on all their child nodes, or the `story_owner` needs to wait until all child stories are `COMPLETED` before submitting the empty PR to transition the Epic to `VERIFYING`. Currently, submitting the Epic when only the planning is done leads to failed audits.
+## 2026-05-24: Invalid Architect Checkbox embedded in PRD
+I audited the `idea-064-smart-route-radar` node and observed its generated downstream node `prd-064-035-smart-route-radar`. The PRD improperly includes an Architect checklist item (`- [ ] Architect: Convert this PRD into an ADR...`) within its markdown body.
+
+**Why this matters:**
+This violates the strict single-owner and pipeline boundary rules. `PRD` nodes are owned by the `epic_planner`. If an architectural design (ADR) or architect-specific logic is required during the PRD phase, the `product_manager` must spawn a separate `TASK` node for the `architect` rather than inappropriately adding architect tasks as checkboxes within a `PRD`. By burying it as a checkbox in the PRD, the Architect persona is never explicitly dispatched by the orchestrator to perform this work. Implementation Epics must explicitly include the newly spawned ADR TASK's ID in their `depends_on` array so implementation cannot begin until the ADR is completed.
+
+**Recommendation/Learnings:**
+The system must reject ideas that generate PRDs containing out-of-scope personas. We must enforce strict separation where ADR requirements spawn distinct `TASK` nodes assigned to the `architect` persona, and implementation Epics depend on that TASK node.

--- a/.foundry/tasks/task-035-143-smart-route-radar-adr.md
+++ b/.foundry/tasks/task-035-143-smart-route-radar-adr.md
@@ -1,0 +1,33 @@
+---
+id: task-035-143-smart-route-radar-adr
+type: TASK
+title: Smart Route Radar ADR Design
+status: PENDING
+owner_persona: architect
+created_at: '2026-05-24'
+updated_at: '2026-05-24'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-064-035-smart-route-radar
+tags:
+  - feature
+  - ux
+  - map
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Smart Route Radar ADR Design
+
+## Context
+During the PRD phase for the Smart Route Radar (idea-064), a requirement was identified to convert the technical approach into an Architecture Decision Record (ADR) detailing the system design for joining static encounter data with dynamic save state in the UI.
+
+This task was originally incorrectly embedded within `prd-064-035-smart-route-radar`. The Auditor persona has spawned this detached task to ensure the `architect` persona is properly dispatched by the orchestrator to perform this design work.
+
+## Acceptance Criteria
+- [ ] Write an ADR detailing the system design for the Smart Route Radar.
+- [ ] Save the ADR document in `.foundry/docs/adrs/`.


### PR DESCRIPTION
As the Auditor persona, I verified the `idea-064-smart-route-radar` node. The Idea successfully generated the PRD, so its acceptance criteria were met. However, I identified an architectural anti-pattern within the generated PRD artifact: an improperly embedded Architect checklist item. 

To correct the pipeline and ensure the Architect is properly dispatched by the orchestrator, I extracted this learning to the Auditor's journal and spawned a new detached downstream task node (`task-035-143-smart-route-radar-adr`) assigned to the `architect` persona. 

The original node's YAML was intentionally left unmodified, and this Empty PR submission will correctly advance `idea-064-smart-route-radar` to `COMPLETED`.

---
*PR created automatically by Jules for task [4625416827053340742](https://jules.google.com/task/4625416827053340742) started by @szubster*