### PR TITLE
chore(qa): Complete Gen 3 Hidden Item Event Flags Parsing QA

### DIFF
--- a/.foundry/tasks/task-097-158-gen3-hidden-item-parsing-qa.md
+++ b/.foundry/tasks/task-097-158-gen3-hidden-item-parsing-qa.md
@@ -34,10 +34,10 @@ This QA task verifies the coder's implementation for Gen 3 hidden item parsing (
 4. **Verify Test Coverage**: Check the Gen 3 save parser unit tests. They must provide adequate mock data reflecting the Gen 3 save format and assert that `hiddenItemFlags` are extracted properly with the correct byte values. Tests must pass successfully.
 
 ## Acceptance Criteria
-- [ ] Code strictly adheres to ADR 010 (`DataView` API usage).
-- [ ] Out-of-bounds `DataView` accesses are handled gracefully.
-- [ ] Gen 3 section parsing logic accurately targets and extracts the hidden item flags.
-- [ ] Unit tests for Gen 3 hidden item parsing exist, provide sufficient coverage, and pass.
+- [x] Code strictly adheres to ADR 010 (`DataView` API usage).
+- [x] Out-of-bounds `DataView` accesses are handled gracefully.
+- [x] Gen 3 section parsing logic accurately targets and extracts the hidden item flags.
+- [x] Unit tests for Gen 3 hidden item parsing exist, provide sufficient coverage, and pass.
 
 ## IMPORTANT REMINDERS
 - **If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.**


### PR DESCRIPTION
This PR marks the `task-097-158-gen3-hidden-item-parsing-qa` as completed by checking off the acceptance criteria after verifying that the Gen 3 parser correctly utilizes the `DataView` API and successfully extracts the hidden item flags. Tested via `pnpm lint && pnpm test`.

---
*PR created automatically by Jules for task [5684633099217674844](https://jules.google.com/task/5684633099217674844) started by @szubster*