### PR TITLE
feat: Implement DAG Data Parsing for Rejection Count

### DIFF
--- a/.foundry/tasks/task-085-142-impl-extract-rejection-count.md
+++ b/.foundry/tasks/task-085-142-impl-extract-rejection-count.md
@@ -34,9 +34,9 @@ In order to display permanent failures on the DAG dashboard, we need to surface 
 3. Verify that the React context layer correctly exposes the property to connected UI views.
 
 ## Acceptance Criteria
-- [ ] Coder: Update parsing logic.
-- [ ] Coder: Update `FoundryNode` TypeScript types.
-- [ ] Coder: Ensure React context layer correctly exposes the property.
+- [x] Coder: Update parsing logic.
+- [x] Coder: Update `FoundryNode` TypeScript types.
+- [x] Coder: Ensure React context layer correctly exposes the property.
 
 ## Reminders
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/src/components/dag/DagNode.tsx
+++ b/src/components/dag/DagNode.tsx
@@ -10,6 +10,7 @@ export type DagNodeData = Record<string, unknown> & {
   label?: string;
   isHighlighted?: boolean;
   isDimmed?: boolean;
+  rejection_count?: number;
 };
 
 export function DagNode({ data }: { data: DagNodeData }) {

--- a/src/utils/dag/builder.ts
+++ b/src/utils/dag/builder.ts
@@ -11,6 +11,7 @@ export interface GraphNode {
     type: string;
     status: string;
     owner_persona: string;
+    rejection_count?: number;
   };
 }
 
@@ -45,13 +46,19 @@ export function buildDagGraph(parsedNodes: ParsedNode[]): DagGraph {
       pathToIdMap.set(`./${node.filePath}`, id);
     }
 
+    const graphNodeData: GraphNode['data'] = {
+      type: node.data.type,
+      status: node.data.status,
+      owner_persona: node.data.owner_persona,
+    };
+
+    if (node.data.rejection_count !== undefined) {
+      graphNodeData.rejection_count = node.data.rejection_count;
+    }
+
     nodes.push({
       id,
-      data: {
-        type: node.data.type,
-        status: node.data.status,
-        owner_persona: node.data.owner_persona,
-      },
+      data: graphNodeData,
     });
   }
 

--- a/src/utils/dag/parser.test.ts
+++ b/src/utils/dag/parser.test.ts
@@ -22,6 +22,27 @@ depends_on:
     });
   });
 
+  it('should parse rejection_count correctly if it exists', () => {
+    const rawContent = `---
+id: task-043-074-parse-frontmatter
+type: TASK
+status: READY
+owner_persona: coder
+rejection_count: 3
+depends_on: []
+---
+# Content here`;
+    const result = parseFoundryNode(rawContent);
+    expect(result).toEqual({
+      id: 'task-043-074-parse-frontmatter',
+      type: 'TASK',
+      status: 'READY',
+      owner_persona: 'coder',
+      rejection_count: 3,
+      depends_on: [],
+    });
+  });
+
   it('should handle empty depends_on correctly', () => {
     const rawContent = `---
 id: task-1

--- a/src/utils/dag/parser.ts
+++ b/src/utils/dag/parser.ts
@@ -6,6 +6,7 @@ export interface FoundryNodeData {
   status: string;
   owner_persona: string;
   depends_on: string[];
+  rejection_count?: number | undefined;
 }
 
 export function parseFoundryNode(rawContent: string): FoundryNodeData | null {
@@ -29,7 +30,7 @@ export function parseFoundryNode(rawContent: string): FoundryNodeData | null {
       return null;
     }
 
-    return {
+    const nodeData: FoundryNodeData = {
       // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
       id: data['id'],
       // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
@@ -41,6 +42,14 @@ export function parseFoundryNode(rawContent: string): FoundryNodeData | null {
       // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
       depends_on: data['depends_on'],
     };
+
+    // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+    if (typeof data['rejection_count'] === 'number') {
+      // biome-ignore lint/complexity/useLiteralKeys: TSConfig strictly requires bracket notation
+      nodeData.rejection_count = data['rejection_count'];
+    }
+
+    return nodeData;
   } catch {
     // If gray-matter fails to parse, return null
     return null;

--- a/vite-plugins/foundry-plugin.ts
+++ b/vite-plugins/foundry-plugin.ts
@@ -9,6 +9,7 @@ interface FoundryNodeData {
   status: string;
   owner_persona: string;
   depends_on: string[];
+  rejection_count?: number;
 }
 
 export interface ParsedNode {
@@ -46,15 +47,20 @@ export function foundryPlugin(): Plugin {
             typeof data['owner_persona'] === 'string' &&
             Array.isArray(data['depends_on'])
           ) {
+            const nodeData: FoundryNodeData = {
+              id: data['id'],
+              type: data['type'],
+              status: data['status'],
+              owner_persona: data['owner_persona'],
+              depends_on: data['depends_on'],
+            };
+            if (typeof data['rejection_count'] === 'number') {
+              nodeData.rejection_count = data['rejection_count'];
+            }
+
             nodes.push({
               filePath: `.foundry/${dir}/${file}`,
-              data: {
-                id: data['id'],
-                type: data['type'],
-                status: data['status'],
-                owner_persona: data['owner_persona'],
-                depends_on: data['depends_on'],
-              },
+              data: nodeData,
             });
           }
         } catch {


### PR DESCRIPTION
Implements the DAG Data Parsing update for Rejection Count.
    - Updated `parseFoundryNode` to extract the `rejection_count`
    - Updated `vite-plugins/foundry-plugin.ts` to forward `rejection_count`
    - Updated `DagGraph` nodes and `DagNodeData` TS types to include it.
    - Added tests for `rejection_count` parsing in `src/utils/dag/parser.test.ts`.

---
*PR created automatically by Jules for task [10307410569802856023](https://jules.google.com/task/10307410569802856023) started by @szubster*