### PR TITLE
Fix Wait and Wake Cancellation Bug in Orchestrator

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -587,7 +587,7 @@ function main(): void {
       const parentPath = resolveNodePath(node.frontmatter.parent);
       if (parentPath) {
         const parentNode = nodeMap.get(parentPath);
-        if (parentNode && parentNode.frontmatter.status !== 'ACTIVE' && parentNode.frontmatter.status !== 'READY') {
+        if (parentNode && parentNode.frontmatter.status !== 'ACTIVE' && parentNode.frontmatter.status !== 'READY' && parentNode.frontmatter.status !== 'COMPLETED') {
           info(`Impossible Loop: waking up parent ${parentNode.repoPath}`);
           if (parentNode.frontmatter.owner_persona === 'human') {
             promoteNodeStatus(parentNode, parentNode.frontmatter.status, 'ACTIVE');


### PR DESCRIPTION
This PR fixes an issue where the orchestrator modified immutable `COMPLETED` nodes to `PENDING` during the Wait and Wake phase, which incorrectly swept them up into cascade cancellation logic. We updated `Phase 3.6: IMPOSSIBLE LOOP` to strictly avoid waking up `COMPLETED` parent nodes.

---
*PR created automatically by Jules for task [6180384085684182267](https://jules.google.com/task/6180384085684182267) started by @szubster*