### PR TITLE
🧭 Strategist: Prompt improvement - Prevent premature verification for all macro nodes

### DIFF
--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -28,6 +28,7 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **CRITICAL:** Do NOT submit an Empty PR to transition a PRD to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child EPIC nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints.
 
 
 ### Handling Rejections & Aborts

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -21,6 +21,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **CRITICAL:** Do NOT submit an Empty PR to transition an IDEA to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child PRD nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints.
 
 ### Handling Rejections & Aborts
 If you encounter a permanent failure or must abort a node:

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -35,6 +35,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - When creating a new node, strictly follow the Parent-Linked ID Schema: `<type>-<parent_NNN>-<NNN>-<slug>` as detailed in `.foundry/docs/schema.md`.
 - Append references to newly created child nodes directly into the markdown body of the parent node, and check off corresponding acceptance criteria checkboxes WITHOUT modifying the parent's YAML frontmatter.
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- **CRITICAL:** Do NOT submit an Empty PR to transition a Story to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child TASK nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints.
 
 **HANDLING PERMANENT CHILD FAILURES (THE IMPOSSIBLE LOOP):**
 If you are woken up by the Orchestrator because a child node reached its Max Rejection Count (e.g., a `coder` TASK failed permanently), you MUST:

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -150,3 +150,9 @@
 **Outcome:** Accepted
 **Why:** The Auditor journal showed that Epics were transitioning to VERIFYING prematurely when their Acceptance Criteria (spawning child stories) were checked off, leading to failed audits because the actual implementation described was not merged.
 **Pattern:** When an agent (like the Story Owner) is responsible for breaking down high-level nodes, it must wait for the generated execution nodes to finish before submitting its Empty PR to complete the parent node.
+
+## YYYY-MM-DD - [Accepted] - Prompt improvement - Prevent premature verification for all macro nodes
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The Auditor journal showed that macro nodes (e.g. Epics, Stories) were transitioning to VERIFYING prematurely when their immediate Acceptance Criteria (spawning child nodes) were met, even though the actual implementation described in their requirements had not yet been merged into the codebase.
+**Pattern:** When an agent (like the Epic Planner, Story Owner, or Tech Lead) is responsible for breaking down high-level nodes, it must wait for the generated execution nodes to reach COMPLETED before submitting its Empty PR to complete the parent node, ensuring the macroscopic progress representation accurately reflects implementation reality.


### PR DESCRIPTION
**Proposal**: Update the Tech Lead, Epic Planner, and Product Manager prompts to strictly forbid transitioning a parent node (STORY, PRD, IDEA respectively) to VERIFYING until all of its generated child nodes have transitioned to COMPLETED.

**Justification**: The Auditor's journal explicitly identified that macro nodes were being prematurely verified because they transitioned to VERIFYING as soon as their immediate Acceptance Criteria (spawning child nodes) were met. This violated strict hierarchical completion and resulted in false progress signaling, causing downstream nodes to be unblocked before the codebase was actually ready.

**Evidence**: 
From `.foundry/journals/auditor.md` (2026-05-23 and 2026-05-24):
"I've noticed a recurring pattern where EPIC nodes transition to the VERIFYING status prematurely. Specifically, the Epic is marked as complete because its immediate Acceptance Criteria (which is often just to create the child Story nodes) is met, even though the actual implementation described in the Epic's requirements has not yet been merged into the codebase..."

"...this pattern applies generally to macro nodes (e.g., Story nodes as well). The system requires strict hierarchical completion enforcement. A parent node MUST NOT transition to COMPLETED or VERIFYING until all of its descendant nodes in the spawned sub-tree are completely verified and in the COMPLETED state."

---
*PR created automatically by Jules for task [879378415991366473](https://jules.google.com/task/879378415991366473) started by @szubster*