### PR TITLE
Epic Planner: Extract DAG Utilities to Shared Module

### DIFF
--- a/.foundry/epics/epic-036-053-shared-dag-utilities.md
+++ b/.foundry/epics/epic-036-053-shared-dag-utilities.md
@@ -1,0 +1,42 @@
+---
+id: epic-036-053-shared-dag-utilities
+type: EPIC
+title: Shared DAG Utilities Module
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-31'
+updated_at: '2026-05-31'
+depends_on: []
+jules_session_id: null
+parent: prd-067-036-extract-dag-utils
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: Spawned from prd-067-036-extract-dag-utils.
+---
+
+# Extract Shared DAG Utilities
+
+## 1. Introduction
+This epic extracts pure functions from `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts` into a shared module `.github/scripts/dag-utils.ts` to reduce duplicate DAG management logic.
+
+## 2. Scope
+- Create `.github/scripts/dag-utils.ts`.
+- Extract utility functions like `todayISO` and `logToJournal`.
+- Extract pure functions:
+  - `buildReverseDependencyGraph(nodes, resolveNodePath)`
+  - `getOrphanedNodes(startNodePath, reverseGraph)`
+- Create unit tests for complex logic within `dag-utils.ts`.
+- Update the DAG orchestration tests to use the new module.
+
+## Next Steps
+- [ ] Story Owner: Write Story to create the `dag-utils.ts` module with pure functions and basic utilities.
+
+## Acceptance Criteria
+- [ ] `dag-utils.ts` is created and contains the extracted pure functions and utilities.
+- [ ] New unit tests are written for `dag-utils.ts`.
+- [ ] Existing tests still pass.

--- a/.foundry/epics/epic-036-054-unify-state-transitions.md
+++ b/.foundry/epics/epic-036-054-unify-state-transitions.md
@@ -1,0 +1,42 @@
+---
+id: epic-036-054-unify-state-transitions
+type: EPIC
+title: Unify DAG Node State Transitions
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-05-31'
+updated_at: '2026-05-31'
+depends_on:
+  - epic-036-053-shared-dag-utilities
+jules_session_id: null
+parent: prd-067-036-extract-dag-utils
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: Spawned from prd-067-036-extract-dag-utils.
+---
+
+# Unify DAG Node State Transitions
+
+## 1. Introduction
+This epic extracts state transition functions into the new shared module `.github/scripts/dag-utils.ts` and updates both the orchestrator and heartbeat scripts to uniformly apply these functions.
+
+## 2. Scope
+- Move node state transition functions to `.github/scripts/dag-utils.ts`:
+  - `transitionNodeToFailed(node, repoRoot, rejectionReason, dryRun)`
+  - `transitionNodeToCompleted(node, repoRoot, prNumber, dryRun, hasChildrenCheck)`
+  - `transitionNodeToReady(node, repoRoot, reason, dryRun)`
+- Refactor `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts` to replace local status mutations with the unified `dag-utils.ts` functions.
+- Ensure the state transitions apply ADR 006 and handle metadata consistently.
+
+## Next Steps
+- [ ] Story Owner: Write Story to extract and use transition functions.
+
+## Acceptance Criteria
+- [ ] State transition functions are centralized in `dag-utils.ts`.
+- [ ] Both orchestrator and heartbeat scripts use the centralized functions.
+- [ ] All DAG orchestration tests pass.

--- a/.foundry/prds/prd-067-036-extract-dag-utils.md
+++ b/.foundry/prds/prd-067-036-extract-dag-utils.md
@@ -47,7 +47,9 @@ Create `.github/scripts/dag-utils.ts`.
 - Ensure the test suite correctly executes `pnpm install && npx vitest run` in `.github/scripts/` to validate changes across both files.
 
 ## Next Steps
-- [ ] Epic Planner: Evaluate this PRD and convert it to Epics to extract the DAG utilities to a shared module.
+- [x] Epic Planner: Evaluate this PRD and convert it to Epics to extract the DAG utilities to a shared module.
+- [ ] .foundry/epics/epic-036-053-shared-dag-utilities.md
+- [ ] .foundry/epics/epic-036-054-unify-state-transitions.md
 
 ## Acceptance Criteria
 - [ ] `dag-utils.ts` created with shared functions.


### PR DESCRIPTION
Evaluated PRD `prd-067-036-extract-dag-utils` and broke it down into granular Epic nodes to extract DAG utilities and unify state transitions.

Created Epics:
- `epic-036-053-shared-dag-utilities.md`
- `epic-036-054-unify-state-transitions.md`

Updated parent PRD with links to the generated Epics. Checked off "Next Steps" but intentionally left acceptance criteria unchecked to conform to Empty PR policy and prevent premature completion.

---
*PR created automatically by Jules for task [10684426308324052754](https://jules.google.com/task/10684426308324052754) started by @szubster*