### PR TITLE
🧭 Strategist: Prompt improvement - Require Coder to read rejection reasons for failed tasks

### DIFF
--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -37,6 +37,8 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 
 ### Handling Rejections & Aborts
+**CRITICAL - RESUMING FAILED TASKS:** If you are assigned to a TASK node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the QA persona's journal (`.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting the same code.
+
 If you encounter a permanent failure or must abort a task:
 1. You MUST update the target task's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
 2. You MUST provide a clear `rejection_reason` in the target task's YAML frontmatter.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -215,3 +215,9 @@
 **Outcome:** Merged
 **Why:** The coder journal highlighted a regression (`2026-05-31: Foundry DAG ID Strictness`) where using `.md` extensions or full file paths in the `depends_on` or `parent` fields causes the orchestrator to fail to resolve the dependency graph. The TPM agent prompt already had a rule for Node IDs, but the agents responsible for creating the nodes initially (Product Manager, Epic Planner, Story Owner, Tech Lead) were not explicitly warned.
 **Pattern:** When a critical schema constraint is identified (like Node IDs vs file paths in frontmatter), codify it across all relevant upstream generative personas, not just the downstream maintenance ones, to prevent the issue at the source.
+
+## 2026-06-10 - [Accepted] - Prompt improvement - Require Coder to read rejection reasons for failed tasks
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** To prevent impossible loops, implementation agents must not ignore rejection reasons when resurrecting failed tasks.
+**Pattern:** Explicitly instruct implementation agents (like the Coder) to read the `rejection_reason` and the QA journal when resuming a previously failed task to ensure they fix the actual problem rather than blindly resubmitting.


### PR DESCRIPTION
**Proposal**: Improve the Coder persona prompt to explicitly require reading the `rejection_reason` and the QA journal when assigned to a resurrected `FAILED` task.
**Justification**: Implementation agents were previously resurrecting failed tasks without addressing the root cause of the previous failure, leading to impossible loops and wasted cycles.
**Evidence**: The QA journal repeatedly recorded instances where the Coder failed a task for an architectural violation (e.g., tight coupling of state) and upon resurrection, blindly resubmitted without fixing the underlying issue.

---
*PR created automatically by Jules for task [1738668887192261857](https://jules.google.com/task/1738668887192261857) started by @szubster*