### PR TITLE
🛠️ Infras: resolve DAG resolution warnings

### DIFF
--- a/.foundry/epics/epic-036-051-time-capsule-validation-logic.md
+++ b/.foundry/epics/epic-036-051-time-capsule-validation-logic.md
@@ -9,7 +9,7 @@ updated_at: "2026-05-30"
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: prd-066-036-time-capsule-validator.md
+parent: prd-066-036-time-capsule-validator
 tags:
   - feature
   - gen2

--- a/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
+++ b/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
@@ -7,10 +7,10 @@ owner_persona: story_owner
 created_at: "2026-05-30"
 updated_at: "2026-05-30"
 depends_on:
-  - .foundry/epics/epic-036-051-time-capsule-validation-logic.md
+  - epic-036-051-time-capsule-validation-logic
 jules_session_id: null
 pr_number: null
-parent: prd-066-036-time-capsule-validator.md
+parent: prd-066-036-time-capsule-validator
 tags:
   - feature
   - gen2

--- a/.foundry/prds/prd-066-036-time-capsule-validator.md
+++ b/.foundry/prds/prd-066-036-time-capsule-validator.md
@@ -9,7 +9,7 @@ updated_at: "2026-05-30"
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: idea-066-time-capsule-validator.md
+parent: idea-066-time-capsule-validator
 tags:
   - feature
   - gen2


### PR DESCRIPTION
### 🎯 What
Corrected `parent` and `depends_on` fields in several Foundry node files to use strictly Node IDs instead of file paths or names with `.md` extensions.

### 💡 Why
The Foundry DAG orchestrator emitted warnings because it could not resolve parents specified with the `.md` extension or full paths. Following the convention of using only the ID fixes these unresolvable dependencies.

### 🚀 Impact on DX/CI
Resolves resolution warnings during the orchestrator execution, ensuring a clean DAG build and preventing potential CI failures in strict mode.

### 📝 Setup notes
None.

Fixes #1959

---
*PR created automatically by Jules for task [2923187686411238768](https://jules.google.com/task/2923187686411238768) started by @szubster*