### PR TITLE
🧱 Mason: TacticalSelect extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -83,3 +83,6 @@
 - **Why**: Reduced duplicated JSX in `PokemonEvolutions.tsx`. Standardized interaction styles, underline offsets, and hover variants for typical navigation links without needing to pass down the large class string every time.
 - **Key Learnings**:
   - Make sure to extend standard attributes (e.g. `React.ButtonHTMLAttributes<HTMLButtonElement>`) and forward refs (`React.forwardRef`) so accessibility properties like `aria-label` or raw `onClick` handlers pass down appropriately without breaking.
+
+### React Form Element Extraction & Tailwind Sibling States
+When extracting standard HTML form elements (like `<select>` or `<input>`) that are paired with custom decorative icons using Tailwind sibling selectors (`peer-hover`, `peer-focus`), it is crucial to explicitly preserve the `peer` class on the extracted HTML element itself. Failing to map the `peer` class onto the root input/select element within the new reusable component will break the hover/focus styling of its sibling icons.

--- a/src/components/TacticalSelect.tsx
+++ b/src/components/TacticalSelect.tsx
@@ -1,0 +1,32 @@
+import { ChevronDown } from 'lucide-react';
+import React from 'react';
+import { cn } from '../utils/cn';
+
+export interface TacticalSelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  containerClassName?: string;
+  iconClassName?: string;
+}
+
+export const TacticalSelect = React.forwardRef<HTMLSelectElement, TacticalSelectProps>(
+  ({ className, containerClassName, iconClassName, children, ...props }, ref) => {
+    return (
+      <div className={cn('relative w-full', containerClassName)}>
+        <select
+          ref={ref}
+          className={cn(
+            'peer w-full cursor-pointer appearance-none rounded-none border border-zinc-800 border-dashed bg-zinc-950 px-3 py-2 pr-8 font-black font-mono text-[9px] text-zinc-500 uppercase tracking-widest transition-all hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </select>
+        <div className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-zinc-500 transition-colors peer-hover:text-zinc-300">
+          <ChevronDown size={14} className={iconClassName} />
+        </div>
+      </div>
+    );
+  },
+);
+
+TacticalSelect.displayName = 'TacticalSelect';

--- a/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx
@@ -218,7 +218,7 @@ describe('AssistantSuggestionCard', () => {
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 30, minLevel: 6, maxLevel: 6 },
           { aid: 0, method: 'walk', chance: 20, minLevel: 7, maxLevel: 7 },
-        ]
+        ],
       },
     };
 
@@ -246,8 +246,7 @@ describe('AssistantSuggestionCard', () => {
       title: 'Catch an unknown mon',
       description: 'Find it if you can.',
       pokemonIds: [10],
-      encounterInfo: {
-      },
+      encounterInfo: {},
     };
 
     const areaNames = { 0: 'Route 1' };
@@ -262,6 +261,7 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+    await expect.element(page.getByText('Catch an unknown mon')).toBeVisible();
   });
 
   it('renders correctly when one of the encounter chances is equal to mainEnc chance', async () => {
@@ -276,7 +276,7 @@ describe('AssistantSuggestionCard', () => {
         10: [
           { aid: 0, method: 'walk', chance: 10, minLevel: 5, maxLevel: 5 },
           { aid: 0, method: 'walk', chance: 10, minLevel: 6, maxLevel: 6 },
-        ]
+        ],
       },
     };
 
@@ -292,6 +292,7 @@ describe('AssistantSuggestionCard', () => {
         areaNames={areaNames}
       />,
     );
+    await expect.element(page.getByText('Catch an equal mon')).toBeVisible();
   });
 
   it('renders correctly when category is not catch and pokemonIds exist', async () => {
@@ -313,5 +314,6 @@ describe('AssistantSuggestionCard', () => {
         getPokemonName={mockGetPokemonName}
       />,
     );
+    await expect.element(page.getByText('Evolve something')).toBeVisible();
   });
 });

--- a/src/components/settings/SettingsControls.tsx
+++ b/src/components/settings/SettingsControls.tsx
@@ -4,6 +4,7 @@ import type { GenerationConfig } from '../../utils/generationConfig';
 import { getGenerationConfig } from '../../utils/generationConfig';
 import { SettingsRow } from '../SettingsRow';
 import { TacticalSegmentedControl } from '../TacticalSegmentedControl';
+import { TacticalSelect } from '../TacticalSelect';
 
 interface SettingsControlsProps {
   effectiveVersion: GameVersion | 'unknown';
@@ -128,11 +129,11 @@ export function SettingsControls({
         iconColorClass="border-red-500/20 bg-red-500/10"
         label="Graveyard"
       >
-        <select
+        <TacticalSelect
           aria-label="Select Nuzlocke Graveyard Box"
           value={nuzlockeGraveyardBox || ''}
           onChange={(e) => setNuzlockeGraveyardBox(e.target.value === '' ? null : e.target.value)}
-          className="w-full appearance-none rounded-none border border-zinc-800 border-dashed bg-zinc-950 px-3 py-2 font-black font-mono text-[9px] text-zinc-500 uppercase tracking-widest transition-all hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+          className="focus-visible:ring-red-500"
         >
           <option value="">[ NONE ]</option>
           {storageLocations.map((loc) => (
@@ -140,7 +141,7 @@ export function SettingsControls({
               [ {loc.toUpperCase()} ]
             </option>
           ))}
-        </select>
+        </TacticalSelect>
       </SettingsRow>
     </div>
   );


### PR DESCRIPTION
🎯 **What**
Extracted a heavily stylized tactical `<select>` element from `SettingsControls.tsx` into a reusable `<TacticalSelect>` component. Added proper prop forwarding and a baked-in generic Lucide `ChevronDown` icon. Fixed a few preexisting test lint errors in `AssistantSuggestionCard.test.tsx` (`expect-expect` rule) to keep the pipeline green.

💡 **Why**
The standard `<select>` element was cluttered with 15+ highly specific tactical styling classes (`appearance-none rounded-none border-dashed ...`) that made it difficult to read and verbose to reuse. Centralizing this standard HTML form element reduces duplication and enforces the tactical design system's aesthetic globally whenever a `<select>` drop-down is needed.

✅ **Verification**
- `pnpm lint`: Passed. Handled a minor `useSortedClasses` Biome formatting rule.
- `pnpm test`: Fixed `AssistantSuggestionCard` `expect-expect` test errors. Passed 100%.
- `pnpm test:e2e`: Playwright E2E passed.
- Frontend Verification: Confirmed visually through playwright snapshot that the `<TacticalSelect>` correctly renders inside the Settings Modal.

✨ **Result**
Code duplication is reduced, `<TacticalSelect>` is cleanly typed using `React.forwardRef<HTMLSelectElement, TacticalSelectProps>`, and the application maintains its visual styling integrity.

---
*PR created automatically by Jules for task [14388776350793875424](https://jules.google.com/task/14388776350793875424) started by @szubster*