### PR TITLE
Draft tasks for Gen 3 hidden item parsing

### DIFF
--- a/.foundry/stories/story-058-097-gen3-hidden-item-parsing.md
+++ b/.foundry/stories/story-058-097-gen3-hidden-item-parsing.md
@@ -32,3 +32,5 @@ This story focuses on the third part of the epic `epic-037-058-hidden-items-save
 ## Acceptance Criteria
 - [ ] `parseGen3` correctly extracts hidden item event flags.
 - [ ] Unit tests for the Gen 3 save parser are updated and pass.
+- [ ] .foundry/tasks/task-097-157-gen3-hidden-item-parsing-impl.md
+- [ ] .foundry/tasks/task-097-158-gen3-hidden-item-parsing-qa.md

--- a/.foundry/tasks/task-097-157-gen3-hidden-item-parsing-impl.md
+++ b/.foundry/tasks/task-097-157-gen3-hidden-item-parsing-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-097-157-gen3-hidden-item-parsing-impl
+type: TASK
+title: Gen 3 Hidden Item Event Flags Parsing Implementation
+status: READY
+owner_persona: coder
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-058-097-gen3-hidden-item-parsing
+tags:
+  - gen3
+  - save-parsing
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Hidden Item Event Flags Parsing Implementation
+
+## Context
+This task implements the third part of the epic `epic-037-058-hidden-items-save-parsing`. The `SaveData` interface already supports optional `hiddenItemFlags` (`Uint8Array`). The Gen 3 save parser needs to be extended to properly parse the save sections and extract the hidden item event flags.
+
+## Implementation Details
+1. **Research Gen 3 Save Structure**: Investigate the Gen 3 save format (e.g., Ruby/Sapphire, Emerald, FireRed/LeafGreen) to determine how section data is structured, which section contains the event flags, and the exact offsets and sizes for hidden items. Note that Gen 3 uses 4KB sections.
+2. **Implement Extraction**: Update the `parseGen3` function in `src/engine/saveParser/parsers/gen3.ts` to locate the correct section and extract the hidden item flags.
+3. **Strict DataView Compliance**: In accordance with **ADR 010**, you MUST exclusively use the native `DataView` API (e.g., `getUint8`, `getUint16`, `getUint32`) for all parsing logic. Do not use raw `Uint8Array` manipulations. The parser must rely on `DataView` to throw `RangeError` on out-of-bounds reads and handle these gracefully.
+4. **Update Tests**: Add or update unit tests for the Gen 3 save parser to assert that the `hiddenItemFlags` are parsed correctly, injecting mock byte values into the dummy save buffer to verify extraction logic.
+
+## Acceptance Criteria
+- [ ] `parseGen3` correctly parses the save file sections to locate the event flags.
+- [ ] `parseGen3` extracts the hidden item flags into a `Uint8Array` using exclusively the `DataView` API.
+- [ ] Bounds checking is handled natively by catching `DataView` `RangeError`s and propagating them appropriately.
+- [ ] Unit tests for the Gen 3 save parser verify hidden item parsing logic.
+
+## IMPORTANT REMINDERS
+- **If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.**
+- **If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.**

--- a/.foundry/tasks/task-097-158-gen3-hidden-item-parsing-qa.md
+++ b/.foundry/tasks/task-097-158-gen3-hidden-item-parsing-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-097-158-gen3-hidden-item-parsing-qa
+type: TASK
+title: Gen 3 Hidden Item Event Flags Parsing QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - task-097-157-gen3-hidden-item-parsing-impl
+jules_session_id: null
+pr_number: null
+parent: story-058-097-gen3-hidden-item-parsing
+tags:
+  - gen3
+  - save-parsing
+  - feature
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Hidden Item Event Flags Parsing QA
+
+## Context
+This QA task verifies the coder's implementation for Gen 3 hidden item parsing (`task-097-157-gen3-hidden-item-parsing-impl`). The goal is to ensure the save parsing engine correctly extracts hidden item event flags for Gen 3 games while strictly adhering to ADR 010.
+
+## QA Verification Steps
+1. **Verify ADR 010 Compliance**: Review `src/engine/saveParser/parsers/gen3.ts`. Ensure the parsing logic *exclusively* uses the native `DataView` API (e.g., `getUint8`, `getUint16`, `getUint32`) and avoids raw `Uint8Array` access.
+2. **Verify Error Handling**: Confirm that `RangeError` exceptions thrown by out-of-bounds `DataView` accesses are properly caught and handled gracefully (e.g., re-thrown as specific validation errors like "Corrupted Save File").
+3. **Verify Extraction Logic**: Ensure that the code correctly navigates the Gen 3 4KB section structure to locate the event flags and extract the proper sub-section for hidden items.
+4. **Verify Test Coverage**: Check the Gen 3 save parser unit tests. They must provide adequate mock data reflecting the Gen 3 save format and assert that `hiddenItemFlags` are extracted properly with the correct byte values. Tests must pass successfully.
+
+## Acceptance Criteria
+- [ ] Code strictly adheres to ADR 010 (`DataView` API usage).
+- [ ] Out-of-bounds `DataView` accesses are handled gracefully.
+- [ ] Gen 3 section parsing logic accurately targets and extracts the hidden item flags.
+- [ ] Unit tests for Gen 3 hidden item parsing exist, provide sufficient coverage, and pass.
+
+## IMPORTANT REMINDERS
+- **If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.**
+- **If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.**


### PR DESCRIPTION
Creates technical tasks `task-097-157-gen3-hidden-item-parsing-impl` and `task-097-158-gen3-hidden-item-parsing-qa` to fulfill the story requirements for extracting Gen 3 hidden item event flags. Appended these as unchecked dependencies to the `story-058-097-gen3-hidden-item-parsing` node, adhering to proper schema and architectural rules.

---
*PR created automatically by Jules for task [5400694130827819732](https://jules.google.com/task/5400694130827819732) started by @szubster*