### PR TITLE
🧪 Sentinel: Add test coverage for AssistantSuggestionCard

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -103,3 +103,9 @@ Mocking module exports in Vitest using vi.mock is safer than vi.spyOn for ensuri
 **Coverage:** Increased `src/engine/saveParser/parsers/gen2.ts` branch coverage from ~82% to ~92%.
 **Why:** The `pcItems` fallback structures (Crystal offset vs Gold/Silver offset) were completely untested, risking regressions.
 **Result:** All critical PC Item extraction logic paths in generation 2 are verified.
+
+### Vitest Browser Tests
+When writing component tests with `@vitest/browser` and `vitest-browser-react`, the `render()` function (and derived custom wrappers) is asynchronous and must be explicitly `await`ed to prevent Biome `lint/correctness/noFloatingPromises` errors.
+
+### Vitest Reporters
+When running manual Vitest coverage checks via bash, use `pnpm vitest run --coverage --reporter=default` instead of `--reporter=text` to avoid custom reporter load errors.

--- a/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
@@ -1,0 +1,207 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createRootRoute, createRoute, createRouter, Outlet, RouterProvider } from '@tanstack/react-router';
+import type React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import type { Suggestion } from '../../../engine/assistant/strategies/types';
+import type { SaveData } from '../../../engine/saveParser/index';
+import { AssistantSuggestionCard } from '../AssistantSuggestionCard';
+
+// Setup basic router for links
+const rootRoute = createRootRoute({
+  component: () => <Outlet />,
+});
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+function renderWithProviders(ui: React.ReactNode) {
+  const testRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => ui,
+  });
+  // Add a dummy pokemonId route since the card links to it
+  const pokemonRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/pokemon/$pokemonId',
+    component: () => <div>Pokemon Details</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([testRoute, pokemonRoute]),
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('AssistantSuggestionCard', () => {
+  const mockGetPokemonName = vi.fn<(id: number) => string>((id) => {
+    const names: Record<number, string> = { 1: 'Bulbasaur', 4: 'Charmander', 7: 'Squirtle' };
+    return names[id] ?? `#${id}`;
+  });
+
+  const mockSaveData: SaveData = {
+    generation: 1,
+    gameVersion: 'red',
+    trainerId: 12345,
+    trainerName: 'ASH',
+    badges: 0,
+    inventory: [{ id: 1, quantity: 1 }],
+    pcItems: [],
+    party: [],
+    pc: [],
+    partyDetails: [],
+    pcDetails: [],
+    owned: new Set(),
+    seen: new Set(),
+    currentMapId: 0,
+    currentBoxCount: 0,
+    hallOfFameCount: 0,
+  };
+
+  const defaultStyle = {
+    icon: <span data-testid="test-icon">Icon</span>,
+    color: 'border-red-500/30 text-red-100',
+    bg: 'bg-red-500/10',
+  };
+
+  it('renders a basic suggestion properly', async () => {
+    const suggestion: Suggestion = {
+      id: 'test-1',
+      priority: 10,
+      category: 'Utility',
+      title: 'Do the thing',
+      description: 'You should really do this thing.',
+    };
+
+    await renderWithProviders(
+      <AssistantSuggestionCard
+        suggestion={suggestion}
+        style={defaultStyle}
+        showDebug={false}
+        saveData={mockSaveData}
+        getPokemonName={mockGetPokemonName}
+      />,
+    );
+
+    await expect.element(page.getByText('Do the thing')).toBeVisible();
+    await expect.element(page.getByText('You should really do this thing.')).toBeVisible();
+    await expect.element(page.getByText('Utility')).toBeVisible();
+  });
+
+  it('replaces PIDs in title and description', async () => {
+    const suggestion: Suggestion = {
+      id: 'test-2',
+      priority: 10,
+      category: 'Evolve',
+      title: 'Evolve #1',
+      description: 'Get a #4 and #7',
+    };
+
+    await renderWithProviders(
+      <AssistantSuggestionCard
+        suggestion={suggestion}
+        style={defaultStyle}
+        showDebug={false}
+        saveData={mockSaveData}
+        getPokemonName={mockGetPokemonName}
+      />,
+    );
+
+    await expect.element(page.getByText('Evolve Bulbasaur')).toBeVisible();
+    await expect.element(page.getByText('Get a Charmander and Squirtle')).toBeVisible();
+  });
+
+  it('renders a single pokemon suggestion with sprite', async () => {
+    const suggestion: Suggestion = {
+      id: 'test-3',
+      priority: 10,
+      category: 'Catch',
+      title: 'Catch a pokemon',
+      description: 'Go catch it.',
+      pokemonId: 1,
+    };
+
+    await renderWithProviders(
+      <AssistantSuggestionCard
+        suggestion={suggestion}
+        style={defaultStyle}
+        showDebug={false}
+        saveData={mockSaveData}
+        getPokemonName={mockGetPokemonName}
+      />,
+    );
+
+    await expect.element(page.getByText('TARGET ACQUIRED')).toBeVisible();
+    await expect.element(page.getByText('#001')).toBeVisible();
+  });
+
+  it('renders multiple pokemon suggestions with methods', async () => {
+    const suggestion: Suggestion = {
+      id: 'test-4',
+      priority: 10,
+      category: 'Catch',
+      title: 'Catch these',
+      description: 'Go catch them.',
+      pokemonIds: [1, 4],
+      encounterInfo: {
+        1: [{ aid: 0, method: 'walk', chance: 20, minLevel: 5, maxLevel: 5 }],
+        4: [{ aid: 0, method: 'surf', chance: 10, minLevel: 10, maxLevel: 15 }],
+      },
+    };
+
+    const areaNames = { 0: 'Pallet Town' };
+
+    await renderWithProviders(
+      <AssistantSuggestionCard
+        suggestion={suggestion}
+        style={defaultStyle}
+        showDebug={false}
+        saveData={mockSaveData}
+        getPokemonName={mockGetPokemonName}
+        areaNames={areaNames}
+      />,
+    );
+
+    await expect.element(page.getByText('WALK')).toBeVisible();
+    await expect.element(page.getByText('SURF')).toBeVisible();
+    await expect.element(page.getByText('20%')).toBeVisible();
+    await expect.element(page.getByText('10%')).toBeVisible();
+    await expect.element(page.getByText('Lv. 5')).toBeVisible();
+    await expect.element(page.getByText('Lv. 10-15')).toBeVisible();
+  });
+
+  it('renders warning and debug info', async () => {
+    const suggestion: Suggestion = {
+      id: 'test-5',
+      priority: 99,
+      category: 'Event',
+      title: 'CRITICAL MISSION',
+      description: 'Warning description',
+      warning: 'Watch out!',
+    };
+
+    await renderWithProviders(
+      <AssistantSuggestionCard
+        suggestion={suggestion}
+        style={defaultStyle}
+        showDebug={true}
+        saveData={mockSaveData}
+        getPokemonName={mockGetPokemonName}
+      />,
+    );
+
+    await expect.element(page.getByText('CRITICAL MISSION')).toBeVisible();
+    await expect.element(page.getByText(/WARNING: Watch out!/i)).toBeVisible();
+    await expect.element(page.getByText(/P: 99/)).toBeVisible();
+  });
+});


### PR DESCRIPTION
🎯 What
Adds `src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx` to test the previously untested `AssistantSuggestionCard` React component.

📊 Coverage
Increases the overall test coverage within `src/components/assistant` by providing comprehensive coverage for its primary UI card component.

✨ Result
Ensures all variant renders of the `AssistantSuggestionCard` (single target, multiple targets, method breakdowns, and warnings) behave as expected. Adheres to strict `vi.fn<...>()` typing and browser test constraints. All tests and linters pass.

---
*PR created automatically by Jules for task [4838101842942993808](https://jules.google.com/task/4838101842942993808) started by @szubster*