### PR TITLE
chore: QA Rejection for AliveTeamView otName usage

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -14,3 +14,5 @@ During the validation of `task-072-128-implement-dag-cancellation`, I discovered
 
 ## Missing Integration Failures
 When an implementation task only creates standalone UI components but fails to integrate or render them anywhere in the main application (making them inaccessible to the user), the task MUST be rejected. The purpose of implementation isn't just to write code that passes isolated unit tests; it is to deliver accessible features.
+
+**Constraint/Lesson**: When displaying Pokémon names in the UI (e.g. AliveTeamView), the code must use the Pokémon's `nickname` (or a fallback to the species name), NOT the `otName` (Original Trainer Name). The save parser must be updated to extract nicknames from the save data, and the UI components must be updated to consume this new property.

--- a/.foundry/tasks/task-071-134-run-dashboard-ui-impl.md
+++ b/.foundry/tasks/task-071-134-run-dashboard-ui-impl.md
@@ -2,7 +2,7 @@
 id: task-071-134-run-dashboard-ui-impl
 type: TASK
 title: Implement Dashboard Alive Team View
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-05-22'
 updated_at: '2026-05-23'
@@ -15,7 +15,7 @@ tags:
   - nuzlocke
   - verification
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'The AliveTeamView incorrectly displays the Original Trainer name (otName) instead of the Pokémon nickname or species name. The save parser needs to extract nicknames, and the UI should use them instead.'
 notes: ''
 ---
 
@@ -25,5 +25,5 @@ notes: ''
 Implement the "Alive" team view for the Run Dashboard UI.
 
 ## Acceptance Criteria
-- [x] Implement the UI to display the current "Alive" Nuzlocke team.
-- [x] Ensure the UI components match the Nuzlocke Tracker mode requirements.
+- [ ] Implement the UI to display the current "Alive" Nuzlocke team.
+- [ ] Ensure the UI components match the Nuzlocke Tracker mode requirements.

--- a/.foundry/tasks/task-071-135-run-dashboard-ui-qa.md
+++ b/.foundry/tasks/task-071-135-run-dashboard-ui-qa.md
@@ -25,6 +25,8 @@ notes: ''
 ## Description
 QA the "Alive" team view for the Run Dashboard UI.
 
+Validation Failed: The implementation incorrectly uses the Original Trainer Name (`otName`) instead of the Pokémon's nickname. The save parser needs to be updated to extract nicknames, and the UI should use them instead.
+
 ## Acceptance Criteria
 - [ ] Verify the "Alive" team view displays correctly.
 - [ ] Verify the UI meets all requirements for the Nuzlocke Tracker mode.


### PR DESCRIPTION
During QA of the `AliveTeamView` component, it was discovered that the component incorrectly displays the Original Trainer Name (`otName`) instead of the Pokémon's nickname (or species name). The save parser currently only extracts `otName`, and the UI is mapping this to the display name.

This PR properly documents the failure by:
1. Updating the target implementation task (`task-071-134-run-dashboard-ui-impl`) to `FAILED` with a clear `rejection_reason`.
2. Unchecking the Acceptance Criteria in the failed task.
3. Updating the QA task (`task-071-135-run-dashboard-ui-qa`) markdown body to explain the validation failure (leaving the YAML frontmatter intact and Active).
4. Updating the `qa.md` persona journal to log the architectural constraint that UI components must use `nickname` instead of `otName`.

---
*PR created automatically by Jules for task [5023324842966507681](https://jules.google.com/task/5023324842966507681) started by @szubster*