### PR TITLE
feat(foundry): generate epics for missing hidden items finder

### DIFF
--- a/.foundry/epics/epic-037-058-hidden-items-save-parsing.md
+++ b/.foundry/epics/epic-037-058-hidden-items-save-parsing.md
@@ -1,0 +1,38 @@
+---
+id: epic-037-058-hidden-items-save-parsing
+type: EPIC
+title: Parse Hidden Item Event Flags
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-04'
+updated_at: '2026-06-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-068-037-hidden-items-finder
+tags:
+  - feature
+  - tool
+  - quality-of-life
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Parse Hidden Item Event Flags
+
+## 1. Context & Background
+This Epic corresponds to the first requirement in the Missing Hidden Items Finder PRD (`prd-068-037-hidden-items-finder`). We need to extend the existing save parsing engines to read the underlying event flags for hidden items across Gen 1, Gen 2, and Gen 3.
+
+## 2. Product Requirements
+- Extend the Gen 1 save parsing engine to read the hidden item event flags.
+- Extend the Gen 2 save parsing engine to read the hidden item event flags.
+- Extend the Gen 3 save parsing engine to read the hidden item event flags.
+- Ensure the parsed flags can be mapped to known hidden item locations in each game.
+
+## 3. Acceptance Criteria
+- [ ] Save parsing engine successfully extracts event flags for Gen 1 hidden items.
+- [ ] Save parsing engine successfully extracts event flags for Gen 2 hidden items.
+- [ ] Save parsing engine successfully extracts event flags for Gen 3 hidden items.
+- [ ] Appropriate unit tests are added for the save parser extensions.

--- a/.foundry/epics/epic-037-059-hidden-items-data-layer.md
+++ b/.foundry/epics/epic-037-059-hidden-items-data-layer.md
@@ -1,0 +1,35 @@
+---
+id: epic-037-059-hidden-items-data-layer
+type: EPIC
+title: Hidden Items Data Structure & Aggregation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-04'
+updated_at: '2026-06-04'
+depends_on:
+  - epic-037-058-hidden-items-save-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-068-037-hidden-items-finder
+tags:
+  - feature
+  - tool
+  - quality-of-life
+  - data
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Hidden Items Data Structure & Aggregation
+
+## 1. Context & Background
+This Epic corresponds to the second requirement in the Missing Hidden Items Finder PRD (`prd-068-037-hidden-items-finder`). We need to structure the parsed event flags mapping to locations and item types, and prepare it for UI consumption.
+
+## 2. Product Requirements
+- Define a structured data model to represent hidden item details: location, item type, and whether it has been acquired (based on the save state).
+- Ensure the data can easily be mapped and filtered.
+
+## 3. Acceptance Criteria
+- [ ] Data model accurately maps hidden items to location and type.
+- [ ] Data aggregation allows logical mapping and filtering of the parsed hidden item event flags.

--- a/.foundry/epics/epic-037-060-hidden-items-ui.md
+++ b/.foundry/epics/epic-037-060-hidden-items-ui.md
@@ -1,0 +1,38 @@
+---
+id: epic-037-060-hidden-items-ui
+type: EPIC
+title: Missing Hidden Items Finder UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-04'
+updated_at: '2026-06-04'
+depends_on:
+  - epic-037-059-hidden-items-data-layer
+jules_session_id: null
+pr_number: null
+parent: prd-068-037-hidden-items-finder
+tags:
+  - feature
+  - tool
+  - quality-of-life
+  - ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Missing Hidden Items Finder UI
+
+## 1. Context & Background
+This Epic corresponds to the third requirement in the Missing Hidden Items Finder PRD (`prd-068-037-hidden-items-finder`). We need to present the unified, dynamic checklist to the user in a dedicated view within DexHelper.
+
+## 2. Product Requirements
+- Create a dedicated "Missing Hidden Items Finder" view within DexHelper.
+- Display a categorized checklist of valuable hidden items (grouped by route, town, or region).
+- Dynamically check off items that the player has already picked up in their current save file.
+- Implement the 'tactical hardware/snooping' aesthetic (sharp edges, dashed borders, monospaced telemetry fonts) for this component as defined in ADR 008.
+
+## 3. Acceptance Criteria
+- [ ] UI component is built displaying the checklist, filtered and grouped logically.
+- [ ] UI updates dynamically to check off acquired items upon save file hydration.
+- [ ] E2E tests verify the new view correctly renders based on an initialized save state.

--- a/.foundry/prds/prd-068-037-hidden-items-finder.md
+++ b/.foundry/prds/prd-068-037-hidden-items-finder.md
@@ -51,3 +51,8 @@ As DexHelper already parses the save file, we can read the underlying event flag
 - [ ] UI updates dynamically to check off acquired items upon save file hydration.
 - [ ] Appropriate unit tests are added for the save parser extensions.
 - [ ] E2E tests verify the new view correctly renders based on an initialized save state.
+
+## 4. Generated Epics
+- [Parse Hidden Item Event Flags](../epics/epic-037-058-hidden-items-save-parsing.md)
+- [Hidden Items Data Structure & Aggregation](../epics/epic-037-059-hidden-items-data-layer.md)
+- [Missing Hidden Items Finder UI](../epics/epic-037-060-hidden-items-ui.md)


### PR DESCRIPTION
Generated epics based on the PRD `prd-068-037-hidden-items-finder`.

The epics are:
- `epic-037-058-hidden-items-save-parsing`
- `epic-037-059-hidden-items-data-layer`
- `epic-037-060-hidden-items-ui`

Dependencies between the epics have been setup properly using node IDs instead of file paths. The PRD has been updated to include references to the generated epics. Checkboxes in the PRD remain unchecked per rule requirements.

---
*PR created automatically by Jules for task [17022816590318221252](https://jules.google.com/task/17022816590318221252) started by @szubster*