### PR TITLE
🧭 Strategist: Prompt improvement - Update Tech Lead Empty PR instructions

### DIFF
--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -52,3 +52,4 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
+When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -156,3 +156,9 @@
 **Outcome:** Merged
 **Why:** The Auditor journal showed that macro nodes (e.g. Epics, Stories) were transitioning to VERIFYING prematurely when their immediate Acceptance Criteria (spawning child nodes) were met, even though the actual implementation described in their requirements had not yet been merged into the codebase.
 **Pattern:** When an agent (like the Epic Planner, Story Owner, or Tech Lead) is responsible for breaking down high-level nodes, it must wait for the generated execution nodes to reach COMPLETED before submitting its Empty PR to complete the parent node, ensuring the macroscopic progress representation accurately reflects implementation reality.
+
+## 2026-07-09 - [Accepted] - Prompt improvement - Ensure Tech Lead checks unchecked checkboxes for empty PRs
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The Tech Lead was missing the explicit instruction about checking unchecked Acceptance Criteria checkboxes when submitting an empty PR, which is present in other persona prompts and required by ADR 007 and ADR 009.
+**Pattern:** Codify system memory constraints into agent prompts to avoid regressions and ensure consistency across personas.


### PR DESCRIPTION
**Proposal**: Update `.github/agents/tech_lead.md` to include explicit instructions about checking unchecked Acceptance Criteria checkboxes when submitting an empty PR.
**Justification**: The instruction was missing from the Tech Lead's `## Core Policies` section, whereas it is present for all other persona prompts. Adding this instruction prevents the Tech Lead from submitting empty PRs with unchecked boxes, which violates ADR 007 and ADR 009.
**Evidence**: Agent journals and prompt reviews showed this constraint was codified in most agents, but missed in `tech_lead.md`. This ensures consistency across all agents.

---
*PR created automatically by Jules for task [13565198405125646562](https://jules.google.com/task/13565198405125646562) started by @szubster*