### PR TITLE
feat: spawn downstream nodes for Tailwind v4 utility migration (IDEA 071)

### DIFF
--- a/.foundry/ideas/idea-071-tailwind-v4-utilities-migration.md
+++ b/.foundry/ideas/idea-071-tailwind-v4-utilities-migration.md
@@ -44,6 +44,10 @@ The eventual implementation must be an incremental migration to avoid breaking c
 This significantly improves DX (Developer Experience) and readability. Components will have drastically shorter `className` attributes, reducing noise while making it much easier to universally adjust the "tactical" aesthetic constraints in a single source of truth (`src/index.css`).
 
 ## Next Steps
-- [ ] Product Manager: Create RESEARCH nodes to deeply explore Tailwind v4 APIs and primitives.
+- [x] Product Manager: Create RESEARCH nodes to deeply explore Tailwind v4 APIs and primitives.
 - [ ] Technical Lead: Based on research findings, draft an ADR outlining the chosen consolidation strategy.
 - [ ] Technical Lead: Outline an incremental migration strategy to update components across `src/components/` without regressions.
+
+- [ ] .foundry/research/research-071-137-tailwind-v4-utilities.md
+- [ ] .foundry/tasks/task-071-150-tailwind-v4-adr.md
+- [ ] .foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md

--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -1,0 +1,46 @@
+---
+id: prd-071-040-tailwind-v4-utilities-migration
+type: PRD
+title: Tailwind v4 @utility Consolidation
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - task-071-150-tailwind-v4-adr
+jules_session_id: null
+pr_number: null
+parent: idea-071-tailwind-v4-utilities-migration
+tags:
+  - tech-debt
+  - styling
+  - refactor
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Tailwind v4 @utility Consolidation
+
+## Executive Summary
+DexHelper is transitioning from repetitive inline Tailwind classes to semantic custom utilities defined in `src/index.css` via Tailwind v4's new `@utility` directive. This change will drastically improve the developer experience by DRYing out the codebase while maintaining our strict "tactical hardware/snooping" aesthetic.
+
+## Functional Requirements
+1. **Utility Consolidation**: The project must introduce centralized `@utility` classes in `src/index.css` to represent heavily used aesthetic combinations.
+2. **Tactical Primitives**: At minimum, abstractions must be created for:
+   - Panel borders (`border-dashed`, `rounded-none`, etc.)
+   - Focus states (`focus-visible:ring-[var(--theme-primary)]`, etc.)
+3. **Incremental Component Migration**: Existing components in `src/components/` must be updated to replace raw class combinations with the new semantic utility classes.
+4. **No Visual Regressions**: The migration must perfectly preserve the existing user interface. The tactical, sharp terminal-like appearance must remain unaltered.
+
+## Scope
+- Updating `src/index.css` with the new Tailwind v4 syntax.
+- Migrating components within the `src/components/` directory.
+
+## Out of Scope
+- Redesigning the current aesthetic.
+- Migrating generic unrepeated utility classes.
+
+## Acceptance Criteria
+- [ ] Epics are created to handle the migration in manageable chunks.

--- a/.foundry/research/research-071-137-tailwind-v4-utilities.md
+++ b/.foundry/research/research-071-137-tailwind-v4-utilities.md
@@ -1,0 +1,39 @@
+---
+id: research-071-137-tailwind-v4-utilities
+type: RESEARCH
+title: Explore Tailwind v4 APIs and Primitives
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-071-tailwind-v4-utilities-migration
+tags:
+  - tech-debt
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Tailwind v4 @utility Consolidation
+
+## Objective
+Deeply explore Tailwind v4 APIs and primitives to determine the optimal strategy for consolidating repetitive UI classes into native `@utility` definitions. Specifically, research how to cleanly replace the deprecated `@layer components` syntax.
+
+## Focus Areas
+1. **The `@utility` API:** Investigate the exact syntax and capabilities of the `@utility` directive in Tailwind v4 for creating custom utilities.
+2. **Nesting and `@apply`:** Determine if and how `@apply` can be safely used inside `@utility` blocks to inherit variants (like `hover:`, `md:`) natively without complex configuration.
+3. **Migration Edge Cases:** Identify potential pitfalls when migrating from inline classes (like `border border-dashed rounded-none border-zinc-800`) to custom utilities (like `tactical-panel`).
+
+## Deliverables
+- A comprehensive summary of Tailwind v4 utility configuration.
+- A proposed structure for `src/index.css` to house these new tactical primitives.
+
+## Tasks
+- [ ] Research the `@utility` directive documentation for Tailwind v4.
+- [ ] Document findings and formulate a concrete strategy for `src/index.css`.

--- a/.foundry/tasks/task-071-150-tailwind-v4-adr.md
+++ b/.foundry/tasks/task-071-150-tailwind-v4-adr.md
@@ -1,0 +1,39 @@
+---
+id: task-071-150-tailwind-v4-adr
+type: TASK
+title: Draft ADR for Tailwind v4 Utilities
+status: PENDING
+owner_persona: architect
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - research-071-137-tailwind-v4-utilities
+jules_session_id: null
+pr_number: null
+parent: idea-071-tailwind-v4-utilities-migration
+tags:
+  - tech-debt
+  - styling
+  - adr
+research_references:
+  - .foundry/research/research-071-137-tailwind-v4-utilities.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Draft ADR for Tailwind v4 Utilities
+
+## Context
+Based on the research conducted on Tailwind v4's `@utility` API, we need an Architecture Decision Record (ADR) that formally outlines the consolidation strategy for replacing repetive utility combinations with custom primitives in `src/index.css`.
+
+## Requirements
+- Create a new ADR document in `.foundry/docs/adrs/`.
+- The ADR must describe the exact naming conventions for the new utilities (e.g., `tactical-panel`, `tactical-focus`).
+- The ADR must outline an incremental migration strategy to update components across `src/components/` without regressions.
+
+## Acceptance Criteria
+- [ ] Read the research findings.
+- [ ] Create a new ADR document.
+- [ ] The ADR details the chosen consolidation strategy and naming conventions.
+- [ ] The ADR outlines the incremental migration approach.


### PR DESCRIPTION
This PR completes the Product Manager duties for `idea-071-tailwind-v4-utilities-migration`. 

It creates the necessary downstream nodes:
- `research-071-137-tailwind-v4-utilities`: A RESEARCH node assigned to `researcher` to explore Tailwind v4 APIs.
- `task-071-150-tailwind-v4-adr`: A TASK node assigned to `architect` to draft an ADR based on the research.
- `prd-071-040-tailwind-v4-utilities-migration`: A PRD node assigned to `epic_planner` outlining the functional requirements for the migration.

The dependencies are correctly linked (`PRD` awaits `TASK` awaits `RESEARCH`), and the parent `IDEA` file has been updated with its checked acceptance criteria and the new node references appended as unchecked tasks.

CI tests passed successfully.

---
*PR created automatically by Jules for task [13726744166988360043](https://jules.google.com/task/13726744166988360043) started by @szubster*