### PR TITLE
⚙️ Foundry: Enforce implicit dependency for late-binding orchestrator nodes

### DIFF
--- a/.foundry/epics/epic-035-048-implicit-dependency-enforcement.md
+++ b/.foundry/epics/epic-035-048-implicit-dependency-enforcement.md
@@ -30,7 +30,7 @@ Update the `foundry-orchestrator.ts` to enforce implicit dependency. A node cann
 
 ## Acceptance Criteria
 - [x] Create STORY nodes to implement the implicit dependency enforcement in `foundry-orchestrator.ts`.
-- [ ] Ensure unit tests in `.github/scripts/foundry-orchestrator.test.ts` are updated or added.
+- [x] Ensure unit tests in `.github/scripts/foundry-orchestrator.test.ts` are updated or added.
 
 ### Implementation Stories
 - [.foundry/stories/story-048-086-implement-implicit-dependency-check.md](.foundry/stories/story-048-086-implement-implicit-dependency-check.md)

--- a/.foundry/stories/story-048-086-implement-implicit-dependency-check.md
+++ b/.foundry/stories/story-048-086-implement-implicit-dependency-check.md
@@ -26,4 +26,4 @@ notes: ''
 We need to enforce implicit dependencies for macroscopic nodes like EPIC and STORY nodes so they cannot transition to VERIFYING (or COMPLETED) prematurely.
 
 ## Acceptance Criteria
-- [ ] Update `isHierarchicallyIncomplete` or node resolution logic in `foundry-orchestrator.ts` to ensure that a parent node isn't ready if its descendant tree has any nodes not in the COMPLETED state.
+- [x] Update `isHierarchicallyIncomplete` or node resolution logic in `foundry-orchestrator.ts` to ensure that a parent node isn't ready if its descendant tree has any nodes not in the COMPLETED state.

--- a/.foundry/stories/story-048-087-update-orchestrator-tests.md
+++ b/.foundry/stories/story-048-087-update-orchestrator-tests.md
@@ -27,4 +27,4 @@ notes: ''
 Tests must reflect the new implicit dependency enforcement logic added in the orchestrator.
 
 ## Acceptance Criteria
-- [ ] Add unit tests in `.github/scripts/foundry-orchestrator.test.ts` to verify implicit dependency evaluation.
+- [x] Add unit tests in `.github/scripts/foundry-orchestrator.test.ts` to verify implicit dependency evaluation.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -439,6 +439,45 @@ describe('foundry-orchestrator', () => {
     expect(epicContent).toContain('status: PENDING');
   });
 
+  test('Hierarchical Completion: suspends ACTIVE parent to PENDING if it has incomplete children', () => {
+    // Epic 1: ACTIVE (started work, but child isn't done)
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "ACTIVE",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: "sess-123",
+    });
+
+    // Story 1: Child of Epic 1, PENDING
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/epics/epic-001.md",
+      jules_session_id: null,
+    });
+
+    main();
+
+    // Epic 1 SHOULD be suspended back to PENDING because its child is incomplete
+    const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
+    expect(epicContent).toContain('status: PENDING');
+
+    // Story 1 SHOULD become READY because it has no dependencies
+    const storyContent = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-001.md'), 'utf-8');
+    expect(storyContent).toContain('status: READY');
+  });
+
   test('Cascade Cancellation: cancels child nodes of CANCELLED parent recursively', () => {
     createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
       id: "epic-001",

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -535,6 +535,16 @@ function main(): void {
 
 
 
+    if (!shouldSuspend) {
+      const children = parentToChildren.get(node.repoPath) || [];
+      for (const child of children) {
+        if (isHierarchicallyIncomplete(child.repoPath, node.repoPath)) {
+          shouldSuspend = true;
+          break;
+        }
+      }
+    }
+
     if (shouldSuspend) {
       info(`Suspending ${node.frontmatter.status} node: ${node.repoPath}`);
       promoteNodeStatus(node, node.frontmatter.status, 'PENDING');


### PR DESCRIPTION
This PR ensures that macroscopic nodes (like `EPIC` and `STORY` nodes) cannot transition to `VERIFYING` or `COMPLETED` prematurely before their descendant child nodes are actually implemented.

1.  **Updated `foundry-orchestrator.ts`**: Modified Phase 3.5 (SUSPEND) to dynamically suspend `ACTIVE` or `VERIFYING` parent nodes back to `PENDING` if `isHierarchicallyIncomplete` returns true for any of their descendant children. This explicitly enforces the hierarchical completion graph.
2.  **Updated `foundry-orchestrator.test.ts`**: Added a test asserting that an `ACTIVE` parent node correctly suspends to `PENDING` when its child is incomplete, and verified that the child node transitions correctly independently.
3.  **Completed Acceptance Criteria**: Marked checkboxes completed for the implementation stories and parent epic.

---
*PR created automatically by Jules for task [16341634079643629858](https://jules.google.com/task/16341634079643629858) started by @szubster*