### PR TITLE
🎨 Palette: Add ARIA alert roles to GlobalError

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -98,3 +98,7 @@
 ## 2026-06-25 - Proper Segmented Control Semantics
 **Learning:** For custom segmented controls that act as mutually exclusive options (like "Version", "Living Dex", or "Ball Style"), using `<div role="group">` and `<button aria-pressed="true/false">` is incorrect semantics. Screen readers need these to be identified as radio button groups.
 **Action:** When implementing custom segmented controls with buttons, wrap them in `<div role="radiogroup" aria-label="...">` and use `<button role="radio" aria-checked={isActive}>`. Also, since the project enforces semantic HTML over ARIA roles where possible, add suppression comments (`/* oxlint-disable jsx-a11y/prefer-tag-over-role */` and `/* biome-ignore lint/a11y/useSemanticElements: segmented control needs proper styling */`) if styling constraints prevent using native `<input type="radio">` tags.
+
+## 2026-06-25 - ARIA Roles for Global Error Messages
+**Learning:** When rendering dynamic global error messages or panels (e.g., `GlobalError.tsx`), screen readers are not inherently aware of the new DOM elements appearing on the screen. Users might miss critical system errors.
+**Action:** Ensure the container for these global error messages uses `role="alert"` and `aria-live="assertive"`. This guarantees that screen readers will immediately interrupt the current announcement to read the error message, ensuring equal access to system feedback.

--- a/src/components/GlobalError.tsx
+++ b/src/components/GlobalError.tsx
@@ -12,6 +12,8 @@ export function GlobalError({ error }: GlobalErrorProps) {
     <TacticalPanel
       variant="red"
       className="fade-in slide-in-from-top-2 relative mx-4 mt-4 mb-0 flex animate-in items-center gap-4 border-red-500/50 p-5 text-red-500"
+      role="alert"
+      aria-live="assertive"
     >
       <AlertTriangle size={24} className="relative z-10 flex-shrink-0" />
       <div className="relative z-10 flex flex-col">


### PR DESCRIPTION
Added `role="alert"` and `aria-live="assertive"` to the `GlobalError` component's `TacticalPanel`. This guarantees that screen readers will immediately announce the error message when it appears, making the error state accessible to visually impaired users.

---
*PR created automatically by Jules for task [6561888291634820505](https://jules.google.com/task/6561888291634820505) started by @szubster*