### PR TITLE
Break down Gen 3 Roamer Data Structure Standardization story into tasks

### DIFF
--- a/.foundry/stories/story-067-104-gen3-roamer-data-structure.md
+++ b/.foundry/stories/story-067-104-gen3-roamer-data-structure.md
@@ -28,4 +28,6 @@ Currently, Gen 2 provides `speciesId`, `level`, `mapGroup`, and `mapId` for its 
 ## Acceptance Criteria
 - [ ] Ensure `SaveData.roamingLegendaries` is robust for both generations.
 - [ ] Document map group/id differences between Gen 2 and Gen 3 within the interface comments.
-- [ ] Break down this Story into executable Tasks.
+- [x] Break down this Story into executable Tasks.
+- [ ] .foundry/tasks/task-104-159-gen3-roamer-interface-impl.md
+- [ ] .foundry/tasks/task-104-159-gen3-roamer-interface-qa.md

--- a/.foundry/tasks/task-104-159-gen3-roamer-interface-impl.md
+++ b/.foundry/tasks/task-104-159-gen3-roamer-interface-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-104-159-gen3-roamer-interface-impl
+type: TASK
+title: Update SaveData.roamingLegendaries interface for Gen 3
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-067-104-gen3-roamer-data-structure
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update SaveData.roamingLegendaries interface for Gen 3
+
+## Objective
+Standardize the `roamingLegendaries` interface in `src/engine/saveParser/parsers/common.ts` to cleanly support Gen 3 roamer data while maintaining backward compatibility with Gen 2.
+
+## Context
+Gen 2 provides `speciesId`, `level`, `mapGroup`, and `mapId` for its roamers (Raikou, Entei, Suicune). Gen 3 (Latios/Latias) will also need this property populated, utilizing its own `mapGroup` and `mapId` definitions based on the unified Map ID format `(GroupIndex << 8) | MapIndex`.
+We need to ensure the `roamingLegendaries` type signature in the `SaveData` interface is robust for both generations and well-documented.
+
+## Requirements
+- Update the `roamingLegendaries` property documentation in the `SaveData` interface (`src/engine/saveParser/parsers/common.ts`) to indicate it applies to both Gen 2 and Gen 3.
+- Document within the interface comments the differences in how `mapGroup` and `mapId` are structured or interpreted between Gen 2 and Gen 3.
+  - Gen 2: Separate bytes for `mapGroup` and `mapId`.
+  - Gen 3: Utilizes the unified Map Group / Map Index architecture.
+
+## Acceptance Criteria
+- [ ] `roamingLegendaries` documentation in `SaveData` explicitly states support for Gen 2 and Gen 3 roamers.
+- [ ] Interface comments explain the map group/id differences between the generations.
+- [ ] If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-104-159-gen3-roamer-interface-qa.md
+++ b/.foundry/tasks/task-104-159-gen3-roamer-interface-qa.md
@@ -1,0 +1,37 @@
+---
+id: task-104-159-gen3-roamer-interface-qa
+type: TASK
+title: QA - Verify Gen 3 Roamer Interface Update
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-10'
+updated_at: '2026-06-10'
+depends_on:
+  - task-104-159-gen3-roamer-interface-impl
+jules_session_id: null
+pr_number: null
+parent: story-067-104-gen3-roamer-data-structure
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Verify Gen 3 Roamer Interface Update
+
+## Objective
+Verify that the `SaveData.roamingLegendaries` interface documentation in `src/engine/saveParser/parsers/common.ts` correctly handles Gen 3 differences.
+
+## Context
+A coder task (`task-104-159-gen3-roamer-interface-impl`) has been implemented to update the `SaveData.roamingLegendaries` documentation for Gen 2 vs Gen 3 differences in map group/id structure. This QA task ensures those changes are correct and robust.
+
+## Requirements
+- Verify that `src/engine/saveParser/parsers/common.ts` has been correctly updated.
+- Ensure the interface comments explicitly describe Gen 2 map properties and Gen 3 map properties (unified map group/index).
+
+## Acceptance Criteria
+- [ ] Verified `SaveData.roamingLegendaries` documentation supports both Gen 2 and Gen 3.
+- [ ] Verified interface comments explain map group/id differences between generations.
+- [ ] If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR breaks down the `story-067-104-gen3-roamer-data-structure` node into actionable technical blueprint TASK nodes.
It defines clear contracts for the coder to implement the `SaveData.roamingLegendaries` interface updates, and for the QA to verify those changes, adhering to the project's node generation rules and dependency graph constraints.

---
*PR created automatically by Jules for task [9692195046910554050](https://jules.google.com/task/9692195046910554050) started by @szubster*