### PR TITLE
feat(foundry): Extract Gen 3 Mirage Island Value Epics

### DIFF
--- a/.foundry/epics/epic-038-061-mirage-island-save-parsing.md
+++ b/.foundry/epics/epic-038-061-mirage-island-save-parsing.md
@@ -1,0 +1,35 @@
+---
+id: epic-038-061-mirage-island-save-parsing
+type: EPIC
+title: "Parse Daily Mirage Island Value"
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-06-08"
+updated_at: "2026-06-08"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-068-038-mirage-island-data-extraction
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Parse Daily Mirage Island Value
+
+## Context
+As defined in PRD `prd-068-038-mirage-island-data-extraction`, we need to implement a predictor for Mirage Island in Gen 3 games. The first step is to extract the daily Mirage Island value from the save file's daily/random variables block.
+
+## Requirements
+1. **Locate Data Block**: Identify the location of the daily Mirage Island value within the Gen 3 save file structure (Ruby, Sapphire, Emerald).
+2. **Implement Parser**: Update the Gen 3 save parser engine to extract this value.
+3. **Strict DataView Compliance**: As per ADR 010, the parsing logic MUST strictly use the native `DataView` API rather than raw `Uint8Array` manipulations.
+4. **Graceful Error Handling**: Ensure `RangeError` on out-of-bounds reads are explicitly caught and propagated as validation errors (e.g., "Corrupted Save File").
+
+## Acceptance Criteria
+- [ ] Story Owner: Generate child stories to implement the save file parsing logic and integrate it into the parser engine.

--- a/.foundry/epics/epic-038-062-personality-value-extraction.md
+++ b/.foundry/epics/epic-038-062-personality-value-extraction.md
@@ -1,0 +1,34 @@
+---
+id: epic-038-062-personality-value-extraction
+type: EPIC
+title: "Extract Pokemon Personality Values"
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-06-08"
+updated_at: "2026-06-08"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-068-038-mirage-island-data-extraction
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Extract Pokemon Personality Values
+
+## Context
+As defined in PRD `prd-068-038-mirage-island-data-extraction`, the appearance of Mirage Island depends on whether the daily Mirage Island value matches the lower two bytes (16 bits) of the personality value of any Pokémon in the player's party/PC.
+
+## Requirements
+1. **Full 32-bit PV Parsing**: Ensure the Gen 3 Pokémon data extraction correctly parses the full 32-bit personality value (PV) for every Pokémon.
+2. **Lower 16-bit Availability**: Ensure that the lower 16 bits of the PV, which are necessary for the Mirage Island check, are easily accessible or pre-calculated.
+3. **DataView API**: Comply with ADR 010 by using the `DataView` API for any new PV parsing logic.
+
+## Acceptance Criteria
+- [ ] Story Owner: Generate child stories to ensure the personality value is correctly extracted and formatted.

--- a/.foundry/epics/epic-038-063-mirage-island-data-hydration.md
+++ b/.foundry/epics/epic-038-063-mirage-island-data-hydration.md
@@ -1,0 +1,36 @@
+---
+id: epic-038-063-mirage-island-data-hydration
+type: EPIC
+title: "Hydrate Mirage Island State"
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-06-08"
+updated_at: "2026-06-08"
+depends_on:
+  - epic-038-061-mirage-island-save-parsing
+  - epic-038-062-personality-value-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-068-038-mirage-island-data-extraction
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Hydrate Mirage Island State
+
+## Context
+Once the daily Mirage Island value and the Pokémon personality values are parsed from the save file (handled by earlier Epics), they must be incorporated into the unified application state (`PokeDB` or equivalent) for consumption by UI components.
+
+## Requirements
+1. **Extend Unified State Payload**: Expose the parsed daily Mirage Island value and the relevant Pokémon personality value segments in the unified data payload.
+2. **Backwards Compatibility**: Ensure that this structural change to the data payload maintains backwards compatibility with Gen 1 and Gen 2 files (e.g., fields might be null/undefined for older generations).
+3. **System Integrity**: Ensure no existing functionality is broken by adding these fields to the shared payload.
+
+## Acceptance Criteria
+- [ ] Story Owner: Generate child stories to implement the data hydration and ensure it correctly surfaces the required fields in the application state.

--- a/.foundry/prds/prd-068-038-mirage-island-data-extraction.md
+++ b/.foundry/prds/prd-068-038-mirage-island-data-extraction.md
@@ -37,4 +37,7 @@ As defined in `idea-068-mirage-island-predictor`, we need to implement a predict
 - The parsed value should be included in the unified data payload and must maintain backwards compatibility with Gen 1 and Gen 2 files.
 
 ## Acceptance Criteria
-- [ ] Epic Planner: Generate child epics that implement the save file parsing updates and the application state hydration.
+- [x] Epic Planner: Generate child epics that implement the save file parsing updates and the application state hydration.
+- [ ] .foundry/epics/epic-038-061-mirage-island-save-parsing.md
+- [ ] .foundry/epics/epic-038-062-personality-value-extraction.md
+- [ ] .foundry/epics/epic-038-063-mirage-island-data-hydration.md


### PR DESCRIPTION
Breaks down PRD `prd-068-038-mirage-island-data-extraction` into three Epics: save parsing, personality value extraction, and data hydration. Follows the Foundry DAG schema and properly sets up `depends_on` rules using Node IDs, while unblocking the parent correctly.

---
*PR created automatically by Jules for task [15760875483858750259](https://jules.google.com/task/15760875483858750259) started by @szubster*