### PR TITLE
Foundry Task Scaffold: Gen 3 Roamer Location Data Extraction

### DIFF
--- a/.foundry/stories/story-072-108-gen3-roamer-location-extraction.md
+++ b/.foundry/stories/story-072-108-gen3-roamer-location-extraction.md
@@ -32,4 +32,6 @@ The Gen 3 roamer's active map group and map number are stored outside the primar
 ## Acceptance Criteria
 - [ ] Research/determine the exact offset for the roamer's map group and map number.
 - [ ] Implement the parsing logic using `DataView` to extract the location index from Gen 3 saves.
-- [ ] Tech Lead: Break down this Story into execution Tasks (implementation & QA).
+- [x] Tech Lead: Break down this Story into execution Tasks (implementation & QA).
+- [ ] .foundry/tasks/task-108-161-gen3-roamer-location-impl.md
+- [ ] .foundry/tasks/task-108-162-gen3-roamer-location-qa.md

--- a/.foundry/tasks/task-108-161-gen3-roamer-location-impl.md
+++ b/.foundry/tasks/task-108-161-gen3-roamer-location-impl.md
@@ -1,0 +1,41 @@
+---
+id: task-108-161-gen3-roamer-location-impl
+type: TASK
+title: Implement Gen 3 Roamer Location Data Extraction
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - research-071-138-gen3-roamer-offsets
+jules_session_id: null
+pr_number: null
+parent: story-072-108-gen3-roamer-location-extraction
+tags:
+  - gen3
+  - roamer
+  - map
+research_references:
+  - .foundry/research/research-071-138-gen3-roamer-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Roamer Location Data Extraction
+
+## Objective
+Implement the `DataView` parsing logic to extract the map group and map number for the active Gen 3 roamer from the `.sav` file.
+
+## Description
+The Gen 3 roamer's location is stored outside the primary 20-byte struct in an EWRAM/save block structure (e.g., `sRoamerLocation`). Your task is to update the parsing engine to extract this location data (map group and map number) directly from the save file.
+
+**CRITICAL INSTRUCTIONS:**
+- You MUST use the `DataView` API exclusively for parsing, as mandated by ADR 010. Raw `Uint8Array` access is forbidden.
+- Bounds checking must be correctly implemented and gracefully handled via `DataView` RangeErrors.
+- If you find that this task is impossible to complete or if you permanently fail, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. Do NOT set it to `COMPLETED` manually.
+- If you submit an empty PR because the logic already exists, you MUST check all Acceptance Criteria checkboxes before doing so.
+
+## Acceptance Criteria
+- [ ] Implement robust `DataView`-based extraction for the Gen 3 roamer map group and map number within the save parsing logic.
+- [ ] Provide tests that verify the extraction logic handles corrupted or truncated buffers gracefully via RangeError capture.

--- a/.foundry/tasks/task-108-162-gen3-roamer-location-qa.md
+++ b/.foundry/tasks/task-108-162-gen3-roamer-location-qa.md
@@ -1,0 +1,42 @@
+---
+id: task-108-162-gen3-roamer-location-qa
+type: TASK
+title: QA Gen 3 Roamer Location Data Extraction
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - task-108-161-gen3-roamer-location-impl
+jules_session_id: null
+pr_number: null
+parent: story-072-108-gen3-roamer-location-extraction
+tags:
+  - gen3
+  - roamer
+  - map
+  - qa
+research_references:
+  - .foundry/research/research-071-138-gen3-roamer-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 Roamer Location Data Extraction
+
+## Objective
+Verify the implementation of the Gen 3 roamer location data extraction.
+
+## Description
+The `coder` persona was tasked with implementing the `DataView` parsing logic to extract the map group and map number for the active Gen 3 roamer from the `.sav` file. Your task is to verify that this implementation is correct, adheres to the established architectural decisions (specifically ADR 010 regarding `DataView` usage), and that the associated tests provide adequate coverage including error handling for corrupted saves.
+
+**CRITICAL INSTRUCTIONS:**
+- If the implementation is missing, flawed, or fails tests, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. Do NOT set it to `COMPLETED` manually.
+- You must verify the existence of the implementation files before attempting validation.
+- If you submit an empty PR because the verification passes without requiring code changes, you MUST check all Acceptance Criteria checkboxes before doing so.
+
+## Acceptance Criteria
+- [ ] Verify that the `DataView` API is used exclusively for the Gen 3 roamer location extraction.
+- [ ] Verify that bounds checking is correctly implemented and RangeErrors are gracefully handled.
+- [ ] Verify that the provided tests adequately cover the extraction logic and error conditions.

--- a/update_tasks.cjs
+++ b/update_tasks.cjs
@@ -1,0 +1,17 @@
+const fs = require('fs');
+
+const implPath = '.foundry/tasks/task-108-161-gen3-roamer-location-impl.md';
+let implContent = fs.readFileSync(implPath, 'utf8');
+implContent = implContent.replace(
+  'depends_on:\n  - .foundry/research/research-071-138-gen3-roamer-offsets.md',
+  'depends_on:\n  - research-071-138-gen3-roamer-offsets'
+);
+fs.writeFileSync(implPath, implContent);
+
+const qaPath = '.foundry/tasks/task-108-162-gen3-roamer-location-qa.md';
+let qaContent = fs.readFileSync(qaPath, 'utf8');
+qaContent = qaContent.replace(
+  'depends_on:\n  - .foundry/tasks/task-108-161-gen3-roamer-location-impl.md',
+  'depends_on:\n  - task-108-161-gen3-roamer-location-impl'
+);
+fs.writeFileSync(qaPath, qaContent);


### PR DESCRIPTION
Created `task-108-161-gen3-roamer-location-impl.md` and `task-108-162-gen3-roamer-location-qa.md` to break down `story-072-108-gen3-roamer-location-extraction.md`. Updated the story node to include the child tasks as unchecked checkboxes and marked the breakdown acceptance criteria as complete. All DAG relationships strictly use node IDs rather than file paths, adhering to architectural decisions.

---
*PR created automatically by Jules for task [10505697721765927623](https://jules.google.com/task/10505697721765927623) started by @szubster*