### PR TITLE
Add Tasks for Gen 1 Checksum Validation

### DIFF
--- a/.foundry/stories/story-053-091-health-scanner-gen1-checksum-validation.md
+++ b/.foundry/stories/story-053-091-health-scanner-gen1-checksum-validation.md
@@ -34,4 +34,8 @@ Generation 1 save files rely on a specific main checksum to verify the integrity
 * Return appropriate diagnostic models (defined in `story-053-090`) if a checksum mismatch is detected.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break this Story down into actionable Tasks for the coder.
+- [x] Tech Lead: Break this Story down into actionable Tasks for the coder.
+
+## Child Tasks
+- [ ] .foundry/tasks/task-091-155-gen1-checksum-impl.md
+- [ ] .foundry/tasks/task-091-156-gen1-checksum-qa.md

--- a/.foundry/tasks/task-091-155-gen1-checksum-impl.md
+++ b/.foundry/tasks/task-091-155-gen1-checksum-impl.md
@@ -1,0 +1,41 @@
+---
+id: task-091-155-gen1-checksum-impl
+type: TASK
+title: Implement Gen 1 Checksum Calculation
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-053-091-health-scanner-gen1-checksum-validation
+tags:
+  - feature
+  - gen1
+  - save-file
+  - checksum
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Gen 1 Checksum Calculation
+
+## Context
+Generation 1 save files rely on a main checksum to verify the integrity of the active save data. We need to calculate this checksum and compare it against the stored value.
+
+## Requirements
+* Implement logic to calculate the Gen 1 checksum.
+* Implement logic to extract the stored checksum from Gen 1 save data.
+* Implement logic to compare the calculated and stored checksums.
+* If a mismatch is detected, return appropriate diagnostic models (e.g., `HealthScanResult`, `Anomaly`) as defined in `story-053-090`.
+
+## Acceptance Criteria
+- [ ] Implement checksum calculation and validation logic.
+- [ ] Ensure validation logic handles missing or invalid save data structures gracefully.
+
+## Reminders
+* If you permanently fail or abort this task, you MUST update the YAML frontmatter to status: FAILED or status: CANCELLED with a rejection_reason.
+* If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-091-156-gen1-checksum-qa.md
+++ b/.foundry/tasks/task-091-156-gen1-checksum-qa.md
@@ -1,0 +1,43 @@
+---
+id: task-091-156-gen1-checksum-qa
+type: TASK
+title: QA Gen 1 Checksum Calculation
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-09'
+updated_at: '2026-06-09'
+depends_on:
+  - task-091-155-gen1-checksum-impl
+jules_session_id: null
+pr_number: null
+parent: story-053-091-health-scanner-gen1-checksum-validation
+tags:
+  - feature
+  - gen1
+  - save-file
+  - checksum
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Gen 1 Checksum Calculation
+
+## Context
+The Coder has implemented the Generation 1 checksum validation logic. As QA, you need to verify its correctness.
+
+## Requirements
+* Review the implementation for checksum calculation, extraction, and comparison.
+* Ensure tests are written to verify the functionality with valid and corrupted save data.
+* Verify that diagnostic models are returned correctly on mismatch.
+
+## Acceptance Criteria
+- [ ] Validate the checksum calculation logic against known good values.
+- [ ] Validate the correct diagnostic models are returned for checksum mismatches.
+- [ ] Ensure adequate test coverage.
+
+## Reminders
+* If you permanently fail or abort this task, you MUST update the YAML frontmatter to status: FAILED or status: CANCELLED with a rejection_reason.
+* If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Created `task-091-155-gen1-checksum-impl.md` for Coder and `task-091-156-gen1-checksum-qa.md` for QA to handle Gen 1 checksum verification, and linked them in `story-053-091-health-scanner-gen1-checksum-validation.md`.

---
*PR created automatically by Jules for task [3449106203281378252](https://jules.google.com/task/3449106203281378252) started by @szubster*