### PR TITLE
🗃️ Archivist: duplicate and transient journal entries cleanup

### DIFF
--- a/.foundry/journals/tpm.md
+++ b/.foundry/journals/tpm.md
@@ -1,9 +1,1 @@
 # TPM Journal
-
-- **2026-06-05**: System failure detected for `task-080-132-refactor-generation-exports-impl`. Reason: Session terminated with state: COMPLETED. Transitioned back to READY without penalty.
-
-- **2026-06-05**: System failure detected for `task-080-132-refactor-generation-exports-impl`. Reason: Session terminated with state: FAILED. Transitioned back to READY without penalty.
-
-- **2026-06-05**: System failure detected for `task-081-144-preserve-enum-optimizations-retry-impl`. Reason: Session timed out (>24h). Transitioned back to READY without penalty.
-
-- **2026-06-05**: System failure detected for `task-081-130-preserve-enum-optimizations-impl`. Reason: Session terminated with state: FAILED. Transitioned back to READY without penalty.

--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -38,12 +38,6 @@
 **Action:** When evaluating `EVO_TRIGGER.BREED` (or general breeding recommendations), check `isInDaycare`. If true and `length === 1`, suggest "Need Partner" and advise leaving a compatible partner (like Ditto). If false, explicitly advise leaving the target AND a compatible partner.
 ## 2024-05-20 - Multi-stage Evolution Deduplication
 **Learning:** The suggestion engine previously generated redundant suggestions for multi-stage evolutions if multiple subsequent stages were missing (e.g., both Charmeleon and Charizard missing from Pokedex would generate two "Evolve Charmander" suggestions).
-**Action:** When iterating over , skip generation if  AND the intermediate  is also present in . This allows the engine to naturally generate a single "Path to" suggestion for the intermediate stage without flooding the UI.
-## 2024-05-20 - Intermediate Evolution Suggestion Clarity
-**Learning:** For multi-stage evolutions where an intermediate stage is required (e.g. "Path to #Charizard" needing a Charmeleon), the previous title ("Level Up Evolution") and description were misleading, implying the immediate evolution would yield the final target.
-**Action:** Dynamically rewrite the title (e.g., `Path to #${targetId}`) and description (e.g., `into #${immediateEvoTargetId} to progress towards #${targetId}`) when  to clarify the intermediate progression step.
-## 2024-05-20 - Multi-stage Evolution Deduplication
-**Learning:** The suggestion engine previously generated redundant suggestions for multi-stage evolutions if multiple subsequent stages were missing (e.g., both Charmeleon and Charizard missing from Pokedex would generate two "Evolve Charmander" suggestions).
 **Action:** When iterating over `immediateEvoTarget.det`, skip generation if `immediateEvoTargetId !== targetId` AND the intermediate `immediateEvoTargetId` is also present in `missingIds`. This allows the engine to naturally generate a single "Path to" suggestion for the intermediate stage without flooding the UI.
 ## 2024-05-20 - Intermediate Evolution Suggestion Clarity
 **Learning:** For multi-stage evolutions where an intermediate stage is required (e.g. "Path to #Charizard" needing a Charmeleon), the previous title ("Level Up Evolution") and description were misleading, implying the immediate evolution would yield the final target.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -49,9 +49,6 @@
 **Learning:** When expanding to new generations (like Gen 3), target the unique, generation-specific mechanics (like RTC-based berry farming) that present new pain points for players. Automating time-based or heavily localized systems provides immediate high value that generic static views cannot match.
 **Outcome:** Created IDEA node.
 
-## 2026-06-01
-**Idea:** Gen 3 Mirage Island Predictor
-**Learning:** Building on the Gen 3 support expansions, targeting obscure, RNG-based, or hidden daily mechanics (like Mirage Island, which relies on a matching RNG value with the party Pokémon) provides players with "superpower" utilities that they cannot easily achieve through normal gameplay. This aligns with DexHelper's vision as a premium companion app capable of deeply introspecting save states.
 ## 2026-05-31
 **Idea:** Unown Form Tracker
 **Learning:** Catering to end-game completionists adds significant value. Gen 2 has a specific quest to collect all 26 Unown forms (A-Z) which are determined by DVs. Since `DexHelper` already parses DVs for stats and shininess, extending this to explicitly track Unown forms gives players a visual checklist, transforming a tedious manual process into a highly actionable feature.
@@ -62,7 +59,8 @@
 **Learning:** Expanding the app's capability to parse time-based data (RTC) from Gen 2 save files lets us create dynamic "daily to-do checklists". Turning a static collection viewer into an active agenda that reminds players of time-gated events (like swarms or daily rare encounters) solves a massive pain point for retro gamers without guides, continuing our trend of surfacing hidden state into actionable UI.
 **Outcome:** Created IDEA node.
 **Feedback Update:** Noted that RTC is not reliably stored in all emulator `.sav` files. Instead of relying solely on the `.sav` file's RTC, we should use the user's system device clock combined with the save file's event flags to power this feature. This avoids creating features that break depending on the emulator used. Also learned to add filtering to only show events relevant to uncaught Pokémon to increase usefulness.
+
 ## 2026-06-02
 **Idea:** Gen 3 Mirage Island Predictor
-**Learning:** Continuing the trend of surfacing hidden global state (like Feebas tiles or daily swarms) and cross-referencing it with the player's large entity datasets (like hundreds of PC Pokémon PIDs), we can eliminate extremely tedious brute-force mechanics. This provides immediate, tangible value that perfectly aligns with our offline-first programmatic parsing strengths.
+**Learning:** Building on the Gen 3 support expansions, targeting obscure, RNG-based, or hidden daily mechanics (like Mirage Island, which relies on a matching RNG value with the party Pokémon) provides players with "superpower" utilities that they cannot easily achieve through normal gameplay. Continuing the trend of surfacing hidden global state (like Feebas tiles or daily swarms) and cross-referencing it with the player's large entity datasets (like hundreds of PC Pokémon PIDs), we can eliminate extremely tedious brute-force mechanics. This provides immediate, tangible value that perfectly aligns with our offline-first programmatic parsing strengths.
 **Outcome:** Created IDEA node.

--- a/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
@@ -218,7 +218,7 @@ describe('AssistantSuggestionCard', () => {
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 30, minLevel: 6, maxLevel: 6 },
           { aid: 0, method: 'walk', chance: 20, minLevel: 7, maxLevel: 7 },
-        ]
+        ],
       },
     };
 
@@ -246,8 +246,7 @@ describe('AssistantSuggestionCard', () => {
       title: 'Catch an unknown mon',
       description: 'Find it if you can.',
       pokemonIds: [10],
-      encounterInfo: {
-      },
+      encounterInfo: {},
     };
 
     const areaNames = { 0: 'Route 1' };
@@ -262,6 +261,7 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+    await expect.element(page.getByText('Catch an unknown mon')).toBeVisible();
   });
 
   it('renders correctly when one of the encounter chances is equal to mainEnc chance', async () => {
@@ -276,7 +276,7 @@ describe('AssistantSuggestionCard', () => {
         10: [
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 10, minLevel: 6, maxLevel: 6 },
-        ]
+        ],
       },
     };
 
@@ -292,6 +292,7 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+    await expect.element(page.getByText('Catch an equal mon')).toBeVisible();
   });
 
   it('renders correctly when category is not catch and pokemonIds exist', async () => {
@@ -311,7 +312,9 @@ describe('AssistantSuggestionCard', () => {
         showDebug={false}
         saveData={mockSaveData}
         getPokemonName={mockGetPokemonName}
+        areaNames={{}}
       />,
     );
+    await expect.element(page.getByText('Evolve something')).toBeVisible();
   });
 });


### PR DESCRIPTION
**What was stale/wrong:**
Agent journals contained duplicate, fragmented, and transient logs that bloated context windows without providing long-term value. Specifically, the TPM journal acted as an execution logbook instead of a critical learning repository, the trainer journal contained malformed duplicates due to stripped variables, and the visionary journal had fragmented entries for the same idea spanning multiple dates.

**How it was verified:**
Manually read the un-truncated files using `cat` and `sed` to verify accurate replacement, ran `pnpm lint` and `pnpm test` (resolving Biome formatting errors and adding missing vitest assertions inadvertently exposed during the sweep) to ensure no regressions were introduced to agent testing workflows.

**What was removed/updated:**
- Overwrote `.foundry/journals/tpm.md` to clear execution logs, leaving only the header.
- Merged the "Gen 3 Mirage Island Predictor" ideas in `.jules/visionary.md` into one comprehensive entry.
- Removed the malformed, duplicate "Multi-stage Evolution Deduplication" and "Intermediate Evolution Suggestion Clarity" entries from `.jules/trainer.md`.

---
*PR created automatically by Jules for task [1073109692381703639](https://jules.google.com/task/1073109692381703639) started by @szubster*