### PR TITLE
🛠️ Agile Coach: Clear `rejection_reason` on orchestrator status transitions

### DIFF
--- a/.foundry/tasks/task-067-117-clear-rejection-reason-in-orchestrator.md
+++ b/.foundry/tasks/task-067-117-clear-rejection-reason-in-orchestrator.md
@@ -1,0 +1,31 @@
+---
+id: task-067-117-clear-rejection-reason-in-orchestrator
+type: TASK
+title: Clear Rejection Reason in Orchestrator
+status: COMPLETED
+owner_persona: tech_lead
+created_at: '2026-06-04'
+updated_at: '2026-06-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-067-clear-rejection-reason
+tags:
+  - foundry
+  - lifecycle
+  - orchestrator
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Clear Rejection Reason in Orchestrator
+
+## Description
+Modifies the DAG Orchestrator (`foundry-orchestrator.ts`) to automatically clear the `rejection_reason` property whenever it successfully transitions a node into a valid operating state (`ACTIVE`, `READY`, `PENDING`, `VERIFYING`, or `COMPLETED`).
+
+This mitigates a bug where stale metadata from a previously failed retry causes subsequent non-related errors to be miscategorized as Impossible Loops (since `rejection_reason` wasn't blanked out on recovery).
+
+## Acceptance Criteria
+- [x] Modify `promoteNodeStatus` in `foundry-orchestrator.ts` to clear `rejection_reason` on valid state transitions.
+- [x] Write an automated test in `foundry-orchestrator.test.ts` to ensure `rejection_reason` is correctly cleared.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -32,6 +32,34 @@ describe('foundry-orchestrator', () => {
 
 
 
+  test('PromoteNodeStatus: clears rejection_reason on valid transition', () => {
+    createValidTestNode(tmpDir, '.foundry/tasks/task-001.md', {
+      id: "task-001",
+      type: "TASK",
+      title: "Task 1",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+      rejection_reason: "Previous failure reason"
+    });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    main();
+
+    const output = consoleSpy.mock.calls[0][0];
+    const readyNodes = JSON.parse(output);
+
+    expect(readyNodes).toHaveLength(1);
+    expect(readyNodes[0].id).toBe('task-001');
+
+    const fileContent = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-001.md'), 'utf-8');
+    expect(fileContent).toContain('status: READY');
+    expect(fileContent).toContain("rejection_reason: ''");
+  });
+
   test('Happy Path: promotes PENDING to READY when all dependencies are COMPLETED', () => {
     createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
       id: "idea-001",

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -251,7 +251,14 @@ function promoteNodeStatus(node: ParsedNode, currentStatus: Status, targetStatus
     return;
   }
 
+  const clearRejectionReasonStatuses: Status[] = ['ACTIVE', 'READY', 'PENDING', 'VERIFYING', 'COMPLETED'];
+
   const newData = { ...node.frontmatter, status: targetStatus, updated_at: dateStr };
+
+  if (clearRejectionReasonStatuses.includes(targetStatus)) {
+    newData.rejection_reason = '';
+  }
+
   const newContent = matter.stringify(node.body, newData);
 
   if (!DRY_RUN) {


### PR DESCRIPTION
This PR addresses the issue outlined in `idea-067-clear-rejection-reason.md`.

**Why:**
When a node fails, agents or the system assign a `rejection_reason`. Previously, if the node later retried and succeeded, or transitioned to `ACTIVE` or `READY`, this `rejection_reason` was not cleared in the DAG orchestrator script (`foundry-orchestrator.ts`). This caused stale metadata to persist, leading to incorrect system behavior such as False Positive Impossible Loops.

**What:**
- Modified `promoteNodeStatus` in `foundry-orchestrator.ts` to explicitly clear the `rejection_reason` property (setting it to an empty string) whenever a node successfully transitions to `ACTIVE`, `READY`, `PENDING`, `VERIFYING`, or `COMPLETED`.
- Wrote an automated unit test `PromoteNodeStatus: clears rejection_reason on valid transition` in `foundry-orchestrator.test.ts` to verify the fix.
- Autonomously generated the task `.foundry/tasks/task-067-117-clear-rejection-reason-in-orchestrator.md` marked as `COMPLETED` mapping it to the parent idea to document the system improvement.

---
*PR created automatically by Jules for task [1892904705766560321](https://jules.google.com/task/1892904705766560321) started by @szubster*