### PR TITLE
Fix Foundry Orchestration Failures

### DIFF
--- a/.foundry/stories/story-048-089-route-radar-density-aggregation.md
+++ b/.foundry/stories/story-048-089-route-radar-density-aggregation.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-05-31'
 updated_at: '2026-06-12'
 depends_on:
-  - .foundry/stories/story-048-088-create-route-radar-controller.md
+  - story-048-088-create-route-radar-controller
 jules_session_id: '12287065830069308303'
 pr_number: null
 parent: epic-035-048-smart-radar-data-unification

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -19,6 +19,11 @@ function resolveNodeIdToPath(nodeId: string): string {
   const folder = folderMap[type];
   if (!folder) return nodeId;
 
+  const rootPath = `.foundry/${nodeId}.md`;
+  if (fs.existsSync(rootPath)) {
+    return rootPath;
+  }
+
   const basePath = `.foundry/${folder}/${nodeId}.md`;
   if (fs.existsSync(basePath)) {
     return basePath;


### PR DESCRIPTION
This PR fixes CI failures in the Foundry Engine orchestration phase.

Key changes:
1. **Metadata Correction**: Updated `.foundry/stories/story-048-089-route-radar-density-aggregation.md` to reference `story-048-088-create-route-radar-controller` by ID rather than a hardcoded file path. This ensures compatibility with the schema validator and link checker, even when files are moved to the archive.
2. **Link Checker Enhancement**: Updated `scripts/check-links.ts` to include the `.foundry/` root directory in its search path for node ID resolution. This correctly handles dynamic `RESEARCH` nodes which are placed at the root level.

Verified by running `scripts/check-links.ts` and `scripts/validate-foundry-schema.ts` on affected files, as well as the full project lint and test suites.

Fixes #2421

---
*PR created automatically by Jules for task [6816606527504377047](https://jules.google.com/task/6816606527504377047) started by @szubster*