### PR TITLE
chore(foundry): generate tasks to verify late-binding orchestrator logic

### DIFF
--- a/.foundry/stories/story-049-116-verify-late-binding-logic.md
+++ b/.foundry/stories/story-049-116-verify-late-binding-logic.md
@@ -29,4 +29,6 @@ The orchestrator must handle late-binding correctly with the new hierarchical co
 Create tasks to verify the late-binding logic in `foundry-orchestrator.ts` and ensure comprehensive test coverage for this specific scenario.
 
 ## Acceptance Criteria
-- [ ] Break down into TASK nodes to verify late-binding logic and tests.
+- [x] Break down into TASK nodes to verify late-binding logic and tests.
+- [ ] task-116-169-verify-late-binding-impl
+- [ ] task-116-170-verify-late-binding-qa

--- a/.foundry/tasks/task-116-169-verify-late-binding-impl.md
+++ b/.foundry/tasks/task-116-169-verify-late-binding-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-116-169-verify-late-binding-impl
+type: TASK
+title: Implement Verification for Late-Binding Logic
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-049-116-verify-late-binding-logic
+tags:
+  - foundry
+  - process
+  - orchestrator
+  - tests
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Verification for Late-Binding Logic
+
+## Context
+The orchestrator natively supports late-binding stories, meaning a `PENDING` parent node that already has children will not block those children from starting. This is implemented in `.github/scripts/foundry-orchestrator.ts`, specifically via the exception for children of PENDING parents, where it doesn't block if `parentStatus === 'PENDING' && parentChildren.length > 0`. There's also `Late-Binding Parent Waking Up` logic where the parent can be promoted if all children are completed.
+
+We need to review and verify this logic comprehensively, ensuring solid test coverage in `.github/scripts/foundry-orchestrator.test.ts`.
+
+## Goal
+Verify the late-binding logic in the orchestrator and add any missing test cases or correct edge cases where the orchestrator might deadlock or behave incorrectly for late-binding.
+
+## Constraints
+- **CRITICAL**: If you permanently fail or abort this task, you MUST update the YAML frontmatter `status` to `FAILED` or `CANCELLED` and provide a `rejection_reason`. DO NOT check off the acceptance criteria checkboxes.
+- **CRITICAL**: If you submit an empty PR because the logic is already sound and tests are adequate, you MUST check off all Acceptance Criteria checkboxes before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009.
+- Ensure test changes are robust and maintain current testing patterns. Do not modify global graph state tests without extreme caution.
+
+## Acceptance Criteria
+- [ ] Review late-binding logic (`Late-Binding Parent` handling, exceptions for PENDING parents) in `.github/scripts/foundry-orchestrator.ts`.
+- [ ] Add or verify comprehensive test cases for late-binding logic in `.github/scripts/foundry-orchestrator.test.ts`.
+- [ ] Ensure `pnpm test` passes.

--- a/.foundry/tasks/task-116-170-verify-late-binding-qa.md
+++ b/.foundry/tasks/task-116-170-verify-late-binding-qa.md
@@ -1,0 +1,41 @@
+---
+id: task-116-170-verify-late-binding-qa
+type: TASK
+title: QA Verification for Late-Binding Logic Test Coverage
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on:
+  - task-116-169-verify-late-binding-impl
+jules_session_id: null
+pr_number: null
+parent: story-049-116-verify-late-binding-logic
+tags:
+  - foundry
+  - process
+  - orchestrator
+  - tests
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Verification for Late-Binding Logic Test Coverage
+
+## Context
+The coder has implemented or verified the tests for the orchestrator's late-binding logic. The orchestrator must handle situations where a parent is `PENDING` but has children, meaning the parent is waiting for those children. It must not block the children from starting. Also, it handles cases where the parent wakes up upon completion of its children.
+
+## Goal
+Verify the test coverage added by the coder for the late-binding logic in `foundry-orchestrator.ts`. Ensure all edge cases (missing dependencies, existing dependencies, multiple children, etc.) are tested in `foundry-orchestrator.test.ts` and the tests pass.
+
+## Constraints
+- **CRITICAL**: If you permanently fail or abort this task, you MUST update the YAML frontmatter `status` to `FAILED` or `CANCELLED` and provide a `rejection_reason`. DO NOT check off the acceptance criteria checkboxes.
+- **CRITICAL**: If you submit an empty PR because the logic is already sound and tests are adequate, you MUST check off all Acceptance Criteria checkboxes before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009.
+
+## Acceptance Criteria
+- [ ] Review the PR or changes made by the coder for `foundry-orchestrator.test.ts`.
+- [ ] Ensure that tests adequately cover the late-binding specific logic, including exceptions for children of PENDING parents and waking up PENDING parents.
+- [ ] Confirm that running `pnpm test` successfully executes the new tests without failures.


### PR DESCRIPTION
This PR addresses the Story `story-049-116-verify-late-binding-logic`. It breaks down the requirement into two new tasks:
1. `task-116-169-verify-late-binding-impl`: Assigned to the `coder` to implement/verify comprehensive test coverage for late-binding orchestrator logic in `foundry-orchestrator.test.ts`.
2. `task-116-170-verify-late-binding-qa`: Assigned to the `qa` persona to verify the coder's tests.

The story's acceptance criteria have been updated and checked, and references to the new pending child nodes have been appended.

---
*PR created automatically by Jules for task [16829829035142579108](https://jules.google.com/task/16829829035142579108) started by @szubster*