### PR TITLE
Fix Foundry DAG Resolution Warnings

### DIFF
--- a/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
+++ b/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
@@ -3,7 +3,7 @@ id: prd-070-044-hall-of-fame-exporter
 type: PRD
 title: Hall of Fame Timeline and Certificate Exporter
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-09'
 updated_at: '2026-06-09'
 depends_on: []

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -3,7 +3,7 @@ id: prd-071-044-gen3-roamer-tracker
 type: PRD
 title: Gen 3 Roaming Legendary Tracker and IV Glitch Inspector
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-09'
 updated_at: '2026-06-09'
 depends_on:


### PR DESCRIPTION
This PR fixes the "Invalid mapping" warnings encountered by the Foundry orchestrator. The `owner_persona` for PRD nodes `prd-070-044-hall-of-fame-exporter` and `prd-071-044-gen3-roamer-tracker` was incorrectly set to `architect`, which violated the orchestrator's validation schema. They have been updated to `epic_planner`.

Fixes #2236

---
*PR created automatically by Jules for task [3604966011363580932](https://jules.google.com/task/3604966011363580932) started by @szubster*