### PR TITLE
chore: QA verification for Gen3 32-bit PV parsing

### DIFF
--- a/.foundry/tasks/task-098-158-gen3-parse-pv-qa.md
+++ b/.foundry/tasks/task-098-158-gen3-parse-pv-qa.md
@@ -33,6 +33,6 @@ As part of the Mirage Island checking feature (Epic `epic-038-062-personality-va
 4. **Important for QA**: If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verify `DataView` parsing logic correctly extracts Gen 3 PV.
-- [ ] Verify `RangeError` is properly caught and handled for out-of-bounds reads.
-- [ ] Verify Gen 1 and Gen 2 handlers remain functional and are not altered.
+- [x] Verify `DataView` parsing logic correctly extracts Gen 3 PV.
+- [x] Verify `RangeError` is properly caught and handled for out-of-bounds reads.
+- [x] Verify Gen 1 and Gen 2 handlers remain functional and are not altered.


### PR DESCRIPTION
Checked off the acceptance criteria for the QA task verifying Gen3 32-bit PV parsing.

The implementation successfully uses the native DataView API as specified in ADR 010. It properly handles bounds checking by throwing and catching RangeError. Gen 1 and Gen 2 legacy handlers are untouched and their test coverage remains passing.

---
*PR created automatically by Jules for task [5680546562727182216](https://jules.google.com/task/5680546562727182216) started by @szubster*