### PR TITLE
💡 Visionary: Unown Form Tracker

### DIFF
--- a/.foundry/ideas/idea-068-unown-tracker.md
+++ b/.foundry/ideas/idea-068-unown-tracker.md
@@ -1,0 +1,33 @@
+---
+id: idea-068-unown-tracker
+type: IDEA
+title: "Unown Form Tracker"
+status: PENDING
+owner_persona: "product_manager"
+created_at: "2026-05-31"
+updated_at: "2026-05-31"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags: ["feature", "gen2", "tracking"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: "Capturing Unown forms is a specific, grindy Gen 2 activity."
+---
+
+# Unown Form Tracker
+
+## Problem
+In Generation 2 (Gold/Silver/Crystal), Unown has 26 distinct forms based on its DVs. Collecting all 26 forms to unlock the Unown Dex in the Ruins of Alph is a major end-game side quest. Currently, `DexHelper` treats all Unown as a single species and does not track which specific letter forms the player has captured in their PC/party.
+
+## Solution
+Leverage our existing programmatic DV parsing in `saveParser` to explicitly compute and display a player's Unown form collection.
+
+1. **DV to Form Logic**: In Gen 2, an Unown's form is determined entirely by its DVs: reading the middle 2 bits of the Attack, Defense, Speed, and Special DVs, combining them into an 8-bit integer, and taking modulo 28 (where 0-25 map to A-Z).
+2. **Parser Update**: Modify `parseGen2PokemonInstance` (or a helper) to calculate the `unownForm` string ('A', 'B', etc.) if the `speciesId` is 201.
+3. **UI Addition**: Add a dedicated "Unown Dex" panel or filter in the Storage Viewer to show which forms are collected and which are missing, turning a tedious manual search into a clean visual checklist.
+
+## Why it Matters
+This directly aligns with the core vision of `DexHelper` as a premium collection manager for hardcore players, turning hidden data (DVs) into a highly actionable and visually satisfying checklist.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -51,3 +51,8 @@
 **Idea:** Save State Version History and Metadata Inference
 **Learning:** Older generation games lack metadata (like "date caught" or "encounter location" in Gen 1). However, by storing a history of sequential save file uploads and diffing them (e.g., "Pikachu appeared in Box 1 between upload A and upload B"), we can infer and enrich the data locally, creating modern metadata for retro games. This completely redefines the tool from a static state viewer into a progressive timeline tracker.
 **Outcome:** Created IDEA node.
+
+## 2026-05-31
+**Idea:** Unown Form Tracker
+**Learning:** Catering to end-game completionists adds significant value. Gen 2 has a specific quest to collect all 26 Unown forms (A-Z) which are determined by DVs. Since `DexHelper` already parses DVs for stats and shininess, extending this to explicitly track Unown forms gives players a visual checklist, transforming a tedious manual process into a highly actionable feature.
+**Outcome:** Created IDEA node.


### PR DESCRIPTION
This PR proposes a new feature to track the specific forms (A-Z) of Unown captured by the player in Generation 2 saves. 

Since Unown forms are entirely determined by their DVs in Gen 2, and `DexHelper` already parses DVs for stat and shiny calculations, explicitly tracking which letter forms a player has collected provides immense value for end-game completionists aiming to complete the Unown Dex at the Ruins of Alph.

It adds a new node in `.foundry/ideas/idea-068-unown-tracker.md` and logs the learning in the `.jules/visionary.md` journal.

---
*PR created automatically by Jules for task [2211657886464797173](https://jules.google.com/task/2211657886464797173) started by @szubster*