### PR TITLE
docs: define rendering constraints in ADR 022

### DIFF
--- a/.foundry/docs/adrs/adr-044-022-hof-certificate-generation.md
+++ b/.foundry/docs/adrs/adr-044-022-hof-certificate-generation.md
@@ -29,5 +29,10 @@ We need a way to generate visually appealing "Hall of Fame Certificates" from th
 ## Decision
 We will use an HTML5 Canvas or SVG approach to render high-resolution certificates on the client side, ensuring privacy and avoiding server-side image generation costs.
 
+Specifically, we will use the `html-to-image` library against a hidden React component.
+Constraints include:
+- Execution must be entirely local (client-side only).
+- The solution must explicitly handle custom font loading to ensure consistent rendering.
+
 ## Acceptance Criteria
-- [ ] Define the rendering technology and constraints.
+- [x] Define the rendering technology and constraints.


### PR DESCRIPTION
Updates ADR 022 to define the rendering technology (`html-to-image` library with a hidden React component) and constraints (local execution only, explicit custom font handling) for Hall of Fame certificate generation. Marks the Acceptance Criteria as complete.

---
*PR created automatically by Jules for task [17850356702365656365](https://jules.google.com/task/17850356702365656365) started by @szubster*