### PR TITLE
docs: document gen 3 berry patch offsets

### DIFF
--- a/.foundry/docs/knowledge_base/gen3_berry_patch_offsets.md
+++ b/.foundry/docs/knowledge_base/gen3_berry_patch_offsets.md
@@ -25,6 +25,12 @@ The `BerryTree` struct represents the state of a single berry patch. Due to 32-b
 
 *Total Size: 8 bytes per BerryTree.*
 
+### Unstored and Implicit Fields
+
+- **Map ID / Location:** Not stored. The array is statically ordered. The 128 indices correspond 1:1 with specific map locations (defined as `BERRY_TREE_*` constants in the game code, such as `#define BERRY_TREE_ROUTE_102_PECHA 1`).
+- **Time Planted:** Not stored. The game manages growth using the countdown timer (`minutesUntilNextStage`).
+- **Last Watered Time:** Not stored. The game only records the boolean state of whether watering occurred during a given stage (`watered1`-`watered4`).
+
 ## 2. Enigma Berry Data
 
 Gen 3 introduced the Enigma Berry, which acts as a dynamic placeholder for e-Reader berries. Its data is also stored within `SaveBlock1`.

--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -18,3 +18,4 @@ When implementing new pipeline states that involve temporary ownership handoffs 
 ## Cloudflare Native Authentication
 - **Finding:** For Cloudflare Pages, `@cloudflare/pages-plugin-cloudflare-access` provides native middleware to validate JWTs from Cloudflare Access.
 - **Why it matters:** Generic Node.js OAuth libraries are difficult to maintain in edge environments. Relying on Cloudflare Access to handle the Google SSO flow at the infrastructure level removes the need to write custom callback/session management code. It also allows single-user restrictions to be configured via Zero Trust policies instead of application logic.
+When investigating decompilations (like pokeemerald) to discover save file offsets, prioritize searching struct definitions and array index mappings over runtime timestamp values, as many hardware-constrained systems compute time deltas or use implicit array-to-map mappings instead of raw storage.

--- a/.foundry/research-095-157-gen2-event-flag-offsets.md
+++ b/.foundry/research-095-157-gen2-event-flag-offsets.md
@@ -1,5 +1,5 @@
 ---
-id: research-task-095-157-gen2-event-flag-offsets
+id: research-095-157-gen2-event-flag-offsets
 type: RESEARCH
 title: Investigate Gen 2 Event Flag Offsets
 status: PENDING

--- a/.foundry/research-095-158-gen3-berry-missing-offsets.md
+++ b/.foundry/research-095-158-gen3-berry-missing-offsets.md
@@ -29,7 +29,17 @@ During the implementation of `task-095-157-gen3-berry-dataview-parsing`, the PRD
 However, the knowledge base (`gen3_berry_patch_offsets.md`) only documents `berry ID`, `stage`, `stopGrowth`, `minutesUntilNextStage`, `berryYield`, `regrowthCount`, and `watered` stages. The exact memory offsets and block structures for the requested fields are missing.
 
 ## Requirements
-- Investigate where `map ID`, `time planted`, and `last watered time` are stored in the Gen 3 save format.
-- Document the exact byte offsets, types, and bitwise logic necessary to extract these fields.
-- Determine if `map ID` is implicit (based on the array index) or stored explicitly.
-- Determine if `time planted` and `last watered time` can be derived from existing fields or are stored separately.
+- [x] Investigate where `map ID`, `time planted`, and `last watered time` are stored in the Gen 3 save format.
+- [x] Document the exact byte offsets, types, and bitwise logic necessary to extract these fields.
+- [x] Determine if `map ID` is implicit (based on the array index) or stored explicitly.
+- [x] Determine if `time planted` and `last watered time` can be derived from existing fields or are stored separately.
+
+## Findings
+
+Based on an analysis of the `pret/pokeemerald` decompilation (specifically `src/berry.c` and `include/global.berry.h`):
+
+1. **Map ID is Implicit**: The `Map ID` is not stored in the `BerryTree` save structure. Instead, the game stores exactly 128 berry patches in a flat array (`gSaveBlock1Ptr->berryTrees`). The indices of this array statically map to predefined tree IDs (e.g., `#define BERRY_TREE_ROUTE_102_PECHA 1`), which correspond to specific maps and locations. Thus, to determine the location of a berry patch, the parser must rely on the array index and a static lookup table.
+
+2. **Time Planted is Not Stored**: The game does not store an absolute timestamp for when a berry was planted. Instead, it initializes a countdown timer (`minutesUntilNextStage`) using `GetStageDurationByBerryType(berry)` when the berry is planted. This timer is decremented as real-world minutes pass.
+
+3. **Last Watered Time is Not Stored**: The game does not track the timestamp of when a berry was last watered. It only tracks whether the patch was watered during each of its four growth stages using a set of bit flags (`watered1:1`, `watered2:1`, `watered3:1`, `watered4:1`).

--- a/.foundry/tasks/task-095-157-gen2-event-flag-impl.md
+++ b/.foundry/tasks/task-095-157-gen2-event-flag-impl.md
@@ -2,13 +2,12 @@
 id: task-095-157-gen2-event-flag-impl
 type: TASK
 title: Gen 2 Event Flag Extraction - Implementation
-depends_on:
-  - research-task-095-157-gen2-event-flag-offsets
 status: ACTIVE
 owner_persona: coder
 created_at: '2026-06-10'
 updated_at: '2026-06-12'
-depends_on: []
+depends_on:
+  - research-095-157-gen2-event-flag-offsets
 jules_session_id: '12729977573204018786'
 pr_number: null
 parent: story-061-095-gen2-event-flag-extraction


### PR DESCRIPTION
Completed the research task to investigate missing Gen 3 berry patch offsets. Discovered that Map IDs are implicit based on array indices, while Time Planted and Last Watered times are handled via growth countdowns and state bitfields instead of explicit timestamps. Updated the `gen3_berry_patch_offsets.md` knowledge base file to reflect this. Also fixed an improperly named Gen 2 research node along the way.

---
*PR created automatically by Jules for task [1929460678560929935](https://jules.google.com/task/1929460678560929935) started by @szubster*