### PR TITLE
feat: Generate Story nodes for Gen 3 Berry Tracker data extraction

### DIFF
--- a/.foundry/epics/epic-037-055-gen3-berry-tracker-data-extraction.md
+++ b/.foundry/epics/epic-037-055-gen3-berry-tracker-data-extraction.md
@@ -38,3 +38,7 @@ As mandated by ADR 010 (`010-gen3-data-parsing.md`), all data parsing must stric
 - [ ] Handle bounds checking gracefully (e.g., throwing and catching `RangeError` on out-of-bounds reads).
 - [ ] Extract map location, berry ID, growth stage, and time metadata.
 - [ ] Serialize the extracted data using `msgpackr` and integrate with the runtime data API.
+
+### Generated Stories
+- [ ] .foundry/stories/story-055-095-gen3-berry-data-parsing.md
+- [ ] .foundry/stories/story-055-096-gen3-berry-msgpack-integration.md

--- a/.foundry/stories/story-055-095-gen3-berry-data-parsing.md
+++ b/.foundry/stories/story-055-095-gen3-berry-data-parsing.md
@@ -1,0 +1,32 @@
+---
+id: story-055-095-gen3-berry-data-parsing
+type: STORY
+title: Gen 3 Berry Tracker DataView Parsing Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-055-gen3-berry-tracker-data-extraction
+tags:
+  - feature
+  - gen3
+  - berries
+  - engine
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Berry Tracker DataView Parsing Logic
+
+## Overview
+Implement the extraction logic for Gen 3 berry patches using the native `DataView` API.
+
+## Acceptance Criteria
+- [ ] Implement `DataView` reading logic for Gen 3 berry patches.
+- [ ] Implement graceful handling of bounds checking by throwing/catching `RangeError`.
+- [ ] Extract map ID, berry ID, current growth stage, time planted, and last watered time.

--- a/.foundry/stories/story-055-096-gen3-berry-msgpack-integration.md
+++ b/.foundry/stories/story-055-096-gen3-berry-msgpack-integration.md
@@ -1,0 +1,33 @@
+---
+id: story-055-096-gen3-berry-msgpack-integration
+type: STORY
+title: Gen 3 Berry Tracker MsgPack Serialization
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on:
+  - story-055-095-gen3-berry-data-parsing
+jules_session_id: null
+pr_number: null
+parent: epic-037-055-gen3-berry-tracker-data-extraction
+tags:
+  - feature
+  - gen3
+  - berries
+  - engine
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Berry Tracker MsgPack Serialization
+
+## Overview
+Serialize the extracted Gen 3 berry patch data using `msgpackr` and integrate with the runtime data API, following ADR 010.
+
+## Acceptance Criteria
+- [ ] Serialize the extracted berry data using `msgpackr`.
+- [ ] Integrate serialized data with PokeData storage generation pipeline.
+- [ ] Expose through runtime API.


### PR DESCRIPTION
Generated downstream `STORY` nodes from `epic-037-055-gen3-berry-tracker-data-extraction.md` for the Gen 3 Berry Farming Tracker data extraction implementation.

Adheres to:
- ADR 010 (DataView parsing and MsgPack serialization)
- Foundry Architecture rules (Parent-Linked ID schema, no circular `depends_on`, `tech_lead` handoff, strict state transitions).

---
*PR created automatically by Jules for task [18157944186847607148](https://jules.google.com/task/18157944186847607148) started by @szubster*