### PR TITLE
Break down Gen 3 Contest Optimization Advisor PRD into Epics

### DIFF
--- a/.foundry/epics/epic-042-064-gen3-contest-advisor-algorithm.md
+++ b/.foundry/epics/epic-042-064-gen3-contest-advisor-algorithm.md
@@ -1,0 +1,47 @@
+---
+id: epic-042-064-gen3-contest-advisor-algorithm
+type: EPIC
+title: Gen 3 Contest Advisor Algorithm
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-06-09"
+updated_at: "2026-06-09"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-070-042-gen3-contest-optimization-advisor
+tags:
+  - feature
+  - gen3
+  - contests
+  - advisor
+  - algorithm
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Gen 3 Contest Advisor Algorithm
+
+## 1. Context
+Derived from `prd-070-042-gen3-contest-optimization-advisor`, this epic focuses on implementing the underlying backend logic and recommendation algorithm for the Gen 3 Contest Optimization Advisor. It requires translating game mechanics—such as Nature preferences, Condition stats, and Sheen limits—into a programmatic recommendation engine.
+
+## 2. Requirements
+
+### 2.1 Nature Mapping
+- Implement a robust data mapping of all 25 Pokémon Natures to their preferred and disliked Pokéblock flavors.
+- Ensure these flavors correctly align with the five Contest Conditions: Cool, Beauty, Cute, Smart, and Tough.
+
+### 2.2 Recommendation Algorithm
+- Develop an algorithm that accepts a Pokémon's current Natures, Condition values, and Sheen level.
+- The algorithm must calculate the "remaining potential" for each condition (factoring in the maximum Sheen limit of 255).
+- It should output the top 1-2 recommended Contest categories based on a weighted combination of:
+  1. Nature preference (bonus to preferred, penalty to disliked).
+  2. Current highest base stats in the relevant Condition.
+  3. Feasibility of maxing out the stat before hitting the Sheen cap.
+
+## 3. Acceptance Criteria
+- [ ] Create the data structure for Nature-to-Condition mappings.
+- [ ] Implement the core recommendation algorithm function.
+- [ ] Write unit tests to verify the recommendation engine outputs mathematically sound suggestions across various edge cases (e.g., max Sheen, conflicting Natures, all stats equal).

--- a/.foundry/epics/epic-042-065-gen3-contest-advisor-ui.md
+++ b/.foundry/epics/epic-042-065-gen3-contest-advisor-ui.md
@@ -1,0 +1,49 @@
+---
+id: epic-042-065-gen3-contest-advisor-ui
+type: EPIC
+title: Gen 3 Contest Advisor UI
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-06-09"
+updated_at: "2026-06-09"
+depends_on:
+  - epic-042-064-gen3-contest-advisor-algorithm
+jules_session_id: null
+pr_number: null
+parent: prd-070-042-gen3-contest-optimization-advisor
+tags:
+  - feature
+  - gen3
+  - contests
+  - advisor
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Gen 3 Contest Advisor UI
+
+## 1. Context
+Derived from `prd-070-042-gen3-contest-optimization-advisor`, this epic handles the frontend integration of the Gen 3 Contest Optimization Advisor. It will consume the outputs from the algorithm epic (`epic-042-064-gen3-contest-advisor-algorithm`) to display actionable insights to the user.
+
+## 2. Requirements
+
+### 2.1 UI Components
+- Design and build reusable UI components to display Contest recommendations.
+- Integrate these components into the individual Pokémon detail view, alongside existing Contest Stats.
+
+### 2.2 Result Presentation
+- Clearly display the top 1-2 recommended Contest categories.
+- Provide a brief, generated explanation for *why* a category was chosen (e.g., highlighting favorable Nature or high existing stat).
+
+### 2.3 Warning States
+- Implement visual warnings for edge cases identified by the algorithm.
+- Specifically, alert users when a Pokémon has maxed out its Sheen but lacks the requisite stats for Master Rank contests, indicating a dead-end for optimization.
+
+## 3. Acceptance Criteria
+- [ ] Develop UI components for Contest recommendations.
+- [ ] Integrate components into the Pokémon detail view.
+- [ ] Implement clear reasoning copy for recommendations.
+- [ ] Implement and test visual warning states for maxed Sheen scenarios.

--- a/.foundry/prds/prd-070-042-gen3-contest-optimization-advisor.md
+++ b/.foundry/prds/prd-070-042-gen3-contest-optimization-advisor.md
@@ -45,3 +45,7 @@ Beyond simply displaying Contest statistics and Ribbons, DexHelper aims to provi
 - [ ] Create UI components to display the recommendations clearly.
 - [ ] Implement warning states for Pokémon with maxed Sheen and suboptimal stats.
 - [ ] Write unit tests verifying the recommendation logic produces expected outcomes for various Nature/Stat combinations.
+
+### Breakdown Tasks
+- [ ] epic-042-064-gen3-contest-advisor-algorithm
+- [ ] epic-042-065-gen3-contest-advisor-ui


### PR DESCRIPTION
This PR breaks down the `prd-070-042-gen3-contest-optimization-advisor` into two actionable epics:
1. `epic-042-064-gen3-contest-advisor-algorithm`
2. `epic-042-065-gen3-contest-advisor-ui`

The parent node has been updated to list these as unchecked breakdown tasks.

---
*PR created automatically by Jules for task [17614109815219284121](https://jules.google.com/task/17614109815219284121) started by @szubster*