### PR TITLE
docs: Breakdown story-078-118 into tasks

### DIFF
--- a/.foundry/stories/story-078-118-refactor-parser-for-rejection-count.md
+++ b/.foundry/stories/story-078-118-refactor-parser-for-rejection-count.md
@@ -28,4 +28,8 @@ Update the existing DAG data parser to read and extract the `rejection_count` pr
 As required by ADR 017, we need to extract the `rejection_count` to display permanent failures on the DAG dashboard. The parser must capture this field alongside existing properties.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks
+- [x] Break down into Tasks
+
+### Generated Tasks
+- [ ] task-118-168-impl-extract-rejection-count
+- [ ] task-118-169-qa-extract-rejection-count

--- a/.foundry/tasks/task-118-168-impl-extract-rejection-count.md
+++ b/.foundry/tasks/task-118-168-impl-extract-rejection-count.md
@@ -1,0 +1,43 @@
+---
+id: task-118-168-impl-extract-rejection-count
+type: TASK
+title: Implement DAG Data Parsing for Rejection Count
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-078-118-refactor-parser-for-rejection-count
+tags:
+  - foundry
+  - ui
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement DAG Data Parsing for Rejection Count
+
+## Objective
+Update the existing DAG data parser to read and extract the `rejection_count` property from the YAML frontmatter of `.foundry` files. Update associated frontend models to include this data and ensure it's exposed through the shared React Context layer for the DAG Dashboard UI.
+
+## Context
+In order to display permanent failures on the DAG dashboard, we need to surface the `rejection_count` of each node in the UI. We need to introduce a "Permanent Failures" view within the DAG Dashboard (ADR 017). The UI relies on the shared React Context (ADR 013), so ensure the context is updated properly.
+
+## Requirements
+1.  Update parsing logic to capture `rejection_count` from the `.foundry` markdown files YAML frontmatter.
+2.  Update the `FoundryNode` TypeScript types.
+3.  Update the React Context layer to expose the `rejection_count` property to all connected UI views.
+
+## Acceptance Criteria
+- [ ] Coder: Update parsing logic.
+- [ ] Coder: Update `FoundryNode` TypeScript types.
+- [ ] Coder: Ensure React context layer correctly exposes the property.
+
+## Reminders
+- If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-118-169-qa-extract-rejection-count.md
+++ b/.foundry/tasks/task-118-169-qa-extract-rejection-count.md
@@ -1,0 +1,43 @@
+---
+id: task-118-169-qa-extract-rejection-count
+type: TASK
+title: QA DAG Data Parsing for Rejection Count
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-12'
+updated_at: '2026-06-12'
+depends_on:
+  - task-118-168-impl-extract-rejection-count
+jules_session_id: null
+pr_number: null
+parent: story-078-118-refactor-parser-for-rejection-count
+tags:
+  - foundry
+  - ui
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA DAG Data Parsing for Rejection Count
+
+## Objective
+Verify that the DAG data parsing logic correctly extracts the `rejection_count` property, the `FoundryNode` TypeScript types are properly updated, and that the React context layer accurately broadcasts the `rejection_count` property.
+
+## Context
+This is a verification task for `task-118-168-impl-extract-rejection-count`. In order to display permanent failures on the DAG dashboard, we need to surface the `rejection_count` of each node in the UI.
+
+## Requirements
+1. Verify parser extracts `rejection_count`.
+2. Verify models are updated.
+3. Verify context layer broadcasts `rejection_count` correctly, per ADR 013 and ADR 017.
+
+## Acceptance Criteria
+- [ ] QA: Verify parser extracts `rejection_count`.
+- [ ] QA: Verify models are updated.
+- [ ] QA: Verify context layer broadcasts `rejection_count`.
+
+## Reminders
+- If QA validation fails, you MUST update the target implementation task's YAML frontmatter (set `status: FAILED`, provide `rejection_reason`, increment `rejection_count`), leave its Acceptance Criteria unchecked, and document the failure in `.foundry/journals/qa.md`, while leaving this QA task's frontmatter completely untouched.


### PR DESCRIPTION
Breaks down story-078-118-refactor-parser-for-rejection-count into concrete engineering and QA tasks. Ensures adherence to ID schema and updates markdown criteria.

---
*PR created automatically by Jules for task [16441439296571923452](https://jules.google.com/task/16441439296571923452) started by @szubster*