### PR TITLE
Breakdown Epic 042-064 Gen 3 Contest Advisor Algorithm

### DIFF
--- a/.foundry/epics/epic-042-064-gen3-contest-advisor-algorithm.md
+++ b/.foundry/epics/epic-042-064-gen3-contest-advisor-algorithm.md
@@ -45,3 +45,5 @@ Derived from `prd-070-042-gen3-contest-optimization-advisor`, this epic focuses 
 - [ ] Create the data structure for Nature-to-Condition mappings.
 - [ ] Implement the core recommendation algorithm function.
 - [ ] Write unit tests to verify the recommendation engine outputs mathematically sound suggestions across various edge cases (e.g., max Sheen, conflicting Natures, all stats equal).
+- [ ] story-064-101-gen3-nature-condition-mapping
+- [ ] story-064-102-gen3-contest-recommendation-algorithm

--- a/.foundry/stories/story-064-101-gen3-nature-condition-mapping.md
+++ b/.foundry/stories/story-064-101-gen3-nature-condition-mapping.md
@@ -1,0 +1,35 @@
+---
+id: story-064-101-gen3-nature-condition-mapping
+type: STORY
+title: Gen 3 Nature to Contest Condition Mapping
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-042-064-gen3-contest-advisor-algorithm
+tags:
+  - gen3
+  - contests
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Nature to Contest Condition Mapping
+
+## 1. Context
+This story implements the first part of `epic-042-064-gen3-contest-advisor-algorithm`. We need a robust data structure to map the 25 Pokémon Natures to their preferred and disliked Pokéblock flavors, which directly correspond to the five Contest Conditions (Cool, Beauty, Cute, Smart, Tough).
+
+## 2. Requirements
+- Implement a robust data mapping of all 25 Pokémon Natures to their preferred and disliked Pokéblock flavors.
+- Ensure these flavors correctly align with the five Contest Conditions: Cool (Spicy), Beauty (Dry), Cute (Sweet), Smart (Bitter), and Tough (Sour).
+- Expose functions or constants to easily query the preferred/disliked conditions for any given Nature.
+
+## 3. Acceptance Criteria
+- [ ] Create the data structure mapping Natures to Contest Conditions.
+- [ ] Implement utility functions for querying preferences.
+- [ ] Write unit tests to verify the mappings are accurate for all 25 natures.

--- a/.foundry/stories/story-064-102-gen3-contest-recommendation-algorithm.md
+++ b/.foundry/stories/story-064-102-gen3-contest-recommendation-algorithm.md
@@ -1,0 +1,40 @@
+---
+id: story-064-102-gen3-contest-recommendation-algorithm
+type: STORY
+title: Gen 3 Contest Recommendation Algorithm
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - story-064-101-gen3-nature-condition-mapping
+jules_session_id: null
+pr_number: null
+parent: epic-042-064-gen3-contest-advisor-algorithm
+tags:
+  - gen3
+  - contests
+  - algorithm
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Contest Recommendation Algorithm
+
+## 1. Context
+This story implements the core logic for `epic-042-064-gen3-contest-advisor-algorithm`. Using the Nature mapping from the previous story, we will build the recommendation engine that advises users on the best Contest categories for their Pokémon.
+
+## 2. Requirements
+- Develop an algorithm that accepts a Pokémon's current Nature, Condition values (Cool, Beauty, Cute, Smart, Tough), and Sheen level.
+- Calculate the "remaining potential" for each condition, factoring in the maximum Sheen limit of 255.
+- Output the top 1-2 recommended Contest categories based on a weighted combination of:
+  1. Nature preference (bonus to preferred, penalty to disliked).
+  2. Current highest base stats in the relevant Condition.
+  3. Feasibility of maxing out the stat before hitting the Sheen cap.
+
+## 3. Acceptance Criteria
+- [ ] Implement the core recommendation algorithm function.
+- [ ] Write unit tests to verify outputs for max Sheen scenarios.
+- [ ] Write unit tests for conflicting Natures and edge cases (e.g., all stats equal).


### PR DESCRIPTION
This PR breaks down the Gen 3 Contest Advisor Algorithm Epic into 2 granular STORY nodes:
1. `story-064-101-gen3-nature-condition-mapping` - for mapping Nature to Contest Conditions.
2. `story-064-102-gen3-contest-recommendation-algorithm` - for developing the actual algorithm.

These children have been correctly linked and appended to the parent epic node, maintaining the strict single-owner DAG architecture.

---
*PR created automatically by Jules for task [9537044494465755809](https://jules.google.com/task/9537044494465755809) started by @szubster*