### PR TITLE
Fix invalid owner_persona for PRD nodes in Foundry DAG

### DIFF
--- a/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
+++ b/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
@@ -3,9 +3,9 @@ id: prd-070-044-hall-of-fame-exporter
 type: PRD
 title: Hall of Fame Timeline and Certificate Exporter
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-09'
-updated_at: '2026-06-09'
+updated_at: '2026-06-10'
 depends_on: []
 jules_session_id: null
 pr_number: null

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -3,9 +3,9 @@ id: prd-071-044-gen3-roamer-tracker
 type: PRD
 title: Gen 3 Roaming Legendary Tracker and IV Glitch Inspector
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-09'
-updated_at: '2026-06-09'
+updated_at: '2026-06-10'
 depends_on:
   - research-071-138-gen3-roamer-offsets
 jules_session_id: null


### PR DESCRIPTION
This change resolves DAG resolution warnings in the Foundry Engine by correcting the `owner_persona` mapping for PRD nodes. Specifically, it changes the owner of `prd-070-044-hall-of-fame-exporter.md` and `prd-071-044-gen3-roamer-tracker.md` from `architect` to `epic_planner`, which is an allowed persona for PRD nodes. it also updates the `updated_at` timestamp.

Fixes #2240

---
*PR created automatically by Jules for task [3907988723845335802](https://jules.google.com/task/3907988723845335802) started by @szubster*