### PR TITLE
chore: Break down Feebas Backend Parsing Epic

### DIFF
--- a/.foundry/epics/epic-036-058-feebas-backend-parsing.md
+++ b/.foundry/epics/epic-036-058-feebas-backend-parsing.md
@@ -28,3 +28,5 @@ Create a utility module that reads the parsed save file's data at the identified
 - [ ] Create a utility module for Feebas seed extraction.
 - [ ] Implement Gen 3 algorithm to calculate the 6 tile coordinates based on the seed.
 - [ ] Ensure fast calculation concurrent with save file hydration.
+- [ ] .foundry/stories/story-058-095-feebas-seed-extraction.md
+- [ ] .foundry/stories/story-058-096-feebas-tile-calculation.md

--- a/.foundry/stories/story-058-095-feebas-seed-extraction.md
+++ b/.foundry/stories/story-058-095-feebas-seed-extraction.md
@@ -1,0 +1,32 @@
+---
+id: story-058-095-feebas-seed-extraction
+type: STORY
+title: Feebas Seed Extraction Utility
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-036-058-feebas-backend-parsing
+tags:
+  - gen3
+  - backend
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Feebas Seed Extraction Utility
+
+## Objective
+Implement a utility function to extract the 16-bit Feebas seed from Gen 3 save files (Ruby, Sapphire, Emerald) using the native `DataView` API.
+
+## Acceptance Criteria
+- [ ] Create `src/engine/gen3/feebas.ts` (if it doesn't exist).
+- [ ] Implement `extractFeebasSeed(saveData: DataView, gameVersion: GameVersion)` function.
+- [ ] Handle version-specific offsets (`0x2DD6` for Ruby/Sapphire, `0x2E66` for Emerald) within `SaveBlock1`.
+- [ ] Use `DataView` API (e.g. `getUint16`) to read the seed value.
+- [ ] Write unit tests to verify extraction for all supported Gen 3 versions.

--- a/.foundry/stories/story-058-096-feebas-tile-calculation.md
+++ b/.foundry/stories/story-058-096-feebas-tile-calculation.md
@@ -1,0 +1,34 @@
+---
+id: story-058-096-feebas-tile-calculation
+type: STORY
+title: Feebas Tile Calculation Algorithm
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on:
+  - .foundry/stories/story-058-095-feebas-seed-extraction.md
+jules_session_id: null
+pr_number: null
+parent: epic-036-058-feebas-backend-parsing
+tags:
+  - gen3
+  - backend
+  - algorithm
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Feebas Tile Calculation Algorithm
+
+## Objective
+Implement the Gen 3 Linear Congruential Generator (LCG) algorithm to translate the 16-bit Feebas seed into the 6 specific valid spot IDs on Route 119, and map those spot IDs to physical map coordinates.
+
+## Acceptance Criteria
+- [ ] Add `calculateFeebasTiles(seed: number)` to `src/engine/gen3/feebas.ts`.
+- [ ] Implement the LCG formula: `sFeebasRngValue = 1103515245 * sFeebasRngValue + 12345`.
+- [ ] Implement spot selection modulo math: `(sFeebasRngValue >> 16) % 447` and force `0` to `447`.
+- [ ] Implement spot rejection for values `< 4` (inaccessible spots), looping until 6 valid spot IDs are selected.
+- [ ] Add `mapSpotIdsToCoordinates(spotIds: number[])` to map 1D spot IDs to `(x, y)` relative grid coordinates.
+- [ ] Write unit tests verifying the exact 6 spots generated for a set of known seeds.


### PR DESCRIPTION
This PR fulfills the Story Owner's responsibility for `epic-036-058-feebas-backend-parsing`. It breaks down the Epic into two granular `STORY` nodes for the Tech Lead to consume, explicitly maintaining proper dependency trees without circular parent references.

---
*PR created automatically by Jules for task [167553798989106226](https://jules.google.com/task/167553798989106226) started by @szubster*