### PR TITLE
feat(foundry): break down epic-041-064 into story nodes

### DIFF
--- a/.foundry/epics/epic-041-064-contest-ui-shared-components.md
+++ b/.foundry/epics/epic-041-064-contest-ui-shared-components.md
@@ -32,6 +32,11 @@ This epic aims to build the basic foundation blocks for the new Gen 3 Contest Co
 - Develop badge/icon components for rendering individual Ribbons correctly.
 
 ## 3. Acceptance Criteria
-- [ ] Create numerical view components for Cool, Beauty, Cute, Smart, and Tough.
-- [ ] Create a Sheen display component.
-- [ ] Create ribbon display components.
+- [x] Create numerical view components for Cool, Beauty, Cute, Smart, and Tough.
+- [x] Create a Sheen display component.
+- [x] Create ribbon display components.
+
+## 4. Child Nodes
+- [ ] .foundry/stories/story-064-101-contest-condition-stats-ui.md
+- [ ] .foundry/stories/story-064-102-contest-sheen-display-ui.md
+- [ ] .foundry/stories/story-064-103-contest-ribbons-display-ui.md

--- a/.foundry/stories/story-064-101-contest-condition-stats-ui.md
+++ b/.foundry/stories/story-064-101-contest-condition-stats-ui.md
@@ -1,0 +1,38 @@
+---
+id: story-064-101-contest-condition-stats-ui
+type: STORY
+title: Contest Condition Stats UI Component
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-041-064-contest-ui-shared-components
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Contest Condition Stats UI Component
+
+## 1. Context
+Derived from `epic-041-064-contest-ui-shared-components`, this story focuses on creating the reusable UI component(s) to display a Pokémon's Contest stats: Cool, Beauty, Cute, Smart, and Tough.
+
+## 2. Requirements
+- The component must accept numerical values (0-255) for all five condition categories.
+- The visual presentation should be clear and accessible (e.g., a spider graph, bar charts, or a cleanly formatted numerical table).
+- The component must adhere to the tactical styling and color palette described in the project style guides.
+- The component must handle cases where the data is missing or zero gracefully.
+
+## 3. Acceptance Criteria
+- [ ] Implement the `ContestConditionStats` React component.
+- [ ] Add rendering tests to verify that it displays values correctly.
+- [ ] Ensure proper styling matching the project's aesthetics.

--- a/.foundry/stories/story-064-102-contest-sheen-display-ui.md
+++ b/.foundry/stories/story-064-102-contest-sheen-display-ui.md
@@ -1,0 +1,38 @@
+---
+id: story-064-102-contest-sheen-display-ui
+type: STORY
+title: Contest Sheen Display UI Component
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-041-064-contest-ui-shared-components
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Contest Sheen Display UI Component
+
+## 1. Context
+Derived from `epic-041-064-contest-ui-shared-components`, this story focuses on creating the reusable UI component to visualize a Pokémon's Sheen value.
+
+## 2. Requirements
+- The component must accept a numerical Sheen value between 0 and 255.
+- It must visually represent this value relative to the maximum of 255 (e.g., as a progress bar or radial meter).
+- The styling must match the tactical hardware aesthetic of the application.
+- It should visually indicate when the Sheen is maxed out.
+
+## 3. Acceptance Criteria
+- [ ] Implement the `ContestSheenDisplay` React component.
+- [ ] Add rendering tests to verify empty, partial, and full sheen displays.
+- [ ] Ensure proper styling matching the project's aesthetics.

--- a/.foundry/stories/story-064-103-contest-ribbons-display-ui.md
+++ b/.foundry/stories/story-064-103-contest-ribbons-display-ui.md
@@ -1,0 +1,38 @@
+---
+id: story-064-103-contest-ribbons-display-ui
+type: STORY
+title: Contest Ribbons Display UI Component
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-041-064-contest-ui-shared-components
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Contest Ribbons Display UI Component
+
+## 1. Context
+Derived from `epic-041-064-contest-ui-shared-components`, this story focuses on creating the reusable UI components to display the Contest Ribbons a Pokémon has earned.
+
+## 2. Requirements
+- The component must take a list or object representing the earned Contest Ribbons.
+- It must render distinct icons or badges for each Ribbon type (Cool, Beauty, Cute, Smart, Tough) and their respective ranks (Normal, Super, Hyper, Master).
+- If appropriate, include tooltips to describe the Ribbon.
+- The styling must follow the global tactical UI guidelines.
+
+## 3. Acceptance Criteria
+- [ ] Implement the `ContestRibbonBadge` (or similar) React component(s).
+- [ ] Add rendering tests to verify various Ribbon combinations display correctly.
+- [ ] Ensure proper styling matching the project's aesthetics.


### PR DESCRIPTION
Creates three new STORY nodes for the Contest UI Shared Components:
- `story-064-101-contest-condition-stats-ui`
- `story-064-102-contest-sheen-display-ui`
- `story-064-103-contest-ribbons-display-ui`

Appends these child nodes as unchecked tasks to the parent Epic markdown body to prevent premature pipeline verification.

---
*PR created automatically by Jules for task [11085096447987553785](https://jules.google.com/task/11085096447987553785) started by @szubster*