### PR TITLE
🧱 Mason: DiagnosticCard extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -66,3 +66,9 @@
 - **Key Learnings**:
   - Separating `labelClassName` and `valueClassName` allows for necessary typographic variations (like alignment or colors) while still leveraging the base structural pattern.
   - Always manually verify existing files using tools like `grep` before attempting substitutions, as files may have drifted from expected state.
+
+## DiagnosticCard Extraction
+- **What**: Extracted repeated telemetry/diagnostic card layout into `<DiagnosticCard>` component.
+- **Why**: Reduced duplicated JSX across `AssistantDebugView` which had 4 identical blocks. It can also be reused if other parts of the app need a telemetry card.
+- **Key Learnings**:
+  - The `valueClassName` prop is crucial when extracting text components, allowing customization like `truncate` or `uppercase` while maintaining identical base text styles.

--- a/src/components/DiagnosticCard.tsx
+++ b/src/components/DiagnosticCard.tsx
@@ -1,0 +1,21 @@
+import type React from 'react';
+import { cn } from '../utils/cn';
+
+interface DiagnosticCardProps {
+  label: string;
+  value: React.ReactNode;
+  subValue?: React.ReactNode;
+  valueClassName?: string;
+}
+
+export function DiagnosticCard({ label, value, subValue, valueClassName }: DiagnosticCardProps) {
+  return (
+    <div className="rounded-none border border-white/10 border-dashed bg-zinc-800/50 p-4 shadow-sm">
+      <p className="mb-1 font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-widest">
+        {label}
+      </p>
+      <p className={cn('font-black font-display text-lg text-white', valueClassName)}>{value}</p>
+      {subValue && <p className="font-mono text-[10px] text-zinc-600">{subValue}</p>}
+    </div>
+  );
+}

--- a/src/components/__tests__/DiagnosticCard.test.tsx
+++ b/src/components/__tests__/DiagnosticCard.test.tsx
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { DiagnosticCard } from '../DiagnosticCard';
+
+test('DiagnosticCard renders correctly with all props', async () => {
+  await render(<DiagnosticCard label="SYS.VER" value="Red" subValue="Gen: 1" valueClassName="uppercase" />);
+
+  await expect.element(page.getByText('SYS.VER')).toBeInTheDocument();
+  await expect.element(page.getByText('Red')).toBeInTheDocument();
+  await expect.element(page.getByText('Red')).toHaveClass(/uppercase/);
+  await expect.element(page.getByText('Gen: 1')).toBeInTheDocument();
+});
+
+test('DiagnosticCard renders correctly without subValue', async () => {
+  await render(<DiagnosticCard label="SYS.VER" value="Red" />);
+
+  await expect.element(page.getByText('SYS.VER')).toBeInTheDocument();
+  await expect.element(page.getByText('Red')).toBeInTheDocument();
+});

--- a/src/components/assistant/AssistantDebugView.tsx
+++ b/src/components/assistant/AssistantDebugView.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, Bug } from 'lucide-react';
 import type { RejectedSuggestion } from '../../engine/assistant/strategies/types';
 import type { SaveData } from '../../engine/saveParser/index';
+import { DiagnosticCard } from '../DiagnosticCard';
 import { PokemonSprite } from '../pokemon/PokemonSprite';
 import { TacticalBadge } from '../TacticalBadge';
 import { TacticalPanel } from '../TacticalPanel';
@@ -27,37 +28,24 @@ export function AssistantDebugView({ rejected, getPokemonName, saveData }: Assis
 
       <TacticalPanel variant="default" className="space-y-4 rounded-none border-dashed p-6 shadow-inner">
         <div className="grid grid-cols-2 gap-4 text-center md:grid-cols-4">
-          <div className="rounded-none border border-white/10 border-dashed bg-zinc-800/50 p-4 shadow-sm">
-            <p className="mb-1 font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-widest">
-              MAP.LOC
-            </p>
-            <p className="font-black font-display text-lg text-white">{saveData.currentMapName}</p>
-            <p className="font-mono text-[10px] text-zinc-600">
-              ID: {saveData.currentMapId} (0x
-              {saveData.currentMapId.toString(16).toUpperCase().padStart(2, '0')})
-            </p>
-          </div>
-          <div className="rounded-none border border-white/10 border-dashed bg-zinc-800/50 p-4 shadow-sm">
-            <p className="mb-1 font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-widest">
-              SYS.VER
-            </p>
-            <p className="font-black font-display text-lg text-white uppercase">{saveData.gameVersion}</p>
-            <p className="font-mono text-[10px] text-zinc-600">Gen: {saveData.generation}</p>
-          </div>
-          <div className="rounded-none border border-white/10 border-dashed bg-zinc-800/50 p-4 shadow-sm">
-            <p className="mb-1 font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-widest">
-              SYS.DEX
-            </p>
-            <p className="font-black font-display text-lg text-white">{saveData.owned.size}</p>
-            <p className="font-mono text-[10px] text-zinc-600">Owned</p>
-          </div>
-          <div className="rounded-none border border-white/10 border-dashed bg-zinc-800/50 p-4 shadow-sm">
-            <p className="mb-1 font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-widest">
-              USR.ID
-            </p>
-            <p className="truncate px-2 font-black font-display text-lg text-white">{saveData.trainerName}</p>
-            <p className="font-mono text-[10px] text-zinc-600">ID: {saveData.trainerId}</p>
-          </div>
+          <DiagnosticCard
+            label="MAP.LOC"
+            value={saveData.currentMapName}
+            subValue={`ID: ${saveData.currentMapId} (0x${saveData.currentMapId.toString(16).toUpperCase().padStart(2, '0')})`}
+          />
+          <DiagnosticCard
+            label="SYS.VER"
+            value={saveData.gameVersion}
+            valueClassName="uppercase"
+            subValue={`Gen: ${saveData.generation}`}
+          />
+          <DiagnosticCard label="SYS.DEX" value={saveData.owned.size} subValue="Owned" />
+          <DiagnosticCard
+            label="USR.ID"
+            value={saveData.trainerName}
+            valueClassName="truncate px-2"
+            subValue={`ID: ${saveData.trainerId}`}
+          />
         </div>
       </TacticalPanel>
 


### PR DESCRIPTION
🎯 What
Extracted a repeating telemetry/diagnostic card layout into a reusable `DiagnosticCard` component. 

💡 Why
`AssistantDebugView` had four identical code blocks utilizing the exact same container styling and title formatting. Extracting this improves modularity and standardizes telemetry cards across the application.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no functionality or UI was broken during the extraction. The `valueClassName` prop was used to preserve specific overrides like `uppercase` and `truncate`.

✨ Result
Reduced duplicated JSX in `AssistantDebugView.tsx` and created a modular, standard telemetry card component for future use.

---
*PR created automatically by Jules for task [7506970489243037253](https://jules.google.com/task/7506970489243037253) started by @szubster*