### PR TITLE
feat: Gen 2 hidden items parsing impl

### DIFF
--- a/.foundry/tasks/task-096-157-gen2-hidden-item-parsing-impl.md
+++ b/.foundry/tasks/task-096-157-gen2-hidden-item-parsing-impl.md
@@ -32,9 +32,9 @@ This task implements the second part of the epic `epic-037-058-hidden-items-save
 4. **Update Tests**: Update the unit tests in `src/engine/saveParser/parsers/gen2.test.ts` to assert that the `eventFlags` and `hiddenItemFlags` are parsed correctly, injecting mock byte values into the dummy save buffer to test both Gold/Silver and Crystal offsets.
 
 ## Acceptance Criteria
-- [ ] `SaveData` interface includes `hiddenItemFlags?: Uint8Array;`.
-- [ ] `parseGen2` correctly extracts the event flags for Gen 2 (Crystal and GS) into `SaveData.hiddenItemFlags`.
-- [ ] Unit tests for the Gen 2 save parser are updated to verify hidden item parsing logic.
+- [x] `SaveData` interface includes `hiddenItemFlags?: Uint8Array;`.
+- [x] `parseGen2` correctly extracts the event flags for Gen 2 (Crystal and GS) into `SaveData.hiddenItemFlags`.
+- [x] Unit tests for the Gen 2 save parser are updated to verify hidden item parsing logic.
 
 ## IMPORTANT REMINDERS
 - **If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.**

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -272,6 +272,44 @@ describe('gen2 parsers', () => {
         mapId: 3,
       });
     });
+
+    it('should extract eventFlags and hiddenItemFlags for Gold/Silver', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x288a, 1);
+      view.setUint8(0x288b, 1);
+      view.setUint8(0x288b + 7, 1);
+
+      // Set some bytes in the GS wEventFlags block
+      view.setUint8(0x2624, 0x11);
+      view.setUint8(0x2624 + 255, 0x99);
+
+      const data = parseGen2(view, false);
+      expect(data.eventFlags).toBeDefined();
+      expect(data.eventFlags?.[0]).toBe(0x11);
+      expect(data.eventFlags?.[255]).toBe(0x99);
+      expect(data.eventFlags?.length).toBe(0x100);
+      expect(data.hiddenItemFlags).toBe(data.eventFlags);
+    });
+
+    it('should extract eventFlags and hiddenItemFlags for Crystal', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x2865, 1);
+      view.setUint8(0x2866, 1);
+      view.setUint8(0x2866 + 7, 1);
+
+      // Set some bytes in the Crystal wEventFlags block
+      view.setUint8(0x2600, 0x22);
+      view.setUint8(0x2600 + 255, 0xaa);
+
+      const data = parseGen2(view, true);
+      expect(data.eventFlags).toBeDefined();
+      expect(data.eventFlags?.[0]).toBe(0x22);
+      expect(data.eventFlags?.[255]).toBe(0xaa);
+      expect(data.eventFlags?.length).toBe(0x100);
+      expect(data.hiddenItemFlags).toBe(data.eventFlags);
+    });
   });
 
   describe('parseGen2 - PC Items', () => {

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -588,6 +588,10 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
 
   const roamingLegendaries = parseRoamingLegendaries(view, isCrystal);
 
+  const eventFlagsOffset = isCrystal ? 0x2600 : 0x2624;
+  const eventFlags = new Uint8Array(view.buffer, view.byteOffset + eventFlagsOffset, 0x100);
+  const hiddenItemFlags = eventFlags;
+
   return {
     generation: 2,
     owned,
@@ -612,5 +616,7 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
     currentBoxCount: 0,
     hallOfFameCount,
     roamingLegendaries,
+    eventFlags,
+    hiddenItemFlags,
   };
 }


### PR DESCRIPTION
Fixes part two of epic-037-058-hidden-items-save-parsing by extracting `wEventFlags` and returning them as `hiddenItemFlags` inside Gen 2 parser execution.

---
*PR created automatically by Jules for task [18004726635697906525](https://jules.google.com/task/18004726635697906525) started by @szubster*