### PR TITLE
feat: implement ContestConditionStats component

### DIFF
--- a/.foundry/tasks/task-101-157-contest-condition-stats-ui-impl.md
+++ b/.foundry/tasks/task-101-157-contest-condition-stats-ui-impl.md
@@ -37,6 +37,6 @@ Implement a reusable React component `ContestConditionStats` to display a Pokém
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 4. Acceptance Criteria
-- [ ] Create the `ContestConditionStats` React component.
-- [ ] Add rendering tests for the component.
-- [ ] Ensure the styling strictly follows the project's tactical style guidelines.
+- [x] Create the `ContestConditionStats` React component.
+- [x] Add rendering tests for the component.
+- [x] Ensure the styling strictly follows the project's tactical style guidelines.

--- a/src/components/ContestConditionStats.tsx
+++ b/src/components/ContestConditionStats.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { cn } from '../utils/cn';
+import { TacticalPanel } from './TacticalPanel';
+
+export interface ContestConditionStatsProps extends React.HTMLAttributes<HTMLDivElement> {
+  cool?: number;
+  beauty?: number;
+  cute?: number;
+  smart?: number;
+  tough?: number;
+}
+
+const StatBar = ({
+  label,
+  value,
+  max = 255,
+  colorClass,
+  bgClass,
+}: {
+  label: string;
+  value: number;
+  max?: number;
+  colorClass: string;
+  bgClass: string;
+}) => {
+  const percentage = Math.min(100, Math.max(0, (value / max) * 100));
+
+  return (
+    <div className="flex flex-col gap-1 font-mono text-sm">
+      <div className="flex justify-between text-white/70">
+        <span className="uppercase tracking-wider">{label}</span>
+        <span>{value}</span>
+      </div>
+      <div className={cn('h-3 w-full rounded-none border border-dashed p-[1px]', borderClassMap[colorClass])}>
+        <div
+          className={cn('h-full rounded-none', bgClass)}
+          style={{ width: `${percentage}%` }}
+          data-role="progressbar"
+          data-valuenow={value}
+        />
+      </div>
+    </div>
+  );
+};
+
+const borderClassMap: Record<string, string> = {
+  'bg-red-500': 'border-red-500/50',
+  'bg-blue-500': 'border-blue-500/50',
+  'bg-pink-500': 'border-pink-500/50',
+  'bg-emerald-500': 'border-emerald-500/50',
+  'bg-amber-500': 'border-amber-500/50',
+};
+
+export const ContestConditionStats = React.forwardRef<HTMLDivElement, ContestConditionStatsProps>(
+  ({ cool = 0, beauty = 0, cute = 0, smart = 0, tough = 0, className, ...props }, ref) => {
+    return (
+      <TacticalPanel ref={ref} variant="default" className={cn('flex flex-col gap-4 p-4', className)} {...props}>
+        <div className="flex items-center gap-2 border-white/20 border-b border-dashed pb-2">
+          <span className="font-bold font-mono text-sm text-white uppercase tracking-widest">Contest Conditions</span>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <StatBar label="Cool" value={cool} colorClass="bg-red-500" bgClass="bg-red-500/60" />
+          <StatBar label="Beauty" value={beauty} colorClass="bg-blue-500" bgClass="bg-blue-500/60" />
+          <StatBar label="Cute" value={cute} colorClass="bg-pink-500" bgClass="bg-pink-500/60" />
+          <StatBar label="Smart" value={smart} colorClass="bg-emerald-500" bgClass="bg-emerald-500/60" />
+          <StatBar label="Tough" value={tough} colorClass="bg-amber-500" bgClass="bg-amber-500/60" />
+        </div>
+      </TacticalPanel>
+    );
+  },
+);
+
+ContestConditionStats.displayName = 'ContestConditionStats';

--- a/src/components/__tests__/ContestConditionStats.test.tsx
+++ b/src/components/__tests__/ContestConditionStats.test.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { ContestConditionStats } from '../ContestConditionStats';
+
+test('renders ContestConditionStats with default values', async () => {
+  const { container } = await render(<ContestConditionStats />);
+  await expect.element(page.getByText('Contest Conditions')).toBeInTheDocument();
+  await expect.element(page.getByText('COOL')).toBeInTheDocument();
+  await expect.element(page.getByText('BEAUTY')).toBeInTheDocument();
+  await expect.element(page.getByText('CUTE')).toBeInTheDocument();
+  await expect.element(page.getByText('SMART')).toBeInTheDocument();
+  await expect.element(page.getByText('TOUGH')).toBeInTheDocument();
+
+  // All values should default to 0
+  const progressBars = container.querySelectorAll('[data-role="progressbar"]');
+  expect(progressBars.length).toBe(5);
+  for (const bar of progressBars) {
+    expect(bar.getAttribute('data-valuenow')).toBe('0');
+  }
+});
+
+test('renders ContestConditionStats with provided values', async () => {
+  const { container } = await render(
+    <ContestConditionStats cool={50} beauty={100} cute={150} smart={200} tough={255} />,
+  );
+
+  const progressBars = container.querySelectorAll('[data-role="progressbar"]');
+  expect(progressBars.length).toBe(5);
+
+  expect(progressBars[0]?.getAttribute('data-valuenow')).toBe('50');
+  expect(progressBars[1]?.getAttribute('data-valuenow')).toBe('100');
+  expect(progressBars[2]?.getAttribute('data-valuenow')).toBe('150');
+  expect(progressBars[3]?.getAttribute('data-valuenow')).toBe('200');
+  expect(progressBars[4]?.getAttribute('data-valuenow')).toBe('255');
+});
+
+test('handles missing values gracefully', async () => {
+  const { container } = await render(<ContestConditionStats cool={10} />);
+
+  const progressBars = container.querySelectorAll('[data-role="progressbar"]');
+  expect(progressBars.length).toBe(5);
+
+  expect(progressBars[0]?.getAttribute('data-valuenow')).toBe('10');
+  expect(progressBars[1]?.getAttribute('data-valuenow')).toBe('0');
+});


### PR DESCRIPTION
Implemented a reusable React component `ContestConditionStats` to display a Pokémon's Contest stats (Cool, Beauty, Cute, Smart, Tough). Component matches the tactical hardware UI constraints, rendering dynamic CSS bar graphs relative to the 0-255 max limits.

**Testing:**
- Complete rendering test suite generated using `@testing-library/react` running via `vitest-browser-react`. Checked behavior with default, dynamic, and missing inputs.
- Validated via Playwright automation script locally simulating a complete visual workflow render.

---
*PR created automatically by Jules for task [10866943988801587640](https://jules.google.com/task/10866943988801587640) started by @szubster*