### PR TITLE
docs(foundry): Break down Gen 3 Roamer Data Extraction epic

### DIFF
--- a/.foundry/epics/epic-043-067-roamer-data-extraction.md
+++ b/.foundry/epics/epic-043-067-roamer-data-extraction.md
@@ -33,4 +33,8 @@ Implement roamer data extraction for Gen 3 (Ruby, Sapphire, Emerald) in the save
 - [ ] Gen 3 save parser correctly extracts the species ID and level of the roaming Pokémon.
 - [ ] Only released roamers are considered active.
 - [ ] The return structure in `common.ts` is standardized for both Gen 2 and Gen 3.
-- [ ] Story Owner: Break down this Epic into executable Stories.
+- [x] Story Owner: Break down this Epic into executable Stories.
+
+### Generated Stories
+- [ ] .foundry/stories/story-067-104-gen3-roamer-data-structure.md
+- [ ] .foundry/stories/story-067-105-gen3-roamer-parser-implementation.md

--- a/.foundry/stories/story-067-104-gen3-roamer-data-structure.md
+++ b/.foundry/stories/story-067-104-gen3-roamer-data-structure.md
@@ -1,0 +1,31 @@
+---
+id: story-067-104-gen3-roamer-data-structure
+type: STORY
+title: Gen 3 Roamer Data Structure Standardization
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-043-067-roamer-data-extraction
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Data Structure Standardization
+
+## Objective
+Review and standardize the `roamingLegendaries` interface in `src/engine/saveParser/parsers/common.ts` to ensure it can accommodate the data structures required for both Generation 2 and Generation 3 roamers.
+
+## Description
+Currently, Gen 2 provides `speciesId`, `level`, `mapGroup`, and `mapId` for its roamers. We must ensure this structure is adequate for Gen 3 (Latios/Latias), and document any generation-specific differences in the unified structure so the suggestion engine can properly route them.
+
+## Acceptance Criteria
+- [ ] Ensure `SaveData.roamingLegendaries` is robust for both generations.
+- [ ] Document map group/id differences between Gen 2 and Gen 3 within the interface comments.
+- [ ] Break down this Story into executable Tasks.

--- a/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
+++ b/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
@@ -1,0 +1,33 @@
+---
+id: story-067-105-gen3-roamer-parser-implementation
+type: STORY
+title: Gen 3 Roamer Save Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - story-067-104-gen3-roamer-data-structure
+jules_session_id: null
+pr_number: null
+parent: epic-043-067-roamer-data-extraction
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Save Parsing
+
+## Objective
+Implement binary parsing logic in `src/engine/saveParser/parsers/gen3.ts` to extract the Latios/Latias roaming data.
+
+## Description
+Identify the exact memory offsets for Latios/Latias in Ruby/Sapphire/Emerald save files. Update the parser to extract the `speciesId`, `level`, and `mapId`/`mapGroup` of the active roamer using the `DataView` API. Crucially, the parser must only consider a roamer as "active" if the corresponding event flag indicating it has been released is set in the save file.
+
+## Acceptance Criteria
+- [ ] Parser extracts Latios/Latias map group and ID.
+- [ ] Parser extracts species ID and level.
+- [ ] Parser verifies event flags before marking roamer as active.
+- [ ] Break down this Story into executable Tasks.


### PR DESCRIPTION
Breaks down the "Roamer Data Extraction" Epic into two executable Stories: one for standardizing the data structure in `common.ts` and another for implementing the actual binary parsing in `gen3.ts`. The Epic has been updated with unchecked references to these new children to ensure it remains in the DAG correctly.

---
*PR created automatically by Jules for task [9634779150468346977](https://jules.google.com/task/9634779150468346977) started by @szubster*