### PR TITLE
feat: Epic Breakdown for Hall of Fame Exporter

### DIFF
--- a/.foundry/epics/epic-044-070-hof-data-parsing.md
+++ b/.foundry/epics/epic-044-070-hof-data-parsing.md
@@ -1,0 +1,30 @@
+---
+id: epic-044-070-hof-data-parsing
+type: EPIC
+title: Parse Gen 1 and Gen 2 Hall of Fame Data
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - adr-044-021-hof-data-parsing-architecture
+jules_session_id: null
+pr_number: null
+parent: prd-070-044-hall-of-fame-exporter
+tags:
+  - epic
+  - parsing
+  - hall-of-fame
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Parse Gen 1 and Gen 2 Hall of Fame Data
+
+## Overview
+This epic covers the implementation details for extracting Hall of Fame data from Generation 1 and Generation 2 save files. This includes properly reading the offset in Gen 2 (0xA8 from Johto badges).
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-044-071-hof-certificate-rendering.md
+++ b/.foundry/epics/epic-044-071-hof-certificate-rendering.md
@@ -1,0 +1,31 @@
+---
+id: epic-044-071-hof-certificate-rendering
+type: EPIC
+title: Hall of Fame Certificate Generation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - adr-044-022-hof-certificate-generation
+  - epic-044-070-hof-data-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-070-044-hall-of-fame-exporter
+tags:
+  - epic
+  - hall-of-fame
+  - rendering
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Hall of Fame Certificate Generation
+
+## Overview
+This epic implements the generation of visually appealing Hall of Fame Certificates, transforming the parsed Hall of Fame data into shareable Canvas or SVG images.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-044-072-hof-timeline-ui.md
+++ b/.foundry/epics/epic-044-072-hof-timeline-ui.md
@@ -1,0 +1,31 @@
+---
+id: epic-044-072-hof-timeline-ui
+type: EPIC
+title: Hall of Fame Timeline UI Architecture
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - adr-044-023-hof-timeline-ui
+  - epic-044-071-hof-certificate-rendering
+jules_session_id: null
+pr_number: null
+parent: prd-070-044-hall-of-fame-exporter
+tags:
+  - epic
+  - ui
+  - hall-of-fame
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Hall of Fame Timeline UI Architecture
+
+## Overview
+This epic implements the frontend UI that allows users to view multiple past League victories in a timeline format and integrates the certificate generation capabilities.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
+++ b/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
@@ -36,3 +36,7 @@ Transform DexHelper into a social sharing utility by parsing Hall of Fame record
 - [ ] .foundry/docs/adrs/021-hof-data-parsing-architecture.md
 - [ ] .foundry/docs/adrs/022-hof-certificate-generation.md
 - [ ] .foundry/docs/adrs/023-hof-timeline-ui.md
+- [x] Break down into Epics
+- [ ] .foundry/epics/epic-044-070-hof-data-parsing.md
+- [ ] .foundry/epics/epic-044-071-hof-certificate-rendering.md
+- [ ] .foundry/epics/epic-044-072-hof-timeline-ui.md


### PR DESCRIPTION
Breaks down the `prd-070-044-hall-of-fame-exporter.md` into three detailed `.foundry/epics/` files, accurately mapping dependencies on generated ADRs. Follows strict Foundry structure without editing the parent node's frontmatter.

---
*PR created automatically by Jules for task [9891222269027956027](https://jules.google.com/task/9891222269027956027) started by @szubster*