### PR TITLE
Draft tasks for orchestrator implicit dependency checking

### DIFF
--- a/.foundry/tasks/task-086-144-impl-implicit-dependency-check.md
+++ b/.foundry/tasks/task-086-144-impl-implicit-dependency-check.md
@@ -1,15 +1,15 @@
 ---
-id: story-048-086-implement-implicit-dependency-check
-type: STORY
+id: task-086-144-impl-implicit-dependency-check
+type: TASK
 title: Implement Implicit Dependency Check in Orchestrator
-status: READY
-owner_persona: tech_lead
-created_at: '2026-05-28'
+status: PENDING
+owner_persona: coder
+created_at: '2026-05-30'
 updated_at: '2026-05-30'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: epic-035-048-implicit-dependency-enforcement
+parent: story-048-086-implement-implicit-dependency-check
 tags:
   - foundry
   - process
@@ -27,5 +27,5 @@ We need to enforce implicit dependencies for macroscopic nodes like EPIC and STO
 
 ## Acceptance Criteria
 - [ ] Update `isHierarchicallyIncomplete` or node resolution logic in `foundry-orchestrator.ts` to ensure that a parent node isn't ready if its descendant tree has any nodes not in the COMPLETED state.
-- [ ] [.foundry/tasks/task-086-144-impl-implicit-dependency-check.md](./.foundry/tasks/task-086-144-impl-implicit-dependency-check.md)
-- [ ] [.foundry/tasks/task-086-145-qa-implicit-dependency-check.md](./.foundry/tasks/task-086-145-qa-implicit-dependency-check.md)
+- [ ] If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-086-145-qa-implicit-dependency-check.md
+++ b/.foundry/tasks/task-086-145-qa-implicit-dependency-check.md
@@ -1,0 +1,32 @@
+---
+id: task-086-145-qa-implicit-dependency-check
+type: TASK
+title: QA Implicit Dependency Check in Orchestrator
+status: PENDING
+owner_persona: qa
+created_at: '2026-05-30'
+updated_at: '2026-05-30'
+depends_on:
+  - .foundry/tasks/task-086-144-impl-implicit-dependency-check.md
+jules_session_id: null
+pr_number: null
+parent: story-048-086-implement-implicit-dependency-check
+tags:
+  - foundry
+  - process
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Implicit Dependency Check in Orchestrator
+
+## Context
+We need to verify the implicit dependencies logic for macroscopic nodes like EPIC and STORY nodes in `foundry-orchestrator.ts`.
+
+## Acceptance Criteria
+- [ ] Verify that `isHierarchicallyIncomplete` or node resolution logic in `foundry-orchestrator.ts` ensures that a parent node isn't ready if its descendant tree has any nodes not in the COMPLETED state.
+- [ ] If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Draft tasks for orchestrator implicit dependency checking

This commit generates the necessary downstream blueprint nodes for `story-048-086-implement-implicit-dependency-check.md`, assigning the implementation to the `coder` and the verification to the `qa` persona. The parent story has been updated with the corresponding unchecked markdown boxes.

---
*PR created automatically by Jules for task [15101485974496466922](https://jules.google.com/task/15101485974496466922) started by @szubster*