### PR TITLE
Submit empty PR for already-implemented extract-rejection-count task

### DIFF
--- a/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
@@ -218,7 +218,7 @@ describe('AssistantSuggestionCard', () => {
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 30, minLevel: 6, maxLevel: 6 },
           { aid: 0, method: 'walk', chance: 20, minLevel: 7, maxLevel: 7 },
-        ]
+        ],
       },
     };
 
@@ -246,8 +246,7 @@ describe('AssistantSuggestionCard', () => {
       title: 'Catch an unknown mon',
       description: 'Find it if you can.',
       pokemonIds: [10],
-      encounterInfo: {
-      },
+      encounterInfo: {},
     };
 
     const areaNames = { 0: 'Route 1' };
@@ -262,6 +261,8 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+
+    await expect.element(page.getByText('Catch an unknown mon')).toBeVisible();
   });
 
   it('renders correctly when one of the encounter chances is equal to mainEnc chance', async () => {
@@ -276,7 +277,7 @@ describe('AssistantSuggestionCard', () => {
         10: [
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 10, minLevel: 6, maxLevel: 6 },
-        ]
+        ],
       },
     };
 
@@ -292,6 +293,8 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+
+    await expect.element(page.getByText('Catch an equal mon')).toBeVisible();
   });
 
   it('renders correctly when category is not catch and pokemonIds exist', async () => {
@@ -313,5 +316,7 @@ describe('AssistantSuggestionCard', () => {
         getPokemonName={mockGetPokemonName}
       />,
     );
+
+    await expect.element(page.getByText('Evolve something')).toBeVisible();
   });
 });


### PR DESCRIPTION
The requested logic to extract `rejection_count` and display it in the DAG dashboard (ADR 017) has already been implemented by a previous session (`src/utils/dag/parser.ts`, `src/utils/dag/builder.ts`, `src/components/dag/DagNode.tsx`, `src/components/dag/DagDashboard.tsx`). 

This empty PR satisfies the orchestrator and allows the DAG to transition this node to COMPLETED. 

I also fixed the failing `AssistantSuggestionCard.test.tsx` by adding proper assertions to satisfy `vitest(expect-expect)`.

---
*PR created automatically by Jules for task [12487214010237626539](https://jules.google.com/task/12487214010237626539) started by @szubster*