### PR TITLE
🛡️ Nurse: [type improvement] Replace unsafe cast with typeof guard in pokemon route

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -94,3 +94,4 @@ To avoid unsafe `as` casts in callbacks for generic UI components like `Tactical
 ## $(date +%Y-%m-%d) - Type-Safety: `as keyof typeof` for static objects
 **Learning:** When sorting or reducing over Object keys/entries that are inferred as `string`, using `[a as keyof typeof MY_OBJ]` bypasses TypeScript's strict mode checks.
 **Action:** Replace `as keyof typeof` casts by implementing a strict type guard function, e.g., `function isValidKey(k: string): k is KeyType { return k in MY_OBJ; }`. Using this type guard inside loops or `sort` functions safely narrows the string to the correct key type without needing `as`.
+- **Safe `unknown` handling with `typeof`**: Avoid unsafe casting like `(obj['key'] as string)` when extracting properties from `Record<string, unknown>`. Instead, use standard type guards like `typeof obj['key'] === 'string' ? obj['key'] : fallback` to safely narrow the type at runtime.

--- a/src/routes/__tests__/-pokemon.$pokemonId.test.tsx
+++ b/src/routes/__tests__/-pokemon.$pokemonId.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { Route } from '../pokemon.$pokemonId';
+
+describe('Pokemon Route', () => {
+  describe('validateSearch', () => {
+    const validateSearch = Route.options.validateSearch as (search: Record<string, unknown>) => { from: string };
+
+    it('returns the string from search', () => {
+      expect(validateSearch({ from: '/pokedex' })).toEqual({ from: '/pokedex' });
+    });
+
+    it('returns default "/" if from is not a string', () => {
+      expect(validateSearch({ from: 123 })).toEqual({ from: '/' });
+      expect(validateSearch({ from: null })).toEqual({ from: '/' });
+      expect(validateSearch({})).toEqual({ from: '/' });
+    });
+  });
+});

--- a/src/routes/pokemon.$pokemonId.tsx
+++ b/src/routes/pokemon.$pokemonId.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/pokemon/$pokemonId')({
   validateSearch: (search: Record<string, unknown>) => {
     return {
       // biome-ignore lint/complexity/useLiteralKeys: Bracket notation required for index signature under noPropertyAccessFromIndexSignature
-      from: (search['from'] as string) || '/',
+      from: typeof search['from'] === 'string' ? search['from'] : '/',
     };
   },
   component: PokemonPage,


### PR DESCRIPTION
🛡️ Nurse: [type improvement] Replace unsafe cast with typeof guard in pokemon route

What was unsafe:
The `validateSearch` function in `src/routes/pokemon.$pokemonId.tsx` used an unsafe cast `(search['from'] as string)` to extract the `from` property from an `unknown` record, bypassing the TypeScript compiler.

How it was fixed:
Replaced the `as string` cast with a proper runtime type guard (`typeof search['from'] === 'string' ? search['from'] : '/'`).

What the compiler now catches:
The TypeScript compiler now successfully verifies that the return type is strictly a string under strict configurations without relying on an escape hatch, preventing runtime errors if `search['from']` receives an unexpected object or array value.

---
*PR created automatically by Jules for task [1569554238134913538](https://jules.google.com/task/1569554238134913538) started by @szubster*