### PR TITLE
Epic Breakdown: DagDashboard Context Refactor

### DIFF
--- a/.foundry/epics/epic-045-070-implement-dag-context.md
+++ b/.foundry/epics/epic-045-070-implement-dag-context.md
@@ -1,0 +1,35 @@
+---
+id: epic-045-070-implement-dag-context
+type: EPIC
+title: Implement DagContext and Provider for DAG Data
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-073-045-refactor-dag-dashboard-context
+tags:
+  - architecture
+  - ui
+  - dashboard
+  - context
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement DagContext and Provider for DAG Data
+
+## Overview
+As per ADR 013 and ADR 017, the core DAG data state must be lifted into a shared React Context to serve as a single source of truth for both the Graph View (React Flow) and the upcoming Kanban Board and Permanent Failure Dashboard.
+
+## Requirements
+- Create `DagContext` to manage the core DAG data state (nodes, edges).
+- Implement `DagProvider` to wrap the DAG views.
+- The context should expose the parsed DAG data.
+- Ensure the state structure is designed to support the upcoming Kanban Board and Permanent Failure Dashboard requirements.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-045-071-refactor-data-parsing-layer.md
+++ b/.foundry/epics/epic-045-071-refactor-data-parsing-layer.md
@@ -1,0 +1,34 @@
+---
+id: epic-045-071-refactor-data-parsing-layer
+type: EPIC
+title: Refactor Data Parsing Layer for rejection_count
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - epic-045-070-implement-dag-context
+
+jules_session_id: null
+pr_number: null
+parent: prd-073-045-refactor-dag-dashboard-context
+tags:
+  - data
+  - dashboard
+  - context
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Refactor Data Parsing Layer for rejection_count
+
+## Overview
+As per ADR 017, the Permanent Failure Dashboard requires access to the \`rejection_count\` of each node. The data parsing layer needs to be updated to extract this field from the markdown frontmatter.
+
+## Requirements
+- Update the DAG data parsing layer to extract the \`rejection_count\` field from the YAML frontmatter.
+- Ensure the \`rejection_count\` is passed along with the rest of the node data to the \`DagContext\`.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-045-072-refactor-views.md
+++ b/.foundry/epics/epic-045-072-refactor-views.md
@@ -1,0 +1,36 @@
+---
+id: epic-045-072-refactor-views
+type: EPIC
+title: Refactor DagDashboard Views to consume DagContext
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - epic-045-071-refactor-data-parsing-layer
+
+jules_session_id: null
+pr_number: null
+parent: prd-073-045-refactor-dag-dashboard-context
+tags:
+  - ui
+  - dashboard
+  - react-flow
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Refactor DagDashboard Views to consume DagContext
+
+## Overview
+With \`DagContext\` in place, the existing React Flow DAG visualizer (and any other DAG views) need to be refactored to consume data from this shared context instead of maintaining their own isolated state.
+
+## Requirements
+- Refactor the existing React Flow DAG visualizer to consume data from \`DagContext\`.
+- Ensure that the visualizer correctly renders nodes and edges based on the context data.
+- Ensure that any future views (Kanban, Permanent Failures) can seamlessly consume this context.
+- Verify that there are no performance regressions due to the context refactoring.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/prds/prd-073-045-refactor-dag-dashboard-context.md
+++ b/.foundry/prds/prd-073-045-refactor-dag-dashboard-context.md
@@ -30,4 +30,8 @@ Recent implementation attempts permanently failed because the state was left tig
 - Extract `rejection_count` from node frontmatter during data parsing so it is available in the shared context (as per ADR 017).
 
 ## Acceptance Criteria
-- [ ] Break down into Epics
+- [x] Break down into Epics
+
+- [ ] .foundry/epics/epic-045-070-implement-dag-context.md
+- [ ] .foundry/epics/epic-045-071-refactor-data-parsing-layer.md
+- [ ] .foundry/epics/epic-045-072-refactor-views.md


### PR DESCRIPTION
Breaks down the DagDashboard refactor PRD into 3 granular, dependent Epics to implement the DagContext as per ADR 013 and ADR 017.

---
*PR created automatically by Jules for task [16203138639735173443](https://jules.google.com/task/16203138639735173443) started by @szubster*