### PR TITLE
Canvas: Tactical Telemetry Datacube Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -167,3 +167,9 @@
 **Outcome:** Accepted
 **Why:** Brings the granular data display components in line with the established specialized hardware motif. The previous `DataPoint` was too generic and didn't fit the "snooping" fantasy, whereas the new design looks like individual data nodes connected to a larger telemetry stream.
 **Pattern:** Apply tactical aesthetics (dashed borders acting as connecting lines, absolute positioning markers, tight monospace typography) even to the smallest, most granular data display elements to maintain absolute visual coherence deep within complex data views.
+
+## 2026-07-08 - [Accepted] - 🖼️ Canvas: Tactical Telemetry Datacube Redesign
+**What:** Redesigned the main Pokedex grid (`PokedexCard.tsx` and `PokemonStatusBadge.tsx`) to act as dense, "tactical telemetry datacubes". Replaced rounded corner web cards with edge-to-edge dashed borders, integrated `<LcdGrid>` and `<HoverScanner>`, and added strict telemetry text arrays (`[ DATA.SYS ]`). Converted the status badge from a padded pill to a full-width segmented terminal block.
+**Outcome:** Accepted
+**Why:** Brings the primary data grid of the application deeply in line with the terminal scanning hardware motif. The original grid felt like a generic web Pokedex, whereas the new implementation solidifies the feeling of looking through a specialized hardware surveillance scanner.
+**Pattern:** Eliminate generic web cards entirely. When rendering lists or grids of items, treat each item container as a raw data terminal block, utilizing edge-to-edge dashed borders, CRT grid backgrounds, scanner animations, and segmented blocks for badges instead of floating pill shapes.

--- a/src/components/PokedexCard.tsx
+++ b/src/components/PokedexCard.tsx
@@ -1,13 +1,16 @@
 import { useNavigate } from '@tanstack/react-router';
-import { ChevronRight, CircleDot, Monitor, Sparkles } from 'lucide-react';
+import { CircleDot, Monitor, Sparkles } from 'lucide-react';
 import React from 'react';
 import type { SaveData } from '../engine/saveParser';
 import { cn } from '../utils/cn';
 import type { PokemonListItem } from '../utils/pokemonQueries';
+import { DataPoint } from './DataPoint';
+import { HoverScanner } from './HoverScanner';
 import { LcdGrid } from './LcdGrid';
 import { PokemonSprite } from './pokemon/PokemonSprite';
 import { PokemonStatusBadge } from './pokemon/PokemonStatusBadge';
 import { TacticalCard } from './TacticalCard';
+import { TelemetryDecoration } from './TelemetryDecoration';
 
 interface PokedexCardProps {
   pokemon: PokemonListItem;
@@ -63,26 +66,17 @@ export const PokedexCard = React.memo(function PokedexCard({
       onClick={() => navigate({ to: `/pokemon/${pokemon.id}`, search: { from: '/' } })}
       variant={variant}
       style={{ animationDelay: `${(idx % 20) * 0.02}s` }}
+      className="!p-0"
     >
-      {/* Card Header: Num & Icons */}
-      <div className="mb-3 flex items-center justify-between">
-        <div className="flex items-center gap-1 rounded-none border border-zinc-800 border-dashed bg-white/5 px-2 py-0.5">
-          <span className="font-black font-mono text-[9px] text-zinc-500 uppercase tracking-tighter">ID</span>
-          <span className="font-black font-mono text-[10px] text-zinc-300">
-            {pokemon.id.toString().padStart(3, '0')}
-          </span>
-        </div>
-
-        {saveData && !isUnseen && (
-          <div className="flex gap-1">
-            {inParty && <CircleDot size={12} className="animate-pulse text-rose-500" />}
-            {inPC && <Monitor size={12} className="text-[var(--theme-primary)]" />}
-          </div>
-        )}
-      </div>
+      <TelemetryDecoration
+        label={pokemon.name}
+        className="top-0 right-0 left-0 justify-center border-r-0 border-l-0"
+        textClassName={cn(isUnseen ? 'text-zinc-700' : isShiny ? 'text-amber-400' : 'text-white')}
+        dotClassName={cn(isUnseen ? 'hidden' : '')}
+      />
 
       {/* Sprite Container */}
-      <div className="relative mb-4 flex aspect-square items-center justify-center overflow-hidden border border-white/5 bg-black/40 transition-colors group-hover:bg-black/60">
+      <div className="relative mt-6 flex aspect-square items-center justify-center overflow-hidden border-zinc-800 border-b border-dashed bg-black/40 transition-colors group-hover:bg-black/60">
         {/* LCD Grid Background */}
         <LcdGrid className="opacity-[0.05]" />
 
@@ -91,6 +85,8 @@ export const PokedexCard = React.memo(function PokedexCard({
             <Sparkles size={16} fill="currentColor" className="animate-[pulse_4s_cubic-bezier(0.4,0,0.6,1)_infinite]" />
           </div>
         )}
+
+        <HoverScanner />
 
         <PokemonSprite
           pokemonId={pokemon.id}
@@ -109,38 +105,35 @@ export const PokedexCard = React.memo(function PokedexCard({
 
         {/* Scanline overlay for sprite */}
         <div className="scanline-overlay pointer-events-none absolute inset-0 opacity-20" />
-
-        {/* Scanner overlay on hover */}
-        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-[var(--theme-primary)]/20 to-transparent opacity-0 transition-opacity group-hover:animate-[scan_2s_linear_infinite] group-hover:opacity-100" />
       </div>
 
-      {/* Card Footer: Name & Status */}
-      <div className="space-y-2">
-        <h3
-          className={cn(
-            'truncate text-center font-black text-[10px] uppercase tracking-widest sm:text-[11px]',
-            isUnseen ? 'text-zinc-700' : isShiny ? 'text-amber-400' : 'text-white',
-          )}
-        >
-          {pokemon.name}
-        </h3>
-
-        {saveData && (
-          <div className="flex justify-center">
-            <PokemonStatusBadge
-              hasInStorage={hasInStorage}
-              isOwnedInDex={isOwnedInDex}
-              isSeenInDex={isSeenInDex}
-              isShiny={isShiny}
-            />
+      <div className="flex w-full divide-x divide-dashed divide-zinc-800">
+        <div className="flex-1 p-2">
+          <DataPoint
+            label="ID"
+            value={pokemon.id.toString().padStart(3, '0')}
+            labelClassName="text-[7px]"
+            valueClassName="text-[10px]"
+          />
+        </div>
+        {saveData && !isUnseen && (
+          <div className="flex items-center justify-center p-2">
+            <div className="flex gap-1.5">
+              {inParty && <CircleDot size={12} className="animate-pulse text-rose-500" />}
+              {inPC && <Monitor size={12} className="text-[var(--theme-primary)]" />}
+            </div>
           </div>
         )}
       </div>
 
-      {/* Corner Accent */}
-      <div className="absolute right-[-10px] bottom-[-10px] p-4 opacity-0 transition-opacity group-hover:opacity-100">
-        <ChevronRight size={14} className="text-[var(--theme-primary)]" />
-      </div>
+      {saveData && (
+        <PokemonStatusBadge
+          hasInStorage={hasInStorage}
+          isOwnedInDex={isOwnedInDex}
+          isSeenInDex={isSeenInDex}
+          isShiny={isShiny}
+        />
+      )}
     </TacticalCard>
   );
 });

--- a/src/components/pokemon/PokemonStatusBadge.tsx
+++ b/src/components/pokemon/PokemonStatusBadge.tsx
@@ -18,7 +18,7 @@ export const PokemonStatusBadge = React.memo(function PokemonStatusBadge({
     return (
       <div
         className={cn(
-          'flex items-center gap-1.5 rounded-none border border-dashed px-2.5 py-1',
+          'flex w-full items-center justify-center border-t border-dashed py-1.5',
           isShiny ? 'border-amber-500/50 bg-amber-500/10' : 'border-emerald-500/50 bg-emerald-500/10',
         )}
       >
@@ -36,7 +36,7 @@ export const PokemonStatusBadge = React.memo(function PokemonStatusBadge({
 
   if (isOwnedInDex) {
     return (
-      <div className="flex items-center gap-1.5 rounded-none border border-amber-500/50 border-dashed bg-amber-500/10 px-2.5 py-1">
+      <div className="flex w-full items-center justify-center border-amber-500/50 border-t border-dashed bg-amber-500/10 py-1.5">
         <span className="font-black font-mono text-[8px] text-amber-400 uppercase tracking-widest">[ DEX_ONLY ]</span>
       </div>
     );
@@ -44,14 +44,14 @@ export const PokemonStatusBadge = React.memo(function PokemonStatusBadge({
 
   if (isSeenInDex) {
     return (
-      <div className="flex items-center gap-1.5 rounded-none border border-rose-500/50 border-dashed bg-rose-500/10 px-2.5 py-1">
+      <div className="flex w-full items-center justify-center border-rose-500/50 border-t border-dashed bg-rose-500/10 py-1.5">
         <span className="font-black font-mono text-[8px] text-rose-400 uppercase tracking-widest">[ SEEN ]</span>
       </div>
     );
   }
 
   return (
-    <div className="flex items-center gap-1.5 rounded-none border border-zinc-700 border-dashed bg-white/5 px-2.5 py-1">
+    <div className="flex w-full items-center justify-center border-zinc-700 border-t border-dashed bg-white/5 py-1.5">
       <span className="font-black font-mono text-[8px] text-zinc-600 uppercase tracking-widest">[ UNKNOWN ]</span>
     </div>
   );


### PR DESCRIPTION
This PR completely overhauls the main Pokédex grid view. It removes standard web design metaphors (cards, rounded corners, soft shadows, float pills) in favor of the strict "Tactical Telemetry" aesthetic.

By transforming `PokedexCard.tsx` and `PokemonStatusBadge.tsx`, the grid now appears as a dense matrix of raw intelligence datacubes, complete with CRT scanlines, dashed interface piping, and strict segment allocations, better fitting the application's core visual theme.

---
*PR created automatically by Jules for task [5199125749880551710](https://jules.google.com/task/5199125749880551710) started by @szubster*