### PR TITLE
🖼️ Canvas: Tactical Data Node Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -161,3 +161,9 @@
 **Outcome:** Accepted
 **Why:** Brings the Assistant view entirely in line with the terminal scanning and data stream motifs. Eliminates the generic web UI "card" layout by treating smart suggestions like raw intelligence readouts.
 **Pattern:** Apply CRT background grids (`<LcdGrid>`), scanning beam animations (`<HoverScanner>`), and strict uppercase monospace typography to dynamic AI/smart suggestion components, treating them as specialized hardware intelligence readouts instead of generic info cards.
+
+## 2026-07-07 - [Accepted] - 🖼️ Canvas: Tactical Data Node Redesign
+**What:** Redesigned the `DataPoint` component into a "Tactical Data Node". Replaced the simple flex column text pair with a relative container featuring a dashed left border acting as a data pipe, an absolute positioned marker on the border, and fully monospaced uppercase telemetry typography (`text-[9px]` for labels, `text-[11px]` for values).
+**Outcome:** Accepted
+**Why:** Brings the granular data display components in line with the established specialized hardware motif. The previous `DataPoint` was too generic and didn't fit the "snooping" fantasy, whereas the new design looks like individual data nodes connected to a larger telemetry stream.
+**Pattern:** Apply tactical aesthetics (dashed borders acting as connecting lines, absolute positioning markers, tight monospace typography) even to the smallest, most granular data display elements to maintain absolute visual coherence deep within complex data views.

--- a/src/components/DataPoint.tsx
+++ b/src/components/DataPoint.tsx
@@ -12,11 +12,16 @@ interface DataPointProps {
 
 export function DataPoint({ label, value, children, className, labelClassName, valueClassName }: DataPointProps) {
   return (
-    <div className={cn('flex flex-col', className)}>
-      <span className={cn('font-black text-[9px] text-zinc-500 uppercase tracking-widest', labelClassName)}>
+    <div className={cn('relative flex flex-col border-zinc-800 border-l border-dashed pl-3', className)}>
+      <div className="absolute top-1.5 left-[-2px] h-1.5 w-1.5 border border-zinc-500 bg-zinc-950" />
+      <span
+        className={cn('mb-0.5 font-black font-mono text-[9px] text-zinc-500 uppercase tracking-widest', labelClassName)}
+      >
         {label}
       </span>
-      <span className={cn('font-bold text-xs text-zinc-300 uppercase', valueClassName)}>{value || children}</span>
+      <span className={cn('font-bold font-mono text-[11px] text-zinc-300 uppercase tracking-tight', valueClassName)}>
+        {value || children}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
Redesigned the `DataPoint` component into a "Tactical Data Node". Replaced the simple flex column text pair with a relative container featuring a dashed left border acting as a data pipe, an absolute positioned marker on the border, and fully monospaced uppercase telemetry typography (`text-[9px]` for labels, `text-[11px]` for values).

Brings the granular data display components in line with the established specialized hardware motif. The previous `DataPoint` was too generic and didn't fit the "snooping" fantasy, whereas the new design looks like individual data nodes connected to a larger telemetry stream.

---
*PR created automatically by Jules for task [8555126859777879289](https://jules.google.com/task/8555126859777879289) started by @szubster*