### PR TITLE
feat: Implement RouteRadarController Heatmap Logic

### DIFF
--- a/.foundry/tasks/task-089-153-implement-radar-heatmap-logic.md
+++ b/.foundry/tasks/task-089-153-implement-radar-heatmap-logic.md
@@ -40,10 +40,10 @@ Implement the data transformation pipeline inside the `RouteRadarController` in 
 Also, write unit tests in `src/engine/radar/__tests__/RouteRadarController.test.ts` to validate the logic (including empty array handling, single CatchSuggestion on multiple areas, multiple CatchSuggestions on same area, and StandardSuggestion handling).
 
 ## Acceptance Criteria
-- [ ] Implement the aggregation method in `RouteRadarController`.
-- [ ] Ensure the density score correctly maps `areaId`s to their corresponding unique missing species counts.
-- [ ] Ensure it accurately processes edge cases (e.g., areas with 0 missing encounters should not be present in the output or have a score of 0).
-- [ ] Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs.
+- [x] Implement the aggregation method in `RouteRadarController`.
+- [x] Ensure the density score correctly maps `areaId`s to their corresponding unique missing species counts.
+- [x] Ensure it accurately processes edge cases (e.g., areas with 0 missing encounters should not be present in the output or have a score of 0).
+- [x] Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs.
 
 **Important Persona Instructions:**
 - **CODER**: If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the frontmatter otherwise.

--- a/src/engine/radar/RouteRadarController.ts
+++ b/src/engine/radar/RouteRadarController.ts
@@ -17,10 +17,33 @@ export class RouteRadarController {
   /**
    * Calculates the heatmap density data from the provided suggestions.
    *
-   * @param _suggestions The raw output from the suggestionEngine.
+   * @param suggestions The raw output from the suggestionEngine.
    * @returns Heatmap data mapping areaId to density score.
    */
-  public calculateHeatmap(_suggestions: Suggestion[]): RouteRadarHeatmap {
-    throw new Error('Not implemented');
+  public calculateHeatmap(suggestions: Suggestion[]): RouteRadarHeatmap {
+    const heatmap: RouteRadarHeatmap = {};
+
+    for (const suggestion of suggestions) {
+      if (suggestion.category === 'Catch' && suggestion.encounterInfo) {
+        const uniqueAreaIds = new Set<number>();
+
+        // Iterate through all map IDs (keys) and extract areaIds (aid) from the encounter details
+        for (const mapId in suggestion.encounterInfo) {
+          const encounters = suggestion.encounterInfo[mapId];
+          if (encounters) {
+            for (const encounter of encounters) {
+              uniqueAreaIds.add(encounter.aid);
+            }
+          }
+        }
+
+        // Increment the density score for each unique areaId found for this suggestion
+        for (const areaId of uniqueAreaIds) {
+          heatmap[areaId] = (heatmap[areaId] || 0) + 1;
+        }
+      }
+    }
+
+    return heatmap;
   }
 }

--- a/src/engine/radar/__tests__/RouteRadarController.test.ts
+++ b/src/engine/radar/__tests__/RouteRadarController.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Suggestion } from '../../assistant/strategies/types';
+import type { CatchSuggestion, StandardSuggestion } from '../../assistant/strategies/types';
 import { RouteRadarController } from '../RouteRadarController';
 
 describe('RouteRadarController', () => {
@@ -8,12 +8,113 @@ describe('RouteRadarController', () => {
     expect(controller).toBeInstanceOf(RouteRadarController);
   });
 
-  it('should throw Not implemented for calculateHeatmap currently', () => {
-    const controller = new RouteRadarController();
-    const suggestions: Suggestion[] = [];
+  describe('calculateHeatmap', () => {
+    it('should return an empty heatmap for an empty array of suggestions', () => {
+      const controller = new RouteRadarController();
+      const heatmap = controller.calculateHeatmap([]);
+      expect(heatmap).toEqual({});
+    });
 
-    expect(() => {
-      controller.calculateHeatmap(suggestions);
-    }).toThrowError('Not implemented');
+    it('should ignore standard (non-Catch) suggestions', () => {
+      const controller = new RouteRadarController();
+      const standardSuggestion: StandardSuggestion = {
+        id: '1',
+        title: 'Evolve Pidgey',
+        description: 'Level up',
+        priority: 1,
+        category: 'Evolve',
+      };
+      const heatmap = controller.calculateHeatmap([standardSuggestion]);
+      expect(heatmap).toEqual({});
+    });
+
+    it('should handle a single CatchSuggestion with multiple unique areas', () => {
+      const controller = new RouteRadarController();
+      const catchSuggestion: CatchSuggestion = {
+        id: '2',
+        title: 'Catch Pidgey',
+        description: 'Wild encounter',
+        priority: 1,
+        category: 'Catch',
+        encounterInfo: {
+          // mapId 1 has areaId 10
+          1: [{ chance: 50, method: 'grass', minLevel: 2, aid: 10 }],
+          // mapId 2 has areaId 20
+          2: [{ chance: 40, method: 'grass', minLevel: 3, aid: 20 }],
+        },
+      };
+
+      const heatmap = controller.calculateHeatmap([catchSuggestion]);
+      expect(heatmap).toEqual({
+        10: 1,
+        20: 1,
+      });
+    });
+
+    it('should not double-count the same areaId within a single CatchSuggestion', () => {
+      const controller = new RouteRadarController();
+      const catchSuggestion: CatchSuggestion = {
+        id: '3',
+        title: 'Catch Rattata',
+        description: 'Wild encounter',
+        priority: 1,
+        category: 'Catch',
+        encounterInfo: {
+          // mapId 1 has areaId 10 twice (e.g. morning/night or different levels)
+          1: [
+            { chance: 50, method: 'grass', minLevel: 2, aid: 10 },
+            { chance: 30, method: 'grass', minLevel: 4, aid: 10 },
+          ],
+        },
+      };
+
+      const heatmap = controller.calculateHeatmap([catchSuggestion]);
+      // Density score should only increment once for areaId 10
+      expect(heatmap).toEqual({ 10: 1 });
+    });
+
+    it('should correctly sum density scores for multiple CatchSuggestions on the same area', () => {
+      const controller = new RouteRadarController();
+      const suggestion1: CatchSuggestion = {
+        id: '1',
+        title: 'Catch Pidgey',
+        description: 'Wild encounter',
+        priority: 1,
+        category: 'Catch',
+        encounterInfo: {
+          1: [{ chance: 50, method: 'grass', minLevel: 2, aid: 10 }],
+        },
+      };
+
+      const suggestion2: CatchSuggestion = {
+        id: '2',
+        title: 'Catch Rattata',
+        description: 'Wild encounter',
+        priority: 1,
+        category: 'Catch',
+        encounterInfo: {
+          2: [{ chance: 50, method: 'grass', minLevel: 2, aid: 10 }],
+        },
+      };
+
+      const heatmap = controller.calculateHeatmap([suggestion1, suggestion2]);
+      // Both suggestions can be found in area 10, so density should be 2
+      expect(heatmap).toEqual({ 10: 2 });
+    });
+
+    it('should handle CatchSuggestion without encounterInfo gracefully', () => {
+      const controller = new RouteRadarController();
+      const suggestion: CatchSuggestion = {
+        id: '1',
+        title: 'Catch Pidgey',
+        description: 'Wild encounter',
+        priority: 1,
+        category: 'Catch',
+        // encounterInfo missing
+      };
+
+      const heatmap = controller.calculateHeatmap([suggestion]);
+      expect(heatmap).toEqual({});
+    });
   });
 });


### PR DESCRIPTION
Implemented the requested logic for `RouteRadarController` in `src/engine/radar/RouteRadarController.ts` which transforms the list of recommended encounters from the `suggestionEngine` into a structured density heatmap for UI rendering.

Changes made:
- Added `calculateHeatmap` method mapping `areaId`s to a density score.
- Excluded duplicate area ID counting per suggestion.
- Handled filtering to only include `Catch` category suggestions with `encounterInfo`.
- Added comprehensive Vitest unit tests in `src/engine/radar/__tests__/RouteRadarController.test.ts`.
- Verified formatting using `biome`.
- Checked off acceptance criteria in the Markdown task node `task-089-153-implement-radar-heatmap-logic.md`.

---
*PR created automatically by Jules for task [15596705652860509977](https://jules.google.com/task/15596705652860509977) started by @szubster*