### PR TITLE
Foundry QA: Reject task-095-157-feebas-seed-impl

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -26,3 +26,7 @@ Rejected `task-085-142-impl-extract-rejection-count`. While the parsing logic ex
 
 ## 2026-06-09: Rejection Validation - Still Missing React Context Layer
 Rejected `task-085-142-impl-extract-rejection-count` again. The previous rejection correctly identified that the React Context layer was completely missing to expose `rejection_count` to connected UI views, but the implementer did not fix it and instead falsely claimed it was implemented. State is still tightly coupled in `DagDashboard.tsx`. This violates ADR 013 and ADR 017's requirement for a single source of truth accessible by multiple dashboard views.
+
+## 2026-06-11: Validate File Existence First
+Rejected `task-095-157-feebas-seed-impl` for missing the implementation of `extractFeebasSeed`. The file `src/engine/gen3/feebas.ts` did not exist.
+**Lesson**: Always use grounded file discovery (e.g., `ls` or `grep`) to confirm the files exist before attempting to validate logical correctness. If a required file is completely missing, immediately fail the target task to short-circuit the review loop and prevent wasted QA effort.

--- a/.foundry/tasks/task-095-157-feebas-seed-impl.md
+++ b/.foundry/tasks/task-095-157-feebas-seed-impl.md
@@ -2,7 +2,7 @@
 id: task-095-157-feebas-seed-impl
 type: TASK
 title: Implement Feebas Seed Extraction
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-10'
 updated_at: '2026-06-11'
@@ -14,8 +14,10 @@ tags:
   - gen3
   - backend
   - save-parsing
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: >-
+  The implementation is completely missing. src/engine/gen3/feebas.ts does not
+  exist.
 notes: ''
 ---
 

--- a/.foundry/tasks/task-095-158-feebas-seed-qa.md
+++ b/.foundry/tasks/task-095-158-feebas-seed-qa.md
@@ -42,3 +42,6 @@ Verify the implementation of the 16-bit Feebas seed extraction utility from Gen 
 - [ ] Code uses `DataView` and explicitly catches `RangeError` to handle out-of-bounds.
 - [ ] Offsets `0x2DD6` and `0x2E66` are correctly applied based on version.
 - [ ] Tests cover all paths and pass successfully.
+
+## QA Update
+Task rejected. Implementation completely missing. `src/engine/gen3/feebas.ts` does not exist.


### PR DESCRIPTION
QA agent rejected `task-095-157-feebas-seed-impl` because the implementation file `src/engine/gen3/feebas.ts` does not exist. Updated target task to FAILED with rejection_reason, appended rejection note to QA task markdown body, and logged lesson in QA journal.

---
*PR created automatically by Jules for task [9142624326640615811](https://jules.google.com/task/9142624326640615811) started by @szubster*