### PR TITLE
🧱 Mason: InlineLink extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -77,3 +77,9 @@
 - **Why**: Reduced duplicated JSX across `AssistantDebugView` which had 4 identical blocks. It can also be reused if other parts of the app need a telemetry card.
 - **Key Learnings**:
   - The `valueClassName` prop is crucial when extracting text components, allowing customization like `truncate` or `uppercase` while maintaining identical base text styles.
+
+## InlineLink Extraction
+- **What**: Extracted repeated inline link button elements (standard `<button className="rounded-none underline..."></button>` with variant-specific colors) into an `InlineLink` reusable component.
+- **Why**: Reduced duplicated JSX in `PokemonEvolutions.tsx`. Standardized interaction styles, underline offsets, and hover variants for typical navigation links without needing to pass down the large class string every time.
+- **Key Learnings**:
+  - Make sure to extend standard attributes (e.g. `React.ButtonHTMLAttributes<HTMLButtonElement>`) and forward refs (`React.forwardRef`) so accessibility properties like `aria-label` or raw `onClick` handlers pass down appropriately without breaking.

--- a/src/components/InlineLink.tsx
+++ b/src/components/InlineLink.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { cn } from '../utils/cn';
+
+interface InlineLinkProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'red' | 'purple' | 'blue' | 'pink' | 'emerald';
+  children: React.ReactNode;
+}
+
+export const InlineLink = React.forwardRef<HTMLButtonElement, InlineLinkProps>(
+  ({ className, variant = 'blue', children, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={cn(
+          'rounded-none underline underline-offset-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+          {
+            'text-red-400 decoration-red-500/30 hover:text-white': variant === 'red',
+            'text-white decoration-purple-500/30 hover:text-purple-400': variant === 'purple',
+            'text-white decoration-blue-500/30 hover:text-blue-400': variant === 'blue',
+            'text-white decoration-pink-500/30 hover:text-pink-400': variant === 'pink',
+            'text-emerald-400 decoration-emerald-500/30 hover:text-white': variant === 'emerald',
+          },
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+InlineLink.displayName = 'InlineLink';

--- a/src/components/pokemon/details/PokemonEvolutions.tsx
+++ b/src/components/pokemon/details/PokemonEvolutions.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { stadiumRewardsData } from '../../../engine/data/shared/staticData';
 import type { SaveData } from '../../../engine/saveParser/index';
 import { cn } from '../../../utils/cn';
+import { InlineLink } from '../../InlineLink';
 import { TacticalPanel } from '../../TacticalPanel';
 
 interface EvoReq {
@@ -64,14 +65,13 @@ function ProcurementStrategy({
         {evoReq ? (
           <>
             {' '}
-            <button
-              type="button"
+            <InlineLink
               aria-label={`Navigate to ${evoReq.fromName} details`}
               onClick={() => onNavigate(evoReq.fromId, evoReq.fromName)}
-              className="rounded-none text-red-400 underline decoration-red-500/30 underline-offset-4 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+              variant="red"
             >
               Evolving {evoReq.fromName.toUpperCase()}
-            </button>
+            </InlineLink>
             .
           </>
         ) : (
@@ -120,14 +120,13 @@ function EvolutionFrom({
       </h3>
       <div className="relative z-10 font-bold text-xs text-zinc-300 leading-relaxed">
         FROM{' '}
-        <button
-          type="button"
+        <InlineLink
           aria-label={`Navigate to ${evoReq.fromName} details`}
           onClick={() => onNavigate(evoReq.fromId, evoReq.fromName)}
-          className="rounded-none text-white underline decoration-purple-500/30 underline-offset-4 transition-colors hover:text-purple-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+          variant="purple"
         >
           {evoReq.fromName.toUpperCase()}
-        </button>
+        </InlineLink>
         <div className="mt-1 font-black text-[10px] text-purple-400/60 uppercase">METHOD: {evoReq.method}</div>
       </div>
       <div
@@ -162,14 +161,13 @@ function EvolutionTo({
         {evolvesTo.map((evo) => (
           <div key={evo.id} className="font-bold text-xs text-zinc-300 leading-relaxed">
             TO{' '}
-            <button
-              type="button"
+            <InlineLink
               aria-label={`Navigate to ${evo.name} details`}
               onClick={() => onNavigate(evo.id, evo.name)}
-              className="rounded-none text-white underline decoration-blue-500/30 underline-offset-4 transition-colors hover:text-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+              variant="blue"
             >
               {evo.name.toUpperCase()}
-            </button>
+            </InlineLink>
             <div className="mt-1 font-black text-[10px] text-blue-400/60 uppercase">VIA {evo.method}</div>
           </div>
         ))}
@@ -200,17 +198,16 @@ function BreedingProtocol({
         CROSS-REF:{' '}
         {breedingInfo.parentNames.map((name: string, i: number) => (
           <React.Fragment key={name}>
-            <button
-              type="button"
+            <InlineLink
               aria-label={`Navigate to ${name} details`}
               onClick={() => {
                 const id = breedingInfo.parentIds[i];
                 if (id) onNavigate(id, name);
               }}
-              className="rounded-none text-white underline decoration-pink-500/30 underline-offset-4 transition-colors hover:text-pink-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+              variant="pink"
             >
               {name.toUpperCase()}
-            </button>
+            </InlineLink>
             {i < breedingInfo.parentNames.length - 1 ? ', ' : ''}
           </React.Fragment>
         ))}


### PR DESCRIPTION
🎯 What
Extracted repeated inline link buttons (the native `<button className="rounded-none underline...">`) with various theme colors into an `InlineLink` reusable component.

💡 Why
Reduced duplicated JSX class names inside `PokemonEvolutions.tsx`. Standardized interaction styles, underline offsets, and hover variants for generic navigation links without needing to pass down the large class string every time.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to verify behavior unchanged. Evaluated diff to ensure accessibility attributes are forwarded.

✨ Result
Cleaner and modularized standard HTML element extraction across `PokemonEvolutions`.

---
*PR created automatically by Jules for task [6195118384904522770](https://jules.google.com/task/6195118384904522770) started by @szubster*