### PR TITLE
Generate child stories for shared DAG utilities epic

### DIFF
--- a/.foundry/epics/epic-036-053-shared-dag-utilities.md
+++ b/.foundry/epics/epic-036-053-shared-dag-utilities.md
@@ -37,6 +37,12 @@ This epic extracts pure functions from `.github/scripts/foundry-orchestrator.ts`
 - [x] Story Owner: Write Story to create the `dag-utils.ts` module with pure functions and basic utilities.
   - Spawned: `.foundry/stories/story-053-090-extract-dag-utilities.md`
 
+
+- [ ] Story Owner: Write Story to create unit tests for `dag-utils.ts`.
+  - Spawned: `.foundry/stories/story-053-106-dag-utils-unit-tests.md`
+- [ ] Story Owner: Write Story to update DAG orchestration tests.
+  - Spawned: `.foundry/stories/story-053-107-update-dag-orchestration-tests.md`
+
 ## Acceptance Criteria
 - [ ] `dag-utils.ts` is created and contains the extracted pure functions and utilities.
 - [ ] New unit tests are written for `dag-utils.ts`.

--- a/.foundry/stories/story-053-106-dag-utils-unit-tests.md
+++ b/.foundry/stories/story-053-106-dag-utils-unit-tests.md
@@ -1,0 +1,36 @@
+---
+id: story-053-106-dag-utils-unit-tests
+type: STORY
+title: Unit Tests for Shared DAG Utilities
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - story-053-090-extract-dag-utilities
+jules_session_id: null
+pr_number: null
+parent: epic-036-053-shared-dag-utilities
+tags:
+  - testing
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: Spawned from epic-036-053-shared-dag-utilities
+---
+
+# Unit Tests for Shared DAG Utilities
+
+## 1. Introduction
+This story details the technical steps for creating unit tests for the extracted shared DAG utility functions in `dag-utils.ts`.
+
+## 2. Technical Tasks
+- Create `.github/scripts/dag-utils.test.ts`.
+- Write unit tests for `buildReverseDependencyGraph`.
+- Write unit tests for `getOrphanedNodes`.
+
+## Acceptance Criteria
+- [ ] Appropriate unit tests are added in `dag-utils.test.ts`.
+- [ ] Existing functionality works seamlessly utilizing the new utility file.

--- a/.foundry/stories/story-053-107-update-dag-orchestration-tests.md
+++ b/.foundry/stories/story-053-107-update-dag-orchestration-tests.md
@@ -1,0 +1,35 @@
+---
+id: story-053-107-update-dag-orchestration-tests
+type: STORY
+title: Update DAG Orchestration Tests
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - story-053-106-dag-utils-unit-tests
+jules_session_id: null
+pr_number: null
+parent: epic-036-053-shared-dag-utilities
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: Spawned from epic-036-053-shared-dag-utilities
+---
+
+# Update DAG Orchestration Tests
+
+## 1. Introduction
+This story details the technical steps for updating the DAG orchestration tests to use the new module `.github/scripts/dag-utils.ts`.
+
+## 2. Technical Tasks
+- Update DAG orchestration tests to import from `dag-utils.ts`.
+- Ensure all existing tests pass after the refactor.
+
+## Acceptance Criteria
+- [ ] Existing orchestration tests are updated to use the new module.
+- [ ] All existing tests pass successfully.


### PR DESCRIPTION
This PR generates two new child stories for `epic-036-053-shared-dag-utilities`: one for creating unit tests, and one for updating the orchestrator tests. They have been properly linked and appended to the Epic markdown body as unchecked tasks, ensuring the Epic waits for their completion.

---
*PR created automatically by Jules for task [8740520313147171068](https://jules.google.com/task/8740520313147171068) started by @szubster*