### PR TITLE
docs: PRD - Gen 3 Roaming Legendary Tracker and IV Glitch Inspector

### DIFF
--- a/.foundry/ideas/idea-071-gen3-roamer-tracker.md
+++ b/.foundry/ideas/idea-071-gen3-roamer-tracker.md
@@ -37,4 +37,6 @@ Leverage DexHelper's programmatic save parsing to extract the hidden data struct
 This feature perfectly aligns with DexHelper's vision as a premium companion app by surfacing critical hidden state. It directly prevents hours of wasted effort caused by obscure retro game mechanics and engine glitches, providing immense utility for shiny hunters, completionists, and competitive players.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD to detail the save offsets required for extracting the roamer data structure across different Gen 3 versions.
+- [x] Product Manager: Convert this idea into a PRD to detail the save offsets required for extracting the roamer data structure across different Gen 3 versions.
+- [ ] .foundry/prds/prd-071-044-gen3-roamer-tracker.md
+- [ ] .foundry/research/research-071-138-gen3-roamer-offsets.md

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -1,0 +1,30 @@
+---
+id: prd-071-044-gen3-roamer-tracker
+type: PRD
+title: Gen 3 Roaming Legendary Tracker and IV Glitch Inspector
+status: PENDING
+owner_persona: architect
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - research-071-138-gen3-roamer-offsets
+jules_session_id: null
+pr_number: null
+parent: idea-071-gen3-roamer-tracker
+tags: ["gen3", "roamer", "iv-glitch"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# PRD: Gen 3 Roaming Legendary Tracker and IV Glitch Inspector
+
+## Purpose
+Provide an immediate, exact breakdown of a roaming legendary's internal state (Nature, IVs, HP, location) parsed directly from the `.sav` file.
+
+## Scope
+- Parse roamer data structure from Gen 3 save files using DataView.
+- Extract and display Nature, IVs, HP, status condition, and location index.
+- Detect and display a warning if the "Roamer IV Glitch" affects the Pokémon.
+- Provide a Route Radar to map the roamer's current location index.

--- a/.foundry/research/research-071-138-gen3-roamer-offsets.md
+++ b/.foundry/research/research-071-138-gen3-roamer-offsets.md
@@ -1,0 +1,26 @@
+---
+id: research-071-138-gen3-roamer-offsets
+type: RESEARCH
+title: Investigate Gen 3 Roamer Save Offsets
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-071-gen3-roamer-tracker
+tags: ["gen3", "roamer", "save-offsets"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Investigate Gen 3 Roamer Save Offsets
+
+We need to extract the hidden data structure of the currently active roaming Pokémon directly from the `.sav` file for Gen 3 games (Ruby/Sapphire/Emerald and FireRed/LeafGreen) to track Nature, IVs, HP, status condition, and location index.
+
+## Acceptance Criteria
+- [ ] Find and document the save offsets for the roamer data structure across different Gen 3 versions.
+- [ ] Document the data structure format (how IVs, Nature, HP, status, and location are stored).


### PR DESCRIPTION
Transitions the Gen 3 Roaming Legendary Tracker and IV Glitch Inspector IDEA to a PRD. Since the save offsets for the roamer data structure are unknown, a RESEARCH node was dynamically generated to investigate them before finalizing the PRD implementation. Both the PRD and RESEARCH nodes were successfully linked to the parent IDEA node using unchecked checkboxes to prevent premature verification.

---
*PR created automatically by Jules for task [16470446756348541606](https://jules.google.com/task/16470446756348541606) started by @szubster*