### PR TITLE
Tech Lead: Break down Gen 3 Roamer DataView Extraction Story

### DIFF
--- a/.foundry/stories/story-070-108-gen3-roamer-dataview-extraction.md
+++ b/.foundry/stories/story-070-108-gen3-roamer-dataview-extraction.md
@@ -31,4 +31,8 @@ This story handles the base extraction logic in the save parser for Gen 3. The `
 ## Acceptance Criteria
 - [ ] Implement `DataView` reading logic for the 20-byte Gen 3 roamer structure.
 - [ ] Implement parsing logic for IVs, HP, and Level from the structure.
-- [ ] Tech Lead: Break down this Story into executable Tasks.
+- [x] Tech Lead: Break down this Story into executable Tasks.
+
+## Generated Tasks
+- [ ] task-108-161-gen3-roamer-dataview-extraction-impl
+- [ ] task-108-162-gen3-roamer-dataview-extraction-qa

--- a/.foundry/tasks/task-108-161-gen3-roamer-dataview-extraction-impl.md
+++ b/.foundry/tasks/task-108-161-gen3-roamer-dataview-extraction-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-108-161-gen3-roamer-dataview-extraction-impl
+type: TASK
+title: Implement Gen 3 Roamer DataView Extraction and Core Parsing
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-070-108-gen3-roamer-dataview-extraction
+tags:
+  - gen3
+  - roamer
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Roamer DataView Extraction and Core Parsing
+
+## Objective
+Implement the logic to extract the 20-byte hidden roamer data structure from Gen 3 save files using the `DataView` API, and accurately parse the IVs, HP, and Level.
+
+## Description
+Following ADR 010, the base extraction logic in the save parser for Gen 3 must safely read the 20-byte roamer structure exclusively using the `DataView` API. After extraction, correctly parse the IVs, HP, and Level of the roamer from this raw byte structure. Ensure that any out-of-bounds reads result in a `RangeError` that is caught and handled gracefully by propagating a validation error (e.g., "Corrupted Save File").
+
+## Acceptance Criteria
+- [ ] Read the 20-byte Gen 3 roamer structure strictly using the `DataView` API.
+- [ ] Parse IVs, HP, and Level correctly from the extracted structure.
+- [ ] Handle `RangeError` on out-of-bounds reads gracefully and throw a clear validation error.
+- [ ] Tests and lint must pass.
+
+**Important Instructions:**
+If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-108-162-gen3-roamer-dataview-extraction-qa.md
+++ b/.foundry/tasks/task-108-162-gen3-roamer-dataview-extraction-qa.md
@@ -1,0 +1,40 @@
+---
+id: task-108-162-gen3-roamer-dataview-extraction-qa
+type: TASK
+title: QA Gen 3 Roamer DataView Extraction and Core Parsing
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - task-108-161-gen3-roamer-dataview-extraction-impl
+jules_session_id: null
+pr_number: null
+parent: story-070-108-gen3-roamer-dataview-extraction
+tags:
+  - gen3
+  - roamer
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 Roamer DataView Extraction and Core Parsing
+
+## Objective
+Verify the implementation of Gen 3 roamer data extraction using `DataView` and the parsing of IVs, HP, and Level.
+
+## Description
+Verify that the implementation safely reads the 20-byte roamer structure exclusively using the `DataView` API according to ADR 010. Confirm that the parsing of IVs, HP, and Level from this raw byte structure is accurate. Ensure that any out-of-bounds reads throw a `RangeError` which is caught and gracefully handled (e.g., throwing "Corrupted Save File").
+
+## Acceptance Criteria
+- [ ] Confirm the 20-byte Gen 3 roamer structure is read exclusively using the `DataView` API.
+- [ ] Confirm IVs, HP, and Level are correctly parsed.
+- [ ] Confirm out-of-bounds reads result in a `RangeError` that is gracefully handled and propagated as a validation error.
+- [ ] Confirm all tests and linting checks pass.
+
+**Important Instructions:**
+If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR acts as the Tech Lead breaking down `story-070-108-gen3-roamer-dataview-extraction` into actionable engineering tasks.

Created two tasks:
1. `task-108-161-gen3-roamer-dataview-extraction-impl`: Assigned to the `coder` to implement the `DataView` parsing of the 20-byte roamer structure, extracting IVs/HP/Level, and throwing proper `RangeError`s for out-of-bounds reads.
2. `task-108-162-gen3-roamer-dataview-extraction-qa`: Assigned to the `qa` persona to verify the implementation.

The parent Story node's markdown has been updated to check off the Tech Lead requirement and link the newly generated tasks. YAML frontmatter rules and dependencies strictly followed.

---
*PR created automatically by Jules for task [13620656847034843130](https://jules.google.com/task/13620656847034843130) started by @szubster*