### PR TITLE
🧪 Sentinel: Gen 2 Key Items and Balls Parser Coverage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -125,3 +125,9 @@ When testing components that utilize `@tanstack/react-router` features like `<Li
 **Coverage Before/After:** Test coverage for `AssistantDebugView.tsx` increased from 0% to 100%.
 **Why this target matters:** Ensures the debug view properly renders telemetry data and rejected logs without crashing, which is critical for troubleshooting AI assistant suggestions.
 **Learning:** When asserting the absence of an element using vitest-browser-react, ensure you use `not.toBeInTheDocument()` instead of `.not.toBeVisible()` if the element is conditionally excluded from the DOM entirely (e.g. `rejected.length > 0 && <div.../>`). Also, if the element returned by `render` is completely empty (e.g. `saveData` is null), `container.innerHTML` doesn't work, use `baseElement.innerHTML === '<div></div>'`. For matching text exactly, use `{ exact: true }` in `getByText` to avoid ambiguous matching if multiple elements share partial strings.
+
+## 2026-06-25 - Gen 2 Save Parser Player Inventory Coverage
+**What:** Added test cases for `src/engine/saveParser/parsers/gen2.ts` covering Key Items and Balls pockets in both Gold/Silver and Crystal saves.
+**Coverage:** Increased statement coverage and branch coverage in `gen2.ts` for handling various pocket arrays.
+**Why:** The `inventory` tracking arrays handling logic for extracting Player's "Key Items" and "Balls" were completely untested for generation 2 variants, opening a vulnerability for regression mapping UI requirements later.
+**Result:** Gen 2 parsing accurately extracts and structures Key Items and Balls with associated quantities mapping to the application's overarching Pokemon UI data safely.

--- a/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
@@ -218,7 +218,7 @@ describe('AssistantSuggestionCard', () => {
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 30, minLevel: 6, maxLevel: 6 },
           { aid: 0, method: 'walk', chance: 20, minLevel: 7, maxLevel: 7 },
-        ]
+        ],
       },
     };
 
@@ -246,8 +246,7 @@ describe('AssistantSuggestionCard', () => {
       title: 'Catch an unknown mon',
       description: 'Find it if you can.',
       pokemonIds: [10],
-      encounterInfo: {
-      },
+      encounterInfo: {},
     };
 
     const areaNames = { 0: 'Route 1' };
@@ -262,6 +261,8 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+
+    await expect.element(page.getByText('Catch an unknown mon')).toBeVisible();
   });
 
   it('renders correctly when one of the encounter chances is equal to mainEnc chance', async () => {
@@ -276,7 +277,7 @@ describe('AssistantSuggestionCard', () => {
         10: [
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 10, minLevel: 6, maxLevel: 6 },
-        ]
+        ],
       },
     };
 
@@ -292,6 +293,8 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+
+    await expect.element(page.getByText('Catch an equal mon')).toBeVisible();
   });
 
   it('renders correctly when category is not catch and pokemonIds exist', async () => {
@@ -313,5 +316,7 @@ describe('AssistantSuggestionCard', () => {
         getPokemonName={mockGetPokemonName}
       />,
     );
+
+    await expect.element(page.getByText('Evolve something')).toBeVisible();
   });
 });

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -301,4 +301,94 @@ describe('gen2 parsers', () => {
       );
     });
   });
+
+  describe('parseGen2 - Player Inventory', () => {
+    it('should parse Key Items pocket correctly for Gold/Silver', () => {
+      const buffer = new ArrayBuffer(0x8000);
+      const view = new DataView(buffer);
+
+      // Gold/Silver Key Items offset is 0x244a
+      view.setUint8(0x244a, 2); // 2 items
+      view.setUint8(0x244a + 1, 0x46); // Item ID 0x46 (Bicycle)
+      view.setUint8(0x244a + 2, 0x47); // Item ID 0x47 (Itemfinder)
+
+      const data = parseGen2(view);
+
+      expect(data.inventory).toEqual(
+        expect.arrayContaining([
+          { id: 0x46, quantity: 1 },
+          { id: 0x47, quantity: 1 },
+        ]),
+      );
+    });
+
+    it('should parse Balls pocket correctly for Gold/Silver', () => {
+      const buffer = new ArrayBuffer(0x8000);
+      const view = new DataView(buffer);
+
+      // Gold/Silver Balls offset is 0x2465
+      view.setUint8(0x2465, 2); // 2 items
+      view.setUint8(0x2465 + 1, 0x01); // Item ID 0x01 (Master Ball)
+      view.setUint8(0x2465 + 2, 5); // Quantity 5
+      view.setUint8(0x2465 + 3, 0x02); // Item ID 0x02 (Ultra Ball)
+      view.setUint8(0x2465 + 4, 15); // Quantity 15
+
+      const data = parseGen2(view);
+
+      expect(data.inventory).toEqual(
+        expect.arrayContaining([
+          { id: 0x01, quantity: 5 },
+          { id: 0x02, quantity: 15 },
+        ]),
+      );
+    });
+
+    it('should parse Key Items pocket correctly for Crystal', () => {
+      const buffer = new ArrayBuffer(0x8000);
+      const view = new DataView(buffer);
+
+      // Crystal Key Items offset is 0x242c
+      view.setUint8(0x2865, 1); // Mark as Crystal
+      view.setUint8(0x2866 + 1, 0xff); // Terminator
+      view.setUint8(0x2866, 1); // Bulbasaur
+
+      view.setUint8(0x242c, 2); // 2 items
+      view.setUint8(0x242c + 1, 0x46); // Item ID 0x46 (Bicycle)
+      view.setUint8(0x242c + 2, 0x47); // Item ID 0x47 (Itemfinder)
+
+      const data = parseGen2(view, true);
+
+      expect(data.inventory).toEqual(
+        expect.arrayContaining([
+          { id: 0x46, quantity: 1 },
+          { id: 0x47, quantity: 1 },
+        ]),
+      );
+    });
+
+    it('should parse Balls pocket correctly for Crystal', () => {
+      const buffer = new ArrayBuffer(0x8000);
+      const view = new DataView(buffer);
+
+      // Crystal Balls offset is 0x2447
+      view.setUint8(0x2865, 1); // Mark as Crystal
+      view.setUint8(0x2866 + 1, 0xff); // Terminator
+      view.setUint8(0x2866, 1); // Bulbasaur
+
+      view.setUint8(0x2447, 2); // 2 items
+      view.setUint8(0x2447 + 1, 0x01); // Item ID 0x01 (Master Ball)
+      view.setUint8(0x2447 + 2, 5); // Quantity 5
+      view.setUint8(0x2447 + 3, 0x02); // Item ID 0x02 (Ultra Ball)
+      view.setUint8(0x2447 + 4, 15); // Quantity 15
+
+      const data = parseGen2(view, true);
+
+      expect(data.inventory).toEqual(
+        expect.arrayContaining([
+          { id: 0x01, quantity: 5 },
+          { id: 0x02, quantity: 15 },
+        ]),
+      );
+    });
+  });
 });


### PR DESCRIPTION
🎯 **What**
Added missing test cases in `src/engine/saveParser/parsers/gen2.test.ts` to cover the previously untested lines for `Key Items` and `Balls` parsing logic for both Gold/Silver and Crystal Generation 2 saves. Additionally, repaired missing expect assertions in `AssistantSuggestionCard.test.tsx` that were surfacing as linter errors.

📊 **Coverage**
Increased `src/engine/saveParser/parsers/gen2.ts` branch and statement coverage. All logical blocks in `parseInventory` are now thoroughly tested against correctly-structured DataView binary inputs mirroring raw game saves.

✨ **Result**
Engine test suites now guarantee stable interpretation of generation 2 storage inventories across game variants, and `pnpm lint` errors resolved cleanly.

---
*PR created automatically by Jules for task [15403558451609160158](https://jules.google.com/task/15403558451609160158) started by @szubster*