### PR TITLE
Blueprint Tasks for Hierarchical Completion Logic

### DIFF
--- a/.foundry/stories/story-070-108-orchestrator-hierarchical-completion-logic.md
+++ b/.foundry/stories/story-070-108-orchestrator-hierarchical-completion-logic.md
@@ -40,3 +40,6 @@ Update `.github/scripts/foundry-orchestrator.ts` to block `VERIFYING` and `COMPL
 - [ ] `childToParents` and `parentToChildren` maps are correctly populated.
 - [ ] `isDescendant` accurately traverses multiple parents using `childToParents`.
 - [ ] Hierarchical completion strictly blocks transition when either explicit or markdown-referenced children are incomplete.
+
+- [ ] .foundry/tasks/task-108-161-hierarchical-completion-impl.md
+- [ ] .foundry/tasks/task-108-162-hierarchical-completion-qa.md

--- a/.foundry/tasks/task-108-161-hierarchical-completion-impl.md
+++ b/.foundry/tasks/task-108-161-hierarchical-completion-impl.md
@@ -1,0 +1,49 @@
+---
+id: task-108-161-hierarchical-completion-impl
+type: TASK
+title: Implement Hierarchical Completion and Markdown Link Extraction in Orchestrator
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-070-108-orchestrator-hierarchical-completion-logic
+tags:
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Hierarchical Completion and Markdown Link Extraction in Orchestrator
+
+## Objective
+Update `.github/scripts/foundry-orchestrator.ts` to block `VERIFYING` and `COMPLETED` transitions for any node that has children not in the `COMPLETED` state, and ensure children are identified via both the `parent` frontmatter field and markdown body references.
+
+## Requirements
+1. **Child Identification via Markdown**:
+   - In `Phase 3: BUILD MAPS` of `.github/scripts/foundry-orchestrator.ts`, introduce a new `Map` called `childToParents`. `childToParents` maps `string` -> `Set<string>`.
+   - While building `parentToChildren`, also populate `childToParents` using the explicitly defined `frontmatter.parent`. Add the referenced node to `childToParents.get(node.repoPath)`.
+   - After explicitly processing `frontmatter.parent`, parse `node.body` of every node using the regex `/\.foundry\/(?:ideas|prds|epics|stories|tasks|research)\/[^\s"'`\)]+\.md/g`.
+   - For every extracted path match from the body, add the *referencing node* (`node.repoPath`) as a parent of the *matched referenced child node* in `childToParents`, and add the matched referenced child node to the referencing node's `parentToChildren`. Be mindful of using Sets or deduplicating to avoid duplicate entries in `parentToChildren`.
+
+2. **Hierarchical Completion Checks**:
+   - Update `isDescendant(childPath, ancestorPath)` to use a Breadth-First Search (BFS) over the `childToParents` map, instead of a simple `while` loop that only checks `frontmatter.parent`.
+   - Update the `Check parent inheritance` block in Phase 4. `currParent` logic currently walks up via `frontmatter.parent`. This must be updated to use a BFS queue over `childToParents` to verify if any recursive parent is blocking the node from dispatch.
+
+3. **Incomplete check in `isHierarchicallyIncomplete`**:
+   - `isHierarchicallyIncomplete` correctly leverages `parentToChildren` already, but make sure it handles any type changes (e.g. deduplicating arrays).
+
+4. **Reminders to Coder**:
+   - Do NOT modify the YAML frontmatter of the task node, except for `status: FAILED` or `status: CANCELLED` and `rejection_reason` if you need to abort.
+   - If you submit an empty PR for this completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] `childToParents` map is populated correctly using both explicit `frontmatter.parent` and regex markdown links.
+- [ ] `parentToChildren` includes children discovered via regex markdown links.
+- [ ] `isDescendant` handles multi-parent traversal correctly via BFS.
+- [ ] Phase 4 inheritance check uses BFS over `childToParents` instead of single-parent traversal.

--- a/.foundry/tasks/task-108-162-hierarchical-completion-qa.md
+++ b/.foundry/tasks/task-108-162-hierarchical-completion-qa.md
@@ -1,0 +1,45 @@
+---
+id: task-108-162-hierarchical-completion-qa
+type: TASK
+title: QA Hierarchical Completion and Markdown Link Extraction in Orchestrator
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - task-108-161-hierarchical-completion-impl
+jules_session_id: null
+pr_number: null
+parent: story-070-108-orchestrator-hierarchical-completion-logic
+tags:
+  - orchestrator
+  - architecture
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Hierarchical Completion and Markdown Link Extraction in Orchestrator
+
+## Objective
+Verify that the `foundry-orchestrator.ts` correctly blocks node transitions when explicit or markdown-referenced children are incomplete.
+
+## Requirements
+1. **Verify Child Identification**:
+   - Verify that `childToParents` and `parentToChildren` maps are correctly populated.
+   - Verify that markdown links matching `/\.foundry\/(?:ideas|prds|epics|stories|tasks|research)\/[^\s"'`\)]+\.md/g` are correctly identified as child relationships.
+2. **Verify Multi-Parent Traversal**:
+   - Verify that `isDescendant` handles multi-parent traversal correctly via BFS over `childToParents`.
+   - Verify that the Phase 4 inheritance check uses BFS over `childToParents`.
+3. **Run Tests**:
+   - Run unit tests to verify the behavior works as expected. Check `.github/scripts/foundry-orchestrator.test.ts` or add a specific test if none exists for this new markdown parsing.
+4. **Reminders to QA**:
+   - Do NOT modify the YAML frontmatter of the task node, except for `status: FAILED` or `status: CANCELLED` and `rejection_reason` if you need to abort.
+   - If you submit an empty PR for this completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] `foundry-orchestrator.ts` parses markdown links and adds them to `parentToChildren` and `childToParents`.
+- [ ] Multiple parents are correctly traversed.
+- [ ] Tests pass verifying hierarchical completion blocks `VERIFYING` or `COMPLETED` when any explicit or markdown child is not `COMPLETED`.


### PR DESCRIPTION
Created tasks 108-161 (impl) and 108-162 (qa) to update the foundry-orchestrator to correctly handle parent-child hierarchy completion rules based on both frontmatter and markdown links. Updated the parent story to reference these new tasks.

---
*PR created automatically by Jules for task [2123102646458203608](https://jules.google.com/task/2123102646458203608) started by @szubster*