### PR TITLE
🧪 Oak: Fix DAG resolution warnings for Time Capsule Validator

### DIFF
--- a/.foundry/epics/epic-036-051-time-capsule-validation-logic.md
+++ b/.foundry/epics/epic-036-051-time-capsule-validation-logic.md
@@ -9,7 +9,7 @@ updated_at: "2026-05-30"
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: prd-066-036-time-capsule-validator.md
+parent: prd-066-036-time-capsule-validator
 tags:
   - feature
   - gen2

--- a/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
+++ b/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
@@ -7,10 +7,10 @@ owner_persona: story_owner
 created_at: "2026-05-30"
 updated_at: "2026-05-30"
 depends_on:
-  - .foundry/epics/epic-036-051-time-capsule-validation-logic.md
+  - epic-036-051-time-capsule-validation-logic
 jules_session_id: null
 pr_number: null
-parent: prd-066-036-time-capsule-validator.md
+parent: prd-066-036-time-capsule-validator
 tags:
   - feature
   - gen2

--- a/.foundry/prds/prd-066-036-time-capsule-validator.md
+++ b/.foundry/prds/prd-066-036-time-capsule-validator.md
@@ -9,7 +9,7 @@ updated_at: "2026-05-30"
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: idea-066-time-capsule-validator.md
+parent: idea-066-time-capsule-validator
 tags:
   - feature
   - gen2


### PR DESCRIPTION
What was wrong: Frontmatter 'parent' and 'depends_on' fields used filenames/paths instead of Node IDs. Canonical source used: Project memory on Node ID schema. Impact on users: Resolves DAG orchestrator warnings and ensures correct node promotion.

Fixes #1999

---
*PR created automatically by Jules for task [14036362500419488041](https://jules.google.com/task/14036362500419488041) started by @szubster*