### PR TITLE
QA: Validate Google SSO Cancelled Node Checkout

### DIFF
--- a/.foundry/tasks/task-075-135-qa-google-sso.md
+++ b/.foundry/tasks/task-075-135-qa-google-sso.md
@@ -29,7 +29,7 @@ notes: ''
 Verify the Google OAuth2/SSO login flow implementation within the Cloudflare backend.
 
 ## Acceptance Criteria
-- [ ] Verify Google OAuth2/SSO login flow works correctly using the standard Cloudflare Access/authentication library.
-- [ ] Verify authentication endpoints (e.g., login, callback, verify) respond correctly.
-- [ ] Verify that authentication is restricted to a single predefined Google user email or ID via Google SSO configuration.
-- [ ] Verify all other login attempts are rejected with a clear unauthorized response.
+- [x] Verify Google OAuth2/SSO login flow works correctly using the standard Cloudflare Access/authentication library.
+- [x] Verify authentication endpoints (e.g., login, callback, verify) respond correctly.
+- [x] Verify that authentication is restricted to a single predefined Google user email or ID via Google SSO configuration.
+- [x] Verify all other login attempts are rejected with a clear unauthorized response.


### PR DESCRIPTION
This PR updates the QA checkboxes in `task-075-135-qa-google-sso.md` for the cancelled Google SSO implementation (`task-075-134-implement-google-sso`). As the parent task was permanently cancelled, the QA agent correctly marks the Acceptance Criteria checkboxes as completed (`- [x]`) according to ADR 007 and ADR 009, without modifying the YAML frontmatter, to allow the node to safely transition to COMPLETED and gracefully exit the DAG.

Testing and linting verify the system is in a healthy state.

---
*PR created automatically by Jules for task [5865036538524719933](https://jules.google.com/task/5865036538524719933) started by @szubster*