### PR TITLE
feat: implement Gen 1 species validity check

### DIFF
--- a/.foundry/tasks/task-088-148-gen1-species-validity-impl.md
+++ b/.foundry/tasks/task-088-148-gen1-species-validity-impl.md
@@ -40,6 +40,6 @@ Implement the logic to determine if a Generation 2 Pokémon is a valid Generatio
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Utility function implemented.
-- [ ] Unit tests pass.
-- [ ] `pnpm type-check` passes.
+- [x] Utility function implemented.
+- [x] Unit tests pass.
+- [x] `pnpm type-check` passes.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/utils/species.test.ts
+++ b/src/utils/species.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { isGen1Species } from './species';
+
+describe('isGen1Species', () => {
+  it('should return true for Gen 1 species IDs', () => {
+    expect(isGen1Species(1)).toBe(true);
+    expect(isGen1Species(151)).toBe(true);
+  });
+
+  it('should return false for non-Gen 1 species IDs', () => {
+    expect(isGen1Species(0)).toBe(false);
+    expect(isGen1Species(152)).toBe(false);
+    expect(isGen1Species(251)).toBe(false);
+  });
+});

--- a/src/utils/species.ts
+++ b/src/utils/species.ts
@@ -1,0 +1,3 @@
+export function isGen1Species(pokemonId: number): boolean {
+  return pokemonId >= 1 && pokemonId <= 151;
+}


### PR DESCRIPTION
Implemented a utility function `isGen1Species` in `src/utils/species.ts` to verify if a given Pokemon ID belongs to Gen 1. Also added corresponding unit tests in `src/utils/species.test.ts`. This fulfills the requirements specified in `task-088-148-gen1-species-validity-impl.md`.

---
*PR created automatically by Jules for task [4689644771659424164](https://jules.google.com/task/4689644771659424164) started by @szubster*