### PR TITLE
chore: break down Feebas seed extraction story into tasks

### DIFF
--- a/.foundry/stories/story-058-095-feebas-seed-extraction.md
+++ b/.foundry/stories/story-058-095-feebas-seed-extraction.md
@@ -25,8 +25,10 @@ notes: ''
 Implement a utility function to extract the 16-bit Feebas seed from Gen 3 save files (Ruby, Sapphire, Emerald) using the native `DataView` API.
 
 ## Acceptance Criteria
-- [ ] Create `src/engine/gen3/feebas.ts` (if it doesn't exist).
-- [ ] Implement `extractFeebasSeed(saveData: DataView, gameVersion: GameVersion)` function.
-- [ ] Handle version-specific offsets (`0x2DD6` for Ruby/Sapphire, `0x2E66` for Emerald) within `SaveBlock1`.
-- [ ] Use `DataView` API (e.g. `getUint16`) to read the seed value.
-- [ ] Write unit tests to verify extraction for all supported Gen 3 versions.
+- [x] Create `src/engine/gen3/feebas.ts` (if it doesn't exist).
+- [x] Implement `extractFeebasSeed(saveData: DataView, gameVersion: GameVersion)` function.
+- [x] Handle version-specific offsets (`0x2DD6` for Ruby/Sapphire, `0x2E66` for Emerald) within `SaveBlock1`.
+- [x] Use `DataView` API (e.g. `getUint16`) to read the seed value.
+- [x] Write unit tests to verify extraction for all supported Gen 3 versions.
+- [ ] .foundry/tasks/task-095-157-feebas-seed-impl.md
+- [ ] .foundry/tasks/task-095-158-feebas-seed-qa.md

--- a/.foundry/tasks/task-095-157-feebas-seed-impl.md
+++ b/.foundry/tasks/task-095-157-feebas-seed-impl.md
@@ -1,0 +1,53 @@
+---
+id: task-095-157-feebas-seed-impl
+type: TASK
+title: Implement Feebas Seed Extraction
+status: READY
+owner_persona: coder
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-058-095-feebas-seed-extraction
+tags:
+  - gen3
+  - backend
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Feebas Seed Extraction
+
+## Objective
+Implement a utility function to extract the 16-bit Feebas seed from Gen 3 save files (Ruby, Sapphire, Emerald) using the native `DataView` API.
+
+## Architecture & Constraints (ADR 010)
+- You **MUST** exclusively use the native `DataView` API (e.g. `getUint16`) to read the seed value.
+- You **MUST NOT** use raw `Uint8Array` manipulations.
+- You **MUST** rely on `DataView` to throw a `RangeError` on out-of-bounds reads.
+- You **MUST** explicitly catch `RangeError` and throw a new Error with the message `"The save file is corrupted or incomplete."`
+
+## Technical Blueprint
+
+1. Create `src/engine/gen3/feebas.ts` (and its test file `feebas.test.ts`). Note that `src/engine/gen3` might not exist yet.
+2. Implement `extractFeebasSeed(saveData: DataView, gameVersion: GameVersion)` function.
+3. The function must extract the 16-bit seed at specific offsets within `SaveBlock1`:
+    - `0x2DD6` for Ruby/Sapphire
+    - `0x2E66` for Emerald
+4. Add unit tests for `extractFeebasSeed` verifying:
+    - Correct extraction for Ruby/Sapphire.
+    - Correct extraction for Emerald.
+    - Graceful handling of corrupted/truncated saves (verifying the `RangeError` is caught and re-thrown as the corrupted save error).
+
+## Developer Reminders
+- If you encounter a permanent failure or need to abort, you **MUST** update this node's YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
+- If you submit an Empty PR for a completed task (e.g., the code already existed), you **MUST** check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] `src/engine/gen3/feebas.ts` exists and implements `extractFeebasSeed`.
+- [ ] Uses `DataView` API with explicit `RangeError` bounds-checking catch logic.
+- [ ] Handles version-specific offsets correctly.
+- [ ] Unit tests added and passing.

--- a/.foundry/tasks/task-095-158-feebas-seed-qa.md
+++ b/.foundry/tasks/task-095-158-feebas-seed-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-095-158-feebas-seed-qa
+type: TASK
+title: QA Feebas Seed Extraction
+status: READY
+owner_persona: qa
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - task-095-157-feebas-seed-impl
+jules_session_id: null
+pr_number: null
+parent: story-058-095-feebas-seed-extraction
+tags:
+  - gen3
+  - backend
+  - save-parsing
+  - qa
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Feebas Seed Extraction
+
+## Objective
+Verify the implementation of the 16-bit Feebas seed extraction utility from Gen 3 save files.
+
+## Review Instructions
+
+1. Verify `src/engine/gen3/feebas.ts` exists.
+2. Verify `extractFeebasSeed(saveData: DataView, gameVersion: GameVersion)` strictly uses the `DataView` API (e.g., `getUint16`).
+3. Verify that the correct version-specific offsets are used (`0x2DD6` for Ruby/Sapphire, `0x2E66` for Emerald).
+4. Verify ADR 010 compliance: the code must catch `RangeError` from `DataView` operations and re-throw an Error with `"The save file is corrupted or incomplete."`
+5. Verify unit tests are comprehensive and pass. Tests should cover version differences and bounds checking (truncated files).
+
+## QA Reminders
+- If the implementation fails your review, you **MUST** update this node's YAML frontmatter to `status: FAILED` and provide a clear `rejection_reason` explaining what the coder needs to fix.
+- If the implementation passes and you submit an Empty PR, you **MUST** check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Code uses `DataView` and explicitly catches `RangeError` to handle out-of-bounds.
+- [ ] Offsets `0x2DD6` and `0x2E66` are correctly applied based on version.
+- [ ] Tests cover all paths and pass successfully.


### PR DESCRIPTION
Broke down the Story node `story-058-095-feebas-seed-extraction` into actionable engineering tasks.

Created two new task nodes:
1.  **`task-095-157-feebas-seed-impl`**: Assigned to `coder`. Provides the technical blueprint for creating `src/engine/gen3/feebas.ts` and implementing the `extractFeebasSeed` function, strictly adhering to ADR 010 (using `DataView` API and handling `RangeError`).
2.  **`task-095-158-feebas-seed-qa`**: Assigned to `qa`. Instructs the QA persona to verify the implementation against the technical blueprint and ADR 010 requirements.

Appended references to these newly created task nodes as unchecked checkboxes to the parent story `story-058-095-feebas-seed-extraction`, and checked off the original criteria in the parent node to ensure the story transitions to VERIFYING only after the child tasks are completed.

---
*PR created automatically by Jules for task [16576950842066505975](https://jules.google.com/task/16576950842066505975) started by @szubster*