### PR TITLE
feat: implement gen 1 checksum validation

### DIFF
--- a/.foundry/tasks/task-091-155-gen1-checksum-impl.md
+++ b/.foundry/tasks/task-091-155-gen1-checksum-impl.md
@@ -33,8 +33,8 @@ Generation 1 save files rely on a main checksum to verify the integrity of the a
 * If a mismatch is detected, return appropriate diagnostic models (e.g., `HealthScanResult`, `Anomaly`) as defined in `story-053-090`.
 
 ## Acceptance Criteria
-- [ ] Implement checksum calculation and validation logic.
-- [ ] Ensure validation logic handles missing or invalid save data structures gracefully.
+- [x] Implement checksum calculation and validation logic.
+- [x] Ensure validation logic handles missing or invalid save data structures gracefully.
 
 ## Reminders
 * If you permanently fail or abort this task, you MUST update the YAML frontmatter to status: FAILED or status: CANCELLED with a rejection_reason.

--- a/src/engine/healthScanner/gen1.test.ts
+++ b/src/engine/healthScanner/gen1.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { validateGen1Checksum } from './gen1';
+
+describe('validateGen1Checksum', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return UnknownAnomaly if file is too small', () => {
+    const buffer = new ArrayBuffer(0x3000);
+    const view = new DataView(buffer);
+
+    const result = validateGen1Checksum(view);
+
+    expect(result.isValid).toBe(false);
+    expect(result.anomalies).toHaveLength(1);
+    expect(result.anomalies[0]).toEqual({
+      code: 'UnknownAnomaly',
+      severity: 'Critical',
+      location: { type: 'global_state' },
+      description: 'Save file is too small to contain a valid Generation 1 checksum.',
+    });
+    expect(result.scannedAt).toEqual(new Date('2026-06-10T12:00:00Z'));
+  });
+
+  it('should return valid if checksum is correct', () => {
+    const buffer = new ArrayBuffer(32768);
+    const view = new DataView(buffer);
+
+    // Initial value is 255
+    let gen1Sum = 255;
+
+    // Set some dummy data
+    view.setUint8(0x2598, 10);
+    view.setUint8(0x2599, 20);
+
+    for (let i = 0x2598; i <= 0x3522; i++) {
+      gen1Sum -= view.getUint8(i);
+    }
+
+    // Set the checksum byte
+    view.setUint8(0x3523, gen1Sum & 0xff);
+
+    const result = validateGen1Checksum(view);
+
+    expect(result.isValid).toBe(true);
+    expect(result.anomalies).toHaveLength(0);
+    expect(result.scannedAt).toEqual(new Date('2026-06-10T12:00:00Z'));
+  });
+
+  it('should return ChecksumError if checksum is incorrect', () => {
+    const buffer = new ArrayBuffer(32768);
+    const view = new DataView(buffer);
+
+    // Initial value is 255
+    let gen1Sum = 255;
+
+    // Set some dummy data
+    view.setUint8(0x2598, 10);
+    view.setUint8(0x2599, 20);
+
+    for (let i = 0x2598; i <= 0x3522; i++) {
+      gen1Sum -= view.getUint8(i);
+    }
+
+    const correctChecksum = gen1Sum & 0xff;
+    const invalidChecksum = (correctChecksum + 1) & 0xff;
+
+    // Set the checksum byte to an invalid value
+    view.setUint8(0x3523, invalidChecksum);
+
+    const result = validateGen1Checksum(view);
+
+    expect(result.isValid).toBe(false);
+    expect(result.anomalies).toHaveLength(1);
+    expect(result.anomalies[0]).toEqual({
+      code: 'ChecksumError',
+      severity: 'Critical',
+      location: { type: 'global_state' },
+      description: `Gen 1 checksum mismatch. Expected 0x${correctChecksum.toString(16).padStart(2, '0').toUpperCase()}, but found 0x${invalidChecksum.toString(16).padStart(2, '0').toUpperCase()}.`,
+    });
+    expect(result.scannedAt).toEqual(new Date('2026-06-10T12:00:00Z'));
+  });
+});

--- a/src/engine/healthScanner/gen1.ts
+++ b/src/engine/healthScanner/gen1.ts
@@ -1,0 +1,48 @@
+import type { Anomaly, HealthScanResult } from './models';
+
+export function validateGen1Checksum(view: DataView): HealthScanResult {
+  const anomalies: Anomaly[] = [];
+  const scannedAt = new Date();
+
+  // Ensure the view is large enough to contain the Gen 1 checksum byte
+  if (view.byteLength < 0x3524) {
+    anomalies.push({
+      code: 'UnknownAnomaly',
+      severity: 'Critical',
+      location: { type: 'global_state' },
+      description: 'Save file is too small to contain a valid Generation 1 checksum.',
+    });
+    return {
+      isValid: false,
+      anomalies,
+      scannedAt,
+    };
+  }
+
+  // Gen 1 Checksum
+  // Gen 1 calculates its checksum by iterating over the main save data block (0x2598 to 0x3522),
+  // subtracting each byte's value from an initial value of 255 (0xFF).
+  // The result is stored at 0x3523.
+  let gen1Sum = 255;
+  for (let i = 0x2598; i <= 0x3522; i++) {
+    gen1Sum -= view.getUint8(i);
+  }
+
+  const calculatedChecksum = gen1Sum & 0xff;
+  const storedChecksum = view.getUint8(0x3523);
+
+  if (calculatedChecksum !== storedChecksum) {
+    anomalies.push({
+      code: 'ChecksumError',
+      severity: 'Critical',
+      location: { type: 'global_state' },
+      description: `Gen 1 checksum mismatch. Expected 0x${calculatedChecksum.toString(16).padStart(2, '0').toUpperCase()}, but found 0x${storedChecksum.toString(16).padStart(2, '0').toUpperCase()}.`,
+    });
+  }
+
+  return {
+    isValid: anomalies.length === 0,
+    anomalies,
+    scannedAt,
+  };
+}


### PR DESCRIPTION
This PR implements the Generation 1 checksum validation logic as outlined in Task 091-155. It calculates the Gen 1 checksum and validates it against the stored value, returning a robust `HealthScanResult` object with appropriate anomalies if mismatches or size boundary violations occur. Tests were added to cover valid, invalid, and malformed files.

---
*PR created automatically by Jules for task [15894191402877134460](https://jules.google.com/task/15894191402877134460) started by @szubster*