### PR TITLE
🧪 Oak: [Data correction] Fix Emerald version exclusives

### DIFF
--- a/.jules/oak.md
+++ b/.jules/oak.md
@@ -52,3 +52,5 @@
 # Oak Learnings
 
 - Within the `engine/exclusives/` data domain, the version-specific arrays (e.g., `GEN1_VERSION_EXCLUSIVES`, `GEN2_VERSION_EXCLUSIVES`) store the IDs of Pokémon that are **unobtainable (excluded)** in that game version, rather than the ones exclusively available. This is crucial for verifying data against Bulbapedia.
+## Data Integrity - Gen 3 Exclusives
+* **Data Pipeline Gotchas:** The Gen 3 version exclusives list for Emerald incorrectly assumed it was just a combination of Ruby and Sapphire exclusives. However, Emerald has its own distinct missing list (Surskit, Masquerain, Meditite, Medicham, Roselia, Zangoose, and Lunatone). Always verify against PokeAPI encounters or canonical sources rather than assuming third versions simply exclude both base version exclusives.

--- a/src/engine/exclusives/__tests__/gen3Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen3Exclusives.test.ts
@@ -18,5 +18,16 @@ describe('gen3Exclusives', () => {
       const ownedSet = new Set<number>([382]);
       expect(getGen3UnobtainableReason(382, 'ruby', 0, ownedSet)).toBeNull();
     });
+
+    it('should return reason for Emerald exclusive missing', () => {
+      const ownedSet = new Set<number>();
+      const reason = getGen3UnobtainableReason(335, 'emerald', 0, ownedSet); // Zangoose
+      expect(reason).toContain('not available in Emerald');
+    });
+
+    it('should return null for Seedot in Emerald', () => {
+      const ownedSet = new Set<number>();
+      expect(getGen3UnobtainableReason(273, 'emerald', 0, ownedSet)).toBeNull();
+    });
   });
 });

--- a/src/engine/exclusives/gen3Exclusives.ts
+++ b/src/engine/exclusives/gen3Exclusives.ts
@@ -4,8 +4,8 @@ export const GEN3_VERSION_EXCLUSIVES: Record<string, number[]> = {
   ruby: [270, 271, 272, 302, 336, 337, 382],
   // Sapphire missing (Ruby exclusives)
   sapphire: [273, 274, 275, 303, 335, 338, 383],
-  // Emerald missing (Ruby & Sapphire exclusives)
-  emerald: [273, 274, 275, 303, 335, 338, 383, 270, 271, 272, 302, 336, 337],
+  // Emerald missing
+  emerald: [283, 284, 307, 308, 315, 335, 337],
   // FireRed missing (LeafGreen exclusives)
   firered: [27, 28, 37, 38, 69, 70, 71, 79, 80, 199, 120, 121, 126, 127, 183, 184, 298],
   // LeafGreen missing (FireRed exclusives)


### PR DESCRIPTION
What was wrong: The Emerald exclusives list was incorrectly formed by merging Ruby and Sapphire missing lists.
Canonical source used: PokeAPI encounter data / decompiled ROM data.
Impact on users: Users can now correctly track Pokémon like Seedot and Lotad in Emerald, while being properly restricted from Surskit, Meditite, etc.

---
*PR created automatically by Jules for task [8180307982294562577](https://jules.google.com/task/8180307982294562577) started by @szubster*