### PR TITLE
feat: generate child stories for Gen 3 PV extraction

### DIFF
--- a/.foundry/epics/epic-038-062-personality-value-extraction.md
+++ b/.foundry/epics/epic-038-062-personality-value-extraction.md
@@ -31,4 +31,8 @@ As defined in PRD `prd-068-038-mirage-island-data-extraction`, the appearance of
 3. **DataView API**: Comply with ADR 010 by using the `DataView` API for any new PV parsing logic.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Generate child stories to ensure the personality value is correctly extracted and formatted.
+- [x] Story Owner: Generate child stories to ensure the personality value is correctly extracted and formatted.
+
+## Generated Stories
+- [ ] story-062-098-gen3-parse-32bit-pv
+- [ ] story-062-099-gen3-expose-lower-16bit-pv

--- a/.foundry/stories/story-062-098-gen3-parse-32bit-pv.md
+++ b/.foundry/stories/story-062-098-gen3-parse-32bit-pv.md
@@ -1,0 +1,33 @@
+---
+id: story-062-098-gen3-parse-32bit-pv
+type: STORY
+title: Extract full 32-bit PV using DataView API
+status: PENDING
+owner_persona: "tech_lead"
+created_at: "2026-06-09"
+updated_at: "2026-06-09"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-038-062-personality-value-extraction
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Extract full 32-bit PV using DataView API
+
+## Context
+As part of the Mirage Island checking feature (Epic `epic-038-062-personality-value-extraction`), we need to parse the full 32-bit personality value (PV) for Gen 3 Pokémon. This requires adhering to ADR 010 by using the native `DataView` API for safe and maintainable binary parsing.
+
+## Requirements
+1. **Implementation Details**: Write task definitions to safely extract the 32-bit PV using the `DataView` API. Ensure that the parser throws explicit, catchable `RangeError` on out-of-bounds reads and propagates them properly.
+2. **Backwards Compatibility**: Keep the original Gen 1 and Gen 2 handlers functional without altering legacy parsing.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Generate child tasks to update the extraction logic.

--- a/.foundry/stories/story-062-099-gen3-expose-lower-16bit-pv.md
+++ b/.foundry/stories/story-062-099-gen3-expose-lower-16bit-pv.md
@@ -1,0 +1,34 @@
+---
+id: story-062-099-gen3-expose-lower-16bit-pv
+type: STORY
+title: Expose lower 16-bits of PV
+status: PENDING
+owner_persona: "tech_lead"
+created_at: "2026-06-09"
+updated_at: "2026-06-09"
+depends_on:
+  - story-062-098-gen3-parse-32bit-pv
+jules_session_id: null
+pr_number: null
+parent: epic-038-062-personality-value-extraction
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Expose lower 16-bits of PV
+
+## Context
+As part of the Mirage Island checking feature (Epic `epic-038-062-personality-value-extraction`), after parsing the 32-bit PV, we need to pre-calculate and expose its lower 16 bits. This specific 16-bit value is compared against the daily generated Mirage Island value to determine if the island will appear.
+
+## Requirements
+1. **Pre-calculation**: Ensure that the lower 16 bits of the 32-bit PV are calculated and exposed during the data parsing and processing phases.
+2. **Data Structure Consistency**: Add this logic securely and optimally alongside the newly minted 32-bit PV value.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Generate child tasks to update formatting and exposure logic.


### PR DESCRIPTION
As requested, this PR breaks down the `epic-038-062-personality-value-extraction` Epic into two child STORY nodes (`story-062-098-gen3-parse-32bit-pv` and `story-062-099-gen3-expose-lower-16bit-pv`). 

The Epic has been updated with the generated child stories as unchecked tasks and the acceptance criteria has been checked off.

The dependency linking follows the strict node ID naming rule per ADR 002. All tests and linting passed locally.

---
*PR created automatically by Jules for task [1906844815588971971](https://jules.google.com/task/1906844815588971971) started by @szubster*