### PR TITLE
Draft Technical Blueprints for Gen 2 Exclusive Moves Check

### DIFF
--- a/.foundry/stories/story-051-089-gen2-exclusive-moves.md
+++ b/.foundry/stories/story-051-089-gen2-exclusive-moves.md
@@ -29,3 +29,7 @@ Implement the logic to cross-reference the Pokémon's current 4 moves against th
 
 ## Scope
 - Create a utility to check move IDs to determine if any are Generation 2 exclusive.
+
+## Implementation Tasks
+- [ ] task-089-163-gen2-exclusive-moves-impl
+- [ ] task-089-164-gen2-exclusive-moves-qa

--- a/.foundry/tasks/task-089-163-gen2-exclusive-moves-impl.md
+++ b/.foundry/tasks/task-089-163-gen2-exclusive-moves-impl.md
@@ -1,0 +1,47 @@
+---
+id: task-089-163-gen2-exclusive-moves-impl
+type: TASK
+title: Implement Gen 2 exclusive moves check
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-051-089-gen2-exclusive-moves
+tags:
+  - feature
+  - gen2
+  - trade
+  - tool
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 2 exclusive moves check
+
+## Objective
+Implement a utility function to determine if any of a Pokémon's 4 moves are Generation 2 exclusive.
+
+## Contract
+- Create a utility function (e.g., `hasGen2ExclusiveMove(moves: number[])`) that takes an array of move IDs and returns a boolean.
+- Generation 1 moves are IDs 1 through 165 inclusive.
+- Generation 2 introduced new moves starting from ID 166. A move is Generation 2 exclusive if its ID is greater than 165.
+- The function should return `true` if any move in the provided array is a Gen 2 exclusive move.
+- Empty slots (often represented by move ID `0`) should be ignored and not considered Gen 2 exclusive.
+- Write unit tests for this function, ensuring it handles edge cases (e.g., empty arrays, move ID `0`, boundary IDs like `165` and `166`).
+- Do not modify architectural constraints (ADR 001).
+- Ensure any missing types or type errors are corrected, and `pnpm type-check` passes.
+- Run `pnpm test` to verify the tests pass.
+
+## Notes for Coder
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Utility function implemented.
+- [ ] Unit tests pass.
+- [ ] `pnpm type-check` passes.

--- a/.foundry/tasks/task-089-164-gen2-exclusive-moves-qa.md
+++ b/.foundry/tasks/task-089-164-gen2-exclusive-moves-qa.md
@@ -1,0 +1,45 @@
+---
+id: task-089-164-gen2-exclusive-moves-qa
+type: TASK
+title: QA Gen 2 exclusive moves check
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on:
+  - task-089-163-gen2-exclusive-moves-impl
+jules_session_id: null
+pr_number: null
+parent: story-051-089-gen2-exclusive-moves
+tags:
+  - feature
+  - gen2
+  - trade
+  - tool
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 2 exclusive moves check
+
+## Objective
+Verify the implementation of the Gen 2 exclusive moves check utility.
+
+## Contract
+- Verify that a utility function exists to check if any moves in an array are Generation 2 exclusive.
+- Confirm the logic correctly identifies Generation 1 moves (IDs 1-165) as NOT Gen 2 exclusive.
+- Confirm the logic correctly identifies Generation 2 moves (IDs > 165) as Gen 2 exclusive.
+- Confirm move ID `0` is ignored.
+- Review the unit tests for comprehensiveness (edge cases, boundaries).
+- Ensure `pnpm lint` and `pnpm test` pass.
+
+## Notes for QA
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Utility function verified.
+- [ ] Logic correctly distinguishes Gen 1 and Gen 2 moves based on ID threshold (165).
+- [ ] Tests comprehensively cover functionality.


### PR DESCRIPTION
This PR scaffolds the technical blueprints required to determine if a Pokémon's 4 moves are Generation 2 exclusive.

- Creates `task-089-163-gen2-exclusive-moves-impl.md`
- Creates `task-089-164-gen2-exclusive-moves-qa.md`
- Appends unchecked checklist references to the parent `story-051-089-gen2-exclusive-moves.md` markdown body.
- Adheres to the strict `depends_on` schema rules (no relative path or extensions) and guarantees the DAG graph remains intact and deadlock-free.

---
*PR created automatically by Jules for task [2044040157066764004](https://jules.google.com/task/2044040157066764004) started by @szubster*