### PR TITLE
feat: Extract and broadcast rejection count in DAG data parsing

### DIFF
--- a/src/utils/dag/builder.test.ts
+++ b/src/utils/dag/builder.test.ts
@@ -12,6 +12,7 @@ describe('buildDagGraph', () => {
           status: 'COMPLETED',
           owner_persona: 'coder',
           depends_on: [],
+          rejection_count: 0,
         },
       },
       {
@@ -22,6 +23,7 @@ describe('buildDagGraph', () => {
           status: 'PENDING',
           owner_persona: 'qa',
           depends_on: ['.foundry/tasks/task-1.md'],
+          rejection_count: 0,
         },
       },
     ];
@@ -36,6 +38,7 @@ describe('buildDagGraph', () => {
             type: 'TASK',
             status: 'COMPLETED',
             owner_persona: 'coder',
+            rejection_count: 0,
           },
         },
         {
@@ -44,6 +47,7 @@ describe('buildDagGraph', () => {
             type: 'TASK',
             status: 'PENDING',
             owner_persona: 'qa',
+            rejection_count: 0,
           },
         },
       ],
@@ -66,6 +70,7 @@ describe('buildDagGraph', () => {
           status: 'COMPLETED',
           owner_persona: 'coder',
           depends_on: [],
+          rejection_count: 0,
         },
       },
       {
@@ -76,6 +81,7 @@ describe('buildDagGraph', () => {
           status: 'PENDING',
           owner_persona: 'qa',
           depends_on: ['./.foundry/tasks/task-1.md'],
+          rejection_count: 0,
         },
       },
     ];
@@ -100,6 +106,7 @@ describe('buildDagGraph', () => {
           status: 'PENDING',
           owner_persona: 'coder',
           depends_on: ['.foundry/tasks/unknown-task.md'],
+          rejection_count: 0,
         },
       },
     ];
@@ -114,6 +121,7 @@ describe('buildDagGraph', () => {
             type: 'TASK',
             status: 'PENDING',
             owner_persona: 'coder',
+            rejection_count: 0,
           },
         },
       ],
@@ -125,11 +133,25 @@ describe('buildDagGraph', () => {
     const parsedNodes: ParsedNode[] = [
       {
         filePath: 'task-1.md',
-        data: { id: 't1', type: 'TASK', status: 'COMPLETED', owner_persona: 'coder', depends_on: [] },
+        data: {
+          id: 't1',
+          type: 'TASK',
+          status: 'COMPLETED',
+          owner_persona: 'coder',
+          depends_on: [],
+          rejection_count: 0,
+        },
       },
       {
         filePath: 'task-2.md',
-        data: { id: 't2', type: 'TASK', status: 'COMPLETED', owner_persona: 'coder', depends_on: [] },
+        data: {
+          id: 't2',
+          type: 'TASK',
+          status: 'COMPLETED',
+          owner_persona: 'coder',
+          depends_on: [],
+          rejection_count: 0,
+        },
       },
       {
         filePath: 'task-3.md',
@@ -139,6 +161,7 @@ describe('buildDagGraph', () => {
           status: 'READY',
           owner_persona: 'coder',
           depends_on: ['task-1.md', 'task-2.md'],
+          rejection_count: 0,
         },
       },
     ];

--- a/src/utils/dag/builder.ts
+++ b/src/utils/dag/builder.ts
@@ -11,6 +11,7 @@ export interface GraphNode {
     type: string;
     status: string;
     owner_persona: string;
+    rejection_count: number;
   };
 }
 
@@ -51,6 +52,7 @@ export function buildDagGraph(parsedNodes: ParsedNode[]): DagGraph {
         type: node.data.type,
         status: node.data.status,
         owner_persona: node.data.owner_persona,
+        rejection_count: node.data.rejection_count,
       },
     });
   }

--- a/src/utils/dag/parser.test.ts
+++ b/src/utils/dag/parser.test.ts
@@ -19,6 +19,28 @@ depends_on:
       status: 'READY',
       owner_persona: 'coder',
       depends_on: ['.foundry/tasks/task-043-073-read-foundry-files.md'],
+      rejection_count: 0,
+    });
+  });
+
+  it('should parse rejection_count correctly if present', () => {
+    const rawContent = `---
+id: task-043-074-parse-frontmatter
+type: TASK
+status: READY
+owner_persona: coder
+depends_on: []
+rejection_count: 3
+---
+# Content here`;
+    const result = parseFoundryNode(rawContent);
+    expect(result).toEqual({
+      id: 'task-043-074-parse-frontmatter',
+      type: 'TASK',
+      status: 'READY',
+      owner_persona: 'coder',
+      depends_on: [],
+      rejection_count: 3,
     });
   });
 
@@ -38,6 +60,7 @@ depends_on: []
       status: 'PENDING',
       owner_persona: 'coder',
       depends_on: [],
+      rejection_count: 0,
     });
   });
 

--- a/src/utils/dag/parser.ts
+++ b/src/utils/dag/parser.ts
@@ -6,6 +6,7 @@ export interface FoundryNodeData {
   status: string;
   owner_persona: string;
   depends_on: string[];
+  rejection_count: number;
 }
 
 export function parseFoundryNode(rawContent: string): FoundryNodeData | null {
@@ -29,6 +30,10 @@ export function parseFoundryNode(rawContent: string): FoundryNodeData | null {
       return null;
     }
 
+    // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+    const parsedRejectionCount = data['rejection_count'];
+    const rejection_count = typeof parsedRejectionCount === 'number' ? parsedRejectionCount : 0;
+
     return {
       // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
       id: data['id'],
@@ -40,6 +45,7 @@ export function parseFoundryNode(rawContent: string): FoundryNodeData | null {
       owner_persona: data['owner_persona'],
       // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
       depends_on: data['depends_on'],
+      rejection_count,
     };
   } catch {
     // If gray-matter fails to parse, return null


### PR DESCRIPTION
Implemented DAG parser update to extract the `rejection_count` property from the `.foundry` Markdown files YAML frontmatter and expose it via `FoundryNodeData` and `GraphNode`. This allows the property to be broadcasted through the DAG Builder so it can be consumed by the UI for the Permanent Failure Dashboard as detailed in ADR 017.

- Updated `src/utils/dag/parser.ts` to parse `rejection_count`
- Updated `src/utils/dag/parser.test.ts` to verify default and specific logic
- Updated `src/utils/dag/builder.ts` to copy `rejection_count` into `GraphNode`
- Updated `src/utils/dag/builder.test.ts`
- Verified tests pass via `pnpm test`

---
*PR created automatically by Jules for task [14271103325217615947](https://jules.google.com/task/14271103325217615947) started by @szubster*