### PR TITLE
Generate tasks for implicit dependency tests

### DIFF
--- a/.foundry/stories/story-048-087-update-orchestrator-tests.md
+++ b/.foundry/stories/story-048-087-update-orchestrator-tests.md
@@ -28,3 +28,7 @@ Tests must reflect the new implicit dependency enforcement logic added in the or
 
 ## Acceptance Criteria
 - [x] Add unit tests in `.github/scripts/foundry-orchestrator.test.ts` to verify implicit dependency evaluation.
+
+## Generated Tasks
+- [ ] `.foundry/tasks/task-087-150-impl-orchestrator-tests.md`
+- [ ] `.foundry/tasks/task-087-151-qa-orchestrator-tests.md`

--- a/.foundry/tasks/task-087-150-impl-orchestrator-tests.md
+++ b/.foundry/tasks/task-087-150-impl-orchestrator-tests.md
@@ -1,0 +1,39 @@
+---
+id: task-087-150-impl-orchestrator-tests
+type: TASK
+title: Implement Orchestrator Tests for Implicit Dependencies
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-048-087-update-orchestrator-tests
+tags:
+  - foundry
+  - process
+  - orchestrator
+  - tests
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Orchestrator Tests for Implicit Dependencies
+
+## Context
+Tests must reflect the new implicit dependency enforcement logic added in the orchestrator.
+
+## Technical Blueprint & Contract
+- Add unit tests in `.github/scripts/foundry-orchestrator.test.ts` to verify implicit dependency evaluation.
+- Specifically, tests should verify that nodes with missing or unresolvable dependencies are handled correctly, or that sibling dependencies are managed properly based on the recent changes.
+
+## Acceptance Criteria
+- [ ] Added unit tests in `.github/scripts/foundry-orchestrator.test.ts` for implicit dependencies.
+- [ ] Run `pnpm test` successfully within `.github/scripts`.
+
+## Coder Contract
+- If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task (e.g. tests are already passing), you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-087-151-qa-orchestrator-tests.md
+++ b/.foundry/tasks/task-087-151-qa-orchestrator-tests.md
@@ -1,0 +1,40 @@
+---
+id: task-087-151-qa-orchestrator-tests
+type: TASK
+title: QA Orchestrator Tests for Implicit Dependencies
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on:
+  - task-087-150-impl-orchestrator-tests
+jules_session_id: null
+pr_number: null
+parent: story-048-087-update-orchestrator-tests
+tags:
+  - foundry
+  - process
+  - orchestrator
+  - tests
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Orchestrator Tests for Implicit Dependencies
+
+## Context
+Verify the tests added for the new implicit dependency enforcement logic in the orchestrator.
+
+## Technical Blueprint & Contract
+- Verify unit tests in `.github/scripts/foundry-orchestrator.test.ts` to verify implicit dependency evaluation.
+- Run the tests to ensure they execute successfully and pass.
+
+## Acceptance Criteria
+- [ ] Unit tests for implicit dependencies exist and provide adequate coverage in `.github/scripts/foundry-orchestrator.test.ts`.
+- [ ] `pnpm test` runs successfully within `.github/scripts`.
+
+## QA Contract
+- If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR introduces new downstream engineering implementation and QA tasks derived from `story-048-087-update-orchestrator-tests` as requested. It follows the correct `id` schema, sets proper dependencies, and appends the new tasks to the original story body while keeping the story's frontmatter intact.

---
*PR created automatically by Jules for task [5107381610001890912](https://jules.google.com/task/5107381610001890912) started by @szubster*