### PR TITLE
Foundry: QA rejected task-085-142-impl-extract-rejection-count

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -23,3 +23,6 @@ Rejected `task-085-142-impl-extract-rejection-count`. The implementation success
 
 ## 2026-06-08: Rejection Validation - Missing React Context Layer
 Rejected `task-085-142-impl-extract-rejection-count`. While the parsing logic extracted `rejection_count` correctly and models were updated, the required React Context layer to expose this data to connected UI views (as specified in ADR 013 and ADR 017) was completely missing. The state remained tightly coupled within `DagDashboard.tsx` instead of being lifted into a shared context. This violates the architectural decision requiring a single source of truth accessible by multiple dashboard views.
+
+## 2026-06-09: Rejection Validation - Still Missing React Context Layer
+Rejected `task-085-142-impl-extract-rejection-count` again. The previous rejection correctly identified that the React Context layer was completely missing to expose `rejection_count` to connected UI views, but the implementer did not fix it and instead falsely claimed it was implemented. State is still tightly coupled in `DagDashboard.tsx`. This violates ADR 013 and ADR 017's requirement for a single source of truth accessible by multiple dashboard views.

--- a/.foundry/tasks/task-085-142-impl-extract-rejection-count.md
+++ b/.foundry/tasks/task-085-142-impl-extract-rejection-count.md
@@ -15,7 +15,7 @@ tags:
   - ui
   - dashboard
 research_references: []
-rejection_count: 3
+rejection_count: 4
 rejection_reason: 'The required React Context layer to expose rejection_count to connected UI views (as specified in ADR 013 and ADR 017) was not implemented. The state is still tightly coupled within DagDashboard.tsx.'
 notes: ''
 ---
@@ -34,9 +34,9 @@ In order to display permanent failures on the DAG dashboard, we need to surface 
 3. Verify that the React context layer correctly exposes the property to connected UI views.
 
 ## Acceptance Criteria
-- [x] Coder: Update parsing logic.
-- [x] Coder: Update `FoundryNode` TypeScript types.
-- [x] Coder: Ensure React context layer correctly exposes the property.
+- [ ] Coder: Update parsing logic.
+- [ ] Coder: Update `FoundryNode` TypeScript types.
+- [ ] Coder: Ensure React context layer correctly exposes the property.
 
 ## Reminders
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.


### PR DESCRIPTION
QA Agent rejected the implementation for task-085-142-impl-extract-rejection-count.

- Updated `.foundry/tasks/task-085-142-impl-extract-rejection-count.md` to increment `rejection_count` to 4 and unchecked its acceptance criteria. Note that its `status` is correctly `FAILED`.
- Appended the rejection reasoning to `.foundry/journals/qa.md` explaining the persistent architectural violation of missing the React Context layer, violating ADR 013 and ADR 017.

---
*PR created automatically by Jules for task [17578172966147140534](https://jules.google.com/task/17578172966147140534) started by @szubster*