### PR TITLE
chore(foundry): Auditor rejection of idea-066 due to pending descendants

### DIFF
--- a/.foundry/ideas/idea-066-save-file-health-scanner.md
+++ b/.foundry/ideas/idea-066-save-file-health-scanner.md
@@ -44,4 +44,4 @@ This feature pivots DexHelper from just a tracking tool into a critical utility 
 - [ ] `.foundry/prds/prd-066-036-save-file-health-scanner.md`
 
 ### Auditor Rejection
-The generated PRD (`prd-066-036-save-file-health-scanner.md`) is still in the `PENDING` state. Macro nodes MUST NOT be verified or completed until all generated descendant nodes (the PRD, Epics, Stories, Tasks) have fully transitioned to `COMPLETED`. Do not submit this IDEA node for verification until its functional requirements have been fully implemented by the downstream pipeline.
+The generated PRD and Epic nodes are still PENDING. This IDEA node must wait until its entire generated sub-tree is COMPLETED. I have spawned a new node `.foundry/ideas/idea-072-strict-macro-node-completion.md` to address this recurring systemic issue.

--- a/.foundry/ideas/idea-072-strict-macro-node-completion.md
+++ b/.foundry/ideas/idea-072-strict-macro-node-completion.md
@@ -1,0 +1,31 @@
+---
+id: idea-072-strict-macro-node-completion
+type: IDEA
+title: Strict Macro Node Completion Enforcement
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Strict Macro Node Completion Enforcement
+
+## Context
+I am still seeing instances where macro generation nodes (like `IDEA` or `PRD` nodes) are transitioned to `VERIFYING` immediately after they successfully spawn their first set of child nodes, despite those children (and their subsequent descendants) still being in `PENDING` or `ACTIVE` states.
+
+## Proposal
+We need to strongly enforce the rule that a macro node (IDEA, PRD, EPIC, STORY) MUST NOT be verified until its *functional requirements* are implemented and merged by its downstream child tasks. All generated descendant nodes must have fully transitioned to `COMPLETED` first before the parent can be transitioned to `COMPLETED`.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD.

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -19,3 +19,6 @@ As noted previously, this breaks the dependency graph and the concept of complet
 
 **Recommendation/Learnings:**
 We need to strongly enforce the rule that a macro node (IDEA, PRD, EPIC, STORY) MUST NOT be verified until its *functional requirements* are implemented and merged by its downstream child tasks. Submitting an empty PR to transition these nodes when merely their planning phase (child generation) is complete is incorrect. All generated descendant nodes must have fully transitioned to `COMPLETED` first.
+
+## 2026-06-09: Spawning Strict Macro Node Completion Idea
+I am still seeing instances of macro generation nodes (like idea-066) being transitioned to VERIFYING prematurely. We need strict hierarchical completion enforcement. Spawned `idea-072-strict-macro-node-completion` to systematically prevent this.


### PR DESCRIPTION
The `idea-066-save-file-health-scanner` node was prematurely submitted for verification while its child nodes (PRD, Epics) were still in the `PENDING` state. This violates strict hierarchical completion enforcement. 

This PR performs the following according to the Auditor initialization rules:
- Appends an `### Auditor Rejection` section to the `idea-066` markdown body to fail the verification, without touching the YAML frontmatter.
- Spawns a new detached IDEA node (`idea-072-strict-macro-node-completion.md`) to propose an orchestrator-level enforcement of this rule.
- Records this pattern in `.foundry/journals/auditor.md`.

---
*PR created automatically by Jules for task [17989734643566830295](https://jules.google.com/task/17989734643566830295) started by @szubster*