### PR TITLE
chore: break down epic-046-078 into stories

### DIFF
--- a/.foundry/epics/epic-046-078-gen3-battle-frontier-data-extraction.md
+++ b/.foundry/epics/epic-046-078-gen3-battle-frontier-data-extraction.md
@@ -31,3 +31,6 @@ Extend the Gen 3 save parser to extract Battle Frontier data using the offsets d
 - [ ] Parse win streaks, max records, and symbol status for all 7 facilities.
 - [ ] Parse total BP.
 - [ ] Handle out-of-bounds reads gracefully via `DataView`.
+- [ ] story-078-121-gen3-parse-battle-frontier-win-streaks
+- [ ] story-078-122-gen3-parse-battle-frontier-symbols
+- [ ] story-078-123-gen3-parse-battle-points

--- a/.foundry/stories/story-078-121-gen3-parse-battle-frontier-win-streaks.md
+++ b/.foundry/stories/story-078-121-gen3-parse-battle-frontier-win-streaks.md
@@ -1,0 +1,33 @@
+---
+id: story-078-121-gen3-parse-battle-frontier-win-streaks
+type: STORY
+title: Gen 3 Parse Battle Frontier Win Streaks
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on:
+  - research-046-140-gen3-battle-frontier
+jules_session_id: null
+pr_number: null
+parent: epic-046-078-gen3-battle-frontier-data-extraction
+tags:
+  - feature
+  - gen3
+  - endgame
+research_references:
+  - research-046-140-gen3-battle-frontier
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Parse Battle Frontier Win Streaks
+
+## Description
+Based on the offset research in `research-046-140-gen3-battle-frontier`, extract the current and max win streaks for the 7 Battle Frontier facilities from SaveBlock2 using `DataView`.
+
+## Acceptance Criteria
+- [ ] Extract current win streaks for Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid.
+- [ ] Extract max win records for all 7 facilities.
+- [ ] Implement error handling for out-of-bounds reads.

--- a/.foundry/stories/story-078-122-gen3-parse-battle-frontier-symbols.md
+++ b/.foundry/stories/story-078-122-gen3-parse-battle-frontier-symbols.md
@@ -1,0 +1,33 @@
+---
+id: story-078-122-gen3-parse-battle-frontier-symbols
+type: STORY
+title: Gen 3 Parse Battle Frontier Symbols
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on:
+  - story-078-121-gen3-parse-battle-frontier-win-streaks
+jules_session_id: null
+pr_number: null
+parent: epic-046-078-gen3-battle-frontier-data-extraction
+tags:
+  - feature
+  - gen3
+  - endgame
+research_references:
+  - research-046-140-gen3-battle-frontier
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Parse Battle Frontier Symbols
+
+## Description
+Extract the Gold and Silver symbol status flags for the 7 Battle Frontier facilities from the SaveBlock1 flags array, using `DataView` for bit manipulation, as discovered in `research-046-140-gen3-battle-frontier`.
+
+## Acceptance Criteria
+- [ ] Parse Silver and Gold symbol flags for all 7 facilities.
+- [ ] Read correctly using byte offsets and bit indices within the flags array.
+- [ ] Fail gracefully if out of bounds.

--- a/.foundry/stories/story-078-123-gen3-parse-battle-points.md
+++ b/.foundry/stories/story-078-123-gen3-parse-battle-points.md
@@ -1,0 +1,32 @@
+---
+id: story-078-123-gen3-parse-battle-points
+type: STORY
+title: Gen 3 Parse Total Battle Points
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on:
+  - story-078-122-gen3-parse-battle-frontier-symbols
+jules_session_id: null
+pr_number: null
+parent: epic-046-078-gen3-battle-frontier-data-extraction
+tags:
+  - feature
+  - gen3
+  - endgame
+research_references:
+  - research-046-140-gen3-battle-frontier
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Parse Total Battle Points
+
+## Description
+Extract the total accumulated Battle Points (BP) from SaveBlock2 using `DataView`, based on the offset research in `research-046-140-gen3-battle-frontier`.
+
+## Acceptance Criteria
+- [ ] Parse total BP correctly.
+- [ ] Implement error handling for out-of-bounds reads.


### PR DESCRIPTION
Breakdown of Epic 046-078 (Gen 3 Battle Frontier Data Extraction) into 3 discrete stories based on research-046-140-gen3-battle-frontier.

- `story-078-121-gen3-parse-battle-frontier-win-streaks`
- `story-078-122-gen3-parse-battle-frontier-symbols`
- `story-078-123-gen3-parse-battle-points`

---
*PR created automatically by Jules for task [15788758606280647564](https://jules.google.com/task/15788758606280647564) started by @szubster*