### PR TITLE
Fix Foundry DAG Resolution Warnings for ADRs

### DIFF
--- a/.foundry/docs/adrs/001-the-foundry-architecture.md
+++ b/.foundry/docs/adrs/001-the-foundry-architecture.md
@@ -1,3 +1,23 @@
+---
+id: adr-001-foundry-architecture
+type: ADR
+title: The Foundry Autonomous Software Factory Architecture
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-04-20'
+updated_at: '2026-04-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # The Foundry Autonomous Software Factory Architecture
 
 ## Vision

--- a/.foundry/docs/adrs/002-collision-free-id-schema.md
+++ b/.foundry/docs/adrs/002-collision-free-id-schema.md
@@ -1,3 +1,23 @@
+---
+id: adr-002-collision-free-id-schema
+type: ADR
+title: 'ADR 002: Parent-Linked Distributed ID Schema'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-04-20'
+updated_at: '2026-04-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 002: Parent-Linked Distributed ID Schema
 
 ## Status

--- a/.foundry/docs/adrs/003-gastown-migration-decision.md
+++ b/.foundry/docs/adrs/003-gastown-migration-decision.md
@@ -1,3 +1,23 @@
+---
+id: adr-003-gastown-migration-decision
+type: ADR
+title: 'ADR 003: Gastown Migration Decision'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-04-20'
+updated_at: '2026-04-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 003: Gastown Migration Decision
 
 ## Status

--- a/.foundry/docs/adrs/004-research-context-propagation.md
+++ b/.foundry/docs/adrs/004-research-context-propagation.md
@@ -1,3 +1,23 @@
+---
+id: adr-004-research-context-propagation
+type: ADR
+title: 'ADR 004: Research Context Propagation'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-04-20'
+updated_at: '2026-04-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 004: Research Context Propagation
 
 ## Status

--- a/.foundry/docs/adrs/005-sibling-dependency-enforcement.md
+++ b/.foundry/docs/adrs/005-sibling-dependency-enforcement.md
@@ -1,3 +1,23 @@
+---
+id: adr-005-sibling-dependency-enforcement
+type: ADR
+title: 'ADR 005: Sibling Dependency Recommendations'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-04-20'
+updated_at: '2026-04-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 005: Sibling Dependency Recommendations
 
 ## Status

--- a/.foundry/docs/adrs/006-gray-matter-parsing.md
+++ b/.foundry/docs/adrs/006-gray-matter-parsing.md
@@ -1,3 +1,23 @@
+---
+id: adr-006-gray-matter-parsing
+type: ADR
+title: 'ADR 006: Gray-Matter Markdown Parsing Migration'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-04-20'
+updated_at: '2026-04-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 006: Gray-Matter Markdown Parsing Migration
 
 ## Status

--- a/.foundry/docs/adrs/007-enforce-acceptance-criteria-checkboxes.md
+++ b/.foundry/docs/adrs/007-enforce-acceptance-criteria-checkboxes.md
@@ -1,3 +1,23 @@
+---
+id: adr-007-enforce-acceptance-criteria-checkboxes
+type: ADR
+title: 'ADR 007: Enforce Acceptance Criteria Checkboxes'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-11'
+updated_at: '2026-05-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 007: Enforce Acceptance Criteria Checkboxes
 
 ## Date

--- a/.foundry/docs/adrs/008-graph-rendering-library-selection.md
+++ b/.foundry/docs/adrs/008-graph-rendering-library-selection.md
@@ -1,3 +1,23 @@
+---
+id: adr-008-graph-rendering-library-selection
+type: ADR
+title: 'ADR 008: Graph Rendering Library Selection'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-12'
+updated_at: '2026-05-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 008: Graph Rendering Library Selection
 
 ## Date

--- a/.foundry/docs/adrs/009-enforce-acceptance-criteria-empty-prs.md
+++ b/.foundry/docs/adrs/009-enforce-acceptance-criteria-empty-prs.md
@@ -1,3 +1,23 @@
+---
+id: adr-009-enforce-acceptance-criteria-empty-prs
+type: ADR
+title: 'ADR 009: Enforce Acceptance Criteria Checkboxes Before Empty PR Auto-Merge'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-12'
+updated_at: '2026-05-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 009: Enforce Acceptance Criteria Checkboxes Before Empty PR Auto-Merge
 
 ## Date

--- a/.foundry/docs/adrs/010-gen3-data-parsing.md
+++ b/.foundry/docs/adrs/010-gen3-data-parsing.md
@@ -1,3 +1,23 @@
+---
+id: adr-010-gen3-data-parsing
+type: ADR
+title: 'ADR 010: Gen3 Data Parsing Strategy'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-15'
+updated_at: '2026-05-15'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 010: Gen3 Data Parsing Strategy
 
 ## Status

--- a/.foundry/docs/adrs/010-gen3-map-graph-design.md
+++ b/.foundry/docs/adrs/010-gen3-map-graph-design.md
@@ -1,3 +1,23 @@
+---
+id: adr-010-gen3-map-graph-design
+type: ADR
+title: 'ADR 010: Gen 3 Map Graph Design'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-17'
+updated_at: '2026-05-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 010: Gen 3 Map Graph Design
 
 ## Date

--- a/.foundry/docs/adrs/010-msgpack-for-gen3-data.md
+++ b/.foundry/docs/adrs/010-msgpack-for-gen3-data.md
@@ -1,3 +1,23 @@
+---
+id: adr-010-msgpack-for-gen3-data
+type: ADR
+title: 'ADR 010: Transition to MsgPack for Generation 3 Data'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-17'
+updated_at: '2026-05-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 010: Transition to MsgPack for Generation 3 Data
 
 ## Date

--- a/.foundry/docs/adrs/013-kanban-board-state-management.md
+++ b/.foundry/docs/adrs/013-kanban-board-state-management.md
@@ -1,3 +1,23 @@
+---
+id: adr-013-kanban-board-state-management
+type: ADR
+title: 'ADR 013: Kanban Board State Management and Integration'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-19'
+updated_at: '2026-05-19'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 013: Kanban Board State Management and Integration
 
 ## Date

--- a/.foundry/docs/adrs/014-auditor-persona-state-machine.md
+++ b/.foundry/docs/adrs/014-auditor-persona-state-machine.md
@@ -1,3 +1,23 @@
+---
+id: adr-014-auditor-persona-state-machine
+type: ADR
+title: 'ADR 014: Auditor Persona and VERIFYING State Machine Modifications'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-20'
+updated_at: '2026-05-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 014: Auditor Persona and VERIFYING State Machine Modifications
 
 ## Context

--- a/.foundry/docs/adrs/015-revert-data-optimizations.md
+++ b/.foundry/docs/adrs/015-revert-data-optimizations.md
@@ -1,3 +1,23 @@
+---
+id: adr-015-revert-data-optimizations
+type: ADR
+title: 'ADR 015: Revert Data Format Optimizations (Short Property Names)'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 015: Revert Data Format Optimizations (Short Property Names)
 
 ## Date

--- a/.foundry/docs/adrs/016-file-system-access-api-sync.md
+++ b/.foundry/docs/adrs/016-file-system-access-api-sync.md
@@ -1,3 +1,23 @@
+---
+id: adr-016-file-system-access-api-sync
+type: ADR
+title: 'ADR 016: File System Access API & Emulator Auto-Sync'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-21'
+updated_at: '2026-05-21'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 016: File System Access API & Emulator Auto-Sync
 
 ## Date

--- a/.foundry/docs/adrs/017-permanent-failure-dashboard.md
+++ b/.foundry/docs/adrs/017-permanent-failure-dashboard.md
@@ -1,3 +1,23 @@
+---
+id: adr-017-permanent-failure-dashboard
+type: ADR
+title: 'ADR 017: Permanent Failure Dashboard & State Synchronization Architecture'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-22'
+updated_at: '2026-05-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 017: Permanent Failure Dashboard & State Synchronization Architecture
 
 ## Date

--- a/.foundry/docs/adrs/018-smart-route-radar.md
+++ b/.foundry/docs/adrs/018-smart-route-radar.md
@@ -1,3 +1,23 @@
+---
+id: adr-018-smart-route-radar
+type: ADR
+title: 'ADR 018: Smart Route Radar Architecture'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-25'
+updated_at: '2026-05-25'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 018: Smart Route Radar Architecture
 
 ## Status

--- a/.foundry/docs/adrs/019-cloudflare-native-authentication.md
+++ b/.foundry/docs/adrs/019-cloudflare-native-authentication.md
@@ -1,3 +1,23 @@
+---
+id: adr-019-cloudflare-native-authentication
+type: ADR
+title: 'ADR 019: Cloudflare Native Authentication'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-05-28'
+updated_at: '2026-05-28'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 019: Cloudflare Native Authentication
 
 ## Status

--- a/.foundry/docs/adrs/020-feebas-visualization-architecture.md
+++ b/.foundry/docs/adrs/020-feebas-visualization-architecture.md
@@ -1,3 +1,23 @@
+---
+id: adr-020-feebas-visualization-architecture
+type: ADR
+title: 'ADR 020: Feebas Route 119 Visualizer Integration Strategy'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-06-07'
+updated_at: '2026-06-07'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
 # ADR 020: Feebas Route 119 Visualizer Integration Strategy
 
 ## Date


### PR DESCRIPTION
Added missing YAML frontmatter to 20 ADR files to resolve Foundry Engine DAG resolution warnings. Verified the fix using the orchestrator's dry-run mode and ensured overall project health by running lints and tests.

Fixes #2343

---
*PR created automatically by Jules for task [11086757256868691488](https://jules.google.com/task/11086757256868691488) started by @szubster*