### PR TITLE
📝 Story Owner: Add Smart Radar Data Unification Stories

### DIFF
--- a/.foundry/epics/epic-035-048-smart-radar-data-unification.md
+++ b/.foundry/epics/epic-035-048-smart-radar-data-unification.md
@@ -31,5 +31,7 @@ As defined in PRD `prd-064-035-smart-route-radar`, we need to integrate dynamic 
 Unify the data structures used by the suggestion engine and the map rendering components (as will be defined by the ADR produced in `task-035-142-smart-radar-adr`).
 
 ## Acceptance Criteria
-- [ ] Write stories to implement data unification according to the ADR.
+- [x] Write stories to implement data unification according to the ADR.
 - [ ] Complete child stories/tasks for data unification.
+- [ ] .foundry/stories/story-048-088-create-route-radar-controller.md
+- [ ] .foundry/stories/story-048-089-route-radar-density-aggregation.md

--- a/.foundry/stories/story-048-088-create-route-radar-controller.md
+++ b/.foundry/stories/story-048-088-create-route-radar-controller.md
@@ -1,0 +1,36 @@
+---
+id: story-048-088-create-route-radar-controller
+type: STORY
+title: Create RouteRadarController Structure
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-31'
+updated_at: '2026-05-31'
+depends_on:
+  - .foundry/tasks/task-035-142-smart-radar-adr.md
+jules_session_id: null
+pr_number: null
+parent: epic-035-048-smart-radar-data-unification
+tags:
+  - feature
+  - ux
+  - map
+  - data
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Create RouteRadarController Structure
+
+## Context
+As defined in Epic `epic-035-048-smart-radar-data-unification` and ADR `018-smart-route-radar`, we need to implement the base structure for the `RouteRadarController`. This controller is responsible for bridging the dynamic `suggestionEngine` output with the static map UI components.
+
+## Scope
+Scaffold the `RouteRadarController` module. It should act as the central dispatcher, taking the dynamic save state from the orchestrator and the output of the `suggestionEngine`, and structuring it in a way that the React map components can easily consume it.
+
+## Acceptance Criteria
+- [ ] Create `RouteRadarController` in the appropriate directory (e.g., `src/engine/radar/` or similar).
+- [ ] Define the interface for its input (the raw suggestion engine output) and its expected heatmap data output.
+- [ ] Write unit tests to verify instantiation and basic method structures.

--- a/.foundry/stories/story-048-089-route-radar-density-aggregation.md
+++ b/.foundry/stories/story-048-089-route-radar-density-aggregation.md
@@ -1,0 +1,37 @@
+---
+id: story-048-089-route-radar-density-aggregation
+type: STORY
+title: Implement Density Aggregation Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-05-31'
+updated_at: '2026-05-31'
+depends_on:
+  - .foundry/stories/story-048-088-create-route-radar-controller.md
+jules_session_id: null
+pr_number: null
+parent: epic-035-048-smart-radar-data-unification
+tags:
+  - feature
+  - ux
+  - map
+  - data
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Implement Density Aggregation Logic
+
+## Context
+Following the creation of the `RouteRadarController` in `story-048-088-create-route-radar-controller`, we need to implement its core computational logic. The controller must transform the list of recommended encounters from the `suggestionEngine` into a structured density heatmap map that the UI can render.
+
+## Scope
+Implement the data transformation pipeline inside the `RouteRadarController`. It must aggregate missing encounter suggestions by their `areaId` (e.g., Route 1, Viridian Forest) and calculate a "density" score (number of unique missing species) for each area.
+
+## Acceptance Criteria
+- [ ] Implement the aggregation method in `RouteRadarController`.
+- [ ] Ensure the density score correctly maps `areaId`s to their corresponding missing species counts.
+- [ ] Ensure it accurately processes edge cases (e.g., areas with 0 missing encounters should not be present in the output or have a score of 0).
+- [ ] Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs.


### PR DESCRIPTION
Adds two granular STORY nodes for the `RouteRadarController` and its density aggregation logic to break down epic `epic-035-048-smart-radar-data-unification`. Links the stories back to the parent epic as unchecked AC checkboxes.

---
*PR created automatically by Jules for task [5717196107938478589](https://jules.google.com/task/5717196107938478589) started by @szubster*