### PR TITLE
chore(foundry): log target artifact anomaly for idea-064-smart-route-radar

### DIFF
--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -6,3 +6,10 @@ Currently, macroscopic Foundry nodes (such as Epics and Stories) transition to t
 
 **Architectural Constraint:**
 This violates the spirit of the dependency graph. An Epic represents a "macroscopic functional chunk" of work. If it completes before its functional requirements are implemented, it provides a false sense of progress and can cause downstream nodes dependent on the Epic to be dispatched before the codebase is ready for them. The orchestrator must be updated to enforce strict hierarchical completion timing, preventing parent nodes from completing until all of their spawned descendant nodes are fully completed. This ensures that "Epic implementation is done" is semantically accurate across the DAG.
+
+## Anomaly: Target Artifact Exists Prior to Session (2026-05-28)
+**Observation:**
+During the session for node `idea-064-smart-route-radar`, it was discovered that the target artifact `prd-064-035-smart-route-radar.md` and all its child nodes already existed in the `.foundry` directory prior to execution. Additionally, the acceptance criteria in the parent IDEA node were already checked off.
+
+**Impact:**
+This implies that either a previous session successfully generated the node but failed to correctly transition the IDEA node's status, or there was a desync in the orchestrator. This behavior should be reviewed by the Agile Coach to prevent redundant work or silent failures in node progression.


### PR DESCRIPTION
Appended an entry to the Product Manager journal detailing an anomaly where the target PRD artifact (`prd-064-035-smart-route-radar.md`) and all its child nodes for `idea-064-smart-route-radar` already existed prior to session execution. The acceptance criteria in the parent IDEA node were also already checked. This satisfies the requirement to execute an Empty PR policy when the target artifact exists but still submit a PR to advance the DAG and log the event for the Agile Coach.

---
*PR created automatically by Jules for task [1090915287785223708](https://jules.google.com/task/1090915287785223708) started by @szubster*