### PR TITLE
feat: create technical blueprint tasks for Gen 2 HoF parsing

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -49,3 +49,7 @@ All new Gen 3 Sheen data parsing logic MUST exclusively use the native `DataView
 
 ## Consequences
 Prevents silent failures and ensures backwards compatibility.
+## 2026-06-11: Reliable Offsets via Anchors (Gen 2 Hall of Fame)
+
+- **Observation**: Standard documentation often lists Hall of Fame counts at fixed absolute offsets (e.g. `0x24EC` for GS). However, relying on these can be unreliable due to emulator artifacts or regional shifts, causing task failures.
+- **Action**: When drafting tasks for parsing variable save data, enforce the use of relative offsets based on known, stable anchor points within the player data block. For example, explicitly mapping the Hall of Fame count to `johtoBadgesOffset + 0xA8` ensures cross-version stability and prevents rigid absolute offset failures.

--- a/.foundry/stories/story-070-112-parse-gen2-hof-data.md
+++ b/.foundry/stories/story-070-112-parse-gen2-hof-data.md
@@ -32,4 +32,7 @@ Implement logic to extract the Hall of Fame data and count from Generation 2 (Go
 - Parse the value at `johtoBadgesOffset + 0xA8` as an 8-bit unsigned integer.
 
 ## Acceptance Criteria
-- [ ] Create task to implement parsing for Gen 2 Hall of Fame.
+- [x] Create task to implement parsing for Gen 2 Hall of Fame.
+
+- [ ] task-112-165-implement-gen2-hof-parsing
+- [ ] task-112-166-qa-gen2-hof-parsing

--- a/.foundry/tasks/task-112-165-implement-gen2-hof-parsing.md
+++ b/.foundry/tasks/task-112-165-implement-gen2-hof-parsing.md
@@ -1,0 +1,46 @@
+---
+id: task-112-165-implement-gen2-hof-parsing
+type: TASK
+title: Implement Gen 2 Hall of Fame Parsing
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-070-112-parse-gen2-hof-data
+tags:
+  - parsing
+  - hall-of-fame
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 2 Hall of Fame Parsing
+
+## Context
+As part of the social sharing utility expansion, we need to extract the Hall of Fame records from Gen 2 save files (Gold, Silver, Crystal). The core requirement is to parse the Hall of Fame count gracefully.
+
+## Technical Requirements
+- **Offset Logic**: The Hall of Fame count in Gen 2 is determined using a relative offset based on the `johtoBadgesOffset`.
+  - The `johtoBadgesOffset` is `0x23E5` for Crystal and `0x23E4` for Gold/Silver.
+  - The exact offset for the Hall of Fame count is calculated as `johtoBadgesOffset + 0xA8` (168 bytes after).
+- **Data Type**: Parse the value at this specific offset as a single 8-bit unsigned integer (`getUint8`).
+- **Engine Policy**: Ensure parsing leverages the `DataView` API.
+
+## References
+- `.foundry/docs/adrs/adr-044-021-hof-data-parsing-architecture.md`
+- `.foundry/docs/knowledge_base/engine/save_parsing/gen2_hall_of_fame.md`
+
+## Acceptance Criteria
+- [ ] Parsing logic correctly calculates the offset relative to `johtoBadgesOffset`.
+- [ ] Logic correctly extracts the 8-bit unsigned integer count.
+- [ ] Unit tests are added to verify the extraction logic specifically for Gen 2.
+
+> **IMPORTANT REMINDER**:
+> - If you permanently fail or abort this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+> - If you submit an Empty PR (e.g., target artifacts are already complete), you MUST explicitly check off all Acceptance Criteria checkboxes (`- [x]`) in this markdown file before submitting to satisfy the strict completeness contract (ADR 007).

--- a/.foundry/tasks/task-112-166-qa-gen2-hof-parsing.md
+++ b/.foundry/tasks/task-112-166-qa-gen2-hof-parsing.md
@@ -1,0 +1,42 @@
+---
+id: task-112-166-qa-gen2-hof-parsing
+type: TASK
+title: QA Gen 2 Hall of Fame Parsing
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-11'
+updated_at: '2026-06-11'
+depends_on:
+  - task-112-165-implement-gen2-hof-parsing
+jules_session_id: null
+pr_number: null
+parent: story-070-112-parse-gen2-hof-data
+tags:
+  - qa
+  - parsing
+  - hall-of-fame
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 2 Hall of Fame Parsing
+
+## Context
+A coder has implemented the parsing logic for extracting the Hall of Fame count from Gen 2 save files. The core requirement is that the extraction uses a relative offset of `0xA8` after the `johtoBadgesOffset`. This task is to verify the correctness of that implementation.
+
+## Validation Requirements
+- Verify that the parsing logic calculates the Hall of Fame count offset strictly using the `johtoBadgesOffset` plus `0xA8` (168).
+- Ensure that the value extracted is an 8-bit unsigned integer.
+- Confirm that unit tests adequately cover this specific Gen 2 parsing logic.
+
+## Acceptance Criteria
+- [ ] Code properly calculates the relative offset.
+- [ ] Code extracts the unsigned 8-bit integer.
+- [ ] Unit tests pass and provide sufficient coverage.
+
+> **IMPORTANT REMINDER**:
+> - If you permanently fail or abort this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+> - If you submit an Empty PR (e.g., target artifacts are already complete), you MUST explicitly check off all Acceptance Criteria checkboxes (`- [x]`) in this markdown file before submitting to satisfy the strict completeness contract (ADR 007).


### PR DESCRIPTION
Drafted technical task nodes for the Coder (`task-112-165`) and QA (`task-112-166`) to implement and verify the parsing of Gen 2 Hall of Fame data, according to the relative offset rules established in ADR-044-021.
Updated the parent story node (`story-070-112`) with references to the new child tasks and checked off its generation criteria.
Added a note to the Tech Lead journal highlighting the importance of using anchor-relative offsets for Game Boy saves rather than absolute ones to improve robustness.

---
*PR created automatically by Jules for task [2297758788653275586](https://jules.google.com/task/2297758788653275586) started by @szubster*