### PR TITLE
Story Owner: Add story for extracting shared DAG utilities

### DIFF
--- a/.foundry/epics/epic-036-053-shared-dag-utilities.md
+++ b/.foundry/epics/epic-036-053-shared-dag-utilities.md
@@ -34,7 +34,8 @@ This epic extracts pure functions from `.github/scripts/foundry-orchestrator.ts`
 - Update the DAG orchestration tests to use the new module.
 
 ## Next Steps
-- [ ] Story Owner: Write Story to create the `dag-utils.ts` module with pure functions and basic utilities.
+- [x] Story Owner: Write Story to create the `dag-utils.ts` module with pure functions and basic utilities.
+  - Spawned: `.foundry/stories/story-053-090-extract-dag-utilities.md`
 
 ## Acceptance Criteria
 - [ ] `dag-utils.ts` is created and contains the extracted pure functions and utilities.

--- a/.foundry/stories/story-053-090-extract-dag-utilities.md
+++ b/.foundry/stories/story-053-090-extract-dag-utilities.md
@@ -1,0 +1,43 @@
+---
+id: story-053-090-extract-dag-utilities
+type: STORY
+title: Extract Shared DAG Utilities
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-02'
+updated_at: '2026-06-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-036-053-shared-dag-utilities
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: Spawned from epic-036-053-shared-dag-utilities
+---
+
+# Extract Shared DAG Utilities
+
+## 1. Introduction
+This story details the technical steps for extracting shared DAG utility functions from existing orchestrator scripts (`foundry-orchestrator.ts` and `foundry-heartbeat.ts`) into a new shared module `dag-utils.ts`.
+
+## 2. Technical Tasks
+- Create `.github/scripts/dag-utils.ts`.
+- Extract basic utility functions (e.g., `todayISO`, `logToJournal`).
+- Extract the pure DAG traversal functions:
+  - `buildReverseDependencyGraph(nodes, resolveNodePath)`
+  - `getOrphanedNodes(startNodePath, reverseGraph)`
+- Create unit tests for the extracted logic inside `dag-utils.ts`.
+- Update the DAG orchestration scripts and their tests to import and use the new module.
+
+## Next Steps
+- [ ] Tech Lead: Write Tasks to implement the file creation, extraction, test writing, and test updates.
+
+## Acceptance Criteria
+- [ ] `dag-utils.ts` is created containing `todayISO`, `logToJournal`, `buildReverseDependencyGraph`, and `getOrphanedNodes`.
+- [ ] Appropriate unit tests are added for the new utility file.
+- [ ] Existing functionality works seamlessly utilizing the new utility file.


### PR DESCRIPTION
This PR adds a STORY node for extracting shared DAG utilities and updates the parent EPIC node accordingly. As a planning task, this is an empty PR with no direct code changes.

---
*PR created automatically by Jules for task [1874916531199522660](https://jules.google.com/task/1874916531199522660) started by @szubster*