### PR TITLE
🗿 Sculptor: Refactor ad-hoc segmented controls into TacticalSegmentedControl

### DIFF
--- a/.jules/sculptor.md
+++ b/.jules/sculptor.md
@@ -1,0 +1,2 @@
+
+- Ad-hoc segmented controls in the tactical UI create excessive visual noise for AI tools. By abstracting them into a single `TacticalSegmentedControl` component, we consolidate accessibility logic (handling `aria-pressed` vs `aria-checked` properly for multi/single modes) and improve the readability of consuming components significantly.

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -4,6 +4,7 @@ import { FILTER_TYPES, useStore } from '../store';
 import { LocationSuggestions } from './LocationSuggestions';
 import { TacticalInput } from './TacticalInput';
 import { TacticalPanel } from './TacticalPanel';
+import { TacticalSegmentedControl } from './TacticalSegmentedControl';
 import { TelemetryDecoration } from './TelemetryDecoration';
 
 export function SearchAndFilters() {
@@ -58,41 +59,24 @@ export function SearchAndFilters() {
           <fieldset className="m-0 flex min-w-0 flex-col gap-2 border-none p-0">
             <legend className="sr-only">Filter Pokémon</legend>
             <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ FILTER_PARAMETERS ]</span>
-            <div className="flex flex-wrap border border-zinc-800 border-dashed sm:flex-nowrap">
-              <button
-                type="button"
-                onClick={() => setFilters([])}
-                aria-pressed={filtersSet.size === 0}
-                className={`min-w-[100px] flex-1 border-zinc-800 border-r border-dashed px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
-                  filtersSet.size === 0
-                    ? 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'
-                    : 'bg-zinc-950/50 text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400'
-                }`}
-              >
-                [ ALL ]
-              </button>
-
-              {FILTER_TYPES.map((f, idx) => {
-                const isLast = idx === FILTER_TYPES.length - 1;
-                const isActive = filtersSet.has(f);
-                return (
-                  <button
-                    type="button"
-                    key={f}
-                    onClick={() => toggleFilter(f)}
-                    aria-pressed={isActive}
-                    data-testid={`filter-${f}`}
-                    className={`min-w-[100px] flex-1 ${!isLast ? 'border-zinc-800 border-r border-dashed' : ''} px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
-                      isActive
-                        ? 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'
-                        : 'bg-zinc-950/50 text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400'
-                    }`}
-                  >
-                    [ {f === 'secured' ? 'SECURED' : f === 'missing' ? 'MISSING' : 'DEX ONLY'} ]
-                  </button>
-                );
-              })}
-            </div>
+            <TacticalSegmentedControl
+              isMulti
+              ariaLabel="Filter Pokémon"
+              value={filtersSet.size === 0 ? new Set(['all']) : (filtersSet as unknown as Set<string>)}
+              onChange={(val) => {
+                if (val === 'all') setFilters([]);
+                else toggleFilter(val as (typeof FILTER_TYPES)[number]);
+              }}
+              options={[
+                { id: 'all', label: '[ ALL ]' },
+                ...FILTER_TYPES.map((f) => ({
+                  id: f,
+                  label: `[ ${f === 'secured' ? 'SECURED' : f === 'missing' ? 'MISSING' : 'DEX ONLY'} ]`,
+                  testId: `filter-${f}`,
+                })),
+              ]}
+              buttonClassName="min-w-[100px]"
+            />
           </fieldset>
         </div>
       </TacticalPanel>

--- a/src/components/TacticalSegmentedControl.tsx
+++ b/src/components/TacticalSegmentedControl.tsx
@@ -1,0 +1,74 @@
+import type React from 'react';
+import { cn } from '../utils/cn';
+
+export interface SegmentedControlOption<T extends string | number> {
+  id: T;
+  label: React.ReactNode;
+  activeClassName?: string;
+  inactiveClassName?: string;
+  testId?: string;
+}
+
+export interface TacticalSegmentedControlProps<T extends string | number> {
+  options: SegmentedControlOption<T>[];
+  value: T | T[] | Set<T>;
+  onChange: (value: T) => void;
+  isMulti?: boolean;
+  className?: string;
+  buttonClassName?: string;
+  defaultActiveClassName?: string;
+  defaultInactiveClassName?: string;
+  ariaLabel?: string;
+}
+
+export function TacticalSegmentedControl<T extends string | number>({
+  options,
+  value,
+  onChange,
+  isMulti = false,
+  className,
+  buttonClassName,
+  defaultActiveClassName = 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]',
+  defaultInactiveClassName = 'bg-zinc-950/50 text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400',
+  ariaLabel,
+}: TacticalSegmentedControlProps<T>) {
+  const isSelected = (id: T) => {
+    if (value instanceof Set) return value.has(id);
+    if (Array.isArray(value)) return value.includes(id);
+    return value === id;
+  };
+
+  return (
+    <div
+      className={cn('flex flex-wrap border border-zinc-800 border-dashed sm:flex-nowrap', className)}
+      role={isMulti ? 'group' : 'radiogroup'}
+      {...(ariaLabel ? { 'aria-label': ariaLabel } : {})}
+    >
+      {options.map((opt, idx) => {
+        const isLast = idx === options.length - 1;
+        const active = isSelected(opt.id);
+
+        return (
+          <button
+            key={String(opt.id)}
+            type="button"
+            role={isMulti ? undefined : 'radio'}
+            {...(isMulti ? { 'aria-pressed': active } : { 'aria-checked': active })}
+            data-testid={opt.testId}
+            onClick={() => onChange(opt.id)}
+            className={cn(
+              'flex-1 px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+              !isLast ? 'border-zinc-800 border-r border-dashed' : '',
+              active
+                ? opt.activeClassName || defaultActiveClassName
+                : opt.inactiveClassName || defaultInactiveClassName,
+              buttonClassName,
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
🎯 What:
Extracted ad-hoc, inline segmented controls from `SearchAndFilters.tsx` into a reusable `TacticalSegmentedControl` component.

💡 Why (AI Readability Impact):
Ad-hoc segmented controls in the tactical UI create excessive visual noise for AI tools. By abstracting them into a single `TacticalSegmentedControl` component, we consolidate accessibility logic (handling `aria-pressed` vs `aria-checked` properly for multi/single modes) and improve the readability of consuming components significantly.

✅ Verification:
- Ran `pnpm lint` without regressions (handled types/ARIA rule exclusions properly).
- Ran `pnpm test` (Unit/integration suites passed successfully).
- Ran `pnpm test:e2e` (Playwright tests passed with proper ARIA assertions acting normally).

✨ Result:
Cleaner, highly readable component files with centralized state styling handling.

---
*PR created automatically by Jules for task [12854516083286469407](https://jules.google.com/task/12854516083286469407) started by @szubster*