### PR TITLE
feat: Breakdown PRD for Tailwind v4 utility migration into Epics

### DIFF
--- a/.foundry/epics/epic-071-074-define-tailwind-v4-utilities.md
+++ b/.foundry/epics/epic-071-074-define-tailwind-v4-utilities.md
@@ -1,0 +1,41 @@
+---
+id: epic-071-074-define-tailwind-v4-utilities
+type: EPIC
+title: Define Tailwind v4 Tactical Utilities
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - task-071-150-tailwind-v4-adr
+jules_session_id: null
+pr_number: null
+parent: prd-071-040-tailwind-v4-utilities-migration
+tags:
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Define Tailwind v4 Tactical Utilities
+
+## Objective
+Extract and consolidate common, repetitive Tailwind class patterns used throughout `src/components/` into semantic custom utilities. Define these new primitives using Tailwind v4's native `@utility` directive in `src/index.css`.
+
+## Scope
+1. **Analyze existing codebase**: Identify repetitive tactical styling patterns such as panels with dashed borders, sharp corners (`rounded-none`), monospaced retro text, and specific focus states.
+2. **Define Utilities**: Create corresponding `@utility` definitions in `src/index.css`. Expected primitives include:
+    - `tactical-panel`
+    - `tactical-button`
+    - `tactical-focus`
+    - `tactical-card`
+    - `tactical-input`
+    - `tactical-text` (or equivalent variations)
+3. **Verify Compliance**: Ensure all custom utilities correctly use `@apply` or raw CSS to define the desired baseline "tactical hardware" aesthetic as dictated by ADR 024. Confirm that hover and focus states can be correctly inherited natively through v4's directive structure.
+
+## Acceptance Criteria
+- [ ] Appropriate `@utility` primitives are defined in `src/index.css`.
+- [ ] Tailwind v4 formatting and structure is respected.

--- a/.foundry/epics/epic-071-075-migrate-core-tactical-components.md
+++ b/.foundry/epics/epic-071-075-migrate-core-tactical-components.md
@@ -1,0 +1,45 @@
+---
+id: epic-071-075-migrate-core-tactical-components
+type: EPIC
+title: Migrate Core Tactical Components
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - epic-071-074-define-tailwind-v4-utilities
+jules_session_id: null
+pr_number: null
+parent: prd-071-040-tailwind-v4-utilities-migration
+tags:
+  - styling
+  - refactor
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Migrate Core Tactical Components
+
+## Objective
+Refactor the fundamental tactical UI components within the `src/components/` directory to utilize the new `@utility` classes defined in `src/index.css`.
+
+## Scope
+1. **Target Components**: Focus on foundational, reusable UI building blocks. Examples include, but are not limited to:
+   - `TacticalPanel.tsx`
+   - `TacticalButton.tsx`
+   - `TacticalCard.tsx`
+   - `TacticalInput.tsx`
+   - `TacticalSelect.tsx`
+   - `TacticalBadge.tsx`
+   - `TacticalSegmentedControl.tsx`
+   - `TacticalMultiSelectControl.tsx`
+2. **Refactoring Process**: Replace long strings of repetitive inline Tailwind classes (like `border-dashed`, `rounded-none`, etc.) with their equivalent semantic `tactical-*` classes (e.g., `tactical-panel`, `tactical-button`).
+3. **No Visual Regressions**: Ensure that the migration accurately preserves the pre-existing visual appearance.
+4. **Clean up Specificity and Overrides**: Ensure that any component-specific overrides (like changing padding or colors via props) still function correctly alongside the new base utility classes.
+
+## Acceptance Criteria
+- [ ] Core tactical components are updated to use the new `tactical-*` utilities.
+- [ ] Component aesthetics remain strictly consistent with the tactical hardware style (no visual regressions).
+- [ ] Components pass `pnpm run lint` and `pnpm test`.

--- a/.foundry/epics/epic-071-076-migrate-complex-app-components.md
+++ b/.foundry/epics/epic-071-076-migrate-complex-app-components.md
@@ -1,0 +1,48 @@
+---
+id: epic-071-076-migrate-complex-app-components
+type: EPIC
+title: Migrate Complex Application Components
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - epic-071-075-migrate-core-tactical-components
+jules_session_id: null
+pr_number: null
+parent: prd-071-040-tailwind-v4-utilities-migration
+tags:
+  - styling
+  - refactor
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Migrate Complex Application Components
+
+## Objective
+Refactor the more complex, composite application components and page layouts to utilize the new `@utility` classes, or to swap out raw HTML elements for the newly refactored core `Tactical*` components.
+
+## Scope
+1. **Target Components**: Focus on higher-level components that compose the application UI. Examples include:
+   - `AppLayout.tsx`
+   - `AppHeader.tsx`
+   - `AssistantPanel.tsx`
+   - `PokedexCard.tsx`
+   - `PokedexGrid.tsx`
+   - `PokemonDetails.tsx`
+   - `SearchAndFilters.tsx`
+   - `SettingsModal.tsx`
+   - `SettingsRow.tsx`
+   - Components under `src/components/dag/`, `src/components/pokemon/`, `src/components/run/`, etc.
+2. **Refactoring Process**:
+   - Replace long strings of repetitive inline Tailwind classes with the semantic `tactical-*` classes.
+   - Replace standard HTML elements (e.g., `<button className="border-dashed...">`) with their corresponding core tactical components (e.g., `<TacticalButton>`) where appropriate to reduce code duplication and improve modularity.
+3. **No Visual Regressions**: Ensure that the overarching UI remains visually identical and strictly adheres to the tactical hardware aesthetic.
+
+## Acceptance Criteria
+- [ ] Complex application components and layouts are updated to use the new `tactical-*` utilities or refactored to use the newly updated core `Tactical*` components.
+- [ ] The overall application aesthetic is perfectly preserved without visual regressions.
+- [ ] Components pass `pnpm run lint` and `pnpm test`.

--- a/.foundry/epics/epic-071-077-tailwind-designer-persona.md
+++ b/.foundry/epics/epic-071-077-tailwind-designer-persona.md
@@ -1,0 +1,35 @@
+---
+id: epic-071-077-tailwind-designer-persona
+type: EPIC
+title: Implement Tailwind Designer Persona Ownership
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - task-071-150-tailwind-v4-adr
+jules_session_id: null
+pr_number: null
+parent: prd-071-040-tailwind-v4-utilities-migration
+tags:
+  - styling
+  - agents
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Implement Tailwind Designer Persona Ownership
+
+## Objective
+Establish the `designer` persona (or extend `palette_agent`) as the official owner and maintainer of the Tailwind and styling ecosystem, as recommended in ADR 024.
+
+## Scope
+1. **Persona Prompt/Role Definition**: Update the relevant agent prompts or system configurations to explicitly define the `designer` persona's responsibility for maintaining `src/index.css`, enforcing the tactical hardware aesthetic, and managing custom `@utility` primitives.
+2. **Review Workflows**: Configure the Foundry Orchestrator or GitHub Actions (if applicable) to route styling-heavy PRs or tasks that modify `src/index.css` to this persona for review or implementation.
+3. **Documentation**: Update `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` to formally document this new domain ownership within the multi-agent pipeline.
+
+## Acceptance Criteria
+- [ ] Agent prompts/configurations are updated to assign styling ownership to the `designer` persona.
+- [ ] Relevant documentation is updated to reflect this new responsibility.

--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -43,4 +43,9 @@ DexHelper is transitioning from repetitive inline Tailwind classes to semantic c
 - Migrating generic unrepeated utility classes.
 
 ## Acceptance Criteria
-- [ ] Epics are created to handle the migration in manageable chunks.
+- [x] Epics are created to handle the migration in manageable chunks.
+
+
+- [ ] epic-071-074-define-tailwind-v4-utilities
+- [ ] epic-071-075-migrate-core-tactical-components
+- [ ] epic-071-076-migrate-complex-app-components

--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -49,3 +49,5 @@ DexHelper is transitioning from repetitive inline Tailwind classes to semantic c
 - [ ] epic-071-074-define-tailwind-v4-utilities
 - [ ] epic-071-075-migrate-core-tactical-components
 - [ ] epic-071-076-migrate-complex-app-components
+
+- [ ] epic-071-077-tailwind-designer-persona


### PR DESCRIPTION
This PR introduces the breakdown of PRD `prd-071-040-tailwind-v4-utilities-migration` into granular Epics.

1. **Epic 074**: Define the custom `@utility` primitives in `src/index.css`.
2. **Epic 075**: Migrate core `Tactical*` UI components to use the new utilities.
3. **Epic 076**: Migrate complex application components and page layouts to utilize the updated system.

The parent PRD has been updated to reflect the spawned child Epics in its markdown body without modifying its YAML frontmatter, adhering to strict DAG hierarchical completion policies.

---
*PR created automatically by Jules for task [3415293177128936236](https://jules.google.com/task/3415293177128936236) started by @szubster*