### PR TITLE
feat(foundry): Break down Gen 3 Contest Tracker IDEA into PRDs

### DIFF
--- a/.foundry/ideas/idea-070-gen3-contest-tracker.md
+++ b/.foundry/ideas/idea-070-gen3-contest-tracker.md
@@ -35,4 +35,7 @@ Leverage DexHelper's programmatic save parsing to expose these hidden Contest st
 This caters directly to the hardcore completionist community, transforming an opaque and tedious endgame grind into a highly actionable, data-driven feature. It aligns perfectly with DexHelper's mission to surface hidden state and provide premium companion tools.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD to define the data structures needed for parsing Contest stats and Ribbons from Gen 3 save formats.
+- [x] Product Manager: Convert this idea into a PRD to define the data structures needed for parsing Contest stats and Ribbons from Gen 3 save formats.
+- [ ] .foundry/prds/prd-070-040-gen3-contest-data-parsing.md
+- [ ] .foundry/prds/prd-070-041-gen3-contest-ui-viewer.md
+- [ ] .foundry/prds/prd-070-042-gen3-contest-optimization-advisor.md

--- a/.foundry/prds/prd-070-040-gen3-contest-data-parsing.md
+++ b/.foundry/prds/prd-070-040-gen3-contest-data-parsing.md
@@ -1,0 +1,51 @@
+---
+id: prd-070-040-gen3-contest-data-parsing
+type: PRD
+title: Gen 3 Contest Data Parsing
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-070-gen3-contest-tracker
+tags:
+  - feature
+  - gen3
+  - contests
+  - parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Gen 3 Contest Data Parsing
+
+## 1. Context
+As part of the Gen 3 Contest Stat and Ribbon Tracker feature, DexHelper needs the ability to extract hidden contest-related statistics and ribbons directly from Gen 3 save files. This includes data for Condition (Cool, Beauty, Cute, Smart, Tough), Sheen, and Contest Ribbons across all Pokémon in the player's collection.
+
+## 2. Requirements
+
+### 2.1 Parsing Engine Compatibility
+- The parsing engine must be updated to locate and extract contest-related data from the appropriate blocks in Gen 3 save formats (Ruby, Sapphire, Emerald, FireRed, LeafGreen).
+
+### 2.2 Strict DataView API Usage
+- All parsing logic for contest data MUST exclusively use the native `DataView` API (e.g., `getUint8`, `getUint16`, `getUint32`) as mandated by ADR 010.
+- Out-of-bounds reads must gracefully propagate as specific validation errors, avoiding application crashes.
+
+### 2.3 Required Data Points
+- Extract the following hidden Condition stats per Pokémon: Cool, Beauty, Cute, Smart, and Tough.
+- Extract the Pokémon's Sheen value.
+- Extract the bitfield/flags associated with all Contest Ribbons.
+
+### 2.4 Backwards Compatibility
+- The addition of Gen 3 contest parsing logic must not break or modify existing parsing interfaces for Gen 1 and Gen 2, ensuring strict backwards compatibility.
+
+## 3. Acceptance Criteria
+- [ ] Implement `DataView`-based parsing logic for Gen 3 Condition, Sheen, and Ribbon data.
+- [ ] Map the extracted data to appropriate fields in the internal Pokémon data structure.
+- [ ] Graceful error handling for corrupted or incomplete save segments is implemented.
+- [ ] All existing Gen 1 and Gen 2 save parsing tests pass without modification.
+- [ ] New unit tests confirm accurate extraction of contest data from known Gen 3 save file fixtures.

--- a/.foundry/prds/prd-070-041-gen3-contest-ui-viewer.md
+++ b/.foundry/prds/prd-070-041-gen3-contest-ui-viewer.md
@@ -1,0 +1,50 @@
+---
+id: prd-070-041-gen3-contest-ui-viewer
+type: PRD
+title: Gen 3 Contest Condition and Ribbon Viewer UI
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-070-gen3-contest-tracker
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Gen 3 Contest Condition and Ribbon Viewer UI
+
+## 1. Context
+Following the data extraction phase, DexHelper must present the extracted Gen 3 Contest statistics (Condition and Sheen) and Ribbons to the user. The current in-game representations are vague (e.g., pentagon graphs without numeric values) and checking ribbons across hundreds of Pokémon is tedious. This UI aims to provide clear, tabular, and actionable views of this data.
+
+## 2. Requirements
+
+### 2.1 Contest Stats Viewer
+- **Numerical Display**: Replace the vague in-game visual representation with exact numerical values for Cool, Beauty, Cute, Smart, and Tough.
+- **Sheen Display**: Clearly show the current Sheen value alongside its maximum limit (255) to indicate how many more Pokéblocks a Pokémon can consume.
+- **Integration**: This viewer must be integrated into the detailed view of individual Pokémon.
+
+### 2.2 Ribbon Checklist
+- **Aggregate View**: Create a centralized dashboard or checklist view that aggregates Contest Ribbon data across the entire Living Dex (or current PC boxes).
+- **Master Rank Tracking**: Highlight Pokémon that have achieved Master Rank in specific contest categories.
+- **Missing Ribbons**: Provide a clear indication of which Pokémon are missing which Ribbons to aid completionists.
+
+### 2.3 UI Components & Styling
+- Adhere to existing design system components (`TacticalButton`, `TacticalMultiSelectControl`, etc.) where applicable.
+- Ensure the UI is responsive and accessible, handling large datasets (entire PC) gracefully.
+
+## 3. Acceptance Criteria
+- [ ] Implement a detailed view component displaying numerical Contest stats and Sheen for a single Pokémon.
+- [ ] Implement a global Ribbon Checklist view aggregating data across all stored Pokémon.
+- [ ] Provide filtering/sorting options in the Ribbon Checklist (e.g., sort by missing Ribbons, filter by category).
+- [ ] Ensure rendering performance is maintained when viewing hundreds of Pokémon in the checklist.
+- [ ] Pass visual regression and accessibility checks.

--- a/.foundry/prds/prd-070-042-gen3-contest-optimization-advisor.md
+++ b/.foundry/prds/prd-070-042-gen3-contest-optimization-advisor.md
@@ -1,0 +1,47 @@
+---
+id: prd-070-042-gen3-contest-optimization-advisor
+type: PRD
+title: Gen 3 Contest Optimization Advisor
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-070-gen3-contest-tracker
+tags:
+  - feature
+  - gen3
+  - contests
+  - advisor
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Gen 3 Contest Optimization Advisor
+
+## 1. Context
+Beyond simply displaying Contest statistics and Ribbons, DexHelper aims to provide actionable insights. The Gen 3 Contest Optimization Advisor will leverage the extracted Condition stats, Sheen, and a Pokémon's Nature to recommend the best Contest categories for that specific Pokémon. This tool will simplify the complex interplay between Natures and Pokéblock preferences.
+
+## 2. Requirements
+
+### 2.1 Optimization Logic
+- **Nature Analysis**: Incorporate game logic that maps Pokémon Natures to their preferred and disliked Pokéblock flavors (which correspond directly to Contest Conditions: Cool, Beauty, Cute, Smart, Tough).
+- **Condition Assessment**: Analyze the current numerical values of the Pokémon's Conditions.
+- **Sheen Limitation**: Factor in the remaining Sheen capacity (255 - current Sheen) to determine if there is enough "room" left to significantly boost a specific condition via Pokéblocks.
+- **Recommendation Algorithm**: Develop an algorithm that combines Nature preference, current highest stats, and remaining Sheen to suggest the top 1-2 recommended Contest categories to enter or optimize for.
+
+### 2.2 Advisor UI
+- **Integration**: Embed the advisor recommendations within the individual Pokémon detail view, ideally adjacent to the Contest Stats Viewer.
+- **Clear Guidance**: Present the recommendations clearly, explaining *why* a category is suggested (e.g., "Recommended: Cool - High base stat and favorable Nature (Adamant)").
+- **Warning States**: Display warnings if a Pokémon has maxed out its Sheen but lacks competitive stats for Master Rank contests, indicating further optimization via Pokéblocks is impossible.
+
+## 3. Acceptance Criteria
+- [ ] Implement the logic mapping Natures to Contest Condition preferences.
+- [ ] Develop the recommendation algorithm based on Nature, current Conditions, and Sheen.
+- [ ] Create UI components to display the recommendations clearly.
+- [ ] Implement warning states for Pokémon with maxed Sheen and suboptimal stats.
+- [ ] Write unit tests verifying the recommendation logic produces expected outcomes for various Nature/Stat combinations.


### PR DESCRIPTION
This PR transitions the IDEA for the "Gen 3 Contest Stat and Ribbon Tracker" into granular PRD nodes as per the Product Manager persona responsibilities. It creates three new PRDs covering Data Parsing, UI Viewing, and Optimization Advisor features. The parent IDEA node's markdown has been updated to reflect the new child dependencies as unchecked list items.

---
*PR created automatically by Jules for task [3723843092276655015](https://jules.google.com/task/3723843092276655015) started by @szubster*