### PR TITLE
feat: create pokerus byte parsing blueprint tasks

### DIFF
--- a/.foundry/stories/story-061-095-pokerus-byte-parsing.md
+++ b/.foundry/stories/story-061-095-pokerus-byte-parsing.md
@@ -26,4 +26,6 @@ notes: ''
 Parse the raw pokerus byte into structured state for Pokemon in Gen 2 saves.
 
 ## Acceptance Criteria
-- [ ] Parse raw pokerus byte.
+- [x] Parse raw pokerus byte.
+- [ ] .foundry/tasks/task-095-157-pokerus-byte-parsing-impl.md
+- [ ] .foundry/tasks/task-095-158-pokerus-byte-parsing-qa.md

--- a/.foundry/tasks/task-095-157-pokerus-byte-parsing-impl.md
+++ b/.foundry/tasks/task-095-157-pokerus-byte-parsing-impl.md
@@ -1,0 +1,56 @@
+---
+id: task-095-157-pokerus-byte-parsing-impl
+type: TASK
+title: Implement Pokerus Byte Parsing
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-061-095-pokerus-byte-parsing
+tags:
+  - gen2
+  - save-engine
+  - pokerus
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Pokerus Byte Parsing
+
+## Description
+The Pokerus byte contains information about the strain and the days remaining. We need to parse this raw byte into a structured object within `PokemonInstance`.
+
+The Pokerus byte is an 8-bit integer:
+- The upper 4 bits (bits 4-7) represent the strain.
+- The lower 4 bits (bits 0-3) represent the days remaining.
+
+We should update `PokemonInstance` in `src/engine/saveParser/parsers/common.ts` to reflect this structured object:
+```typescript
+pokerus?: {
+  strain: number;
+  daysRemaining: number;
+} | undefined;
+```
+If the raw byte is 0, the pokemon has no pokerus. If the strain is 0, but the byte is > 0, it means the pokemon has an invalid pokerus, but typically the game handles it. Wait, the strain is upper 4 bits, if strain is > 0, the pokemon has or had pokerus. If daysRemaining > 0, it's contagious. If daysRemaining == 0, it's cured.
+Let's parse it as:
+```typescript
+const pokerus = rawPokerusByte > 0 ? {
+  strain: rawPokerusByte >> 4,
+  daysRemaining: rawPokerusByte & 0x0F
+} : undefined;
+```
+
+Update `parseGen2PokemonInstance` in `src/engine/saveParser/parsers/gen2.ts` to parse the raw byte into this object.
+
+## Acceptance Criteria
+- [ ] Update `PokemonInstance.pokerus` type in `src/engine/saveParser/parsers/common.ts`
+- [ ] Update `parseGen2PokemonInstance` to parse the pokerus byte into the structured object.
+
+### Critical Contract Reminders
+- If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-095-158-pokerus-byte-parsing-qa.md
+++ b/.foundry/tasks/task-095-158-pokerus-byte-parsing-qa.md
@@ -1,0 +1,36 @@
+---
+id: task-095-158-pokerus-byte-parsing-qa
+type: TASK
+title: QA Pokerus Byte Parsing
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-08'
+updated_at: '2026-06-08'
+depends_on:
+  - task-095-157-pokerus-byte-parsing-impl
+jules_session_id: null
+pr_number: null
+parent: story-061-095-pokerus-byte-parsing
+tags:
+  - gen2
+  - save-engine
+  - pokerus
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Pokerus Byte Parsing
+
+## Description
+Verify the implementation of Pokerus byte parsing.
+
+## Acceptance Criteria
+- [ ] Verify `PokemonInstance.pokerus` type in `src/engine/saveParser/parsers/common.ts` is updated.
+- [ ] Verify `parseGen2PokemonInstance` correctly parses the raw byte into `strain` and `daysRemaining`.
+
+### Critical Contract Reminders
+- If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Created technical blueprints for the Pokerus byte parsing story.
- Task 157: Implementation of parsing pokerus byte into `strain` and `daysRemaining`.
- Task 158: QA verification of the parsing logic.
- Checked off parent story acceptance criteria.

---
*PR created automatically by Jules for task [13929312085420309840](https://jules.google.com/task/13929312085420309840) started by @szubster*