### PR TITLE
🧪 Oak: fix DAG resolution warnings in Time Capsule Validator nodes

### DIFF
--- a/.foundry/epics/epic-036-051-time-capsule-validation-logic.md
+++ b/.foundry/epics/epic-036-051-time-capsule-validation-logic.md
@@ -9,7 +9,7 @@ updated_at: "2026-05-30"
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: prd-066-036-time-capsule-validator.md
+parent: prd-066-036-time-capsule-validator
 tags:
   - feature
   - gen2

--- a/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
+++ b/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
@@ -7,10 +7,10 @@ owner_persona: story_owner
 created_at: "2026-05-30"
 updated_at: "2026-05-30"
 depends_on:
-  - .foundry/epics/epic-036-051-time-capsule-validation-logic.md
+  - epic-036-051-time-capsule-validation-logic
 jules_session_id: null
 pr_number: null
-parent: prd-066-036-time-capsule-validator.md
+parent: prd-066-036-time-capsule-validator
 tags:
   - feature
   - gen2

--- a/.foundry/prds/prd-066-036-time-capsule-validator.md
+++ b/.foundry/prds/prd-066-036-time-capsule-validator.md
@@ -9,7 +9,7 @@ updated_at: "2026-05-30"
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: idea-066-time-capsule-validator.md
+parent: idea-066-time-capsule-validator
 tags:
   - feature
   - gen2


### PR DESCRIPTION
Corrected parent and depends_on fields in Time Capsule Validator nodes to use Node IDs instead of file paths or extensions, resolving DAG orchestrator warnings.

Fixes #1992

---
*PR created automatically by Jules for task [665493818238394553](https://jules.google.com/task/665493818238394553) started by @szubster*