### PR TITLE
Resolve Foundry ADR Dependency resolution warnings

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1395,6 +1395,7 @@ describe('foundry-orchestrator', () => {
   });
 
   test('Mapping Validation: Enforces type to persona mappings before dispatch', () => {
+    createValidTestNode(tmpDir, '.foundry/docs/adrs/adr-001.md', { id: "adr-001", type: "ADR", title: "ADR 1", status: "PENDING", owner_persona: "architect", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
     createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', { id: "idea-001", type: "IDEA", title: "Idea", status: "PENDING", owner_persona: "product_manager", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
     createValidTestNode(tmpDir, '.foundry/prds/prd-invalid.md', { id: "prd-invalid", type: "PRD", title: "Invalid PRD", status: "PENDING", owner_persona: "coder", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
     createValidTestNode(tmpDir, '.foundry/tasks/task-human.md', { id: "task-human", type: "TASK", title: "Human Task", status: "PENDING", owner_persona: "human", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
@@ -1404,6 +1405,9 @@ describe('foundry-orchestrator', () => {
     createValidTestNode(tmpDir, '.foundry/tasks/task-architect.md', { id: "task-architect", type: "TASK", title: "Architect Task", status: "PENDING", owner_persona: "architect", created_at: "2026-04-20", updated_at: "2026-04-20", depends_on: [], jules_session_id: null });
 
     main();
+
+    const adrResult = fs.readFileSync(path.join(tmpDir, '.foundry/docs/adrs/adr-001.md'), 'utf-8');
+    expect(adrResult).toContain('status: READY');
 
     const ideaResult = fs.readFileSync(path.join(tmpDir, '.foundry/ideas/idea-001.md'), 'utf-8');
     expect(ideaResult).toContain('status: READY');

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -48,7 +48,7 @@ const VALID_STATUSES = [
 
 type Status = (typeof VALID_STATUSES)[number];
 
-const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH'] as const;
+const VALID_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK', 'RESEARCH', 'ADR'] as const;
 type NodeType = (typeof VALID_TYPES)[number];
 
 /** Mirrors the YAML frontmatter schema defined in .foundry/docs/schema.md §3 */
@@ -137,8 +137,13 @@ function discoverNodeFiles(dir: string): string[] {
       const fullPath = path.join(current, entry.name);
 
       if (entry.isDirectory()) {
-        // Skip the journals/ and docs/ subtrees entirely.
-        if (entry.name === 'journals' || entry.name === 'docs') continue;
+        // Skip journals and docs subtrees, EXCEPT for docs/adrs/
+        if (entry.name === 'journals') continue;
+        if (entry.name === 'docs') {
+          const adrsPath = path.join(fullPath, 'adrs');
+          if (fs.existsSync(adrsPath)) walk(adrsPath);
+          continue;
+        }
         walk(fullPath);
       } else if (entry.isFile() && entry.name.endsWith('.md')) {
         results.push(fullPath);
@@ -871,6 +876,7 @@ function main(): void {
     STORY: ['tech_lead', 'story_owner'],
     TASK: ['coder', 'qa', 'tech_lead', 'architect'],
     RESEARCH: ['researcher'],
+    ADR: ['architect'],
   };
 
   for (const node of finalEligible) {


### PR DESCRIPTION
Resolved "Unresolvable dependency" warnings in the Foundry Engine DAG by enabling the orchestrator to discover and process ADR nodes located in `.foundry/docs/adrs/`. This involved updating the file discovery logic, node type validation, and persona mappings in `foundry-orchestrator.ts`. Verified the fix with new test cases and a successful dry-run.

Fixes #2336

---
*PR created automatically by Jules for task [7254350414290771077](https://jules.google.com/task/7254350414290771077) started by @szubster*