### PR TITLE
🖼️ Canvas: Tactical Multi-Select Filters

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -150,3 +150,9 @@
 **Outcome:** Accepted
 **Why:** Brings the loading state interface in line with the heavily tactical, specialized hardware motif. Wrapping loaders and sync views in `TacticalPanel` ensures they fit the "terminal scanning" visual identity of the rest of the application.
 **Pattern:** Consistently utilize `TacticalPanel` for utility and overlay elements instead of relying on custom styled divs with generic shadows and blurs, and replace standard progress indicators with segmented, tactical layouts.
+
+## 2026-07-02 - [Accepted] - 🖼️ Canvas: Tactical Multi-Select Filters
+**What:** Created a new `TacticalMultiSelectControl` component based on `TacticalSegmentedControl` but adapted for multi-select functionality using `role="group"` and `aria-pressed`. Refactored `SearchAndFilters` to use this new component instead of custom raw buttons, standardizing the filter toggles.
+**Outcome:** Accepted
+**Why:** Previous filter toggles were raw buttons styled to look like segmented controls, but they allowed multi-select (unlike the settings panels). By creating a dedicated `TacticalMultiSelectControl`, we maintain the strict hardware-style visual coherence while enforcing correct accessibility semantics for multi-select toggle groups.
+**Pattern:** Do not use `TacticalSegmentedControl` for multi-select scenarios as it breaks `role="radiogroup"` semantics. Use the dedicated `TacticalMultiSelectControl` for cohesive hardware aesthetics when multiple options can be toggled simultaneously.

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import { FILTER_TYPES, useStore } from '../store';
 import { LocationSuggestions } from './LocationSuggestions';
 import { TacticalInput } from './TacticalInput';
+import { TacticalMultiSelectControl } from './TacticalMultiSelectControl';
 import { TacticalPanel } from './TacticalPanel';
 import { TelemetryDecoration } from './TelemetryDecoration';
 
@@ -55,47 +56,39 @@ export function SearchAndFilters() {
           </TacticalInput>
 
           {/* Tactical Filter Toggles Segmented Control */}
-          <fieldset className="m-0 flex min-w-0 flex-col gap-2 border-none p-0">
-            <legend className="sr-only">Filter Pokémon</legend>
-            <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ FILTER_PARAMETERS ]</span>
-            <div className="flex flex-wrap border border-zinc-800 border-dashed sm:flex-nowrap">
-              <button
-                type="button"
-                onClick={() => setFilters([])}
-                aria-pressed={filtersSet.size === 0}
-                title="Clear filters"
-                className={`min-w-[100px] flex-1 border-zinc-800 border-r border-dashed px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
-                  filtersSet.size === 0
-                    ? 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'
-                    : 'bg-zinc-950/50 text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400'
-                }`}
-              >
-                [ ALL ]
-              </button>
-
-              {FILTER_TYPES.map((f, idx) => {
-                const isLast = idx === FILTER_TYPES.length - 1;
-                const isActive = filtersSet.has(f);
-                return (
-                  <button
-                    type="button"
-                    key={f}
-                    onClick={() => toggleFilter(f)}
-                    aria-pressed={isActive}
+          <TacticalMultiSelectControl<(typeof FILTER_TYPES)[number] | 'all'>
+            ariaLabel="Filter Pokémon"
+            legendLabel="[ FILTER_PARAMETERS ]"
+            selectedValues={
+              filtersSet.size === 0
+                ? new Set(['all'])
+                : (filtersSet as unknown as Set<(typeof FILTER_TYPES)[number] | 'all'>)
+            }
+            onToggle={(value) => {
+              if (value === 'all') {
+                setFilters([]);
+              } else {
+                toggleFilter(value as (typeof FILTER_TYPES)[number]);
+              }
+            }}
+            items={[
+              {
+                id: 'all',
+                label: <span title="Clear filters">[ ALL ]</span>,
+                className: 'min-w-[100px]',
+              },
+              ...FILTER_TYPES.map((f) => ({
+                id: f,
+                label: (
+                  <span
                     title={`${f} filter`}
-                    data-testid={`filter-${f}`}
-                    className={`min-w-[100px] flex-1 ${!isLast ? 'border-zinc-800 border-r border-dashed' : ''} px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
-                      isActive
-                        ? 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'
-                        : 'bg-zinc-950/50 text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400'
-                    }`}
-                  >
-                    [ {f === 'secured' ? 'SECURED' : f === 'missing' ? 'MISSING' : 'DEX ONLY'} ]
-                  </button>
-                );
-              })}
-            </div>
-          </fieldset>
+                  >{`[ ${f === 'secured' ? 'SECURED' : f === 'missing' ? 'MISSING' : 'DEX ONLY'} ]`}</span>
+                ),
+                testId: `filter-${f}`,
+                className: 'min-w-[100px]',
+              })),
+            ]}
+          />
         </div>
       </TacticalPanel>
     </div>

--- a/src/components/TacticalMultiSelectControl.tsx
+++ b/src/components/TacticalMultiSelectControl.tsx
@@ -1,0 +1,84 @@
+import type React from 'react';
+import { cn } from '../utils/cn';
+
+interface MultiSelectControlItem<T extends string | number | readonly string[]> {
+  id: T;
+  label: React.ReactNode;
+  activeClassName?: string;
+  inactiveClassName?: string;
+  className?: string;
+  disabled?: boolean;
+  testId?: string;
+}
+
+interface TacticalMultiSelectControlProps<T extends string | number | readonly string[]> {
+  items: MultiSelectControlItem<T>[];
+  selectedValues: Set<T>;
+  onToggle: (value: T) => void;
+  ariaLabel?: string;
+  legendLabel?: string;
+  containerClassName?: string;
+  buttonBaseClassName?: string;
+  defaultActiveClassName?: string;
+  defaultInactiveClassName?: string;
+}
+
+export function TacticalMultiSelectControl<T extends string | number | readonly string[]>({
+  items,
+  selectedValues,
+  onToggle,
+  ariaLabel,
+  legendLabel,
+  containerClassName,
+  buttonBaseClassName,
+  defaultActiveClassName = 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]',
+  defaultInactiveClassName = 'bg-zinc-950/50 text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400',
+}: TacticalMultiSelectControlProps<T>) {
+  return (
+    <fieldset className={cn('m-0 flex min-w-0 flex-col gap-2 border-none p-0', containerClassName)}>
+      {legendLabel && (
+        <>
+          <legend className="sr-only">{ariaLabel || legendLabel}</legend>
+          <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">{legendLabel}</span>
+        </>
+      )}
+      {!legendLabel && ariaLabel && <legend className="sr-only">{ariaLabel}</legend>}
+
+      {/* oxlint-disable jsx-a11y/prefer-tag-over-role */}
+      {/* biome-ignore lint/a11y/useSemanticElements: tactical multi-select control needs to use a div internally with role=group */}
+      <div
+        className="flex flex-wrap border border-zinc-800 border-dashed sm:flex-nowrap"
+        role="group"
+        aria-label={ariaLabel}
+      >
+        {items.map((item, idx) => {
+          const isLast = idx === items.length - 1;
+          const isActive = selectedValues.has(item.id);
+
+          const activeClass = item.activeClassName ?? defaultActiveClassName;
+          const inactiveClass = item.inactiveClassName ?? defaultInactiveClassName;
+
+          return (
+            <button
+              key={String(item.id)}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => onToggle(item.id)}
+              disabled={item.disabled}
+              data-testid={item.testId}
+              className={cn(
+                'flex-1 px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+                !isLast && 'border-zinc-800 border-r border-dashed',
+                isActive ? activeClass : inactiveClass,
+                buttonBaseClassName,
+                item.className,
+              )}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}


### PR DESCRIPTION
Created a new `TacticalMultiSelectControl` component to handle multi-select toggle groups with the tactical hardware aesthetic. This resolves an architectural issue where `SearchAndFilters` used custom raw buttons that looked like segmented controls, but needed to support multiple active filters simultaneously (which breaks `role="radiogroup"` semantics). 

The new component ensures visual consistency with `TacticalSegmentedControl` while providing the correct HTML semantics (`role="group"`, `aria-pressed`). Also appended the rationale to `.jules/canvas.md`.

---
*PR created automatically by Jules for task [17514419958374585537](https://jules.google.com/task/17514419958374585537) started by @szubster*