### PR TITLE
docs: Break down Gen 3 Battle Frontier PRD into Epics

### DIFF
--- a/.foundry/epics/epic-046-078-gen3-battle-frontier-data-extraction.md
+++ b/.foundry/epics/epic-046-078-gen3-battle-frontier-data-extraction.md
@@ -1,0 +1,33 @@
+---
+id: epic-046-078-gen3-battle-frontier-data-extraction
+type: EPIC
+title: Gen 3 Battle Frontier Data Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - research-046-140-gen3-battle-frontier
+jules_session_id: null
+pr_number: null
+parent: prd-074-046-gen3-battle-frontier-tracker
+tags:
+  - feature
+  - gen3
+  - endgame
+research_references:
+  - .foundry/research/research-046-140-gen3-battle-frontier.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Gen 3 Battle Frontier Data Extraction
+
+## Description
+Extend the Gen 3 save parser to extract Battle Frontier data using the offsets discovered in the research phase. It must strictly use the `DataView` API as per ADR 010.
+
+## Acceptance Criteria
+- [ ] Parse win streaks, max records, and symbol status for all 7 facilities.
+- [ ] Parse total BP.
+- [ ] Handle out-of-bounds reads gracefully via `DataView`.

--- a/.foundry/epics/epic-046-079-gen3-battle-frontier-dashboard-ui.md
+++ b/.foundry/epics/epic-046-079-gen3-battle-frontier-dashboard-ui.md
@@ -1,0 +1,32 @@
+---
+id: epic-046-079-gen3-battle-frontier-dashboard-ui
+type: EPIC
+title: Gen 3 Battle Frontier Dashboard UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-074-046-gen3-battle-frontier-tracker
+tags:
+  - feature
+  - gen3
+  - endgame
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Gen 3 Battle Frontier Dashboard UI
+
+## Description
+Create the `BattleFrontierDashboard` UI component. It must adhere to the "tactical hardware/snooping" aesthetic, displaying facility cards, BP wallet, and progress visuals.
+
+## Acceptance Criteria
+- [ ] Create UI for the 7 facilities.
+- [ ] Create BP wallet display.
+- [ ] Create progress visuals towards the next Frontier Brain encounter.
+- [ ] Apply tactical styling (ADR 008, ADR 024).

--- a/.foundry/epics/epic-046-080-gen3-battle-frontier-data-integration.md
+++ b/.foundry/epics/epic-046-080-gen3-battle-frontier-data-integration.md
@@ -1,0 +1,32 @@
+---
+id: epic-046-080-gen3-battle-frontier-data-integration
+type: EPIC
+title: Gen 3 Battle Frontier Data Integration
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - epic-046-078-gen3-battle-frontier-data-extraction
+  - epic-046-079-gen3-battle-frontier-dashboard-ui
+jules_session_id: null
+pr_number: null
+parent: prd-074-046-gen3-battle-frontier-tracker
+tags:
+  - feature
+  - gen3
+  - endgame
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Gen 3 Battle Frontier Data Integration
+
+## Description
+Connect the extracted save data to the new Dashboard UI, ensuring dynamic updates when a new save file is uploaded or synced (ADR 016).
+
+## Acceptance Criteria
+- [ ] Wire parsed Battle Frontier data to the `BattleFrontierDashboard`.
+- [ ] Ensure data syncs correctly on save file upload.

--- a/.foundry/prds/prd-074-046-gen3-battle-frontier-tracker.md
+++ b/.foundry/prds/prd-074-046-gen3-battle-frontier-tracker.md
@@ -58,4 +58,8 @@ As outlined in `idea-074-gen3-battle-frontier-tracker`, players of Generation 3 
 - Ensure the dashboard updates dynamically when a new save file is uploaded or synced (ADR 016).
 
 ## Acceptance Criteria
-- [ ] Epic Planner: Break down this PRD into Epics. Epics should cover Data Parsing (and potentially research for offsets), Dashboard UI creation, and Data Integration.
+- [x] Epic Planner: Break down this PRD into Epics. Epics should cover Data Parsing (and potentially research for offsets), Dashboard UI creation, and Data Integration.
+- [ ] research-046-140-gen3-battle-frontier
+- [ ] epic-046-078-gen3-battle-frontier-data-extraction
+- [ ] epic-046-079-gen3-battle-frontier-dashboard-ui
+- [ ] epic-046-080-gen3-battle-frontier-data-integration

--- a/.foundry/research/research-046-140-gen3-battle-frontier.md
+++ b/.foundry/research/research-046-140-gen3-battle-frontier.md
@@ -1,0 +1,37 @@
+---
+id: research-046-140-gen3-battle-frontier
+type: RESEARCH
+title: Gen 3 Battle Frontier Offset Research
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-074-046-gen3-battle-frontier-tracker
+tags:
+  - research
+  - gen3
+  - endgame
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Gen 3 Battle Frontier Offsets
+
+## Context
+Since the exact memory offsets and byte structures for the Battle Frontier data (win streaks, max records, Silver/Gold symbol status, BP) are missing, we need to spawn a `RESEARCH` node to investigate and document them. This adheres to the Groundedness Rule for Data Assumptions. The findings will be used by downstream data extraction tasks.
+
+## Requirements
+We need to find the exact save file structure and offsets for:
+- Current win streaks for all 7 facilities
+- Max win records for all 7 facilities
+- Silver/Gold symbol status for all 7 facilities
+- Total Battle Points (BP)
+
+## Acceptance Criteria
+- [ ] Extract all required offsets for the 7 facilities and BP.
+- [ ] Document the offsets in this research markdown file.


### PR DESCRIPTION
This PR breaks down the `prd-074-046-gen3-battle-frontier-tracker` PRD into its constituent Epic nodes, mapping their dependencies to create a logical implementation sequence for the new Gen 3 Battle Frontier Dashboard. A prerequisite Research node was also generated to safely identify save parsing byte offsets before implementation.

### Changes
- **New Nodes:**
  - `research-046-140-gen3-battle-frontier.md`
  - `epic-046-078-gen3-battle-frontier-data-extraction.md`
  - `epic-046-079-gen3-battle-frontier-dashboard-ui.md`
  - `epic-046-080-gen3-battle-frontier-data-integration.md`
- **Updated:**
  - `prd-074-046-gen3-battle-frontier-tracker.md` (checked off criteria, appended children)

---
*PR created automatically by Jules for task [16658035023970796916](https://jules.google.com/task/16658035023970796916) started by @szubster*