### PR TITLE
💡 Visionary: Pokerus Tracker and Infection Spread Assistant

### DIFF
--- a/.foundry/ideas/idea-068-069-pokerus-tracker.md
+++ b/.foundry/ideas/idea-068-069-pokerus-tracker.md
@@ -1,0 +1,39 @@
+---
+id: idea-068-069-pokerus-tracker
+type: IDEA
+title: Pokerus Tracker and Infection Spread Assistant
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-06-03'
+updated_at: '2026-06-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - feature
+  - tool
+  - quality-of-life
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Pokerus Tracker and Infection Spread Assistant
+
+## Context
+Pokerus is an incredibly rare, hidden status condition introduced in Generation 2 that doubles the EVs (Stat Exp) a Pokémon earns from battle. It is highly sought after by dedicated players. However, its mechanics are entirely hidden from the player: there is no in-game indication of *which* specific strain of Pokerus a Pokémon has, exactly how many days are left before it is "cured" (becomes immune to spreading it but keeps the EV bonus), or any visual tool to help spread the infection across a team or PC box efficiently.
+
+## Proposal
+Create a **Pokerus Tracker and Infection Spread Assistant** within DexHelper that exposes this hidden state and makes it actionable.
+
+1. **Pokerus State Exfiltration**: Since we already parse `.sav` files, we can read the specific byte flags for Pokerus for every Pokémon in the party and PC.
+2. **Visual Tracker**:
+    - Add clear, distinct visual badges on Pokémon lists and detail views to indicate their exact Pokerus status: `Uninfected`, `Infected (Contagious)`, and `Cured (Immune)`.
+    - For contagious Pokémon, calculate and explicitly display the remaining days/time until they are cured based on their specific strain and the game's RTC (Real Time Clock).
+3. **Spread Planner**:
+    - Provide a dedicated tool or view that helps players strategically plan how to spread Pokerus. For example, suggesting which infected Pokémon to keep in the party alongside uninfected target Pokémon, and warning players if an infected Pokémon is about to be cured, advising them to deposit it in the PC (which pauses the timer).
+
+## Value Proposition
+This takes an obtuse, highly stressful hidden mechanic and turns it into a clear, manageable process. Dedicated players currently resort to spreadsheets or meticulous manual time-tracking to manage Pokerus. This feature eliminates that entirely, heavily aligning with DexHelper's vision of being a premium companion app that surfaces hidden state for actionable utility.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -41,6 +41,9 @@
 **Learning:** Finding hidden items (like Rare Candies or TMs) in Gen 1/2 is extremely tedious without a guide, and players often forget which ones they've already picked up since the games don't track them explicitly in a user-facing way. By parsing the event flags in the save file, we can dynamically generate a checklist of *remaining* hidden items, turning static guide knowledge into personalized, actionable insights. This continues the trend of surfacing hidden save state to solve high-friction retro gaming pain points.
 **Outcome:** Created IDEA node.
 
+**Idea:** Pokerus Tracker and Infection Spread Assistant
+**Learning:** Pokerus is an incredibly rare, highly sought-after, and poorly explained hidden mechanic in Gen 2+. Players have no easy way of tracking which Pokemon have it, how many days until it cures, and who is contagious, forcing them to guess or carefully count days. Uncovering this hidden state allows us to create an infection planner, taking another opaque game mechanic and turning it into an actionable utility for dedicated trainers.
+
 ## Learning
 **Idea:** Gen 3 Berry Farming Tracker
 **Learning:** When expanding to new generations (like Gen 3), target the unique, generation-specific mechanics (like RTC-based berry farming) that present new pain points for players. Automating time-based or heavily localized systems provides immediate high value that generic static views cannot match.


### PR DESCRIPTION
Generates a new IDEA node for a Pokerus Tracker and Infection Spread Assistant, aligning with the project's goal of surfacing hidden state to create actionable utility for dedicated players. Also updates the Visionary agent's private journal with the core learning.

---
*PR created automatically by Jules for task [12354987544562944850](https://jules.google.com/task/12354987544562944850) started by @szubster*