### PR TITLE
QA: Implicit dependency check updates

### DIFF
--- a/.foundry/tasks/task-086-147-qa-implicit-dependency-check.md
+++ b/.foundry/tasks/task-086-147-qa-implicit-dependency-check.md
@@ -29,6 +29,6 @@ If you abort or permanently fail a task, you MUST update the YAML frontmatter to
 If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verify that `isHierarchicallyIncomplete` or node resolution logic in `foundry-orchestrator.ts` ensures that a parent node isn't ready if its descendant tree has any nodes not in the COMPLETED or CANCELLED state.
-- [ ] Verify that `CANCELLED` nodes satisfy hierarchical completeness.
-- [ ] Verify that unit tests in `foundry-orchestrator.test.ts` pass and correctly test the new implicit dependency logic.
+- [x] Verify that `isHierarchicallyIncomplete` or node resolution logic in `foundry-orchestrator.ts` ensures that a parent node isn't ready if its descendant tree has any nodes not in the COMPLETED or CANCELLED state.
+- [x] Verify that `CANCELLED` nodes satisfy hierarchical completeness.
+- [x] Verify that unit tests in `foundry-orchestrator.test.ts` pass and correctly test the new implicit dependency logic.


### PR DESCRIPTION
Verify the changes implemented in `task-086-146-impl-implicit-dependency-check`.

If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

---
*PR created automatically by Jules for task [12266150144703094306](https://jules.google.com/task/12266150144703094306) started by @szubster*