### PR TITLE
chore(foundry): break down hall of fame PRD into ADRs

### DIFF
--- a/.foundry/docs/adrs/021-hof-data-parsing-architecture.md
+++ b/.foundry/docs/adrs/021-hof-data-parsing-architecture.md
@@ -1,0 +1,32 @@
+---
+id: adr-044-021-hof-data-parsing-architecture
+type: ADR
+title: Hall of Fame Data Parsing Architecture
+status: PENDING
+owner_persona: architect
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-070-044-hall-of-fame-exporter
+tags:
+  - architecture
+  - hall-of-fame
+  - parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# ADR 021: Hall of Fame Data Parsing Architecture
+
+## Context
+We need to extract Hall of Fame records from Gen 1 and Gen 2 save files to build a social sharing utility. Gen 2 has a specific requirement involving a 0xA8 offset from Johto badges.
+
+## Decision
+We will extend the existing save parsing engine to include specific logic for Gen 1 and Gen 2 Hall of Fame data blocks. The parser must gracefully handle the 0xA8 offset for Gen 2.
+
+## Acceptance Criteria
+- [ ] Detail the parsing logic and offsets for Gen 1 and Gen 2.

--- a/.foundry/docs/adrs/022-hof-certificate-generation.md
+++ b/.foundry/docs/adrs/022-hof-certificate-generation.md
@@ -1,0 +1,33 @@
+---
+id: adr-044-022-hof-certificate-generation
+type: ADR
+title: Hall of Fame Certificate Generation
+status: PENDING
+owner_persona: architect
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - adr-044-021-hof-data-parsing-architecture
+jules_session_id: null
+pr_number: null
+parent: prd-070-044-hall-of-fame-exporter
+tags:
+  - architecture
+  - hall-of-fame
+  - rendering
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# ADR 022: Hall of Fame Certificate Generation
+
+## Context
+We need a way to generate visually appealing "Hall of Fame Certificates" from the parsed data for social sharing.
+
+## Decision
+We will use an HTML5 Canvas or SVG approach to render high-resolution certificates on the client side, ensuring privacy and avoiding server-side image generation costs.
+
+## Acceptance Criteria
+- [ ] Define the rendering technology and constraints.

--- a/.foundry/docs/adrs/023-hof-timeline-ui.md
+++ b/.foundry/docs/adrs/023-hof-timeline-ui.md
@@ -1,0 +1,33 @@
+---
+id: adr-044-023-hof-timeline-ui
+type: ADR
+title: Hall of Fame Timeline UI Architecture
+status: PENDING
+owner_persona: architect
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - adr-044-022-hof-certificate-generation
+jules_session_id: null
+pr_number: null
+parent: prd-070-044-hall-of-fame-exporter
+tags:
+  - architecture
+  - hall-of-fame
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# ADR 023: Hall of Fame Timeline UI Architecture
+
+## Context
+The user interface must display multiple past League victories in a timeline format and provide export functionality.
+
+## Decision
+We will build a React component that visualizes the Hall of Fame data as a timeline. It will integrate the certificate rendering engine to provide social sharing hooks.
+
+## Acceptance Criteria
+- [ ] Define the React component structure and integration points.

--- a/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
+++ b/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
@@ -32,4 +32,7 @@ Transform DexHelper into a social sharing utility by parsing Hall of Fame record
 4. Build a UI timeline component to view multiple past victories.
 
 ## Acceptance Criteria
-- [ ] Break down into ADRs
+- [x] Break down into ADRs
+- [ ] .foundry/docs/adrs/021-hof-data-parsing-architecture.md
+- [ ] .foundry/docs/adrs/022-hof-certificate-generation.md
+- [ ] .foundry/docs/adrs/023-hof-timeline-ui.md


### PR DESCRIPTION
This PR addresses the requirement to break down the "Hall of Fame Timeline and Certificate Exporter" PRD (`prd-070-044`) into granular architectural nodes. 

Three new ADRs have been created under `.foundry/docs/adrs/`:
1. `021-hof-data-parsing-architecture.md`
2. `022-hof-certificate-generation.md`
3. `023-hof-timeline-ui.md`

The parent PRD has been updated to check off the "Break down into ADRs" task and append the new child nodes as unchecked checkboxes to ensure proper lifecycle management. All new nodes pass the strict schema validation.

---
*PR created automatically by Jules for task [1472469941934137476](https://jules.google.com/task/1472469941934137476) started by @szubster*