### PR TITLE
Epic Planner: Generate Unown Tracker Epics

### DIFF
--- a/.foundry/epics/epic-037-058-unown-tracker-engine.md
+++ b/.foundry/epics/epic-037-058-unown-tracker-engine.md
@@ -1,0 +1,39 @@
+---
+id: epic-037-058-unown-tracker-engine
+type: EPIC
+title: Unown Form Tracker Engine Updates
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-06-04"
+updated_at: "2026-06-04"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-068-037-unown-tracker
+tags:
+  - feature
+  - gen2
+  - tracking
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Unown Form Tracker Engine Updates
+
+## Objective
+Enhance the Gen 2 save parser to correctly identify and expose Unown forms.
+
+## Logic
+For Unown (`speciesId` 201) in Gen 2, determine the form by extracting the middle 2 bits of the Attack, Defense, Speed, and Special DVs. Combine them into an 8-bit integer and calculate modulo 28. (0-25 correspond to forms A-Z).
+
+## Output
+The parser must append an `unownForm` property (e.g., `'A'`, `'B'`) to the parsed Pokemon instance structure so it can be consumed by the UI.
+
+## Testing
+Requires unit tests verifying the exact bitwise calculation against known DV combinations for Unown forms.
+
+## Acceptance Criteria
+- [ ] Story for parser logic created.
+- [ ] Story for parser unit tests created.

--- a/.foundry/epics/epic-037-059-unown-tracker-ui.md
+++ b/.foundry/epics/epic-037-059-unown-tracker-ui.md
@@ -1,0 +1,41 @@
+---
+id: epic-037-059-unown-tracker-ui
+type: EPIC
+title: Unown Form Tracker UI Updates
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-06-04"
+updated_at: "2026-06-04"
+depends_on:
+  - epic-037-058-unown-tracker-engine
+jules_session_id: null
+pr_number: null
+parent: prd-068-037-unown-tracker
+tags:
+  - feature
+  - gen2
+  - tracking
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Unown Form Tracker UI Updates
+
+## Objective
+Surface the parsed Unown forms in the user interface to provide a checklist.
+
+## Logic
+Add a dedicated "Unown Dex" panel or filter within the existing Storage Viewer.
+
+## Display
+It should visually represent which of the 26 Gen 2 forms are currently owned by the player (in Party or PC) and which are missing.
+
+## Design Constraints
+Must adhere strictly to the "tactical hardware/snooping" aesthetic (`rounded-none`, dashed borders, monospace fonts) as defined in ADR 008.
+
+## Acceptance Criteria
+- [ ] Story for Unown Dex panel UI created.
+- [ ] Story for Unown Dex panel data integration created.

--- a/.foundry/prds/prd-068-037-unown-tracker.md
+++ b/.foundry/prds/prd-068-037-unown-tracker.md
@@ -42,5 +42,5 @@ To ensure granular execution and minimize complexity, this PRD should be broken 
 - **Design Constraints**: Must adhere strictly to the "tactical hardware/snooping" aesthetic (`rounded-none`, dashed borders, monospace fonts) as defined in ADR 008.
 
 ## Acceptance Criteria
-- [ ] Epic 1 (Engine Updates) node created.
-- [ ] Epic 2 (UI Updates) node created.
+- [x] Epic 1 (Engine Updates) node created. (.foundry/epics/epic-037-058-unown-tracker-engine.md)
+- [x] Epic 2 (UI Updates) node created. (.foundry/epics/epic-037-059-unown-tracker-ui.md)


### PR DESCRIPTION
Broke down the Unown Tracker PRD (`prd-068-037-unown-tracker`) into two actionable Epic nodes (`epic-037-058-unown-tracker-engine`, `epic-037-059-unown-tracker-ui`). Checked off the acceptance criteria within the PRD to mark generation as complete without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [7483780772996906755](https://jules.google.com/task/7483780772996906755) started by @szubster*