### PR TITLE
🎨 Canvas: Redesign Search and Filters (Tactical UI)

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -128,3 +128,9 @@
 **Outcome:** Accepted
 **Why:** Brings the mobile navigation interface tightly in line with the rest of the application's established tactical hardware motif (matching `AppLayout`, `Grid`, and `Details`), correcting the previous web-standard smooth transitions.
 **Pattern:** Ensure mobile layout structural components adhere to strict tactical aesthetics (sharp borders, corner crosshairs, scanning/flicker animations, monospace telemetry text) rather than generic app-like smoothed navigation bars, to maintain the specialized device illusion.
+
+## 2025-06-25 - [Accepted] - 🖼️ Canvas: Tactical SearchAndFilters Redesign
+**What:** Redesigned the filter toggles in the `SearchAndFilters` component. Wrapped the simple flex container of filter buttons in a `TacticalPanel` and added a `[ SYS.FILTER ]` monospaced diagnostic header to create a specialized hardware "segmented control" terminal look.
+**Outcome:** Accepted
+**Why:** Brings the filter controls fully in line with the heavily tactical, snooping-focused aesthetic (matching the recently updated `TacticalInput` and details panels). Removing basic flex containers in favor of `TacticalPanel` wrappers solidifies the specialized device illusion.
+**Pattern:** Consistently eliminate generic grouping containers in favor of `TacticalPanel` wrappers with diagnostic headers for input groups, maintaining the specialized hardware UI language across all system interactions.

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -1,9 +1,10 @@
-import { Search } from 'lucide-react';
+import { Filter, Search } from 'lucide-react';
 import { useRef } from 'react';
 import { FILTER_TYPES, useStore } from '../store';
 import { LocationSuggestions } from './LocationSuggestions';
 import { TacticalButton } from './TacticalButton';
 import { TacticalInput } from './TacticalInput';
+import { TacticalPanel } from './TacticalPanel';
 
 export function SearchAndFilters() {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -52,32 +53,39 @@ export function SearchAndFilters() {
         </TacticalInput>
 
         {/* Tactical Filter Toggles */}
-        <fieldset className="no-scrollbar m-0 mt-2 flex min-w-0 gap-2 overflow-x-auto border-none p-0 px-1 pb-2">
-          <legend className="sr-only">Filter Pokémon</legend>
-          <TacticalButton
-            type="button"
-            onClick={() => setFilters([])}
-            aria-pressed={filtersSet.size === 0}
-            variant={filtersSet.size === 0 ? 'primary' : 'default'}
-            hasCrosshairs="corners"
-          >
-            All
-          </TacticalButton>
+        <TacticalPanel className="mt-2 shrink-0 p-3 pt-4 sm:p-4 sm:pt-5">
+          <div className="absolute -top-1.5 left-4 flex items-center gap-1.5 bg-zinc-950 px-2 text-zinc-500">
+            <Filter size={10} className="text-[var(--theme-primary)]" />
+            <span className="font-mono text-[9px] uppercase tracking-widest">[ SYS.FILTER ]</span>
+          </div>
 
-          {FILTER_TYPES.map((f) => (
+          <fieldset className="no-scrollbar m-0 flex min-w-0 gap-2 overflow-x-auto border-none p-0">
+            <legend className="sr-only">Filter Pokémon</legend>
             <TacticalButton
               type="button"
-              key={f}
-              onClick={() => toggleFilter(f)}
-              aria-pressed={filtersSet.has(f)}
-              data-testid={`filter-${f}`}
-              variant={filtersSet.has(f) ? 'primary' : 'default'}
+              onClick={() => setFilters([])}
+              aria-pressed={filtersSet.size === 0}
+              variant={filtersSet.size === 0 ? 'primary' : 'default'}
               hasCrosshairs="corners"
             >
-              {f === 'secured' ? 'Secured' : f === 'missing' ? 'Missing' : 'Dex Only'}
+              All
             </TacticalButton>
-          ))}
-        </fieldset>
+
+            {FILTER_TYPES.map((f) => (
+              <TacticalButton
+                type="button"
+                key={f}
+                onClick={() => toggleFilter(f)}
+                aria-pressed={filtersSet.has(f)}
+                data-testid={`filter-${f}`}
+                variant={filtersSet.has(f) ? 'primary' : 'default'}
+                hasCrosshairs="corners"
+              >
+                {f === 'secured' ? 'Secured' : f === 'missing' ? 'Missing' : 'Dex Only'}
+              </TacticalButton>
+            ))}
+          </fieldset>
+        </TacticalPanel>
       </div>
     </div>
   );

--- a/src/components/__tests__/SearchAndFilters.test.tsx
+++ b/src/components/__tests__/SearchAndFilters.test.tsx
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { useStore } from '../../store';
+import { SearchAndFilters } from '../SearchAndFilters';
+
+vi.mock('../../store', () => ({
+  useStore: vi.fn<() => unknown>(),
+  FILTER_TYPES: ['secured', 'missing', 'dexOnly'],
+}));
+
+vi.mock('../LocationSuggestions', () => ({
+  LocationSuggestions: () => <div data-testid="location-suggestions" />,
+}));
+
+const mockUseStore = useStore as unknown as ReturnType<typeof vi.fn>;
+
+describe('SearchAndFilters', () => {
+  const defaultStore = {
+    saveData: {},
+    searchTerm: '',
+    setSearchTerm: vi.fn<(term: string) => void>(),
+    filters: [],
+    toggleFilter: vi.fn<(filter: string) => void>(),
+    setFilters: vi.fn<(filters: string[]) => void>(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseStore.mockImplementation((selector: (state: typeof defaultStore) => unknown) => selector(defaultStore));
+  });
+
+  test('renders input and buttons', async () => {
+    await render(<SearchAndFilters />);
+    await expect.element(page.getByTestId('search-input')).toBeInTheDocument();
+    await expect.element(page.getByText('All')).toBeInTheDocument();
+    await expect.element(page.getByText('Secured')).toBeInTheDocument();
+    await expect.element(page.getByText('Missing')).toBeInTheDocument();
+    await expect.element(page.getByText('Dex Only')).toBeInTheDocument();
+  });
+
+  test('calls setSearchTerm on input change', async () => {
+    await render(<SearchAndFilters />);
+    const input = page.getByTestId('search-input');
+    await input.fill('pikachu');
+    expect(defaultStore.setSearchTerm).toHaveBeenCalledWith('pikachu');
+  });
+
+  test('toggles filters', async () => {
+    await render(<SearchAndFilters />);
+    await page.getByText('Secured').click();
+    expect(defaultStore.toggleFilter).toHaveBeenCalledWith('secured');
+
+    await page.getByText('All').click();
+    expect(defaultStore.setFilters).toHaveBeenCalledWith([]);
+  });
+});


### PR DESCRIPTION
Applies the 'tactical hardware' design pattern to `SearchAndFilters.tsx` by wrapping the filter toggle buttons in a `TacticalPanel` and utilizing `TacticalButton` with `CornerCrosshairs`. Includes a diagnostic `[ SYS.FILTER ]` heading. This change adheres to the Canvas session constraints and design principles documented in `.jules/canvas.md`.

---
*PR created automatically by Jules for task [8075344903392249013](https://jules.google.com/task/8075344903392249013) started by @szubster*