### PR TITLE
Research: Missing Gen 3 Berry Patch Offsets

### DIFF
--- a/.foundry/docs/knowledge_base/gen3_berry_patch_offsets.md
+++ b/.foundry/docs/knowledge_base/gen3_berry_patch_offsets.md
@@ -65,3 +65,10 @@ The `EnigmaBerry` struct is composed of a `Berry2` structure (which defines the 
 
 The `DataView` parser in `task-095-157-gen3-berry-dataview-parsing` should seek to offset `0x169C` in `SaveBlock1` and iterate 128 times, advancing by 8 bytes per iteration.
 Bitwise operations will be needed for offsets `0x01` and `0x05` to extract the correct growth stages, stop flags, regrowth counts, and watering history.
+## 3. Implicit and Missing Data (Map ID, Time Planted, Last Watered)
+
+During research, it was found that certain data points often assumed to exist are **not explicitly stored** in the Gen 3 save format.
+
+- **Map ID:** The Map ID is not stored within the `BerryTree` struct. Instead, the 128 `BerryTree` slots are pre-allocated to specific locations in the game world. The mapping between the array index (the "Berry Tree ID") and its location is implicit. In the game's code, `constants/berry.h` defines constants like `BERRY_TREE_ROUTE_102_PECHA` which correspond to these array indices. In map data (`map.json`), these IDs are directly assigned to the `trainerRange_berryTreeId` field of `ObjectEvent` entities. Therefore, to determine a berry patch's map location, one must map the array index to its hardcoded map location.
+- **Time Planted:** The exact time a berry was planted is not saved. The game instead uses the `lastBerryTreeUpdate` global timestamp (stored at offset `0xA0` in `SaveBlock2`) and calculates time differences to decrement the `minutesUntilNextStage` value.
+- **Last Watered Time:** The time a berry was last watered is not recorded. The `BerryTree` struct only tracks boolean flags (`watered1`, `watered2`, `watered3`, `watered4`) for whether the plant was watered during each of its four growth stages.

--- a/.foundry/research-095-158-gen3-berry-missing-offsets.md
+++ b/.foundry/research-095-158-gen3-berry-missing-offsets.md
@@ -29,7 +29,18 @@ During the implementation of `task-095-157-gen3-berry-dataview-parsing`, the PRD
 However, the knowledge base (`gen3_berry_patch_offsets.md`) only documents `berry ID`, `stage`, `stopGrowth`, `minutesUntilNextStage`, `berryYield`, `regrowthCount`, and `watered` stages. The exact memory offsets and block structures for the requested fields are missing.
 
 ## Requirements
-- Investigate where `map ID`, `time planted`, and `last watered time` are stored in the Gen 3 save format.
-- Document the exact byte offsets, types, and bitwise logic necessary to extract these fields.
-- Determine if `map ID` is implicit (based on the array index) or stored explicitly.
-- Determine if `time planted` and `last watered time` can be derived from existing fields or are stored separately.
+- [x] Investigate where `map ID`, `time planted`, and `last watered time` are stored in the Gen 3 save format.
+- [x] Document the exact byte offsets, types, and bitwise logic necessary to extract these fields.
+- [x] Determine if `map ID` is implicit (based on the array index) or stored explicitly.
+- [x] Determine if `time planted` and `last watered time` can be derived from existing fields or are stored separately.
+
+## Findings
+Based on our research into the `pret/pokeemerald` decompilation:
+
+1. **Map ID**: Map IDs are not stored explicitly per Berry Tree. Instead, the `berryTrees` array contains 128 elements. These elements are implicitly mapped to specific locations via constants in `constants/berry.h` (e.g., `BERRY_TREE_ROUTE_102_PECHA 1`). These IDs are assigned directly to the `trainerRange_berryTreeId` field of `ObjectEvent` inside map layout definitions (`map.json`). Map locations must be resolved by hardcoding these indices.
+
+2. **Time Planted**: The time a berry was planted is NOT explicitly stored in the save file. The `BerryTree` struct only contains `minutesUntilNextStage` and `stage`. The game calculates remaining time by comparing the global timestamp `lastBerryTreeUpdate` (located in SaveBlock2) to the current time, rather than storing individual planted times.
+
+3. **Last Watered Time**: This is also NOT stored explicitly. The `BerryTree` struct keeps boolean bitflags (`watered1`, `watered2`, `watered3`, `watered4`) to record whether the patch was watered during each of its four growth stages. The exact timestamps of watering events are not recorded.
+
+The knowledge base (`gen3_berry_patch_offsets.md`) has been updated to reflect these missing explicit data structures.


### PR DESCRIPTION
Updates the Gen 3 Berry Patch offsets documentation based on research using the `pret/pokeemerald` decompilation. Documents that Map IDs are implicit based on array indexing, Time Planted is calculated from `SaveBlock2`'s `lastBerryTreeUpdate`, and Last Watered Time is stored as boolean flags per growth stage. Also marks the tasks as completed in the associated research file without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [4472931738996298865](https://jules.google.com/task/4472931738996298865) started by @szubster*