### PR TITLE
Fix invalid PRD owner persona mapping

### DIFF
--- a/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
+++ b/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
@@ -3,7 +3,7 @@ id: prd-070-044-hall-of-fame-exporter
 type: PRD
 title: Hall of Fame Timeline and Certificate Exporter
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-09'
 updated_at: '2026-06-09'
 depends_on: []

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -3,7 +3,7 @@ id: prd-071-044-gen3-roamer-tracker
 type: PRD
 title: Gen 3 Roaming Legendary Tracker and IV Glitch Inspector
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: '2026-06-09'
 updated_at: '2026-06-09'
 depends_on:


### PR DESCRIPTION
Resolved a Foundry Engine orchestration failure caused by invalid `owner_persona` mappings in PRD files. PRD nodes cannot be owned by the `architect` persona according to the schema. 

Changes:
- Updated `.foundry/prds/prd-070-044-hall-of-fame-exporter.md`: changed `owner_persona` from `architect` to `epic_planner`.
- Updated `.foundry/prds/prd-071-044-gen3-roamer-tracker.md`: changed `owner_persona` from `architect` to `epic_planner`.

Verification:
- Ran `node --experimental-strip-types scripts/validate-foundry-schema.ts` and confirmed all nodes passed.
- Ran `pnpm lint` and `pnpm exec vitest run` to ensure no regressions.

Fixes #2241

---
*PR created automatically by Jules for task [12511063595736368893](https://jules.google.com/task/12511063595736368893) started by @szubster*