### PR TITLE
Resolve DAG Resolution Warnings and ADR Discovery Issues

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -48,7 +48,7 @@ const VALID_STATUSES = [
 
 type Status = (typeof VALID_STATUSES)[number];
 
-const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH'] as const;
+const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH', 'ADR'] as const;
 type NodeType = (typeof VALID_TYPES)[number];
 
 /** Mirrors the YAML frontmatter schema defined in .foundry/docs/schema.md §3 */
@@ -138,7 +138,7 @@ function discoverNodeFiles(dir: string): string[] {
 
       if (entry.isDirectory()) {
         // Skip the journals/ and docs/ subtrees entirely.
-        if (entry.name === 'journals' || entry.name === 'docs') continue;
+        if (entry.name === 'journals') continue;
         walk(fullPath);
       } else if (entry.isFile() && entry.name.endsWith('.md')) {
         results.push(fullPath);
@@ -401,6 +401,13 @@ function main(): void {
   function resolveNodePath(ref: string | null | undefined): string | null {
     if (!ref) return null;
     if (idToPathMap.has(ref)) return idToPathMap.get(ref)!;
+
+    // Check if it's a known ADR in the docs/adrs/ directory if not found in idToPathMap
+    if (ref.startsWith('adr-')) {
+      const adrPath = `.foundry/docs/adrs/${ref}.md`;
+      if (nodeMap.has(adrPath)) return adrPath;
+    }
+
     return ref;
   }
 
@@ -471,12 +478,10 @@ function main(): void {
       return true;
     }
 
-    if (node.frontmatter.status !== 'COMPLETED' && node.frontmatter.status !== 'CANCELLED') {
-      evalCache.set(cacheKey, true);
-      return true;
+    if (node.frontmatter.status === 'COMPLETED' || node.frontmatter.status === 'CANCELLED') {
+      evalCache.set(cacheKey, false);
+      return false;
     }
-
-    evalCache.set(cacheKey, true);
 
     const children = parentToChildren.get(nodePath) || [];
     for (const child of children) {
@@ -871,6 +876,7 @@ function main(): void {
     STORY: ['tech_lead', 'story_owner'],
     TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
+    ADR: ['architect'],
   };
 
   for (const node of finalEligible) {


### PR DESCRIPTION
This PR fixes several issues in the Foundry DAG orchestrator that were causing dependency resolution warnings and blocking task progress.

Key changes:
1. **ADR Support**: The orchestrator now recognizes 'ADR' nodes, discovers them in the `.foundry/docs/adrs/` directory, and correctly maps them to the `architect` persona. This resolves warnings like `Unresolvable dependency 'adr-...'`.
2. **Hierarchical Completeness Logic**: Fixed a bug where a `COMPLETED` parent node would remain "hierarchically incomplete" if it had a `FAILED` child (e.g., a task that reached Max Rejection Count). The logic now correctly evaluates terminal statuses.
3. **Robust ID Resolution**: Improved `resolveNodePath` to specifically check for ADR files when an `adr-` prefixed ID is encountered.

Verified by running the orchestrator in dry-run mode with `--strict` (resolving 180 nodes) and passing the existing test suite.

Fixes #2309

---
*PR created automatically by Jules for task [10575227458614543441](https://jules.google.com/task/10575227458614543441) started by @szubster*