### PR TITLE
🧬 Oak: [data correction]

### DIFF
--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -49,3 +49,6 @@
 
 ## Data Integrity - Gen 1/2 Exclusives Refactoring
 * **Data Pipeline Gotchas:** The Gen 1 and Gen 2 version exclusive lists were missing some unobtainable Pokémon, or listing some as unobtainable when they are in fact obtainable. For example, Gen 1 Yellow exclusives missed a few entries, and Gen 2 Crystal missing exclusives also lacked some entries (like Arcanine / Growlithe line). PokeAPI encounters are the source of truth for base-form availability, but one must carefully check all versions (`version_details`) in the encounter data.
+
+## Data Integrity - Gen 2 Exclusives (Growlithe and Arcanine)
+* **Data Pipeline Gotchas:** The Gen 2 version exclusives list for Crystal (`crystal` array in `src/engine/exclusives/gen2Exclusives.ts`) incorrectly included Growlithe (58) and Arcanine (59). While Growlithe is exclusive to Gold when comparing just Gold and Silver (missing in Silver), it is actually obtainable natively in Crystal (e.g. Route 8, 36, 37). When verifying "unobtainable" lists, always explicitly check the `crystal` version details in the PokeAPI encounters array, as Crystal's availability rules often break the standard Gold/Silver dichotomies.

--- a/src/engine/exclusives/__tests__/gen2Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen2Exclusives.test.ts
@@ -104,18 +104,16 @@ describe('gen2Exclusives', () => {
         expect(reason).toContain('not available in Crystal');
       });
 
-      it('should lock Arcanine (59) in Crystal', () => {
+      it('should not lock Arcanine (59) in Crystal', () => {
         const ownedSet = new Set<number>();
         const reason = getGen2UnobtainableReason(59, 'crystal', 0, ownedSet);
-        expect(typeof reason).toBe('string');
-        expect(reason).toContain('not available in Crystal');
+        expect(reason).toBeNull();
       });
 
-      it('should lock Growlithe (58) in Crystal', () => {
+      it('should not lock Growlithe (58) in Crystal', () => {
         const ownedSet = new Set<number>();
         const reason = getGen2UnobtainableReason(58, 'crystal', 0, ownedSet);
-        expect(typeof reason).toBe('string');
-        expect(reason).toContain('not available in Crystal');
+        expect(reason).toBeNull();
       });
 
       it('should lock Girafarig (203) in Crystal', () => {

--- a/src/engine/exclusives/gen2Exclusives.ts
+++ b/src/engine/exclusives/gen2Exclusives.ts
@@ -1,7 +1,7 @@
 export const GEN2_VERSION_EXCLUSIVES: Record<string, number[]> = {
   gold: [37, 38, 52, 53, 165, 166, 225, 227, 231, 232],
   silver: [56, 57, 58, 59, 167, 168, 207, 216, 217, 226],
-  crystal: [37, 38, 56, 57, 58, 59, 179, 180, 181, 203, 223, 224],
+  crystal: [37, 38, 56, 57, 179, 180, 181, 203, 223, 224],
 };
 
 export function getGen2UnobtainableReason(


### PR DESCRIPTION
**What was wrong**: The `crystal` array in `src/engine/exclusives/gen2Exclusives.ts`, which functions as a list of unobtainable Pokémon for that version, incorrectly included Growlithe (58) and Arcanine (59). While Growlithe is a Gold exclusive when comparing just Gold and Silver, it is obtainable in the wild in Crystal version.
**Canonical source used**: PokeAPI encounters (`https://pokeapi.co/api/v2/pokemon/58/encounters`), which confirmed `version: "crystal"` on multiple Johto/Kanto routes (Route 8, 36, 37).
**Impact on users**: Players running a Crystal save file will no longer be erroneously told that they must trade to obtain Growlithe or Arcanine.

---
*PR created automatically by Jules for task [13467927691924790654](https://jules.google.com/task/13467927691924790654) started by @szubster*