### PR TITLE
Generate PRD and Epics for Time Capsule Readiness Validator

### DIFF
--- a/.foundry/epics/epic-036-051-time-capsule-validation-logic.md
+++ b/.foundry/epics/epic-036-051-time-capsule-validation-logic.md
@@ -1,0 +1,31 @@
+---
+id: epic-036-051-time-capsule-validation-logic
+type: EPIC
+title: Time Capsule Validation Core Logic
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-05-30"
+updated_at: "2026-05-30"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-066-036-time-capsule-validator.md
+tags:
+  - feature
+  - gen2
+  - trade
+  - tool
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Time Capsule Validation Core Logic
+
+## Objective
+Implement the underlying engine logic to validate Time Capsule readiness.
+
+## Scope
+- Determine Gen 1 species validity.
+- Determine if any of the Pokémon's 4 moves are Generation 2 exclusive.

--- a/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
+++ b/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
@@ -1,0 +1,32 @@
+---
+id: epic-036-052-time-capsule-ui-indicators
+type: EPIC
+title: Time Capsule UI Indicators
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-05-30"
+updated_at: "2026-05-30"
+depends_on:
+  - .foundry/epics/epic-036-051-time-capsule-validation-logic.md
+jules_session_id: null
+pr_number: null
+parent: prd-066-036-time-capsule-validator.md
+tags:
+  - feature
+  - gen2
+  - trade
+  - tool
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Time Capsule UI Indicators
+
+## Objective
+Update the DexHelper UI to visualize Time Capsule readiness based on the validation core logic.
+
+## Scope
+- Integrate a visual indicator in the Storage View for ready Pokémon.
+- Highlight specific invalid moves in the detailed individual Pokémon stat view.

--- a/.foundry/ideas/idea-066-time-capsule-validator.md
+++ b/.foundry/ideas/idea-066-time-capsule-validator.md
@@ -37,3 +37,8 @@ By utilizing our programmatic access to the save file data, we can implement an 
 3.  **Detailed View:** In the individual Pokémon stat view, explicitly highlight the specific move(s) preventing the trade, saving the player time diagnosing the issue.
 
 This directly aligns with the app's goal of being a premium companion tool and bridges the gap in the offline-first environment by solving a known cross-generational friction point.
+
+## Acceptance Criteria
+- [x] Generated PRD: `.foundry/prds/prd-066-036-time-capsule-validator.md`
+- [x] Generated Epic: `.foundry/epics/epic-036-051-time-capsule-validation-logic.md`
+- [x] Generated Epic: `.foundry/epics/epic-036-052-time-capsule-ui-indicators.md`

--- a/.foundry/prds/prd-066-036-time-capsule-validator.md
+++ b/.foundry/prds/prd-066-036-time-capsule-validator.md
@@ -1,0 +1,40 @@
+---
+id: prd-066-036-time-capsule-validator
+type: PRD
+title: Time Capsule Readiness Validator
+status: PENDING
+owner_persona: epic_planner
+created_at: "2026-05-30"
+updated_at: "2026-05-30"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-066-time-capsule-validator.md
+tags:
+  - feature
+  - gen2
+  - trade
+  - tool
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Time Capsule Readiness Validator
+
+## Objective
+Implement an automated validator to determine if a Generation 1 Pokémon located in a Generation 2 save file is eligible for the Time Capsule (i.e. can be traded back to Generation 1).
+
+## Scope
+- Validate that the Pokémon is a Generation 1 species.
+- Cross-reference the Pokémon's current 4 moves against the database of Generation 2 exclusive moves (Generation 1 vs 2 moves).
+- Provide visual indicators for valid/invalid Pokémon.
+
+## Requirements
+- **Logic Validation:** Create a utility to check species ID and move IDs.
+- **UI Storage Indicator:** Display an icon or "Time Capsule Ready" tag in the storage view for eligible Pokémon.
+- **Detailed UI View:** In the individual Pokémon stat view, explicitly highlight moves that are preventing the trade (Gen 2 exclusive moves).
+
+## Non-Goals
+- We are not modifying the save file or trading Pokémon. This is purely a UI readiness check.


### PR DESCRIPTION
Generated PRD and Epics for the Time Capsule Readiness Validator feature.
- Generated `prd-066-036-time-capsule-validator.md` to outline the requirements and scope for the Time Capsule Validator.
- Generated `epic-036-051-time-capsule-validation-logic.md` for the core engine validation logic.
- Generated `epic-036-052-time-capsule-ui-indicators.md` for the UI visual indicators in the app.
- Updated the parent `idea-066-time-capsule-validator.md` with checked acceptance criteria in the markdown body.

---
*PR created automatically by Jules for task [11449756846678210122](https://jules.google.com/task/11449756846678210122) started by @szubster*