### PR TITLE
feat(foundry): scaffold Gen 3 PID extraction tasks

### DIFF
--- a/.foundry/stories/story-061-099-extract-pokemon-pids.md
+++ b/.foundry/stories/story-061-099-extract-pokemon-pids.md
@@ -29,4 +29,8 @@ Parse the 32-bit personality values (PIDs) from all Pokémon in the player's act
 Use the `DataView` API for safe data parsing as per ADR 010.
 
 ## Acceptance Criteria
-- [ ] Create/Update TASK nodes to implement parsing the 32-bit PIDs for all party and PC Pokémon in Gen 3 saves.
+- [x] Create/Update TASK nodes to implement parsing the 32-bit PIDs for all party and PC Pokémon in Gen 3 saves.
+
+### Implementation Tasks
+- [ ] .foundry/tasks/task-099-157-gen3-extract-pokemon-pids-impl.md
+- [ ] .foundry/tasks/task-099-158-gen3-extract-pokemon-pids-qa.md

--- a/.foundry/tasks/task-099-157-gen3-extract-pokemon-pids-impl.md
+++ b/.foundry/tasks/task-099-157-gen3-extract-pokemon-pids-impl.md
@@ -1,0 +1,41 @@
+---
+id: task-099-157-gen3-extract-pokemon-pids-impl
+type: TASK
+title: Implement Gen 3 Pokemon PID Extraction
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-061-099-extract-pokemon-pids
+tags:
+  - gen3
+  - data-parsing
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Pokemon PID Extraction
+
+## Context
+As part of the Mirage Island Engine updates, we need to extract the 32-bit Personality Values (PIDs) from all Pokémon in the player's active party and PC storage boxes for Gen 3 saves.
+
+## Requirements
+1.  **Parse Party PIDs**: Implement logic to iterate through the active party in a Gen 3 save and extract the 32-bit PID for each Pokémon.
+2.  **Parse PC PIDs**: Implement logic to iterate through all PC boxes in a Gen 3 save and extract the 32-bit PID for each stored Pokémon.
+3.  **Use DataView API**: You MUST strictly use the native `DataView` API (e.g., `getUint32`) for safe data parsing as mandated by ADR 010.
+4.  **Graceful Error Handling**: Do not crash on out-of-bounds reads. Rely on `DataView` throwing `RangeError` and handle it gracefully by propagating specific validation errors (e.g., "Corrupted Save File").
+
+## Acceptance Criteria
+- [ ] Implement Gen 3 party parsing logic using `DataView` to extract PIDs.
+- [ ] Implement Gen 3 PC box parsing logic using `DataView` to extract PIDs.
+- [ ] Ensure `RangeError` is caught and handled gracefully as per ADR 010.
+
+## Coder Persona Reminders
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
+- If you submit an empty PR for a completed task (e.g., if the work is already done), you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the frontmatter in this case.

--- a/.foundry/tasks/task-099-158-gen3-extract-pokemon-pids-qa.md
+++ b/.foundry/tasks/task-099-158-gen3-extract-pokemon-pids-qa.md
@@ -1,0 +1,41 @@
+---
+id: task-099-158-gen3-extract-pokemon-pids-qa
+type: TASK
+title: QA Gen 3 Pokemon PID Extraction
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - task-099-157-gen3-extract-pokemon-pids-impl
+jules_session_id: null
+pr_number: null
+parent: story-061-099-extract-pokemon-pids
+tags:
+  - gen3
+  - qa
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 Pokemon PID Extraction
+
+## Context
+Verify the implementation of Gen 3 32-bit PID extraction for both party and PC box Pokémon.
+
+## Requirements
+1.  **Verify DataView Usage**: Ensure that the implementation strictly uses the `DataView` API (ADR 010) and does not use raw `Uint8Array` access.
+2.  **Verify Error Handling**: Ensure `RangeError` is properly caught and handled to prevent silent crashes or corrupted parsing.
+3.  **Test Coverage**: Write unit tests to verify correct extraction of 32-bit PIDs for Party and PC box Pokémon in Gen 3 saves.
+
+## Acceptance Criteria
+- [ ] Verify the usage of `DataView` API.
+- [ ] Verify graceful error handling of out-of-bounds reads.
+- [ ] Write and pass tests for the PID extraction logic.
+
+## QA Persona Reminders
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
+- If you submit an empty PR for a completed task (e.g., if the work is already done), you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the frontmatter in this case.


### PR DESCRIPTION
This PR completes Story `story-061-099-extract-pokemon-pids` by scaffolding the required `TASK` nodes to parse 32-bit PIDs for Party and PC box Pokémon in Gen 3 saves.

- Implements strict node ID tracking and Sibling Dependency (`task-099-158` depends on `task-099-157`).
- Integrates specific architectural reminders per ADR 010 (DataView migration).
- Passes all orchestrator schema validation checks and unit tests.

---
*PR created automatically by Jules for task [3254474542916920523](https://jules.google.com/task/3254474542916920523) started by @szubster*