### PR TITLE
build(foundry): break down Gen 3 Secret Base PRD into Epics

### DIFF
--- a/.foundry/epics/epic-045-070-gen3-secret-base-parsing.md
+++ b/.foundry/epics/epic-045-070-gen3-secret-base-parsing.md
@@ -1,0 +1,35 @@
+---
+id: epic-045-070-gen3-secret-base-parsing
+type: EPIC
+title: Gen 3 Secret Base Save File Parsing
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-073-045-gen3-secret-base-viewer
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Gen 3 Secret Base Save File Parsing
+
+## Context
+As part of the Gen 3 Secret Base and Mixed Record Viewer, we need to parse the save file to identify all active Secret Bases and extract NPC trainer data from mixed records. This data includes the friend's trainer name, team composition, and EV yields, as well as whether the player has battled them today.
+
+## Objectives
+- Implement save parsing logic using `DataView` (per ADR 010) for Gen 3 Secret Base locations.
+- Extract mixed record data, including NPC trainer names, teams, and EV yields.
+- Track daily rematch status for these NPC trainers.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into actionable Stories.

--- a/.foundry/epics/epic-045-071-gen3-secret-base-radar-integration.md
+++ b/.foundry/epics/epic-045-071-gen3-secret-base-radar-integration.md
@@ -1,0 +1,36 @@
+---
+id: epic-045-071-gen3-secret-base-radar-integration
+type: EPIC
+title: Gen 3 Secret Base Smart Route Radar Integration
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - epic-045-070-gen3-secret-base-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-073-045-gen3-secret-base-viewer
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - map-radar
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Gen 3 Secret Base Smart Route Radar Integration
+
+## Context
+Once Secret Base data is parsed from the save file, we need to map their exact locations on the Smart Route Radar. This allows players to visually locate where their friends' Secret Bases have spawned.
+
+## Objectives
+- Map the parsed Secret Base locations to the UnifiedLocation map graph.
+- Update the Smart Route Radar to display Secret Base markers.
+- Ensure integration respects the Smart Route Radar Architecture (ADR 018).
+
+## Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into actionable Stories.

--- a/.foundry/epics/epic-045-072-gen3-secret-base-dashboard.md
+++ b/.foundry/epics/epic-045-072-gen3-secret-base-dashboard.md
@@ -1,0 +1,36 @@
+---
+id: epic-045-072-gen3-secret-base-dashboard
+type: EPIC
+title: Gen 3 Secret Base NPC Trainer Dashboard
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - epic-045-070-gen3-secret-base-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-073-045-gen3-secret-base-viewer
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Gen 3 Secret Base NPC Trainer Dashboard
+
+## Context
+With the NPC trainer intel extracted from mixed records, we need a dashboard to display this information to the user. This includes trainer names, team compositions, EV yields, and daily rematch availability.
+
+## Objectives
+- Build a UI component to list active Secret Base NPC trainers.
+- Display each trainer's team composition and calculated EV yields for efficient training.
+- Indicate daily rematch status clearly on the dashboard.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into actionable Stories.

--- a/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
+++ b/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
@@ -32,4 +32,7 @@ Leverage DexHelper's programmatic save parsing to expose hidden Secret Base and 
 - **Daily Rematch Tracker:** Track whether the player has already battled the Secret Base trainer today.
 
 ## Next Steps
-- [ ] Epic Planner: Break this down into Epics (e.g., Save File Parsing, UI/Dashboard updates).
+- [x] Epic Planner: Break this down into Epics (e.g., Save File Parsing, UI/Dashboard updates).
+  - [ ] .foundry/epics/epic-045-070-gen3-secret-base-parsing.md
+  - [ ] .foundry/epics/epic-045-071-gen3-secret-base-radar-integration.md
+  - [ ] .foundry/epics/epic-045-072-gen3-secret-base-dashboard.md


### PR DESCRIPTION
As the Epic Planner, I have successfully transformed the PRD `prd-073-045-gen3-secret-base-viewer` into three granular Epic nodes.

Key changes:
1. Created `.foundry/epics/epic-045-070-gen3-secret-base-parsing.md` for save file parsing.
2. Created `.foundry/epics/epic-045-071-gen3-secret-base-radar-integration.md` for radar UI mapping.
3. Created `.foundry/epics/epic-045-072-gen3-secret-base-dashboard.md` for the NPC trainer display.
4. Linked dependencies via exact Node IDs (`epic-045-070-gen3-secret-base-parsing`) per the schema rules.
5. Assigned the `story_owner` persona to the new epics.
6. Checked off the planner task and appended the children as unchecked boxes directly in the PRD's markdown body, leaving its YAML frontmatter intact to respect the orchestrator DAG.
7. Validated all nodes via `validate-foundry-schema.ts`.

---
*PR created automatically by Jules for task [11823894027790031953](https://jules.google.com/task/11823894027790031953) started by @szubster*