### PR TITLE
chore(foundry): create shiny carrier parsing tasks

### DIFF
--- a/.foundry/stories/story-044-083-pc-party-shiny-flag.md
+++ b/.foundry/stories/story-044-083-pc-party-shiny-flag.md
@@ -37,4 +37,6 @@ Update the existing Gen 2 PC and party data parsing mechanisms to analyze and fl
 - [ ] Resulting Pokémon objects include an accurate `isShinyCarrier` property.
 
 ## Next Steps
-- [ ] Tech Lead: Break down into backend Tasks.
+- [x] Tech Lead: Break down into backend Tasks.
+- [ ] .foundry/tasks/task-083-146-flag-shiny-carriers-impl.md
+- [ ] .foundry/tasks/task-083-147-flag-shiny-carriers-qa.md

--- a/.foundry/tasks/task-083-146-flag-shiny-carriers-impl.md
+++ b/.foundry/tasks/task-083-146-flag-shiny-carriers-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-083-146-flag-shiny-carriers-impl
+type: TASK
+title: "Implement isShinyCarrier Property in Parsed Data"
+status: PENDING
+owner_persona: coder
+created_at: "2026-06-01"
+updated_at: "2026-06-01"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-044-083-pc-party-shiny-flag
+tags:
+  - feature
+  - breeding
+  - gen2
+  - backend
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement isShinyCarrier Property in Parsed Data
+
+## Context
+We need to expose the Shiny Carrier status in the Pokémon objects parsed from Gen 1 and Gen 2 saves. Currently, the save parsing utilities extract DVs and calculate `hasShinyGene`, but the product requirement dictates that the property should be named `isShinyCarrier`.
+
+## Objective
+Update `PokemonInstance` in the `common.ts` parser logic to use the `isShinyCarrier` boolean property name (instead of `hasShinyGene`) and update all parsing paths (Gen 1 and Gen 2) to correctly set this property.
+
+## Requirements
+1. In `src/engine/saveParser/parsers/common.ts`, rename the optional `hasShinyGene?: boolean;` property on the `PokemonInstance` interface to `isShinyCarrier?: boolean;`.
+2. In `src/engine/saveParser/parsers/gen1.ts`, update the parsed data population to set `isShinyCarrier` using the result of `checkShinyGene(dvs)`.
+3. In `src/engine/saveParser/parsers/gen2.ts`, update the parsed data population to set `isShinyCarrier` using the result of `checkShinyGene(dvs)`.
+4. Ensure all related unit tests are updated and pass.
+
+## Acceptance Criteria
+- [ ] `PokemonInstance` interface uses `isShinyCarrier` instead of `hasShinyGene`.
+- [ ] Gen 1 and Gen 2 parsers correctly assign `isShinyCarrier`.
+- [ ] Unit tests are updated and pass without errors.
+
+## Reminder for Coder and QA
+- If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-083-147-flag-shiny-carriers-qa.md
+++ b/.foundry/tasks/task-083-147-flag-shiny-carriers-qa.md
@@ -1,0 +1,43 @@
+---
+id: task-083-147-flag-shiny-carriers-qa
+type: TASK
+title: "QA: Verify isShinyCarrier Property in Parsed Data"
+status: PENDING
+owner_persona: qa
+created_at: "2026-06-01"
+updated_at: "2026-06-01"
+depends_on:
+  - task-083-146-flag-shiny-carriers-impl
+jules_session_id: null
+pr_number: null
+parent: story-044-083-pc-party-shiny-flag
+tags:
+  - feature
+  - breeding
+  - gen2
+  - backend
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA: Verify isShinyCarrier Property in Parsed Data
+
+## Context
+The coder has implemented changes to expose the Shiny Carrier status as `isShinyCarrier` on Pokémon instances parsed from PC and Party data.
+
+## Objective
+Verify that the `isShinyCarrier` boolean property is correctly populated when parsing Pokémon data from save files.
+
+## Requirements
+1. Verify that `isShinyCarrier` correctly reflects the DV logic (`def === 10` and `spc === 2 || 10`) for Gen 1 and Gen 2 saves.
+2. Ensure the property appears properly structured in the output data.
+
+## Acceptance Criteria
+- [ ] Manual or automated verification confirms `isShinyCarrier` is correctly populated for Shiny Carriers and is missing/false for others.
+
+## Reminder for Coder and QA
+- If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Creates the implementation task `task-083-146-flag-shiny-carriers-impl` and QA task `task-083-147-flag-shiny-carriers-qa` to implement the `isShinyCarrier` property on Gen 1 and Gen 2 parsed save data. Also updates the parent story `story-044-083-pc-party-shiny-flag` to reference these newly created tasks.

---
*PR created automatically by Jules for task [10091447919003846222](https://jules.google.com/task/10091447919003846222) started by @szubster*