### PR TITLE
🧭 Strategist: Prompt improvement - Prevent premature Epic verification

### DIFF
--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -25,6 +25,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **CRITICAL:** Do NOT submit an Empty PR to transition an Epic to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child STORY nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints.
 
 **HANDLING PERMANENT CHILD FAILURES (THE IMPOSSIBLE LOOP):**
 If you are woken up by the Orchestrator because a child node reached its Max Rejection Count (e.g., a TASK failed permanently), you MUST:

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -144,3 +144,9 @@
 **Outcome:** Merged
 **Why:** The Strategist was only instructed to read `.jules/*.md` to assess agent prompt quality, missing all Foundry execution personas which log their learnings to `.foundry/journals/*.md` (e.g., coder, qa, tech_lead). This gap prevented the Strategist from identifying prompt quality issues for the most active execution agents.
 **Pattern:** Update prompts to ensure they have access to the correct and complete set of journals for all personas, specifically including both `.jules/` and `.foundry/journals/` when reading logs to identify issues.
+
+## 2026-05-24 - [Accepted] - Prompt improvement - Prevent premature Epic verification
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The Auditor journal showed that Epics were transitioning to VERIFYING prematurely when their Acceptance Criteria (spawning child stories) were checked off, leading to failed audits because the actual implementation described was not merged.
+**Pattern:** When an agent (like the Story Owner) is responsible for breaking down high-level nodes, it must wait for the generated execution nodes to finish before submitting its Empty PR to complete the parent node.


### PR DESCRIPTION
**Proposal**: Update the Story Owner schedule prompt to prevent it from submitting an Empty PR for an Epic until all generated child STORY nodes are `COMPLETED`.
**Justification**: The Auditor agent repeatedly failed to verify Epics because they were transitioning to `VERIFYING` prematurely (when their Acceptance Criteria of creating child Stories were checked off), even though the actual implementation described was not merged yet. This update enforces the dependency graph constraints.
**Evidence**: The `.foundry/journals/auditor.md` explicitly noted: "The system needs a clearer distinction between 'Epic planning is done' and 'Epic implementation is done'... Currently, submitting the Epic when only the planning is done leads to failed audits."

---
*PR created automatically by Jules for task [10998843319594584119](https://jules.google.com/task/10998843319594584119) started by @szubster*