### PR TITLE
Implement Pokerus Byte Parsing

### DIFF
--- a/.foundry/tasks/task-095-157-pokerus-byte-parsing-impl.md
+++ b/.foundry/tasks/task-095-157-pokerus-byte-parsing-impl.md
@@ -48,8 +48,8 @@ const pokerus = rawPokerusByte > 0 ? {
 Update `parseGen2PokemonInstance` in `src/engine/saveParser/parsers/gen2.ts` to parse the raw byte into this object.
 
 ## Acceptance Criteria
-- [ ] Update `PokemonInstance.pokerus` type in `src/engine/saveParser/parsers/common.ts`
-- [ ] Update `parseGen2PokemonInstance` to parse the pokerus byte into the structured object.
+- [x] Update `PokemonInstance.pokerus` type in `src/engine/saveParser/parsers/common.ts`
+- [x] Update `parseGen2PokemonInstance` to parse the pokerus byte into the structured object.
 
 ### Critical Contract Reminders
 - If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -25,7 +25,7 @@ export interface PokemonInstance {
   item?: number | undefined;
   moves: number[];
   friendship?: number | undefined;
-  pokerus?: number | undefined;
+  pokerus?: { strain: number; daysRemaining: number } | undefined;
   currentHp?: number | undefined;
   dvs?: { hp: number; atk: number; def: number; spd: number; spc: number };
   statExp?: { hp: number; atk: number; def: number; spd: number; spc: number };

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -129,6 +129,22 @@ describe('gen2 parsers', () => {
       expect(typeof data.partyDetails[2]?.caughtData?.locationName).toBe('string');
     });
 
+    it('should parse pokerus byte correctly', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x288a, 2); // 2 in party
+      view.setUint8(0x288b, 1);
+      view.setUint8(0x288c, 2);
+      view.setUint8(0x288b + 7, 1); // p1
+      view.setUint8(0x288b + 7 + 28, 0x00); // 0 pokerus
+      view.setUint8(0x288b + 7 + 48, 2); // p2
+      view.setUint8(0x288b + 7 + 48 + 28, 0x1a); // pokerus: strain 1, days 10
+
+      const data = parseGen2(view, false);
+      expect(data.partyDetails[0]?.pokerus).toBeUndefined();
+      expect(data.partyDetails[1]?.pokerus).toEqual({ strain: 1, daysRemaining: 10 });
+    });
+
     it('should correctly detect silver/gold using pokedex seen/owned', () => {
       const buffer = new ArrayBuffer(32768);
       const view = new DataView(buffer);

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -87,7 +87,14 @@ function parseGen2PokemonInstance(
   const isShiny = checkShiny(dvs);
   const isShinyCarrier = checkShinyGene(dvs);
   const friendship = view.getUint8(offset + 27);
-  const pokerus = view.getUint8(offset + 28);
+  const rawPokerus = view.getUint8(offset + 28);
+  const pokerus =
+    rawPokerus > 0
+      ? {
+          strain: rawPokerus >> 4,
+          daysRemaining: rawPokerus & 0x0f,
+        }
+      : undefined;
   const level = view.getUint8(offset + 31);
   const currentHp = storageLocation === 'Party' ? view.getUint16(offset + 34, false) : undefined;
   const caughtData = isCrystal ? parseCaughtData(view, offset) : undefined;


### PR DESCRIPTION
Implemented parsing for the raw pokerus byte in Generation 2 save files. The raw 8-bit integer is now parsed into a structured object containing the strain (upper 4 bits) and daysRemaining (lower 4 bits) within the `PokemonInstance`. Tests and linting pass.

---
*PR created automatically by Jules for task [2790675517966690274](https://jules.google.com/task/2790675517966690274) started by @szubster*