### PR TITLE
feat: implement Gen 2 exclusive moves check utility

### DIFF
--- a/.foundry/tasks/task-089-163-gen2-exclusive-moves-impl.md
+++ b/.foundry/tasks/task-089-163-gen2-exclusive-moves-impl.md
@@ -42,6 +42,6 @@ Implement a utility function to determine if any of a Pokémon's 4 moves are Gen
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Utility function implemented.
-- [ ] Unit tests pass.
-- [ ] `pnpm type-check` passes.
+- [x] Utility function implemented.
+- [x] Unit tests pass.
+- [x] `pnpm type-check` passes.

--- a/src/engine/moves/__tests__/gen2Moves.test.ts
+++ b/src/engine/moves/__tests__/gen2Moves.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { hasGen2ExclusiveMove } from '../gen2Moves';
+
+describe('hasGen2ExclusiveMove', () => {
+  it('should return false for an empty array', () => {
+    expect(hasGen2ExclusiveMove([])).toBe(false);
+  });
+
+  it('should return false for an array with all zeros', () => {
+    expect(hasGen2ExclusiveMove([0, 0, 0, 0])).toBe(false);
+  });
+
+  it('should return false for an array with only Gen 1 moves', () => {
+    expect(hasGen2ExclusiveMove([1, 50, 100, 165])).toBe(false);
+  });
+
+  it('should return true for an array with Gen 2 moves', () => {
+    expect(hasGen2ExclusiveMove([166, 200, 250, 251])).toBe(true);
+  });
+
+  it('should return true for an array with a mix of Gen 1 and Gen 2 moves', () => {
+    expect(hasGen2ExclusiveMove([1, 165, 0, 166])).toBe(true);
+  });
+
+  it('should return false for boundary condition (165 is Gen 1)', () => {
+    expect(hasGen2ExclusiveMove([165])).toBe(false);
+  });
+
+  it('should return true for boundary condition (166 is Gen 2)', () => {
+    expect(hasGen2ExclusiveMove([166])).toBe(true);
+  });
+
+  it('should handle undefined or null gracefully', () => {
+    // @ts-expect-error Testing invalid input
+    expect(hasGen2ExclusiveMove(undefined)).toBe(false);
+    // @ts-expect-error Testing invalid input
+    expect(hasGen2ExclusiveMove(null)).toBe(false);
+  });
+});

--- a/src/engine/moves/gen2Moves.ts
+++ b/src/engine/moves/gen2Moves.ts
@@ -1,0 +1,7 @@
+export function hasGen2ExclusiveMove(moves: number[]): boolean {
+  if (!moves || moves.length === 0) {
+    return false;
+  }
+
+  return moves.some((moveId) => moveId > 165);
+}


### PR DESCRIPTION
Fixes task-089-163-gen2-exclusive-moves-impl.

Implemented the `hasGen2ExclusiveMove` utility function which takes an array of move IDs and checks if any move is greater than 165, ignoring empty slots. Comprehensive unit tests are included.

---
*PR created automatically by Jules for task [12626021209880016295](https://jules.google.com/task/12626021209880016295) started by @szubster*