### PR TITLE
Implement Gen 3 Assistant Strategy

### DIFF
--- a/.foundry/tasks/task-064-142-gen3-strategy-impl.md
+++ b/.foundry/tasks/task-064-142-gen3-strategy-impl.md
@@ -23,10 +23,10 @@ rejection_reason: ''
 Integrate the newly parsed Gen 3 encounter data into the suggestion engine and map graph by implementing the Gen 3 Assistant Strategy.
 
 ## Acceptance Criteria
-- [ ] `src/engine/exclusives/gen3Exclusives.ts` is created and defines `GEN3_VERSION_EXCLUSIVES` for Ruby, Sapphire, Emerald, FireRed, LeafGreen, and exports `getGen3UnobtainableReason`.
-- [ ] `src/engine/assistant/strategies/gen3Strategy.ts` is created and implements the `AssistantStrategy` interface for Gen 3.
-- [ ] `src/engine/assistant/strategies/index.ts` is updated to include `gen3Strategy`.
-- [ ] Tests are written for `gen3Exclusives.ts` and `gen3Strategy.ts`.
+- [x] `src/engine/exclusives/gen3Exclusives.ts` is created and defines `GEN3_VERSION_EXCLUSIVES` for Ruby, Sapphire, Emerald, FireRed, LeafGreen, and exports `getGen3UnobtainableReason`.
+- [x] `src/engine/assistant/strategies/gen3Strategy.ts` is created and implements the `AssistantStrategy` interface for Gen 3.
+- [x] `src/engine/assistant/strategies/index.ts` is updated to include `gen3Strategy`.
+- [x] Tests are written for `gen3Exclusives.ts` and `gen3Strategy.ts`.
 
 ## Technical Blueprint
 1. **Create `src/engine/exclusives/gen3Exclusives.ts`**:

--- a/src/engine/assistant/strategies/gen3Strategy.test.ts
+++ b/src/engine/assistant/strategies/gen3Strategy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { UnifiedLocation } from '../../../db/schema';
+import type { SaveData } from '../../saveParser/index';
+import { gen3Strategy } from './gen3Strategy';
+
+describe('gen3Strategy', () => {
+  it('should have correct generation', () => {
+    expect(gen3Strategy.generation).toBe(3);
+  });
+
+  it('isInternallyObtainable should return correct value', () => {
+    expect(gen3Strategy.isInternallyObtainable(65, 'ruby')).toBe(false);
+    expect(gen3Strategy.isInternallyObtainable(1, 'ruby')).toBe(true);
+  });
+
+  it('getSpecialSuggestions should track roamers', () => {
+    const saveData = { roamingLegendaries: [{ speciesId: 380, level: 40, mapGroup: 0, mapId: 1 }] } as SaveData;
+    const suggestions = gen3Strategy.getSpecialSuggestions(saveData, [380]);
+    expect(suggestions.length).toBe(1);
+    expect(suggestions[0]?.title).toBe('Track Latias');
+  });
+
+  it('resolveMapAid should resolve outdoor map', () => {
+    const saveData = { currentMapId: 1 } as SaveData;
+    const allLocations = [{ id: 1, prnt: 2 }, { id: 2 }] as UnifiedLocation[];
+    expect(gen3Strategy.resolveMapAid(saveData, allLocations)).toBe(2);
+  });
+
+  it('getMapDistance should return correct distance', () => {
+    const allLocations = [
+      { id: 1, n: 'Start', dist: { 2: 5 } },
+      { id: 2, n: 'Target' },
+    ] as UnifiedLocation[];
+    const result = gen3Strategy.getMapDistance(1, 2, allLocations);
+    expect(result).toEqual({ distance: 5, name: 'Target' });
+  });
+});

--- a/src/engine/assistant/strategies/gen3Strategy.ts
+++ b/src/engine/assistant/strategies/gen3Strategy.ts
@@ -1,0 +1,76 @@
+import type { UnifiedLocation } from '../../../db/schema';
+import { getGen3UnobtainableReason } from '../../exclusives/gen3Exclusives';
+import { getDistanceToMap, resolveOutdoorMapId } from '../../mapGraph/gen3Graph';
+import type { SaveData } from '../../saveParser/index';
+import type { AssistantStrategy, Suggestion } from './types';
+
+export const gen3Strategy: AssistantStrategy = {
+  generation: 3,
+
+  resolveMapAid(saveData: SaveData, allLocations: UnifiedLocation[]): number | null {
+    return resolveOutdoorMapId(allLocations, saveData.currentMapId);
+  },
+
+  getMapDistance(currentMapId: number, targetAid: number, allLocations: UnifiedLocation[]) {
+    return getDistanceToMap(allLocations, currentMapId, targetAid);
+  },
+
+  getUnobtainableReason(pokemonId: number, version: string, _ownedCount: number, ownedSet: Set<number>) {
+    return getGen3UnobtainableReason(pokemonId, version, _ownedCount, ownedSet);
+  },
+
+  getSpecialSuggestions(saveData: SaveData, missingIds: number[]): Suggestion[] {
+    const suggestions: Suggestion[] = [];
+    const missingSet = new Set(missingIds);
+
+    const roamerMap = new Map(saveData.roamingLegendaries?.map((r) => [r.speciesId, r]));
+    const roamers = [
+      { id: 380, name: 'Latias' },
+      { id: 381, name: 'Latios' },
+    ];
+
+    for (const roamer of roamers) {
+      if (missingSet.has(roamer.id)) {
+        let isTracked = false;
+        const rData = roamerMap.get(roamer.id);
+        if (rData && rData.mapId !== 0) {
+          isTracked = true;
+        }
+
+        suggestions.push({
+          id: `roamer-${roamer.id}`,
+          category: 'Catch',
+          title: `Track ${roamer.name}`,
+          description: isTracked
+            ? `${roamer.name} is currently roaming! Check your Pokédex to see its current route.`
+            : `Encounter ${roamer.name} in the wild, then use your Pokédex to track its location!`,
+          pokemonId: roamer.id,
+          priority: 85,
+        });
+      }
+    }
+
+    return suggestions;
+  },
+
+  isInternallyObtainable(baseId: number, _version: string): boolean {
+    const unobtainableInternally = new Set([
+      65, // Alakazam
+      68, // Machamp
+      76, // Golem
+      94, // Gengar
+      186, // Politoed
+      199, // Slowking
+      208, // Steelix
+      212, // Scizor
+      230, // Kingdra
+      233, // Porygon2
+      367, // Huntail
+      368, // Gorebyss
+      385, // Jirachi
+      386, // Deoxys
+    ]);
+
+    return !unobtainableInternally.has(baseId);
+  },
+};

--- a/src/engine/assistant/strategies/index.test.ts
+++ b/src/engine/assistant/strategies/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { gen1Strategy } from './gen1Strategy';
 import { gen2Strategy } from './gen2Strategy';
+import { gen3Strategy } from './gen3Strategy';
 import { getStrategy } from './index';
 
 describe('getStrategy', () => {
@@ -11,6 +12,10 @@ describe('getStrategy', () => {
 
   it('returns gen2Strategy for generation 2', () => {
     expect(getStrategy(2)).toBe(gen2Strategy);
+  });
+
+  it('returns gen3Strategy for generation 3', () => {
+    expect(getStrategy(3)).toBe(gen3Strategy);
   });
 
   it('returns fallbackStrategy for unknown generation', () => {

--- a/src/engine/assistant/strategies/index.ts
+++ b/src/engine/assistant/strategies/index.ts
@@ -1,5 +1,6 @@
 import { gen1Strategy } from './gen1Strategy';
 import { gen2Strategy } from './gen2Strategy';
+import { gen3Strategy } from './gen3Strategy';
 import type { AssistantStrategy } from './types';
 
 const fallbackStrategy: AssistantStrategy = {
@@ -14,6 +15,7 @@ const fallbackStrategy: AssistantStrategy = {
 const STRATEGIES: Record<number, AssistantStrategy> = {
   1: gen1Strategy,
   2: gen2Strategy,
+  3: gen3Strategy,
 };
 
 /**

--- a/src/engine/exclusives/__tests__/gen3Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen3Exclusives.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getGen3UnobtainableReason } from '../gen3Exclusives';
+
+describe('gen3Exclusives', () => {
+  describe('getGen3UnobtainableReason', () => {
+    it('should return null for non-exclusive Pokemon', () => {
+      const ownedSet = new Set<number>();
+      expect(getGen3UnobtainableReason(1, 'ruby', 0, ownedSet)).toBeNull();
+    });
+
+    it('should return reason for exclusive Pokemon not owned', () => {
+      const ownedSet = new Set<number>();
+      const reason = getGen3UnobtainableReason(382, 'ruby', 0, ownedSet); // 382 is Kyogre, missing in Ruby
+      expect(reason).toContain('not available in Ruby');
+    });
+
+    it('should return null for exclusive Pokemon already owned', () => {
+      const ownedSet = new Set<number>([382]);
+      expect(getGen3UnobtainableReason(382, 'ruby', 0, ownedSet)).toBeNull();
+    });
+  });
+});

--- a/src/engine/exclusives/gen3Exclusives.ts
+++ b/src/engine/exclusives/gen3Exclusives.ts
@@ -1,0 +1,28 @@
+// Following Gen 1 and 2 patterns, these lists represent Pokémon that are UNOBTAINABLE in the key's version.
+export const GEN3_VERSION_EXCLUSIVES: Record<string, number[]> = {
+  // Ruby missing (Sapphire exclusives)
+  ruby: [270, 271, 272, 302, 336, 337, 382],
+  // Sapphire missing (Ruby exclusives)
+  sapphire: [273, 274, 275, 303, 335, 338, 383],
+  // Emerald missing (Ruby & Sapphire exclusives)
+  emerald: [273, 274, 275, 303, 335, 338, 383, 270, 271, 272, 302, 336, 337],
+  // FireRed missing (LeafGreen exclusives)
+  firered: [27, 28, 37, 38, 69, 70, 71, 79, 80, 199, 120, 121, 126, 127, 183, 184, 298],
+  // LeafGreen missing (FireRed exclusives)
+  leafgreen: [23, 24, 43, 44, 45, 182, 54, 55, 58, 59, 66, 67, 68, 90, 91, 125, 123, 212, 238, 239, 240],
+};
+
+export function getGen3UnobtainableReason(
+  pokemonId: number,
+  gameVersion: string,
+  _ownedCount: number,
+  ownedSet: Set<number>,
+): string | null {
+  const exclusives = GEN3_VERSION_EXCLUSIVES[gameVersion] || [];
+
+  if (exclusives.includes(pokemonId) && !ownedSet.has(pokemonId)) {
+    return `This Pokémon is not available in ${gameVersion.charAt(0).toUpperCase() + gameVersion.slice(1)}. Must be traded from another version.`;
+  }
+
+  return null;
+}

--- a/src/engine/mapGraph/gen3Graph.test.ts
+++ b/src/engine/mapGraph/gen3Graph.test.ts
@@ -1,16 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
-import { pokeDB } from '../../db/PokeDB';
+import { describe, expect, it } from 'vitest';
 import type { UnifiedLocation } from '../../db/schema';
 import { gen3HoennMapGraph, gen3KantoMapGraph, getDistanceToMap, resolveOutdoorMapId } from './gen3Graph';
-
-// Mock the pokeDB dependency
-vi.mock('../../db/PokeDB', () => {
-  return {
-    pokeDB: {
-      getAllAreas: vi.fn<() => Promise<UnifiedLocation[]>>(),
-    },
-  };
-});
 
 const mockLocations: UnifiedLocation[] = [
   { id: 0, n: 'Littleroot Town', conn: [1], dist: { 0: 0, 1: 1, 2: 2 } },
@@ -26,111 +16,95 @@ const mockLocations: UnifiedLocation[] = [
 
 describe('gen3Graph', () => {
   describe('getDistanceToMap', () => {
-    it('returns distance 0 when starting map is the target', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await getDistanceToMap(0, 0);
+    it('returns distance 0 when starting map is the target', () => {
+      const result = getDistanceToMap(mockLocations, 0, 0);
       expect(result).toEqual({ distance: 0, name: 'Littleroot Town' });
     });
 
-    it('returns distance 1 for an adjacent map', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await getDistanceToMap(0, 1);
+    it('returns distance 1 for an adjacent map', () => {
+      const result = getDistanceToMap(mockLocations, 0, 1);
       expect(result).toEqual({ distance: 1, name: 'Route 101' });
     });
 
-    it('gracefully falls back to parent map for indoor locations', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await getDistanceToMap(3, 1);
+    it('gracefully falls back to parent map for indoor locations', () => {
+      const result = getDistanceToMap(mockLocations, 3, 1);
       expect(result).toEqual({ distance: 1, name: 'Route 101' });
     });
 
-    it('gracefully falls back to root parent map for multi-level indoor locations', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await getDistanceToMap(4, 1);
+    it('gracefully falls back to root parent map for multi-level indoor locations', () => {
+      const result = getDistanceToMap(mockLocations, 4, 1);
       expect(result).toEqual({ distance: 1, name: 'Route 101' });
     });
 
-    it('gracefully falls back to parent map for indoor locations in Kanto', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await getDistanceToMap(44, 43);
+    it('gracefully falls back to parent map for indoor locations in Kanto', () => {
+      const result = getDistanceToMap(mockLocations, 44, 43);
       expect(result).toEqual({ distance: 1, name: 'Route 1' });
     });
 
-    it('gracefully falls back to root parent map for multi-level indoor locations in Kanto', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await getDistanceToMap(45, 43);
+    it('gracefully falls back to root parent map for multi-level indoor locations in Kanto', () => {
+      const result = getDistanceToMap(mockLocations, 45, 43);
       expect(result).toEqual({ distance: 1, name: 'Route 1' });
     });
 
-    it('defaults to map ID 0 for an unknown starting map', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await getDistanceToMap(999, 1);
+    it('defaults to map ID 0 for an unknown starting map', () => {
+      const result = getDistanceToMap(mockLocations, 999, 1);
       expect(result).toEqual({ distance: 1, name: 'Route 101' });
     });
 
-    it('returns null for an unknown target aid', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await getDistanceToMap(0, 9999);
+    it('returns null for an unknown target aid', () => {
+      const result = getDistanceToMap(mockLocations, 0, 9999);
       expect(result).toBeNull();
     });
 
-    it('returns null when start location cannot be resolved (no map id and no fallback map ID 0)', async () => {
+    it('returns null when start location cannot be resolved (no map id and no fallback map ID 0)', () => {
       const locationsWithoutZero: UnifiedLocation[] = [{ id: 1, n: 'Route 101', conn: [], dist: { 1: 0 } }];
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(locationsWithoutZero);
-      const result = await getDistanceToMap(999, 1);
+      const result = getDistanceToMap(locationsWithoutZero, 999, 1);
       expect(result).toBeNull();
     });
 
-    it('returns null when no distance is precomputed between start and target', async () => {
+    it('returns null when no distance is precomputed between start and target', () => {
       const locationsWithoutDist: UnifiedLocation[] = [
         { id: 0, n: 'Littleroot Town', conn: [], dist: {} },
         { id: 1, n: 'Route 101', conn: [], dist: {} },
       ];
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(locationsWithoutDist);
-      const result = await getDistanceToMap(0, 1);
+      const result = getDistanceToMap(locationsWithoutDist, 0, 1);
       expect(result).toBeNull();
     });
   });
 
   describe('resolveOutdoorMapId', () => {
-    it('correctly resolves a map ID with no prnt to itself', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await resolveOutdoorMapId(0);
+    it('correctly resolves a map ID with no prnt to itself', () => {
+      const result = resolveOutdoorMapId(mockLocations, 0);
       expect(result).toBe(0);
     });
 
-    it('correctly resolves a single-level indoor map to its outdoor hub', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await resolveOutdoorMapId(3);
+    it('correctly resolves a single-level indoor map to its outdoor hub', () => {
+      const result = resolveOutdoorMapId(mockLocations, 3);
       expect(result).toBe(0);
     });
 
-    it('correctly resolves a multi-level indoor map to its root outdoor hub', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await resolveOutdoorMapId(4);
+    it('correctly resolves a multi-level indoor map to its root outdoor hub', () => {
+      const result = resolveOutdoorMapId(mockLocations, 4);
       expect(result).toBe(0);
     });
 
-    it('correctly resolves a single-level indoor map to its outdoor hub in Kanto', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await resolveOutdoorMapId(44);
+    it('correctly resolves a single-level indoor map to its outdoor hub in Kanto', () => {
+      const result = resolveOutdoorMapId(mockLocations, 44);
       expect(result).toBe(42);
     });
 
-    it('correctly resolves a multi-level indoor map to its root outdoor hub in Kanto', async () => {
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(mockLocations);
-      const result = await resolveOutdoorMapId(45);
+    it('correctly resolves a multi-level indoor map to its root outdoor hub in Kanto', () => {
+      const result = resolveOutdoorMapId(mockLocations, 45);
       expect(result).toBe(42);
     });
 
-    it('handles circular prnt references gracefully', async () => {
+    it('handles circular prnt references gracefully', () => {
       const circularLocations = [
         ...mockLocations,
         { id: 90, n: 'Loop A', prnt: 91, conn: [], dist: {} },
         { id: 91, n: 'Loop B', prnt: 90, conn: [], dist: {} },
       ];
-      vi.mocked(pokeDB.getAllAreas).mockResolvedValue(circularLocations);
-      const result = await resolveOutdoorMapId(90);
+      const result = resolveOutdoorMapId(circularLocations, 90);
       expect(result).toBe(90);
     });
   });

--- a/src/engine/mapGraph/gen3Graph.ts
+++ b/src/engine/mapGraph/gen3Graph.ts
@@ -1,4 +1,3 @@
-import { pokeDB } from '../../db/PokeDB';
 import type { UnifiedLocation } from '../../db/schema';
 
 /**
@@ -34,8 +33,7 @@ function getLocation(allLocations: UnifiedLocation[], id: number): UnifiedLocati
  * @param mapId The ID to resolve.
  * @returns The resolved top-level outdoor map ID.
  */
-export async function resolveOutdoorMapId(mapId: number): Promise<number> {
-  const allLocations = await pokeDB.getAllAreas();
+export function resolveOutdoorMapId(allLocations: UnifiedLocation[], mapId: number): number {
   let currentId = mapId;
   const visited = new Set<number>();
 
@@ -55,15 +53,16 @@ export async function resolveOutdoorMapId(mapId: number): Promise<number> {
 
 /**
  * Calculates the distance between a starting map and a target map using precomputed dist mapping.
+ * @param allLocations The array of all locations.
  * @param startMapId The ID of the starting map.
  * @param targetAid The ID of the target map.
  * @returns An object containing distance and target name, or null if unresolvable.
  */
-export async function getDistanceToMap(
+export function getDistanceToMap(
+  allLocations: UnifiedLocation[],
   startMapId: number,
   targetAid: number,
-): Promise<{ distance: number; name: string } | null> {
-  const allLocations = await pokeDB.getAllAreas();
+): { distance: number; name: string } | null {
   const targetLocation = getLocation(allLocations, targetAid);
 
   if (!targetLocation) {
@@ -71,7 +70,7 @@ export async function getDistanceToMap(
   }
 
   // Resolve start map to an outdoor map if it's indoor
-  let startOutdoorId = await resolveOutdoorMapId(startMapId);
+  let startOutdoorId = resolveOutdoorMapId(allLocations, startMapId);
   let startLocation = getLocation(allLocations, startOutdoorId);
 
   // If the starting location isn't valid, try to default to Littleroot Town (0)


### PR DESCRIPTION
Completes the TASK node task-064-142-gen3-strategy-impl.

Implementation of the Gen 3 Assistant Strategy.
It properly handles version exclusives logic using unobtainable missing lists for RSE and FRLG. It correctly delegates map resolving and distances synchronously to the Gen 3 Map Graph. Includes roaming legendary suggestions for Latias and Latios, and checks for Gen 3 specific trade evolutions.

---
*PR created automatically by Jules for task [11200701881166441865](https://jules.google.com/task/11200701881166441865) started by @szubster*