### PR TITLE
fix(foundry): correct premature PRD checkboxes and enforce repo-relative depends_on paths

### DIFF
--- a/.foundry/epics/epic-035-048-smart-radar-data-unification.md
+++ b/.foundry/epics/epic-035-048-smart-radar-data-unification.md
@@ -5,9 +5,9 @@ title: Smart Radar Data Unification
 status: PENDING
 owner_persona: story_owner
 created_at: '2026-05-23'
-updated_at: '2026-05-23'
+updated_at: '2026-05-30'
 depends_on:
-  - task-035-142-smart-radar-adr
+  - .foundry/tasks/task-035-142-smart-radar-adr.md
 jules_session_id: null
 pr_number: null
 parent: prd-064-035-smart-route-radar

--- a/.foundry/epics/epic-035-049-smart-radar-heatmap-generation.md
+++ b/.foundry/epics/epic-035-049-smart-radar-heatmap-generation.md
@@ -5,9 +5,9 @@ title: Smart Radar Heatmap Generation
 status: PENDING
 owner_persona: story_owner
 created_at: '2026-05-23'
-updated_at: '2026-05-23'
+updated_at: '2026-05-30'
 depends_on:
-  - epic-035-048-smart-radar-data-unification
+  - .foundry/epics/epic-035-048-smart-radar-data-unification.md
 jules_session_id: null
 pr_number: null
 parent: prd-064-035-smart-route-radar

--- a/.foundry/epics/epic-035-050-smart-radar-interactive-ui.md
+++ b/.foundry/epics/epic-035-050-smart-radar-interactive-ui.md
@@ -5,9 +5,9 @@ title: Smart Radar Interactive UI
 status: PENDING
 owner_persona: story_owner
 created_at: '2026-05-23'
-updated_at: '2026-05-23'
+updated_at: '2026-05-30'
 depends_on:
-  - epic-035-049-smart-radar-heatmap-generation
+  - .foundry/epics/epic-035-049-smart-radar-heatmap-generation.md
 jules_session_id: null
 pr_number: null
 parent: prd-064-035-smart-route-radar

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -1,5 +1,7 @@
 Learning: For Gen 3 which encompasses games set in two different regions (Hoenn and Kanto), it's important to design a unified map graph architecture that supports both regions within a single module (gen3Graph.ts). This ensures consistency and simplifies strategy development across RSE and FRLG.
 When extracting Stories from an Epic that specifies acceptance criteria corresponding directly to the resulting tasks, we can map Epic criteria directly to Story completion criteria, ensuring they are explicitly checked off in the Epic but implemented down the chain.
 
-## Smart Route Radar (2026-05-23)
+## Smart Route Radar
 When creating Epic breakdowns that involve significant new architecture, such as combining dynamic save states with static map rendering logic (as seen in the Smart Route Radar feature), it is necessary to schedule an architectural TASK (assigned to `architect`) alongside the EPICS. The subsequent implementation EPICS (e.g., Data Unification) MUST explicitly declare a `depends_on` on the architect's TASK to ensure the ADR is written before the implementation stories are planned. This prevents the `story_owner` from starting work without an approved system design.
+
+Furthermore, when generating child nodes, always ensure that their references appended to the parent's markdown body are strictly unchecked (`- [ ]`) to prevent premature completion. The `depends_on` field of downstream nodes MUST use full, repo-relative file paths (e.g., `.foundry/tasks/task-000.md`) rather than short IDs to comply with the schema.

--- a/.foundry/prds/prd-064-035-smart-route-radar.md
+++ b/.foundry/prds/prd-064-035-smart-route-radar.md
@@ -43,11 +43,11 @@ Visualizing the assistant's data geographically shifts DexHelper from being just
 3.  **Interactive Nodes**: The map nodes must be clickable, triggering a detail view that shows the specific missing encounters, similar to the existing static map views but filtered by the user's save state.
 
 ## Next Steps
-- [x] Architect: Convert this PRD into an ADR detailing the system design for joining static encounter data with dynamic save state in the UI.
+- [ ] Architect: Convert this PRD into an ADR detailing the system design for joining static encounter data with dynamic save state in the UI.
 
 
 ## Generated Tasks
-- [x] [task-035-142-smart-radar-adr](.foundry/tasks/task-035-142-smart-radar-adr.md)
-- [x] [epic-035-048-smart-radar-data-unification](.foundry/epics/epic-035-048-smart-radar-data-unification.md)
-- [x] [epic-035-049-smart-radar-heatmap-generation](.foundry/epics/epic-035-049-smart-radar-heatmap-generation.md)
-- [x] [epic-035-050-smart-radar-interactive-ui](.foundry/epics/epic-035-050-smart-radar-interactive-ui.md)
+- [ ] [task-035-142-smart-radar-adr](.foundry/tasks/task-035-142-smart-radar-adr.md)
+- [ ] [epic-035-048-smart-radar-data-unification](.foundry/epics/epic-035-048-smart-radar-data-unification.md)
+- [ ] [epic-035-049-smart-radar-heatmap-generation](.foundry/epics/epic-035-049-smart-radar-heatmap-generation.md)
+- [ ] [epic-035-050-smart-radar-interactive-ui](.foundry/epics/epic-035-050-smart-radar-interactive-ui.md)


### PR DESCRIPTION
Fixes an issue where a PRD was prematurely transitioned due to unchecked generated task checkboxes. Also fixes the `depends_on` paths of the child epics to use repo-relative paths instead of short IDs, which fixes a schema violation. Updates the Epic Planner journal to record the new learnings.

---
*PR created automatically by Jules for task [3180153957064964970](https://jules.google.com/task/3180153957064964970) started by @szubster*