### PR TITLE
📜 Scribe: Document Gen 2 Save Parser Memory Structures

### DIFF
--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -42,10 +42,16 @@ function parseCaughtData(view: DataView, offset: number) {
 /**
  * Extracts details for a single Pokémon from a Generation 2 save block.
  *
+ * **Memory Structure Differences:**
+ * - Party Pokémon use a 48-byte structure, which includes 16 additional bytes at the end for dynamic battle stats (e.g. current HP, max HP, attack, etc.).
+ * - PC/Box Pokémon use a smaller 32-byte structure, as these battle stats are recalculated upon withdrawal.
+ * - Unlike Gen 1, Daycare Pokémon store their Original Trainer (OT) name immediately adjacent to their data block (at `offset + 32`),
+ *   whereas Party and Box instances store OT names in entirely separate string array blocks elsewhere in memory.
+ *
  * @param view - The raw save file view.
- * @param offset - The memory offset for the start of the Pokémon's 32-byte data block.
- * @param isCrystal - Whether the save file is from Pokémon Crystal (determines if caught data exists).
- * @param storageLocation - A string indicating where the Pokémon is stored (e.g., 'Party', 'Box 1').
+ * @param offset - The memory offset for the start of the Pokémon's data block.
+ * @param isCrystal - Whether the save file is from Pokémon Crystal. Crystal uniquely utilizes bytes 29 and 30 for caught time/level/location data.
+ * @param storageLocation - A string indicating where the Pokémon is stored (e.g., 'Party', 'Box 1', 'Daycare').
  * @param slot - The 1-indexed slot the Pokémon occupies in its storage container.
  * @returns A fully constructed PokemonInstance object, or undefined if the species ID is invalid.
  */
@@ -202,15 +208,14 @@ function parsePokedex(view: DataView, offsets: { owned: number; seen: number }) 
  * Parses the player's active party from a Generation 2 save.
  *
  * **Memory Layout:**
- * The party structure is identical to Gen 1 but expanded:
- * 1. A 1-byte count (max 6).
- * 2. A 7-byte species array (terminated by `0xFF`).
- * 3. The 48-byte full data structures for each Pokémon.
+ * - The party block begins with a 1-byte count of the current party size (max 6).
+ * - This is immediately followed by a 7-byte array containing the species IDs of the party members (terminated by `0xFF`).
+ * - Following the species array is the sequential block of 48-byte Pokémon data instances (`offset + 7`).
  *
  * @param view - The raw save file DataView.
- * @param offsets - The dynamically resolved start offsets for the party list.
- * @param isCrystal - True if the save is Crystal (to correctly parse caught data).
- * @returns The simple list of species IDs (`party`) and the detailed instances (`partyDetails`).
+ * @param offsets - Dynamic offsets containing the start address for `partyCount` and `partySpecies`.
+ * @param isCrystal - True if the save file is Pokémon Crystal.
+ * @returns An object containing the simple species ID list and the array of fully constructed `PokemonInstance`s.
  */
 function parseParty(view: DataView, offsets: { partyCount: number; partySpecies: number }, isCrystal: boolean) {
   const partyCount = view.getUint8(offsets.partyCount);


### PR DESCRIPTION
This PR improves the documentation within the `engine/saveParser` module, specifically targeting the highly complex Generation 2 parsers (`gen2.ts`).

### What
Added JSDoc blocks to `parseGen2PokemonInstance` and `parseParty` explaining their expected memory layout inputs.

### Why
The Gen 2 save parser relies on hardcoded binary offsets that cascade. A single byte misunderstanding can corrupt the extracted state. This documentation explains *why* the parser expects specific byte offsets (e.g., 48-byte vs 32-byte structures, and the structural differences regarding where OT Names are stored between Daycare vs Party).

### Summary of additions
- Documented `parseGen2PokemonInstance` with details on Party vs PC/Box data struct sizes.
- Documented `parseParty` detailing the sequential layout of the party block (count -> species list -> data struct block).

---
*PR created automatically by Jules for task [12992723043916972279](https://jules.google.com/task/12992723043916972279) started by @szubster*