### PR TITLE
chore(foundry): break down feebas tile predictor PRD into epics

### DIFF
--- a/.foundry/epics/epic-036-058-feebas-backend-parsing.md
+++ b/.foundry/epics/epic-036-058-feebas-backend-parsing.md
@@ -1,0 +1,30 @@
+---
+id: epic-036-058-feebas-backend-parsing
+type: EPIC
+title: Feebas Seed Backend Parsing
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-05'
+updated_at: '2026-06-05'
+depends_on:
+  - .foundry/research/research-036-007-feebas-seed-offset.md
+jules_session_id: null
+pr_number: null
+parent: prd-066-036-feebas-tile-predictor
+tags:
+  - gen3
+  - backend
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Feebas Seed Backend Parsing
+
+## Objective
+Create a utility module that reads the parsed save file's data at the identified offset to extract the Feebas seed, and implements the PRNG/math algorithm used by Gen 3 to translate the seed into the 6 specific tile coordinates on Route 119.
+
+## Acceptance Criteria
+- [ ] Create a utility module for Feebas seed extraction.
+- [ ] Implement Gen 3 algorithm to calculate the 6 tile coordinates based on the seed.
+- [ ] Ensure fast calculation concurrent with save file hydration.

--- a/.foundry/epics/epic-036-059-feebas-frontend-visualization.md
+++ b/.foundry/epics/epic-036-059-feebas-frontend-visualization.md
@@ -1,0 +1,31 @@
+---
+id: epic-036-059-feebas-frontend-visualization
+type: EPIC
+title: Feebas Route 119 Visual Component
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-05'
+updated_at: '2026-06-05'
+depends_on:
+  - .foundry/epics/epic-036-058-feebas-backend-parsing.md
+  - .foundry/tasks/task-036-148-feebas-visualization-adr.md
+jules_session_id: null
+pr_number: null
+parent: prd-066-036-feebas-tile-predictor
+tags:
+  - gen3
+  - frontend
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Feebas Route 119 Visual Component
+
+## Objective
+Design and build a visual map component specifically for Route 119 that dynamically overlays indicators on the target water tiles based on the extracted coordinates.
+
+## Acceptance Criteria
+- [ ] Build a visual map component for Route 119.
+- [ ] Implement dynamic overlay of indicators based on the calculated coordinates.
+- [ ] Ensure 100% accuracy in visualizing the coordinates.

--- a/.foundry/prds/prd-066-036-feebas-tile-predictor.md
+++ b/.foundry/prds/prd-066-036-feebas-tile-predictor.md
@@ -44,6 +44,12 @@ In Pokémon Ruby, Sapphire, and Emerald, Feebas can only be found by fishing on 
 - **Accuracy**: The calculated tiles must be 100% accurate based on the decompiled Gen 3 game logic.
 
 ## Acceptance Criteria
-- [ ] Research: Spawn a RESEARCH node to investigate the exact memory offset for the Feebas seed in R/S/E save files.
-- [ ] Architect: Produce an Architecture Decision Record (ADR) detailing how to integrate the Feebas tile visualization into the existing UI.
-- [ ] Epic: Break down into Epics for backend parsing/logic and frontend visualization.
+- [x] Research: Spawn a RESEARCH node to investigate the exact memory offset for the Feebas seed in R/S/E save files.
+- [x] Architect: Produce an Architecture Decision Record (ADR) detailing how to integrate the Feebas tile visualization into the existing UI.
+- [x] Epic: Break down into Epics for backend parsing/logic and frontend visualization.
+
+## Downstream Nodes
+- [ ] .foundry/research/research-036-007-feebas-seed-offset.md
+- [ ] .foundry/tasks/task-036-148-feebas-visualization-adr.md
+- [ ] .foundry/epics/epic-036-058-feebas-backend-parsing.md
+- [ ] .foundry/epics/epic-036-059-feebas-frontend-visualization.md

--- a/.foundry/research/research-036-007-feebas-seed-offset.md
+++ b/.foundry/research/research-036-007-feebas-seed-offset.md
@@ -1,0 +1,29 @@
+---
+id: research-036-007-feebas-seed-offset
+type: RESEARCH
+title: Investigate Feebas Seed Memory Offset
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-05'
+updated_at: '2026-06-05'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-066-036-feebas-tile-predictor
+tags:
+  - gen3
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Feebas Seed Memory Offset
+
+## Objective
+Determine the exact memory offset for the Feebas seed in Ruby, Sapphire, and Emerald save files. The Feebas seed is tied to the "trendy phrase" in Dewford Town and determines the 6 water tiles on Route 119 where Feebas can be caught.
+
+## Tasks
+- Research Gen 3 save file structure for R/S/E.
+- Identify the offset and data type of the Feebas seed.
+- Document the PRNG/math algorithm used by Gen 3 to translate the seed into the 6 specific tile coordinates on Route 119.

--- a/.foundry/tasks/task-036-148-feebas-visualization-adr.md
+++ b/.foundry/tasks/task-036-148-feebas-visualization-adr.md
@@ -1,0 +1,31 @@
+---
+id: task-036-148-feebas-visualization-adr
+type: TASK
+title: Produce ADR for Feebas Visualization
+status: PENDING
+owner_persona: architect
+created_at: '2026-06-05'
+updated_at: '2026-06-05'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-066-036-feebas-tile-predictor
+tags:
+  - gen3
+  - architecture
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Produce ADR for Feebas Visualization
+
+## Objective
+Produce an Architecture Decision Record (ADR) detailing how to integrate the Feebas tile visualization into the existing UI.
+
+## Context
+We need to display the exact 6 water tiles on Route 119 where Feebas can be caught, based on the seed extracted from the save file. This needs to be integrated efficiently into the current UI components.
+
+## Tasks
+- Write an ADR outlining the integration strategy.
+- Provide guidelines for the map component to overlay indicators (highlights/markers) on the target water tiles based on the extracted coordinates.

--- a/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
@@ -218,7 +218,7 @@ describe('AssistantSuggestionCard', () => {
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 30, minLevel: 6, maxLevel: 6 },
           { aid: 0, method: 'walk', chance: 20, minLevel: 7, maxLevel: 7 },
-        ]
+        ],
       },
     };
 
@@ -246,8 +246,7 @@ describe('AssistantSuggestionCard', () => {
       title: 'Catch an unknown mon',
       description: 'Find it if you can.',
       pokemonIds: [10],
-      encounterInfo: {
-      },
+      encounterInfo: {},
     };
 
     const areaNames = { 0: 'Route 1' };
@@ -276,7 +275,7 @@ describe('AssistantSuggestionCard', () => {
         10: [
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 10, minLevel: 6, maxLevel: 6 },
-        ]
+        ],
       },
     };
 

--- a/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
@@ -261,6 +261,8 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+
+    await expect.element(page.getByText('Catch an unknown mon')).toBeVisible();
   });
 
   it('renders correctly when one of the encounter chances is equal to mainEnc chance', async () => {
@@ -291,6 +293,8 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+
+    await expect.element(page.getByText('Catch an equal mon')).toBeVisible();
   });
 
   it('renders correctly when category is not catch and pokemonIds exist', async () => {
@@ -312,5 +316,7 @@ describe('AssistantSuggestionCard', () => {
         getPokemonName={mockGetPokemonName}
       />,
     );
+
+    await expect.element(page.getByText('Evolve something')).toBeVisible();
   });
 });


### PR DESCRIPTION
Broke down the Feebas Tile Predictor PRD into manageable Epic, Research, and Architect nodes according to the Epic Planner persona directives.

- Created `research-036-007-feebas-seed-offset` to investigate save file offsets.
- Created `task-036-148-feebas-visualization-adr` to outline the UI integration.
- Created `epic-036-058-feebas-backend-parsing` for backend extraction and PRNG logic.
- Created `epic-036-059-feebas-frontend-visualization` for the UI rendering.
- Updated `prd-066-036-feebas-tile-predictor` markdown body to check off acceptance criteria and track the new downstream nodes.

---
*PR created automatically by Jules for task [10691932586182049513](https://jules.google.com/task/10691932586182049513) started by @szubster*