### PR TITLE
Create task for DagContext interfaces and types

### DIFF
--- a/.foundry/stories/story-070-108-create-dag-context-interfaces.md
+++ b/.foundry/stories/story-070-108-create-dag-context-interfaces.md
@@ -25,4 +25,5 @@ notes: ''
 Define the TypeScript interfaces and types for the `DagContext`. This includes the shape of the context state (nodes, edges, and potentially `rejection_count`), and any actions or reducers if needed.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks
+- [x] Break down into Tasks
+- [ ] .foundry/tasks/task-108-161-create-dag-context-types.md

--- a/.foundry/tasks/task-108-161-create-dag-context-types.md
+++ b/.foundry/tasks/task-108-161-create-dag-context-types.md
@@ -1,0 +1,38 @@
+---
+id: task-108-161-create-dag-context-types
+type: TASK
+title: Create DagContext Interfaces and Types
+status: PENDING
+owner_persona: coder
+created_at: "2026-06-11"
+updated_at: "2026-06-11"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-070-108-create-dag-context-interfaces
+tags:
+  - architecture
+  - ui
+  - context
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Create DagContext Interfaces and Types
+
+## Overview
+Define the TypeScript interfaces and types for the `DagContext`. The board needs to maintain a shared state between the React Flow visualizer and the Kanban board according to ADR 013 and ADR 017.
+
+## Architectural Scaffolding
+Following ADR 013 and ADR 017:
+- The `DagContext` should be defined first before implementing UI components to prevent tight coupling.
+- The context must hold the raw parsed DAG data (nodes, edges).
+- Nodes must explicitly include the `rejection_count` property to support the Permanent Failure Dashboard logic in the future.
+
+## Acceptance Criteria
+- [ ] Create `DagContext` types file (e.g. `src/components/dashboard/DagContext.tsx` or similar central place).
+- [ ] Define the shape of the node data, including fields like `id`, `status`, `owner_persona`, `depends_on`, and explicitly `rejection_count`.
+- [ ] Define the context state shape (nodes list, edges list, potentially loading states or currently selected view).
+- [ ] Ensure the Coder and QA personas are explicitly reminded: if they abort or permanently fail a task, they MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- [ ] Ensure the Coder and QA personas are explicitly reminded: if they submit an empty PR for a completed task, they MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Creates the implementation task (`task-108-161-create-dag-context-types.md`) to build the TypeScript interfaces and types for the `DagContext`.

The task serves as a technical blueprint explicitly enforcing the requirements from ADR 013 (Kanban Board Shared Data) and ADR 017 (Permanent Failure Dashboard), specifying the context shape and the inclusion of the `rejection_count` field. The task is assigned to the `coder` persona, and the parent STORY has been correctly updated to reference the new pending task.

---
*PR created automatically by Jules for task [958809707671882622](https://jules.google.com/task/958809707671882622) started by @szubster*