### PR TITLE
feat(saveParser): implement Gen 2 hidden item event flags parsing

### DIFF
--- a/.foundry/tasks/task-096-157-gen2-hidden-item-parsing-impl.md
+++ b/.foundry/tasks/task-096-157-gen2-hidden-item-parsing-impl.md
@@ -32,9 +32,9 @@ This task implements the second part of the epic `epic-037-058-hidden-items-save
 4. **Update Tests**: Update the unit tests in `src/engine/saveParser/parsers/gen2.test.ts` to assert that the `eventFlags` and `hiddenItemFlags` are parsed correctly, injecting mock byte values into the dummy save buffer to test both Gold/Silver and Crystal offsets.
 
 ## Acceptance Criteria
-- [ ] `SaveData` interface includes `hiddenItemFlags?: Uint8Array;`.
-- [ ] `parseGen2` correctly extracts the event flags for Gen 2 (Crystal and GS) into `SaveData.hiddenItemFlags`.
-- [ ] Unit tests for the Gen 2 save parser are updated to verify hidden item parsing logic.
+- [x] `SaveData` interface includes `hiddenItemFlags?: Uint8Array;`.
+- [x] `parseGen2` correctly extracts the event flags for Gen 2 (Crystal and GS) into `SaveData.hiddenItemFlags`.
+- [x] Unit tests for the Gen 2 save parser are updated to verify hidden item parsing logic.
 
 ## IMPORTANT REMINDERS
 - **If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.**

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -90,6 +90,8 @@ export interface SaveData {
   hallOfFameCount: number;
   /** Raw byte array containing all in-game event flags (e.g., claimed static gifts, story progression). */
   eventFlags?: Uint8Array;
+  /** Gen 2 specific: Raw byte array containing all hidden item flags. In Gen 2, this is identical to event flags. */
+  hiddenItemFlags?: Uint8Array;
   /** Bitflags representing which in-game NPC trades have already been completed. */
   npcTradeFlags?: number;
   /** Detailed structural data for Pokémon currently left in the Daycare (Gen 2). */

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -301,4 +301,46 @@ describe('gen2 parsers', () => {
       );
     });
   });
+
+  describe('parseGen2 - Event Flags', () => {
+    it('should parse eventFlags correctly for Gold/Silver', () => {
+      const buffer = new ArrayBuffer(0x8000);
+      const view = new DataView(buffer);
+
+      // GS event flags offset is 0x2624
+      view.setUint8(0x2624, 0x11);
+      view.setUint8(0x2624 + 0xff, 0x88);
+
+      const data = parseGen2(view, false);
+
+      expect(data.eventFlags).toBeDefined();
+      expect(data.eventFlags?.length).toBe(0x100);
+      expect(data.eventFlags?.[0]).toBe(0x11);
+      expect(data.eventFlags?.[0xff]).toBe(0x88);
+
+      // Hidden item flags should map to the same array
+      expect(data.hiddenItemFlags).toBeDefined();
+      expect(data.hiddenItemFlags?.[0]).toBe(0x11);
+    });
+
+    it('should parse eventFlags correctly for Crystal', () => {
+      const buffer = new ArrayBuffer(0x8000);
+      const view = new DataView(buffer);
+
+      // Crystal event flags offset is 0x2600
+      view.setUint8(0x2600, 0x22);
+      view.setUint8(0x2600 + 0xff, 0x99);
+
+      const data = parseGen2(view, true);
+
+      expect(data.eventFlags).toBeDefined();
+      expect(data.eventFlags?.length).toBe(0x100);
+      expect(data.eventFlags?.[0]).toBe(0x22);
+      expect(data.eventFlags?.[0xff]).toBe(0x99);
+
+      // Hidden item flags should map to the same array
+      expect(data.hiddenItemFlags).toBeDefined();
+      expect(data.hiddenItemFlags?.[0]).toBe(0x22);
+    });
+  });
 });

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -569,6 +569,9 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
 
   const roamingLegendaries = parseRoamingLegendaries(view, isCrystal);
 
+  const eventFlagsOffset = isCrystal ? 0x2600 : 0x2624;
+  const eventFlags = new Uint8Array(view.buffer, view.byteOffset + eventFlagsOffset, 0x100);
+
   return {
     generation: 2,
     owned,
@@ -593,5 +596,7 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
     currentBoxCount: 0,
     hallOfFameCount,
     roamingLegendaries,
+    eventFlags,
+    hiddenItemFlags: eventFlags,
   };
 }


### PR DESCRIPTION
* Added `hiddenItemFlags?: Uint8Array` to `SaveData` interface in `common.ts`.
* Updated `parseGen2` to calculate the `eventFlagsOffset` based on whether the save is Crystal (`0x2600`) or Gold/Silver (`0x2624`).
* Extracted the 256 bytes into a `Uint8Array` safely mapped to the data view's native byte offset buffer.
* Mapped the extracted array to both `eventFlags` and `hiddenItemFlags` in the `parseGen2` return object.
* Added corresponding unit tests in `gen2.test.ts` to assert that event flags and hidden item flags are parsed successfully for both Crystal and GS formats.
* Verified that formatting and typing remain clean by running `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [4149783240877723034](https://jules.google.com/task/4149783240877723034) started by @szubster*