### PR TITLE
chore(foundry): generate epics for pokerus tracker

### DIFF
--- a/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
+++ b/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
@@ -1,0 +1,26 @@
+---
+id: epic-038-061-pokerus-state-exfiltration
+type: EPIC
+title: Pokerus State Exfiltration Epic
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-06-07"
+updated_at: "2026-06-07"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: "prd-069-038-pokerus-tracker"
+tags: ["gen2", "save-engine", "pokerus"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Pokerus State Exfiltration Epic
+
+## Description
+Read the specific byte flags for Pokerus for every Pokemon in the party and PC from the Gen 2 sav files.
+
+## Acceptance Criteria
+- [ ] Extract pokerus data

--- a/.foundry/epics/epic-038-062-pokerus-visual-tracker.md
+++ b/.foundry/epics/epic-038-062-pokerus-visual-tracker.md
@@ -1,0 +1,26 @@
+---
+id: epic-038-062-pokerus-visual-tracker
+type: EPIC
+title: Pokerus Visual Tracker Epic
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-06-07"
+updated_at: "2026-06-07"
+depends_on: ["epic-038-061-pokerus-state-exfiltration"]
+jules_session_id: null
+pr_number: null
+parent: "prd-069-038-pokerus-tracker"
+tags: ["ui", "pokerus"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Pokerus Visual Tracker Epic
+
+## Description
+Add UI badges indicating Pokerus status (Uninfected, Infected/Contagious, Cured/Immune) and explicitly calculate and display remaining days for contagious Pokemon using RTC.
+
+## Acceptance Criteria
+- [ ] Add UI badges for pokerus status

--- a/.foundry/epics/epic-038-063-pokerus-spread-planner.md
+++ b/.foundry/epics/epic-038-063-pokerus-spread-planner.md
@@ -1,0 +1,26 @@
+---
+id: epic-038-063-pokerus-spread-planner
+type: EPIC
+title: Pokerus Spread Planner Epic
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-06-07"
+updated_at: "2026-06-07"
+depends_on: ["epic-038-061-pokerus-state-exfiltration"]
+jules_session_id: null
+pr_number: null
+parent: "prd-069-038-pokerus-tracker"
+tags: ["ui", "pokerus", "planner"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Pokerus Spread Planner Epic
+
+## Description
+Create a dedicated tool to strategically plan Pokerus spread, suggesting party configurations and warning before a cure.
+
+## Acceptance Criteria
+- [ ] Create spread planner tool

--- a/.foundry/prds/prd-069-038-pokerus-tracker.md
+++ b/.foundry/prds/prd-069-038-pokerus-tracker.md
@@ -23,3 +23,8 @@ Add UI badges indicating Pokerus status (Uninfected, Infected/Contagious, Cured/
 
 ## 3. Spread Planner Epic
 Create a dedicated tool to strategically plan Pokerus spread, suggesting party configurations and warning before a cure.
+
+## Generated Epics
+- [ ] epic-038-061-pokerus-state-exfiltration
+- [ ] epic-038-062-pokerus-visual-tracker
+- [ ] epic-038-063-pokerus-spread-planner


### PR DESCRIPTION
Transformed PRD into actionable Epics for the Pokerus Tracker feature.

- Extracted 3 epics based on PRD:
  1. Pokerus State Exfiltration (Epic 1)
  2. Pokerus Visual Tracker (Epic 2)
  3. Pokerus Spread Planner (Epic 3)
- Correctly mapped sequential dependencies (Epic 2 and 3 depend on Epic 1).
- Updated PRD's markdown body with `- [ ]` checkboxes to reference the created epics without altering the YAML frontmatter.

---
*PR created automatically by Jules for task [6690642495306356441](https://jules.google.com/task/6690642495306356441) started by @szubster*