### PR TITLE
Foundry: Create STORY nodes for Unown Form Tracker Engine

### DIFF
--- a/.foundry/epics/epic-037-058-unown-tracker-engine.md
+++ b/.foundry/epics/epic-037-058-unown-tracker-engine.md
@@ -35,5 +35,7 @@ The parser must append an `unownForm` property (e.g., `'A'`, `'B'`) to the parse
 Requires unit tests verifying the exact bitwise calculation against known DV combinations for Unown forms.
 
 ## Acceptance Criteria
-- [ ] Story for parser logic created.
-- [ ] Story for parser unit tests created.
+- [x] Story for parser logic created.
+- [x] Story for parser unit tests created.
+- [ ] .foundry/stories/story-058-095-unown-parser-logic.md
+- [ ] .foundry/stories/story-058-096-unown-parser-tests.md

--- a/.foundry/stories/story-058-095-unown-parser-logic.md
+++ b/.foundry/stories/story-058-095-unown-parser-logic.md
@@ -1,0 +1,38 @@
+---
+id: story-058-095-unown-parser-logic
+type: STORY
+title: Unown Form Parser Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-058-unown-tracker-engine
+tags:
+  - feature
+  - gen2
+  - tracking
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Unown Form Parser Logic
+
+## Objective
+Implement the logic to extract the Unown form from its DVs (Determinant Values).
+
+## Context
+As defined in the parent Epic, for Unown (`speciesId` 201) in Generation 2, we can determine its form by extracting the middle 2 bits of its Attack, Defense, Speed, and Special DVs. These 2 bits from each DV are concatenated into an 8-bit integer, and the form is determined by `modulo 28`. The result maps `0-25` to the letters `'A'-'Z'`.
+
+## Requirements
+- When parsing Gen 2 Pokemon instances, detect if `speciesId === 201`.
+- If so, calculate the form using the DVs.
+- Add an `unownForm` property (e.g., `'A'`, `'B'`) to the resulting parsed Pokemon instance structure.
+- **Do not write tests in this story**. Unit tests will be handled in a separate story to encourage granular tasks.
+
+## Acceptance Criteria
+- [ ] Task created for implementing the unown form parser logic.

--- a/.foundry/stories/story-058-096-unown-parser-tests.md
+++ b/.foundry/stories/story-058-096-unown-parser-tests.md
@@ -1,0 +1,38 @@
+---
+id: story-058-096-unown-parser-tests
+type: STORY
+title: Unown Form Parser Unit Tests
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on:
+  - .foundry/stories/story-058-095-unown-parser-logic.md
+jules_session_id: null
+pr_number: null
+parent: epic-037-058-unown-tracker-engine
+tags:
+  - testing
+  - gen2
+  - tracking
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Unown Form Parser Unit Tests
+
+## Objective
+Write comprehensive unit tests for the newly added Unown form parser logic.
+
+## Context
+The logic for determining the Unown form in Gen 2 uses a bitwise operation on the Attack, Defense, Speed, and Special DVs. This logic is implemented in the previous story. This story focuses solely on ensuring its correctness.
+
+## Requirements
+- Verify the exact bitwise calculation against known DV combinations for Unown forms (e.g., test cases for forms A, Z, and edge cases).
+- Ensure the `unownForm` property is correctly appended to the output structure when `speciesId` is 201.
+- Ensure the property is omitted or undefined for non-Unown Pokemon.
+
+## Acceptance Criteria
+- [ ] Task created for implementing unit tests for the unown form parser logic.


### PR DESCRIPTION
This PR breaks down the Epic `epic-037-058-unown-tracker-engine` into two granular `STORY` nodes for implementation by the Tech Lead.

1. `story-058-095-unown-parser-logic`: Focuses on implementing the specific bitwise parsing logic to determine the Gen 2 Unown form based on DVs.
2. `story-058-096-unown-parser-tests`: Focuses on implementing comprehensive unit tests for the newly added parsing logic.

The parent Epic has been updated to reflect these new dependencies in its markdown body without modifying its YAML frontmatter, in compliance with Foundry architecture guidelines.

---
*PR created automatically by Jules for task [12160991834065947716](https://jules.google.com/task/12160991834065947716) started by @szubster*