### PR TITLE
Create palette persona update tasks

### DIFF
--- a/.foundry/stories/story-077-113-update-palette-persona.md
+++ b/.foundry/stories/story-077-113-update-palette-persona.md
@@ -31,3 +31,5 @@ Update the relevant agent prompts or system configurations to explicitly define 
 ## Acceptance Criteria
 - [ ] Agent prompt explicitly states `palette` persona owns `src/index.css`.
 - [ ] Palette persona is tasked with enforcing the tactical hardware aesthetic and managing custom `@utility` primitives.
+- [ ] task-113-167-update-palette-persona-impl
+- [ ] task-113-168-update-palette-persona-qa

--- a/.foundry/tasks/task-113-167-update-palette-persona-impl.md
+++ b/.foundry/tasks/task-113-167-update-palette-persona-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-113-167-update-palette-persona-impl
+type: TASK
+title: Update palette agent prompt to define ownership of Tailwind styling
+status: READY
+owner_persona: coder
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-077-113-update-palette-persona
+tags:
+  - styling
+  - agents
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update palette agent prompt to define ownership of Tailwind styling
+
+## Objective
+Update `.github/agents/palette.md` to explicitly define the scheduled `palette` persona's responsibility for maintaining `src/index.css`, enforcing the tactical hardware aesthetic, and managing custom `@utility` primitives via ADR 024.
+
+## Context
+As per `story-077-113-update-palette-persona` and `ADR 024`, the Tailwind v4 migration necessitates custom primitive utilities in `src/index.css` to define the project's strict tactical hardware aesthetic (sharp edges, dashed borders, monospaced fonts). The `palette` agent must be instructed to own these primitives and aesthetic.
+
+## Task Details
+1. Update `.github/agents/palette.md` to state that the `palette` persona owns `src/index.css`.
+2. Update the "Focus Areas" and/or "Boundaries" to instruct the persona to enforce the tactical hardware aesthetic.
+3. Update the instructions so that the persona manages custom `@utility` primitives per ADR 024.
+4. Modify the boundary "Use existing design system classes — don't add custom CSS" to reflect that `palette` CAN and SHOULD maintain custom `@utility` primitives in `src/index.css` for the design system.
+
+## Acceptance Criteria
+- [ ] `.github/agents/palette.md` is updated to define `palette` ownership of `src/index.css`.
+- [ ] `.github/agents/palette.md` explicitly tasks the `palette` persona with enforcing the tactical hardware aesthetic and managing custom `@utility` primitives via ADR 024.
+
+## Critical Reminders
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-113-168-update-palette-persona-qa.md
+++ b/.foundry/tasks/task-113-168-update-palette-persona-qa.md
@@ -1,0 +1,45 @@
+---
+id: task-113-168-update-palette-persona-qa
+type: TASK
+title: QA - Update palette agent prompt to define ownership of Tailwind styling
+status: READY
+owner_persona: qa
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on:
+  - task-113-167-update-palette-persona-impl
+jules_session_id: null
+pr_number: null
+parent: story-077-113-update-palette-persona
+tags:
+  - styling
+  - agents
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Update palette agent prompt to define ownership of Tailwind styling
+
+## Objective
+Verify the changes implemented in `task-113-167-update-palette-persona-impl` to `.github/agents/palette.md`.
+
+## Context
+The coder was tasked with updating the `palette` agent prompt to assign ownership of `src/index.css`, enforce the tactical hardware aesthetic, and manage custom `@utility` primitives via ADR 024. This verification task ensures those requirements were met.
+
+## Validation Steps
+1. Verify that `.github/agents/palette.md` explicitly states that the `palette` persona owns `src/index.css`.
+2. Verify that the agent is explicitly tasked with enforcing the tactical hardware aesthetic.
+3. Verify that the agent manages custom `@utility` primitives per ADR 024.
+4. Verify that the constraint prohibiting adding custom CSS has been removed or modified to allow for `@utility` definitions.
+
+## Acceptance Criteria
+- [ ] Confirmed `.github/agents/palette.md` asserts `palette` ownership of `src/index.css`.
+- [ ] Confirmed `.github/agents/palette.md` tasks `palette` with enforcing tactical hardware aesthetic and managing custom `@utility` primitives.
+
+## Critical Reminders
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- If QA validation fails, you MUST update the target implementation task's YAML frontmatter (set `status: FAILED`, provide `rejection_reason`, increment `rejection_count`), leave its Acceptance Criteria unchecked, and document the failure in `.foundry/journals/qa.md`, while leaving this QA task's frontmatter completely untouched.


### PR DESCRIPTION
Creates `task-113-167-update-palette-persona-impl` and `task-113-168-update-palette-persona-qa` to implement the required modifications to the palette agent persona.

Appends these as unchecked requirements to the `story-077-113-update-palette-persona.md` parent node.

---
*PR created automatically by Jules for task [14524732701200208071](https://jules.google.com/task/14524732701200208071) started by @szubster*