### PR TITLE
Enable ADR Resolution in Foundry DAG Orchestrator

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -61,7 +61,7 @@ Every node file (idea, PRD, epic, story, task) **must** begin with a YAML frontm
 ```yaml
 ---
 id: ""                  # Required. Globally unique slug. Convention: <type>-<parent_NNN>-<NNN>-<slug>
-type: ""                # Required. Enum: IDEA | PRD | EPIC | STORY | TASK | RESEARCH
+type: ""                # Required. Enum: IDEA | PRD | EPIC | STORY | TASK | RESEARCH | ADR
 title: ""               # Required. Human-readable short title.
 status: ""              # Required. Enum: see Status Lifecycle section.
 owner_persona: "coder"  # Required. Enum: see Owner Persona section.
@@ -84,7 +84,7 @@ notes: ""               # Optional. Free-form Markdown remarks.
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `id` | `string` | ✅ | Globally unique. Convention: `<type>-<parent_NNN>-<NNN>-<slug>` (IDEA nodes omit parent NNN). Used by humans and search; the DAG uses file paths. |
-| `type` | `enum` | ✅ | `IDEA \| PRD \| EPIC \| STORY \| TASK \| RESEARCH` |
+| `type` | `enum` | ✅ | `IDEA \| PRD \| EPIC \| STORY \| TASK \| RESEARCH \| ADR` |
 | `title` | `string` | ✅ | Short, human-readable description. |
 | `status` | `enum` | ✅ | Current lifecycle state. See §4. |
 | `owner_persona` | `enum` | ✅ | Persona responsible for progressing this node. Must be exactly one assigned persona (no arrays or multiple personas). See §5. |

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1716,4 +1716,38 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     expect(verifyingResult).toContain('owner_persona: coder');
   });
 
+  test('ADR Resolution: resolves dependencies pointing to ADRs in .foundry/docs/adrs/', () => {
+    // 1. Create COMPLETED ADR in .foundry/docs/adrs/
+    createValidTestNode(tmpDir, '.foundry/docs/adrs/021-hof-parsing.md', {
+      id: "adr-044-021-hof-parsing",
+      type: "ADR",
+      title: "ADR 021",
+      status: "COMPLETED",
+      owner_persona: "architect",
+      created_at: "2026-06-10",
+      updated_at: "2026-06-10",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    // 2. Create PENDING Epic depending on ADR ID
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-06-10",
+      updated_at: "2026-06-10",
+      depends_on: ["adr-044-021-hof-parsing"],
+      jules_session_id: null,
+    });
+
+    main();
+
+    // 3. Verify Epic promoted to READY
+    const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
+    expect(epicContent).toContain('status: READY');
+  });
+
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -48,7 +48,7 @@ const VALID_STATUSES = [
 
 type Status = (typeof VALID_STATUSES)[number];
 
-const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH'] as const;
+const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH', 'ADR'] as const;
 type NodeType = (typeof VALID_TYPES)[number];
 
 /** Mirrors the YAML frontmatter schema defined in .foundry/docs/schema.md §3 */
@@ -137,8 +137,13 @@ function discoverNodeFiles(dir: string): string[] {
       const fullPath = path.join(current, entry.name);
 
       if (entry.isDirectory()) {
-        // Skip the journals/ and docs/ subtrees entirely.
-        if (entry.name === 'journals' || entry.name === 'docs') continue;
+        // Skip journals entirely. For docs, only explore the adrs/ subdirectory.
+        if (entry.name === 'journals') continue;
+        if (entry.name === 'docs') {
+          const adrsPath = path.join(fullPath, 'adrs');
+          if (fs.existsSync(adrsPath)) walk(adrsPath);
+          continue;
+        }
         walk(fullPath);
       } else if (entry.isFile() && entry.name.endsWith('.md')) {
         results.push(fullPath);
@@ -871,6 +876,7 @@ function main(): void {
     STORY: ['tech_lead', 'story_owner'],
     TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
+    ADR: ['architect'],
   };
 
   for (const node of finalEligible) {


### PR DESCRIPTION
This PR resolves the "unresolvable dependency" warnings in the Foundry DAG orchestrator by allowing it to recognize and process Architecture Decision Records (ADRs) as formal nodes.

Key changes:
1.  **Orchestrator Logic**: Modified `discoverNodeFiles` in `.github/scripts/foundry-orchestrator.ts` to walk the `.foundry/docs/adrs/` directory. ADRs are now included in the `VALID_TYPES` and correctly mapped to the `architect` persona.
2.  **Schema Update**: Updated `.foundry/docs/schema.md` to formally document `ADR` as a valid node type.
3.  **Testing**: Enhanced `foundry-test-utils.ts` and added a new test case in `foundry-orchestrator.test.ts` to ensure that nodes depending on ADR IDs are correctly unblocked when the ADR is `COMPLETED`.

These changes ensure that Epics and other nodes can successfully depend on ADRs without causing DAG resolution failures.

Fixes #2299

---
*PR created automatically by Jules for task [14458083208548075038](https://jules.google.com/task/14458083208548075038) started by @szubster*