### PR TITLE
chore(foundry): spawn tasks for gen 3 nature to contest mapping

### DIFF
--- a/.foundry/stories/story-064-101-gen3-nature-condition-mapping.md
+++ b/.foundry/stories/story-064-101-gen3-nature-condition-mapping.md
@@ -33,3 +33,7 @@ This story implements the first part of `epic-042-064-gen3-contest-advisor-algor
 - [ ] Create the data structure mapping Natures to Contest Conditions.
 - [ ] Implement utility functions for querying preferences.
 - [ ] Write unit tests to verify the mappings are accurate for all 25 natures.
+
+## 4. Breakdown
+- [ ] .foundry/tasks/task-101-157-gen3-nature-condition-mapping-impl.md
+- [ ] .foundry/tasks/task-101-158-gen3-nature-condition-mapping-qa.md

--- a/.foundry/tasks/task-101-157-gen3-nature-condition-mapping-impl.md
+++ b/.foundry/tasks/task-101-157-gen3-nature-condition-mapping-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-101-157-gen3-nature-condition-mapping-impl
+type: TASK
+title: Implement Gen 3 Nature to Contest Condition Mapping
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-064-101-gen3-nature-condition-mapping
+tags:
+  - gen3
+  - contests
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Nature to Contest Condition Mapping
+
+## Context
+This task implements the logic defined in `story-064-101-gen3-nature-condition-mapping`. We need a robust data structure to map the 25 Pokémon Natures to their preferred and disliked Pokéblock flavors, which correspond to the five Contest Conditions (Cool = Spicy, Beauty = Dry, Cute = Sweet, Smart = Bitter, Tough = Sour).
+
+## Instructions
+1.  **Data Structure**: Create a constant (e.g., in `src/engine/gen3/contests/natureMapping.ts` or similar appropriate file) that maps each of the 25 Pokémon Natures to their preferred and disliked Contest Conditions based on flavor preferences.
+2.  **Utility Functions**: Implement functions to easily query this data, such as:
+    *   `getPreferredCondition(nature: Nature): ContestCondition | null`
+    *   `getDislikedCondition(nature: Nature): ContestCondition | null`
+3.  **Unit Tests**: Write comprehensive unit tests in an adjacent `.test.ts` file to verify that the mappings are accurate for all 25 natures and that the utility functions work correctly.
+
+## Constraints
+- Ensure strict typings are used for Natures and Contest Conditions.
+- Follow existing project conventions for data structures.
+
+## Acceptance Criteria
+- [ ] The data structure mapping all 25 Natures to Contest Conditions is implemented.
+- [ ] Utility functions for querying preferences and dislikes are implemented and exported.
+- [ ] Unit tests cover all 25 natures to verify accuracy.
+
+> **Note to Coder**:
+> - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+> - If you submit an empty PR for a completed task (e.g., if the work is already done), you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-101-158-gen3-nature-condition-mapping-qa.md
+++ b/.foundry/tasks/task-101-158-gen3-nature-condition-mapping-qa.md
@@ -1,0 +1,41 @@
+---
+id: task-101-158-gen3-nature-condition-mapping-qa
+type: TASK
+title: QA Gen 3 Nature to Contest Condition Mapping
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - task-101-157-gen3-nature-condition-mapping-impl
+jules_session_id: null
+pr_number: null
+parent: story-064-101-gen3-nature-condition-mapping
+tags:
+  - gen3
+  - contests
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 Nature to Contest Condition Mapping
+
+## Context
+This task verifies the logic implemented in `task-101-157-gen3-nature-condition-mapping-impl`. We need to ensure that the robust data structure mapping the 25 Pokémon Natures to their preferred and disliked Contest Conditions is fully accurate.
+
+## Instructions
+1.  **Code Review**: Review the PR or code changes from the implementation task to ensure it follows standard practices and that the mapping data structure is robust.
+2.  **Verify Mappings**: Cross-reference the implemented data structure against known Gen 3 Contest mechanics to verify its correctness. Cool = Spicy, Beauty = Dry, Cute = Sweet, Smart = Bitter, Tough = Sour. Ensure neutral natures (e.g. Hardy) have no preferred/disliked flavors.
+3.  **Test Verification**: Verify that the implemented unit tests cover all 25 natures and that they all pass.
+
+## Acceptance Criteria
+- [ ] The data structure mapping all 25 Natures to Contest Conditions is reviewed and correct.
+- [ ] Utility functions for querying preferences and dislikes are verified.
+- [ ] Unit tests are verified to cover all 25 natures successfully.
+
+> **Note to QA**:
+> - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+> - If you submit an empty PR for a completed task (e.g., if the work is already done), you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR introduces the technical blueprints (TASK nodes) required to complete the Gen 3 Nature to Contest Condition Mapping story.

It creates:
1. An implementation task assigned to the `coder` persona.
2. A QA task assigned to the `qa` persona to verify the mapping logic, correctly setting up the `depends_on` relationship.

The parent story node has been updated to track these new descendant tasks.

---
*PR created automatically by Jules for task [12727293576546887761](https://jules.google.com/task/12727293576546887761) started by @szubster*