### PR TITLE
chore: Breakdown Epic 036 052 into Story 052 118

### DIFF
--- a/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
+++ b/.foundry/epics/epic-036-052-time-capsule-ui-indicators.md
@@ -30,3 +30,5 @@ Update the DexHelper UI to visualize Time Capsule readiness based on the validat
 ## Scope
 - Integrate a visual indicator in the Storage View for ready Pokémon.
 - Highlight specific invalid moves in the detailed individual Pokémon stat view.
+
+- [ ] .foundry/stories/story-052-118-time-capsule-ui-indicators.md

--- a/.foundry/stories/story-052-118-time-capsule-ui-indicators.md
+++ b/.foundry/stories/story-052-118-time-capsule-ui-indicators.md
@@ -1,0 +1,33 @@
+---
+id: story-052-118-time-capsule-ui-indicators
+type: STORY
+title: Time Capsule UI Indicators Setup
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-036-052-time-capsule-ui-indicators
+tags:
+  - feature
+  - gen2
+  - trade
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Time Capsule UI Indicators Setup
+
+## Objective
+Implement UI indicators for Time Capsule readiness in the DexHelper Storage View.
+
+## Scope
+- Break down the UI integration into specific tasks for the Storage View and Pokemon stat view.
+- Ensure the visual indicator logic correctly consumes the core validation logic (from Epic 051).
+
+## Tasks


### PR DESCRIPTION
Breakdown Epic 036-052 into a single new Story node to implement Time Capsule UI Indicators in the DexHelper storage view.

1. Appended `- [ ] .foundry/stories/story-052-118-time-capsule-ui-indicators.md` to `.foundry/epics/epic-036-052-time-capsule-ui-indicators.md`.
2. Created `.foundry/stories/story-052-118-time-capsule-ui-indicators.md`.

---
*PR created automatically by Jules for task [14059814909028095262](https://jules.google.com/task/14059814909028095262) started by @szubster*