### PR TITLE
feat(foundry): break down strict macro node completion PRD into Epics

### DIFF
--- a/.foundry/epics/epic-045-070-orchestrator-strict-completion.md
+++ b/.foundry/epics/epic-045-070-orchestrator-strict-completion.md
@@ -1,0 +1,40 @@
+---
+id: epic-045-070-orchestrator-strict-completion
+type: EPIC
+title: Orchestrator Hierarchical Completion Checks
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-06-10"
+updated_at: "2026-06-10"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-072-045-strict-macro-node-completion
+tags:
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Orchestrator Hierarchical Completion Checks
+
+## Context
+Macro nodes (like `IDEA`, `PRD`, `EPIC`, and `STORY`) are transitioning to `VERIFYING` right after spawning their initial child nodes, even though the spawned descendants are still `PENDING` or `ACTIVE`. This is causing problems because a node shouldn't be completed if its requirements, mapped to child tasks, are not implemented.
+
+## Objective
+Update the DAG Orchestrator to ensure strict hierarchical completion. A node must only transition to `VERIFYING` or `COMPLETED` when all of its descendant child nodes are `COMPLETED`.
+
+## Requirements
+1. **Orchestrator Modifications**: Modify `.github/scripts/foundry-orchestrator.ts` to block the `VERIFYING` and `COMPLETED` transitions for any node that has children not in the `COMPLETED` state.
+2. **Child Identification**:
+    - Parse the `parent` field of other nodes to find reverse relationships.
+    - Parse the markdown body for references to generated nodes (e.g. `- [ ] path/to/file.md`).
+3. **Tests**: Add unit tests in `.github/scripts/foundry-orchestrator.test.ts` to ensure these new validations work correctly and don't break existing functionality.
+
+## Acceptance Criteria
+- [ ] Implement hierarchical completion logic in `foundry-orchestrator.ts`.
+- [ ] Add unit tests verifying the behavior blocks transition when children are not completed.
+- [ ] Ensure tests cover both `parent` field links and markdown body references.

--- a/.foundry/epics/epic-045-071-documentation-macro-node-completion.md
+++ b/.foundry/epics/epic-045-071-documentation-macro-node-completion.md
@@ -1,0 +1,39 @@
+---
+id: epic-045-071-documentation-macro-node-completion
+type: EPIC
+title: Documentation Updates for Macro Node Completion
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-06-10"
+updated_at: "2026-06-10"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-072-045-strict-macro-node-completion
+tags:
+  - orchestrator
+  - architecture
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Documentation Updates for Macro Node Completion
+
+## Context
+With the introduction of strict hierarchical completion in the orchestrator, where macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) cannot complete until all descendant nodes are `COMPLETED`, our system documentation needs to reflect these new constraints.
+
+## Objective
+Update the core system documentation to detail the new macro node completion rules so that all personas are aware of the expected behavior and how to properly format parent-child relationships to comply.
+
+## Requirements
+1. **Schema Updates**: Update `.foundry/docs/schema.md` to explain the new rule.
+2. **ADR 001 Updates**: Update `.foundry/docs/adrs/001-the-foundry-architecture.md` to reflect the strict completion checks.
+3. **Other Knowledge Base Updates**: Update any other relevant documents if necessary (e.g. `core_policies.md`).
+
+## Acceptance Criteria
+- [ ] Update `schema.md` with hierarchical completion rules.
+- [ ] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior.
+- [ ] Verify that there are no conflicting statements across other core documentation.

--- a/.foundry/prds/prd-072-045-strict-macro-node-completion.md
+++ b/.foundry/prds/prd-072-045-strict-macro-node-completion.md
@@ -32,4 +32,9 @@ Enforce the rule that a macro node (IDEA, PRD, EPIC, STORY) MUST NOT be verified
 2.  **Documentation Updates**: Update schema rules, `the-foundry-architecture.md` (ADR 001), and any relevant knowledge base articles to explicitly outline this new behavior.
 
 ## Acceptance Criteria
-- [ ] Epic Planner: Break down this PRD into Epics.
+- [x] Epic Planner: Break down this PRD into Epics.
+
+
+### Generated Epics
+- [ ] .foundry/epics/epic-045-070-orchestrator-strict-completion.md
+- [ ] .foundry/epics/epic-045-071-documentation-macro-node-completion.md


### PR DESCRIPTION
This PR fulfills the Epic Planner's responsibilities for PRD `prd-072-045-strict-macro-node-completion.md` by breaking down its requirements into actionable EPICs.

Changes made:
- Created `epic-045-070-orchestrator-strict-completion.md` for the DAG Orchestrator TS implementation.
- Created `epic-045-071-documentation-macro-node-completion.md` for the core system documentation updates.
- Checked off the "Break down this PRD into Epics" acceptance criteria in the parent PRD body.
- Appended unchecked Markdown checkbox references to the newly generated Epics directly into the parent PRD body to adhere to the macro node completion enforcement rule.
- Preserved the parent PRD's YAML frontmatter unaltered to ensure it correctly remains in the `READY` state until its descendants are completed.

All schema validations and test suites pass.

---
*PR created automatically by Jules for task [17818990175469455511](https://jules.google.com/task/17818990175469455511) started by @szubster*