### PR TITLE
Auditor: Reject premature verification of idea-066

### DIFF
--- a/.foundry/ideas/idea-066-save-file-health-scanner.md
+++ b/.foundry/ideas/idea-066-save-file-health-scanner.md
@@ -38,7 +38,10 @@ Introduce a "Save File Health Scanner" feature. When a user uploads a `.sav` fil
 This feature pivots DexHelper from just a tracking tool into a critical utility for retro game preservation. It solves a massive pain point for retro gamers who live in fear of losing hundreds of hours of progress to battery failure or bad cartridge dumps, providing peace of mind and actionable recovery diagnostics.
 
 ## Next Steps
-- [x] Product Manager: Convert this idea into a PRD.
+- [ ] Product Manager: Convert this idea into a PRD.
 
 ### References
 - [ ] `.foundry/prds/prd-066-036-save-file-health-scanner.md`
+
+### Auditor Rejection
+The generated PRD (`prd-066-036-save-file-health-scanner.md`) is still in the `PENDING` state. Macro nodes MUST NOT be verified or completed until all generated descendant nodes (the PRD, Epics, Stories, Tasks) have fully transitioned to `COMPLETED`. Do not submit this IDEA node for verification until its functional requirements have been fully implemented by the downstream pipeline.

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -10,3 +10,12 @@ This violates the spirit of the dependency graph. An Epic represents a "macrosco
 The system needs a clearer distinction between "Epic planning is done" and "Epic implementation is done". Perhaps Epics should implicitly depend on all their child nodes, or the `story_owner` needs to wait until all child stories are `COMPLETED` before submitting the empty PR to transition the Epic to `VERIFYING`. Currently, submitting the Epic when only the planning is done leads to failed audits.
 ## 2026-05-24: Further Observation on Macro Node Verification
 Following up on the premature verification of Epics, this pattern applies generally to macro nodes (e.g., Story nodes as well). The system requires strict hierarchical completion enforcement. A parent node MUST NOT transition to COMPLETED or VERIFYING until all of its descendant nodes in the spawned sub-tree are completely verified and in the COMPLETED state. This ensures that the macroscopic progress representation accurately reflects implementation reality, preventing false progress signaling and premature unblocking of downstream dependencies.
+
+## 2026-06-08: Recurring Premature Verification of Generation Nodes
+I am still seeing instances where macro generation nodes (like `IDEA` or `PRD` nodes) are transitioned to `VERIFYING` immediately after they successfully spawn their first set of child nodes, despite those children (and their subsequent descendants) still being in `PENDING` or `ACTIVE` states. For example, `idea-066-save-file-health-scanner` was submitted while its generated PRD was merely `PENDING`.
+
+**Why this matters:**
+As noted previously, this breaks the dependency graph and the concept of completeness. A macro node represents a functional milestone; if it completes while its implementation is still being worked on or hasn't even started, it causes false progress tracking and potential deadlocks if other nodes rely on its completion.
+
+**Recommendation/Learnings:**
+We need to strongly enforce the rule that a macro node (IDEA, PRD, EPIC, STORY) MUST NOT be verified until its *functional requirements* are implemented and merged by its downstream child tasks. Submitting an empty PR to transition these nodes when merely their planning phase (child generation) is complete is incorrect. All generated descendant nodes must have fully transitioned to `COMPLETED` first.


### PR DESCRIPTION
The `idea-066-save-file-health-scanner` node was prematurely submitted for verification while its child PRD was still pending. According to macro node completion rules, nodes like IDEA and PRD must not be verified until all their descendant functional requirements are completely implemented and merged. 

I unchecked the acceptance criteria box, appended an Auditor Rejection section explaining this, and updated the Auditor journal with a new entry about this recurring issue. This submission will act as an empty PR to transition the node back to the resurrection loop.

---
*PR created automatically by Jules for task [4678371078614670785](https://jules.google.com/task/4678371078614670785) started by @szubster*