### PR TITLE
🛠️ fix: resolve Foundry DAG resolution warnings

### DIFF
--- a/.foundry/epics/epic-036-051-time-capsule-validation-logic.md
+++ b/.foundry/epics/epic-036-051-time-capsule-validation-logic.md
@@ -9,7 +9,7 @@ updated_at: "2026-05-30"
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: prd-066-036-time-capsule-validator.md
+parent: prd-066-036-time-capsule-validator
 tags:
   - feature
   - gen2

--- a/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
+++ b/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
@@ -7,10 +7,10 @@ owner_persona: story_owner
 created_at: "2026-05-30"
 updated_at: "2026-05-30"
 depends_on:
-  - .foundry/epics/epic-036-051-time-capsule-validation-logic.md
+  - epic-036-051-time-capsule-validation-logic
 jules_session_id: null
 pr_number: null
-parent: prd-066-036-time-capsule-validator.md
+parent: prd-066-036-time-capsule-validator
 tags:
   - feature
   - gen2

--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -25,6 +25,11 @@ For Playwright E2E tests failing due to missing browser binaries or system depen
 - Found out Gen 2 Headbutt/Rock Smash didn't actually require badges internally despite some guides saying so.
 - Workaround vitest-browser-react pointer event issues on complex SVGs or wrappers (like ReactFlow) by evaluating the locator directly to the DOM element and calling .click()
 
+## 2026-05-31: Foundry DAG ID Strictness
+- **Constraint**: The `parent` and `depends_on` fields in Foundry node frontmatter MUST strictly use Node IDs (e.g., `prd-066-036-time-capsule-validator`).
+- **Regression**: Including the `.md` extension (e.g., `prd-066-036-time-capsule-validator.md`) or using full paths (e.g., `.foundry/epics/...`) causes the orchestrator to fail to resolve the dependency graph, resulting in "Parent not found" warnings and blocking node promotion.
+- **Verification**: Always run `node --experimental-strip-types .github/scripts/foundry-orchestrator.ts --dry-run --strict` to verify DAG integrity after modifying node frontmatter.
+
 ## 2026-05-18 - Gen 3 Locations
 - The Gen 3 maps define their region mapping string representation inside `region_map_sections.json` within the decomp repo, mapped sequentially. Use this to construct proper lookup lists.
 

--- a/.foundry/prds/prd-066-036-time-capsule-validator.md
+++ b/.foundry/prds/prd-066-036-time-capsule-validator.md
@@ -9,7 +9,7 @@ updated_at: "2026-05-30"
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: idea-066-time-capsule-validator.md
+parent: idea-066-time-capsule-validator
 tags:
   - feature
   - gen2


### PR DESCRIPTION
This PR fixes several "Parent not found" warnings encountered by the Foundry DAG orchestrator. These warnings were caused by using full filenames (including the `.md` extension) or full paths in the `parent` and `depends_on` frontmatter fields, whereas the orchestrator expects strict Node IDs.

Changes:
1. Updated `.foundry/prds/prd-066-036-time-capsule-validator.md`: Corrected `parent` from `idea-066-time-capsule-validator.md` to `idea-066-time-capsule-validator`.
2. Updated `.foundry/epics/epic-036-051-time-capsule-validation-logic.md`: Corrected `parent` from `prd-066-036-time-capsule-validator.md` to `prd-066-036-time-capsule-validator`.
3. Updated `.foundry/epics/epic-036-052-time-capsule-ui-indicators.md`: Corrected `parent` to `prd-066-036-time-capsule-validator` and `depends_on` to `epic-036-051-time-capsule-validation-logic`.
4. Documented the strict ID requirement in `.foundry/journals/coder.md`.

Verification:
- Ran `node --experimental-strip-types .github/scripts/foundry-orchestrator.ts --dry-run --strict` and confirmed 0 warnings.
- Ran full test suite (`pnpm lint && pnpm test && pnpm test:e2e`) and all tests passed.

Fixes #1968

---
*PR created automatically by Jules for task [1140621529076312397](https://jules.google.com/task/1140621529076312397) started by @szubster*