### PR TITLE
feat(foundry): generate Gen 3 Battle Frontier PRD

### DIFF
--- a/.foundry/ideas/idea-074-gen3-battle-frontier-tracker.md
+++ b/.foundry/ideas/idea-074-gen3-battle-frontier-tracker.md
@@ -36,4 +36,5 @@ Leverage DexHelper's programmatic save parsing to extract all Battle Frontier da
 Centralizing highly distributed, endgame state data into a unified, easy-to-read dashboard perfectly aligns with DexHelper's vision as a premium companion app. It removes the friction of in-game navigation and provides hardcore players with a clear, actionable overview of their progress toward one of the most difficult challenges in the entire franchise.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD to outline the technical approach for parsing Frontier data from the Emerald save structure and designing the unified dashboard UI.
+- [x] Product Manager: Convert this idea into a PRD to outline the technical approach for parsing Frontier data from the Emerald save structure and designing the unified dashboard UI.
+- [ ] prd-074-046-gen3-battle-frontier-tracker

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -29,3 +29,6 @@ During the conversion of `idea-066-save-file-health-scanner` to a PRD, the PR wa
 
 **Architectural Constraint:**
 In the Foundry architecture, parent generation nodes (like `IDEA` and `PRD`) MUST include references to their generated child nodes as unchecked task checkboxes (`- [ ] <file_path>`) directly in their markdown body. This is a critical signal to the Orchestrator. If the checkbox is omitted or immediately checked, the Orchestrator assumes the parent node has met all its acceptance criteria and prematurely transitions it to `VERIFYING` before the descendant nodes are actually completed. This violates the dependency graph constraints and triggers a rejection.
+
+## 2026-06-11: Bash Output Truncation Awareness
+When discovering a large number of files or searching for the highest sequence number in a directory with many files (like `.foundry/prds/`), standard bash outputs might be truncated if combined with other output-heavy commands (like `cat`) in the same execution block. This can lead to ungrounded assumptions (e.g., guessing the next sequence number). It is essential to run critical discovery commands (like `ls -1 | sort | tail`) in isolation or pipe them safely to ensure complete data retrieval before acting.

--- a/.foundry/prds/prd-074-046-gen3-battle-frontier-tracker.md
+++ b/.foundry/prds/prd-074-046-gen3-battle-frontier-tracker.md
@@ -1,0 +1,61 @@
+---
+id: prd-074-046-gen3-battle-frontier-tracker
+type: PRD
+title: Gen 3 Battle Frontier Dashboard
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-074-gen3-battle-frontier-tracker
+tags:
+  - feature
+  - gen3
+  - endgame
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Gen 3 Battle Frontier Dashboard
+
+## Context
+As outlined in `idea-074-gen3-battle-frontier-tracker`, players of Generation 3 (specifically Emerald) need a unified way to track their progress in the Battle Frontier. Checking the in-game Frontier Pass or visiting NPCs for all 7 facilities is tedious. DexHelper will leverage programmatic save parsing to aggregate win streaks, records, Battle Points (BP), and Frontier Symbols (Silver/Gold) into a single dashboard.
+
+## Requirements
+
+### 1. Data Extraction (Gen 3 Save Parsing)
+- **Save Parser Integration**: Extend the Gen 3 save parser to extract Battle Frontier data.
+- **Facilities**: Extract data for all 7 facilities:
+  - Battle Tower
+  - Battle Factory
+  - Battle Arena
+  - Battle Dome
+  - Battle Palace
+  - Battle Pike
+  - Battle Pyramid
+- **Data Points per Facility**:
+  - Current win streak
+  - Max (all-time) win streak record
+  - Silver Symbol status (acquired or not)
+  - Gold Symbol status (acquired or not)
+- **Global Data**:
+  - Current Battle Points (BP) total.
+- **Data Constraints**: Ensure data is parsed correctly via `DataView` as per ADR 010 to prevent crashes on out-of-bounds reads. Identify the exact byte offsets in the Emerald save structure for this data. (A research node may be required for the offsets).
+
+### 2. Dashboard UI
+- **Unified Status View**: Create a new UI component (`BattleFrontierDashboard`) to display the data.
+- **Facility Cards**: Display a card or row for each of the 7 facilities, clearly showing the current streak, max record, and symbol status.
+- **BP Wallet**: Prominently display the player's total BP.
+- **Progress Visuals**: Visually highlight progress towards the next Frontier Brain encounter. For example, if the Silver Symbol is acquired at a streak of 21, show a progress bar or text like "7 more wins until Silver Symbol".
+- **Aesthetic**: The UI must adhere to the "tactical hardware/snooping" aesthetic (ADR 008, ADR 024) with sharp edges, dashed borders, and monospaced fonts (`tactical-panel`, `tactical-text`, etc.).
+
+### 3. Data Integration
+- Connect the extracted save data to the new Dashboard UI.
+- Ensure the dashboard updates dynamically when a new save file is uploaded or synced (ADR 016).
+
+## Acceptance Criteria
+- [ ] Epic Planner: Break down this PRD into Epics. Epics should cover Data Parsing (and potentially research for offsets), Dashboard UI creation, and Data Integration.


### PR DESCRIPTION
This PR fulfills the Product Manager's responsibility to transform the Gen 3 Battle Frontier Tracker IDEA into a structured PRD.

Changes:
1. Created `.foundry/prds/prd-074-046-gen3-battle-frontier-tracker.md` to define the requirements for extracting the 7 Battle Frontier facilities data (streaks, records, symbols) and BP from the Gen 3 save file, and visualizing it in a unified dashboard.
2. Updated the parent IDEA node (`idea-074-gen3-battle-frontier-tracker`) to include the unchecked `- [ ]` reference to the new PRD and checked off the initial acceptance criteria.
3. Verified project state using `pnpm lint`, `pnpm test`, and the Foundry Orchestrator dry-run (`node --experimental-strip-types .github/scripts/foundry-orchestrator.ts --dry-run --strict`), confirming no circular dependencies or malformed nodes were introduced.

---
*PR created automatically by Jules for task [3672308030394080779](https://jules.google.com/task/3672308030394080779) started by @szubster*