### PR TITLE
🧭 Strategist: Prompt improvement - Prevent premature verification of high-level nodes

### DIFF
--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -28,6 +28,7 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **CRITICAL**: Do NOT submit an Empty PR to transition the parent node to `VERIFYING` until ALL of its generated child nodes have transitioned to `COMPLETED`. Premature verification violates DAG dependency constraints.
 
 
 ## Journal

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -21,6 +21,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **CRITICAL**: Do NOT submit an Empty PR to transition the parent node to `VERIFYING` until ALL of its generated child nodes have transitioned to `COMPLETED`. Premature verification violates DAG dependency constraints.
 
 ## Journal
 

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -25,6 +25,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **CRITICAL**: Do NOT submit an Empty PR to transition the parent node to `VERIFYING` until ALL of its generated child nodes have transitioned to `COMPLETED`. Premature verification violates DAG dependency constraints.
 
 **HANDLING PERMANENT CHILD FAILURES (THE IMPOSSIBLE LOOP):**
 If you are woken up by the Orchestrator because a child node reached its Max Rejection Count (e.g., a TASK failed permanently), you MUST:

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -35,6 +35,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **CRITICAL**: Do NOT submit an Empty PR to transition the parent node to `VERIFYING` until ALL of its generated child nodes have transitioned to `COMPLETED`. Premature verification violates DAG dependency constraints.
 
 **HANDLING PERMANENT CHILD FAILURES (THE IMPOSSIBLE LOOP):**
 If you are woken up by the Orchestrator because a child node reached its Max Rejection Count (e.g., a `coder` TASK failed permanently), you MUST:

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -144,3 +144,9 @@
 **Outcome:** Merged
 **Why:** The Strategist was only instructed to read `.jules/*.md` to assess agent prompt quality, missing all Foundry execution personas which log their learnings to `.foundry/journals/*.md` (e.g., coder, qa, tech_lead). This gap prevented the Strategist from identifying prompt quality issues for the most active execution agents.
 **Pattern:** Update prompts to ensure they have access to the correct and complete set of journals for all personas, specifically including both `.jules/` and `.foundry/journals/` when reading logs to identify issues.
+
+## 2026-07-09 - [Accepted] - Prompt improvement - Prevent premature verification of high-level nodes
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The Auditor journal noted a recurring pattern where `EPIC` nodes transitioned to the `VERIFYING` status prematurely because their immediate Acceptance Criteria (creating child Story nodes) was met, even though the actual implementation had not been completed by the child tasks. This violates the spirit of the dependency graph and causes downstream nodes to be dispatched prematurely.
+**Pattern:** Update node generation rules for planning agents (Product Manager, Epic Planner, Story Owner, Tech Lead) to explicitly forbid submitting an Empty PR to transition a parent node to `VERIFYING` until all of its generated child nodes have transitioned to `COMPLETED`.


### PR DESCRIPTION
**Proposal**: Update node generation rules for planning agents to explicitly forbid transitioning a parent node to `VERIFYING` until all of its generated child nodes are `COMPLETED`.
**Justification**: The Auditor journal noted a recurring pattern where `EPIC` nodes transitioned to `VERIFYING` prematurely because their immediate Acceptance Criteria (creating child Story nodes) was met, even though the actual implementation had not been completed by the child tasks. This violates the spirit of the dependency graph and causes downstream nodes to be dispatched prematurely.
**Evidence**: `2026-05-23: Premature Verification of Epics` entry in `.foundry/journals/auditor.md`.

---
*PR created automatically by Jules for task [7892694616829399075](https://jules.google.com/task/7892694616829399075) started by @szubster*