### PR TITLE
Fix Foundry schema validation for PRD-073-045

### DIFF
--- a/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
+++ b/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
@@ -3,7 +3,7 @@ id: prd-073-045-gen3-secret-base-viewer
 type: PRD
 title: "Gen 3 Secret Base and Mixed Record Viewer"
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: "2026-06-10"
 updated_at: "2026-06-10"
 depends_on: []


### PR DESCRIPTION
Fixed a schema validation error where a PRD node was incorrectly owned by an 'architect'. Changed ownership to 'epic_planner' as required by the Foundry Orchestrator mapping rules. verified that all Foundry nodes pass schema validation and all existing tests pass.

Fixes #2265

---
*PR created automatically by Jules for task [11739238552154365208](https://jules.google.com/task/11739238552154365208) started by @szubster*