### PR TITLE
docs: mark gen 1 checksum QA as complete

### DIFF
--- a/.foundry/tasks/task-091-156-gen1-checksum-qa.md
+++ b/.foundry/tasks/task-091-156-gen1-checksum-qa.md
@@ -34,9 +34,9 @@ The Coder has implemented the Generation 1 checksum validation logic. As QA, you
 * Verify that diagnostic models are returned correctly on mismatch.
 
 ## Acceptance Criteria
-- [ ] Validate the checksum calculation logic against known good values.
-- [ ] Validate the correct diagnostic models are returned for checksum mismatches.
-- [ ] Ensure adequate test coverage.
+- [x] Validate the checksum calculation logic against known good values.
+- [x] Validate the correct diagnostic models are returned for checksum mismatches.
+- [x] Ensure adequate test coverage.
 
 ## Reminders
 * If you permanently fail or abort this task, you MUST update the YAML frontmatter to status: FAILED or status: CANCELLED with a rejection_reason.


### PR DESCRIPTION
This empty PR formally transitions `task-091-156-gen1-checksum-qa` to COMPLETED, signifying successful QA validation of the Gen 1 checksum implementation (`task-091-155-gen1-checksum-impl`). The acceptance criteria checkboxes have been updated to reflect this completion.

---
*PR created automatically by Jules for task [12661218676157828777](https://jules.google.com/task/12661218676157828777) started by @szubster*