### PR TITLE
feat: implement DAG Data Parsing for Rejection Count

### DIFF
--- a/.foundry/tasks/task-085-142-impl-extract-rejection-count.md
+++ b/.foundry/tasks/task-085-142-impl-extract-rejection-count.md
@@ -34,9 +34,9 @@ In order to display permanent failures on the DAG dashboard, we need to surface 
 3. Verify that the React context layer correctly exposes the property to connected UI views.
 
 ## Acceptance Criteria
-- [ ] Coder: Update parsing logic.
-- [ ] Coder: Update `FoundryNode` TypeScript types.
-- [ ] Coder: Ensure React context layer correctly exposes the property.
+- [x] Coder: Update parsing logic.
+- [x] Coder: Update `FoundryNode` TypeScript types.
+- [x] Coder: Ensure React context layer correctly exposes the property.
 
 ## Reminders
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/src/components/dag/DagNode.tsx
+++ b/src/components/dag/DagNode.tsx
@@ -7,6 +7,7 @@ export type DagNodeData = Record<string, unknown> & {
   type: string;
   status: string;
   owner_persona: string;
+  rejection_count: number;
   label?: string;
   isHighlighted?: boolean;
   isDimmed?: boolean;

--- a/src/components/dag/__tests__/DagDashboard.test.tsx
+++ b/src/components/dag/__tests__/DagDashboard.test.tsx
@@ -17,6 +17,7 @@ test('DagDashboard renders correctly on successful load', async () => {
           owner_persona: 'human',
           label: 'node',
           title: 'Node 1',
+          rejection_count: 0,
           depends_on: [],
         },
       },
@@ -30,6 +31,7 @@ test('DagDashboard renders correctly on successful load', async () => {
           label: 'node',
           title: 'Node 2',
           parent: 'node-1.md',
+          rejection_count: 0,
           depends_on: ['node-1.md'],
         },
       },
@@ -93,6 +95,7 @@ test('DagDashboard handles selection and highlighting', async () => {
           owner_persona: 'human',
           label: 'node',
           title: 'Node 1',
+          rejection_count: 0,
           depends_on: [],
         },
       },
@@ -106,6 +109,7 @@ test('DagDashboard handles selection and highlighting', async () => {
           label: 'node',
           title: 'Node 2',
           parent: 'node-1.md',
+          rejection_count: 0,
           depends_on: ['node-1.md'],
         },
       },
@@ -118,6 +122,7 @@ test('DagDashboard handles selection and highlighting', async () => {
           owner_persona: 'human',
           label: 'node-3',
           title: 'Node 3',
+          rejection_count: 0,
           depends_on: [],
         },
       },
@@ -130,6 +135,7 @@ test('DagDashboard handles selection and highlighting', async () => {
           owner_persona: 'human',
           label: 'node-4',
           title: 'Node 4',
+          rejection_count: 0,
           depends_on: [],
         },
       },
@@ -142,6 +148,7 @@ test('DagDashboard handles selection and highlighting', async () => {
           owner_persona: 'human',
           label: 'node-5',
           title: 'Node 5',
+          rejection_count: 0,
           depends_on: [],
         },
       },
@@ -154,6 +161,7 @@ test('DagDashboard handles selection and highlighting', async () => {
           owner_persona: 'human',
           label: 'node-6',
           title: 'Node 6',
+          rejection_count: 0,
           depends_on: [],
         } as unknown as import('../DagNode').DagNodeData,
       },
@@ -292,49 +300,49 @@ test('getMiniMapNodeColor returns correct color based on status', () => {
     getMiniMapNodeColor({
       id: '1',
       position: { x: 0, y: 0 },
-      data: { status: 'COMPLETED', type: 'TASK', owner_persona: 'human' },
+      data: { rejection_count: 0, status: 'COMPLETED', type: 'TASK', owner_persona: 'human' },
     }),
   ).toBe('#10b981');
   expect(
     getMiniMapNodeColor({
       id: '1',
       position: { x: 0, y: 0 },
-      data: { status: 'ACTIVE', type: 'TASK', owner_persona: 'human' },
+      data: { rejection_count: 0, status: 'ACTIVE', type: 'TASK', owner_persona: 'human' },
     }),
   ).toBe('#ef4444');
   expect(
     getMiniMapNodeColor({
       id: '1',
       position: { x: 0, y: 0 },
-      data: { status: 'IN_PROGRESS', type: 'TASK', owner_persona: 'human' },
+      data: { rejection_count: 0, status: 'IN_PROGRESS', type: 'TASK', owner_persona: 'human' },
     }),
   ).toBe('#ef4444');
   expect(
     getMiniMapNodeColor({
       id: '1',
       position: { x: 0, y: 0 },
-      data: { status: 'FAILED', type: 'TASK', owner_persona: 'human' },
+      data: { rejection_count: 0, status: 'FAILED', type: 'TASK', owner_persona: 'human' },
     }),
   ).toBe('#ef4444');
   expect(
     getMiniMapNodeColor({
       id: '1',
       position: { x: 0, y: 0 },
-      data: { status: 'BLOCKED', type: 'TASK', owner_persona: 'human' },
+      data: { rejection_count: 0, status: 'BLOCKED', type: 'TASK', owner_persona: 'human' },
     }),
   ).toBe('#ef4444');
   expect(
     getMiniMapNodeColor({
       id: '1',
       position: { x: 0, y: 0 },
-      data: { status: 'READY', type: 'TASK', owner_persona: 'human' },
+      data: { rejection_count: 0, status: 'READY', type: 'TASK', owner_persona: 'human' },
     }),
   ).toBe('#f59e0b');
   expect(
     getMiniMapNodeColor({
       id: '1',
       position: { x: 0, y: 0 },
-      data: { status: 'UNKNOWN' },
+      data: { rejection_count: 0, status: 'UNKNOWN' },
     } as unknown as import('@xyflow/react').Node<import('../DagNode').DagNodeData>),
   ).toBe('#52525b');
   expect(

--- a/vite-plugins/foundry-plugin.ts
+++ b/vite-plugins/foundry-plugin.ts
@@ -9,6 +9,7 @@ interface FoundryNodeData {
   status: string;
   owner_persona: string;
   depends_on: string[];
+  rejection_count: number;
 }
 
 export interface ParsedNode {
@@ -54,6 +55,7 @@ export function foundryPlugin(): Plugin {
                 status: data['status'],
                 owner_persona: data['owner_persona'],
                 depends_on: data['depends_on'],
+                rejection_count: typeof data['rejection_count'] === 'number' ? data['rejection_count'] : 0,
               },
             });
           }


### PR DESCRIPTION
Updates the Vite plugin and DAG parser to properly extract the `rejection_count` property from `.foundry` files as per ADR 017. Adds the property to TypeScript types to expose it on the DAG dashboard. All E2E tests passing.

---
*PR created automatically by Jules for task [13536361495268435373](https://jules.google.com/task/13536361495268435373) started by @szubster*