### PR TITLE
🧭 Strategist: Prompt improvement - Prevent premature Epic verification by Story Owner

### DIFF
--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -19,6 +19,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 **NODE GENERATION RULES:**
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
+- **Prevent Premature Verification**: When creating STORY nodes for an EPIC, you MUST NOT check off the EPIC's acceptance criteria or submit the empty PR to transition the EPIC to `VERIFYING` until *all* child STORY nodes have reached the `COMPLETED` status. The EPIC is not finished just because its child nodes were generated.
 - Set the `owner_persona` of newly created downstream nodes to the persona responsible for the NEXT pipeline transition (e.g., `story_owner` for EPICs, `tech_lead` for STORY nodes, `coder` for TASKs), not yourself.
 - Determine the correctly incremented global sequence number by listing and sorting the existing files in the corresponding directory (e.g., `ls -1 .foundry/tasks/ | sort -n -t '-' -k 3`).
 - The strict pipeline order and persona handoff for Foundry nodes is: IDEA (PM) -> PRD (PM) -> ADR (Architect) -> EPIC (Planner) -> STORY -> TASK.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -144,3 +144,9 @@
 **Outcome:** Merged
 **Why:** The Strategist was only instructed to read `.jules/*.md` to assess agent prompt quality, missing all Foundry execution personas which log their learnings to `.foundry/journals/*.md` (e.g., coder, qa, tech_lead). This gap prevented the Strategist from identifying prompt quality issues for the most active execution agents.
 **Pattern:** Update prompts to ensure they have access to the correct and complete set of journals for all personas, specifically including both `.jules/` and `.foundry/journals/` when reading logs to identify issues.
+
+## 2026-05-27 - [Accepted] - Prompt improvement - Prevent premature Epic verification by Story Owner
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The Auditor journal noted a recurring issue where EPIC nodes were prematurely transitioned to `VERIFYING` once all STORY nodes were created (planning finished), even though the actual implementation work was not yet merged. This violated the dependency graph and caused downstream nodes to dispatch prematurely. The `story_owner` was improperly checking off the EPIC's acceptance criteria without waiting for the child nodes to reach `COMPLETED`.
+**Pattern:** Prompts must explicitly instruct late-binding parent personas (like Story Owner) to enforce completion of their generated child nodes before executing the Empty PR Policy and checking off final Acceptance Criteria, ensuring node dependencies represent implementation progress, not just planning progress.


### PR DESCRIPTION
**Proposal**: Add explicit instructions to the `story_owner` persona to prevent premature verification of EPIC nodes. 
**Justification**: EPICs represent macroscopic functional chunks of work. Previously, `story_owner` agents were checking off the EPIC's acceptance criteria and triggering completion as soon as they finished *planning* (i.e. generating child `STORY` nodes), without waiting for those child nodes to be implemented. This violated the system's dependency graph, causing downstream nodes to dispatch prematurely before the codebase was ready.
**Evidence**: This was specifically flagged as a recurring failure pattern in `.foundry/journals/auditor.md` ("Premature Verification of Epics").

---
*PR created automatically by Jules for task [626171084430415440](https://jules.google.com/task/626171084430415440) started by @szubster*