### PR TITLE
Create PRD for DagDashboard Context Refactor

### DIFF
--- a/.foundry/ideas/idea-073-refactor-dag-dashboard-context.md
+++ b/.foundry/ideas/idea-073-refactor-dag-dashboard-context.md
@@ -22,3 +22,5 @@ Recent implementation attempts (e.g., `task-085-142`) permanently failed because
 
 ## Proposal
 Create a dedicated Epic to properly architect and implement the `DagContext` layer before any further UI dashboard features are added. This foundational work will resolve the friction coders are experiencing and allow the Permanent Failure Dashboard to be completed successfully.
+
+- [ ] .foundry/prds/prd-073-045-refactor-dag-dashboard-context.md

--- a/.foundry/prds/prd-073-045-refactor-dag-dashboard-context.md
+++ b/.foundry/prds/prd-073-045-refactor-dag-dashboard-context.md
@@ -1,0 +1,33 @@
+---
+id: prd-073-045-refactor-dag-dashboard-context
+type: PRD
+title: Refactor DagDashboard to use React Context (ADR 013/017)
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+parent: idea-073-refactor-dag-dashboard-context
+tags:
+  - architecture
+  - ui
+  - dashboard
+rejection_count: 0
+rejection_reason: ""
+---
+
+# Refactor DagDashboard to use React Context (ADR 013/017)
+
+## Overview
+Recent implementation attempts permanently failed because the state was left tightly coupled within `DagDashboard.tsx`. ADR 013 (Kanban Board State Management) and ADR 017 (Permanent Failure Dashboard) require the core DAG data state to be lifted out of the isolated component and into a shared React Context (or global store). This single source of truth will be consumed by multiple views (Graph View, Board View, Permanent Failures).
+
+## Requirements
+- Create a `DagContext` to manage the core DAG data state (nodes, edges).
+- The `DagContext` must be the single source of truth for the DAG data.
+- Refactor the existing React Flow DAG visualizer to consume data from `DagContext`.
+- Ensure the state structure supports future views like the Kanban Board and Permanent Failure Dashboard.
+- Extract `rejection_count` from node frontmatter during data parsing so it is available in the shared context (as per ADR 017).
+
+## Acceptance Criteria
+- [ ] Break down into Epics


### PR DESCRIPTION
Generated a new Product Requirements Document (PRD) to outline the refactoring of DagDashboard to use React Context, as proposed in IDEA 073 and mandated by ADR 013/017. The PRD establishes requirements for centralizing the DAG data state into `DagContext` to act as a single source of truth for all current and future dashboard views. The original IDEA node was updated to link to this new PRD as a child node. All schema validations pass.

---
*PR created automatically by Jules for task [13017891390830623794](https://jules.google.com/task/13017891390830623794) started by @szubster*