### PR TITLE
Fix Foundry DAG Resolution Warnings

### DIFF
--- a/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
+++ b/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
@@ -3,7 +3,7 @@ id: prd-073-045-gen3-secret-base-viewer
 type: PRD
 title: "Gen 3 Secret Base and Mixed Record Viewer"
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: "2026-06-10"
 updated_at: "2026-06-10"
 depends_on: []


### PR DESCRIPTION
Corrected the owner_persona mapping in .foundry/prds/prd-073-045-gen3-secret-base-viewer.md from 'architect' to 'epic_planner' to comply with the Foundry schema. Verified that all nodes now pass validation and that no regressions were introduced.

Fixes #2264

---
*PR created automatically by Jules for task [6606843744862764087](https://jules.google.com/task/6606843744862764087) started by @szubster*