### PR TITLE
🛡️ Nurse: type narrow static encounters game version

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -73,3 +73,7 @@ Unnecessary 'as' casts were found where TypeScript already inferred the type cor
 ## 2024-05-21 - Type-Safety: File System Access API
 **Learning:** When using the File System Access API (`window.showOpenFilePicker`, `handle.queryPermission`, etc.), avoid bypassing type checks with `(window as any)`. Instead, add the community definitions like `@types/wicg-file-system-access` to `devDependencies` and explicitly include them in the `types` array of `tsconfig.json`. This allows the TypeScript compiler to natively check options and return types.
 **Action:** Replaced unsafe `as any` casts with correct File System Access API types via `@types/wicg-file-system-access`.
+
+## $(date +%Y-%m-%d) - Type-Safety: `as keyof typeof` for mapped arrays
+**Learning:** Hardcoding string arrays as objects mapped over by keys, and then utilizing `gameVersion as keyof (typeof staticEncounters)[number]` forces an implicit `any` bypass when trying to reference those values elsewhere in components.
+**Action:** Replace `as keyof typeof` casts that attempt to enforce string literals within mapped type arrays with strict type guard functions. By checking `includes` or equivalent logic within an `isValidKey` function and declaring `version is keyof (typeof Array)[number]`, we can natively narrow string literals and remove unsafe casts safely and correctly.

--- a/src/components/pokemon/details/PokemonLocations.tsx
+++ b/src/components/pokemon/details/PokemonLocations.tsx
@@ -1,7 +1,7 @@
 import { AlertTriangle, ArrowUpCircle, MapPin, Target } from 'lucide-react';
 import type { CompactEncounter, CompactEncounterDetail } from '../../../db/schema';
 import { POKE_VERSION_MAP, REVERSE_METHOD_MAP } from '../../../db/schema';
-import { staticEncounters } from '../../../engine/data/shared/staticData';
+import { isValidStaticGameVersion, staticEncounters } from '../../../engine/data/shared/staticData';
 import { TacticalBadge } from '../../TacticalBadge';
 import { TacticalPanel } from '../../TacticalPanel';
 
@@ -46,7 +46,9 @@ export function PokemonLocations({
       ) : (
         <div className="relative z-10 grid grid-cols-1 gap-3" data-testid="location-list">
           {(() => {
-            const staticEnc = staticEncounters[pokemonId]?.[gameVersion as keyof (typeof staticEncounters)[number]];
+            const staticEnc = isValidStaticGameVersion(gameVersion)
+              ? staticEncounters[pokemonId]?.[gameVersion]
+              : undefined;
             const versionEnc = encounters.filter((e) => e.v === currentVersionId);
 
             if ((staticEnc && staticEnc.length > 0) || versionEnc.length > 0 || evoReq) {

--- a/src/engine/data/shared/staticData.ts
+++ b/src/engine/data/shared/staticData.ts
@@ -1,3 +1,7 @@
+export function isValidStaticGameVersion(version: string): version is keyof (typeof staticEncounters)[number] {
+  return ['red', 'blue', 'yellow', 'gold', 'silver', 'crystal'].includes(version);
+}
+
 export const staticEncounters: Record<
   number,
   {


### PR DESCRIPTION
**What was unsafe:**
In `src/components/pokemon/details/PokemonLocations.tsx`, a raw `gameVersion` string was cast using `as keyof (typeof staticEncounters)[number]`. This bypassed TypeScript's strict type checking, masking potential runtime errors if an invalid string was passed.

**How it was fixed:**
A strict type guard `isValidStaticGameVersion(version: string): version is keyof (typeof staticEncounters)[number]` was added to `src/engine/data/shared/staticData.ts`. `PokemonLocations.tsx` now explicitly checks the validity of the string via this type guard before attempting to access the `staticEncounters` object.

**What the compiler now catches:**
The TypeScript compiler now natively understands the narrowed type and properly enforces safety without needing an implicit `any` bypass via `as keyof typeof` casts.

---
*PR created automatically by Jules for task [6868795971128745344](https://jules.google.com/task/6868795971128745344) started by @szubster*