### PR TITLE
🧹 Fix invalid PRD owner persona mappings

### DIFF
--- a/.foundry/prds/prd-066-036-feebas-tile-predictor.md
+++ b/.foundry/prds/prd-066-036-feebas-tile-predictor.md
@@ -3,7 +3,7 @@ id: prd-066-036-feebas-tile-predictor
 type: PRD
 title: Gen 3 Feebas Tile Predictor
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-05-30'
 updated_at: '2026-05-30'
 depends_on: []

--- a/.foundry/prds/prd-068-037-hidden-items-finder.md
+++ b/.foundry/prds/prd-068-037-hidden-items-finder.md
@@ -3,7 +3,7 @@ id: prd-068-037-hidden-items-finder
 type: PRD
 title: Missing Hidden Items Finder Feature
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-01'
 updated_at: '2026-06-01'
 depends_on: []


### PR DESCRIPTION
Updated the `owner_persona` for `.foundry/prds/prd-066-036-feebas-tile-predictor.md` and `.foundry/prds/prd-068-037-hidden-items-finder.md` from `architect` to `epic_planner` to comply with the Foundry orchestrator's mapping rules. This resolves the DAG resolution warnings and allows these nodes to progress through the pipeline. Verification was performed using the orchestrator's dry-run mode and existing test suites.

Fixes #2091

---
*PR created automatically by Jules for task [17055235154770064115](https://jules.google.com/task/17055235154770064115) started by @szubster*