### PR TITLE
Fix Foundry DAG Resolution Warnings and Blockages

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -267,7 +267,7 @@ describe('foundry-orchestrator', () => {
     expect(result).toContain('status: READY');
   });
 
-  test('Hierarchical Completion: blocks external dependent if dependency has incomplete children', () => {
+  test('Hierarchical Completion: does NOT block external dependent if dependency is COMPLETED, even with incomplete children', () => {
     // Story 1: COMPLETED (Planned)
     createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
       id: "story-001",
@@ -314,9 +314,9 @@ describe('foundry-orchestrator', () => {
     const taskContent = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-001.md'), 'utf-8');
     expect(taskContent).toContain('status: READY');
 
-    // Story 2 SHOULD NOT be promoted (it waits for Story 1's children)
+    // Story 2 SHOULD be promoted to READY (it only cares that Story 1 is COMPLETED)
     const story2Content = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-002.md'), 'utf-8');
-    expect(story2Content).toContain('status: PENDING');
+    expect(story2Content).toContain('status: READY');
   });
 
   test('Late-Binding: allows child of PENDING parent to proceed if parent already has children', () => {
@@ -633,7 +633,7 @@ describe('foundry-orchestrator', () => {
     expect(storyResult).toContain('status: READY');
   });
 
-  test('Deep Hierarchical Completion: blocks external dependent if dependency has deep incomplete children', () => {
+  test('Deep Hierarchical Completion: does NOT block external dependent if dependency has deep incomplete children', () => {
     // Story 1: COMPLETED
     createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
       id: "story-001",
@@ -690,9 +690,9 @@ describe('foundry-orchestrator', () => {
 
     main();
 
-    // Story 2 SHOULD NOT be promoted (it waits for Subtask 1)
+    // Story 2 SHOULD be promoted to READY
     const story2Content = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-002.md'), 'utf-8');
-    expect(story2Content).toContain('status: PENDING');
+    expect(story2Content).toContain('status: READY');
   });
 
   test('Human Task Bypass: PENDING human task promotes directly to ACTIVE', () => {
@@ -940,7 +940,7 @@ describe('foundry-orchestrator', () => {
     expect(result).toContain('status: PENDING');
   });
 
-  test('Wait and Wake: Suspends ACTIVE node if dependency is hierarchically incomplete', () => {
+  test('Wait and Wake: Does NOT suspend ACTIVE node if dependency is COMPLETED, even with incomplete children', () => {
     createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
       id: "story-001",
       type: "STORY",
@@ -975,13 +975,13 @@ describe('foundry-orchestrator', () => {
       created_at: "2026-04-20",
       updated_at: "2026-04-20",
       depends_on: [".foundry/stories/story-001.md"],
-      jules_session_id: null,
+      jules_session_id: "sess-123",
     });
 
     main();
 
     const result = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-active.md'), 'utf-8');
-    expect(result).toContain('status: PENDING');
+    expect(result).toContain('status: ACTIVE');
   });
 
   test('Wait and Wake: Does not suspend ACTIVE node if all dependencies are COMPLETED', () => {

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -48,7 +48,7 @@ const VALID_STATUSES = [
 
 type Status = (typeof VALID_STATUSES)[number];
 
-const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH'] as const;
+const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH', 'ADR'] as const;
 type NodeType = (typeof VALID_TYPES)[number];
 
 /** Mirrors the YAML frontmatter schema defined in .foundry/docs/schema.md §3 */
@@ -137,8 +137,8 @@ function discoverNodeFiles(dir: string): string[] {
       const fullPath = path.join(current, entry.name);
 
       if (entry.isDirectory()) {
-        // Skip the journals/ and docs/ subtrees entirely.
-        if (entry.name === 'journals' || entry.name === 'docs') continue;
+        // Skip the journals/ subtrees entirely.
+        if (entry.name === 'journals') continue;
         walk(fullPath);
       } else if (entry.isFile() && entry.name.endsWith('.md')) {
         results.push(fullPath);
@@ -471,32 +471,15 @@ function main(): void {
       return true;
     }
 
-    if (node.frontmatter.status !== 'COMPLETED' && node.frontmatter.status !== 'CANCELLED') {
-      evalCache.set(cacheKey, true);
-      return true;
+    if (node.frontmatter.status === 'COMPLETED' || node.frontmatter.status === 'CANCELLED') {
+      evalCache.set(cacheKey, false);
+      return false;
     }
 
+    // Any other status (PENDING, ACTIVE, READY, FAILED, BLOCKED) is incomplete.
+    // We don't need to check children/dependencies because the node itself is not terminal-success.
     evalCache.set(cacheKey, true);
-
-    const children = parentToChildren.get(nodePath) || [];
-    for (const child of children) {
-      if (evaluatingFor && (child.repoPath === evaluatingFor || isDescendant(evaluatingFor, child.repoPath))) {
-        continue;
-      }
-      if (isHierarchicallyIncomplete(child.repoPath, evaluatingFor)) {
-        return true;
-      }
-    }
-
-    for (const depRef of node.frontmatter.depends_on) {
-      const depPath = resolveNodePath(depRef)!;
-      if (isHierarchicallyIncomplete(depPath, evaluatingFor)) {
-        return true;
-      }
-    }
-
-    evalCache.set(cacheKey, false);
-    return false;
+    return true;
   }
 
   // ── Phase 3.5: SUSPEND (Wait & Wake) ───────────────────────────────────────
@@ -871,6 +854,7 @@ function main(): void {
     STORY: ['tech_lead', 'story_owner'],
     TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
+    ADR: ['architect'],
   };
 
   for (const node of finalEligible) {


### PR DESCRIPTION
This PR fixes the "Unresolvable dependency" warnings and DAG deadlocks in the Foundry orchestrator.

### Changes:
1. **ADR Support**: Added `ADR` to the valid node types and assigned it to the `architect` persona. The orchestrator now scans the `.foundry/docs/` directory, allowing it to resolve dependencies pointing to ADRs.
2. **Simplified Completion Logic**: Refactored `isHierarchicallyIncomplete` in `foundry-orchestrator.ts`. It now returns `false` (complete) if a node is `COMPLETED` or `CANCELLED`, without recursing into children or dependencies. This ensures that even if a sub-task fails permanently (reaching Max Rejection Count), its parent (which is already `COMPLETED`) does not block downstream dependencies.
3. **Test Updates**: Updated three tests in `foundry-orchestrator.test.ts` that were asserting the old, stricter recursive behavior.

### Verification:
- Ran `node --experimental-strip-types .github/scripts/foundry-orchestrator.ts --dry-run --strict`.
- Total READY nodes increased from 25 to 41.
- Confirmed `adr-044-021-hof-data-parsing-architecture.md` is now discovered and promoted.
- Confirmed `story-032-063-gen3-msgpack-transition.md` is no longer blocked by its failed child.
- All 47 vitest unit tests in `.github/scripts/` passed.

Fixes #2329

---
*PR created automatically by Jules for task [6130454306675259829](https://jules.google.com/task/6130454306675259829) started by @szubster*