### PR TITLE
🗃️ Archivist: fix foundry engine orchestration failures

### DIFF
--- a/.foundry/ideas/idea-069-mirage-island-predictor.md
+++ b/.foundry/ideas/idea-069-mirage-island-predictor.md
@@ -10,6 +10,7 @@ depends_on: []
 jules_session_id: null
 parent: null
 tags: ["gen3", "mirage-island", "rng"]
+rejection_reason: ""
 notes: ""
 ---
 

--- a/.foundry/prds/prd-066-036-feebas-tile-predictor.md
+++ b/.foundry/prds/prd-066-036-feebas-tile-predictor.md
@@ -3,7 +3,7 @@ id: prd-066-036-feebas-tile-predictor
 type: PRD
 title: Gen 3 Feebas Tile Predictor
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-05-30'
 updated_at: '2026-05-30'
 depends_on: []

--- a/.foundry/prds/prd-068-037-hidden-items-finder.md
+++ b/.foundry/prds/prd-068-037-hidden-items-finder.md
@@ -3,7 +3,7 @@ id: prd-068-037-hidden-items-finder
 type: PRD
 title: Missing Hidden Items Finder Feature
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-01'
 updated_at: '2026-06-01'
 depends_on: []

--- a/.foundry/stories/story-048-088-create-route-radar-controller.md
+++ b/.foundry/stories/story-048-088-create-route-radar-controller.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-05-31'
 updated_at: '2026-06-02'
 depends_on:
-  - .foundry/tasks/task-035-142-smart-radar-adr.md
+  - task-035-142-smart-radar-adr
 jules_session_id: '16597791177162833819'
 pr_number: null
 parent: epic-035-048-smart-radar-data-unification


### PR DESCRIPTION
🎯 What was stale/wrong:
- `.foundry/ideas/idea-069-mirage-island-predictor.md` was missing the mandatory `rejection_reason` field.
- `.foundry/prds/prd-066-036-feebas-tile-predictor.md` and `.foundry/prds/prd-068-037-hidden-items-finder.md` had an invalid `owner_persona` mapping (`architect` is not allowed to own PRDs).
- `.foundry/stories/story-048-088-create-route-radar-controller.md` used a file path instead of a node ID in `depends_on`, which is forbidden and caused a broken link error.

✅ How it was verified:
- Verified that all Foundry nodes pass schema validation by running `node --experimental-strip-types scripts/validate-foundry-schema.ts`.
- Verified the corrected link by running `node --experimental-strip-types scripts/check-links.ts .foundry/stories/story-048-088-create-route-radar-controller.md`.

✨ What was updated:
- Updated YAML frontmatter in 4 Foundry node files to comply with schema and ownership rules.

Fixes #2092

---
*PR created automatically by Jules for task [5140554439825791997](https://jules.google.com/task/5140554439825791997) started by @szubster*