### PR TITLE
📜 Scribe: Documented useFileSyncController hook

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -125,3 +125,8 @@ Documenting these highlights the fact that they modify the passed `suggestions` 
 **Why:** The Nuzlocke tracker implements specific game rules (permadeath, one catch per route) through constraints in the binary save data structure.
 - **Permadeath (PC Healing Problem):** I learned that we cannot rely solely on `currentHp === 0` to track deaths because depositing a Pokémon in the PC fully heals it in the save data. To circumvent this, the engine relies on the player designating a specific PC box via string comparison (`storageLocation === graveyardBox`).
 - **Route Tracking (Gen 2 Dependency):** The "One Catch Per Route" rule is enforced by checking `caughtData.location` across all Party and PC structures. This means this strict Nuzlocke enforcement feature is inherently dependent on Generation 2 mechanics, as Generation 1 save files do not store catch location data.
+
+## 2026-05-25 - File System Access API Polling Constraints
+
+**Constraint:** The browser's native File System Access API (`showOpenFilePicker`) lacks filesystem watch events (unlike Node's `fs.watch`).
+**Impact:** To achieve a "live sync" feature (e.g. tracking a save file actively being modified by a Game Boy emulator), the application must rely on manual, aggressive polling via `setInterval` to check the file handle's `lastModified` timestamp. This architectural necessity is documented in `src/hooks/useFileSyncController.ts` to prevent developers from incorrectly assuming the browser can push file change events natively.

--- a/src/hooks/useFileSyncController.ts
+++ b/src/hooks/useFileSyncController.ts
@@ -5,6 +5,22 @@ import { useStore } from '../store';
 
 export type SyncStatus = 'disconnected' | 'syncing' | 'live' | 'error';
 
+/**
+ * A React hook that manages continuous synchronization of a Game Boy `.sav` file
+ * using the modern browser File System Access API (`showOpenFilePicker`).
+ *
+ * This allows the application to maintain a live connection to a local save file
+ * (e.g., one actively being written to by an emulator like mGBA), automatically
+ * re-parsing and updating the global store whenever the file is modified on disk.
+ *
+ * @returns An object containing the current sync status, error messages, and control functions.
+ *
+ * @example
+ * const { status, requestSync, resumeSync } = useFileSyncController();
+ * if (status === 'disconnected') {
+ *   <button onClick={requestSync}>Select Save File</button>
+ * }
+ */
 export function useFileSyncController() {
   const [status, setStatus] = useState<SyncStatus>('disconnected');
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -17,6 +33,8 @@ export function useFileSyncController() {
   const setManualVersion = useStore((s) => s.setManualVersion);
   const setIsVersionModalOpen = useStore((s) => s.setIsVersionModalOpen);
 
+  // Centralized handler for parsing a new file buffer, updating the global Zustand store,
+  // handling version heuristics, and persisting a backup of the buffer into IndexedDB.
   const processFile = useCallback(
     async (file: File) => {
       try {
@@ -129,6 +147,9 @@ export function useFileSyncController() {
   }, [processFile]);
 
   // Polling loop
+  // The File System Access API does not currently provide native filesystem watch events.
+  // Therefore, we must aggressively poll the file handle to check for `lastModified` timestamp
+  // changes. This is necessary to achieve the "live sync" experience while an emulator runs.
   useEffect(() => {
     const interval = setInterval(async () => {
       if (!handleRef.current) return;


### PR DESCRIPTION
**What**
Added documentation to the `useFileSyncController` hook.

**Why this module needed docs**
The `useFileSyncController` manages the live sync functionality using the modern browser `File System Access API`. Because this API lacks native watch events, the hook implements a somewhat aggressive polling loop using `setInterval` to check the file's `lastModified` timestamp. It is critical to document this architectural constraint so future developers understand *why* the polling loop exists and do not attempt to mistakenly replace it with non-existent browser push events.

**Summary of additions**
- Added a full JSDoc block to `useFileSyncController` explaining its purpose and providing a usage example.
- Added inline comments explaining the necessity of the polling loop to achieve the "live sync" experience for emulators.
- Added inline comments explaining that `processFile` is the centralized handler for buffer parsing, store updating, version heuristics, and IndexedDB persistence.
- Added an entry to `.jules/scribe.md` to permanently record the File System Access API polling constraints.

---
*PR created automatically by Jules for task [16163850020979018273](https://jules.google.com/task/16163850020979018273) started by @szubster*