### PR TITLE
Agile Coach: Generate DAG and gray-matter improvement ideas

### DIFF
--- a/.foundry/ideas/idea-066-enforce-gray-matter-linter.md
+++ b/.foundry/ideas/idea-066-enforce-gray-matter-linter.md
@@ -27,5 +27,9 @@ ADR 006 established the requirement to exclusively use the `gray-matter` library
 ## Proposal
 Implement a strict programmatic linting rule (e.g., via Biome or an ESLint plugin) that scans the `.github/scripts/` directory and explicitly forbids regex string manipulation or matching patterns commonly used for YAML frontmatter (like `/^---/`). The linter should fail the CI pipeline if such patterns are detected, directing developers to use `matter.stringify()` instead.
 
+## Questionable ROI?
+Note: There are concerns from leadership that a custom linter rule just for this edge case might not be worth the maintenance overhead compared to relying on standard PR reviews.
+**Product Manager and downstream personas MUST strictly evaluate the ROI and technical feasibility of this before proceeding.** It is fully acceptable for this to be declined/cancelled during the PRD or Architecture phase if the cost outweighs the benefit.
+
 ## Next Steps
-- [ ] Product Manager: Evaluate this idea, outline the technical approach for the linter rule, and transform this into a PRD.
+- [ ] Product Manager: Evaluate this idea, outline the technical approach for the linter rule, explicitly evaluate the ROI concerns, and either transform this into a PRD or cancel it.

--- a/.foundry/ideas/idea-066-enforce-gray-matter-linter.md
+++ b/.foundry/ideas/idea-066-enforce-gray-matter-linter.md
@@ -1,0 +1,31 @@
+---
+id: idea-066-enforce-gray-matter-linter
+type: IDEA
+title: Enforce Gray-Matter Linter for Scripts
+status: PENDING
+owner_persona: product_manager
+created_at: "2026-05-25"
+updated_at: "2026-05-25"
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - lint
+  - schema
+  - foundry
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: "Generated autonomously to enforce ADR 006"
+---
+
+# Enforce Gray-Matter Linter for Scripts
+
+## Context
+ADR 006 established the requirement to exclusively use the `gray-matter` library for parsing and modifying YAML frontmatter across all Foundry automation scripts (`.github/scripts/`), explicitly deprecating the use of brittle custom Regular Expressions (`Regex`). Despite this, occasional regressions have been introduced where regex is still utilized, resulting in broken frontmatter and orchestrator failures.
+
+## Proposal
+Implement a strict programmatic linting rule (e.g., via Biome or an ESLint plugin) that scans the `.github/scripts/` directory and explicitly forbids regex string manipulation or matching patterns commonly used for YAML frontmatter (like `/^---/`). The linter should fail the CI pipeline if such patterns are detected, directing developers to use `matter.stringify()` instead.
+
+## Next Steps
+- [ ] Product Manager: Evaluate this idea, outline the technical approach for the linter rule, and transform this into a PRD.

--- a/.foundry/ideas/idea-067-extract-dag-utils.md
+++ b/.foundry/ideas/idea-067-extract-dag-utils.md
@@ -1,0 +1,35 @@
+---
+id: idea-067-extract-dag-utils
+type: IDEA
+title: Extract DAG Utilities to Shared Module
+status: PENDING
+owner_persona: product_manager
+created_at: "2026-05-25"
+updated_at: "2026-05-25"
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: "Generated autonomously to reduce duplication in orchestration scripts"
+---
+
+# Extract DAG Utilities to Shared Module
+
+## Context
+As the Foundry engine has grown, complex logic related to DAG resolution (e.g., parsing nodes, building reverse dependency graphs, and transitioning nodes) has been duplicated across multiple scripts within `.github/scripts/`, most notably between `foundry-orchestrator.ts` and `foundry-heartbeat.ts`. This duplication increases maintenance overhead and the risk of divergent behaviour (such as the recent Impossible Loop handling discrepancies).
+
+## Proposal
+Create a shared utility module (e.g., `dag-utils.ts`) within the `.github/scripts/` directory to encapsulate core DAG operations.
+Operations to extract include:
+- Building reverse dependency graphs.
+- Identifying and traversing orphaned nodes.
+- Standardizing the `transitionNodeToFailed`, `transitionNodeToCompleted`, and `transitionNodeToReady` functions to ensure they uniformly apply ADR 006 (`gray-matter`) and appropriately append metadata like `rejection_reason`.
+
+## Next Steps
+- [ ] Product Manager: Evaluate this proposal and convert it to a PRD detailing the specific functions to be extracted and the testing strategy.

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -19,3 +19,9 @@ I identified a persistent friction point in the system where agents (particularl
 While the instructions were documented, they were not strictly enforced across all relevant persona prompts. I have proactively updated the `coder.md`, `qa.md`, and `tech_lead.md` prompts to explicitly include these directives.
 
 Additionally, to prevent future regressions related to ADR 006 (gray-matter usage), I generated `idea-064-enforce-gray-matter-linter.md` to propose a programmatic linter rule targeting the `.github/scripts/` directory to automatically catch and forbid regex frontmatter manipulation.
+
+## 2026-05-25: Refactoring DAG operations to shared utility module
+
+While analyzing the codebase for systemic improvements, I noticed significant duplication of core DAG operations (such as traversing reverse dependencies and updating node statuses via gray-matter) between `foundry-orchestrator.ts` and `foundry-heartbeat.ts`. This duplication creates a surface area for bugs where one script might diverge from the other (e.g. failing to properly append `rejection_reason` or mutating YAML fields via regex).
+
+To proactively mitigate this technical debt and improve the maintainability of the Foundry engine, I autonomously generated `idea-067-extract-dag-utils.md` to propose extracting these common functions into a shared `dag-utils.ts` module. I also generated `idea-066-enforce-gray-matter-linter.md` to codify the ADR 006 requirements into a CI-enforced linter rule.


### PR DESCRIPTION
As the Agile Coach, I analyzed recent system friction regarding duplicated DAG orchestration logic and regressions violating ADR 006 (using Regex for frontmatter instead of `gray-matter`). 

I have autonomously generated two new IDEA nodes to proactively address these issues:
1. `idea-066-enforce-gray-matter-linter.md`
2. `idea-067-extract-dag-utils.md`

I have also updated my journal to document the context and rationale for these improvements.

---
*PR created automatically by Jules for task [1976662382979569174](https://jules.google.com/task/1976662382979569174) started by @szubster*