### PR TITLE
feat: add isGen1Species utility function

### DIFF
--- a/.foundry/tasks/task-088-148-gen1-species-validity-impl.md
+++ b/.foundry/tasks/task-088-148-gen1-species-validity-impl.md
@@ -40,6 +40,6 @@ Implement the logic to determine if a Generation 2 Pokémon is a valid Generatio
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Utility function implemented.
-- [ ] Unit tests pass.
-- [ ] `pnpm type-check` passes.
+- [x] Utility function implemented.
+- [x] Unit tests pass.
+- [x] `pnpm type-check` passes.

--- a/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
@@ -218,7 +218,7 @@ describe('AssistantSuggestionCard', () => {
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 30, minLevel: 6, maxLevel: 6 },
           { aid: 0, method: 'walk', chance: 20, minLevel: 7, maxLevel: 7 },
-        ]
+        ],
       },
     };
 
@@ -246,8 +246,7 @@ describe('AssistantSuggestionCard', () => {
       title: 'Catch an unknown mon',
       description: 'Find it if you can.',
       pokemonIds: [10],
-      encounterInfo: {
-      },
+      encounterInfo: {},
     };
 
     const areaNames = { 0: 'Route 1' };
@@ -262,6 +261,7 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+    await expect.element(page.getByText('Catch an unknown mon')).toBeVisible();
   });
 
   it('renders correctly when one of the encounter chances is equal to mainEnc chance', async () => {
@@ -276,7 +276,7 @@ describe('AssistantSuggestionCard', () => {
         10: [
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 10, minLevel: 6, maxLevel: 6 },
-        ]
+        ],
       },
     };
 
@@ -292,6 +292,7 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+    await expect.element(page.getByText('Catch an equal mon')).toBeVisible();
   });
 
   it('renders correctly when category is not catch and pokemonIds exist', async () => {
@@ -313,5 +314,6 @@ describe('AssistantSuggestionCard', () => {
         getPokemonName={mockGetPokemonName}
       />,
     );
+    await expect.element(page.getByText('Evolve something')).toBeVisible();
   });
 });

--- a/src/utils/generationConfig.test.ts
+++ b/src/utils/generationConfig.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { GENERATION_CONFIGS, getGenerationConfig, POKEBALL_LABELS, VERSION_THEMES } from './generationConfig';
+import {
+  GENERATION_CONFIGS,
+  getGenerationConfig,
+  isGen1Species,
+  POKEBALL_LABELS,
+  VERSION_THEMES,
+} from './generationConfig';
 
 describe('getGenerationConfig', () => {
   it('should return the correct configuration for an existing generation (Gen 1)', () => {
@@ -28,6 +34,21 @@ describe('getGenerationConfig', () => {
 
   it('should throw an error for an arbitrarily large generation number', () => {
     expect(() => getGenerationConfig(999)).toThrow('Unknown generation: 999');
+  });
+});
+
+describe('isGen1Species', () => {
+  it('returns true for valid Gen 1 species', () => {
+    expect(isGen1Species(1)).toBe(true);
+    expect(isGen1Species(151)).toBe(true);
+    expect(isGen1Species(25)).toBe(true);
+  });
+
+  it('returns false for invalid IDs', () => {
+    expect(isGen1Species(0)).toBe(false);
+    expect(isGen1Species(152)).toBe(false);
+    expect(isGen1Species(251)).toBe(false);
+    expect(isGen1Species(-1)).toBe(false);
   });
 });
 

--- a/src/utils/generationConfig.ts
+++ b/src/utils/generationConfig.ts
@@ -120,6 +120,14 @@ export function getGenerationConfig(gen: number): GenerationConfig {
   return config;
 }
 
+/**
+ * Determines if a Pokémon ID represents a valid Generation 1 species.
+ * Gen 1 species are those with IDs from 1 to 151 inclusive.
+ */
+export function isGen1Species(pokemonId: number): boolean {
+  return pokemonId >= 1 && pokemonId <= 151;
+}
+
 /** Reverse lookup: given a version ID like 'red', find its generation config and version info */
 
 /** The maximum Pokédex number across all registered generations */


### PR DESCRIPTION
Added `isGen1Species` utility function to `src/utils/generationConfig.ts` to cleanly check if a Pokémon ID represents a Gen 1 species (ID 1-151). Implemented comprehensive unit tests covering bounds and invalid values, passing all type checks, linters, and test suites. Fixed strict assertion warnings in unrelated browser tests to satisfy CI. Updated `.foundry/tasks/task-088-148-gen1-species-validity-impl.md` acceptance criteria to denote completion.

---
*PR created automatically by Jules for task [14441890756360177406](https://jules.google.com/task/14441890756360177406) started by @szubster*