### PR TITLE
feat(save-parser): implement Gen 1 hidden item flags parsing

### DIFF
--- a/.foundry/tasks/task-095-151-gen1-hidden-item-parsing-impl.md
+++ b/.foundry/tasks/task-095-151-gen1-hidden-item-parsing-impl.md
@@ -32,9 +32,9 @@ This task implements the first part of the epic `epic-037-058-hidden-items-save-
 4. **Update Tests**: Update the unit tests in `src/engine/saveParser/parsers/gen1.test.ts` to assert that the `hiddenItemFlags` are parsed correctly, injecting mock byte values into the dummy save buffer to test.
 
 ## Acceptance Criteria
-- [ ] `SaveData` interface includes `hiddenItemFlags?: Uint8Array;`.
-- [ ] `parseGen1` correctly calculates the offset (including Yellow `offsetShift`) and extracts the hidden item flags.
-- [ ] Unit tests for the Gen 1 save parser are updated to verify hidden item parsing logic.
+- [x] `SaveData` interface includes `hiddenItemFlags?: Uint8Array;`.
+- [x] `parseGen1` correctly calculates the offset (including Yellow `offsetShift`) and extracts the hidden item flags.
+- [x] Unit tests for the Gen 1 save parser are updated to verify hidden item parsing logic.
 
 ## IMPORTANT REMINDERS
 - **If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.**

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -90,6 +90,8 @@ export interface SaveData {
   hallOfFameCount: number;
   /** Raw byte array containing all in-game event flags (e.g., claimed static gifts, story progression). */
   eventFlags?: Uint8Array;
+  /** Raw byte array containing hidden item event flags. */
+  hiddenItemFlags?: Uint8Array;
   /** Bitflags representing which in-game NPC trades have already been completed. */
   npcTradeFlags?: number;
   /** Detailed structural data for Pokémon currently left in the Daycare (Gen 2). */

--- a/src/engine/saveParser/parsers/gen1.test.ts
+++ b/src/engine/saveParser/parsers/gen1.test.ts
@@ -79,6 +79,11 @@ describe('parseGen1 - specific data extraction', () => {
     view.setUint8(bOff, 153);
     view.setUint8(bOff + 3, 5); // Level
 
+    // Hidden Item Event Flags
+    const hiddenItemOffset = 0x299c;
+    view.setUint8(hiddenItemOffset, 0b10101010);
+    view.setUint8(hiddenItemOffset + 1, 0b01010101);
+
     // Parse!
     const data = parseGen1(view);
 
@@ -100,6 +105,11 @@ describe('parseGen1 - specific data extraction', () => {
     expect(data.pcDetails.length).toBe(1);
     expect(data.pcDetails[0]?.speciesId).toBe(1);
     expect(data.pcDetails[0]?.level).toBe(5);
+
+    expect(data.hiddenItemFlags).toBeDefined();
+    expect(data.hiddenItemFlags?.length).toBe(14);
+    expect(data.hiddenItemFlags?.[0]).toBe(0b10101010);
+    expect(data.hiddenItemFlags?.[1]).toBe(0b01010101);
   });
 
   it('should parse other PC boxes correctly', () => {

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -605,6 +605,8 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
   const hallOfFameRaw = view.getUint8(0x25b3 + offsetShift);
   const eventFlagsOffset = 0x29e6 + offsetShift;
   const eventFlags = new Uint8Array(view.buffer, eventFlagsOffset, 0x118);
+  const hiddenItemFlagsOffset = 0x299c + offsetShift;
+  const hiddenItemFlags = new Uint8Array(view.buffer, hiddenItemFlagsOffset, 14);
 
   return {
     generation: 1,
@@ -626,6 +628,7 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
     currentBoxCount,
     hallOfFameCount: hallOfFameRaw === 0xff ? 0 : hallOfFameRaw,
     eventFlags,
+    hiddenItemFlags,
     npcTradeFlags: view.getUint8(eventFlagsOffset - 16) | (view.getUint8(eventFlagsOffset - 15) << 8),
   };
 }


### PR DESCRIPTION
Implemented Gen 1 hidden item flags parsing. This task adds the `hiddenItemFlags` property to the `SaveData` interface and updates the `parseGen1` function to read the 14-byte block at offset `0x299C + offsetShift`. Unit tests were updated to verify the behavior.

---
*PR created automatically by Jules for task [6712306764376916269](https://jules.google.com/task/6712306764376916269) started by @szubster*