### PR TITLE
chore: Document root cause of Route Radar heatmap failure

### DIFF
--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -18,3 +18,10 @@ When implementing new pipeline states that involve temporary ownership handoffs 
 ## Cloudflare Native Authentication
 - **Finding:** For Cloudflare Pages, `@cloudflare/pages-plugin-cloudflare-access` provides native middleware to validate JWTs from Cloudflare Access.
 - **Why it matters:** Generic Node.js OAuth libraries are difficult to maintain in edge environments. Relying on Cloudflare Access to handle the Google SSO flow at the infrastructure level removes the need to write custom callback/session management code. It also allows single-user restrictions to be configured via Zero Trust policies instead of application logic.
+
+## Missing Architectural Integration & Data Schema Violations
+**Lesson**: When investigating implementation failures, look beyond whether utility functions exist and unit tests pass.
+- **Example (`story-048-089-route-radar-density-aggregation`)**: The heatmap logic implementation failed permanently for two structural reasons:
+  1.  **Missing Architectural Integration (ADR 018)**: `RouteRadarController` was created as an isolated class but was never integrated into the application's data flow (`Save State -> suggestionEngine -> RouteRadarController -> Heatmap State`) nor passed as props to the Map UI component.
+  2.  **Data Schema Violation (ADR 015)**: The implementation continued to use the shortened data property `aid` (as seen in `encounter.aid`) instead of the fully expanded `areaId` property mandated by ADR 015 ("Revert Data Format Optimizations").
+Agents must ensure actual structural integration and strict adherence to data schema ADRs, not just isolated utility completion.

--- a/.foundry/research-089-167-investigate-heatmap-failure.md
+++ b/.foundry/research-089-167-investigate-heatmap-failure.md
@@ -27,7 +27,15 @@ Investigate the root cause of the previous implementation failure related to the
 ## Scope
 The previous attempt at implementing the heatmap logic in `story-048-089-route-radar-density-aggregation` failed permanently (triggering the Impossible Loop). Investigate the `auditor` and `qa` journals, review the rejected task implementations if available, and identify what structural or architectural requirement was missed (such as a missing UI integration or architectural invariant).
 
+## Findings Summary
+The root cause of the failure for `story-048-089-route-radar-density-aggregation` stems from missing architectural integrations and data schema violations:
+
+1.  **Missing Architectural Integration (ADR 018):** `RouteRadarController` was created as an isolated class but was never integrated into the application's data flow (`Save State -> suggestionEngine -> RouteRadarController -> Heatmap State`), nor was it passed as props to the Map UI component.
+2.  **Data Schema Violation (ADR 015):** The implementation continued to use the shortened data property `aid` (as seen in `encounter.aid`) instead of the fully expanded `areaId` mandated by ADR 015 ("Revert Data Format Optimizations").
+
+These findings have been logged in the researcher journal to ensure future agents enforce structural integration and strict adherence to data schema ADRs.
+
 ## Acceptance Criteria
-- [ ] Investigate the root cause of the failure.
-- [ ] Document findings in `.foundry/docs/` or persona journals as appropriate.
-- [ ] Provide a summary here in this markdown body.
+- [x] Investigate the root cause of the failure.
+- [x] Document findings in `.foundry/docs/` or persona journals as appropriate.
+- [x] Provide a summary here in this markdown body.


### PR DESCRIPTION
This PR resolves the research node `research-089-167-investigate-heatmap-failure`. The root cause of the previous failure has been investigated and documented. The failure stemmed from missing architectural integration (ADR 018) and a data schema violation (ADR 015) in the implemented RouteRadarController. These findings have been recorded in the researcher journal to inform future pipeline steps.

---
*PR created automatically by Jules for task [6983425208422488672](https://jules.google.com/task/6983425208422488672) started by @szubster*