### PR TITLE
Generate Epics for Gen 3 Mirage Island Predictor

### DIFF
--- a/.foundry/epics/epic-038-061-mirage-island-engine.md
+++ b/.foundry/epics/epic-038-061-mirage-island-engine.md
@@ -1,0 +1,37 @@
+---
+id: epic-038-061-mirage-island-engine
+type: EPIC
+title: Gen 3 Mirage Island Predictor Engine Updates
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-069-038-mirage-island-predictor
+tags:
+  - gen3
+  - mirage-island
+  - rng
+research_references: []
+notes: ''
+---
+
+# Gen 3 Mirage Island Predictor Engine Updates
+
+## Objective
+Enhance the Gen 3 save parser to extract the Mirage Island random value and cross-reference it with the PIDs of all Pokémon owned by the player.
+
+## Logic
+Use the `DataView` API to parse the daily Mirage Island random 2-byte value from the Gen 3 save file structure.
+
+## Output
+The parsed application data must include the current Mirage Island value and identify any "Mirage Island Key" Pokémon across the active party and all PC storage boxes.
+
+## Acceptance Criteria
+- [ ] Parse daily Mirage Island random value from Gen 3 save.
+- [ ] Parse all Pokémon PIDs from active party and PC boxes.
+- [ ] Cross-reference the random value with Pokémon PIDs.
+- [ ] Add Mirage Island value and matches to parsed application data.
+- [ ] Write unit tests verifying extraction logic and PID matching.

--- a/.foundry/epics/epic-038-062-mirage-island-ui.md
+++ b/.foundry/epics/epic-038-062-mirage-island-ui.md
@@ -1,0 +1,39 @@
+---
+id: epic-038-062-mirage-island-ui
+type: EPIC
+title: Gen 3 Mirage Island Predictor UI Updates
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on:
+  - epic-038-061-mirage-island-engine
+jules_session_id: null
+pr_number: null
+parent: prd-069-038-mirage-island-predictor
+tags:
+  - gen3
+  - mirage-island
+  - rng
+research_references: []
+notes: ''
+---
+
+# Gen 3 Mirage Island Predictor UI Updates
+
+## Objective
+Surface the Mirage Island status in the user interface.
+
+## Logic
+Add a dedicated tracker view or notification indicating whether the player currently possesses a matching Pokémon for the current day.
+
+## Display
+If a match is found, highlight exactly which Pokémon it is and which PC Box it resides in.
+
+## Design Constraints
+Must adhere strictly to the "tactical hardware/snooping" aesthetic (`rounded-none`, dashed borders, monospace fonts) as defined in ADR 008.
+
+## Acceptance Criteria
+- [ ] Add tracker view or notification for Mirage Island status.
+- [ ] Display matching Pokémon information (name, PC Box).
+- [ ] Apply "tactical hardware/snooping" aesthetic constraints (`rounded-none`, dashed borders, monospace fonts).

--- a/.foundry/prds/prd-069-038-mirage-island-predictor.md
+++ b/.foundry/prds/prd-069-038-mirage-island-predictor.md
@@ -42,5 +42,8 @@ To ensure granular execution and minimize complexity, this PRD should be broken 
 - **Design Constraints**: Must adhere strictly to the "tactical hardware/snooping" aesthetic (`rounded-none`, dashed borders, monospace fonts) as defined in ADR 008.
 
 ## Acceptance Criteria
-- [ ] Epic 1 (Engine Updates) node created.
-- [ ] Epic 2 (UI Updates) node created.
+- [x] Epic 1 (Engine Updates) node created.
+- [x] Epic 2 (UI Updates) node created.
+
+- [ ] .foundry/epics/epic-038-061-mirage-island-engine.md
+- [ ] .foundry/epics/epic-038-062-mirage-island-ui.md


### PR DESCRIPTION
This PR generates the Epic markdown files for the Gen 3 Mirage Island Predictor based on the `prd-069-038-mirage-island-predictor` document.

It breaks down the PRD into two Epics:
1. `epic-038-061-mirage-island-engine`: Covers the engine parsing updates to extract the Mirage Island random value and cross-reference PIDs.
2. `epic-038-062-mirage-island-ui`: Covers the UI tracker/notification updates, adhering to the tactical hardware aesthetic.

Dependencies are properly mapped, with the UI Epic depending on the Engine Epic. The parent PRD has been updated to reflect the creation of these nodes, checking off the acceptance criteria and appending the new files as unchecked tasks.

---
*PR created automatically by Jules for task [8612990663727416271](https://jules.google.com/task/8612990663727416271) started by @szubster*