### PR TITLE
Reject task-075-132-implement-heartbeat-verifying-logic

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -14,3 +14,4 @@ During the validation of `task-072-128-implement-dag-cancellation`, I discovered
 
 ## Missing Integration Failures
 When an implementation task only creates standalone UI components but fails to integrate or render them anywhere in the main application (making them inaccessible to the user), the task MUST be rejected. The purpose of implementation isn't just to write code that passes isolated unit tests; it is to deliver accessible features.
+- **2026-05-24**: Rejected task-075-132-implement-heartbeat-verifying-logic. The implementation successfully added VERIFYING nodes to the zombie detection list but failed to update the logic that fails nodes missing a jules_session_id. The check `if (!isHuman && (!sessionId || sessionId === 'null') && node.frontmatter.status === 'ACTIVE')` was not updated to include VERIFYING status.

--- a/.foundry/tasks/task-075-132-implement-heartbeat-verifying-logic.md
+++ b/.foundry/tasks/task-075-132-implement-heartbeat-verifying-logic.md
@@ -2,7 +2,7 @@
 id: task-075-132-implement-heartbeat-verifying-logic
 type: TASK
 title: Implement Heartbeat VERIFYING Logic
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-05-22'
 updated_at: '2026-05-23'
@@ -15,7 +15,10 @@ tags:
   - orchestrator
   - heartbeat
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: >-
+  Zombie detection main loop only monitors ACTIVE nodes for missing
+  jules_session_id. VERIFYING nodes missing jules_session_id are ignored instead
+  of flagged as FAILED.
 ---
 
 # Task: Implement Heartbeat VERIFYING Logic

--- a/.foundry/tasks/task-075-133-qa-heartbeat-verifying-logic.md
+++ b/.foundry/tasks/task-075-133-qa-heartbeat-verifying-logic.md
@@ -27,5 +27,8 @@ rejection_reason: ''
 - Ensure the changes align with the acceptance criteria defined in `task-075-132-implement-heartbeat-verifying-logic`.
 
 ## Acceptance Criteria
-- [ ] Validated `transitionNodeToCompleted` sets status to `VERIFYING`.
-- [ ] Validated zombie detection processes `VERIFYING` nodes.
+- [x] Validated `transitionNodeToCompleted` sets status to `VERIFYING`.
+- [x] Validated zombie detection processes `VERIFYING` nodes.
+
+## Validation Failure
+The implementation for `task-075-132-implement-heartbeat-verifying-logic` failed validation. The zombie detection logic for missing `jules_session_id` was not updated to handle `VERIFYING` nodes. The check in `.github/scripts/foundry-heartbeat.ts` still reads `if (!isHuman && (!sessionId || sessionId === 'null') && node.frontmatter.status === 'ACTIVE')`, ignoring `VERIFYING` nodes and failing to catch zombie auditor sessions.

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -162,6 +162,34 @@ ok: true,
     expect(fs.appendFileSync).not.toHaveBeenCalled();
   });
 
+
+  it.fails('should transition a node to FAILED if VERIFYING and jules_session_id is missing', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'VERIFYING',
+        jules_session_id: null
+      },
+      rawContent: '---\nstatus: VERIFYING\njules_session_id: null\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    // Mock API requests done in the cleanup phase to prevent them from failing the mock verification
+    globalFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => []
+    } as unknown as Response);
+
+    await main();
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+
   it('should transition a node to FAILED if jules_session_id is missing', async () => {
     const mockNode = {
       filePath: '/mock/repo/.foundry/tasks/task-1.md',

--- a/fix_test.cjs
+++ b/fix_test.cjs
@@ -1,9 +1,0 @@
-const fs = require('fs');
-
-const testFile = '.github/scripts/foundry-heartbeat.test.ts';
-let content = fs.readFileSync(testFile, 'utf-8');
-
-content = content.replace(`it('should transition a node to FAILED if VERIFYING and jules_session_id is missing', async () => {`, `it.fails('should transition a node to FAILED if VERIFYING and jules_session_id is missing', async () => {`);
-
-fs.writeFileSync(testFile, content);
-console.log("Test fixed.");

--- a/fix_test.cjs
+++ b/fix_test.cjs
@@ -1,0 +1,9 @@
+const fs = require('fs');
+
+const testFile = '.github/scripts/foundry-heartbeat.test.ts';
+let content = fs.readFileSync(testFile, 'utf-8');
+
+content = content.replace(`it('should transition a node to FAILED if VERIFYING and jules_session_id is missing', async () => {`, `it.fails('should transition a node to FAILED if VERIFYING and jules_session_id is missing', async () => {`);
+
+fs.writeFileSync(testFile, content);
+console.log("Test fixed.");


### PR DESCRIPTION
The implementation in task-075-132 successfully added VERIFYING nodes to the zombie detection list but failed to update the logic that fails nodes missing a `jules_session_id`. The check `if (!isHuman && (!sessionId || sessionId === 'null') && node.frontmatter.status === 'ACTIVE')` was not updated to include `VERIFYING` status.

This PR marks the implementation task as `FAILED` and updates the QA task to document the failure. A failing test has been added to `foundry-heartbeat.test.ts` to reproduce the issue.

---
*PR created automatically by Jules for task [10455639714604870206](https://jules.google.com/task/10455639714604870206) started by @szubster*