### PR TITLE
🧬 Oak: [data correction] Fix Crystal Growlithe Exclusivity

### DIFF
--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -49,3 +49,6 @@
 
 ## Data Integrity - Gen 1/2 Exclusives Refactoring
 * **Data Pipeline Gotchas:** The Gen 1 and Gen 2 version exclusive lists were missing some unobtainable Pokémon, or listing some as unobtainable when they are in fact obtainable. For example, Gen 1 Yellow exclusives missed a few entries, and Gen 2 Crystal missing exclusives also lacked some entries (like Arcanine / Growlithe line). PokeAPI encounters are the source of truth for base-form availability, but one must carefully check all versions (`version_details`) in the encounter data.
+
+## Data Integrity - Crystal Exclusives (Growlithe & Arcanine)
+* **Data Pipeline Gotchas:** The Gen 2 version exclusives list for Crystal incorrectly included Growlithe (58) and Arcanine (59). A cross-reference with PokeAPI (`https://pokeapi.co/api/v2/pokemon/58/encounters`) reveals that Growlithe is obtainable in Crystal on Route 35 and Route 36. They have been removed from the `crystal` unobtainable list. Always check PokeAPI encounters, as version availability diverges notably in the third versions (Yellow/Crystal/Emerald).

--- a/src/engine/exclusives/__tests__/gen2Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen2Exclusives.test.ts
@@ -104,18 +104,16 @@ describe('gen2Exclusives', () => {
         expect(reason).toContain('not available in Crystal');
       });
 
-      it('should lock Arcanine (59) in Crystal', () => {
+      it('should not lock Arcanine (59) in Crystal', () => {
         const ownedSet = new Set<number>();
         const reason = getGen2UnobtainableReason(59, 'crystal', 0, ownedSet);
-        expect(typeof reason).toBe('string');
-        expect(reason).toContain('not available in Crystal');
+        expect(reason).toBeNull();
       });
 
-      it('should lock Growlithe (58) in Crystal', () => {
+      it('should not lock Growlithe (58) in Crystal', () => {
         const ownedSet = new Set<number>();
         const reason = getGen2UnobtainableReason(58, 'crystal', 0, ownedSet);
-        expect(typeof reason).toBe('string');
-        expect(reason).toContain('not available in Crystal');
+        expect(reason).toBeNull();
       });
 
       it('should lock Girafarig (203) in Crystal', () => {

--- a/src/engine/exclusives/gen2Exclusives.ts
+++ b/src/engine/exclusives/gen2Exclusives.ts
@@ -1,7 +1,7 @@
 export const GEN2_VERSION_EXCLUSIVES: Record<string, number[]> = {
   gold: [37, 38, 52, 53, 165, 166, 225, 227, 231, 232],
   silver: [56, 57, 58, 59, 167, 168, 207, 216, 217, 226],
-  crystal: [37, 38, 56, 57, 58, 59, 179, 180, 181, 203, 223, 224],
+  crystal: [37, 38, 56, 57, 179, 180, 181, 203, 223, 224],
 };
 
 export function getGen2UnobtainableReason(


### PR DESCRIPTION
### 🎯 What
Removed Growlithe (58) and Arcanine (59) from the list of unobtainable Pokémon in Crystal Version.

### 🔍 Canonical source used
PokeAPI encounters endpoint (`https://pokeapi.co/api/v2/pokemon/58/encounters`), which confirms that Growlithe is obtainable in Crystal version on Route 35 and Route 36 (morning and day).

### 👥 Impact on users
Users playing Pokémon Crystal will no longer be erroneously told that they must trade to obtain a Growlithe or Arcanine, allowing the app's location tracker to properly point them to the correct wild encounters.

---
*PR created automatically by Jules for task [8220537440147550270](https://jules.google.com/task/8220537440147550270) started by @szubster*