### PR TITLE
chore(foundry): break down epic-037-058 into gen1-3 stories

### DIFF
--- a/.foundry/epics/epic-037-058-hidden-items-save-parsing.md
+++ b/.foundry/epics/epic-037-058-hidden-items-save-parsing.md
@@ -36,3 +36,6 @@ This Epic corresponds to the first requirement in the Missing Hidden Items Finde
 - [ ] Save parsing engine successfully extracts event flags for Gen 2 hidden items.
 - [ ] Save parsing engine successfully extracts event flags for Gen 3 hidden items.
 - [ ] Appropriate unit tests are added for the save parser extensions.
+- [ ] .foundry/stories/story-058-095-gen1-hidden-item-parsing.md
+- [ ] .foundry/stories/story-058-096-gen2-hidden-item-parsing.md
+- [ ] .foundry/stories/story-058-097-gen3-hidden-item-parsing.md

--- a/.foundry/stories/story-058-095-gen1-hidden-item-parsing.md
+++ b/.foundry/stories/story-058-095-gen1-hidden-item-parsing.md
@@ -1,0 +1,37 @@
+---
+id: story-058-095-gen1-hidden-item-parsing
+type: STORY
+title: Gen 1 Hidden Item Event Flags Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-058-hidden-items-save-parsing
+tags:
+  - gen1
+  - save-parsing
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 1 Hidden Item Event Flags Parsing
+
+## Context
+This story focuses on the first part of the epic `epic-037-058-hidden-items-save-parsing`. The `SaveData` interface needs to support hidden items, and the Gen 1 save parser needs to be extended to read the hidden item event flags.
+
+## Product Requirements
+1. Update `SaveData` interface in `src/engine/saveParser/parsers/common.ts` to include a new field, e.g., `hiddenItemFlags?: Uint8Array;`.
+2. Update the `parseGen1` function in `src/engine/saveParser/parsers/gen1.ts` to extract the hidden item flags. In Gen 1, hidden item flags are typically part of the event flags or stored in a specific hidden item bit array, which needs to be correctly identified and extracted. (Hint: The hidden coin flags and hidden item flags are situated around the event flags block).
+3. Ensure backwards compatibility, where older versions of the app might not have `hiddenItemFlags`.
+4. Ensure adequate unit tests are added or updated.
+
+## Acceptance Criteria
+- [ ] `SaveData` interface includes `hiddenItemFlags`.
+- [ ] `parseGen1` correctly extracts hidden item event flags.
+- [ ] Unit tests for the Gen 1 save parser are updated and pass.

--- a/.foundry/stories/story-058-096-gen2-hidden-item-parsing.md
+++ b/.foundry/stories/story-058-096-gen2-hidden-item-parsing.md
@@ -1,0 +1,34 @@
+---
+id: story-058-096-gen2-hidden-item-parsing
+type: STORY
+title: Gen 2 Hidden Item Event Flags Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-058-hidden-items-save-parsing
+tags:
+  - gen2
+  - save-parsing
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 2 Hidden Item Event Flags Parsing
+
+## Context
+This story focuses on the second part of the epic `epic-037-058-hidden-items-save-parsing`. The `SaveData` interface has already been updated (or will be soon), and the Gen 2 save parser needs to be extended to read the hidden item event flags.
+
+## Product Requirements
+1. Update the `parseGen2` function in `src/engine/saveParser/parsers/gen2.ts` to extract the hidden item flags. In Gen 2, hidden item flags are stored in the event flags block, which needs to be correctly identified and extracted into `SaveData.hiddenItemFlags`.
+2. Ensure adequate unit tests are added or updated.
+
+## Acceptance Criteria
+- [ ] `parseGen2` correctly extracts hidden item event flags.
+- [ ] Unit tests for the Gen 2 save parser are updated and pass.

--- a/.foundry/stories/story-058-097-gen3-hidden-item-parsing.md
+++ b/.foundry/stories/story-058-097-gen3-hidden-item-parsing.md
@@ -1,0 +1,34 @@
+---
+id: story-058-097-gen3-hidden-item-parsing
+type: STORY
+title: Gen 3 Hidden Item Event Flags Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-058-hidden-items-save-parsing
+tags:
+  - gen3
+  - save-parsing
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Hidden Item Event Flags Parsing
+
+## Context
+This story focuses on the third part of the epic `epic-037-058-hidden-items-save-parsing`. The `SaveData` interface supports hidden items, and the Gen 3 save parser needs to be extended to read the hidden item event flags.
+
+## Product Requirements
+1. Update the `parseGen3` function in `src/engine/saveParser/parsers/gen3.ts` to extract the hidden item flags. In Gen 3, this data is extracted through parsing the section data properly. Note: The Gen 3 parser might still be a stub or in development, so the extraction logic should be placed appropriately based on the current parser's state.
+2. Ensure adequate unit tests are added or updated.
+
+## Acceptance Criteria
+- [ ] `parseGen3` correctly extracts hidden item event flags.
+- [ ] Unit tests for the Gen 3 save parser are updated and pass.


### PR DESCRIPTION
This PR dynamically breaks down `epic-037-058-hidden-items-save-parsing` into actionable story nodes for the Tech Lead to implement.

**What:**
- Created `story-058-095-gen1-hidden-item-parsing.md`
- Created `story-058-096-gen2-hidden-item-parsing.md`
- Created `story-058-097-gen3-hidden-item-parsing.md`
- Updated the parent epic's markdown body with unchecked references to these new stories.

**Why:**
To progress the Foundry DAG by transforming macroscopic Epic requirements into sequentially actionable Stories, following the parent-linked ID schema and the rule of granularity.

**Verification:**
- Node IDs follow `<type>-<parent_NNN>-<NNN>-<slug>` perfectly.
- Parent YAML frontmatter is strictly untouched.
- `owner_persona` on all new child nodes is `tech_lead`.
- `depends_on: []` prevents circular dependency deadlocks.
- All tests pass.

---
*PR created automatically by Jules for task [14129204104493940775](https://jules.google.com/task/14129204104493940775) started by @szubster*