### PR TITLE
🖼️ Canvas: Tactical SearchAndFilters Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -128,3 +128,9 @@
 **Outcome:** Accepted
 **Why:** Brings the mobile navigation interface tightly in line with the rest of the application's established tactical hardware motif (matching `AppLayout`, `Grid`, and `Details`), correcting the previous web-standard smooth transitions.
 **Pattern:** Ensure mobile layout structural components adhere to strict tactical aesthetics (sharp borders, corner crosshairs, scanning/flicker animations, monospace telemetry text) rather than generic app-like smoothed navigation bars, to maintain the specialized device illusion.
+
+## 2026-06-25 - [Accepted] - 🖼️ Canvas: Tactical SearchAndFilters Redesign
+**What:** Redesigned `SearchAndFilters` to merge the search input and filter buttons into a single unified `TacticalPanel` control deck. Replaced the horizontal scrolling filters with a rigid 2-column segmented control matrix and added hardware-style telemetry labels like `[ SYS.QUERY_STRING ]` and `[ FILTER_MATRIX ]`.
+**Outcome:** Accepted
+**Why:** Elevates the previously generic responsive search layout into a highly cohesive, unified hardware control panel, strictly adhering to the tactical/snooping aesthetic.
+**Pattern:** Merge related but disconnected inputs into cohesive hardware "panels" or "matrices" using rigid grid layouts and telemetry labels to enforce the illusion of a specialized device interface.

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -1,9 +1,10 @@
-import { Search } from 'lucide-react';
+import { Search, X } from 'lucide-react';
 import { useRef } from 'react';
 import { FILTER_TYPES, useStore } from '../store';
+import { cn } from '../utils/cn';
 import { LocationSuggestions } from './LocationSuggestions';
-import { TacticalButton } from './TacticalButton';
-import { TacticalInput } from './TacticalInput';
+import { TacticalPanel } from './TacticalPanel';
+import { TelemetryDecoration } from './TelemetryDecoration';
 
 export function SearchAndFilters() {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -30,55 +31,88 @@ export function SearchAndFilters() {
   };
 
   return (
-    <div className="mb-6 space-y-5 px-4">
-      <div className="flex flex-col gap-4 lg:flex-row">
-        {/* Tactical Hardware Search Terminal */}
-        <TacticalInput
-          ref={inputRef}
-          type="text"
-          data-testid="search-input"
-          placeholder="[ ENTER QUERY_ ]"
-          aria-label="Search Pokedex by name, ID, or location"
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          onKeyDown={handleKeyDown}
-          label="Database Scan"
-          icon={<Search size={14} />}
-          onClear={handleClearSearch}
-          containerClassName="mt-2 flex-1"
-        >
-          {/* Location Suggestions Dropdown */}
-          <LocationSuggestions />
-        </TacticalInput>
+    <div className="mb-6 px-4">
+      <TacticalPanel className="flex flex-col gap-0 border-zinc-800 p-0 sm:flex-row">
+        {/* Left Side: Search Input */}
+        <div className="relative flex-1 border-zinc-800 border-dashed p-4 sm:border-r sm:p-6">
+          <TelemetryDecoration label="SYS.QUERY_STRING" className="-top-3 left-6 z-10 bg-zinc-950" />
 
-        {/* Tactical Filter Toggles */}
-        <fieldset className="no-scrollbar m-0 mt-2 flex min-w-0 gap-2 overflow-x-auto border-none p-0 px-1 pb-2">
-          <legend className="sr-only">Filter Pokémon</legend>
-          <TacticalButton
-            type="button"
-            onClick={() => setFilters([])}
-            aria-pressed={filtersSet.size === 0}
-            variant={filtersSet.size === 0 ? 'primary' : 'default'}
-            hasCrosshairs="corners"
-          >
-            All
-          </TacticalButton>
+          <div className="group relative mt-2 flex items-center border border-zinc-800 border-dashed bg-zinc-950 transition-colors focus-within:border-[var(--theme-primary)]">
+            <div className="absolute top-0 bottom-0 left-0 w-1 bg-zinc-800 transition-colors group-focus-within:bg-[var(--theme-primary)]" />
 
-          {FILTER_TYPES.map((f) => (
-            <TacticalButton
+            <div className="pr-3 pl-6 text-zinc-500 transition-colors group-focus-within:text-[var(--theme-primary)]">
+              <Search size={16} />
+            </div>
+
+            <input
+              ref={inputRef}
+              type="text"
+              data-testid="search-input"
+              placeholder="[ ENTER QUERY_ ]"
+              aria-label="Search Pokedex by name, ID, or location"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="w-full bg-transparent py-4 font-black font-mono text-white text-xs uppercase tracking-[0.2em] outline-none placeholder:text-zinc-700"
+            />
+
+            {searchTerm && (
+              <button
+                type="button"
+                onClick={handleClearSearch}
+                aria-label="Clear input"
+                title="Clear input"
+                className="px-4 text-zinc-600 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)]"
+              >
+                <X size={14} />
+              </button>
+            )}
+
+            {/* Location Suggestions Dropdown */}
+            <LocationSuggestions />
+          </div>
+        </div>
+
+        {/* Right Side: Filters */}
+        <div className="relative w-full bg-zinc-900/30 p-4 sm:w-[320px] sm:p-6 lg:w-[400px]">
+          <TelemetryDecoration label="FILTER_MATRIX" className="-top-3 left-6 z-10 bg-zinc-950" />
+
+          <fieldset className="mt-2 grid grid-cols-2 gap-2" aria-label="Filter Pokémon">
+            <legend className="sr-only">Filter Pokémon</legend>
+            <button
               type="button"
-              key={f}
-              onClick={() => toggleFilter(f)}
-              aria-pressed={filtersSet.has(f)}
-              data-testid={`filter-${f}`}
-              variant={filtersSet.has(f) ? 'primary' : 'default'}
-              hasCrosshairs="corners"
+              onClick={() => setFilters([])}
+              aria-pressed={filtersSet.size === 0}
+              className={cn(
+                'col-span-2 rounded-none border border-dashed px-3 py-3 font-black font-mono text-[9px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] sm:col-span-1',
+                filtersSet.size === 0
+                  ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'
+                  : 'border-zinc-800 bg-zinc-950 text-zinc-500 hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300',
+              )}
             >
-              {f === 'secured' ? 'Secured' : f === 'missing' ? 'Missing' : 'Dex Only'}
-            </TacticalButton>
-          ))}
-        </fieldset>
-      </div>
+              [ ALL ]
+            </button>
+
+            {FILTER_TYPES.map((f) => (
+              <button
+                type="button"
+                key={f}
+                onClick={() => toggleFilter(f)}
+                aria-pressed={filtersSet.has(f)}
+                data-testid={`filter-${f}`}
+                className={cn(
+                  'col-span-1 rounded-none border border-dashed px-3 py-3 font-black font-mono text-[9px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)]',
+                  filtersSet.has(f)
+                    ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'
+                    : 'border-zinc-800 bg-zinc-950 text-zinc-500 hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300',
+                )}
+              >
+                [ {f === 'secured' ? 'SECURED' : f === 'missing' ? 'MISSING' : 'DEX ONLY'} ]
+              </button>
+            ))}
+          </fieldset>
+        </div>
+      </TacticalPanel>
     </div>
   );
 }


### PR DESCRIPTION
This PR redesigns the `SearchAndFilters` component to elevate the previously generic responsive search layout into a highly cohesive, unified hardware control panel. 

Changes include:
- Merging the search input and horizontal filter toggles into a single `TacticalPanel`.
- Converting the scrolling horizontal filters into a rigid 2-column segmented control matrix.
- Styling the search input explicitly to look like a terminal entry (`[ ENTER QUERY_ ]`).
- Adding telemetry accent panels (`[ SYS.QUERY_STRING ]`, `[ FILTER_MATRIX ]`).
- Updating `.jules/canvas.md` to document the pattern of merging disconnected inputs into cohesive hardware panels.

---
*PR created automatically by Jules for task [1214660522174749862](https://jules.google.com/task/1214660522174749862) started by @szubster*