### PR TITLE
Implement Gen 3 Feebas Seed Extraction

### DIFF
--- a/.foundry/tasks/task-095-157-feebas-seed-impl.md
+++ b/.foundry/tasks/task-095-157-feebas-seed-impl.md
@@ -47,7 +47,7 @@ Implement a utility function to extract the 16-bit Feebas seed from Gen 3 save f
 - If you submit an Empty PR for a completed task (e.g., the code already existed), you **MUST** check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] `src/engine/gen3/feebas.ts` exists and implements `extractFeebasSeed`.
-- [ ] Uses `DataView` API with explicit `RangeError` bounds-checking catch logic.
-- [ ] Handles version-specific offsets correctly.
-- [ ] Unit tests added and passing.
+- [x] `src/engine/gen3/feebas.ts` exists and implements `extractFeebasSeed`.
+- [x] Uses `DataView` API with explicit `RangeError` bounds-checking catch logic.
+- [x] Handles version-specific offsets correctly.
+- [x] Unit tests added and passing.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/strictest": "^2.0.8",
     "@tsconfig/vite-react": "^8.0.6",
     "@types/dagre": "^0.7.54",
-    "@types/node": "^25.9.3",
+    "@types/node": "^25.9.1",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@types/wicg-file-system-access": "^2023.10.7",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/strictest": "^2.0.8",
     "@tsconfig/vite-react": "^8.0.6",
     "@types/dagre": "^0.7.54",
-    "@types/node": "^25.9.1",
+    "@types/node": "^25.9.3",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@types/wicg-file-system-access": "^2023.10.7",

--- a/src/engine/gen3/feebas.test.ts
+++ b/src/engine/gen3/feebas.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { extractFeebasSeed } from './feebas';
+
+describe('extractFeebasSeed', () => {
+  it('extracts the Feebas seed for Ruby/Sapphire', () => {
+    // 0x2dd6 + 2 bytes = 11736 bytes
+    const buffer = new ArrayBuffer(12000);
+    const view = new DataView(buffer);
+    view.setUint16(0x2dd6, 0x1234, true);
+
+    const seedRuby = extractFeebasSeed(view, 'ruby');
+    expect(seedRuby).toBe(0x1234);
+
+    const seedSapphire = extractFeebasSeed(view, 'sapphire');
+    expect(seedSapphire).toBe(0x1234);
+  });
+
+  it('extracts the Feebas seed for Emerald', () => {
+    // 0x2e66 + 2 bytes = 11880 bytes
+    const buffer = new ArrayBuffer(12000);
+    const view = new DataView(buffer);
+    view.setUint16(0x2e66, 0x5678, true);
+
+    const seedEmerald = extractFeebasSeed(view, 'emerald');
+    expect(seedEmerald).toBe(0x5678);
+  });
+
+  it('throws an error for unsupported game versions', () => {
+    const buffer = new ArrayBuffer(12000);
+    const view = new DataView(buffer);
+
+    expect(() => extractFeebasSeed(view, 'firered')).toThrow('Unsupported game version');
+    expect(() => extractFeebasSeed(view, 'leafgreen')).toThrow('Unsupported game version');
+    expect(() => extractFeebasSeed(view, 'red')).toThrow('Unsupported game version');
+  });
+
+  it('catches RangeError and re-throws specific corrupted file error', () => {
+    // Buffer too small to read at 0x2dd6 (11734)
+    const buffer = new ArrayBuffer(100);
+    const view = new DataView(buffer);
+
+    expect(() => extractFeebasSeed(view, 'ruby')).toThrow('The save file is corrupted or incomplete.');
+  });
+});

--- a/src/engine/gen3/feebas.ts
+++ b/src/engine/gen3/feebas.ts
@@ -1,0 +1,31 @@
+import type { GameVersion } from '../saveParser/parsers/common';
+
+/**
+ * Extracts the 16-bit Feebas seed from Gen 3 save files using the native DataView API.
+ *
+ * @param saveData - The DataView of the save file.
+ * @param gameVersion - The detected GameVersion of the save file.
+ * @returns The 16-bit Feebas seed.
+ * @throws Error if the save file is corrupted or incomplete.
+ */
+export function extractFeebasSeed(saveData: DataView, gameVersion: GameVersion): number {
+  try {
+    let offset = 0;
+
+    if (gameVersion === 'ruby' || gameVersion === 'sapphire') {
+      offset = 0x2dd6;
+    } else if (gameVersion === 'emerald') {
+      offset = 0x2e66;
+    } else {
+      throw new Error(`Unsupported game version for Feebas seed extraction: ${gameVersion}`);
+    }
+
+    // Gen 3 save values are typically little-endian
+    return saveData.getUint16(offset, true);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
This implements TASK `task-095-157-feebas-seed-impl`.
It creates a dedicated Feebas seed extraction utility that complies with ADR 010. It properly manages version offsets and leverages the native `DataView` API bounds checking via `RangeError` to handle corrupted save files gracefully.

---
*PR created automatically by Jules for task [11183359486521976627](https://jules.google.com/task/11183359486521976627) started by @szubster*