### PR TITLE
📜 Scribe: Documented Nuzlocke tracker module

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -118,3 +118,10 @@ Documenting these functions ensures that future maintainers understand the busin
 - `generateEvolutionSuggestions`: Evaluates player's current boxes and party to find pre-evolutions, with priority boost if evolution criteria are actively met.
 Documenting these highlights the fact that they modify the passed `suggestions` array in-place, which is a key performance optimization that avoids garbage collection overhead for intermediate array allocations in the hot path.
 - **Temporary Scripts**: After executing temporary inline scripts (e.g., `.cjs` Node.js scripts) to modify file contents, you must explicitly delete them (e.g., `rm script.cjs`) before submitting code review to prevent committing execution artifacts and polluting the repository.
+
+## 2026-05-24 - Nuzlocke Tracker Architecture
+
+**What:** Added JSDoc documentation to `src/engine/nuzlocke/tracker.ts`.
+**Why:** The Nuzlocke tracker implements specific game rules (permadeath, one catch per route) through constraints in the binary save data structure.
+- **Permadeath (PC Healing Problem):** I learned that we cannot rely solely on `currentHp === 0` to track deaths because depositing a Pokémon in the PC fully heals it in the save data. To circumvent this, the engine relies on the player designating a specific PC box via string comparison (`storageLocation === graveyardBox`).
+- **Route Tracking (Gen 2 Dependency):** The "One Catch Per Route" rule is enforced by checking `caughtData.location` across all Party and PC structures. This means this strict Nuzlocke enforcement feature is inherently dependent on Generation 2 mechanics, as Generation 1 save files do not store catch location data.

--- a/src/engine/nuzlocke/tracker.ts
+++ b/src/engine/nuzlocke/tracker.ts
@@ -1,11 +1,26 @@
 import type { PokemonInstance, SaveData } from '../saveParser/parsers/common';
 
+/**
+ * Represents a grouping of Pokémon caught in a specific location.
+ * Used to enforce the Nuzlocke 'One Catch per Route' rule.
+ */
 export interface LocationEncounters {
   locationId: number;
   locationName: string;
   encounters: PokemonInstance[];
 }
 
+/**
+ * Aggregates all physically owned Pokémon (Party + PC) by the location where they were caught.
+ *
+ * @param saveData - The parsed save data.
+ * @returns An array of locations and the Pokémon caught in them.
+ *
+ * @remarks
+ * This function relies on the `caughtData.location` property, which is fully supported in
+ * Generation 2 (Crystal) and forward. It is the core heuristic used to detect Nuzlocke
+ * multiple-catch violations.
+ */
 export function aggregateEncountersByLocation(saveData: SaveData): LocationEncounters[] {
   const locationMap = new Map<number, LocationEncounters>();
 
@@ -31,14 +46,46 @@ export function aggregateEncountersByLocation(saveData: SaveData): LocationEncou
   return Array.from(locationMap.values());
 }
 
+/**
+ * Scans the player's save data for violations of the 'One Catch per Route' Nuzlocke rule.
+ *
+ * @param saveData - The parsed save data.
+ * @returns An array of locations where more than one Pokémon was caught.
+ *
+ * @remarks
+ * Any location grouping that contains more than 1 Pokémon is flagged as a violation,
+ * regardless of whether the Pokémon is currently in the party or PC.
+ */
 export function detectNuzlockeViolations(saveData: SaveData): LocationEncounters[] {
   return aggregateEncountersByLocation(saveData).filter((location) => location.encounters.length > 1);
 }
 
+/**
+ * Retrieves any Pokémon in the player's active party that have fainted (0 HP).
+ *
+ * @param saveData - The parsed save data.
+ * @returns An array of dead Pokémon instances.
+ *
+ * @remarks
+ * In Nuzlocke rules, a fainted Pokémon is considered dead and must be released or permanently boxed.
+ * This function only checks the active party, as Pokémon deposited in the PC have their HP fully restored.
+ */
 export function getDeadPokemon(saveData: SaveData): PokemonInstance[] {
   return (saveData.partyDetails || []).filter((p) => p.currentHp === 0);
 }
 
+/**
+ * Retrieves all Pokémon stored in the player's designated Graveyard PC box.
+ *
+ * @param saveData - The parsed save data.
+ * @param graveyardBox - The string identifier of the PC Box used as the graveyard (e.g., 'Box 14').
+ * @returns An array of permanently dead Pokémon instances.
+ *
+ * @remarks
+ * Because PC deposition restores a Pokémon's HP to full, death cannot be tracked
+ * via `currentHp === 0` once boxed. Instead, this tracker relies on the player moving
+ * dead Pokémon into a specific string-matched PC Box.
+ */
 export function getGraveyardPokemon(saveData: SaveData, graveyardBox: string): PokemonInstance[] {
   return (saveData.pcDetails || []).filter((p) => p.storageLocation === graveyardBox);
 }


### PR DESCRIPTION
### What was documented
The `src/engine/nuzlocke/tracker.ts` module, including its main interfaces and exported functions. Also added an entry to the private scribe journal `.jules/scribe.md`.

### Why this module needed docs
The Nuzlocke tracker had zero JSDoc comments. The module enforces Nuzlocke rules (Permadeath, One Catch per Route), but the *why* of its implementation was non-obvious. Since placing a Pokémon in the PC fully heals it in the binary save state, death cannot be tracked merely via `currentHp === 0`. The engine requires a specific string-matched PC box to act as a graveyard. Additionally, route tracking inherently depends on Gen 2 save data constraints since Gen 1 does not store `caughtData.location`.

### Summary of additions
- Added JSDoc to `aggregateEncountersByLocation`, `detectNuzlockeViolations`, `getDeadPokemon`, and `getGraveyardPokemon`.
- Updated `.jules/scribe.md` to note the architectural dependency on Gen 2 mechanics for route tracking and the graveyard PC box workaround for permadeath.

---
*PR created automatically by Jules for task [10552086264715289063](https://jules.google.com/task/10552086264715289063) started by @szubster*