### PR TITLE
Generate PRDs for Gen 3 Mirage Island Predictor

### DIFF
--- a/.foundry/ideas/idea-068-mirage-island-predictor.md
+++ b/.foundry/ideas/idea-068-mirage-island-predictor.md
@@ -36,3 +36,7 @@ This feature transforms an almost impossible-to-find easter egg into a determini
 
 ## Next Steps
 - [ ] Product Manager: Convert this idea into a PRD detailing how to extract the daily Mirage Island value and the UI for alerting the player.
+
+### Generated PRDs
+- [ ] `.foundry/prds/prd-068-038-mirage-island-data-extraction.md`
+- [ ] `.foundry/prds/prd-068-039-mirage-island-ui-alerts.md`

--- a/.foundry/prds/prd-068-038-mirage-island-data-extraction.md
+++ b/.foundry/prds/prd-068-038-mirage-island-data-extraction.md
@@ -1,0 +1,40 @@
+---
+id: prd-068-038-mirage-island-data-extraction
+type: PRD
+title: Extract Gen 3 Mirage Island Value
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-04'
+updated_at: '2026-06-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-068-mirage-island-predictor
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extract Gen 3 Mirage Island Value
+
+## Context
+As defined in `idea-068-mirage-island-predictor`, we need to implement a predictor for Mirage Island in Gen 3 games (Ruby, Sapphire, Emerald). Mirage Island appears if the game's daily Mirage Island value matches the lower two bytes of the personality value of any Pokémon in the player's party. This feature will give players the ability to scan their entire PC box.
+
+## Requirements
+
+1. **Save File Parsing**: Update the save parser engine to extract the daily Mirage Island value. This value is likely stored in the save file's daily/random variables block. As per ADR 010, `DataView` must be strictly used for all parsing logic to ensure robustness against out-of-bounds reads.
+2. **Personality Value Extraction**: We already extract Pokémon data. Ensure that the full 32-bit personality value (or specifically the lower 16 bits) is correctly parsed and made available for every Pokémon in the PC boxes.
+3. **Data Hydration**: Expose the parsed daily Mirage Island value and the relevant Pokémon personality value segments in the unified application state (`PokeDB` or equivalent) for consumption by the suggestion engine or UI controllers.
+
+## Constraints
+- The implementation must strictly adhere to the `DataView` API for all new save parsing logic as mandated by ADR 010.
+- Ensure graceful error handling if the save file is corrupted or truncated.
+- The parsed value should be included in the unified data payload and must maintain backwards compatibility with Gen 1 and Gen 2 files.
+
+## Acceptance Criteria
+- [ ] Epic Planner: Generate child epics that implement the save file parsing updates and the application state hydration.

--- a/.foundry/prds/prd-068-039-mirage-island-ui-alerts.md
+++ b/.foundry/prds/prd-068-039-mirage-island-ui-alerts.md
@@ -1,0 +1,43 @@
+---
+id: prd-068-039-mirage-island-ui-alerts
+type: PRD
+title: Gen 3 Mirage Island UI Alerts
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-04'
+updated_at: '2026-06-04'
+depends_on:
+  - .foundry/prds/prd-068-038-mirage-island-data-extraction.md
+jules_session_id: null
+pr_number: null
+parent: idea-068-mirage-island-predictor
+tags:
+  - feature
+  - gen3
+  - mirage-island
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Mirage Island UI Alerts
+
+## Context
+Following the extraction of the Gen 3 Mirage Island daily value (`prd-068-038-mirage-island-data-extraction`), we need to build the user interface to notify players when they own a Pokémon in their PC box that matches the required value to trigger Mirage Island.
+
+## Requirements
+
+1. **PC Scanner Logic**: Implement a client-side utility or hook that continuously (or on state change) scans all boxed Pokémon and the current party. It should identify any Pokémon whose lower 16 bits of their personality value match the current daily Mirage Island value.
+2. **Alert Component**: Design and implement a notification or alert component that is prominently displayed on the dashboard when a matching Pokémon is found. This alert should clearly state:
+   - That Mirage Island can be triggered today.
+   - Which specific Pokémon (species, nickname, box location) has the matching personality value.
+3. **Empty State / Negative State**: When no matching Pokémon is found, there should be a subtle indication (or no indication) that the scan was performed, without cluttering the UI.
+
+## Constraints
+- The UI must strictly follow the "tactical hardware/snooping" aesthetic as defined in ADR 008 (sharp edges, dashed borders, monospaced fonts).
+- Ensure the alert logic is performant and does not lock the React UI thread, especially given the potentially large number of Pokémon to scan.
+
+## Acceptance Criteria
+- [ ] Epic Planner: Generate child epics that implement the PC scanner logic and the alert component adhering to the tactical aesthetic constraints.


### PR DESCRIPTION
This PR transforms the `idea-068-mirage-island-predictor` IDEA node into two granular PRD nodes:
1. `prd-068-038-mirage-island-data-extraction`
2. `prd-068-039-mirage-island-ui-alerts`

The new PRD nodes correctly link their parent IDEA and are assigned the `epic_planner` persona for the next pipeline transition. The parent IDEA node has been updated to list the generated PRD files as unchecked checkboxes in the `Next Steps` section, avoiding premature verification of the IDEA until the newly generated PRDs are `COMPLETED`.

---
*PR created automatically by Jules for task [5172218851878523942](https://jules.google.com/task/5172218851878523942) started by @szubster*