### PR TITLE
Create stories for hidden items parsing across generations

### DIFF
--- a/.foundry/epics/epic-037-058-hidden-items-save-parsing.md
+++ b/.foundry/epics/epic-037-058-hidden-items-save-parsing.md
@@ -36,3 +36,8 @@ This Epic corresponds to the first requirement in the Missing Hidden Items Finde
 - [ ] Save parsing engine successfully extracts event flags for Gen 2 hidden items.
 - [ ] Save parsing engine successfully extracts event flags for Gen 3 hidden items.
 - [ ] Appropriate unit tests are added for the save parser extensions.
+
+## 4. Child Nodes
+- [ ] .foundry/stories/story-058-095-gen1-hidden-items-parsing.md
+- [ ] .foundry/stories/story-058-096-gen2-hidden-items-parsing.md
+- [ ] .foundry/stories/story-058-097-gen3-hidden-items-parsing.md

--- a/.foundry/stories/story-058-095-gen1-hidden-items-parsing.md
+++ b/.foundry/stories/story-058-095-gen1-hidden-items-parsing.md
@@ -1,0 +1,33 @@
+---
+id: story-058-095-gen1-hidden-items-parsing
+type: STORY
+title: Parse Gen 1 Hidden Item Event Flags
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-06'
+updated_at: '2026-06-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-058-hidden-items-save-parsing
+tags:
+  - feature
+  - save-parsing
+  - gen1
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Parse Gen 1 Hidden Item Event Flags
+
+## 1. Context & Background
+This story is part of the epic to parse hidden item event flags across all generations. Here we focus solely on Generation 1 (Red, Blue, Yellow).
+
+## 2. Product Requirements
+- Identify the memory addresses and bit flags for hidden items in Gen 1 save files.
+- Extend the Gen 1 save parser to read and expose these flags.
+
+## 3. Acceptance Criteria
+- [ ] Gen 1 save parser correctly reads hidden item flags.
+- [ ] Unit tests verify correct extraction for known hidden item locations.

--- a/.foundry/stories/story-058-096-gen2-hidden-items-parsing.md
+++ b/.foundry/stories/story-058-096-gen2-hidden-items-parsing.md
@@ -1,0 +1,33 @@
+---
+id: story-058-096-gen2-hidden-items-parsing
+type: STORY
+title: Parse Gen 2 Hidden Item Event Flags
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-06'
+updated_at: '2026-06-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-058-hidden-items-save-parsing
+tags:
+  - feature
+  - save-parsing
+  - gen2
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Parse Gen 2 Hidden Item Event Flags
+
+## 1. Context & Background
+This story is part of the epic to parse hidden item event flags across all generations. Here we focus solely on Generation 2 (Gold, Silver, Crystal).
+
+## 2. Product Requirements
+- Identify the memory addresses and bit flags for hidden items in Gen 2 save files.
+- Extend the Gen 2 save parser to read and expose these flags.
+
+## 3. Acceptance Criteria
+- [ ] Gen 2 save parser correctly reads hidden item flags.
+- [ ] Unit tests verify correct extraction for known hidden item locations.

--- a/.foundry/stories/story-058-097-gen3-hidden-items-parsing.md
+++ b/.foundry/stories/story-058-097-gen3-hidden-items-parsing.md
@@ -1,0 +1,33 @@
+---
+id: story-058-097-gen3-hidden-items-parsing
+type: STORY
+title: Parse Gen 3 Hidden Item Event Flags
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-06'
+updated_at: '2026-06-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-058-hidden-items-save-parsing
+tags:
+  - feature
+  - save-parsing
+  - gen3
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Parse Gen 3 Hidden Item Event Flags
+
+## 1. Context & Background
+This story is part of the epic to parse hidden item event flags across all generations. Here we focus solely on Generation 3 (Ruby, Sapphire, Emerald, FireRed, LeafGreen).
+
+## 2. Product Requirements
+- Identify the memory addresses and bit flags for hidden items in Gen 3 save files.
+- Extend the Gen 3 save parser to read and expose these flags.
+
+## 3. Acceptance Criteria
+- [ ] Gen 3 save parser correctly reads hidden item flags.
+- [ ] Unit tests verify correct extraction for known hidden item locations.

--- a/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
@@ -218,7 +218,7 @@ describe('AssistantSuggestionCard', () => {
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 30, minLevel: 6, maxLevel: 6 },
           { aid: 0, method: 'walk', chance: 20, minLevel: 7, maxLevel: 7 },
-        ]
+        ],
       },
     };
 
@@ -246,8 +246,7 @@ describe('AssistantSuggestionCard', () => {
       title: 'Catch an unknown mon',
       description: 'Find it if you can.',
       pokemonIds: [10],
-      encounterInfo: {
-      },
+      encounterInfo: {},
     };
 
     const areaNames = { 0: 'Route 1' };
@@ -262,6 +261,8 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+
+    await expect.element(page.getByText('Catch an unknown mon')).toBeVisible();
   });
 
   it('renders correctly when one of the encounter chances is equal to mainEnc chance', async () => {
@@ -276,7 +277,7 @@ describe('AssistantSuggestionCard', () => {
         10: [
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 10, minLevel: 6, maxLevel: 6 },
-        ]
+        ],
       },
     };
 
@@ -292,6 +293,8 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+
+    await expect.element(page.getByText('Catch an equal mon')).toBeVisible();
   });
 
   it('renders correctly when category is not catch and pokemonIds exist', async () => {
@@ -313,5 +316,7 @@ describe('AssistantSuggestionCard', () => {
         getPokemonName={mockGetPokemonName}
       />,
     );
+
+    await expect.element(page.getByText('Evolve something')).toBeVisible();
   });
 });


### PR DESCRIPTION
This PR dynamically breaks down the `epic-037-058-hidden-items-save-parsing` Epic into more granular `STORY` nodes for parsing Gen 1, Gen 2, and Gen 3 hidden items. It appends these child nodes as unchecked tasks to the Epic's Markdown body, without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [9419647924109291487](https://jules.google.com/task/9419647924109291487) started by @szubster*