### PR TITLE
fix: update PRD owner_persona to pass schema validation

### DIFF
--- a/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
+++ b/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
@@ -3,7 +3,7 @@ id: prd-070-044-hall-of-fame-exporter
 type: PRD
 title: Hall of Fame Timeline and Certificate Exporter
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-09'
 updated_at: '2026-06-09'
 depends_on: []

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -3,7 +3,7 @@ id: prd-071-044-gen3-roamer-tracker
 type: PRD
 title: Gen 3 Roaming Legendary Tracker and IV Glitch Inspector
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-09'
 updated_at: '2026-06-09'
 depends_on:


### PR DESCRIPTION
This PR fixes a validation error in the Foundry Engine orchestration phase. The error occurred because PRD nodes were assigned to the `architect` persona, which is not a valid mapping according to `scripts/validate-foundry-schema.ts`. I updated the `owner_persona` of the offending PRDs to `epic_planner` and verified the fix by running the validation script and the project's test suite.

Fixes #2237

---
*PR created automatically by Jules for task [15519842332827201460](https://jules.google.com/task/15519842332827201460) started by @szubster*