### PR TITLE
feat(foundry): break down PRD 070-041 (Gen 3 Contest UI) into Epics

### DIFF
--- a/.foundry/epics/epic-041-064-contest-ui-shared-components.md
+++ b/.foundry/epics/epic-041-064-contest-ui-shared-components.md
@@ -1,0 +1,37 @@
+---
+id: epic-041-064-contest-ui-shared-components
+type: EPIC
+title: Contest UI Shared Components
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-070-041-gen3-contest-ui-viewer
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Contest UI Shared Components
+
+## 1. Context
+This epic aims to build the basic foundation blocks for the new Gen 3 Contest Condition and Ribbon Viewer UI. The components will represent exact numerical values of Contest stats (Cool, Beauty, Cute, Smart, and Tough), the Sheen value visually, and the visual design for Contest Ribbons.
+
+## 2. Requirements
+- Develop a UI component to display Contest stat values clearly (e.g. numerical tables or clearer graphs).
+- Develop a progress bar or similar visual component to represent Sheen against its max value (255).
+- Develop badge/icon components for rendering individual Ribbons correctly.
+
+## 3. Acceptance Criteria
+- [ ] Create numerical view components for Cool, Beauty, Cute, Smart, and Tough.
+- [ ] Create a Sheen display component.
+- [ ] Create ribbon display components.

--- a/.foundry/epics/epic-041-065-individual-contest-stats-view.md
+++ b/.foundry/epics/epic-041-065-individual-contest-stats-view.md
@@ -1,0 +1,37 @@
+---
+id: epic-041-065-individual-contest-stats-view
+type: EPIC
+title: Individual Contest Stats View
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - epic-041-064-contest-ui-shared-components
+jules_session_id: null
+pr_number: null
+parent: prd-070-041-gen3-contest-ui-viewer
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Individual Contest Stats View
+
+## 1. Context
+This epic covers the integration of the shared contest UI components into the detailed view for an individual Pokémon. It directly addresses the need to replace vague in-game contest representations with clear, numeric exactness in DexHelper's individual views.
+
+## 2. Requirements
+- Integrate the individual stats, Sheen, and Ribbon icons into the detailed view component.
+- Ensure the individual view handles different display scenarios gracefully.
+
+## 3. Acceptance Criteria
+- [ ] Integrate numerical contest stats into the detailed Pokémon view.
+- [ ] Integrate the Sheen display into the detailed Pokémon view.
+- [ ] Integrate Ribbons for a single Pokémon.

--- a/.foundry/epics/epic-041-066-global-ribbon-checklist-dashboard.md
+++ b/.foundry/epics/epic-041-066-global-ribbon-checklist-dashboard.md
@@ -1,0 +1,40 @@
+---
+id: epic-041-066-global-ribbon-checklist-dashboard
+type: EPIC
+title: Global Ribbon Checklist Dashboard
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - epic-041-064-contest-ui-shared-components
+jules_session_id: null
+pr_number: null
+parent: prd-070-041-gen3-contest-ui-viewer
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Global Ribbon Checklist Dashboard
+
+## 1. Context
+This epic builds the centralized aggregate view (or dashboard) across the entire Living Dex or current PC boxes to manage Ribbons efficiently. It allows tracking Master Rank achievements and identifying which Pokémon are missing Ribbons.
+
+## 2. Requirements
+- Build a centralized ribbon checklist view that aggregates data.
+- Support tracking of Master Rank achievements.
+- Implement filtering/sorting options (e.g., sort by missing Ribbons, filter by category).
+- Ensure UI responsiveness and accessibility, handling large datasets correctly.
+
+## 3. Acceptance Criteria
+- [ ] Build global Ribbon Checklist dashboard component.
+- [ ] Add tracking elements for Master Rank in specific categories.
+- [ ] Implement filtering and sorting for Ribbons.
+- [ ] Ensure adequate rendering performance for hundreds of Pokémon.

--- a/.foundry/prds/prd-070-041-gen3-contest-ui-viewer.md
+++ b/.foundry/prds/prd-070-041-gen3-contest-ui-viewer.md
@@ -48,3 +48,8 @@ Following the data extraction phase, DexHelper must present the extracted Gen 3 
 - [ ] Provide filtering/sorting options in the Ribbon Checklist (e.g., sort by missing Ribbons, filter by category).
 - [ ] Ensure rendering performance is maintained when viewing hundreds of Pokémon in the checklist.
 - [ ] Pass visual regression and accessibility checks.
+
+## Generated Epics
+- [ ] .foundry/epics/epic-041-064-contest-ui-shared-components.md
+- [ ] .foundry/epics/epic-041-065-individual-contest-stats-view.md
+- [ ] .foundry/epics/epic-041-066-global-ribbon-checklist-dashboard.md


### PR DESCRIPTION
This PR fulfills the Epic Planner persona's responsibility to break down PRD `prd-070-041-gen3-contest-ui-viewer` into actionable Epics. 

It generates three new Epic nodes:
- `epic-041-064-contest-ui-shared-components` (Shared foundational components)
- `epic-041-065-individual-contest-stats-view` (Individual Pokémon view integration)
- `epic-041-066-global-ribbon-checklist-dashboard` (Global aggregate checklist)

The newly created Epics are perfectly linked via exact node IDs without file extensions per schema rules. References to the generated child epics have been appended as unchecked tasks inside the PRD to prevent the parent from transitioning into `VERIFYING` prematurely.

---
*PR created automatically by Jules for task [9483705178920342649](https://jules.google.com/task/9483705178920342649) started by @szubster*