### PR TITLE
epic-planner: Break down PRD 070-043 into Epics

### DIFF
--- a/.foundry/epics/epic-043-067-roamer-data-extraction.md
+++ b/.foundry/epics/epic-043-067-roamer-data-extraction.md
@@ -1,0 +1,36 @@
+---
+id: epic-043-067-roamer-data-extraction
+type: EPIC
+title: Roamer Data Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Roamer Data Extraction
+
+## Objective
+Implement roamer data extraction for Gen 3 (Ruby, Sapphire, Emerald) in the save parser engine. We need to parse the save file for the active roaming Pokémon, its species ID, level, and current map location (map bank/group and map ID). We also need to standardize the return structure for both Gen 2 and Gen 3.
+
+## Description
+- Modify `src/engine/saveParser/parsers/gen3.ts` to identify and extract offset data for Latios/Latias map coordinates and attributes.
+- Ensure the extracted data populates the `saveData.roamingLegendaries` object.
+- Review and standardize the `roamingLegendaries` interface in `common.ts` to guarantee parity in the structure returned by both Gen 2 and Gen 3.
+- Only consider roamers that have been formally released in the save file's event flags.
+
+## Acceptance Criteria
+- [ ] Gen 3 save parser correctly extracts Latios/Latias map group and ID.
+- [ ] Gen 3 save parser correctly extracts the species ID and level of the roaming Pokémon.
+- [ ] Only released roamers are considered active.
+- [ ] The return structure in `common.ts` is standardized for both Gen 2 and Gen 3.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-043-068-roamer-map-translation.md
+++ b/.foundry/epics/epic-043-068-roamer-map-translation.md
@@ -1,0 +1,36 @@
+---
+id: epic-043-068-roamer-map-translation
+type: EPIC
+title: Roamer Map Translation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - epic-043-067-roamer-data-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Roamer Map Translation
+
+## Objective
+Translate the raw `mapGroup` and `mapId` bytes extracted from the Gen 2 and Gen 3 save files into human-readable Route names corresponding to the UI's routing system and map rendering components.
+
+## Description
+- The raw `mapGroup` and `mapId` bytes are internal engine concepts.
+- Implement mapping logic to translate these raw bytes into recognizable route identifiers (e.g., "Route 34", "Route 110").
+- Ensure the translation logic leverages existing `gen2Graph.ts` and `gen3Graph.ts` mapping structures or creates specific lookup tables if necessary.
+- Prepare the data format for easy consumption by the presentation layer.
+
+## Acceptance Criteria
+- [ ] Gen 2 raw map coordinates for roamers are translated into human-readable route names.
+- [ ] Gen 3 raw map coordinates for roamers are translated into human-readable route names.
+- [ ] Fallback logic is present if a map coordinate cannot be translated (e.g., "Unknown Location").
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-043-069-roamer-radar-ui.md
+++ b/.foundry/epics/epic-043-069-roamer-radar-ui.md
@@ -1,0 +1,38 @@
+---
+id: epic-043-069-roamer-radar-ui
+type: EPIC
+title: Roamer Radar UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - epic-043-068-roamer-map-translation
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Roamer Radar UI
+
+## Objective
+Build a visible dashboard or map widget that lists all active roaming Pokémon in the save file, displaying their current location, status tags, and highlighting their current route on an interactive map.
+
+## Description
+- **Roamer Radar Widget**: Construct a UI component that displays a list of active roamers.
+- **Live Location**: The widget should show the human-readable route name where the roamer is currently located, obtained from the Translation Layer.
+- **Status Tags**: Add visual tags to indicate the roamer's status (e.g., "Active", "Caught", "Defeated").
+- **Map Integration**: Highlight the active roamer's current route on the interactive `.foundry/docs/adrs/010-gen3-map-graph-design.md` style map.
+- Ensure the UI component integrates properly with the broader DexHelper application flow.
+
+## Acceptance Criteria
+- [ ] A dedicated UI component displays the list of any active roamers.
+- [ ] The component shows the human-readable route location for each roamer.
+- [ ] Status tags ("Active", "Caught", "Defeated") are correctly displayed based on save data.
+- [ ] The roamer's current route is highlighted on the map.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
+++ b/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
@@ -52,7 +52,10 @@ Based on an initial evaluation of the codebase:
 - [ ] Gen 2 and Gen 3 raw map coordinates are translated into recognizable Route names.
 - [ ] A dedicated UI component displays the current location of any active roamers.
 - [ ] The feature only displays roamers that have actually been released in the save file's event flags.
-- [ ] Break down this PRD into Epics.
+- [x] Break down this PRD into Epics.
 
 ## 5. Next Steps
-- [ ] Epic Planner: Break this PRD down into executable Epics (e.g., Engine Parsing, Mapping Translation, UI Dashboard).
+- [x] Epic Planner: Break this PRD down into executable Epics (e.g., Engine Parsing, Mapping Translation, UI Dashboard).
+- [ ] epic-043-067-roamer-data-extraction
+- [ ] epic-043-068-roamer-map-translation
+- [ ] epic-043-069-roamer-radar-ui


### PR DESCRIPTION
This PR breaks down PRD 070-043 (Roamer Tracking Dashboard) into three Epics:
1. Data Extraction (Engine Layer)
2. Map Translation (Translation Layer)
3. Radar UI (Presentation Layer)

It also updates the parent PRD to check off the relevant breakdown criteria and link to the new Epics.

---
*PR created automatically by Jules for task [7664086471755076321](https://jules.google.com/task/7664086471755076321) started by @szubster*