### PR TITLE
chore(foundry): break down epic-044-072-gen3-roamer-location-radar into stories

### DIFF
--- a/.foundry/epics/epic-044-072-gen3-roamer-location-radar.md
+++ b/.foundry/epics/epic-044-072-gen3-roamer-location-radar.md
@@ -32,4 +32,7 @@ Determine the current map group and map number of the roaming Pokémon from the 
 - [ ] Parse the roamer's current location index from the save file.
 - [ ] Map the location index to the correct route or area in the application.
 - [ ] Integrate this location data with the Route Radar map display.
-- [ ] Story Owner: Break down this Epic into executable Stories.
+- [x] Story Owner: Break down this Epic into executable Stories.
+- [ ] .foundry/stories/story-072-108-gen3-roamer-location-extraction.md
+- [ ] .foundry/stories/story-072-109-gen3-roamer-location-mapping.md
+- [ ] .foundry/stories/story-072-110-gen3-roamer-route-radar-ui.md

--- a/.foundry/stories/story-072-108-gen3-roamer-location-extraction.md
+++ b/.foundry/stories/story-072-108-gen3-roamer-location-extraction.md
@@ -1,0 +1,35 @@
+---
+id: story-072-108-gen3-roamer-location-extraction
+type: STORY
+title: Gen 3 Roamer Location Data Extraction
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-044-072-gen3-roamer-location-radar
+tags:
+  - gen3
+  - roamer
+  - map
+research_references:
+  - .foundry/research/research-071-138-gen3-roamer-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Location Data Extraction
+
+## Objective
+Extract the map group and map number for the roamer from the save file.
+
+## Description
+The Gen 3 roamer's active map group and map number are stored outside the primary 20-byte roamer struct (usually in `sRoamerLocation` or similar structure saved in EWRAM/save block depending on version). Implement the DataView parsing logic to extract these two values so we can track its position.
+
+## Acceptance Criteria
+- [ ] Research/determine the exact offset for the roamer's map group and map number.
+- [ ] Implement the parsing logic using `DataView` to extract the location index from Gen 3 saves.
+- [ ] Tech Lead: Break down this Story into execution Tasks (implementation & QA).

--- a/.foundry/stories/story-072-109-gen3-roamer-location-mapping.md
+++ b/.foundry/stories/story-072-109-gen3-roamer-location-mapping.md
@@ -1,0 +1,35 @@
+---
+id: story-072-109-gen3-roamer-location-mapping
+type: STORY
+title: Gen 3 Roamer Location Mapping
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - story-072-108-gen3-roamer-location-extraction
+jules_session_id: null
+pr_number: null
+parent: epic-044-072-gen3-roamer-location-radar
+tags:
+  - gen3
+  - roamer
+  - map
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Location Mapping
+
+## Objective
+Map the Gen 3 extracted map group and map number to unified location objects.
+
+## Description
+Take the raw location indices parsed from the save file (map group and map number) and use the established `gen3_map_parsing` strategy to resolve them into human-readable area IDs or unified location objects that the app can understand.
+
+## Acceptance Criteria
+- [ ] Map the raw map group and map number to our unified location constants.
+- [ ] Implement logic to handle edge cases (like indoor locations mapping to outdoor parents).
+- [ ] Tech Lead: Break down this Story into execution Tasks (implementation & QA).

--- a/.foundry/stories/story-072-110-gen3-roamer-route-radar-ui.md
+++ b/.foundry/stories/story-072-110-gen3-roamer-route-radar-ui.md
@@ -1,0 +1,36 @@
+---
+id: story-072-110-gen3-roamer-route-radar-ui
+type: STORY
+title: Gen 3 Roamer Route Radar UI Integration
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - story-072-109-gen3-roamer-location-mapping
+jules_session_id: null
+pr_number: null
+parent: epic-044-072-gen3-roamer-location-radar
+tags:
+  - gen3
+  - roamer
+  - map
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Route Radar UI Integration
+
+## Objective
+Integrate the resolved Gen 3 roamer location with the Route Radar UI.
+
+## Description
+Pass the resolved roamer location to the Route Radar UI component. The UI should highlight or place an indicator on the map denoting the roamer's current location, adhering to our tactical hardware aesthetic.
+
+## Acceptance Criteria
+- [ ] Supply the mapped Gen 3 roamer location to the Route Radar component.
+- [ ] Update the UI to visually display the roamer's current location on the map.
+- [ ] Tech Lead: Break down this Story into execution Tasks (implementation & QA).


### PR DESCRIPTION
This PR breaks down `epic-044-072-gen3-roamer-location-radar` into executable Story nodes.

It generates:
1. `story-072-108-gen3-roamer-location-extraction`: Focuses on parsing map group/num from the save file.
2. `story-072-109-gen3-roamer-location-mapping`: Maps the parsed indices to unified location objects.
3. `story-072-110-gen3-roamer-route-radar-ui`: Integrates the mapped location into the UI.

The parent epic has been updated to reflect the newly created children in its markdown body without prematurely checking off its overall acceptance criteria or modifying its YAML.

---
*PR created automatically by Jules for task [10126906515751454538](https://jules.google.com/task/10126906515751454538) started by @szubster*