### PR TITLE
feat: generate child tasks for Gen 3 32-bit PV parsing

### DIFF
--- a/.foundry/stories/story-062-098-gen3-parse-32bit-pv.md
+++ b/.foundry/stories/story-062-098-gen3-parse-32bit-pv.md
@@ -33,3 +33,5 @@ As part of the Mirage Island checking feature (Epic `epic-038-062-personality-va
 - [x] Tech Lead: Generate child tasks to update the extraction logic.
 - [x] .foundry/archive/tasks/task-098-157-gen3-parse-pv-impl.md
 - [x] .foundry/tasks/task-098-158-gen3-parse-pv-qa.md
+- [ ] task-098-169-extract-32bit-pv-impl
+- [ ] task-098-170-extract-32bit-pv-qa

--- a/.foundry/tasks/task-098-169-extract-32bit-pv-impl.md
+++ b/.foundry/tasks/task-098-169-extract-32bit-pv-impl.md
@@ -1,0 +1,37 @@
+---
+id: task-098-169-extract-32bit-pv-impl
+type: TASK
+title: Extract 32-bit PV using DataView
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-062-098-gen3-parse-32bit-pv
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Extract 32-bit PV using DataView
+
+## Context
+As part of the Mirage Island checking feature, we need to parse the full 32-bit personality value (PV) for Gen 3 Pokémon. This requires adhering to ADR 010 by using the native `DataView` API.
+
+## Requirements
+1. Use the native `DataView` API (e.g., `getUint32`) to extract the 32-bit PV.
+2. Ensure that the parser throws explicit, catchable `RangeError` on out-of-bounds reads and propagates them properly.
+3. Keep the original Gen 1 and Gen 2 handlers functional without altering legacy parsing.
+4. If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+5. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement the 32-bit PV extraction using `DataView`.
+- [ ] Explicitly throw and propagate `RangeError` on out-of-bounds reads.
+- [ ] Verify Gen 1 and Gen 2 parsing handlers remain functional.

--- a/.foundry/tasks/task-098-170-extract-32bit-pv-qa.md
+++ b/.foundry/tasks/task-098-170-extract-32bit-pv-qa.md
@@ -1,0 +1,38 @@
+---
+id: task-098-170-extract-32bit-pv-qa
+type: TASK
+title: QA - Extract 32-bit PV using DataView
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - task-098-169-extract-32bit-pv-impl
+jules_session_id: null
+pr_number: null
+parent: story-062-098-gen3-parse-32bit-pv
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# QA - Extract 32-bit PV using DataView
+
+## Context
+The coder has implemented the extraction of the 32-bit personality value (PV) for Gen 3 Pokémon using the native `DataView` API.
+
+## Requirements
+1. Verify the parser safely extracts the 32-bit PV using the `DataView` API as per ADR 010.
+2. Verify explicit `RangeError` is thrown and properly propagated on out-of-bounds reads.
+3. Ensure Gen 1 and Gen 2 legacy handlers still function without alteration.
+4. If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+5. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify Gen 3 PV extraction uses `DataView`.
+- [ ] Verify `RangeError` propagation for out-of-bounds reads.
+- [ ] Verify Gen 1 and 2 handlers are functional.


### PR DESCRIPTION
Generated new `coder` and `qa` child tasks to replace the permanently failed previous attempts for the Gen 3 32-bit PV DataView parser. The new tasks explicitly reiterate constraints to throw `RangeError` on out-of-bounds reads and adhere to backward compatibility logic, strictly following the Parent-Linked DAG ID Schema and system verification protocols. Appended tasks as unchecked checkboxes into the parent story's markdown body without mutating its YAML frontmatter.

---
*PR created automatically by Jules for task [4856856061899924339](https://jules.google.com/task/4856856061899924339) started by @szubster*