### PR TITLE
chore(foundry): reject idea-066 due to incomplete child nodes

### DIFF
--- a/.foundry/ideas/idea-066-save-file-health-scanner.md
+++ b/.foundry/ideas/idea-066-save-file-health-scanner.md
@@ -48,3 +48,6 @@ The generated PRD and Epic nodes are still PENDING. This IDEA node must wait unt
 
 ### Auditor Rejection (Attempt 3)
 The generated PRD and Epic nodes are still PENDING. This IDEA node must wait until its entire generated sub-tree is COMPLETED. The resurrection loop continues to fail because agents are resubmitting without waiting. We must wait for the implementation of IDEA-072 (Strict Macro Node Completion Enforcement).
+
+### Auditor Rejection (Attempt 4)
+The generated PRD and Epic nodes are still PENDING. This IDEA node must wait until its entire generated sub-tree is COMPLETED. The resurrection loop continues to fail because agents are resubmitting without waiting. We must wait for the implementation of IDEA-072 (Strict Macro Node Completion Enforcement).

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -31,3 +31,12 @@ The Resurrection Loop currently relies on the assigned agent actually reading th
 
 **Recommendation/Learnings:**
 This further validates the need for `idea-072-strict-macro-node-completion`. The orchestrator MUST provide a hard lock preventing macro nodes from entering `VERIFYING` if any descendant is not `COMPLETED`, rather than relying on agent compliance.
+
+## 2026-06-12: Recurring Blind Resubmission of Macro Nodes
+I observed that `idea-066-save-file-health-scanner` was submitted for verification yet again (Attempt 4) while its generated child nodes (PRD-066 and Epic) are still in PENDING.
+
+**Why this matters:**
+The Resurrection Loop is failing because agents are blindly resubmitting nodes without reading the previous rejection reasons or verifying that the entire generated sub-tree is COMPLETED. The system is entering an impossible loop of rejections.
+
+**Recommendation/Learnings:**
+The implementation of `idea-072-strict-macro-node-completion` is critically needed. The orchestrator must provide a hard block to prevent macro nodes from entering VERIFYING if any descendant is not COMPLETED, as relying solely on agent compliance is demonstrably insufficient.


### PR DESCRIPTION
The Auditor persona has rejected the verification of `idea-066-save-file-health-scanner` for Attempt 4, because the node's generated sub-tree (PRD and EPIC nodes) are still in `PENDING` state. Appended a new `### Auditor Rejection` section in the markdown body and left the acceptance criteria unchecked to trigger the Resurrection Loop. Also updated the Auditor's journal with this recurring failure pattern.

---
*PR created automatically by Jules for task [12841119178625114608](https://jules.google.com/task/12841119178625114608) started by @szubster*