### PR TITLE
Update implicit dependency check to include CANCELLED

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -543,6 +543,37 @@ describe('foundry-orchestrator', () => {
     expect(task2Result).toContain('status: COMPLETED');
   });
 
+  test('Hierarchical completeness considers CANCELLED nodes as complete', () => {
+    createValidTestNode(tmpDir, '.foundry/epics/epic-cancelled.md', {
+      id: "epic-cancelled",
+      type: "EPIC",
+      title: "Cancelled Epic",
+      status: "CANCELLED",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null
+    });
+
+    createValidTestNode(tmpDir, '.foundry/stories/story-dependent.md', {
+      id: "story-dependent",
+      type: "STORY",
+      title: "Story Dependent on Cancelled Epic",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: ["epic-cancelled"],
+      jules_session_id: null
+    });
+
+    main();
+
+    const storyResult = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-dependent.md'), 'utf-8');
+    expect(storyResult).toContain('status: READY');
+  });
+
   test('Deep Hierarchical Completion: blocks external dependent if dependency has deep incomplete children', () => {
     // Story 1: COMPLETED
     createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -472,7 +472,7 @@ function main(): void {
       return true;
     }
 
-    if (node.frontmatter.status !== 'COMPLETED') {
+    if (node.frontmatter.status !== 'COMPLETED' && node.frontmatter.status !== 'CANCELLED') {
       evalCache.set(cacheKey, true);
       return true;
     }


### PR DESCRIPTION
Update implicit dependency check to include CANCELLED

Modify `isHierarchicallyIncomplete` or node resolution logic in `.github/scripts/foundry-orchestrator.ts` to return `true` if the node's status is neither `COMPLETED` nor `CANCELLED`. Ensure that a parent node isn't ready if its descendant tree has any nodes not in the COMPLETED or CANCELLED state.

---
*PR created automatically by Jules for task [5214529145340645108](https://jules.google.com/task/5214529145340645108) started by @szubster*