### PR TITLE
🖼️ Canvas: Tactical Run Tracker Subcomponents Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -150,3 +150,9 @@
 **Outcome:** Accepted
 **Why:** Brings the loading state interface in line with the heavily tactical, specialized hardware motif. Wrapping loaders and sync views in `TacticalPanel` ensures they fit the "terminal scanning" visual identity of the rest of the application.
 **Pattern:** Consistently utilize `TacticalPanel` for utility and overlay elements instead of relying on custom styled divs with generic shadows and blurs, and replace standard progress indicators with segmented, tactical layouts.
+
+## 2026-07-05 - [Accepted] - 🖼️ Canvas: Tactical Run Tracker Subcomponents Redesign
+**What:** Redesigned `GraveyardView` and `VisitedRoutesChecklist` to fully embrace the tactical "snooping" aesthetic by wrapping them in `<TacticalPanel>` instead of plain `<div>`s or generic classes. The headers were upgraded to use `<TelemetryDecoration>`. Additionally, the inner elements (graveyard cards, route list items) were redesigned with sharp, dashed borders and `<CornerCrosshairs>` to match the `AliveTeamView` components.
+**Outcome:** Accepted
+**Why:** Brings the run tracker's subcomponents deeply in line with the established specialized hardware motif, eliminating generic web UI shapes. Tactical panels and telemetry decorations reinforce the snooping fantasy and maintain consistency across complex views.
+**Pattern:** Ensure even deeply nested subcomponents (like graveyard grids and route lists) adhere strictly to tactical aesthetics (sharp borders, corner crosshairs, telemetry decorations) to maintain absolute visual coherence and prevent reverting to generic structural layouts.

--- a/src/components/run/GraveyardView.tsx
+++ b/src/components/run/GraveyardView.tsx
@@ -1,7 +1,9 @@
 import { Ghost } from 'lucide-react';
 import type { PokemonInstance } from '../../engine/saveParser/parsers/common';
+import { CornerCrosshairs } from '../CornerCrosshairs';
 import { PokemonSprite } from '../pokemon/PokemonSprite';
-import { TacticalCard } from '../TacticalCard';
+import { TacticalPanel } from '../TacticalPanel';
+import { TelemetryDecoration } from '../TelemetryDecoration';
 
 export interface GraveyardViewProps {
   graveyard: PokemonInstance[];
@@ -10,19 +12,17 @@ export interface GraveyardViewProps {
 
 export function GraveyardView({ graveyard, generation }: GraveyardViewProps) {
   return (
-    <div className="flex flex-col gap-3">
-      <h3 className="flex items-center gap-2 font-bold font-mono text-sm text-zinc-500 uppercase tracking-widest">
-        <Ghost className="h-4 w-4" />
-        SYS.GRAVEYARD
-      </h3>
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
+    <TacticalPanel variant="default" className="mb-6 flex flex-col gap-3 p-4 sm:p-6">
+      <TelemetryDecoration label="SYS.GRAVEYARD" className="-top-3 left-4" />
+      <div className="mt-2 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
         {graveyard.map((pokemon, idx) => (
-          <TacticalCard
+          <div
             // biome-ignore lint/suspicious/noArrayIndexKey: Graveyard members might not have unique identifiers
             key={`grave-${idx}-${pokemon.speciesId}`}
-            variant="default"
-            className="flex flex-col items-center rounded-none border-zinc-900/50 border-dashed bg-zinc-950/20 p-3 opacity-80 grayscale hover:border-zinc-500/50"
+            className="group relative flex flex-col items-center rounded-none border border-zinc-900/50 border-dashed bg-zinc-950/20 p-3 opacity-80 grayscale transition-colors hover:border-zinc-500/50"
           >
+            <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700/50 transition-colors group-hover:border-zinc-500" />
+
             <div className="relative mb-2 h-16 w-16">
               <PokemonSprite
                 pokemonId={pokemon.speciesId}
@@ -40,10 +40,11 @@ export function GraveyardView({ graveyard, generation }: GraveyardViewProps) {
                 <span className="font-bold font-mono text-[9px] text-red-900/70">DEAD</span>
               </div>
             </div>
-          </TacticalCard>
+          </div>
         ))}
         {graveyard.length === 0 && (
-          <div className="col-span-full flex flex-col items-center justify-center rounded-none border border-zinc-800/50 border-dashed bg-zinc-950/20 p-8 text-center">
+          <div className="relative col-span-full flex flex-col items-center justify-center border border-zinc-800/50 border-dashed bg-zinc-950/20 p-8 text-center">
+            <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700/50" />
             <Ghost className="mb-3 h-8 w-8 text-zinc-600" />
             <span className="font-bold font-mono text-sm text-zinc-500 uppercase tracking-widest">
               NO CASUALTIES RECORDED
@@ -51,6 +52,6 @@ export function GraveyardView({ graveyard, generation }: GraveyardViewProps) {
           </div>
         )}
       </div>
-    </div>
+    </TacticalPanel>
   );
 }

--- a/src/components/run/VisitedRoutesChecklist.tsx
+++ b/src/components/run/VisitedRoutesChecklist.tsx
@@ -1,6 +1,8 @@
 import { Check, CircleDot } from 'lucide-react';
 import type { PokemonInstance } from '../../engine/saveParser/parsers/common';
-import { TacticalCard } from '../TacticalCard';
+import { CornerCrosshairs } from '../CornerCrosshairs';
+import { TacticalPanel } from '../TacticalPanel';
+import { TelemetryDecoration } from '../TelemetryDecoration';
 
 export interface VisitedRoutesChecklistProps {
   visited: {
@@ -17,52 +19,63 @@ export interface VisitedRoutesChecklistProps {
 export function VisitedRoutesChecklist({ visited, unvisited }: VisitedRoutesChecklistProps) {
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-3">
-        <h3 className="font-bold font-mono text-emerald-500 text-sm uppercase tracking-widest">SYS.VISITED_ROUTES</h3>
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
+      <TacticalPanel variant="emerald" className="mt-4 mb-2 flex flex-col gap-3 p-4 sm:p-6">
+        <TelemetryDecoration
+          label="SYS.VISITED_ROUTES"
+          className="-top-3 left-4"
+          textClassName="text-emerald-500"
+          dotClassName="text-emerald-400"
+        />
+        <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
           {visited.map((route) => (
-            <TacticalCard
+            <div
               key={route.locationId}
-              variant="default"
-              className="flex items-center gap-3 border-emerald-900/50 bg-emerald-950/10 hover:border-emerald-500/50"
+              className="group relative flex items-center gap-3 rounded-none border border-emerald-900/50 border-dashed bg-emerald-950/10 p-3 transition-colors hover:border-emerald-500/50"
             >
+              <CornerCrosshairs className="h-1.5 w-1.5 border-emerald-900/50 transition-colors group-hover:border-emerald-500/80" />
               <Check className="h-4 w-4 shrink-0 text-emerald-500" />
               <div className="flex min-w-0 flex-col">
-                <span className="truncate font-bold text-xs text-zinc-300">{route.locationName}</span>
-                <span className="text-[10px] text-zinc-500">
+                <span className="truncate font-bold text-xs text-zinc-300 uppercase tracking-wider">
+                  {route.locationName}
+                </span>
+                <span className="font-mono text-[10px] text-zinc-500 uppercase tracking-widest">
                   {route.encounters.length} ENCOUNTER{route.encounters.length !== 1 ? 'S' : ''}
                 </span>
               </div>
-            </TacticalCard>
+            </div>
           ))}
           {visited.length === 0 && (
-            <div className="col-span-full rounded-none border border-zinc-800 border-dashed bg-zinc-900/20 p-4 text-center font-mono text-xs text-zinc-500 uppercase">
-              No routes visited yet
+            <div className="relative col-span-full rounded-none border border-zinc-800/50 border-dashed bg-zinc-950/20 p-6 text-center font-mono text-xs text-zinc-500 uppercase">
+              <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700/50" />
+              NO ROUTES VISITED YET
             </div>
           )}
         </div>
-      </div>
+      </TacticalPanel>
 
-      <div className="flex flex-col gap-3">
-        <h3 className="font-bold font-mono text-sm text-zinc-400 uppercase tracking-widest">SYS.UNVISITED_ROUTES</h3>
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
+      <TacticalPanel variant="default" className="mt-4 mb-2 flex flex-col gap-3 p-4 sm:p-6">
+        <TelemetryDecoration label="SYS.UNVISITED_ROUTES" className="-top-3 left-4" />
+        <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
           {unvisited.map((route) => (
-            <TacticalCard
+            <div
               key={route.locationId}
-              variant="default"
-              className="flex items-center gap-3 border-zinc-800 bg-zinc-950/50 hover:border-zinc-700"
+              className="group relative flex items-center gap-3 rounded-none border border-zinc-800 border-dashed bg-zinc-950/50 p-3 transition-colors hover:border-zinc-700"
             >
+              <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700/50 transition-colors group-hover:border-zinc-500" />
               <CircleDot className="h-4 w-4 shrink-0 text-zinc-600" />
-              <span className="truncate font-bold text-xs text-zinc-500">{route.locationName}</span>
-            </TacticalCard>
+              <span className="truncate font-bold text-xs text-zinc-500 uppercase tracking-wider">
+                {route.locationName}
+              </span>
+            </div>
           ))}
           {unvisited.length === 0 && (
-            <div className="col-span-full rounded-none border border-zinc-800 border-dashed bg-zinc-900/20 p-4 text-center font-mono text-xs text-zinc-500 uppercase">
-              All routes visited
+            <div className="relative col-span-full rounded-none border border-zinc-800/50 border-dashed bg-zinc-950/20 p-6 text-center font-mono text-xs text-zinc-500 uppercase">
+              <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700/50" />
+              ALL ROUTES VISITED
             </div>
           )}
         </div>
-      </div>
+      </TacticalPanel>
     </div>
   );
 }


### PR DESCRIPTION
This PR redesigns the `GraveyardView` and `VisitedRoutesChecklist` components to fully embrace the project's tactical "snooping" aesthetic, aligning them with the previously updated `AliveTeamView`.

**Changes include:**
- Wrapping views in `<TacticalPanel>` instead of generic divs.
- Using `<TelemetryDecoration>` for section headers.
- Replacing rounded, generic inner cards/items with sharp edges, dashed borders, and `<CornerCrosshairs>`.
- Appending a journal entry to `.jules/canvas.md` documenting this change.

This ensures deep component trees maintain absolute visual coherence and avoid reverting to generic web UI structural layouts.

---
*PR created automatically by Jules for task [16308645900449894825](https://jules.google.com/task/16308645900449894825) started by @szubster*