### PR TITLE
Update implicit dependency check to include CANCELLED

### DIFF
--- a/.foundry/tasks/task-086-146-impl-implicit-dependency-check.md
+++ b/.foundry/tasks/task-086-146-impl-implicit-dependency-check.md
@@ -28,6 +28,6 @@ If you abort or permanently fail a task, you MUST update the YAML frontmatter to
 If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Update `isHierarchicallyIncomplete` or node resolution logic in `foundry-orchestrator.ts` to ensure that a parent node isn't ready if its descendant tree has any nodes not in the COMPLETED or CANCELLED state.
-- [ ] Update `isHierarchicallyIncomplete` to accept `CANCELLED` state as complete.
-- [ ] Add unit tests in `foundry-orchestrator.test.ts` to verify that `CANCELLED` nodes satisfy hierarchical completeness, and that descendant trees are properly checked.
+- [x] Update `isHierarchicallyIncomplete` or node resolution logic in `foundry-orchestrator.ts` to ensure that a parent node isn't ready if its descendant tree has any nodes not in the COMPLETED or CANCELLED state.
+- [x] Update `isHierarchicallyIncomplete` to accept `CANCELLED` state as complete.
+- [x] Add unit tests in `foundry-orchestrator.test.ts` to verify that `CANCELLED` nodes satisfy hierarchical completeness, and that descendant trees are properly checked.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -208,6 +208,37 @@ describe('foundry-orchestrator', () => {
     expect(epicChar).toContain('status: PENDING');
   });
 
+  test('Hierarchical Completion: considers CANCELLED nodes as complete', () => {
+    createValidTestNode(tmpDir, '.foundry/tasks/task-001.md', {
+      id: "task-001",
+      type: "TASK",
+      title: "Task 1",
+      status: "CANCELLED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-002.md', {
+      id: "task-002",
+      type: "TASK",
+      title: "Task 2",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/tasks/task-001.md"],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-002.md'), 'utf-8');
+    expect(result).toContain('status: READY');
+  });
+
   test('Hierarchical Completion: blocks external dependent if dependency has incomplete children', () => {
     // Story 1: COMPLETED (Planned)
     createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -472,7 +472,7 @@ function main(): void {
       return true;
     }
 
-    if (node.frontmatter.status !== 'COMPLETED') {
+    if (node.frontmatter.status !== 'COMPLETED' && node.frontmatter.status !== 'CANCELLED') {
       evalCache.set(cacheKey, true);
       return true;
     }
@@ -783,7 +783,7 @@ function main(): void {
         // Parent is PENDING and has children. Check if ALL children are COMPLETED.
         let allChildrenCompleted = true;
         for (const child of children) {
-          if (child.frontmatter.status !== 'COMPLETED') {
+          if (child.frontmatter.status !== 'COMPLETED' && child.frontmatter.status !== 'CANCELLED') {
             allChildrenCompleted = false;
             break;
           }


### PR DESCRIPTION
Update implicit dependency check to include CANCELLED

Modified `isHierarchicallyIncomplete` and the Late-Binding Completion logic
in `.github/scripts/foundry-orchestrator.ts` to treat the `CANCELLED` status
as complete, ensuring that parent nodes and dependents aren't unnecessarily
blocked by cancelled tasks. Added corresponding unit tests in
`.github/scripts/foundry-orchestrator.test.ts` and checked off acceptance
criteria in the task node.

---
*PR created automatically by Jules for task [17640303790917484763](https://jules.google.com/task/17640303790917484763) started by @szubster*