### PR TITLE
Implement Gen 3 hidden item event flags parsing

### DIFF
--- a/.foundry/tasks/task-097-157-gen3-hidden-item-parsing-impl.md
+++ b/.foundry/tasks/task-097-157-gen3-hidden-item-parsing-impl.md
@@ -32,10 +32,10 @@ This task implements the third part of the epic `epic-037-058-hidden-items-save-
 4. **Update Tests**: Add or update unit tests for the Gen 3 save parser to assert that the `hiddenItemFlags` are parsed correctly, injecting mock byte values into the dummy save buffer to verify extraction logic.
 
 ## Acceptance Criteria
-- [ ] `parseGen3` correctly parses the save file sections to locate the event flags.
-- [ ] `parseGen3` extracts the hidden item flags into a `Uint8Array` using exclusively the `DataView` API.
-- [ ] Bounds checking is handled natively by catching `DataView` `RangeError`s and propagating them appropriately.
-- [ ] Unit tests for the Gen 3 save parser verify hidden item parsing logic.
+- [x] `parseGen3` correctly parses the save file sections to locate the event flags.
+- [x] `parseGen3` extracts the hidden item flags into a `Uint8Array` using exclusively the `DataView` API.
+- [x] Bounds checking is handled natively by catching `DataView` `RangeError`s and propagating them appropriately.
+- [x] Unit tests for the Gen 3 save parser verify hidden item parsing logic.
 
 ## IMPORTANT REMINDERS
 - **If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.**

--- a/src/engine/saveParser/index.test.ts
+++ b/src/engine/saveParser/index.test.ts
@@ -253,8 +253,8 @@ describe('saveParser - Error Handling and Fallbacks', () => {
     // Mock isGen3Save to return true
     const isGen3Spy = vi.spyOn(gen3Module, 'isGen3Save').mockReturnValue(true);
 
-    // Should call parseGen3, which throws 'Gen 3 parsing not implemented yet'
-    expect(() => parseSaveFile(buffer.buffer)).toThrow('Gen 3 parsing not implemented yet');
+    // Should call parseGen3, which throws 'The save file is corrupted or incomplete.'
+    expect(() => parseSaveFile(buffer.buffer)).toThrow('The save file is corrupted or incomplete.');
 
     isGen3Spy.mockRestore();
   });

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -92,6 +92,8 @@ export interface SaveData {
   eventFlags?: Uint8Array;
   /** Bitflags representing which in-game NPC trades have already been completed. */
   npcTradeFlags?: number;
+  /** Raw byte array containing all in-game hidden item flags. */
+  hiddenItemFlags?: Uint8Array;
   /** Detailed structural data for Pokémon currently left in the Daycare (Gen 2). */
   daycare?: PokemonInstance[];
   /** Gen 2 specific: Indicates if an Egg is currently waiting to be picked up from the Daycare. */

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -8,10 +8,40 @@ describe('gen3 parser scaffolding', () => {
     expect(isGen3Save(view)).toBe(false);
   });
 
-  it('parseGen3 should throw not implemented error normally', () => {
-    const buffer = new ArrayBuffer(8);
+  it('parseGen3 should correctly find the latest save block and extract hidden item flags', () => {
+    // A full Gen 3 save is typically 128KB
+    const buffer = new ArrayBuffer(131072);
     const view = new DataView(buffer);
-    expect(() => parseGen3(view)).toThrowError('Gen 3 parsing not implemented yet');
+
+    // Block A (offset 0) Setup - Section 2 with a lower save index
+    view.setUint16(0x2000 + 4084, 2, true); // Section ID 2
+    view.setUint32(0x2000 + 4088, 0x08012025, true); // Signature
+    view.setUint32(0x2000 + 4092, 10, true); // Save Index 10
+
+    // Block B (offset 0xE000) Setup - Section 2 with a higher save index
+    const blockBSection2Offset = 0xe000 + 2 * 4096; // using index 2 for section 2 offset (it can be anywhere, but let's place it at index 2)
+    view.setUint16(blockBSection2Offset + 4084, 2, true); // Section ID 2
+    view.setUint32(blockBSection2Offset + 4088, 0x08012025, true); // Signature
+    view.setUint32(blockBSection2Offset + 4092, 25, true); // Save Index 25
+
+    // Write mock flags data at Block B, Section 2, offset 0x02F0 + 62
+    const flagsOffset = blockBSection2Offset + 0x02f0;
+
+    // Create a scenario where bits shift correctly
+    // Byte 62: 0b11110000 (top 4 bits are 1) -> maps to bottom 4 bits of extracted byte 0
+    // Byte 63: 0b00001111 (bottom 4 bits are 1) -> maps to top 4 bits of extracted byte 0
+    // Resulting extracted byte 0 should be 0b11111111 = 255
+    view.setUint8(flagsOffset + 62, 0b11110000);
+    view.setUint8(flagsOffset + 63, 0b00001111);
+
+    // Let's set byte 64 as 0 to avoid bleeding into extracted byte 1
+    view.setUint8(flagsOffset + 64, 0);
+
+    const saveData = parseGen3(view);
+    expect(saveData.hiddenItemFlags).toBeDefined();
+    expect(saveData.hiddenItemFlags?.length).toBe(14);
+    expect(saveData.hiddenItemFlags?.[0]).toBe(255);
+    expect(saveData.hiddenItemFlags?.[1]).toBe(0);
   });
 
   it('isGen3Save should catch RangeError and return false', () => {
@@ -31,10 +61,15 @@ describe('gen3 parser scaffolding', () => {
   });
 
   it('parseGen3 should catch RangeError and throw corrupted error', () => {
-    const buffer = new ArrayBuffer(8);
+    const buffer = new ArrayBuffer(131072);
     const view = new DataView(buffer);
 
-    // Mock getUint8 to throw RangeError
+    const blockBSection2Offset = 0xe000 + 2 * 4096;
+    view.setUint16(blockBSection2Offset + 4084, 2, true);
+    view.setUint32(blockBSection2Offset + 4088, 0x08012025, true);
+    view.setUint32(blockBSection2Offset + 4092, 25, true);
+
+    // Mock getUint8 to throw RangeError during flag extraction
     const originalGetUint8 = view.getUint8.bind(view);
     view.getUint8 = () => {
       throw new RangeError('Out of bounds');

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -1,5 +1,58 @@
 import type { GameVersion, SaveData } from './common';
 
+const SIGNATURE = 0x08012025;
+const SECTION_SIZE = 4096;
+const NUM_SECTIONS = 14;
+const SAVE_BLOCK_A = 0x0000;
+const SAVE_BLOCK_B = 0xe000;
+
+function getLatestSectionOffset(view: DataView, targetSectionId: number): number {
+  let saveIndexA = -1;
+  let saveIndexB = -1;
+  let sectionOffsetA = -1;
+  let sectionOffsetB = -1;
+
+  for (let i = 0; i < NUM_SECTIONS; i++) {
+    const offset = SAVE_BLOCK_A + i * SECTION_SIZE;
+    try {
+      const signature = view.getUint32(offset + 4088, true);
+      if (signature === SIGNATURE) {
+        const sectionId = view.getUint16(offset + 4084, true);
+        const saveIndex = view.getUint32(offset + 4092, true);
+        if (saveIndexA === -1) saveIndexA = saveIndex;
+        if (sectionId === targetSectionId) sectionOffsetA = offset;
+      }
+    } catch (error) {
+      if (!(error instanceof RangeError)) throw error;
+    }
+  }
+
+  for (let i = 0; i < NUM_SECTIONS; i++) {
+    const offset = SAVE_BLOCK_B + i * SECTION_SIZE;
+    try {
+      const signature = view.getUint32(offset + 4088, true);
+      if (signature === SIGNATURE) {
+        const sectionId = view.getUint16(offset + 4084, true);
+        const saveIndex = view.getUint32(offset + 4092, true);
+        if (saveIndexB === -1) saveIndexB = saveIndex;
+        if (sectionId === targetSectionId) sectionOffsetB = offset;
+      }
+    } catch (error) {
+      if (!(error instanceof RangeError)) throw error;
+    }
+  }
+
+  if (sectionOffsetA === -1 && sectionOffsetB === -1) {
+    throw new Error('Target section not found or invalid signature.');
+  }
+
+  if (sectionOffsetA !== -1 && sectionOffsetB !== -1) {
+    return saveIndexA > saveIndexB ? sectionOffsetA : sectionOffsetB;
+  }
+
+  return sectionOffsetA !== -1 ? sectionOffsetA : sectionOffsetB;
+}
+
 /**
  * Performs a structural check to verify if the binary data is a valid Generation 3 save.
  * Placeholder implementation for scaffolding.
@@ -33,11 +86,41 @@ export function isGen3Save(view: DataView): boolean {
  */
 export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveData {
   try {
-    // Scaffolding read to allow testing of RangeError handling
-    if (view.byteLength > 0) {
-      view.getUint8(0);
+    let section2Offset: number;
+    try {
+      section2Offset = getLatestSectionOffset(view, 2);
+    } catch {
+      throw new RangeError('Out of bounds during block scan');
     }
-    throw new Error('Gen 3 parsing not implemented yet');
+
+    const flagsOffset = section2Offset + 0x02f0;
+    const hiddenItemFlags = new Uint8Array(14);
+
+    for (let i = 0; i < 14; i++) {
+      const currentByte = view.getUint8(flagsOffset + 62 + i);
+      const nextByte = view.getUint8(flagsOffset + 62 + i + 1);
+      hiddenItemFlags[i] = ((currentByte >> 4) | ((nextByte & 0x0f) << 4)) & 0xff;
+    }
+
+    // Dummy scaffold values for now until fully implemented
+    return {
+      generation: 3,
+      owned: new Set(),
+      seen: new Set(),
+      party: [],
+      pc: [],
+      partyDetails: [],
+      pcDetails: [],
+      gameVersion: _forcedVersion || 'ruby',
+      badges: 0,
+      trainerName: '',
+      trainerId: 0,
+      currentMapId: 0,
+      inventory: [],
+      currentBoxCount: 0,
+      hallOfFameCount: 0,
+      hiddenItemFlags,
+    };
   } catch (error) {
     if (error instanceof RangeError) {
       throw new Error('The save file is corrupted or incomplete.');


### PR DESCRIPTION
This change implements the parsing of hidden item event flags for Gen 3 save files according to the requirements of task-097-157-gen3-hidden-item-parsing-impl.

Key technical details:
- Added `getLatestSectionOffset` to accurately parse `SAVE_BLOCK_A` and `SAVE_BLOCK_B` and locate the most recent valid Section ID 2 (Game State).
- Extracts the 14-byte hidden item flags starting from offset `0x02F0` inside Section 2 by bit-shifting across boundaries.
- Exclusively uses the native `DataView` API in accordance with ADR 010 to propagate native `RangeError`s up to gracefully handle corrupted saves.
- Checked off acceptance criteria in the markdown file.
- Added comprehensive unit tests targeting block discovery, mocked bit shifting correctness, and bounds checks.

---
*PR created automatically by Jules for task [4170935313123243092](https://jules.google.com/task/4170935313123243092) started by @szubster*