### PR TITLE
🗃️ Archivist: Resolve PRD owner persona mapping failures

### DIFF
--- a/.foundry/prds/prd-066-036-feebas-tile-predictor.md
+++ b/.foundry/prds/prd-066-036-feebas-tile-predictor.md
@@ -3,9 +3,9 @@ id: prd-066-036-feebas-tile-predictor
 type: PRD
 title: Gen 3 Feebas Tile Predictor
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-05-30'
-updated_at: '2026-05-30'
+updated_at: '2026-06-04'
 depends_on: []
 jules_session_id: null
 pr_number: null

--- a/.foundry/prds/prd-068-037-hidden-items-finder.md
+++ b/.foundry/prds/prd-068-037-hidden-items-finder.md
@@ -3,9 +3,9 @@ id: prd-068-037-hidden-items-finder
 type: PRD
 title: Missing Hidden Items Finder Feature
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-01'
-updated_at: '2026-06-01'
+updated_at: '2026-06-04'
 depends_on: []
 jules_session_id: null
 pr_number: null


### PR DESCRIPTION
🎯 What
Changed `owner_persona` from `architect` to `epic_planner` in `.foundry/prds/prd-066-036-feebas-tile-predictor.md` and `.foundry/prds/prd-068-037-hidden-items-finder.md`.

💡 Why
The Foundry orchestrator strict mode flagged these nodes as `FAILED` during Phase 4.8 Mapping Validation because `PRD` nodes cannot be owned by the `architect` persona. According to the orchestrator logic and schema, `epic_planner` is a valid owner for `PRD` nodes.

✅ Verification
- Ran the Foundry orchestrator in dry-run mode (`node .github/scripts/foundry-orchestrator.ts --dry-run`) and confirmed the "Invalid mapping" warnings for these nodes are gone.
- Ran orchestrator and heartbeat tests (`cd .github/scripts && npx vitest run`) and confirmed 80/80 tests passed.

✨ Result
The affected PRD nodes are now valid according to the orchestrator's schema validation and can be promoted to `READY` status for dispatch.

Fixes #2087

---
*PR created automatically by Jules for task [16893180556987696429](https://jules.google.com/task/16893180556987696429) started by @szubster*