### PR TITLE
Fix acceptance criteria formatting for idea-066

### DIFF
--- a/.foundry/ideas/idea-066-save-file-health-scanner.md
+++ b/.foundry/ideas/idea-066-save-file-health-scanner.md
@@ -41,4 +41,4 @@ This feature pivots DexHelper from just a tracking tool into a critical utility 
 - [x] Product Manager: Convert this idea into a PRD.
 
 ### References
-- Created PRD: `.foundry/prds/prd-066-036-save-file-health-scanner.md`
+- [ ] `.foundry/prds/prd-066-036-save-file-health-scanner.md`

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -22,3 +22,10 @@ This implies that either a previous session successfully generated the node but 
 
 ## Idea 066 Anomaly: Target PRD Already Exists
 On 2026-06-03, while transitioning idea-066-save-file-health-scanner to PRD, the target artifact (.foundry/prds/prd-066-036-save-file-health-scanner.md) was found to already exist prior to this session. Documenting this for the Agile Coach as required by node generation rules.
+
+## Missing Checkboxes for Child Nodes (2026-06-07)
+**Observation:**
+During the conversion of `idea-066-save-file-health-scanner` to a PRD, the PR was rejected twice. The cause was that the generated child PRD was added as a plain text reference (`- Created PRD: ...`) instead of an unchecked task checkbox (`- [ ] ...`).
+
+**Architectural Constraint:**
+In the Foundry architecture, parent generation nodes (like `IDEA` and `PRD`) MUST include references to their generated child nodes as unchecked task checkboxes (`- [ ] <file_path>`) directly in their markdown body. This is a critical signal to the Orchestrator. If the checkbox is omitted or immediately checked, the Orchestrator assumes the parent node has met all its acceptance criteria and prematurely transitions it to `VERIFYING` before the descendant nodes are actually completed. This violates the dependency graph constraints and triggers a rejection.


### PR DESCRIPTION
### 🎯 What
Modified `idea-066-save-file-health-scanner.md` to use an unchecked markdown checkbox (`- [ ]`) for its child PRD reference, rather than a plain string, and updated the Product Manager journal to log the architectural constraint.

### 💡 Why
The PR for this node was previously rejected twice because omitting the unchecked checkbox signals the Orchestrator that the parent node's acceptance criteria are fully met. This caused the parent IDEA node to prematurely transition to `VERIFYING` before its descendant PRD node was completed, violating strict dependency graph constraints.

### ✅ Verification
- Read file to confirm `idea-066-save-file-health-scanner.md` has the `- [ ]` checkbox and its YAML frontmatter was left unmodified.
- Confirmed the Product Manager journal has the new entry.
- Ran tests via `pnpm test` successfully (after a minor hooks fix).

### ✨ Result
The IDEA node will correctly wait in the PENDING/READY status until the downstream `prd-066` is fully COMPLETED before attempting verification, allowing the DAG to progress smoothly.

---
*PR created automatically by Jules for task [5431566566062875402](https://jules.google.com/task/5431566566062875402) started by @szubster*