### PR TITLE
Fix Orchestrator Wait & Wake Bug for Completed Nodes

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -558,7 +558,7 @@ function main(): void {
       }
     }
 
-    if (shouldSuspend) {
+    if (shouldSuspend && node.frontmatter.status !== 'COMPLETED') {
       info(`Suspending ${node.frontmatter.status} node: ${node.repoPath}`);
       promoteNodeStatus(node, node.frontmatter.status, 'PENDING');
     }


### PR DESCRIPTION
This PR fixes a critical bug in the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.ts`). 

During Phase 3.5 (Wait & Wake), the orchestrator was incorrectly evaluating and mutating `COMPLETED` nodes. Because `COMPLETED` nodes are designed to be immutable once finished, modifying them back to `PENDING` caused them to incorrectly fall into the Cascade Cancellation phase, corrupting the overall DAG state and losing track of finished artifacts.

This fix explicitly adds a check `&& node.frontmatter.status !== 'COMPLETED'` to ensure that completed items are ignored during suspension checks. Tests have been run via Vitest to verify this behavior correctly aligns with the orchestrator rules.

---
*PR created automatically by Jules for task [10365452557761584998](https://jules.google.com/task/10365452557761584998) started by @szubster*