### PR TITLE
💡 Visionary: Gen 3 Mirage Island Predictor

### DIFF
--- a/.foundry/ideas/idea-069-mirage-island-predictor.md
+++ b/.foundry/ideas/idea-069-mirage-island-predictor.md
@@ -1,0 +1,26 @@
+---
+id: idea-069-mirage-island-predictor
+type: IDEA
+title: "Gen 3 Mirage Island Predictor"
+status: PENDING
+owner_persona: "product_manager"
+created_at: "2026-06-02"
+updated_at: "2026-06-02"
+depends_on: []
+jules_session_id: null
+parent: null
+tags: ["gen3", "mirage-island", "rng"]
+notes: ""
+---
+
+# Gen 3 Mirage Island Predictor
+
+## Problem
+In Pokémon Ruby, Sapphire, and Emerald (Gen 3), accessing Mirage Island requires the lower two bytes of a Pokémon's Personality Value (PID) in the player's party to match a random 2-byte value generated daily. Because the daily value is completely hidden and players typically have hundreds of Pokémon sitting in their PC boxes, manually checking each Pokémon by moving them to the party and speaking to the old man in Pacifidlog Town is an extremely tedious, high-friction process. As a result, most players never experience this rare event.
+
+## Proposed Solution
+Leverage DexHelper's programmatic offline-first save file parsing to automatically cross-reference the daily Mirage Island random value against the PIDs of **all** Pokémon currently owned by the player (both in the active party and across all PC storage boxes).
+
+The application would instantly surface a notification or dedicated tracker view indicating whether the player currently possesses a "Mirage Island Key" Pokémon for the current day. If a match is found, it would highlight exactly which Pokémon it is and which PC Box it resides in, transforming a frustrating brute-force mechanic into a rewarding, seamless discovery.
+
+This aligns perfectly with DexHelper's vision as a premium companion app that surfaces hidden state to eliminate tedious manual gameplay loops, similarly to the Gen 3 Feebas Tile Predictor and Gen 2 Shiny Carrier ideas.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -50,3 +50,8 @@
 **Idea:** Unown Form Tracker
 **Learning:** Catering to end-game completionists adds significant value. Gen 2 has a specific quest to collect all 26 Unown forms (A-Z) which are determined by DVs. Since `DexHelper` already parses DVs for stats and shininess, extending this to explicitly track Unown forms gives players a visual checklist, transforming a tedious manual process into a highly actionable feature.
 **Outcome:** Created IDEA node.
+
+## 2026-06-02
+**Idea:** Gen 3 Mirage Island Predictor
+**Learning:** Continuing the trend of surfacing hidden global state (like Feebas tiles or daily swarms) and cross-referencing it with the player's large entity datasets (like hundreds of PC Pokémon PIDs), we can eliminate extremely tedious brute-force mechanics. This provides immediate, tangible value that perfectly aligns with our offline-first programmatic parsing strengths.
+**Outcome:** Created IDEA node.


### PR DESCRIPTION
A proposal to add a feature that cross-references the daily Mirage Island random value with all Pokemon PIDs in the PC and party to instantly tell the player if they can access Mirage Island today.

---
*PR created automatically by Jules for task [5268658609531754204](https://jules.google.com/task/5268658609531754204) started by @szubster*