### PR TITLE
Reject IDEA 066 - Strict Macro Node Completion Enforcement

### DIFF
--- a/.foundry/ideas/idea-066-save-file-health-scanner.md
+++ b/.foundry/ideas/idea-066-save-file-health-scanner.md
@@ -45,3 +45,6 @@ This feature pivots DexHelper from just a tracking tool into a critical utility 
 
 ### Auditor Rejection
 The generated PRD and Epic nodes are still PENDING. This IDEA node must wait until its entire generated sub-tree is COMPLETED. I have spawned a new node `.foundry/ideas/idea-072-strict-macro-node-completion.md` to address this recurring systemic issue.
+
+### Auditor Rejection (Attempt 3)
+The generated PRD and Epic nodes are still PENDING. This IDEA node must wait until its entire generated sub-tree is COMPLETED. The resurrection loop continues to fail because agents are resubmitting without waiting. We must wait for the implementation of IDEA-072 (Strict Macro Node Completion Enforcement).

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -22,3 +22,12 @@ We need to strongly enforce the rule that a macro node (IDEA, PRD, EPIC, STORY) 
 
 ## 2026-06-09: Spawning Strict Macro Node Completion Idea
 I am still seeing instances of macro generation nodes (like idea-066) being transitioned to VERIFYING prematurely. We need strict hierarchical completion enforcement. Spawned `idea-072-strict-macro-node-completion` to systematically prevent this.
+
+## 2026-06-11: Resurrection Loop Blind Resubmission
+I observed that `idea-066-save-file-health-scanner` was submitted for verification again, despite my previous rejection, and its child nodes are *still* in PENDING.
+
+**Why this matters:**
+The Resurrection Loop currently relies on the assigned agent actually reading the rejection reason and taking corrective action (which, in this case, would be to wait for the children). If agents blindly resubmit, it creates an infinite loop of rejections.
+
+**Recommendation/Learnings:**
+This further validates the need for `idea-072-strict-macro-node-completion`. The orchestrator MUST provide a hard lock preventing macro nodes from entering `VERIFYING` if any descendant is not `COMPLETED`, rather than relying on agent compliance.


### PR DESCRIPTION
Rejects idea-066-save-file-health-scanner because its child PRD and Epics are still PENDING. Adds a learning note to the Auditor journal.

---
*PR created automatically by Jules for task [10429304627261126356](https://jules.google.com/task/10429304627261126356) started by @szubster*