### PR TITLE
🧭 Strategist: Prompt improvement - Prevent premature verification of parent nodes

### DIFF
--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -28,6 +28,7 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **Prevent Premature Verification:** You must not submit an Empty PR to transition the parent node to VERIFYING until all of its generated child nodes have transitioned to COMPLETED. Premature verification violates DAG dependency constraints.
 
 
 ## Journal

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -25,6 +25,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **Prevent Premature Verification:** You must not submit an Empty PR to transition the parent node to VERIFYING until all of its generated child nodes have transitioned to COMPLETED. Premature verification violates DAG dependency constraints.
 
 **HANDLING PERMANENT CHILD FAILURES (THE IMPOSSIBLE LOOP):**
 If you are woken up by the Orchestrator because a child node reached its Max Rejection Count (e.g., a TASK failed permanently), you MUST:

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -35,6 +35,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **Prevent Premature Verification:** You must not submit an Empty PR to transition the parent node to VERIFYING until all of its generated child nodes have transitioned to COMPLETED. Premature verification violates DAG dependency constraints.
 
 **HANDLING PERMANENT CHILD FAILURES (THE IMPOSSIBLE LOOP):**
 If you are woken up by the Orchestrator because a child node reached its Max Rejection Count (e.g., a `coder` TASK failed permanently), you MUST:

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -144,3 +144,9 @@
 **Outcome:** Merged
 **Why:** The Strategist was only instructed to read `.jules/*.md` to assess agent prompt quality, missing all Foundry execution personas which log their learnings to `.foundry/journals/*.md` (e.g., coder, qa, tech_lead). This gap prevented the Strategist from identifying prompt quality issues for the most active execution agents.
 **Pattern:** Update prompts to ensure they have access to the correct and complete set of journals for all personas, specifically including both `.jules/` and `.foundry/journals/` when reading logs to identify issues.
+
+## 2026-07-09 - [Accepted] - Prompt improvement - Prevent premature verification of parent nodes
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The Auditor journal noted a recurring pattern where `EPIC` nodes transition to `VERIFYING` prematurely because the planning agent checked off the criteria indicating child nodes were created, even though the actual functional implementation (the child nodes) had not yet completed. This violates DAG dependency constraints.
+**Pattern:** Update node-generating agent prompts (Epic Planner, Story Owner, Tech Lead) with a strict rule forbidding them from submitting an Empty PR to transition the parent node to `VERIFYING` until all of its generated child nodes have reached `COMPLETED`.


### PR DESCRIPTION
**Proposal**: Added a critical rule to node-generating agent prompts (`epic_planner`, `story_owner`, `tech_lead`) to prevent them from submitting an Empty PR to transition their parent node to `VERIFYING` before all generated child nodes are `COMPLETED`.

**Justification**: The `Auditor` journal noted that parent nodes were transitioning to `VERIFYING` prematurely because the planning agent would check off the node generation criteria before the actual functional implementation (the child nodes) had finished. This violates DAG dependency constraints.

**Evidence**: See the new entry in `.jules/strategist.md` and the findings in the `Auditor` journal indicating premature verification of `EPIC` nodes.

---
*PR created automatically by Jules for task [6270009304377242854](https://jules.google.com/task/6270009304377242854) started by @szubster*