### PR TITLE
agile_coach: Generate ideas for standardizing rejection threshold and enforcing gray-matter linter

### DIFF
--- a/.foundry/ideas/idea-066-standardize-rejection-threshold.md
+++ b/.foundry/ideas/idea-066-standardize-rejection-threshold.md
@@ -1,0 +1,34 @@
+---
+id: idea-066-standardize-rejection-threshold
+type: IDEA
+title: Standardize MAX_REJECTION_THRESHOLD
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-05-26'
+updated_at: '2026-05-26'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - process
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Standardize MAX_REJECTION_THRESHOLD
+
+## Context
+While reviewing the recent introduction of the Permanent Failure Dashboard UI (ADR 017), it was observed that `MAX_REJECTION_THRESHOLD` is referenced as a concept but is not formally defined in the system schema or global configuration. Currently, the orchestrator scripts (such as `.github/scripts/foundry-heartbeat.ts` and its associated tests) hardcode the maximum rejection count as `3` instead of relying on a centralized constant.
+
+## Proposal
+Create a formalized, system-wide `MAX_REJECTION_THRESHOLD` constant (e.g., in a global orchestrator config file or environment variable) that all scripts and UI components must read from. This will ensure:
+- The orchestrator's heartbeat script evaluates the "Impossible Loop" consistently against a single source of truth.
+- The React Flow/Kanban dashboard correctly filters nodes that have reached the configured threshold.
+- Future changes to this threshold only require a single update rather than scattering changes across multiple files.
+
+## Next Steps
+- [ ] Product Manager: Evaluate this idea, determine the best place to define the threshold, and convert it to a PRD.

--- a/.foundry/ideas/idea-067-enforce-gray-matter-linter.md
+++ b/.foundry/ideas/idea-067-enforce-gray-matter-linter.md
@@ -1,0 +1,33 @@
+---
+id: idea-067-enforce-gray-matter-linter
+type: IDEA
+title: Enforce Gray Matter Linter Rule
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-05-26'
+updated_at: '2026-05-26'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - linting
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Enforce Gray Matter Linter Rule
+
+## Context
+ADR-006 mandates the use of `gray-matter` for parsing markdown frontmatter to avoid brittle ad-hoc regex manipulations. However, there are still orchestrator files (like `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts`) that might slip back into using regex for performance or convenience if not actively checked.
+
+## Proposal
+Implement an ESLint or Biome rule to statically analyze `.github/scripts/` (and any agent-related tooling) to forbid the use of regex manipulation for extracting or modifying YAML frontmatter blocks.
+- The linter rule should specifically target operations matching the typical frontmatter syntax `^---[\s\S]*?---`.
+- This ensures full compliance with ADR-006 and stops regressions before they are merged.
+
+## Next Steps
+- [ ] Product Manager: Evaluate this idea and draft a PRD outlining the linting strategy.


### PR DESCRIPTION
Proactively generated two new IDEA nodes based on observed friction and hardcoded values in orchestrator scripts:
1. Standardizing `MAX_REJECTION_THRESHOLD` (idea-066).
2. Enforcing a `gray-matter` linter rule for scripts (idea-067).

---
*PR created automatically by Jules for task [17486070743754714916](https://jules.google.com/task/17486070743754714916) started by @szubster*