### PR TITLE
feat(foundry): Create Gen 2 Event Flag Extraction stories

### DIFF
--- a/.foundry/epics/epic-038-061-gen2-event-flag-parsing.md
+++ b/.foundry/epics/epic-038-061-gen2-event-flag-parsing.md
@@ -27,3 +27,8 @@ Develop the core save file parsing engine to extract specific time-gated event f
 ## Acceptance Criteria
 - [ ] Parse event flags indicating completion of daily/weekly events.
 - [ ] Expose this data cleanly to the frontend UI components.
+
+
+### Implementation Tasks
+- [ ] .foundry/stories/story-061-095-gen2-event-flag-extraction.md
+- [ ] .foundry/stories/story-061-096-gen2-event-data-layer.md

--- a/.foundry/stories/story-061-095-gen2-event-flag-extraction.md
+++ b/.foundry/stories/story-061-095-gen2-event-flag-extraction.md
@@ -1,0 +1,29 @@
+---
+id: story-061-095-gen2-event-flag-extraction
+type: STORY
+title: Gen 2 Event Flag Extraction
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-038-061-gen2-event-flag-parsing
+tags:
+  - gen2
+  - backend
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 2 Event Flag Extraction
+
+## Objective
+Implement a parser for Gen 2 save files to extract specific time-gated event flags using the native DataView API.
+
+## Acceptance Criteria
+- [ ] Create extraction functions using DataView.
+- [ ] Add unit tests for successful extraction and bounds checking.

--- a/.foundry/stories/story-061-096-gen2-event-data-layer.md
+++ b/.foundry/stories/story-061-096-gen2-event-data-layer.md
@@ -1,0 +1,30 @@
+---
+id: story-061-096-gen2-event-data-layer
+type: STORY
+title: Gen 2 Event Data Layer
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - story-061-095-gen2-event-flag-extraction
+jules_session_id: null
+pr_number: null
+parent: epic-038-061-gen2-event-flag-parsing
+tags:
+  - gen2
+  - frontend
+  - data-layer
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 2 Event Data Layer
+
+## Objective
+Expose the extracted event flags from the save file cleanly to the frontend UI components.
+
+## Acceptance Criteria
+- [ ] Implement data layer integration for Gen 2 event flags.
+- [ ] Add tests for data layer integration.


### PR DESCRIPTION
I have generated two granular STORY nodes (`story-061-095-gen2-event-flag-extraction` and `story-061-096-gen2-event-data-layer`) derived from `epic-038-061-gen2-event-flag-parsing`. The new nodes are assigned to `tech_lead`, linked via the ID schema, and appended as unchecked tasks inside the parent Epic. The Epic's checkboxes remain unchecked as the child nodes are pending. Dependencies have been defined using exact node IDs.

---
*PR created automatically by Jules for task [13363657694903689953](https://jules.google.com/task/13363657694903689953) started by @szubster*