### PR TITLE
🧬 Oak: [data correction]

### DIFF
--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -49,3 +49,6 @@
 
 ## Data Integrity - Gen 1/2 Exclusives Refactoring
 * **Data Pipeline Gotchas:** The Gen 1 and Gen 2 version exclusive lists were missing some unobtainable Pokémon, or listing some as unobtainable when they are in fact obtainable. For example, Gen 1 Yellow exclusives missed a few entries, and Gen 2 Crystal missing exclusives also lacked some entries (like Arcanine / Growlithe line). PokeAPI encounters are the source of truth for base-form availability, but one must carefully check all versions (`version_details`) in the encounter data.
+# Oak Learnings
+
+- Within the `engine/exclusives/` data domain, the version-specific arrays (e.g., `GEN1_VERSION_EXCLUSIVES`, `GEN2_VERSION_EXCLUSIVES`) store the IDs of Pokémon that are **unobtainable (excluded)** in that game version, rather than the ones exclusively available. This is crucial for verifying data against Bulbapedia.

--- a/src/engine/exclusives/__tests__/gen2Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen2Exclusives.test.ts
@@ -104,18 +104,16 @@ describe('gen2Exclusives', () => {
         expect(reason).toContain('not available in Crystal');
       });
 
-      it('should lock Arcanine (59) in Crystal', () => {
+      it('should not lock Arcanine (59) in Crystal', () => {
         const ownedSet = new Set<number>();
         const reason = getGen2UnobtainableReason(59, 'crystal', 0, ownedSet);
-        expect(typeof reason).toBe('string');
-        expect(reason).toContain('not available in Crystal');
+        expect(reason).toBeNull();
       });
 
-      it('should lock Growlithe (58) in Crystal', () => {
+      it('should not lock Growlithe (58) in Crystal', () => {
         const ownedSet = new Set<number>();
         const reason = getGen2UnobtainableReason(58, 'crystal', 0, ownedSet);
-        expect(typeof reason).toBe('string');
-        expect(reason).toContain('not available in Crystal');
+        expect(reason).toBeNull();
       });
 
       it('should lock Girafarig (203) in Crystal', () => {

--- a/src/engine/exclusives/gen2Exclusives.ts
+++ b/src/engine/exclusives/gen2Exclusives.ts
@@ -1,7 +1,7 @@
 export const GEN2_VERSION_EXCLUSIVES: Record<string, number[]> = {
   gold: [37, 38, 52, 53, 165, 166, 225, 227, 231, 232],
   silver: [56, 57, 58, 59, 167, 168, 207, 216, 217, 226],
-  crystal: [37, 38, 56, 57, 58, 59, 179, 180, 181, 203, 223, 224],
+  crystal: [37, 38, 56, 57, 179, 180, 181, 203, 223, 224],
 };
 
 export function getGen2UnobtainableReason(


### PR DESCRIPTION
Fixes a data inaccuracy where Growlithe and Arcanine (IDs 58 and 59) were erroneously listed as unobtainable in Pokémon Crystal. They are wild-catchable on Routes 8, 36, and 37 in Crystal. 

Canonical Source: Bulbapedia
Impact: Users playing Crystal version will now correctly see that Growlithe and Arcanine are obtainable. Tests updated.

---
*PR created automatically by Jules for task [1015619474282449182](https://jules.google.com/task/1015619474282449182) started by @szubster*