### PR TITLE
Generate PRD for DagDashboard Context Refactor

### DIFF
--- a/.foundry/ideas/idea-074-refactor-dag-dashboard-context.md
+++ b/.foundry/ideas/idea-074-refactor-dag-dashboard-context.md
@@ -22,3 +22,5 @@ Recent implementation attempts (e.g., `task-085-142`) permanently failed because
 
 ## Proposal
 Create a dedicated Epic to properly architect and implement the `DagContext` layer before any further UI dashboard features are added. This foundational work will resolve the friction coders are experiencing and allow the Permanent Failure Dashboard to be completed successfully.
+
+- [ ] .foundry/prds/prd-074-046-dag-context-architecture.md

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -29,3 +29,10 @@ During the conversion of `idea-066-save-file-health-scanner` to a PRD, the PR wa
 
 **Architectural Constraint:**
 In the Foundry architecture, parent generation nodes (like `IDEA` and `PRD`) MUST include references to their generated child nodes as unchecked task checkboxes (`- [ ] <file_path>`) directly in their markdown body. This is a critical signal to the Orchestrator. If the checkbox is omitted or immediately checked, the Orchestrator assumes the parent node has met all its acceptance criteria and prematurely transitions it to `VERIFYING` before the descendant nodes are actually completed. This violates the dependency graph constraints and triggers a rejection.
+
+## Anomaly: Duplicate PRD Node Exists (2026-06-11)
+**Observation:**
+During the generation of `prd-074-046-dag-context-architecture` for `idea-074-refactor-dag-dashboard-context`, it was discovered that an identical PRD (`prd-073-045-refactor-dag-dashboard-context`) already existed, apparently spawned from `idea-073-refactor-dag-dashboard-context`.
+
+**Impact:**
+This duplicate node creation could lead to redundant work being dispatched and confusion within the DAG graph. The Agile Coach should review the system to see why `idea-073` and `idea-074` were created as duplicate entries, and potentially introduce checks to prevent duplicate IDEA generation before they reach the PRD transformation step.

--- a/.foundry/prds/prd-074-046-dag-context-architecture.md
+++ b/.foundry/prds/prd-074-046-dag-context-architecture.md
@@ -1,0 +1,33 @@
+---
+id: prd-074-046-dag-context-architecture
+type: PRD
+title: Refactor DagDashboard to use React Context (ADR 013/017)
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+parent: idea-074-refactor-dag-dashboard-context
+tags:
+  - architecture
+  - ui
+  - dashboard
+rejection_count: 0
+rejection_reason: ''
+---
+
+# Refactor DagDashboard to use React Context (ADR 013/017)
+
+## Overview
+Recent implementation attempts permanently failed because the state was left tightly coupled within `DagDashboard.tsx`. ADR 013 (Kanban Board State Management) and ADR 017 (Permanent Failure Dashboard) require the core DAG data state to be lifted out of the isolated component and into a shared React Context (or global store). This single source of truth will be consumed by multiple views (Graph View, Board View, Permanent Failures).
+
+## Requirements
+- Create a `DagContext` to manage the core DAG data state (nodes, edges).
+- The `DagContext` must be the single source of truth for the DAG data.
+- Refactor the existing React Flow DAG visualizer to consume data from `DagContext`.
+- Ensure the state structure supports future views like the Kanban Board and Permanent Failure Dashboard.
+- Extract `rejection_count` from node frontmatter during data parsing so it is available in the shared context (as per ADR 017).
+
+## Acceptance Criteria
+- [ ] Break down into Epics


### PR DESCRIPTION
This PR transforms `idea-074-refactor-dag-dashboard-context` into a formal PRD node.

It creates `prd-074-046-dag-context-architecture.md` with requirements derived from the idea and architectural decision records 013 (Kanban Board State Management) and 017 (Permanent Failure Dashboard). The parent idea node was updated with a link to the new PRD.

Additionally, an anomaly regarding a duplicate existing PRD was logged into the Product Manager journal for further review by the Agile Coach.

---
*PR created automatically by Jules for task [16827146803144196706](https://jules.google.com/task/16827146803144196706) started by @szubster*