### PR TITLE
🔒 [CWE-209] sanitize error logs in useFileSyncController

### DIFF
--- a/src/hooks/useFileSyncController.ts
+++ b/src/hooks/useFileSyncController.ts
@@ -34,8 +34,8 @@ export function useFileSyncController() {
         await saveDB.putSave('last_save_file', new Uint8Array(buffer));
         setStatus('live');
         setErrorMsg(null);
-      } catch (err) {
-        console.error(err);
+      } catch {
+        console.error('System: sync failed');
         setStatus('error');
         setErrorMsg('Failed to parse live save file.');
       }
@@ -72,7 +72,7 @@ export function useFileSyncController() {
       lastModifiedRef.current = file.lastModified;
       await processFile(file);
     } catch (err) {
-      console.error('User cancelled or error:', err);
+      console.error('System: sync setup failed');
       // Don't set error status if user just cancelled
       if (err instanceof Error && err.name !== 'AbortError') {
         setStatus('error');
@@ -103,8 +103,8 @@ export function useFileSyncController() {
             setStatus('disconnected');
           }
         }
-      } catch (e) {
-        console.error('Failed to restore handle', e);
+      } catch {
+        console.error('System: sync restore failed');
       }
     }
     void restoreHandle();
@@ -124,8 +124,8 @@ export function useFileSyncController() {
           await processFile(file);
         }
       }
-    } catch (err) {
-      console.error('Failed to resume sync', err);
+    } catch {
+      console.error('System: sync resume failed');
       setStatus('error');
     }
   }, [processFile]);
@@ -143,8 +143,8 @@ export function useFileSyncController() {
           lastModifiedRef.current = file.lastModified;
           await processFile(file);
         }
-      } catch (err) {
-        console.error('Polling error:', err);
+      } catch {
+        console.error('System: sync polling failed');
         // We might have lost permission or file was deleted
         setStatus('disconnected');
       }


### PR DESCRIPTION
🎯 What
Sanitize error logs in `useFileSyncController.ts` by replacing raw `err` objects with generic static messages. Uses parameterless `catch { ... }` blocks where possible.

⚠️ Risk
Low. Replaces verbose system error logging with static strings to avoid accidental sensitive data leakage via browser console.

🛡️ Solution
Replaced `console.error(err)` and variants with static strings like `console.error('System: sync failed')`. Ensured `err` is retained in blocks that need to inspect `err.name` (like for `AbortError`). Fixed linting by omitting the catch parameter altogether for entirely unused errors.

---
*PR created automatically by Jules for task [11039810975396113643](https://jules.google.com/task/11039810975396113643) started by @szubster*