### PR TITLE
Break down PRD 074-046 into Epics

### DIFF
--- a/.foundry/epics/epic-046-078-shared-dag-context-foundation.md
+++ b/.foundry/epics/epic-046-078-shared-dag-context-foundation.md
@@ -1,0 +1,31 @@
+---
+id: epic-046-078-shared-dag-context-foundation
+type: EPIC
+title: Shared DagContext Foundation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-074-046-dag-context-architecture
+tags:
+  - architecture
+  - dashboard
+  - state-management
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Shared DagContext Foundation
+
+## Objective
+Implement the core `DagContext` and refactor the data parsing layer to extract `rejection_count` (ADR 017) and provide the single source of truth for DAG data (ADR 013).
+
+## Context
+As required by PRD `prd-074-046-dag-context-architecture`, we need to extract the DAG parsing and state management out of individual visualization components. This epic focuses on the foundation: parsing the `.foundry` files correctly to include `rejection_count` and establishing the `DagContext` React Context to host this state globally.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-046-079-react-flow-visualizer-refactor.md
+++ b/.foundry/epics/epic-046-079-react-flow-visualizer-refactor.md
@@ -1,0 +1,32 @@
+---
+id: epic-046-079-react-flow-visualizer-refactor
+type: EPIC
+title: React Flow Visualizer Refactor
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - epic-046-078-shared-dag-context-foundation
+jules_session_id: null
+pr_number: null
+parent: prd-074-046-dag-context-architecture
+tags:
+  - architecture
+  - dashboard
+  - react-flow
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# React Flow Visualizer Refactor
+
+## Objective
+Refactor the existing React Flow DAG visualizer to consume its nodes and edges strictly from the new `DagContext` instead of managing its own internal data fetching state.
+
+## Context
+As part of the architecture defined in PRD `prd-074-046-dag-context-architecture` and ADR 013, the React Flow visualization should no longer directly parse or maintain its own node state. It must be refactored to consume the unified DAG data from the `DagContext` built in epic `epic-046-078-shared-dag-context-foundation`.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/prds/prd-074-046-dag-context-architecture.md
+++ b/.foundry/prds/prd-074-046-dag-context-architecture.md
@@ -30,4 +30,6 @@ Recent implementation attempts permanently failed because the state was left tig
 - Extract `rejection_count` from node frontmatter during data parsing so it is available in the shared context (as per ADR 017).
 
 ## Acceptance Criteria
-- [ ] Break down into Epics
+- [x] Break down into Epics
+- [ ] epic-046-078-shared-dag-context-foundation
+- [ ] epic-046-079-react-flow-visualizer-refactor


### PR DESCRIPTION
This PR fulfills the Epic Planner responsibilities for `prd-074-046-dag-context-architecture`.

It generates two new Epic nodes:
1. `epic-046-078-shared-dag-context-foundation`
2. `epic-046-079-react-flow-visualizer-refactor`

The parent PRD has been updated to include these child nodes as unchecked acceptance criteria without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [14353729922279820758](https://jules.google.com/task/14353729922279820758) started by @szubster*