### PR TITLE
🐛 Oak: [crystal growlithe correction]

### DIFF
--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -49,3 +49,6 @@
 
 ## Data Integrity - Gen 1/2 Exclusives Refactoring
 * **Data Pipeline Gotchas:** The Gen 1 and Gen 2 version exclusive lists were missing some unobtainable Pokémon, or listing some as unobtainable when they are in fact obtainable. For example, Gen 1 Yellow exclusives missed a few entries, and Gen 2 Crystal missing exclusives also lacked some entries (like Arcanine / Growlithe line). PokeAPI encounters are the source of truth for base-form availability, but one must carefully check all versions (`version_details`) in the encounter data.
+
+## Data Integrity - Gen 2 Crystal Exclusives (Growlithe & Arcanine)
+*   **Data Pipeline Gotchas:** The Gen 2 version exclusive list for Crystal incorrectly included Growlithe (58) and Arcanine (59) as unobtainable. However, Growlithe is explicitly obtainable in the wild in Crystal (Routes 8, 36, and 37), and thus Arcanine is obtainable via Fire Stone evolution. PokeAPI `encounters` data correctly lists Growlithe in Crystal. Always cross-reference multiple canonical sources (like Bulbapedia's missing lists and PokeAPI encounters) to ensure Pokémon are truly missing from a version before adding them to an exclusion array. Furthermore, if a base evolution is obtainable, its item-evolution forms are inherently obtainable and must not be locked.

--- a/src/engine/exclusives/__tests__/gen2Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen2Exclusives.test.ts
@@ -104,20 +104,6 @@ describe('gen2Exclusives', () => {
         expect(reason).toContain('not available in Crystal');
       });
 
-      it('should lock Arcanine (59) in Crystal', () => {
-        const ownedSet = new Set<number>();
-        const reason = getGen2UnobtainableReason(59, 'crystal', 0, ownedSet);
-        expect(typeof reason).toBe('string');
-        expect(reason).toContain('not available in Crystal');
-      });
-
-      it('should lock Growlithe (58) in Crystal', () => {
-        const ownedSet = new Set<number>();
-        const reason = getGen2UnobtainableReason(58, 'crystal', 0, ownedSet);
-        expect(typeof reason).toBe('string');
-        expect(reason).toContain('not available in Crystal');
-      });
-
       it('should lock Girafarig (203) in Crystal', () => {
         const ownedSet = new Set<number>();
         const reason = getGen2UnobtainableReason(203, 'crystal', 0, ownedSet);

--- a/src/engine/exclusives/gen2Exclusives.ts
+++ b/src/engine/exclusives/gen2Exclusives.ts
@@ -1,7 +1,7 @@
 export const GEN2_VERSION_EXCLUSIVES: Record<string, number[]> = {
   gold: [37, 38, 52, 53, 165, 166, 225, 227, 231, 232],
   silver: [56, 57, 58, 59, 167, 168, 207, 216, 217, 226],
-  crystal: [37, 38, 56, 57, 58, 59, 179, 180, 181, 203, 223, 224],
+  crystal: [37, 38, 56, 57, 179, 180, 181, 203, 223, 224],
 };
 
 export function getGen2UnobtainableReason(


### PR DESCRIPTION
**What was wrong:** Growlithe (58) and Arcanine (59) were incorrectly hardcoded as unobtainable (exclusive) in Pokémon Crystal. However, Growlithe is obtainable in the wild on Routes 8, 36, and 37 in Crystal.
**Canonical source used:** PokeAPI encounters (`https://pokeapi.co/api/v2/pokemon/58/encounters`) and Bulbapedia's Crystal Missing Pokémon list.
**Impact on users:** Users playing Crystal version will now correctly see that they can catch Growlithe and evolve it into Arcanine, rather than being erroneously told they must trade for them.

---
*PR created automatically by Jules for task [3385407743776903749](https://jules.google.com/task/3385407743776903749) started by @szubster*