### PR TITLE
Agile Coach: Ensure cascading cancellations provide a rejection reason

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -420,7 +420,7 @@ function main(): void {
     const children = parentToChildren.get(parentPath) || [];
     for (const child of children) {
       if (child.frontmatter.status !== 'COMPLETED' && child.frontmatter.status !== 'CANCELLED') {
-        promoteNodeStatus(child, child.frontmatter.status, 'CANCELLED');
+        promoteNodeToCancelledWithReason(child, 'Cancelled due to cascading cancellation from parent');
         cancelledNodes.add(child.repoPath);
         cascadeCancel(child.repoPath); // Recursive call
       }


### PR DESCRIPTION
Updates the Foundry Orchestrator to use promoteNodeToCancelledWithReason when cascading cancellation to children recursively, so that a rejection reason is properly recorded.

---
*PR created automatically by Jules for task [16559663725510474720](https://jules.google.com/task/16559663725510474720) started by @szubster*