### PR TITLE
Mark QA Pokemon ID and DV Bounds Verification task as completed

### DIFF
--- a/.foundry/tasks/task-093-158-pokemon-bounds-verification-qa.md
+++ b/.foundry/tasks/task-093-158-pokemon-bounds-verification-qa.md
@@ -36,7 +36,7 @@ Verify the implementation of Pokemon ID and DV bounds verification. Ensure that 
 *   Add any missing QA integration or E2E tests, or manual verification notes to ensure coverage.
 
 ## Acceptance Criteria
-- [ ] QA passed: Models correctly outputted and bounds properly validated.
+- [x] QA passed: Models correctly outputted and bounds properly validated.
 
 ## Reminders
 *   If you permanently fail or abort this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.


### PR DESCRIPTION
This PR marks the QA task `task-093-158-pokemon-bounds-verification-qa` as completed. The implementation of Pokemon ID and DV bounds verification was verified successfully using the existing test suite, and the Acceptance Criteria checkbox was ticked accordingly.

---
*PR created automatically by Jules for task [10652216118835407400](https://jules.google.com/task/10652216118835407400) started by @szubster*