### PR TITLE
🧭 Strategist: Prompt improvement - Prevent planner blind resubmission

### DIFF
--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -33,6 +33,8 @@ While the system does not strictly block node creation, ANY scheduled or foundry
 
 
 ### Handling Rejections & Aborts
+**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
+
 If you encounter a permanent failure or must abort a node:
 1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -27,6 +27,8 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 - Parent generation nodes MUST strictly format references to generated child nodes as unchecked task checkboxes (`- [ ] <file_path>`) directly in their markdown body. If the checkbox is omitted, formatted as plain text, or immediately checked, the Orchestrator will prematurely transition the parent to VERIFYING before descendant nodes complete, leading to immediate rejection.
 
 ### Handling Rejections & Aborts
+**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
+
 If you encounter a permanent failure or must abort a node:
 1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -37,6 +37,8 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 
 
 ### Handling Rejections & Aborts
+**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
+
 If you encounter a permanent failure or must abort a node:
 1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -45,6 +45,14 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 3. Append these new nodes to your own markdown body.
 4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending `QA` task nodes associated with the failed implementation. Instead, update the orphaned QA task's Markdown body indicating that it is CANCELLED and replaced by the new tasks.
 
+### Handling Rejections & Aborts
+**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
+
+If you encounter a permanent failure or must abort a node:
+1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
+3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
+4. You MUST document the failure in your persona journal.
 
 ## Journal
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -221,3 +221,9 @@
 **Outcome:** Merged
 **Why:** To prevent impossible loops, implementation agents must not ignore rejection reasons when resurrecting failed tasks.
 **Pattern:** Explicitly instruct implementation agents (like the Coder) to read the `rejection_reason` and the QA journal when resuming a previously failed task to ensure they fix the actual problem rather than blindly resubmitting.
+
+## 2026-06-11 - [Accepted] - Prompt improvement - Prevent planner blind resubmission
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The Auditor journal observed that failed macro nodes (e.g., IDEA, PRD) in the Resurrection Loop were being blindly resubmitted by the planners without addressing the rejection reasons. This led to infinite loops. Planners previously lacked the explicit instructions that implementation agents (like Coder) had for resuming FAILED nodes.
+**Pattern:** Ensure all upstream generating personas (Product Manager, Epic Planner, Story Owner, Tech Lead) have explicit instructions to read the `rejection_reason` and the reviewing persona's journal (Auditor or QA) when assigned a resurrected FAILED node, to fix the actual issue instead of blindly resubmitting.


### PR DESCRIPTION
**Proposal**: Add explicit instructions to `product_manager.md`, `epic_planner.md`, `story_owner.md`, and `tech_lead.md` to prevent blind resubmissions of FAILED nodes. When assigned a resurrected failed node, planners must read its `rejection_reason` and the reviewer's journal (Auditor or QA).
**Justification**: Upstream generative personas were missing the explicit fallback instructions that implementation agents (like Coder) possessed. Without these instructions, if an IDEA or PRD was rejected by the Auditor, the planner would blindly resubmit it upon resurrection, causing infinite rejection loops.
**Evidence**: As logged in `.foundry/journals/auditor.md` on 2026-06-11 (`Resurrection Loop Blind Resubmission`), the Auditor observed agents blindly resubmitting `idea-066-save-file-health-scanner` without correcting the issues causing rejection, specifically ignoring the fact that its child nodes were still in PENDING.

---
*PR created automatically by Jules for task [12169239586210990570](https://jules.google.com/task/12169239586210990570) started by @szubster*