### PR TITLE
🎨 Palette: [ARIA and Title improvements for filter buttons]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -102,3 +102,7 @@
 ## 2026-06-25 - ARIA Roles for Global Error Messages
 **Learning:** When rendering dynamic global error messages or panels (e.g., `GlobalError.tsx`), screen readers are not inherently aware of the new DOM elements appearing on the screen. Users might miss critical system errors.
 **Action:** Ensure the container for these global error messages uses `role="alert"` and `aria-live="assertive"`. This guarantees that screen readers will immediately interrupt the current announcement to read the error message, ensuring equal access to system feedback.
+
+## 2026-06-25 - ARIA Labels and Title tooltips for text buttons
+**Learning:** To prevent WCAG 2.5.3 (Label in Name) violations, do not apply `aria-label` to buttons that already have clear, visible text (like "ALL", "SECURED", "MISSING") if the `aria-label` overwrites and omits the visible text. This breaks voice dictation. Furthermore, if a button already has a semantic `aria-pressed` state handling screen reader announcements, explicitly adding "Toggle" to its `aria-label` or `title` causes redundant verbosity for assistive tech (e.g., "Toggle fire filter, toggle button, pressed").
+**Action:** When adding tooltip hover context to visible text buttons, prefer using the `title` attribute alone without `aria-label`. Ensure the `title` description is concise and omits redundant system states like "Toggle".

--- a/src/components/PokedexGrid.tsx
+++ b/src/components/PokedexGrid.tsx
@@ -96,6 +96,7 @@ export function PokedexGrid({ pokemonList }: { pokemonList: PokemonListItem[] })
         <button
           type="button"
           aria-label="Clear all filters"
+          title="Clear all filters"
           onClick={() => {
             useStore.getState().setSearchTerm('');
             useStore.getState().setFilters([]);

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -63,6 +63,7 @@ export function SearchAndFilters() {
                 type="button"
                 onClick={() => setFilters([])}
                 aria-pressed={filtersSet.size === 0}
+                title="Clear filters"
                 className={`min-w-[100px] flex-1 border-zinc-800 border-r border-dashed px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
                   filtersSet.size === 0
                     ? 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'
@@ -81,6 +82,7 @@ export function SearchAndFilters() {
                     key={f}
                     onClick={() => toggleFilter(f)}
                     aria-pressed={isActive}
+                    title={`${f} filter`}
                     data-testid={`filter-${f}`}
                     className={`min-w-[100px] flex-1 ${!isLast ? 'border-zinc-800 border-r border-dashed' : ''} px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
                       isActive


### PR DESCRIPTION
### What
Added `title` attributes to the dynamic filter buttons and clear filter buttons to provide native browser tooltips on hover.

### Why
Many buttons, like the filter toggles (e.g., "[ SECURED ]") lacked hover context for sighted users using a mouse. Adding a `title` provides a quick, native tooltip explaining the button's action without needing custom CSS tooltips.

### Before/After
**Before:** Hovering over the "[ ALL ]" or "[ SECURED ]" filter buttons did nothing.
**After:** Hovering over these buttons now shows a native tooltip like "Clear filters" or "secured filter".

### Accessibility notes
- The `title` attribute provides tooltip context without overriding the button's text content, avoiding WCAG 2.5.3 (Label in Name) violations that would occur if `aria-label` was used improperly to rename visible text buttons.
- Omitted redundant `aria-label` changes to preserve the native behavior of `aria-pressed`.

---
*PR created automatically by Jules for task [8377468234074648120](https://jules.google.com/task/8377468234074648120) started by @szubster*