### PR TITLE
feat(foundry): Break down Contest Ribbons Display UI story into implement and QA tasks

### DIFF
--- a/.foundry/stories/story-064-103-contest-ribbons-display-ui.md
+++ b/.foundry/stories/story-064-103-contest-ribbons-display-ui.md
@@ -36,3 +36,5 @@ Derived from `epic-041-064-contest-ui-shared-components`, this story focuses on 
 - [ ] Implement the `ContestRibbonBadge` (or similar) React component(s).
 - [ ] Add rendering tests to verify various Ribbon combinations display correctly.
 - [ ] Ensure proper styling matching the project's aesthetics.
+- [ ] .foundry/tasks/task-103-157-contest-ribbons-ui-impl.md
+- [ ] .foundry/tasks/task-103-158-contest-ribbons-ui-qa.md

--- a/.foundry/tasks/task-103-157-contest-ribbons-ui-impl.md
+++ b/.foundry/tasks/task-103-157-contest-ribbons-ui-impl.md
@@ -1,0 +1,43 @@
+---
+id: task-103-157-contest-ribbons-ui-impl
+type: TASK
+title: Implement Contest Ribbons Display UI Component
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-064-103-contest-ribbons-display-ui
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Contest Ribbons Display UI Component
+
+## Context
+This task is derived from `story-064-103-contest-ribbons-display-ui` and involves implementing the reusable UI components to display Contest Ribbons a Pokémon has earned.
+
+## Requirements
+- Create a `ContestRibbonBadge` (or similar) React component.
+- The component must accept properties to specify the Ribbon type (Cool, Beauty, Cute, Smart, Tough) and rank (Normal, Super, Hyper, Master).
+- Implement tooltips to describe the Ribbon.
+- Ensure the styling follows the global tactical UI guidelines.
+- Add rendering tests (e.g., using Vitest/Playwright) to verify various Ribbon combinations display correctly.
+
+## Contract
+- If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement the `ContestRibbonBadge` React component(s).
+- [ ] Ensure proper styling matching the project's aesthetics.
+- [ ] Add rendering tests to verify various Ribbon combinations display correctly.

--- a/.foundry/tasks/task-103-158-contest-ribbons-ui-qa.md
+++ b/.foundry/tasks/task-103-158-contest-ribbons-ui-qa.md
@@ -1,0 +1,42 @@
+---
+id: task-103-158-contest-ribbons-ui-qa
+type: TASK
+title: QA Contest Ribbons Display UI Component
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - task-103-157-contest-ribbons-ui-impl
+jules_session_id: null
+pr_number: null
+parent: story-064-103-contest-ribbons-display-ui
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Contest Ribbons Display UI Component
+
+## Context
+This task verifies the implementation of the `ContestRibbonBadge` UI component as specified in `story-064-103-contest-ribbons-display-ui`.
+
+## Requirements
+- Verify that the component correctly renders distinct icons or badges for each Ribbon type and their respective ranks.
+- Confirm that tooltips describing the Ribbon are present and accurate.
+- Check that the styling adheres to the global tactical UI guidelines.
+- Ensure rendering tests pass successfully.
+
+## Contract
+- If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify `ContestRibbonBadge` rendering behavior and visual correctness.
+- [ ] Review implementation code and tests.


### PR DESCRIPTION
This pull request executes the Tech Lead breakdown of the "Contest Ribbons Display UI Component" Story (`story-064-103-contest-ribbons-display-ui`). 

It generates two new nodes following the Intelligent Verification Protocol:
1. `task-103-157-contest-ribbons-ui-impl`: The implementation blueprint assigned to the `coder` persona.
2. `task-103-158-contest-ribbons-ui-qa`: The corresponding verification blueprint assigned to the `qa` persona, with an explicit `depends_on` referencing the implementation task to prevent DAG deadlocks.

The generated nodes correctly adhere to the Parent-Linked ID schema and Foundry DAG requirements. The parent Story has been updated to include these child nodes as unchecked checkboxes, preventing premature verification. Validation via `scripts/validate-foundry-schema.ts` confirms structural integrity.

---
*PR created automatically by Jules for task [4166943151401351874](https://jules.google.com/task/4166943151401351874) started by @szubster*