### PR TITLE
Foundry Epic Breakdown: Gen 3 Roamer Tracker

### DIFF
--- a/.foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
+++ b/.foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
@@ -1,0 +1,34 @@
+---
+id: epic-044-070-gen3-roamer-core-extraction
+type: EPIC
+title: Gen 3 Roamer Core Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Core Extraction
+
+## Objective
+Extract the hidden roamer data structure directly from the `.sav` file for Gen 3 games (Ruby/Sapphire/Emerald and FireRed/LeafGreen) using the native `DataView` API.
+
+## Description
+Based on the research, the roamer data structure contains critical information such as IVs, Personality Value, HP, Level, and Status Condition. This Epic focuses on safely reading this 20-byte structure from the correct save offset and parsing it into a usable format for downstream logic.
+
+## Acceptance Criteria
+- [ ] Implement robust `DataView` parsing logic to extract the roamer data structure.
+- [ ] Correctly parse IVs, HP, Level, and Status Condition from the raw bytes.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
+++ b/.foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
@@ -1,0 +1,35 @@
+---
+id: epic-044-071-gen3-roamer-iv-glitch
+type: EPIC
+title: Gen 3 Roamer IV Glitch Detection
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - epic-044-070-gen3-roamer-core-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - iv-glitch
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer IV Glitch Detection
+
+## Objective
+Process the extracted roamer data to compute the Pokémon's Nature and detect if the "Roamer IV Glitch" affects it.
+
+## Description
+The "Roamer IV Glitch" is a known bug in specific Gen 3 games (Ruby/Sapphire and FireRed/LeafGreen) where a roaming Pokémon's IVs are corrupted or truncated upon generation. This Epic focuses on adding the logic to calculate the correct Nature and determining if the glitch conditions are met to provide a warning.
+
+## Acceptance Criteria
+- [ ] Implement logic to compute the Nature from the roamer data structure.
+- [ ] Implement detection logic to identify if the roaming Pokémon is affected by the IV Glitch.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-044-072-gen3-roamer-location-radar.md
+++ b/.foundry/epics/epic-044-072-gen3-roamer-location-radar.md
@@ -1,0 +1,35 @@
+---
+id: epic-044-072-gen3-roamer-location-radar
+type: EPIC
+title: Gen 3 Roamer Location Radar
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - map
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Location Radar
+
+## Objective
+Extract the roamer's current location index and integrate it with the Route Radar.
+
+## Description
+Determine the current map group and map number of the roaming Pokémon from the save file (noting that it's stored outside the primary 20-byte roamer struct in EWRAM or save state tracking). Map this location index to the UI's Route Radar so players can see where the roamer is located.
+
+## Acceptance Criteria
+- [ ] Parse the roamer's current location index from the save file.
+- [ ] Map the location index to the correct route or area in the application.
+- [ ] Integrate this location data with the Route Radar map display.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+++ b/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
@@ -1,0 +1,38 @@
+---
+id: epic-044-073-gen3-roamer-dashboard-ui
+type: EPIC
+title: Gen 3 Roamer Dashboard UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - epic-044-070-gen3-roamer-core-extraction
+  - epic-044-071-gen3-roamer-iv-glitch
+  - epic-044-072-gen3-roamer-location-radar
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Dashboard UI
+
+## Objective
+Create a user interface to display the comprehensive breakdown of the roaming legendary's internal state.
+
+## Description
+Develop a dashboard view that presents the exact state of the roaming Pokémon, utilizing the parsed data. It should clearly display the Pokémon's Nature, individual IVs, current HP, status condition, and provide a prominent warning if the IV Glitch has corrupted its stats. It will also interface with the Route Radar.
+
+## Acceptance Criteria
+- [ ] Build a UI component to display the roamer's Nature, IVs, HP, and Status.
+- [ ] Implement a visual warning indicator for the IV Glitch.
+- [ ] Ensure seamless integration with the Route Radar UI component.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -31,3 +31,8 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - Extract and display Nature, IVs, HP, status condition, and location index.
 - Detect and display a warning if the "Roamer IV Glitch" affects the Pokémon.
 - Provide a Route Radar to map the roamer's current location index.
+
+- [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
+- [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
+- [ ] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
+- [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md


### PR DESCRIPTION
This PR introduces the breakdown of PRD `prd-071-044-gen3-roamer-tracker.md` into 4 granular, Parent-Linked ID formatted Epics:
- `epic-044-070-gen3-roamer-core-extraction`
- `epic-044-071-gen3-roamer-iv-glitch`
- `epic-044-072-gen3-roamer-location-radar`
- `epic-044-073-gen3-roamer-dashboard-ui`

Dependencies between the newly created epics use the exact Node IDs without file extensions (e.g. `epic-044-070-gen3-roamer-core-extraction`).

The PRD's body was also modified to append references to these newly generated child nodes as unchecked task checkboxes (`- [ ]`), avoiding premature verification.

---
*PR created automatically by Jules for task [1867253258818244073](https://jules.google.com/task/1867253258818244073) started by @szubster*