### PR TITLE
chore: qa validation for shiny gene utility

### DIFF
--- a/.foundry/tasks/task-082-141-qa-shiny-gene-utility.md
+++ b/.foundry/tasks/task-082-141-qa-shiny-gene-utility.md
@@ -36,10 +36,10 @@ Verify that the DVs are correctly parsed from the save file's binary data using 
 5. Run tests with `pnpm test` to ensure all tests pass.
 
 ## Acceptance Criteria
-- [ ] DVs are successfully decoded from `DataView` memory blocks.
-- [ ] `checkShinyGene` is correctly implemented according to Gen 2 mechanics.
-- [ ] Type definitions are updated correctly.
-- [ ] Unit tests are present and passing.
+- [x] DVs are successfully decoded from `DataView` memory blocks.
+- [x] `checkShinyGene` is correctly implemented according to Gen 2 mechanics.
+- [x] Type definitions are updated correctly.
+- [x] Unit tests are present and passing.
 
 ## Reminder for QA
 - If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.


### PR DESCRIPTION
This empty PR closes the QA validation phase for the Shiny Gene implementation task. It marks the Acceptance Criteria as checked and officially finalizes the task.

---
*PR created automatically by Jules for task [6454736856522977689](https://jules.google.com/task/6454736856522977689) started by @szubster*