### PR TITLE
chore: breakdown epic-071-074 into stories

### DIFF
--- a/.foundry/epics/epic-071-074-define-tailwind-v4-utilities.md
+++ b/.foundry/epics/epic-071-074-define-tailwind-v4-utilities.md
@@ -39,3 +39,8 @@ Extract and consolidate common, repetitive Tailwind class patterns used througho
 ## Acceptance Criteria
 - [ ] Appropriate `@utility` primitives are defined in `src/index.css`.
 - [ ] Tailwind v4 formatting and structure is respected.
+
+### Generated Stories
+- [ ] story-074-113-define-tactical-panel-and-card
+- [ ] story-074-114-define-tactical-button-and-focus
+- [ ] story-074-115-define-tactical-input-and-text

--- a/.foundry/stories/story-074-113-define-tactical-panel-and-card.md
+++ b/.foundry/stories/story-074-113-define-tactical-panel-and-card.md
@@ -1,0 +1,34 @@
+---
+id: story-074-113-define-tactical-panel-and-card
+type: STORY
+title: Define tactical-panel and tactical-card utilities
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-071-074-define-tailwind-v4-utilities
+tags:
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Define tactical-panel and tactical-card utilities
+
+## Objective
+Extract and consolidate common, repetitive Tailwind class patterns used for panels and cards throughout `src/components/` into semantic custom utilities using Tailwind v4's native `@utility` directive in `src/index.css`.
+
+## Scope
+1. **Analyze existing codebase**: Identify repetitive tactical styling patterns for panels and cards (e.g., dashed borders, sharp corners, dark backgrounds).
+2. **Define Utilities**: Create `@utility tactical-panel` and `@utility tactical-card` in `src/index.css`.
+3. **Verify Compliance**: Ensure custom utilities correctly use `@apply` or raw CSS to define the desired baseline "tactical hardware" aesthetic as dictated by ADR 024. Ensure hover and focus states can be correctly inherited natively through v4's directive structure.
+
+## Acceptance Criteria
+- [ ] Appropriate `@utility tactical-panel` and `@utility tactical-card` primitives are defined in `src/index.css`.
+- [ ] Tailwind v4 formatting and structure is respected.

--- a/.foundry/stories/story-074-114-define-tactical-button-and-focus.md
+++ b/.foundry/stories/story-074-114-define-tactical-button-and-focus.md
@@ -1,0 +1,34 @@
+---
+id: story-074-114-define-tactical-button-and-focus
+type: STORY
+title: Define tactical-button and tactical-focus utilities
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-071-074-define-tailwind-v4-utilities
+tags:
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Define tactical-button and tactical-focus utilities
+
+## Objective
+Extract and consolidate common, repetitive Tailwind class patterns used for buttons and focus states throughout `src/components/` into semantic custom utilities using Tailwind v4's native `@utility` directive in `src/index.css`.
+
+## Scope
+1. **Analyze existing codebase**: Identify repetitive tactical styling patterns for buttons and focus outlines (e.g., specific colors, focus rings).
+2. **Define Utilities**: Create `@utility tactical-button` and `@utility tactical-focus` in `src/index.css`.
+3. **Verify Compliance**: Ensure custom utilities correctly use `@apply` or raw CSS to define the desired baseline "tactical hardware" aesthetic as dictated by ADR 024. Ensure hover and focus states can be correctly inherited natively through v4's directive structure.
+
+## Acceptance Criteria
+- [ ] Appropriate `@utility tactical-button` and `@utility tactical-focus` primitives are defined in `src/index.css`.
+- [ ] Tailwind v4 formatting and structure is respected.

--- a/.foundry/stories/story-074-115-define-tactical-input-and-text.md
+++ b/.foundry/stories/story-074-115-define-tactical-input-and-text.md
@@ -1,0 +1,34 @@
+---
+id: story-074-115-define-tactical-input-and-text
+type: STORY
+title: Define tactical-input and tactical-text utilities
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-071-074-define-tailwind-v4-utilities
+tags:
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Define tactical-input and tactical-text utilities
+
+## Objective
+Extract and consolidate common, repetitive Tailwind class patterns used for inputs and text throughout `src/components/` into semantic custom utilities using Tailwind v4's native `@utility` directive in `src/index.css`.
+
+## Scope
+1. **Analyze existing codebase**: Identify repetitive tactical styling patterns for text and input fields (e.g., monospaced fonts, specific colors).
+2. **Define Utilities**: Create `@utility tactical-input` and `@utility tactical-text` (or equivalent variations) in `src/index.css`.
+3. **Verify Compliance**: Ensure custom utilities correctly use `@apply` or raw CSS to define the desired baseline "tactical hardware" aesthetic as dictated by ADR 024. Ensure hover and focus states can be correctly inherited natively through v4's directive structure.
+
+## Acceptance Criteria
+- [ ] Appropriate `@utility tactical-input` and `@utility tactical-text` primitives are defined in `src/index.css`.
+- [ ] Tailwind v4 formatting and structure is respected.


### PR DESCRIPTION
This PR breaks down the `epic-071-074-define-tailwind-v4-utilities` node into three smaller, actionable STORY nodes.
- `story-074-113-define-tactical-panel-and-card`
- `story-074-114-define-tactical-button-and-focus`
- `story-074-115-define-tactical-input-and-text`

The newly generated stories are correctly assigned to the `tech_lead` owner persona, and are linked back to the Epic without checking off the Epic's acceptance criteria, avoiding DAG progression issues.

---
*PR created automatically by Jules for task [5948978297496924844](https://jules.google.com/task/5948978297496924844) started by @szubster*