### PR TITLE
🗿 Sculptor: Extract PokemonStatusBadge component

### DIFF
--- a/.jules/sculptor.md
+++ b/.jules/sculptor.md
@@ -4,3 +4,5 @@
 - AI Readability Impact: Extracts dense, duplicated tailwind classes (with inline ternary operators) into a unified and reusable component. Simplifies JSX trees and standardizes semantic markup (`role="radiogroup"` / `role="radio"`) without needing linter disables.
 - Created `TacticalMultiSelectControl` component based off `TacticalSegmentedControl` to correctly handle multi-select toggle states (using sets) without hacking mutually exclusive components.
 - AI Readability Impact: Avoids hacking single-select components with `selectedValue=""` which breaks ARIA accessibility and test IDs. Using an explicit multi-select control cleanly separates single vs multi-choice patterns in code logic and simplifies filter panel markup.
+Created `PokemonStatusBadge` component to encapsulate and replace deeply nested, duplicated ternary logic for rendering SECURED/DEX_ONLY/SEEN/UNKNOWN badges in `PokedexCard.tsx`.
+AI Readability Impact: Extracts multi-layered inline `cn()` conditional rendering into an isolated component with explicit early returns. Simplifies the main card JSX and improves structural separation for AI reasoning, making state-to-UI mappings obvious.

--- a/src/components/PokedexCard.tsx
+++ b/src/components/PokedexCard.tsx
@@ -6,6 +6,7 @@ import { cn } from '../utils/cn';
 import type { PokemonListItem } from '../utils/pokemonQueries';
 import { LcdGrid } from './LcdGrid';
 import { PokemonSprite } from './pokemon/PokemonSprite';
+import { PokemonStatusBadge } from './pokemon/PokemonStatusBadge';
 import { TacticalCard } from './TacticalCard';
 
 interface PokedexCardProps {
@@ -126,41 +127,12 @@ export const PokedexCard = React.memo(function PokedexCard({
 
         {saveData && (
           <div className="flex justify-center">
-            {hasInStorage ? (
-              <div
-                className={cn(
-                  'flex items-center gap-1.5 rounded-none border border-dashed px-2.5 py-1',
-                  isShiny ? 'border-amber-500/50 bg-amber-500/10' : 'border-emerald-500/50 bg-emerald-500/10',
-                )}
-              >
-                <span
-                  className={cn(
-                    'font-black font-mono text-[8px] uppercase tracking-widest',
-                    isShiny ? 'text-amber-400' : 'text-emerald-400',
-                  )}
-                >
-                  [ SECURED ]
-                </span>
-              </div>
-            ) : isOwnedInDex ? (
-              <div className="flex items-center gap-1.5 rounded-none border border-amber-500/50 border-dashed bg-amber-500/10 px-2.5 py-1">
-                <span className="font-black font-mono text-[8px] text-amber-400 uppercase tracking-widest">
-                  [ DEX_ONLY ]
-                </span>
-              </div>
-            ) : isSeenInDex ? (
-              <div className="flex items-center gap-1.5 rounded-none border border-rose-500/50 border-dashed bg-rose-500/10 px-2.5 py-1">
-                <span className="font-black font-mono text-[8px] text-rose-400 uppercase tracking-widest">
-                  [ SEEN ]
-                </span>
-              </div>
-            ) : (
-              <div className="flex items-center gap-1.5 rounded-none border border-zinc-700 border-dashed bg-white/5 px-2.5 py-1">
-                <span className="font-black font-mono text-[8px] text-zinc-600 uppercase tracking-widest">
-                  [ UNKNOWN ]
-                </span>
-              </div>
-            )}
+            <PokemonStatusBadge
+              hasInStorage={hasInStorage}
+              isOwnedInDex={isOwnedInDex}
+              isSeenInDex={isSeenInDex}
+              isShiny={isShiny}
+            />
           </div>
         )}
       </div>

--- a/src/components/pokemon/PokemonStatusBadge.tsx
+++ b/src/components/pokemon/PokemonStatusBadge.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+interface PokemonStatusBadgeProps {
+  hasInStorage: boolean;
+  isOwnedInDex: boolean;
+  isSeenInDex: boolean;
+  isShiny: boolean;
+}
+
+export const PokemonStatusBadge = React.memo(function PokemonStatusBadge({
+  hasInStorage,
+  isOwnedInDex,
+  isSeenInDex,
+  isShiny,
+}: PokemonStatusBadgeProps) {
+  if (hasInStorage) {
+    return (
+      <div
+        className={cn(
+          'flex items-center gap-1.5 rounded-none border border-dashed px-2.5 py-1',
+          isShiny ? 'border-amber-500/50 bg-amber-500/10' : 'border-emerald-500/50 bg-emerald-500/10',
+        )}
+      >
+        <span
+          className={cn(
+            'font-black font-mono text-[8px] uppercase tracking-widest',
+            isShiny ? 'text-amber-400' : 'text-emerald-400',
+          )}
+        >
+          [ SECURED ]
+        </span>
+      </div>
+    );
+  }
+
+  if (isOwnedInDex) {
+    return (
+      <div className="flex items-center gap-1.5 rounded-none border border-amber-500/50 border-dashed bg-amber-500/10 px-2.5 py-1">
+        <span className="font-black font-mono text-[8px] text-amber-400 uppercase tracking-widest">[ DEX_ONLY ]</span>
+      </div>
+    );
+  }
+
+  if (isSeenInDex) {
+    return (
+      <div className="flex items-center gap-1.5 rounded-none border border-rose-500/50 border-dashed bg-rose-500/10 px-2.5 py-1">
+        <span className="font-black font-mono text-[8px] text-rose-400 uppercase tracking-widest">[ SEEN ]</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 rounded-none border border-zinc-700 border-dashed bg-white/5 px-2.5 py-1">
+      <span className="font-black font-mono text-[8px] text-zinc-600 uppercase tracking-widest">[ UNKNOWN ]</span>
+    </div>
+  );
+});


### PR DESCRIPTION
🎯 What
Extracted the deeply nested ternary rendering logic for status badges from `PokedexCard.tsx` into a dedicated `PokemonStatusBadge` component.

💡 Why (AI Readability Impact)
`PokedexCard` had complex inline conditional rendering using `cn()` for four different states (SECURED, DEX_ONLY, SEEN, UNKNOWN) which bloated the component. Extracting this to an isolated component with explicit early returns simplifies the main card JSX and improves structural separation for AI reasoning.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no regressions.

✨ Result
Simplified `PokedexCard` and introduced a reusable, easily readable `PokemonStatusBadge` component.

---
*PR created automatically by Jules for task [4793832897129787824](https://jules.google.com/task/4793832897129787824) started by @szubster*