### PR TITLE
Scaffold task to update schema.md for macro node completion

### DIFF
--- a/.foundry/stories/story-071-108-update-schema-macro-node-completion.md
+++ b/.foundry/stories/story-071-108-update-schema-macro-node-completion.md
@@ -32,4 +32,5 @@ Update `.foundry/docs/schema.md` to detail the new macro node completion rules s
 Update `.foundry/docs/schema.md` to explain the new hierarchical completion rules. Ensure it explicitly states that macro nodes cannot complete until all their descendants are fully completed.
 
 ## Acceptance Criteria
-- [ ] Update `schema.md` with hierarchical completion rules.
+- [x] Break down into Tasks
+- [ ] task-108-161-update-schema-macro-node-completion-impl

--- a/.foundry/tasks/task-108-161-update-schema-macro-node-completion-impl.md
+++ b/.foundry/tasks/task-108-161-update-schema-macro-node-completion-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-108-161-update-schema-macro-node-completion-impl
+type: TASK
+title: Implement update to schema.md with strict macro node completion rules
+status: PENDING
+owner_persona: coder
+created_at: "2026-06-11"
+updated_at: "2026-06-11"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-071-108-update-schema-macro-node-completion
+tags:
+  - orchestrator
+  - schema
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement update to schema.md with strict macro node completion rules
+
+## Context
+With the introduction of strict hierarchical completion in the orchestrator, where macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) cannot complete until all descendant nodes are `COMPLETED`, our system documentation needs to reflect these new constraints.
+
+## Objective
+Update `.foundry/docs/schema.md` to detail the new macro node completion rules so that all personas are aware of the expected behavior and how to properly format parent-child relationships to comply.
+
+## Requirements
+- Update `.foundry/docs/schema.md` to explain the new hierarchical completion rules. Ensure it explicitly states that macro nodes cannot complete until all their descendants are fully completed.
+
+## Contract / Reminders
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Intelligent Verification Protocol
+- This is a simple/low-risk documentation update. The `coder` is designated to self-verify. Document your self-verification in your task journal.
+
+## Acceptance Criteria
+- [ ] Update `schema.md` to explain hierarchical completion rules.


### PR DESCRIPTION
This commit introduces `task-108-161-update-schema-macro-node-completion-impl` which delegates the work for updating `schema.md` with the new hierarchical completion rules. The task explicitly targets the `coder` persona and instructs them to self-verify due to the low-risk nature of the documentation change. The parent story `story-071-108-update-schema-macro-node-completion` has been updated to reflect this breakdown, tracking the new child task in its markdown body without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [6612972862173719364](https://jules.google.com/task/6612972862173719364) started by @szubster*