### PR TITLE
Break down Gen3 Roamer Core Extraction epic into stories

### DIFF
--- a/.foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
+++ b/.foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
@@ -31,4 +31,6 @@ Based on the research, the roamer data structure contains critical information s
 ## Acceptance Criteria
 - [ ] Implement robust `DataView` parsing logic to extract the roamer data structure.
 - [ ] Correctly parse IVs, HP, Level, and Status Condition from the raw bytes.
-- [ ] Story Owner: Break down this Epic into executable Stories.
+- [x] Story Owner: Break down this Epic into executable Stories.
+- [ ] .foundry/stories/story-070-108-gen3-roamer-dataview-extraction.md
+- [ ] .foundry/stories/story-070-109-gen3-roamer-status-parsing.md

--- a/.foundry/stories/story-070-108-gen3-roamer-dataview-extraction.md
+++ b/.foundry/stories/story-070-108-gen3-roamer-dataview-extraction.md
@@ -1,0 +1,34 @@
+---
+id: story-070-108-gen3-roamer-dataview-extraction
+type: STORY
+title: Gen 3 Roamer DataView Extraction and Core Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-044-070-gen3-roamer-core-extraction
+tags:
+  - gen3
+  - roamer
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer DataView Extraction and Core Parsing
+
+## Objective
+Extract the 20-byte hidden roamer data structure from Gen 3 save files using `DataView` and parse IVs, HP, and Level.
+
+## Description
+This story handles the base extraction logic in the save parser for Gen 3. The `DataView` API must be used to safely read the 20-byte structure. Following extraction, logic should be implemented to correctly parse the IVs, HP, and Level of the roamer from this raw byte structure.
+
+## Acceptance Criteria
+- [ ] Implement `DataView` reading logic for the 20-byte Gen 3 roamer structure.
+- [ ] Implement parsing logic for IVs, HP, and Level from the structure.
+- [ ] Tech Lead: Break down this Story into executable Tasks.

--- a/.foundry/stories/story-070-109-gen3-roamer-status-parsing.md
+++ b/.foundry/stories/story-070-109-gen3-roamer-status-parsing.md
@@ -1,0 +1,34 @@
+---
+id: story-070-109-gen3-roamer-status-parsing
+type: STORY
+title: Gen 3 Roamer Status Condition Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - story-070-108-gen3-roamer-dataview-extraction
+jules_session_id: null
+pr_number: null
+parent: epic-044-070-gen3-roamer-core-extraction
+tags:
+  - gen3
+  - roamer
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Status Condition Parsing
+
+## Objective
+Extract and parse the Status Condition from the 20-byte Gen 3 roamer data structure.
+
+## Description
+Building upon the base structure extracted in the previous story, implement the parsing logic necessary to identify and extract the Status Condition field from the Gen 3 roamer data.
+
+## Acceptance Criteria
+- [ ] Implement parsing logic for the Status Condition from the 20-byte roamer structure.
+- [ ] Tech Lead: Break down this Story into executable Tasks.


### PR DESCRIPTION
This PR breaks down `epic-044-070-gen3-roamer-core-extraction` into two concrete executable stories:

1. `story-070-108-gen3-roamer-dataview-extraction`: Extract the 20-byte base roamer data structure and IVs/HP/Level using `DataView`.
2. `story-070-109-gen3-roamer-status-parsing`: Extract the Status Condition from the structure (depends on 108).

The parent Epic markdown has been updated with the checklist of these new child nodes, while strictly avoiding modifications to its YAML frontmatter. Exact Node IDs are used for all `depends_on` and `parent` fields to satisfy the Foundry schema.

---
*PR created automatically by Jules for task [5698034449009749877](https://jules.google.com/task/5698034449009749877) started by @szubster*