### PR TITLE
🧭 Strategist: Prompt improvement - Require Strategist to read core policies and ADRs

### DIFF
--- a/.github/agents/strategist.md
+++ b/.github/agents/strategist.md
@@ -18,6 +18,7 @@ The current agent roster lives in `.github/agents/`. Before proposing anything, 
 
 **Always:**
 - Read your journal before starting — it's your only memory
+- Explicitly read `.foundry/docs/knowledge_base/agents/core_policies.md` and `.foundry/docs/adrs/` to understand centralized policies and architectural constraints before assessing prompt quality.
 - Include a journal entry for the current change in every PR you open. Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability.
 - Read all files in `.github/agents/` before proposing anything
 - Review agent journals (`.jules/*.md`, `.foundry/journals/*.md`) to assess prompt effectiveness instead of searching git or PR history

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -177,3 +177,9 @@
 **Outcome:** Accepted
 **Why:** The Auditor journal showed that macro nodes (e.g. PRDs) were transitioning to VERIFYING prematurely when their immediate Acceptance Criteria (spawning child nodes) were met, leading to false progress signaling. Product Manager missed this explicit rule which the other planners already had. Auditor also needed explicit instructions to enforce this constraint.
 **Pattern:** Ensure all persona prompts involved in macroscopic planning (IDEA, PRD, EPIC, STORY) and auditing explicitly enforce the dependency graph constraint that a parent node must wait for all child execution nodes to finish before it can transition to VERIFYING or COMPLETED.
+
+## 2026-07-10 - [Accepted] - Prompt improvement - Require Strategist to read core policies and ADRs
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The Strategist's own prompt lacked instructions to read the centralized `.foundry/docs/knowledge_base/agents/core_policies.md` and `.foundry/docs/adrs/` documents. Without this context, the Strategist could not effectively assess if other agents were violating core policies, and risked proposing duplicate or conflicting rules that were already centralized.
+**Pattern:** Ensure meta-agents that evaluate and modify prompts have explicit instructions to read centralized policy and architecture documents so they understand the system's baseline constraints.


### PR DESCRIPTION
**Proposal**: Add explicit instructions for the Strategist to read `.foundry/docs/knowledge_base/agents/core_policies.md` and `.foundry/docs/adrs/`.
**Justification**: The Strategist lacked context of the centralized rules. Without this, it could duplicate policies in agent prompts or fail to spot violations of ADRs when reviewing agent journals.
**Evidence**: Previous Strategist journal entries noted the importance of centralizing policies to conserve context. The lack of core policy instructions in the Strategist's own prompt is a gap that prevents effective review of prompt quality.

---
*PR created automatically by Jules for task [14005841885316374723](https://jules.google.com/task/14005841885316374723) started by @szubster*