### PR TITLE
🧪 Sentinel: Add nuzlockeGraveyardBox coverage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -109,3 +109,7 @@ When writing component tests with `@vitest/browser` and `vitest-browser-react`, 
 
 ### Vitest Reporters
 When running manual Vitest coverage checks via bash, use `pnpm vitest run --coverage --reporter=default` instead of `--reporter=text` to avoid custom reporter load errors.
+
+### 2024-XX-XX
+- While investigating test coverage on `src/store.ts`, realized it's better to verify exact state setter functionality (`setNuzlockeGraveyardBox`) rather than relying on component-level rendering.
+- Even simple state setters like `setNuzlockeGraveyardBox` in Zustand need test coverage to reach 100%. Avoid writing "true === true" tests by explicitly firing the setter and verifying the state mutated via `useStore.getState()`.

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -53,6 +53,11 @@ describe('Zustand Store', () => {
   });
 
   describe('Settings state', () => {
+    it('should set nuzlocke graveyard box', () => {
+      useStore.getState().setNuzlockeGraveyardBox('Box 14');
+      expect(useStore.getState().nuzlockeGraveyardBox).toBe('Box 14');
+    });
+
     it('should toggle filters', () => {
       useStore.getState().toggleFilter('secured');
       expect(useStore.getState().filters).toContain('secured');


### PR DESCRIPTION
🎯 What
Added missing unit test coverage to `src/store.test.ts` for the `setNuzlockeGraveyardBox` state setter in the Zustand store.

📊 Coverage
The `nuzlockeGraveyardBox` was untested in the `src/store.test.ts` suite. This simple test verifies that the setter actually mutates the state by using `useStore.getState().setNuzlockeGraveyardBox` and asserting the output.

✨ Result
Store coverage improved. All unit, component, and E2E tests are passing without regressions.

---
*PR created automatically by Jules for task [7054055897245365954](https://jules.google.com/task/7054055897245365954) started by @szubster*