### PR TITLE
feat(foundry): Break down epic-038-061 into story nodes

### DIFF
--- a/.foundry/epics/epic-038-061-mirage-island-save-parsing.md
+++ b/.foundry/epics/epic-038-061-mirage-island-save-parsing.md
@@ -32,4 +32,6 @@ As defined in PRD `prd-068-038-mirage-island-data-extraction`, we need to implem
 4. **Graceful Error Handling**: Ensure `RangeError` on out-of-bounds reads are explicitly caught and propagated as validation errors (e.g., "Corrupted Save File").
 
 ## Acceptance Criteria
-- [ ] Story Owner: Generate child stories to implement the save file parsing logic and integrate it into the parser engine.
+- [x] Story Owner: Generate child stories to implement the save file parsing logic and integrate it into the parser engine.
+- [ ] story-061-098-locate-mirage-island-data
+- [ ] story-061-099-implement-mirage-island-parser

--- a/.foundry/stories/story-061-098-locate-mirage-island-data.md
+++ b/.foundry/stories/story-061-098-locate-mirage-island-data.md
@@ -1,0 +1,33 @@
+---
+id: story-061-098-locate-mirage-island-data
+type: STORY
+title: Locate Mirage Island Data Block
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-038-061-mirage-island-save-parsing
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Locate Mirage Island Data Block
+
+## Context
+As part of Epic `epic-038-061-mirage-island-save-parsing`, we need to locate the daily Mirage Island value within the Gen 3 save file structure.
+
+## Requirements
+- Identify the exact offset and data structure for the daily/random variables block containing the Mirage Island value in Ruby, Sapphire, and Emerald save files.
+- Document these findings to be used by the implementation tasks.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Generate child tasks to locate and document the offset for the Mirage Island value.

--- a/.foundry/stories/story-061-099-implement-mirage-island-parser.md
+++ b/.foundry/stories/story-061-099-implement-mirage-island-parser.md
@@ -1,0 +1,35 @@
+---
+id: story-061-099-implement-mirage-island-parser
+type: STORY
+title: Implement Mirage Island Save Parser
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - story-061-098-locate-mirage-island-data
+jules_session_id: null
+pr_number: null
+parent: epic-038-061-mirage-island-save-parsing
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Mirage Island Save Parser
+
+## Context
+With the data offsets located, we need to implement the actual parser for the Gen 3 Mirage Island value.
+
+## Requirements
+- Update the Gen 3 save parser engine to extract the Mirage Island value using the located offsets.
+- Strictly adhere to ADR 010: Use the `DataView` API exclusively.
+- Implement graceful error handling by catching `RangeError` on out-of-bounds reads and propagating them as validation errors.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Generate child tasks to implement the parsing logic and integrate it into the parser engine.


### PR DESCRIPTION
As the Story Owner, I have broken down Epic `epic-038-061-mirage-island-save-parsing` (Parse Daily Mirage Island Value) into actionable granular Story nodes.

- **`story-061-098-locate-mirage-island-data`**: A task scoped for the Tech Lead to identify the exact offset of the Mirage Island value in Gen 3 save files.
- **`story-061-099-implement-mirage-island-parser`**: A dependent task for the Tech Lead to implement the parsing logic using the `DataView` API according to ADR 010.

The parent Epic's acceptance criteria have been checked off and the new child stories appended, successfully enabling late-binding without advancing the parent to `VERIFYING` prematurely.

---
*PR created automatically by Jules for task [2035188061545778775](https://jules.google.com/task/2035188061545778775) started by @szubster*