### PR TITLE
🛠️ Infras: Fix Biome Schema Version Mismatch (2.4.16)

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: "2.4.15"
+          version: "2.4.16"
 
       - name: Run Biome
         run: biome ci --error-on-warnings .

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -80,3 +80,6 @@ Critical learnings:
 
 ## 2026-06-05 - Bumped knip to latest
 **Learning:** Evaluated upgrading `knip` to `v6.16.0`. Discovered that the `$schema` URL in `knip.json` also needs to be updated to `@6` to avoid schema validation warnings. Discovered `pnpm knip` failing due to `gh` being used in bash scripts. Fixed this by adding `ignoreBinaries: ["gh"]` to `knip.json`. Also removed an unused barrel file `src/components/run/index.ts` identified by Knip. Finally, the test `AssistantSuggestionCard.test.tsx` needed to have `expect` statements added to satisfy `vitest/expect-expect` rule.
+
+## 2026-06-09 - Fix Biome schema version
+**Learning:** Config drift between `package.json` (`2.4.16`), `biome.yml` (`2.4.15`), and `biome.jsonc` schemas can cause `sort-package-json` or `pnpm lint:package-json` to fail in CI pipelines, as well as lead to config mismatch between local devs and CI runners. Always ensure Biome schema and runner versions are updated in sync when upgrading.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
**What:**
Updated `.github/workflows/biome.yml` runner and `biome.jsonc` schema to version `2.4.16`.

**Why:**
The `@biomejs/biome` dependency in `package.json` was updated to `2.4.16`, but the configuration and CI pipeline were still referencing `2.4.15`. This config drift causes `sort-package-json` to emit schema mismatch warnings during `pnpm lint:package-json` and could lead to inconsistent formatting between local developers and GitHub Actions.

**Impact on DX/CI:**
Fixes the warnings emitted during linting and aligns local/CI formatting rules, ensuring predictable build pipelines.

**Setup notes:**
N/A - just standard version sync.

---
*PR created automatically by Jules for task [16853835988283041692](https://jules.google.com/task/16853835988283041692) started by @szubster*