### PR TITLE
Correct owner_persona for Gen 3 Secret Base Viewer PRD

### DIFF
--- a/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
+++ b/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
@@ -3,7 +3,7 @@ id: prd-073-045-gen3-secret-base-viewer
 type: PRD
 title: "Gen 3 Secret Base and Mixed Record Viewer"
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: "2026-06-10"
 updated_at: "2026-06-10"
 depends_on: []


### PR DESCRIPTION
The Foundry Engine orchestration failed due to an invalid mapping: a PRD node was owned by 'architect', which is not permitted by the schema. This change updates the `owner_persona` to 'epic_planner' and ensures the `updated_at` date is current. Validation and all project tests pass.

Fixes #2269

---
*PR created automatically by Jules for task [14547585414583191204](https://jules.google.com/task/14547585414583191204) started by @szubster*