### PR TITLE
🔐 Shield: Override tmp to fix Path Traversal vulnerability (GHSA-ph9p-34f9-6g65)

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -48,3 +48,5 @@ Overrode the `@tanstack/history` version to `1.161.6` in `package.json`. While t
 
 ## Incomplete URL Substring Matching (CWE-285)
 **Pattern:** While `.includes()` should be avoided for validating URLs (favoring `.startsWith()` or URL parsing), do NOT blindly apply this rule to `ErrorEvent.message` property checks (e.g., catching Vite chunk load errors). Browsers often prepend prefixes like `TypeError: ` to error messages, so `.startsWith()` will fail to match dynamically imported module errors, causing major application regressions. Use `.includes()` for generic error string matching.
+## Resolving Deep Dependencies
+**Pattern:** To resolve vulnerabilities inside deep dependencies found via `pnpm audit` (like `tmp`), add a `pnpm.overrides` section to `package.json` with the safe version constraint, and then run `pnpm install` to enforce the resolution.

--- a/package.json
+++ b/package.json
@@ -102,6 +102,9 @@
       "ignoreCves": [
         "GHSA-rmmr-r34h-pfm5"
       ]
+    },
+    "overrides": {
+      "tmp": ">=0.2.6"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  tmp: '>=0.2.6'
+
 importers:
 
   .:
@@ -4376,8 +4379,8 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -4903,7 +4906,7 @@ snapshots:
       fast-glob: 3.3.3
       mime-types: 3.0.2
       sharp: 0.34.5
-      tmp: 0.2.5
+      tmp: 0.2.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8973,7 +8976,7 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
🎯 What
Audited dependencies and found a high-severity Path Traversal vulnerability (GHSA-ph9p-34f9-6g65) in the `tmp` package (`<0.2.6`), which is a transitive dependency of `@argos-ci/playwright`.

⚠️ Risk
The `tmp` package allows Path Traversal via unsanitized prefix/postfix, which could enable directory escape.

🛡️ Solution
Used the `pnpm.overrides` field in `package.json` to securely enforce the patched version (`>=0.2.6`) down the dependency tree. Ran `pnpm install` and verified `pnpm audit` now reports zero vulnerabilities. Verified all tests, e2e tests, and linters still pass successfully.

---
*PR created automatically by Jules for task [2756367486395482543](https://jules.google.com/task/2756367486395482543) started by @szubster*