### PR TITLE
Story Owner: Breakdown Pokerus Exfiltration Epic

### DIFF
--- a/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
+++ b/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
@@ -27,3 +27,5 @@ Read the specific byte flags for Pokerus for every Pokemon in the party and PC f
 
 ## Acceptance Criteria
 - [ ] Extract pokerus data
+- [ ] .foundry/stories/story-061-095-pokerus-byte-parsing.md
+- [ ] .foundry/stories/story-061-096-pokerus-tests.md

--- a/.foundry/stories/story-061-095-pokerus-byte-parsing.md
+++ b/.foundry/stories/story-061-095-pokerus-byte-parsing.md
@@ -1,0 +1,29 @@
+---
+id: story-061-095-pokerus-byte-parsing
+type: STORY
+title: Pokerus Byte Parsing Story
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-038-061-pokerus-state-exfiltration
+tags:
+  - gen2
+  - save-engine
+  - pokerus
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Pokerus Byte Parsing Story
+
+## Description
+Parse the raw pokerus byte into structured state for Pokemon in Gen 2 saves.
+
+## Acceptance Criteria
+- [ ] Parse raw pokerus byte.

--- a/.foundry/stories/story-061-096-pokerus-tests.md
+++ b/.foundry/stories/story-061-096-pokerus-tests.md
@@ -1,0 +1,31 @@
+---
+id: story-061-096-pokerus-tests
+type: STORY
+title: Pokerus Parser Tests Story
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on:
+  - story-061-095-pokerus-byte-parsing
+jules_session_id: null
+pr_number: null
+parent: epic-038-061-pokerus-state-exfiltration
+tags:
+  - gen2
+  - save-engine
+  - pokerus
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Pokerus Parser Tests Story
+
+## Description
+Implement tests for the Pokerus byte parsing logic.
+
+## Acceptance Criteria
+- [ ] Add tests for Pokerus parsing.


### PR DESCRIPTION
Dynamically broke down Epic `epic-038-061-pokerus-state-exfiltration` into two implementation stories:
- `story-061-095-pokerus-byte-parsing.md` for parsing the Pokerus byte.
- `story-061-096-pokerus-tests.md` for associated tests.

Followed strict DAG dependencies and parent linking schema, ensuring parent EPIC doesn't transition prematurely.

---
*PR created automatically by Jules for task [15178600973982170039](https://jules.google.com/task/15178600973982170039) started by @szubster*