### PR TITLE
Break down epic-045-070 into stories

### DIFF
--- a/.foundry/epics/epic-045-070-implement-dag-context.md
+++ b/.foundry/epics/epic-045-070-implement-dag-context.md
@@ -32,4 +32,6 @@ As per ADR 013 and ADR 017, the core DAG data state must be lifted into a shared
 - Ensure the state structure is designed to support the upcoming Kanban Board and Permanent Failure Dashboard requirements.
 
 ## Acceptance Criteria
-- [ ] Break down into Stories
+- [x] Break down into Stories
+- [ ] .foundry/stories/story-070-108-create-dag-context-interfaces.md
+- [ ] .foundry/stories/story-070-109-implement-dag-provider.md

--- a/.foundry/stories/story-070-108-create-dag-context-interfaces.md
+++ b/.foundry/stories/story-070-108-create-dag-context-interfaces.md
@@ -1,0 +1,28 @@
+---
+id: story-070-108-create-dag-context-interfaces
+type: STORY
+title: Create DagContext Interfaces and Types
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-045-070-implement-dag-context
+tags:
+  - architecture
+  - ui
+  - context
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Create DagContext Interfaces and Types
+
+## Overview
+Define the TypeScript interfaces and types for the `DagContext`. This includes the shape of the context state (nodes, edges, and potentially `rejection_count`), and any actions or reducers if needed.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks

--- a/.foundry/stories/story-070-109-implement-dag-provider.md
+++ b/.foundry/stories/story-070-109-implement-dag-provider.md
@@ -1,0 +1,29 @@
+---
+id: story-070-109-implement-dag-provider
+type: STORY
+title: Implement DagProvider Component
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - story-070-108-create-dag-context-interfaces
+jules_session_id: null
+pr_number: null
+parent: epic-045-070-implement-dag-context
+tags:
+  - architecture
+  - ui
+  - context
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement DagProvider Component
+
+## Overview
+Implement the `DagProvider` React component that will wrap the DAG views and provide the shared DAG state (nodes and edges) to child components.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
I have broken down the `EPIC` node `epic-045-070-implement-dag-context` into two granular `STORY` nodes:

1. `story-070-108-create-dag-context-interfaces`
2. `story-070-109-implement-dag-provider`

I have also updated the `EPIC` node's markdown body to include these new stories as unchecked tasks, and checked off the `Break down into Stories` acceptance criteria. The YAML frontmatter of the `EPIC` node was not modified.

The new `STORY` nodes correctly follow the ID schema and constraints, and correctly assign `tech_lead` as the owner persona.

---
*PR created automatically by Jules for task [7826238330098730560](https://jules.google.com/task/7826238330098730560) started by @szubster*