### PR TITLE
🛠️ Infras: Bump Biome schema and CI action version to 2.4.16

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: "2.4.15"
+          version: "2.4.16"
 
       - name: Run Biome
         run: biome ci --error-on-warnings .

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
**What**
Bumped the `version` field in `.github/workflows/biome.yml` and the `$schema` URL in `biome.jsonc` from `2.4.15` to `2.4.16`.

**Why**
The local version of `@biomejs/biome` in `package.json` was already bumped to `^2.4.16`, but the CI action and configuration schema were left behind at `2.4.15`. This brings all versions into alignment to ensure CI checks against the exact same version and schema as local development.

**Impact on DX/CI**
Cleans up schema validation warnings for developers locally and ensures CI maintains perfect parity with the local formatter environment.

**Setup notes**
None. Local packages already expect `2.4.16`.

---
*PR created automatically by Jules for task [2648195220172230652](https://jules.google.com/task/2648195220172230652) started by @szubster*