### PR TITLE
🛠️ Infras: Centralize Node Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: ".nvmrc"
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: ".nvmrc"
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: ".nvmrc"
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -111,7 +111,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: ".nvmrc"
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: ".nvmrc"
           cache: "pnpm"
           
       - name: Install dependencies

--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24' # Required for --strip-types
+          node-version-file: ".nvmrc" # Required for --strip-types
           cache: "pnpm"
 
       - name: Install dependencies
@@ -159,7 +159,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version-file: ".nvmrc"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: actions/setup-node@v6
       with:
-        node-version: 24
+        node-version-file: ".nvmrc"
         cache: "pnpm"
 
     - name: Install dependencies

--- a/.github/workflows/sync-pokedata.yml
+++ b/.github/workflows/sync-pokedata.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: ".nvmrc"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -75,3 +75,5 @@ Critical learnings:
 
 ## 2026-05-31 - Empty PR Policy for Infrastucture
 **Learning:** When tasked with improving development tooling, if the infrastructure (e.g. Biome, Oxlint, Knip, Lefthook, Dependabot, Caching, Bundlemon, Codecov) is already highly optimized and no further tooling improvement can be cleanly implemented without duplicating or breaking existing tooling, it is strictly preferable to submit an empty PR rather than forcing a change. An empty PR cleanly transitions the task without introducing bloat or technical debt.
+## 2026-06-02 - Use .nvmrc for GitHub Actions
+**Learning:** Replaced hardcoded `node-version: 24` and `node-version: '24'` with `node-version-file: \".nvmrc\"` in all GitHub Actions workflows (`ci.yml`, `deploy.yml`, `foundry-engine.yml`, `playwright.yml`, `sync-pokedata.yml`). This ensures that the CI environment always matches the exact local development version of Node.js specified in `.nvmrc`, providing a single source of truth and preventing version drift between environments.


### PR DESCRIPTION
What: Replaced hardcoded node-version: 24 with node-version-file: ".nvmrc" across all GitHub Actions workflows.

Why: Maintains a single source of truth for the project's Node.js version.

Impact on DX/CI: Prevents future version mismatches between local environments and CI.

Setup notes: None.

---
*PR created automatically by Jules for task [6932764863929507363](https://jules.google.com/task/6932764863929507363) started by @szubster*