### PR TITLE
test: QA sign-off for shiny carrier parsing and test suite fixes

### DIFF
--- a/.foundry/tasks/task-083-147-flag-shiny-carriers-qa.md
+++ b/.foundry/tasks/task-083-147-flag-shiny-carriers-qa.md
@@ -36,7 +36,7 @@ Verify that the `isShinyCarrier` boolean property is correctly populated when pa
 2. Ensure the property appears properly structured in the output data.
 
 ## Acceptance Criteria
-- [ ] Manual or automated verification confirms `isShinyCarrier` is correctly populated for Shiny Carriers and is missing/false for others.
+- [x] Manual or automated verification confirms `isShinyCarrier` is correctly populated for Shiny Carriers and is missing/false for others.
 
 ## Reminder for Coder and QA
 - If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
@@ -218,7 +218,7 @@ describe('AssistantSuggestionCard', () => {
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 30, minLevel: 6, maxLevel: 6 },
           { aid: 0, method: 'walk', chance: 20, minLevel: 7, maxLevel: 7 },
-        ]
+        ],
       },
     };
 
@@ -246,8 +246,7 @@ describe('AssistantSuggestionCard', () => {
       title: 'Catch an unknown mon',
       description: 'Find it if you can.',
       pokemonIds: [10],
-      encounterInfo: {
-      },
+      encounterInfo: {},
     };
 
     const areaNames = { 0: 'Route 1' };
@@ -262,6 +261,8 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+
+    await expect.element(page.getByText('Catch an unknown mon')).toBeVisible();
   });
 
   it('renders correctly when one of the encounter chances is equal to mainEnc chance', async () => {
@@ -276,7 +277,7 @@ describe('AssistantSuggestionCard', () => {
         10: [
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 10, minLevel: 6, maxLevel: 6 },
-        ]
+        ],
       },
     };
 
@@ -292,6 +293,8 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+
+    await expect.element(page.getByText('Catch an equal mon')).toBeVisible();
   });
 
   it('renders correctly when category is not catch and pokemonIds exist', async () => {
@@ -313,5 +316,7 @@ describe('AssistantSuggestionCard', () => {
         getPokemonName={mockGetPokemonName}
       />,
     );
+
+    await expect.element(page.getByText('Evolve something')).toBeVisible();
   });
 });


### PR DESCRIPTION
Completed QA verification for the shiny carrier data parsing feature.

- Tests successfully assert that the new shiny tracking properties are exposed accurately through the data engines (`src/engine/saveParser/parsers/common.test.ts`, etc.).
- Encountered a missing-assertion testing failure in an unrelated test suite (`src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx`), so added the appropriate assertions to get CI passing and verified project health.
- Checked the `[x]` acceptance criteria box within the markdown body of `.foundry/tasks/task-083-147-flag-shiny-carriers-qa.md`.

Submitting changes as a verified Empty PR pipeline update to conclude the task logic.

---
*PR created automatically by Jules for task [17927300998962807055](https://jules.google.com/task/17927300998962807055) started by @szubster*