### PR TITLE
Implement isShinyCarrier Property in Parsed Data

### DIFF
--- a/.foundry/tasks/task-083-146-flag-shiny-carriers-impl.md
+++ b/.foundry/tasks/task-083-146-flag-shiny-carriers-impl.md
@@ -36,9 +36,9 @@ Update `PokemonInstance` in the `common.ts` parser logic to use the `isShinyCarr
 4. Ensure all related unit tests are updated and pass.
 
 ## Acceptance Criteria
-- [ ] `PokemonInstance` interface uses `isShinyCarrier` instead of `hasShinyGene`.
-- [ ] Gen 1 and Gen 2 parsers correctly assign `isShinyCarrier`.
-- [ ] Unit tests are updated and pass without errors.
+- [x] `PokemonInstance` interface uses `isShinyCarrier` instead of `hasShinyGene`.
+- [x] Gen 1 and Gen 2 parsers correctly assign `isShinyCarrier`.
+- [x] Unit tests are updated and pass without errors.
 
 ## Reminder for Coder and QA
 - If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -21,7 +21,7 @@ export interface PokemonInstance {
   speciesId: number;
   level: number;
   isShiny: boolean;
-  hasShinyGene?: boolean;
+  isShinyCarrier?: boolean;
   item?: number | undefined;
   moves: number[];
   friendship?: number | undefined;

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -427,7 +427,7 @@ function parseGen1Pokemon(
   }
   const dvs = parseDVs(view.getUint16(offset + 27, false));
   const isShiny = checkShiny(dvs);
-  const hasShinyGene = checkShinyGene(dvs);
+  const isShinyCarrier = checkShinyGene(dvs);
   const otName = decodeGen12String(view, otOffset);
 
   return {
@@ -435,7 +435,7 @@ function parseGen1Pokemon(
     currentHp,
     level,
     isShiny,
-    hasShinyGene,
+    isShinyCarrier,
     moves,
     dvs,
     otName,

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -85,7 +85,7 @@ function parseGen2PokemonInstance(
   }
   const dvs = parseDVs(view.getUint16(offset + 21, false));
   const isShiny = checkShiny(dvs);
-  const hasShinyGene = checkShinyGene(dvs);
+  const isShinyCarrier = checkShinyGene(dvs);
   const friendship = view.getUint8(offset + 27);
   const pokerus = view.getUint8(offset + 28);
   const level = view.getUint8(offset + 31);
@@ -100,7 +100,7 @@ function parseGen2PokemonInstance(
     currentHp,
     level,
     isShiny,
-    hasShinyGene,
+    isShinyCarrier,
     item,
     moves,
     friendship,


### PR DESCRIPTION
Implements the requirement to expose the Shiny Carrier status under the `isShinyCarrier` property name instead of `hasShinyGene` in parsed Gen 1 and Gen 2 save data. Updates the `PokemonInstance` interface and internal mapping logic. Tests have been run and verified. Acceptance criteria for task `task-083-146-flag-shiny-carriers-impl` have been checked.

---
*PR created automatically by Jules for task [10092150020180186448](https://jules.google.com/task/10092150020180186448) started by @szubster*