### PR TITLE
Break down Gen3 TV Broadcast and Swarm Tracker Epic into Stories

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -40,4 +40,9 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - Extract data indicating if events were inherited from another player's save file via the "Mix Record" feature.
 
 ## 3. Acceptance Criteria
-- [ ] Story Owner: Break down into Stories.
+- [x] Story Owner: Break down into Stories.
+
+- [ ] story-081-121-gen3-tv-block-dataview-parser
+- [ ] story-081-122-gen3-rtc-extraction
+- [ ] story-081-123-gen3-active-swarm-parsing
+- [ ] story-081-124-gen3-event-forecast-schedule

--- a/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
+++ b/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
@@ -1,0 +1,30 @@
+---
+id: story-081-121-gen3-tv-block-dataview-parser
+type: STORY
+title: Parse Gen 3 TV Block Data with DataView
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Parse Gen 3 TV Block Data with DataView
+
+## Description
+Implement the foundational logic to locate and read the TV broadcast data block from the Gen 3 save file structure, strictly utilizing the `DataView` API.
+
+## Acceptance Criteria
+- [ ] Implement parser logic using `DataView` to read the TV event block.
+- [ ] Handle bounds checking and corrupted reads gracefully.

--- a/.foundry/stories/story-081-122-gen3-rtc-extraction.md
+++ b/.foundry/stories/story-081-122-gen3-rtc-extraction.md
@@ -1,0 +1,30 @@
+---
+id: story-081-122-gen3-rtc-extraction
+type: STORY
+title: Extract Gen 3 RTC Data
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Extract Gen 3 RTC Data
+
+## Description
+Extract and parse the Real-Time Clock (RTC) value from Gen 3 save files to allow for time-gated event mapping.
+
+## Acceptance Criteria
+- [ ] Implement parser logic to extract the RTC value from the save.
+- [ ] Provide utility functions to format/interpret the RTC data against current active events.

--- a/.foundry/stories/story-081-123-gen3-active-swarm-parsing.md
+++ b/.foundry/stories/story-081-123-gen3-active-swarm-parsing.md
@@ -1,0 +1,30 @@
+---
+id: story-081-123-gen3-active-swarm-parsing
+type: STORY
+title: Parse Gen 3 Active Swarms
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Parse Gen 3 Active Swarms
+
+## Description
+Extract the data pertaining to active swarms, identifying the specific Pokémon species, map location, and the days remaining.
+
+## Acceptance Criteria
+- [ ] Implement extraction of active swarm data (species, location).
+- [ ] Calculate or extract remaining days for the active swarm.

--- a/.foundry/stories/story-081-124-gen3-event-forecast-schedule.md
+++ b/.foundry/stories/story-081-124-gen3-event-forecast-schedule.md
@@ -1,0 +1,30 @@
+---
+id: story-081-124-gen3-event-forecast-schedule
+type: STORY
+title: Parse Gen 3 Event Forecasting and Mix Records
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Parse Gen 3 Event Forecasting and Mix Records
+
+## Description
+Extract the forecasting schedule for upcoming events (e.g., Energy Guru sales) and parse data indicating if events were inherited from "Mix Record" feature.
+
+## Acceptance Criteria
+- [ ] Extract upcoming event schedule data from the save file.
+- [ ] Extract Mix Record flags/data to identify inherited events.


### PR DESCRIPTION
This PR breaks down `epic-047-081-gen3-tv-swarm-data-extraction` into four smaller, more manageable stories in compliance with Foundry architectural rules. The Epic's markdown body has been updated to check off the breakdown criteria and link the new pending stories.

Closes epic-047-081-gen3-tv-swarm-data-extraction

---
*PR created automatically by Jules for task [5643096688128556905](https://jules.google.com/task/5643096688128556905) started by @szubster*