### PR TITLE
Generate PRD for Strict Macro Node Completion Enforcement

### DIFF
--- a/.foundry/ideas/idea-072-strict-macro-node-completion.md
+++ b/.foundry/ideas/idea-072-strict-macro-node-completion.md
@@ -28,4 +28,5 @@ I am still seeing instances where macro generation nodes (like `IDEA` or `PRD` n
 We need to strongly enforce the rule that a macro node (IDEA, PRD, EPIC, STORY) MUST NOT be verified until its *functional requirements* are implemented and merged by its downstream child tasks. All generated descendant nodes must have fully transitioned to `COMPLETED` first before the parent can be transitioned to `COMPLETED`.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD.
+- [x] Product Manager: Convert this idea into a PRD.
+- [ ] .foundry/prds/prd-072-045-strict-macro-node-completion.md

--- a/.foundry/prds/prd-072-045-strict-macro-node-completion.md
+++ b/.foundry/prds/prd-072-045-strict-macro-node-completion.md
@@ -1,0 +1,35 @@
+---
+id: prd-072-045-strict-macro-node-completion
+type: PRD
+title: Strict Macro Node Completion Enforcement
+status: PENDING
+owner_persona: "epic_planner"
+created_at: "2026-06-10"
+updated_at: "2026-06-10"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-072-strict-macro-node-completion
+tags:
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# PRD: Strict Macro Node Completion Enforcement
+
+## Context
+Macro generation nodes (like `IDEA` or `PRD` nodes) are currently transitioning to `VERIFYING` prematurely. They transition right after spawning their first set of child nodes, despite those children (and their descendants) still being in `PENDING` or `ACTIVE` states.
+
+## Objective
+Enforce the rule that a macro node (IDEA, PRD, EPIC, STORY) MUST NOT be verified until its functional requirements are implemented and merged by its downstream child tasks. All generated descendant nodes must fully transition to `COMPLETED` before the parent can be transitioned to `COMPLETED`.
+
+## Requirements
+1.  **DAG Orchestrator Updates**: Update `.github/scripts/foundry-orchestrator.ts` to implement strict hierarchical completion checks. A node cannot transition to `VERIFYING` or `COMPLETED` if any of its generated child nodes (identified via the `parent` field of those children, or via references in the markdown body) are not `COMPLETED`.
+2.  **Documentation Updates**: Update schema rules, `the-foundry-architecture.md` (ADR 001), and any relevant knowledge base articles to explicitly outline this new behavior.
+
+## Acceptance Criteria
+- [ ] Epic Planner: Break down this PRD into Epics.


### PR DESCRIPTION
This PR completes the IDEA node `idea-072-strict-macro-node-completion` by successfully translating its concept into actionable requirements inside a new downstream PRD (`prd-072-045-strict-macro-node-completion`). The parent idea has been updated to check off its acceptance criteria and link to the new PRD as an unchecked checkbox, ensuring it correctly awaits child completion before transitioning states. Schema validation and tests pass.

---
*PR created automatically by Jules for task [5225755495517265083](https://jules.google.com/task/5225755495517265083) started by @szubster*