### PR TITLE
Draft DAG Utility Extraction Tasks

### DIFF
--- a/.foundry/stories/story-053-090-extract-dag-utilities.md
+++ b/.foundry/stories/story-053-090-extract-dag-utilities.md
@@ -35,7 +35,9 @@ This story details the technical steps for extracting shared DAG utility functio
 - Update the DAG orchestration scripts and their tests to import and use the new module.
 
 ## Next Steps
-- [ ] Tech Lead: Write Tasks to implement the file creation, extraction, test writing, and test updates.
+- [x] Tech Lead: Write Tasks to implement the file creation, extraction, test writing, and test updates.
+  - [.foundry/tasks/task-090-148-extract-dag-utils-impl.md](.foundry/tasks/task-090-148-extract-dag-utils-impl.md)
+  - [.foundry/tasks/task-090-149-extract-dag-utils-qa.md](.foundry/tasks/task-090-149-extract-dag-utils-qa.md)
 
 ## Acceptance Criteria
 - [ ] `dag-utils.ts` is created containing `todayISO`, `logToJournal`, `buildReverseDependencyGraph`, and `getOrphanedNodes`.

--- a/.foundry/tasks/task-090-148-extract-dag-utils-impl.md
+++ b/.foundry/tasks/task-090-148-extract-dag-utils-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-090-148-extract-dag-utils-impl
+type: TASK
+title: Implement DAG Utilities Extraction
+status: PENDING
+owner_persona: coder
+created_at: "2026-06-04"
+updated_at: "2026-06-04"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-053-090-extract-dag-utilities
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: "Spawned from story-053-090-extract-dag-utilities"
+---
+
+# Implement DAG Utilities Extraction
+
+## 1. Introduction
+This task requires extracting shared DAG utility functions from existing orchestrator scripts (`foundry-orchestrator.ts` and `foundry-heartbeat.ts`) into a new shared module `dag-utils.ts` in `.github/scripts/`.
+
+## 2. Technical Specs
+- Create `.github/scripts/dag-utils.ts`.
+- Extract basic utility functions (`todayISO`, `logToJournal`).
+- Extract pure DAG traversal functions (`buildReverseDependencyGraph`, `getOrphanedNodes`).
+- Create `.github/scripts/dag-utils.test.ts` with unit tests for the extracted logic.
+- Update `foundry-orchestrator.ts`, `foundry-heartbeat.ts` and their respective tests to import and use the new module.
+
+## Acceptance Criteria
+- [ ] `dag-utils.ts` is created and contains the extracted functions.
+- [ ] Appropriate unit tests are added in `dag-utils.test.ts`.
+- [ ] Existing functionality works seamlessly utilizing the new utility file.
+
+**Important Instructions:**
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-090-149-extract-dag-utils-qa.md
+++ b/.foundry/tasks/task-090-149-extract-dag-utils-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-090-149-extract-dag-utils-qa
+type: TASK
+title: QA DAG Utilities Extraction
+status: PENDING
+owner_persona: qa
+created_at: "2026-06-04"
+updated_at: "2026-06-04"
+depends_on:
+  - .foundry/tasks/task-090-148-extract-dag-utils-impl.md
+jules_session_id: null
+pr_number: null
+parent: story-053-090-extract-dag-utilities
+tags:
+  - qa
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: "Spawned from story-053-090-extract-dag-utilities"
+---
+
+# QA DAG Utilities Extraction
+
+## 1. Introduction
+This task requires verifying the DAG utility extraction implemented in `.foundry/tasks/task-090-148-extract-dag-utils-impl.md`.
+
+## 2. Verification Steps
+- Verify that `.github/scripts/dag-utils.ts` has been created and exports the necessary utility functions.
+- Verify that unit tests were created in `.github/scripts/dag-utils.test.ts`.
+- Run tests (`cd .github/scripts && pnpm install && npx vitest`) and ensure everything passes.
+- Verify that `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts` successfully import and use these utilities.
+
+## Acceptance Criteria
+- [ ] `dag-utils.ts` is verified to contain extracted functions.
+- [ ] `dag-utils.test.ts` is verified to test the logic correctly.
+- [ ] All orchestrator script tests pass without issue.
+- [ ] Old implementations of the utility functions are removed from their original files.
+
+**Important Instructions:**
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you reject the implementation, update the target task's YAML frontmatter to `status: FAILED`, provide a `rejection_reason`, and log the rejection in the QA journal.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
As the Tech Lead, I have created two tasks spawned from `story-053-090-extract-dag-utilities`:

1. `task-090-148-extract-dag-utils-impl`: A task for the `coder` to implement the extraction of `dag-utils.ts` and its tests.
2. `task-090-149-extract-dag-utils-qa`: A verification task for the `qa` persona to validate the extraction.

I have also appended these new tasks to the story's body and updated the 'Next Steps' checkbox, leaving the parent story's state unchanged per the DAG constraints. All schema verifications passed.

---
*PR created automatically by Jules for task [16307409931802552651](https://jules.google.com/task/16307409931802552651) started by @szubster*