### PR TITLE
Resolve Foundry DAG Resolution Warnings and Invalid Mappings

### DIFF
--- a/.foundry/ideas/idea-072-strict-macro-node-completion.md
+++ b/.foundry/ideas/idea-072-strict-macro-node-completion.md
@@ -2,7 +2,7 @@
 id: idea-072-strict-macro-node-completion
 type: IDEA
 title: Strict Macro Node Completion Enforcement
-status: ACTIVE
+status: PENDING
 owner_persona: product_manager
 created_at: '2026-06-09'
 updated_at: '2026-06-10'

--- a/.foundry/ideas/idea-073-gen3-secret-base-viewer.md
+++ b/.foundry/ideas/idea-073-gen3-secret-base-viewer.md
@@ -2,7 +2,7 @@
 id: idea-073-gen3-secret-base-viewer
 type: IDEA
 title: Gen 3 Secret Base and Mixed Record Viewer
-status: ACTIVE
+status: PENDING
 owner_persona: product_manager
 created_at: '2026-06-10'
 updated_at: '2026-06-10'

--- a/.foundry/ideas/idea-073-refactor-dag-dashboard-context.md
+++ b/.foundry/ideas/idea-073-refactor-dag-dashboard-context.md
@@ -2,7 +2,7 @@
 id: idea-073-refactor-dag-dashboard-context
 type: IDEA
 title: Refactor DagDashboard to use React Context (ADR 013/017)
-status: ACTIVE
+status: PENDING
 owner_persona: product_manager
 created_at: '2026-06-10'
 updated_at: '2026-06-10'

--- a/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
+++ b/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
@@ -3,7 +3,7 @@ id: prd-073-045-gen3-secret-base-viewer
 type: PRD
 title: "Gen 3 Secret Base and Mixed Record Viewer"
 status: PENDING
-owner_persona: architect
+owner_persona: epic_planner
 created_at: "2026-06-10"
 updated_at: "2026-06-10"
 depends_on: []


### PR DESCRIPTION
Fixed the Foundry DAG resolution warnings by correcting an invalid owner_persona mapping in a PRD node and demoting three IDEA nodes that were flagged as suspended by the orchestrator. These changes ensure the local Foundry nodes are in a valid state and correctly reflect the orchestrator's resolution logic.

Fixes #2268

---
*PR created automatically by Jules for task [5927683323267601118](https://jules.google.com/task/5927683323267601118) started by @szubster*