### PR TITLE
feat(radar): create tasks for heatmap logic

### DIFF
--- a/.foundry/stories/story-048-089-route-radar-density-aggregation.md
+++ b/.foundry/stories/story-048-089-route-radar-density-aggregation.md
@@ -35,3 +35,7 @@ Implement the data transformation pipeline inside the `RouteRadarController`. It
 - [ ] Ensure the density score correctly maps `areaId`s to their corresponding missing species counts.
 - [ ] Ensure it accurately processes edge cases (e.g., areas with 0 missing encounters should not be present in the output or have a score of 0).
 - [ ] Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs.
+
+## Generated Tasks
+- [ ] .foundry/tasks/task-089-153-implement-radar-heatmap-logic.md
+- [ ] .foundry/tasks/task-089-154-qa-radar-heatmap-logic.md

--- a/.foundry/tasks/task-089-153-implement-radar-heatmap-logic.md
+++ b/.foundry/tasks/task-089-153-implement-radar-heatmap-logic.md
@@ -1,0 +1,49 @@
+---
+id: task-089-153-implement-radar-heatmap-logic
+type: TASK
+title: Implement RouteRadarController Heatmap Logic
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-048-089-route-radar-density-aggregation
+tags:
+  - feature
+  - ux
+  - map
+  - data
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement RouteRadarController Heatmap Logic
+
+## Context
+As defined in Story `story-048-089-route-radar-density-aggregation`, we need to implement the core computational logic for the `RouteRadarController`. The controller must transform the list of recommended encounters from the `suggestionEngine` into a structured density heatmap map that the UI can render.
+
+## Blueprint / Technical Contract
+Implement the data transformation pipeline inside the `RouteRadarController` in `src/engine/radar/RouteRadarController.ts`.
+
+- You are to update the `calculateHeatmap` function to accept `suggestions: Suggestion[]`.
+- It must initialize an empty `RouteRadarHeatmap` object.
+- Iterate through the `suggestions` array.
+- For each suggestion, check if it's a `CatchSuggestion` by checking if `suggestion.category === 'Catch'` (and ensuring `suggestion.encounterInfo` exists). StandardSuggestions (non-catch) should not contribute to the heatmap.
+- To avoid double counting the same species in the same area, extract unique `areaId`s (the `aid` property inside `EncounterDetail`) for each suggestion. You can iterate over the map IDs (keys) in `encounterInfo` and extract the `aid`s.
+- For each unique `areaId` associated with a particular suggestion, increment the density score for that `areaId` in the `heatmap` object.
+- Return the `heatmap` object.
+
+Also, write unit tests in `src/engine/radar/__tests__/RouteRadarController.test.ts` to validate the logic (including empty array handling, single CatchSuggestion on multiple areas, multiple CatchSuggestions on same area, and StandardSuggestion handling).
+
+## Acceptance Criteria
+- [ ] Implement the aggregation method in `RouteRadarController`.
+- [ ] Ensure the density score correctly maps `areaId`s to their corresponding unique missing species counts.
+- [ ] Ensure it accurately processes edge cases (e.g., areas with 0 missing encounters should not be present in the output or have a score of 0).
+- [ ] Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs.
+
+**Important Persona Instructions:**
+- **CODER**: If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the frontmatter otherwise.

--- a/.foundry/tasks/task-089-154-qa-radar-heatmap-logic.md
+++ b/.foundry/tasks/task-089-154-qa-radar-heatmap-logic.md
@@ -1,0 +1,42 @@
+---
+id: task-089-154-qa-radar-heatmap-logic
+type: TASK
+title: QA RouteRadarController Heatmap Logic
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - task-089-153-implement-radar-heatmap-logic
+jules_session_id: null
+pr_number: null
+parent: story-048-089-route-radar-density-aggregation
+tags:
+  - feature
+  - ux
+  - map
+  - data
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA RouteRadarController Heatmap Logic
+
+## Context
+As defined in Story `story-048-089-route-radar-density-aggregation`, the Coder will implement the aggregation logic inside the `RouteRadarController`.
+
+## Blueprint / Technical Contract
+Review the work performed in `task-089-153-implement-radar-heatmap-logic`.
+Validate that `calculateHeatmap` in `src/engine/radar/RouteRadarController.ts` correctly transforms `Suggestion` arrays into a density `RouteRadarHeatmap`.
+Ensure unit tests in `src/engine/radar/__tests__/RouteRadarController.test.ts` thoroughly test edge cases.
+
+## Acceptance Criteria
+- [ ] Verify the aggregation correctly maps `areaId`s to missing species count without double-counting a species in the same area.
+- [ ] Ensure non-Catch suggestions are ignored.
+- [ ] Validate unit tests cover edge cases.
+- [ ] Run test suite (`pnpm exec vitest run`) and confirm passing.
+
+**Important Persona Instructions:**
+- **QA**: If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the frontmatter otherwise.


### PR DESCRIPTION
This PR drafts the technical blueprints for implementing the RouteRadarController heatmap logic, as required by Story 048-089.

Created nodes:
- `task-089-153-implement-radar-heatmap-logic` (Coder)
- `task-089-154-qa-radar-heatmap-logic` (QA)

The newly created tasks are appended to the story body as unchecked lists, and do not modify the parent story's YAML frontmatter.

---
*PR created automatically by Jules for task [16956738441710758429](https://jules.google.com/task/16956738441710758429) started by @szubster*