### PR TITLE
Epic Planner: Save File Health & Corruption Scanner Breakdown

### DIFF
--- a/.foundry/epics/epic-036-053-health-scanner-core-engine.md
+++ b/.foundry/epics/epic-036-053-health-scanner-core-engine.md
@@ -1,0 +1,43 @@
+---
+id: epic-036-053-health-scanner-core-engine
+type: EPIC
+title: Health Scanner Core Engine
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-05-31"
+updated_at: "2026-05-31"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-066-036-save-file-health-scanner
+tags:
+  - feature
+  - preservation
+  - save-file
+  - gen1
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Health Scanner Core Engine
+
+## 1. Goal
+Implement the core engine for scanning Gen 1 and Gen 2 Pokémon save files (`.sav`). This engine will perform rigorous integrity checks without modifying the underlying data. It must reliably identify corruption caused by failing batteries or faulty retro-dumping hardware.
+
+## 2. Scope
+*   **Checksum Validation:** Re-calculate and verify both main and backup checksums across all relevant save banks for Generation 1 and Generation 2 structures.
+*   **Data Boundary Verification:**
+    *   Identify out-of-bounds Pokémon IDs (e.g., >151 in Gen 1, >251 in Gen 2).
+    *   Verify Determinant Values (DVs) fall within mathematically possible ranges.
+    *   Detect corrupted or mathematically impossible movesets based on internal game logic data.
+    *   Validate inventory items against known good item index lists.
+*   **Diagnostic Output:** The engine should return structured data pinpointing the exact location (e.g., PC Box 8, Party Slot 3, Inventory position) and nature of any detected anomaly, suitable for rendering in a UI.
+
+## 3. Dependencies
+None. This is the foundational engine epic.
+
+## 4. Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into actionable Stories.

--- a/.foundry/epics/epic-036-054-diagnostic-reporting-ui.md
+++ b/.foundry/epics/epic-036-054-diagnostic-reporting-ui.md
@@ -1,0 +1,41 @@
+---
+id: epic-036-054-diagnostic-reporting-ui
+type: EPIC
+title: Diagnostic Reporting & Pre-Render UI
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-05-31"
+updated_at: "2026-05-31"
+depends_on:
+  - epic-036-053-health-scanner-core-engine
+jules_session_id: null
+pr_number: null
+parent: prd-066-036-save-file-health-scanner
+tags:
+  - feature
+  - ui
+  - save-file
+  - diagnostic
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Diagnostic Reporting & Pre-Render UI
+
+## 1. Goal
+Develop the user interface required to surface the results from the Save File Health Scanner core engine. The UI must intercept uploaded `.sav` files, initiate the scan, and clearly present the diagnostic report or a success message before allowing normal application interaction.
+
+## 2. Scope
+*   **Pre-Render Interception:** Modify the file upload flow to run the integrity scan *before* hydrating the main Pokédex or Storage views.
+*   **Diagnostic Report View:** Create a view to present the structured anomaly data returned by the core engine. This view should:
+    *   Pinpoint the exact location of corruption (e.g., PC Box 8, Party Slot 3, Inventory position).
+    *   Explain the nature of the detected anomaly in user-friendly terms.
+*   **Success State:** Provide clear, reassuring feedback when a save dump is validated as 100% healthy, confirming a successful backup from hardware.
+
+## 3. Dependencies
+- Depends on the core engine implementation (epic-036-053-health-scanner-core-engine) to provide the actual scanning logic and data structures.
+
+## 4. Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into actionable Stories.

--- a/.foundry/prds/prd-066-036-save-file-health-scanner.md
+++ b/.foundry/prds/prd-066-036-save-file-health-scanner.md
@@ -47,4 +47,8 @@ Leverage DexHelper's deep understanding of save file structures (checksums, magi
 - Fixing or automatically repairing corrupted save data. This PRD strictly focuses on scanning, diagnostics, and reporting.
 
 ## 5. Acceptance Criteria
-- [ ] Epic Planner: Break this PRD down into actionable Epics.
+- [x] Epic Planner: Break this PRD down into actionable Epics.
+
+## 6. Generated Epics
+- [ ] .foundry/epics/epic-036-053-health-scanner-core-engine.md
+- [ ] .foundry/epics/epic-036-054-diagnostic-reporting-ui.md


### PR DESCRIPTION
This PR breaks down PRD `prd-066-036-save-file-health-scanner` into two granular epics:
1. `epic-036-053-health-scanner-core-engine`: Core integrity engine for save files.
2. `epic-036-054-diagnostic-reporting-ui`: UI to present diagnostics pre-render.

The PRD's Acceptance Criteria has been marked as complete, and references to the newly generated epics were appended.

---
*PR created automatically by Jules for task [12315363704273574589](https://jules.google.com/task/12315363704273574589) started by @szubster*