### PR TITLE
chore: Breakdown Hall of Fame Parsing Epic into Stories

### DIFF
--- a/.foundry/epics/epic-044-070-hof-data-parsing.md
+++ b/.foundry/epics/epic-044-070-hof-data-parsing.md
@@ -27,4 +27,7 @@ notes: ''
 This epic covers the implementation details for extracting Hall of Fame data from Generation 1 and Generation 2 save files. This includes properly reading the offset in Gen 2 (0xA8 from Johto badges).
 
 ## Acceptance Criteria
-- [ ] Break down into Stories
+- [x] Break down into Stories
+
+- [ ] story-070-111-parse-gen1-hof-data
+- [ ] story-070-112-parse-gen2-hof-data

--- a/.foundry/stories/story-070-111-parse-gen1-hof-data.md
+++ b/.foundry/stories/story-070-111-parse-gen1-hof-data.md
@@ -1,0 +1,35 @@
+---
+id: story-070-111-parse-gen1-hof-data
+type: STORY
+title: Parse Gen 1 Hall of Fame Data
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-044-070-hof-data-parsing
+tags:
+  - story
+  - parsing
+  - hall-of-fame
+  - gen1
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Parse Gen 1 Hall of Fame Data
+
+## Overview
+Implement logic to extract the Hall of Fame data and count from Generation 1 (Red, Blue, Yellow) save files.
+
+## Technical Details
+- The Hall of Fame count is located at the base offset `0x25B3`.
+- `offsetShift` needs to be accounted for: `1` for Yellow, `0` for Red/Blue.
+- Parse the value at `0x25B3 + offsetShift` as an 8-bit unsigned integer (ignore `0xFF` by treating it as `0`).
+
+## Acceptance Criteria
+- [ ] Create task to implement parsing for Gen 1 Hall of Fame.

--- a/.foundry/stories/story-070-112-parse-gen2-hof-data.md
+++ b/.foundry/stories/story-070-112-parse-gen2-hof-data.md
@@ -1,0 +1,35 @@
+---
+id: story-070-112-parse-gen2-hof-data
+type: STORY
+title: Parse Gen 2 Hall of Fame Data
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-044-070-hof-data-parsing
+tags:
+  - story
+  - parsing
+  - hall-of-fame
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Parse Gen 2 Hall of Fame Data
+
+## Overview
+Implement logic to extract the Hall of Fame data and count from Generation 2 (Gold, Silver, Crystal) save files.
+
+## Technical Details
+- The count uses a relative offset of `0xA8` (168 bytes) after the `johtoBadgesOffset`.
+- Locate `johtoBadgesOffset` (`0x23E5` for Crystal, `0x23E4` for Gold/Silver).
+- Parse the value at `johtoBadgesOffset + 0xA8` as an 8-bit unsigned integer.
+
+## Acceptance Criteria
+- [ ] Create task to implement parsing for Gen 2 Hall of Fame.


### PR DESCRIPTION
Breaks down the `epic-044-070-hof-data-parsing` node into distinct `STORY` nodes for parsing Hall of Fame data from Generation 1 and Generation 2 save files, allowing them to be individually picked up by the `tech_lead` persona.

---
*PR created automatically by Jules for task [5332562365865694036](https://jules.google.com/task/5332562365865694036) started by @szubster*