### PR TITLE
feat(foundry): Breakdown STORY-071-109 into Tasks

### DIFF
--- a/.foundry/stories/story-071-109-update-adr001-macro-node-completion.md
+++ b/.foundry/stories/story-071-109-update-adr001-macro-node-completion.md
@@ -33,3 +33,6 @@ Update `.foundry/docs/adrs/001-the-foundry-architecture.md` (ADR 001) to reflect
 
 ## Acceptance Criteria
 - [ ] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior.
+
+## Tasks
+- [ ] task-109-161-update-adr001-macro-node-completion-impl

--- a/.foundry/tasks/task-109-161-update-adr001-macro-node-completion-impl.md
+++ b/.foundry/tasks/task-109-161-update-adr001-macro-node-completion-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-109-161-update-adr001-macro-node-completion-impl
+type: TASK
+title: Implement macro node completion rules in ADR 001
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-071-109-update-adr001-macro-node-completion
+tags:
+  - orchestrator
+  - adr
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement macro node completion rules in ADR 001
+
+## Context
+With the introduction of strict hierarchical completion in the orchestrator, macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) cannot complete until all descendant nodes are `COMPLETED` or `CANCELLED`. Our system documentation needs to reflect these new constraints.
+
+## Objective
+Update `.foundry/docs/adrs/001-the-foundry-architecture.md` to detail the new macro node completion rules.
+
+## Requirements
+1. Update `.foundry/docs/adrs/001-the-foundry-architecture.md` (ADR 001) to reflect the strict completion checks.
+2. Specifically, add a rule to Section 7 ("System Invariants") or an appropriate section stating that macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) MUST NOT transition to `COMPLETED` until all of their descendant nodes in the DAG have reached the `COMPLETED` or `CANCELLED` status. A macro node with pending, active, or failed descendants is inherently incomplete.
+3. This task is low risk (documentation only), so the coder is responsible for self-verifying the changes. No separate QA task has been created.
+4. Reminder: If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+5. Reminder: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior of macro nodes completion.


### PR DESCRIPTION
Breaks down the STORY node `story-071-109-update-adr001-macro-node-completion` into actionable TASK nodes for the Coder, correctly linked in the parent node's markdown body.

As per the Tech Lead instructions, a new `TASK` node has been generated using the parent-linked ID schema and the Intelligent Verification Protocol was applied (deferring QA to the coder since it is a simple documentation task). The new task has been linked correctly as an unchecked task in the story's body without altering the story's YAML frontmatter.

---
*PR created automatically by Jules for task [6816560503344240337](https://jules.google.com/task/6816560503344240337) started by @szubster*