### PR TITLE
Extract shared DAG utilities to dag-utils.ts

### DIFF
--- a/.foundry/tasks/task-090-148-extract-dag-utils-impl.md
+++ b/.foundry/tasks/task-090-148-extract-dag-utils-impl.md
@@ -33,9 +33,9 @@ This task requires extracting shared DAG utility functions from existing orchest
 - Update `foundry-orchestrator.ts`, `foundry-heartbeat.ts` and their respective tests to import and use the new module.
 
 ## Acceptance Criteria
-- [ ] `dag-utils.ts` is created and contains the extracted functions.
-- [ ] Appropriate unit tests are added in `dag-utils.test.ts`.
-- [ ] Existing functionality works seamlessly utilizing the new utility file.
+- [x] `dag-utils.ts` is created and contains the extracted functions.
+- [x] Appropriate unit tests are added in `dag-utils.test.ts`.
+- [x] Existing functionality works seamlessly utilizing the new utility file.
 
 **Important Instructions:**
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/.github/scripts/dag-utils.test.ts
+++ b/.github/scripts/dag-utils.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  todayISO,
+  logToJournal,
+  buildReverseDependencyGraph,
+  getOrphanedNodes
+} from './dag-utils.ts';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn<() => boolean>(),
+  mkdirSync: vi.fn<() => void>(),
+  appendFileSync: vi.fn<() => void>(),
+}));
+
+describe('dag-utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('todayISO', () => {
+    it('returns the current date in YYYY-MM-DD format', () => {
+      const iso = todayISO();
+      expect(iso).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe('logToJournal', () => {
+    it('creates directory and appends log entry', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      logToJournal('/repo', 'test entry');
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(path.join('/repo', '.foundry', 'journals'), { recursive: true });
+      expect(fs.appendFileSync).toHaveBeenCalledWith(path.join('/repo', '.foundry', 'journals', 'tpm.md'), 'test entry', 'utf-8');
+    });
+
+    it('appends log entry without creating directory if it exists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      logToJournal('/repo', 'test entry');
+
+      expect(fs.mkdirSync).not.toHaveBeenCalled();
+      expect(fs.appendFileSync).toHaveBeenCalledWith(path.join('/repo', '.foundry', 'journals', 'tpm.md'), 'test entry', 'utf-8');
+    });
+  });
+
+  describe('buildReverseDependencyGraph', () => {
+    it('correctly maps dependencies to dependents', () => {
+      const nodes = [
+        { repoPath: 'a.md', frontmatter: { depends_on: ['b.md'] } },
+        { repoPath: 'b.md', frontmatter: { depends_on: ['c.md'] } },
+        { repoPath: 'c.md', frontmatter: { depends_on: [] } },
+        { repoPath: 'd.md', frontmatter: { depends_on: ['b.md'] } }
+      ];
+      const resolveNodePath = (dep: string) => dep;
+
+      const graph = buildReverseDependencyGraph(nodes, resolveNodePath);
+
+      expect(graph.get('b.md')).toEqual(['a.md', 'd.md']);
+      expect(graph.get('c.md')).toEqual(['b.md']);
+      expect(graph.get('a.md')).toBeUndefined();
+    });
+
+    it('ignores unresolvable dependencies', () => {
+       const nodes = [
+        { repoPath: 'a.md', frontmatter: { depends_on: ['b.md'] } }
+      ];
+      const resolveNodePath = (_dep: string) => null;
+
+      const graph = buildReverseDependencyGraph(nodes, resolveNodePath);
+
+      expect(graph.size).toBe(0);
+    });
+  });
+
+  describe('getOrphanedNodes', () => {
+    it('traverses the reverse graph to find all orphaned nodes', () => {
+      const reverseGraph = new Map([
+        ['start.md', ['child1.md', 'child2.md']],
+        ['child1.md', ['grandchild1.md']],
+        ['child2.md', []],
+        ['grandchild1.md', []],
+        ['unrelated.md', ['child_unrelated.md']]
+      ]);
+
+      const orphaned = getOrphanedNodes('start.md', reverseGraph);
+
+      expect(orphaned).toEqual(new Set(['child1.md', 'child2.md', 'grandchild1.md']));
+    });
+
+    it('handles cycles in the dependency graph', () => {
+      const reverseGraph = new Map([
+        ['start.md', ['node_a.md']],
+        ['node_a.md', ['node_b.md']],
+        ['node_b.md', ['node_a.md', 'node_c.md']],
+        ['node_c.md', []]
+      ]);
+
+      const orphaned = getOrphanedNodes('start.md', reverseGraph);
+
+      expect(orphaned).toEqual(new Set(['node_a.md', 'node_b.md', 'node_c.md']));
+    });
+  });
+});

--- a/.github/scripts/dag-utils.ts
+++ b/.github/scripts/dag-utils.ts
@@ -1,0 +1,70 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Returns today's date in ISO-8601 YYYY-MM-DD format (local time). */
+export function todayISO(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/** Appends a log entry to the TPM journal. */
+export function logToJournal(repoRoot: string, entry: string): void {
+  const journalDir = path.join(repoRoot, '.foundry', 'journals');
+  if (!fs.existsSync(journalDir)) fs.mkdirSync(journalDir, { recursive: true });
+  fs.appendFileSync(path.join(journalDir, 'tpm.md'), entry, 'utf-8');
+}
+
+/**
+ * Builds a reverse dependency graph from a list of nodes.
+ * @param nodes Array of nodes with frontmatter.depends_on and repoPath.
+ * @param resolveNodePath Function to resolve a dependency path to a canonical repoPath.
+ * @returns A Map where keys are repoPaths and values are arrays of dependent repoPaths.
+ */
+export function buildReverseDependencyGraph(
+  nodes: { frontmatter: { depends_on?: string[] }; repoPath: string }[],
+  resolveNodePath: (dep: string) => string | null
+): Map<string, string[]> {
+  const dependents = new Map<string, string[]>();
+  for (const n of nodes) {
+    const deps = (n.frontmatter.depends_on || []).map(resolveNodePath).filter(Boolean) as string[];
+    for (const d of deps) {
+      if (!dependents.has(d)) {
+        dependents.set(d, []);
+      }
+      dependents.get(d)!.push(n.repoPath);
+    }
+  }
+  return dependents;
+}
+
+/**
+ * Traverses the reverse dependency graph to find all orphaned nodes (dependents)
+ * starting from a specific node path.
+ * @param startNodePath The repoPath of the node to start traversing from.
+ * @param reverseGraph The reverse dependency graph built by buildReverseDependencyGraph.
+ * @returns A Set containing the repoPaths of all orphaned dependent nodes.
+ */
+export function getOrphanedNodes(startNodePath: string, reverseGraph: Map<string, string[]>): Set<string> {
+  const orphanedNodes = new Set<string>();
+  const visited = new Set<string>();
+  const queue = [startNodePath];
+  visited.add(startNodePath);
+
+  while (queue.length > 0) {
+    const currentPath = queue.shift()!;
+    const currentDependents = reverseGraph.get(currentPath) || [];
+
+    for (const depPath of currentDependents) {
+      if (!visited.has(depPath)) {
+        visited.add(depPath);
+        queue.push(depPath);
+        orphanedNodes.add(depPath);
+      }
+    }
+  }
+
+  return orphanedNodes;
+}

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -10,6 +10,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import matter from 'gray-matter';
 import { discoverNodeFiles, parseNodeFile } from './foundry-orchestrator.ts';
+import { todayISO, logToJournal } from './dag-utils.ts';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -19,14 +20,6 @@ function warn(msg: string): void {
 
 function info(msg: string): void {
   process.stderr.write(`[heartbeat] INFO  ${msg}\n`);
-}
-
-function todayISO(): string {
-  const d = new Date();
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, '0');
-  const dd = String(d.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
 }
 
 const TERMINAL_STATES = ['FAILED', 'COMPLETED'];
@@ -304,12 +297,6 @@ async function findPRForSession(
   } catch { /* ignore list error */ }
 
   return { pr: null, sessionStatus, updateTime };
-}
-
-function logToJournal(repoRoot: string, entry: string): void {
-  const journalDir = path.join(repoRoot, '.foundry', 'journals');
-  if (!fs.existsSync(journalDir)) fs.mkdirSync(journalDir, { recursive: true });
-  fs.appendFileSync(path.join(journalDir, 'tpm.md'), entry, 'utf-8');
 }
 
 export async function main() {

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -27,6 +27,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createRequire } from 'node:module';
+import { todayISO, buildReverseDependencyGraph, getOrphanedNodes } from './dag-utils.ts';
 
 // gray-matter is CJS; import via require() for clean ESM interop.
 const require = createRequire(import.meta.url);
@@ -113,15 +114,6 @@ function info(msg: string): void {
 }
 
 // ─── Utilities ────────────────────────────────────────────────────────────────
-
-/** Returns today's date in ISO-8601 YYYY-MM-DD format (local time). */
-function todayISO(): string {
-  const d = new Date();
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, '0');
-  const dd = String(d.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
 
 // ─── Phase 1: DISCOVER ───────────────────────────────────────────────────────
 
@@ -574,37 +566,15 @@ function main(): void {
       // Auto-cancel orphaned PENDING nodes depending directly or indirectly on this permanently failed node
 
       // Build a reverse dependency graph
-      const dependents = new Map<string, string[]>();
-      for (const n of nodes) {
-        const deps = (n.frontmatter.depends_on || []).map(resolveNodePath).filter(Boolean) as string[];
-        for (const d of deps) {
-          if (!dependents.has(d)) {
-            dependents.set(d, []);
-          }
-          dependents.get(d)!.push(n.repoPath);
-        }
-      }
+      const dependents = buildReverseDependencyGraph(nodes, resolveNodePath);
+      const orphanedNodes = getOrphanedNodes(node.repoPath, dependents);
 
-      const visited = new Set<string>();
-      const queue = [node.repoPath];
-      visited.add(node.repoPath);
-
-      while (queue.length > 0) {
-        const currentPath = queue.shift()!;
-        const currentDependents = dependents.get(currentPath) || [];
-
-        for (const depPath of currentDependents) {
-          if (!visited.has(depPath)) {
-            visited.add(depPath);
-            queue.push(depPath);
-
-            const dependentNode = nodeMap.get(depPath);
-            if (dependentNode && dependentNode.frontmatter.status === 'PENDING') {
-              promoteNodeToCancelledWithReason(dependentNode, `Cancelled due to permanent failure of dependency: ${node.frontmatter.id}`);
-              cancelledNodes.add(dependentNode.repoPath);
-              cascadeCancel(dependentNode.repoPath);
-            }
-          }
+      for (const depPath of orphanedNodes) {
+        const dependentNode = nodeMap.get(depPath);
+        if (dependentNode && dependentNode.frontmatter.status === 'PENDING') {
+          promoteNodeToCancelledWithReason(dependentNode, `Cancelled due to permanent failure of dependency: ${node.frontmatter.id}`);
+          cancelledNodes.add(dependentNode.repoPath);
+          cascadeCancel(dependentNode.repoPath);
         }
       }
     }


### PR DESCRIPTION
- Created `.github/scripts/dag-utils.ts` and extracted `todayISO`, `logToJournal`, `buildReverseDependencyGraph`, and `getOrphanedNodes` from orchestrator scripts.
- Wrote unit tests for new shared functions in `.github/scripts/dag-utils.test.ts`.
- Updated `foundry-orchestrator.ts` and `foundry-heartbeat.ts` to import and utilize these shared utilities, reducing code duplication.

---
*PR created automatically by Jules for task [10692424749334357665](https://jules.google.com/task/10692424749334357665) started by @szubster*