### PR TITLE
🧹 Fix Foundry schema validation and broken links

### DIFF
--- a/.foundry/ideas/idea-069-mirage-island-predictor.md
+++ b/.foundry/ideas/idea-069-mirage-island-predictor.md
@@ -10,6 +10,8 @@ depends_on: []
 jules_session_id: null
 parent: null
 tags: ["gen3", "mirage-island", "rng"]
+rejection_count: 0
+rejection_reason: ""
 notes: ""
 ---
 

--- a/.foundry/prds/prd-066-036-feebas-tile-predictor.md
+++ b/.foundry/prds/prd-066-036-feebas-tile-predictor.md
@@ -3,7 +3,7 @@ id: prd-066-036-feebas-tile-predictor
 type: PRD
 title: Gen 3 Feebas Tile Predictor
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-05-30'
 updated_at: '2026-05-30'
 depends_on: []

--- a/.foundry/prds/prd-068-037-hidden-items-finder.md
+++ b/.foundry/prds/prd-068-037-hidden-items-finder.md
@@ -3,7 +3,7 @@ id: prd-068-037-hidden-items-finder
 type: PRD
 title: Missing Hidden Items Finder Feature
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-01'
 updated_at: '2026-06-01'
 depends_on: []

--- a/.foundry/stories/story-048-088-create-route-radar-controller.md
+++ b/.foundry/stories/story-048-088-create-route-radar-controller.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-05-31'
 updated_at: '2026-06-02'
 depends_on:
-  - .foundry/tasks/task-035-142-smart-radar-adr.md
+  - task-035-142-smart-radar-adr
 jules_session_id: '16597791177162833819'
 pr_number: null
 parent: epic-035-048-smart-radar-data-unification


### PR DESCRIPTION
🎯 What: Fixed Foundry schema validation errors and broken links.

💡 Why: The Foundry Engine failed during the orchestration phase due to:
1. Missing `rejection_reason` in an IDEA node.
2. Invalid `owner_persona` mapping for PRD nodes (owned by `architect` instead of `epic_planner`).
3. Broken dependency path in a STORY node (using a file path instead of a Node ID).

✅ Verification: 
- Ran `node --experimental-strip-types scripts/validate-foundry-schema.ts` and confirmed it passed.
- Ran `node --experimental-strip-types scripts/check-links.ts` on the modified story file and confirmed it passed.
- Ran orchestrator logic tests in `.github/scripts/` via `vitest` and confirmed all passed.

✨ Result: Foundry orchestration process is restored and metadata is now compliant with the schema.

Fixes #2088

---
*PR created automatically by Jules for task [10014615452242733710](https://jules.google.com/task/10014615452242733710) started by @szubster*