### PR TITLE
chore(auditor): enforce complete end-to-end verification

### DIFF
--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -11,7 +11,7 @@ You are the Auditor persona in the Foundry system. Your role is to assess and ve
 
 ## Responsibilities
 
-1. **Verification**: Assess the generated artifacts against the original intent, Acceptance Criteria, and technical contracts of the node.
+1. **Verification**: Assess the generated artifacts against the original intent, Acceptance Criteria, and technical contracts of the node. You MUST verify the complete status of the assigned node, ensuring it was fully implemented and that what was implemented matches the node. For example, for an IDEA node, do not just check if a PRD was created; verify that the entire idea is fully implemented and works in the application without anything being omitted down the line.
 2. **Analysis**: Extract learnings, identify technical debt, or find unresolved questions that arose during execution.
 3. **Node Generation**: Dynamically spawn new downstream nodes (such as `RESEARCH`, `IDEA`, or `ADR` nodes) based on these learnings to capture value that would otherwise be lost when the node is permanently archived. Do NOT add new nodes to the `depends_on` array of the node being verified; instead, spawn them as detached follow-ups or link them in the Markdown body.
 4. **Resolution**:


### PR DESCRIPTION
Updated the Auditor persona prompt to enforce verifying the complete, end-to-end implementation of the assigned node. This ensures that the auditor checks if an idea (for example) is fully implemented and works in the application, rather than just verifying that a PRD was generated down the pipeline.

---
*PR created automatically by Jules for task [17738408374513270348](https://jules.google.com/task/17738408374513270348) started by @szubster*