### PR TITLE
feat: implement Gen 1 hidden coin flags parsing

### DIFF
--- a/.foundry/tasks/task-095-167-gen1-hidden-coin-parsing-impl.md
+++ b/.foundry/tasks/task-095-167-gen1-hidden-coin-parsing-impl.md
@@ -32,9 +32,9 @@ This task implements the final part of the story `story-058-095-gen1-hidden-item
 4. **Update Tests**: Update the unit tests in `src/engine/saveParser/parsers/gen1.test.ts` to assert that the `hiddenCoinFlags` are parsed correctly, injecting mock byte values into the dummy save buffer to test.
 
 ## Acceptance Criteria
-- [ ] `SaveData` interface includes `hiddenCoinFlags?: Uint8Array;`.
-- [ ] `parseGen1` correctly calculates the offset (including Yellow `offsetShift`) and extracts the hidden coin flags.
-- [ ] Unit tests for the Gen 1 save parser are updated to verify hidden coin parsing logic.
+- [x] `SaveData` interface includes `hiddenCoinFlags?: Uint8Array;`.
+- [x] `parseGen1` correctly calculates the offset (including Yellow `offsetShift`) and extracts the hidden coin flags.
+- [x] Unit tests for the Gen 1 save parser are updated to verify hidden coin parsing logic.
 
 ## IMPORTANT REMINDERS
 - **If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.**

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -93,6 +93,8 @@ export interface SaveData {
   eventFlags?: Uint8Array;
   /** Raw byte array containing hidden item event flags. */
   hiddenItemFlags?: Uint8Array;
+  /** Raw byte array containing hidden coin event flags. */
+  hiddenCoinFlags?: Uint8Array;
   /** Bitflags representing which in-game NPC trades have already been completed. */
   npcTradeFlags?: number;
   /** Detailed structural data for Pokémon currently left in the Daycare (Gen 2). */

--- a/src/engine/saveParser/parsers/gen1.test.ts
+++ b/src/engine/saveParser/parsers/gen1.test.ts
@@ -84,6 +84,11 @@ describe('parseGen1 - specific data extraction', () => {
     view.setUint8(hiddenItemOffset, 0b10101010);
     view.setUint8(hiddenItemOffset + 1, 0b01010101);
 
+    // Hidden Coin Event Flags
+    const hiddenCoinOffset = 0x29aa;
+    view.setUint8(hiddenCoinOffset, 0b11001100);
+    view.setUint8(hiddenCoinOffset + 1, 0b00110011);
+
     // Parse!
     const data = parseGen1(view);
 
@@ -110,6 +115,11 @@ describe('parseGen1 - specific data extraction', () => {
     expect(data.hiddenItemFlags?.length).toBe(14);
     expect(data.hiddenItemFlags?.[0]).toBe(0b10101010);
     expect(data.hiddenItemFlags?.[1]).toBe(0b01010101);
+
+    expect(data.hiddenCoinFlags).toBeDefined();
+    expect(data.hiddenCoinFlags?.length).toBe(2);
+    expect(data.hiddenCoinFlags?.[0]).toBe(0b11001100);
+    expect(data.hiddenCoinFlags?.[1]).toBe(0b00110011);
   });
 
   it('should parse other PC boxes correctly', () => {

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -607,6 +607,8 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
   const eventFlags = new Uint8Array(view.buffer, eventFlagsOffset, 0x118);
   const hiddenItemFlagsOffset = 0x299c + offsetShift;
   const hiddenItemFlags = new Uint8Array(view.buffer, hiddenItemFlagsOffset, 14);
+  const hiddenCoinFlagsOffset = 0x29aa + offsetShift;
+  const hiddenCoinFlags = new Uint8Array(view.buffer, hiddenCoinFlagsOffset, 2);
 
   return {
     generation: 1,
@@ -629,6 +631,7 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
     hallOfFameCount: hallOfFameRaw === 0xff ? 0 : hallOfFameRaw,
     eventFlags,
     hiddenItemFlags,
+    hiddenCoinFlags,
     npcTradeFlags: view.getUint8(eventFlagsOffset - 16) | (view.getUint8(eventFlagsOffset - 15) << 8),
   };
 }


### PR DESCRIPTION
This PR implements parsing for the Gen 1 hidden coin event flags.

It updates the `SaveData` interface to include `hiddenCoinFlags` and implements the extraction logic at the correct offset (`0x29AA`) along with appropriate tests. The acceptance criteria in the task markdown have been updated accordingly.

---
*PR created automatically by Jules for task [11880583601192648566](https://jules.google.com/task/11880583601192648566) started by @szubster*