### PR TITLE
Resolve DAG Resolution Warnings by Enforcing Node IDs

### DIFF
--- a/.foundry/archive/tasks/task-071-150-tailwind-v4-adr.md
+++ b/.foundry/archive/tasks/task-071-150-tailwind-v4-adr.md
@@ -16,7 +16,7 @@ tags:
   - styling
   - adr
 research_references:
-  - .foundry/research/research-071-137-tailwind-v4-utilities.md
+  - research-071-137-tailwind-v4-utilities
 rejection_count: 0
 rejection_reason: ''
 notes: ''

--- a/.foundry/archive/tasks/task-086-147-qa-implicit-dependency-check.md
+++ b/.foundry/archive/tasks/task-086-147-qa-implicit-dependency-check.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-06-01'
 updated_at: '2026-06-08'
 depends_on:
-  - .foundry/tasks/task-086-146-impl-implicit-dependency-check.md
+  - task-086-146-impl-implicit-dependency-check
 jules_session_id: null
 pr_number: null
 parent: story-048-086-implement-implicit-dependency-check

--- a/.foundry/archive/tasks/task-088-147-qa-route-radar-controller.md
+++ b/.foundry/archive/tasks/task-088-147-qa-route-radar-controller.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-06-02'
 updated_at: '2026-06-08'
 depends_on:
-  - .foundry/tasks/task-088-146-scaffold-route-radar-controller.md
+  - task-088-146-scaffold-route-radar-controller
 jules_session_id: null
 pr_number: null
 parent: story-048-088-create-route-radar-controller

--- a/.foundry/archive/tasks/task-088-149-gen1-species-validity-qa.md
+++ b/.foundry/archive/tasks/task-088-149-gen1-species-validity-qa.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-06-04'
 updated_at: '2026-06-11'
 depends_on:
-  - .foundry/tasks/task-088-148-gen1-species-validity-impl.md
+  - task-088-148-gen1-species-validity-impl
 jules_session_id: null
 pr_number: null
 parent: story-051-088-gen1-species-validity

--- a/.foundry/archive/tasks/task-090-149-extract-dag-utils-qa.md
+++ b/.foundry/archive/tasks/task-090-149-extract-dag-utils-qa.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-06-04'
 updated_at: '2026-06-09'
 depends_on:
-  - .foundry/tasks/task-090-148-extract-dag-utils-impl.md
+  - task-090-148-extract-dag-utils-impl
 jules_session_id: null
 pr_number: null
 parent: story-053-090-extract-dag-utilities

--- a/.foundry/docs/adrs/024-tailwind-v4-utility-consolidation.md
+++ b/.foundry/docs/adrs/024-tailwind-v4-utility-consolidation.md
@@ -15,7 +15,7 @@ tags:
   - tailwind
   - styling
 research_references:
-  - .foundry/research/research-071-137-tailwind-v4-utilities.md
+  - research-071-137-tailwind-v4-utilities
 rejection_count: 0
 rejection_reason: ''
 notes: ''

--- a/.foundry/epics/epic-036-058-feebas-backend-parsing.md
+++ b/.foundry/epics/epic-036-058-feebas-backend-parsing.md
@@ -7,7 +7,7 @@ owner_persona: story_owner
 created_at: '2026-06-05'
 updated_at: '2026-06-09'
 depends_on:
-  - .foundry/research/research-036-007-feebas-seed-offset.md
+  - research-036-007-feebas-seed-offset
 jules_session_id: null
 pr_number: null
 parent: prd-066-036-feebas-tile-predictor

--- a/.foundry/epics/epic-036-059-feebas-frontend-visualization.md
+++ b/.foundry/epics/epic-036-059-feebas-frontend-visualization.md
@@ -7,8 +7,8 @@ owner_persona: story_owner
 created_at: '2026-06-05'
 updated_at: '2026-06-05'
 depends_on:
-  - .foundry/epics/epic-036-058-feebas-backend-parsing.md
-  - .foundry/tasks/task-036-148-feebas-visualization-adr.md
+  - epic-036-058-feebas-backend-parsing
+  - task-036-148-feebas-visualization-adr
 jules_session_id: null
 pr_number: null
 parent: prd-066-036-feebas-tile-predictor

--- a/.foundry/epics/epic-046-078-gen3-battle-frontier-data-extraction.md
+++ b/.foundry/epics/epic-046-078-gen3-battle-frontier-data-extraction.md
@@ -16,7 +16,7 @@ tags:
   - gen3
   - endgame
 research_references:
-  - .foundry/research/research-046-140-gen3-battle-frontier.md
+  - research-046-140-gen3-battle-frontier
 rejection_count: 0
 rejection_reason: ''
 notes: ''

--- a/.foundry/prds/prd-068-039-mirage-island-ui-alerts.md
+++ b/.foundry/prds/prd-068-039-mirage-island-ui-alerts.md
@@ -7,7 +7,7 @@ owner_persona: epic_planner
 created_at: '2026-06-04'
 updated_at: '2026-06-04'
 depends_on:
-  - .foundry/prds/prd-068-038-mirage-island-data-extraction.md
+  - prd-068-038-mirage-island-data-extraction
 jules_session_id: null
 pr_number: null
 parent: idea-068-mirage-island-predictor

--- a/.foundry/stories/story-048-089-route-radar-density-aggregation.md
+++ b/.foundry/stories/story-048-089-route-radar-density-aggregation.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-05-31'
 updated_at: '2026-06-12'
 depends_on:
-  - .foundry/stories/story-048-088-create-route-radar-controller.md
+  - story-048-088-create-route-radar-controller
 jules_session_id: '12287065830069308303'
 pr_number: null
 parent: epic-035-048-smart-radar-data-unification

--- a/.foundry/stories/story-053-091-health-scanner-gen1-checksum-validation.md
+++ b/.foundry/stories/story-053-091-health-scanner-gen1-checksum-validation.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-06-02'
 updated_at: '2026-06-10'
 depends_on:
-  - .foundry/stories/story-053-090-health-scanner-diagnostic-models.md
+  - story-053-090-health-scanner-diagnostic-models
 jules_session_id: null
 pr_number: null
 parent: epic-036-053-health-scanner-core-engine

--- a/.foundry/stories/story-053-092-health-scanner-gen2-checksum-validation.md
+++ b/.foundry/stories/story-053-092-health-scanner-gen2-checksum-validation.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-06-02'
 updated_at: '2026-06-10'
 depends_on:
-  - .foundry/stories/story-053-090-health-scanner-diagnostic-models.md
+  - story-053-090-health-scanner-diagnostic-models
 jules_session_id: null
 pr_number: null
 parent: epic-036-053-health-scanner-core-engine

--- a/.foundry/stories/story-053-093-health-scanner-pokemon-bounds-verification.md
+++ b/.foundry/stories/story-053-093-health-scanner-pokemon-bounds-verification.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-06-02'
 updated_at: '2026-06-10'
 depends_on:
-  - .foundry/stories/story-053-090-health-scanner-diagnostic-models.md
+  - story-053-090-health-scanner-diagnostic-models
 jules_session_id: null
 pr_number: null
 parent: epic-036-053-health-scanner-core-engine

--- a/.foundry/stories/story-053-094-health-scanner-moveset-inventory-validation.md
+++ b/.foundry/stories/story-053-094-health-scanner-moveset-inventory-validation.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-06-02'
 updated_at: '2026-06-10'
 depends_on:
-  - .foundry/stories/story-053-090-health-scanner-diagnostic-models.md
+  - story-053-090-health-scanner-diagnostic-models
 jules_session_id: null
 pr_number: null
 parent: epic-036-053-health-scanner-core-engine

--- a/.foundry/stories/story-058-096-feebas-tile-calculation.md
+++ b/.foundry/stories/story-058-096-feebas-tile-calculation.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-06-08'
 updated_at: '2026-06-08'
 depends_on:
-  - .foundry/stories/story-058-095-feebas-seed-extraction.md
+  - story-058-095-feebas-seed-extraction
 jules_session_id: null
 pr_number: null
 parent: epic-036-058-feebas-backend-parsing

--- a/.foundry/stories/story-058-096-unown-parser-tests.md
+++ b/.foundry/stories/story-058-096-unown-parser-tests.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-06-08'
 updated_at: '2026-06-08'
 depends_on:
-  - .foundry/stories/story-058-095-unown-parser-logic.md
+  - story-058-095-unown-parser-logic
 jules_session_id: null
 pr_number: null
 parent: epic-037-058-unown-tracker-engine

--- a/.foundry/stories/story-072-108-gen3-roamer-location-extraction.md
+++ b/.foundry/stories/story-072-108-gen3-roamer-location-extraction.md
@@ -15,7 +15,7 @@ tags:
   - roamer
   - map
 research_references:
-  - .foundry/research/research-071-138-gen3-roamer-offsets.md
+  - research-071-138-gen3-roamer-offsets
 rejection_count: 0
 rejection_reason: ''
 notes: ''

--- a/.foundry/tasks/task-095-152-unown-parser-logic-qa.md
+++ b/.foundry/tasks/task-095-152-unown-parser-logic-qa.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-06-11'
 updated_at: '2026-06-12'
 depends_on:
-  - .foundry/tasks/task-095-151-unown-parser-logic-impl.md
+  - task-095-151-unown-parser-logic-impl
 jules_session_id: null
 pr_number: null
 parent: story-058-095-unown-parser-logic

--- a/.foundry/tasks/task-108-161-gen3-roamer-location-impl.md
+++ b/.foundry/tasks/task-108-161-gen3-roamer-location-impl.md
@@ -16,7 +16,7 @@ tags:
   - roamer
   - map
 research_references:
-  - .foundry/research/research-071-138-gen3-roamer-offsets.md
+  - research-071-138-gen3-roamer-offsets
 rejection_count: 0
 rejection_reason: ''
 notes: ''

--- a/.foundry/tasks/task-108-162-gen3-roamer-location-qa.md
+++ b/.foundry/tasks/task-108-162-gen3-roamer-location-qa.md
@@ -17,7 +17,7 @@ tags:
   - map
   - qa
 research_references:
-  - .foundry/research/research-071-138-gen3-roamer-offsets.md
+  - research-071-138-gen3-roamer-offsets
 rejection_count: 0
 rejection_reason: ''
 notes: ''


### PR DESCRIPTION
Resolved DAG orchestrator warnings by strictly enforcing the use of Node IDs instead of file paths in the YAML frontmatter. This fix addresses the issue where the orchestrator could not resolve dependencies for nodes that had been moved to the `archive/` directory.

Key changes:
- Audited all `.foundry/` nodes for path-based references.
- Replaced `.foundry/.../*.md` paths with their corresponding `id` slugs in `depends_on`, `parent`, and `research_references` fields.
- Verified the fix by running the orchestrator in `--strict --dry-run` mode.
- Confirmed system stability by running the full project test and linting suites.

Fixes #2420

---
*PR created automatically by Jules for task [9883178263740808255](https://jules.google.com/task/9883178263740808255) started by @szubster*