### PR TITLE
🖼️ Canvas: Tactical Search Console Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -128,3 +128,9 @@
 **Outcome:** Accepted
 **Why:** Brings the mobile navigation interface tightly in line with the rest of the application's established tactical hardware motif (matching `AppLayout`, `Grid`, and `Details`), correcting the previous web-standard smooth transitions.
 **Pattern:** Ensure mobile layout structural components adhere to strict tactical aesthetics (sharp borders, corner crosshairs, scanning/flicker animations, monospace telemetry text) rather than generic app-like smoothed navigation bars, to maintain the specialized device illusion.
+
+## 2026-06-25 - [Accepted] - 🖼️ Canvas: Tactical Search Console Redesign
+**What:** Wrapped the entire `SearchAndFilters` component in a `<TacticalPanel>`, giving it a `[ SYS.QUERY_TERMINAL ]` telemetry header and redesigning the filter toggles below the search input as an interconnected segmented control to match settings configurations instead of side-scrolling pills.
+**Outcome:** Accepted
+**Why:** Brings the search console vertically closer to the top-level application aesthetic by eliminating standard layouts in favor of the established sharp-edged, dashed-border hardware terminal layout.
+**Pattern:** Combine related navigation and filtering inputs into unified `<TacticalPanel>` structures rather than letting inputs float freely, and utilize segmented controls over generic pill arrays for filters.

--- a/src/components/LocationSuggestions.tsx
+++ b/src/components/LocationSuggestions.tsx
@@ -16,13 +16,14 @@ export function LocationSuggestions() {
   const [isOpen, setIsOpen] = useState(false);
 
   // ⚡ Bolt: Cache locations query to prevent redundant IndexedDB hits on every keystroke debounce
-  const { data: locations = [] } = useQuery({
+  const { data: locations } = useQuery({
     queryKey: ['locations'],
     queryFn: () => pokeDB.getLocations(),
     staleTime: Infinity,
   });
 
   useEffect(() => {
+    const locs = locations || [];
     if (!searchTerm || searchTerm.length < 2 || selectedLocationId) {
       setSuggestions([]);
       setIsOpen(false);
@@ -34,8 +35,8 @@ export function LocationSuggestions() {
 
       // ⚡ Bolt: Replaced O(N) filter().slice() with a fast-breaking loop to avoid scanning all locations once 5 matches are found
       const filtered = [];
-      for (let i = 0; i < locations.length; i++) {
-        const l = locations[i];
+      for (let i = 0; i < locs.length; i++) {
+        const l = locs[i];
         if (l?.n.toLowerCase().includes(term)) {
           filtered.push(l);
           if (filtered.length >= 5) break;

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -2,8 +2,9 @@ import { Search } from 'lucide-react';
 import { useRef } from 'react';
 import { FILTER_TYPES, useStore } from '../store';
 import { LocationSuggestions } from './LocationSuggestions';
-import { TacticalButton } from './TacticalButton';
 import { TacticalInput } from './TacticalInput';
+import { TacticalPanel } from './TacticalPanel';
+import { TelemetryDecoration } from './TelemetryDecoration';
 
 export function SearchAndFilters() {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -30,55 +31,71 @@ export function SearchAndFilters() {
   };
 
   return (
-    <div className="mb-6 space-y-5 px-4">
-      <div className="flex flex-col gap-4 lg:flex-row">
-        {/* Tactical Hardware Search Terminal */}
-        <TacticalInput
-          ref={inputRef}
-          type="text"
-          data-testid="search-input"
-          placeholder="[ ENTER QUERY_ ]"
-          aria-label="Search Pokedex by name, ID, or location"
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          onKeyDown={handleKeyDown}
-          label="Database Scan"
-          icon={<Search size={14} />}
-          onClear={handleClearSearch}
-          containerClassName="mt-2 flex-1"
-        >
-          {/* Location Suggestions Dropdown */}
-          <LocationSuggestions />
-        </TacticalInput>
+    <div className="mb-6 px-4">
+      <TacticalPanel className="p-4 sm:p-6" variant="default">
+        <TelemetryDecoration label="SYS.QUERY_TERMINAL" className="top-2 right-4" />
 
-        {/* Tactical Filter Toggles */}
-        <fieldset className="no-scrollbar m-0 mt-2 flex min-w-0 gap-2 overflow-x-auto border-none p-0 px-1 pb-2">
-          <legend className="sr-only">Filter Pokémon</legend>
-          <TacticalButton
-            type="button"
-            onClick={() => setFilters([])}
-            aria-pressed={filtersSet.size === 0}
-            variant={filtersSet.size === 0 ? 'primary' : 'default'}
-            hasCrosshairs="corners"
+        <div className="flex flex-col gap-6 pt-4">
+          <TacticalInput
+            ref={inputRef}
+            type="text"
+            data-testid="search-input"
+            placeholder="[ ENTER QUERY_ ]"
+            aria-label="Search Pokedex by name, ID, or location"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            onKeyDown={handleKeyDown}
+            label="Database Scan"
+            icon={<Search size={14} />}
+            onClear={handleClearSearch}
+            containerClassName="w-full"
           >
-            All
-          </TacticalButton>
+            {/* Location Suggestions Dropdown */}
+            <LocationSuggestions />
+          </TacticalInput>
 
-          {FILTER_TYPES.map((f) => (
-            <TacticalButton
-              type="button"
-              key={f}
-              onClick={() => toggleFilter(f)}
-              aria-pressed={filtersSet.has(f)}
-              data-testid={`filter-${f}`}
-              variant={filtersSet.has(f) ? 'primary' : 'default'}
-              hasCrosshairs="corners"
-            >
-              {f === 'secured' ? 'Secured' : f === 'missing' ? 'Missing' : 'Dex Only'}
-            </TacticalButton>
-          ))}
-        </fieldset>
-      </div>
+          {/* Tactical Filter Toggles Segmented Control */}
+          <fieldset className="m-0 flex min-w-0 flex-col gap-2 border-none p-0">
+            <legend className="sr-only">Filter Pokémon</legend>
+            <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ FILTER_PARAMETERS ]</span>
+            <div className="flex flex-wrap border border-zinc-800 border-dashed sm:flex-nowrap">
+              <button
+                type="button"
+                onClick={() => setFilters([])}
+                aria-pressed={filtersSet.size === 0}
+                className={`min-w-[100px] flex-1 border-zinc-800 border-r border-dashed px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
+                  filtersSet.size === 0
+                    ? 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'
+                    : 'bg-zinc-950/50 text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400'
+                }`}
+              >
+                [ ALL ]
+              </button>
+
+              {FILTER_TYPES.map((f, idx) => {
+                const isLast = idx === FILTER_TYPES.length - 1;
+                const isActive = filtersSet.has(f);
+                return (
+                  <button
+                    type="button"
+                    key={f}
+                    onClick={() => toggleFilter(f)}
+                    aria-pressed={isActive}
+                    data-testid={`filter-${f}`}
+                    className={`min-w-[100px] flex-1 ${!isLast ? 'border-zinc-800 border-r border-dashed' : ''} px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
+                      isActive
+                        ? 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'
+                        : 'bg-zinc-950/50 text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400'
+                    }`}
+                  >
+                    [ {f === 'secured' ? 'SECURED' : f === 'missing' ? 'MISSING' : 'DEX ONLY'} ]
+                  </button>
+                );
+              })}
+            </div>
+          </fieldset>
+        </div>
+      </TacticalPanel>
     </div>
   );
 }

--- a/src/components/__tests__/PokedexCard.test.tsx
+++ b/src/components/__tests__/PokedexCard.test.tsx
@@ -54,8 +54,8 @@ describe('PokedexCard', () => {
     await render(<RouterProvider router={router} />);
 
     // Test for ID styling
-    await expect.element(page.getByText('ID')).toBeInTheDocument();
-    await expect.element(page.getByText('001')).toBeInTheDocument();
+    await expect.element(page.getByText('ID', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('001', { exact: true })).toBeInTheDocument();
   });
 
   test('renders [ SECURED ] when in storage', async () => {

--- a/src/components/__tests__/SearchAndFilters.test.tsx
+++ b/src/components/__tests__/SearchAndFilters.test.tsx
@@ -1,0 +1,54 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createMemoryHistory, createRootRoute, createRouter, RouterProvider } from '@tanstack/react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { useStore } from '../../store';
+import { SearchAndFilters } from '../SearchAndFilters';
+
+describe('SearchAndFilters', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const rootRoute = createRootRoute({
+    component: () => <SearchAndFilters />,
+  });
+
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory(),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useStore.getState().setSaveData({
+      gameVersion: 'emerald',
+      generation: 3,
+      trainerName: 'TEST',
+      trainerId: 12345,
+      party: [],
+      pc: [],
+      partyDetails: [],
+      pcDetails: [],
+      seen: new Set(),
+      owned: new Set(),
+      // biome-ignore lint/suspicious/noExplicitAny: Required for partial save mock
+    } as any);
+  });
+
+  it('renders correctly', async () => {
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    );
+
+    await expect.element(page.getByText('[ FILTER_PARAMETERS ]')).toBeInTheDocument();
+    await expect.element(page.getByText('[ ALL ]')).toBeInTheDocument();
+    await expect.element(page.getByText('[ SECURED ]')).toBeInTheDocument();
+    await expect.element(page.getByText('[ MISSING ]')).toBeInTheDocument();
+    await expect.element(page.getByText('[ DEX ONLY ]')).toBeInTheDocument();
+    await expect.element(page.getByPlaceholder('[ ENTER QUERY_ ]')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/SearchAndFilters.test.tsx
+++ b/src/components/__tests__/SearchAndFilters.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createMemoryHistory, createRootRoute, createRouter, RouterProvider } from '@tanstack/react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
 import { useStore } from '../../store';
 import { SearchAndFilters } from '../SearchAndFilters';
@@ -35,6 +35,20 @@ describe('SearchAndFilters', () => {
       owned: new Set(),
       // biome-ignore lint/suspicious/noExplicitAny: Required for partial save mock
     } as any);
+    useStore.getState().setSearchTerm('');
+    useStore.getState().setFilters([]);
+  });
+
+  it('returns null when no saveData is available', async () => {
+    useStore.getState().setSaveData(null);
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    );
+
+    // It should not render anything
+    await expect.element(page.getByText('[ FILTER_PARAMETERS ]')).not.toBeInTheDocument();
   });
 
   it('renders correctly', async () => {
@@ -45,10 +59,70 @@ describe('SearchAndFilters', () => {
     );
 
     await expect.element(page.getByText('[ FILTER_PARAMETERS ]')).toBeInTheDocument();
-    await expect.element(page.getByText('[ ALL ]')).toBeInTheDocument();
-    await expect.element(page.getByText('[ SECURED ]')).toBeInTheDocument();
-    await expect.element(page.getByText('[ MISSING ]')).toBeInTheDocument();
-    await expect.element(page.getByText('[ DEX ONLY ]')).toBeInTheDocument();
-    await expect.element(page.getByPlaceholder('[ ENTER QUERY_ ]')).toBeInTheDocument();
+  });
+
+  it('updates search term on input', async () => {
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    );
+
+    const input = page.getByPlaceholder('[ ENTER QUERY_ ]');
+    await input.fill('pikachu');
+    await expect.element(input).toHaveValue('pikachu');
+    expect(useStore.getState().searchTerm).toBe('pikachu');
+  });
+
+  it('clears search term on escape key', async () => {
+    useStore.getState().setSearchTerm('bulbasaur');
+
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    );
+
+    const input = page.getByPlaceholder('[ ENTER QUERY_ ]');
+    await input.click();
+    await input.fill('test');
+
+    // React specific simulation of keyDown
+    await userEvent.keyboard('{Escape}');
+
+    expect(useStore.getState().searchTerm).toBe('');
+  });
+
+  it('clears search term when clear button is clicked', async () => {
+    useStore.getState().setSearchTerm('bulbasaur');
+
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    );
+
+    const clearButton = page.getByRole('button', { name: 'Clear input' });
+    await clearButton.click();
+
+    expect(useStore.getState().searchTerm).toBe('');
+  });
+
+  it('toggles filters', async () => {
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    );
+
+    const missingBtn = page.getByTestId('filter-missing');
+    await missingBtn.click();
+
+    expect(useStore.getState().filters).toContain('missing');
+
+    const allBtn = page.getByText('[ ALL ]');
+    await allBtn.click();
+
+    expect(useStore.getState().filters.length).toBe(0);
   });
 });


### PR DESCRIPTION
Wrapped the entire `SearchAndFilters` component in a `<TacticalPanel>`, giving it a `[ SYS.QUERY_TERMINAL ]` telemetry header and redesigning the filter toggles below the search input as an interconnected segmented control to match settings configurations instead of side-scrolling pills. Brings the search console vertically closer to the top-level application aesthetic.

---
*PR created automatically by Jules for task [13303757244190038632](https://jules.google.com/task/13303757244190038632) started by @szubster*