### PR TITLE
chore(epic): breakdown PRD for Gen 3 contest parsing

### DIFF
--- a/.foundry/epics/epic-040-064-gen3-contest-data-extraction.md
+++ b/.foundry/epics/epic-040-064-gen3-contest-data-extraction.md
@@ -1,0 +1,42 @@
+---
+id: epic-040-064-gen3-contest-data-extraction
+type: EPIC
+title: Gen 3 Contest Data Extraction Engine
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-070-040-gen3-contest-data-parsing
+tags:
+  - feature
+  - gen3
+  - contests
+  - parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Gen 3 Contest Data Extraction Engine
+
+## 1. Context
+As derived from PRD `prd-070-040-gen3-contest-data-parsing`, DexHelper requires the ability to extract hidden contest-related statistics and ribbons directly from Gen 3 save files.
+
+This Epic focuses specifically on the core extraction logic, navigating the Gen 3 save format blocks to locate and read the Condition (Cool, Beauty, Cute, Smart, Tough), Sheen, and Contest Ribbons across all Pokémon.
+
+## 2. Requirements
+- The parsing engine must be updated to target the correct blocks and offsets for Gen 3 save formats (Ruby, Sapphire, Emerald, FireRed, LeafGreen) to locate contest data.
+- **Strict DataView API Usage**: All parsing logic for contest data MUST exclusively use the native `DataView` API (e.g., `getUint8`, `getUint16`, `getUint32`) as mandated by ADR 010.
+- Extract the following hidden Condition stats per Pokémon: Cool, Beauty, Cute, Smart, and Tough.
+- Extract the Pokémon's Sheen value.
+- Extract the bitfield/flags associated with all Contest Ribbons.
+
+## 3. Acceptance Criteria
+- [ ] Implement `DataView`-based parsing logic for Gen 3 Condition stats (Cool, Beauty, Cute, Smart, Tough).
+- [ ] Implement `DataView`-based parsing logic for Gen 3 Sheen data.
+- [ ] Implement `DataView`-based parsing logic to extract Gen 3 Ribbon bitfields.
+- [ ] Write targeted unit tests confirming extraction logic accurately reads raw binary fixtures representing Gen 3 contest data.

--- a/.foundry/epics/epic-040-065-gen3-contest-data-integration.md
+++ b/.foundry/epics/epic-040-065-gen3-contest-data-integration.md
@@ -1,0 +1,39 @@
+---
+id: epic-040-065-gen3-contest-data-integration
+type: EPIC
+title: Gen 3 Contest Data Integration & Validation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - epic-040-064-gen3-contest-data-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-070-040-gen3-contest-data-parsing
+tags:
+  - feature
+  - gen3
+  - contests
+  - parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Gen 3 Contest Data Integration & Validation
+
+## 1. Context
+As derived from PRD `prd-070-040-gen3-contest-data-parsing`, this Epic handles integrating the raw Gen 3 contest extraction logic (`epic-040-064-gen3-contest-data-extraction`) into the broader DexHelper application state. It focuses on mapping data to internal structures, enforcing graceful error handling, and maintaining backwards compatibility.
+
+## 2. Requirements
+- Out-of-bounds reads during contest data extraction must gracefully propagate as specific validation errors, avoiding application crashes.
+- Map the extracted contest data (Condition stats, Sheen, and Ribbons) to appropriate fields in the internal Pokémon `PokeData` structure.
+- **Backwards Compatibility**: Ensure that Gen 3 contest parsing logic does not break or modify existing parsing interfaces for Gen 1 and Gen 2.
+
+## 3. Acceptance Criteria
+- [ ] Implement graceful error handling (e.g. `RangeError` from `DataView`) for corrupted or incomplete save segments.
+- [ ] Map the extracted Condition, Sheen, and Ribbon data to appropriate fields in the internal Pokémon data structure.
+- [ ] Confirm all existing Gen 1 and Gen 2 save parsing tests pass without modification.
+- [ ] Write integration tests confirming the parsing engine successfully processes full Gen 3 save files and maps contest data correctly.

--- a/.foundry/prds/prd-070-040-gen3-contest-data-parsing.md
+++ b/.foundry/prds/prd-070-040-gen3-contest-data-parsing.md
@@ -49,3 +49,7 @@ As part of the Gen 3 Contest Stat and Ribbon Tracker feature, DexHelper needs th
 - [ ] Graceful error handling for corrupted or incomplete save segments is implemented.
 - [ ] All existing Gen 1 and Gen 2 save parsing tests pass without modification.
 - [ ] New unit tests confirm accurate extraction of contest data from known Gen 3 save file fixtures.
+
+### Epic Breakdown
+- [ ] `epic-040-064-gen3-contest-data-extraction`
+- [ ] `epic-040-065-gen3-contest-data-integration`


### PR DESCRIPTION
Breaks down the `prd-070-040-gen3-contest-data-parsing` node into two granular epics for the implementation of Gen 3 contest parsing.

- **Extraction Engine Epic**: Focuses on navigating Gen 3 blocks using `DataView` to extract Condition stats, Sheen, and Ribbon bitfields.
- **Integration & Validation Epic**: Focuses on graceful error handling, backwards compatibility, and mapping the parsed data into DexHelper's internal structures.

Both nodes are explicitly linked into the DAG following standard schema rules. All tests passed.

---
*PR created automatically by Jules for task [1436217445101503047](https://jules.google.com/task/1436217445101503047) started by @szubster*