### PR TITLE
feat(gen3): implement 32-bit personality value parsing

### DIFF
--- a/.foundry/tasks/task-098-157-gen3-parse-pv-impl.md
+++ b/.foundry/tasks/task-098-157-gen3-parse-pv-impl.md
@@ -31,6 +31,6 @@ As part of the Mirage Island checking feature (Epic `epic-038-062-personality-va
 3. **Important for Coder**: If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement the `DataView` parsing logic for Gen 3 PV extraction.
-- [ ] Ensure `RangeError` is explicitly caught and propagated for out-of-bounds reads.
-- [ ] Ensure Gen 1 and Gen 2 parsing logic is untouched.
+- [x] Implement the `DataView` parsing logic for Gen 3 PV extraction.
+- [x] Ensure `RangeError` is explicitly caught and propagated for out-of-bounds reads.
+- [x] Ensure Gen 1 and Gen 2 parsing logic is untouched.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isGen3Save, parseGen3 } from './gen3';
+import { isGen3Save, parseGen3, parseGen3PersonalityValue } from './gen3';
 
 describe('gen3 parser scaffolding', () => {
   it('isGen3Save should return false normally', () => {
@@ -44,5 +44,31 @@ describe('gen3 parser scaffolding', () => {
 
     // Restore
     view.getUint8 = originalGetUint8;
+  });
+});
+
+describe('parseGen3PersonalityValue', () => {
+  it('should extract a 32-bit little-endian value correctly', () => {
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer);
+
+    // Set up a 32-bit value at offset 2: 0x12345678 (little endian)
+    // 0x78, 0x56, 0x34, 0x12
+    view.setUint8(2, 0x78);
+    view.setUint8(3, 0x56);
+    view.setUint8(4, 0x34);
+    view.setUint8(5, 0x12);
+
+    const result = parseGen3PersonalityValue(view, 2);
+
+    expect(result).toBe(0x12345678);
+  });
+
+  it('should explicitly catch RangeError on out-of-bounds reads and throw a corrupted file error', () => {
+    const buffer = new ArrayBuffer(4);
+    const view = new DataView(buffer);
+
+    // Attempting to read a 32-bit integer (4 bytes) starting at offset 2 will exceed the 4-byte buffer
+    expect(() => parseGen3PersonalityValue(view, 2)).toThrowError('The save file is corrupted or incomplete.');
   });
 });

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -45,3 +45,22 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     throw error;
   }
 }
+
+/**
+ * Parses the 32-bit Personality Value (PV) from a Gen 3 save file.
+ *
+ * @param view - The raw save file DataView.
+ * @param offset - The offset within the buffer to read the PV from.
+ * @returns The 32-bit unsigned integer representing the PV.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3PersonalityValue(view: DataView, offset: number): number {
+  try {
+    return view.getUint32(offset, true);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
This PR implements the `parseGen3PersonalityValue` function in `src/engine/saveParser/parsers/gen3.ts` to extract the 32-bit Personality Value (PV) from Generation 3 save files using the `DataView` API.

It explicitly catches `RangeError` on out-of-bounds reads and propagates a specific 'The save file is corrupted or incomplete.' error, as required by ADR 010.

It also includes unit tests verifying both successful extraction and proper error handling.

---
*PR created automatically by Jules for task [4852823949984517042](https://jules.google.com/task/4852823949984517042) started by @szubster*