### PR TITLE
🎨 Palette: Removed redundant ARIA labels and titles from DAG filter buttons

### DIFF
--- a/src/components/dag/DagFilterPanel.tsx
+++ b/src/components/dag/DagFilterPanel.tsx
@@ -24,8 +24,7 @@ export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onSt
                 key={type}
                 type="button"
                 aria-pressed={isActive}
-                aria-label={`Toggle ${type} type filter`}
-                title={`Toggle ${type} type filter`}
+                title={`${type} type filter`}
                 onClick={() => onTypeToggle(type)}
                 className={cn(
                   'rounded-none border border-dashed px-2 py-1 transition-colors hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
@@ -71,8 +70,7 @@ export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onSt
                 key={status}
                 type="button"
                 aria-pressed={isActive}
-                aria-label={`Toggle ${status} status filter`}
-                title={`Toggle ${status} status filter`}
+                title={`${status} status filter`}
                 onClick={() => onStatusToggle(status)}
                 className={cn(
                   'rounded-none border border-dashed px-2 py-1 transition-colors hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',


### PR DESCRIPTION
**What**: Removed `aria-label` attributes and the word "Toggle" from the `title` attributes of the type and status filter buttons in `DagFilterPanel`.

**Why**: To prevent screen reader redundancy and fix WCAG 2.5.3 (Label in Name) violations. Setting an `aria-label` completely suppresses the visible text of the button. Since the text inside the button ("IDEA", "COMPLETED") is clear and visible, falling back to it is preferred. Additionally, because the buttons use the `aria-pressed={isActive}` property, the screen reader already announces them as toggle buttons, so adding "Toggle" in the title causes redundant verbosity (e.g. "Toggle IDEA type filter, toggle button, pressed").

**Accessibility notes**: Screen readers will now announce the button's visible text, correctly identifying it as a toggle button via `aria-pressed`, and optionally reading the `title` (e.g. "IDEA type filter") as a description without duplicating the word "Toggle".

---
*PR created automatically by Jules for task [16382959631160841406](https://jules.google.com/task/16382959631160841406) started by @szubster*