### PR TITLE
Break down epic-046-078-gen3-battle-frontier-data-extraction into stories

### DIFF
--- a/.foundry/epics/epic-046-078-gen3-battle-frontier-data-extraction.md
+++ b/.foundry/epics/epic-046-078-gen3-battle-frontier-data-extraction.md
@@ -31,3 +31,6 @@ Extend the Gen 3 save parser to extract Battle Frontier data using the offsets d
 - [ ] Parse win streaks, max records, and symbol status for all 7 facilities.
 - [ ] Parse total BP.
 - [ ] Handle out-of-bounds reads gracefully via `DataView`.
+
+- [ ] story-078-118-gen3-battle-frontier-win-streaks-parsing
+- [ ] story-078-119-gen3-battle-frontier-bp-parsing

--- a/.foundry/research-095-157-gen2-event-flag-offsets.md
+++ b/.foundry/research-095-157-gen2-event-flag-offsets.md
@@ -1,5 +1,5 @@
 ---
-id: research-task-095-157-gen2-event-flag-offsets
+id: research-095-157-gen2-event-flag-offsets
 type: RESEARCH
 title: Investigate Gen 2 Event Flag Offsets
 status: PENDING

--- a/.foundry/stories/story-078-118-gen3-battle-frontier-win-streaks-parsing.md
+++ b/.foundry/stories/story-078-118-gen3-battle-frontier-win-streaks-parsing.md
@@ -1,0 +1,32 @@
+---
+id: story-078-118-gen3-battle-frontier-win-streaks-parsing
+type: STORY
+title: Gen 3 Battle Frontier Win Streaks Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-046-078-gen3-battle-frontier-data-extraction
+tags:
+  - feature
+  - gen3
+  - endgame
+research_references:
+  - research-046-140-gen3-battle-frontier
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Battle Frontier Win Streaks Parsing
+
+## Description
+This story covers extending the Gen 3 save parser to extract Battle Frontier win streaks, max records, and symbol status for all 7 facilities. It must strictly use the `DataView` API as per ADR 010 to handle out-of-bounds reads gracefully.
+
+## Acceptance Criteria
+- [ ] Implement `DataView` parsing logic for win streaks, max records, and symbol statuses.
+- [ ] Ensure all 7 Battle Frontier facilities are supported.
+- [ ] Implement bounds checking handling by explicitly throwing and catching `RangeError` on out-of-bounds reads.

--- a/.foundry/stories/story-078-119-gen3-battle-frontier-bp-parsing.md
+++ b/.foundry/stories/story-078-119-gen3-battle-frontier-bp-parsing.md
@@ -1,0 +1,32 @@
+---
+id: story-078-119-gen3-battle-frontier-bp-parsing
+type: STORY
+title: Gen 3 Battle Frontier Total BP Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on:
+  - story-078-118-gen3-battle-frontier-win-streaks-parsing
+jules_session_id: null
+pr_number: null
+parent: epic-046-078-gen3-battle-frontier-data-extraction
+tags:
+  - feature
+  - gen3
+  - endgame
+research_references:
+  - research-046-140-gen3-battle-frontier
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Battle Frontier Total BP Parsing
+
+## Description
+This story covers extending the Gen 3 save parser to extract Battle Frontier total BP. It must strictly use the `DataView` API as per ADR 010 to handle out-of-bounds reads gracefully.
+
+## Acceptance Criteria
+- [ ] Implement `DataView` parsing logic for total BP extraction.
+- [ ] Implement bounds checking handling by explicitly throwing and catching `RangeError` on out-of-bounds reads.

--- a/.foundry/tasks/task-095-157-gen2-event-flag-impl.md
+++ b/.foundry/tasks/task-095-157-gen2-event-flag-impl.md
@@ -2,13 +2,12 @@
 id: task-095-157-gen2-event-flag-impl
 type: TASK
 title: Gen 2 Event Flag Extraction - Implementation
-depends_on:
-  - research-task-095-157-gen2-event-flag-offsets
 status: ACTIVE
 owner_persona: coder
 created_at: '2026-06-10'
 updated_at: '2026-06-12'
-depends_on: []
+depends_on:
+  - research-095-157-gen2-event-flag-offsets
 jules_session_id: '12729977573204018786'
 pr_number: null
 parent: story-061-095-gen2-event-flag-extraction


### PR DESCRIPTION
Break down the Gen 3 Battle Frontier Data Extraction Epic into multiple granular Story nodes to be tackled sequentially. Addressed YAML validation errors in unrelated Gen 2 research tasks.

---
*PR created automatically by Jules for task [14648937743480549343](https://jules.google.com/task/14648937743480549343) started by @szubster*