### PR TITLE
Draft Gen 1 species validity tasks

### DIFF
--- a/.foundry/stories/story-051-088-gen1-species-validity.md
+++ b/.foundry/stories/story-051-088-gen1-species-validity.md
@@ -28,3 +28,7 @@ Implement the logic to determine if a Generation 2 Pokémon is a valid Generatio
 
 ## Scope
 - Create a utility function to validate species ID against Generation 1 species.
+
+## Implementation Tasks
+- [ ] Implement Gen 1 species validity check (`.foundry/tasks/task-088-148-gen1-species-validity-impl.md`)
+- [ ] QA Gen 1 species validity check (`.foundry/tasks/task-088-149-gen1-species-validity-qa.md`)

--- a/.foundry/tasks/task-088-148-gen1-species-validity-impl.md
+++ b/.foundry/tasks/task-088-148-gen1-species-validity-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-088-148-gen1-species-validity-impl
+type: TASK
+title: Implement Gen 1 species validity check
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-04'
+updated_at: '2026-06-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-051-088-gen1-species-validity
+tags:
+  - feature
+  - gen2
+  - trade
+  - tool
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 1 species validity check
+
+## Objective
+Implement the logic to determine if a Generation 2 Pokémon is a valid Generation 1 species.
+
+## Contract
+- Create a utility function (e.g., `isGen1Species(pokemonId)`) that takes a Pokémon ID and returns a boolean.
+- Gen 1 species are those with IDs from 1 to 151 inclusive.
+- Write unit tests for this function, ensuring it handles edge cases (e.g., ID 0, ID 151, ID 152).
+- Do not modify architectural constraints (ADR 001).
+- Ensure any missing types or type errors are corrected, and `pnpm type-check` passes.
+- Do NOT use the `msgpackr` PokeData properties, as this is a simple integer check based on species IDs.
+- Run `pnpm test` to verify the tests pass.
+
+## Notes for Coder
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Utility function implemented.
+- [ ] Unit tests pass.
+- [ ] `pnpm type-check` passes.

--- a/.foundry/tasks/task-088-149-gen1-species-validity-qa.md
+++ b/.foundry/tasks/task-088-149-gen1-species-validity-qa.md
@@ -1,0 +1,43 @@
+---
+id: task-088-149-gen1-species-validity-qa
+type: TASK
+title: QA Gen 1 species validity check
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-04'
+updated_at: '2026-06-04'
+depends_on:
+  - .foundry/tasks/task-088-148-gen1-species-validity-impl.md
+jules_session_id: null
+pr_number: null
+parent: story-051-088-gen1-species-validity
+tags:
+  - feature
+  - gen2
+  - trade
+  - tool
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 1 species validity check
+
+## Objective
+Verify the implementation of the Generation 1 species validity check.
+
+## Verification Steps
+- Check that the function correctly identifies Gen 1 species (IDs 1-151) and rejects others.
+- Ensure that unit tests exist and cover edge cases.
+- Run `pnpm test` to confirm tests pass.
+- Run `pnpm type-check` to confirm no type regressions.
+
+## Notes for QA
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you reject the Coder's implementation, update the target task's `status` to `FAILED` and provide a `rejection_reason`, and increment its `rejection_count`. Update the markdown body of this task to reflect the rejection.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Functionality verified.
+- [ ] Tests verified.


### PR DESCRIPTION
Drafted implementation and QA tasks for determining Gen 1 species validity. Appended to the parent story `story-051-088-gen1-species-validity.md` as unchecked items. Checked node schemas.

---
*PR created automatically by Jules for task [7657600701761297450](https://jules.google.com/task/7657600701761297450) started by @szubster*