### PR TITLE
💡 Visionary: Gen 3 PokéNav Match Call & Rematch Tracker

### DIFF
--- a/.foundry/ideas/idea-077-gen3-match-call-tracker.md
+++ b/.foundry/ideas/idea-077-gen3-match-call-tracker.md
@@ -1,0 +1,39 @@
+---
+id: idea-077-gen3-match-call-tracker
+type: IDEA
+title: Gen 3 PokéNav Match Call & Rematch Tracker
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - feature
+  - gen3
+  - tracking
+  - endgame
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Gen 3 PokéNav Match Call & Rematch Tracker
+
+## Context
+In Pokémon Emerald, the PokéNav's Match Call feature tracks registered NPC trainers and gym leaders who are ready for a rematch. Rematching these trainers is a crucial endgame mechanic for both farming EXP and acquiring specific EVs without grinding wild encounters. However, the in-game UI requires scrolling through a long, linear list, and players often forget which trainers give which EVs or where they are located. Additionally, rematch flags are triggered by a hidden "step counter" mechanic which the game obfuscates.
+
+## Proposal
+Leverage DexHelper's save parsing to read the Trainer Hill/Match Call data block in the Emerald `.sav` file. By surfacing the hidden rematch flags, we can create an optimized "Rematch Dashboard".
+- Extract the list of all registered trainers and determine which ones currently have the "ready for rematch" flag set.
+- Enrich this data with static information: the route/location of the trainer, the Pokémon on their team (which scales with the rematch tier), and the aggregate EVs yielded by defeating them.
+- Present this in a filterable UI (e.g., "Show me trainers ready for a rematch that yield Speed EVs").
+
+## Value Proposition
+This perfectly aligns with DexHelper's vision as an intelligent companion app. It takes a tedious, opaque in-game system and transforms it into an actionable utility for competitive training and endgame optimization, offering massive value to the hardcore playerbase.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD to detail the UI requirements and required memory offsets for Emerald Match Call flags.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -89,3 +89,7 @@
 ## 2026-06-12
 **Idea:** Gen 3 TV Broadcast and Swarm Tracker
 **Learning:** Gen 3 features a hidden time-based event system driven by in-game TV broadcasts (which trigger swarms, sales, etc.). Like the Berry Tracker and Daily Events ideas, targeting time-gated mechanics that players easily miss without playing every day provides a massive QoL improvement. Automating these reminders based on save file event timers perfectly leverages our programmatic access to create actionable schedules.
+
+## 2026-06-13
+**Idea:** Gen 3 PokéNav Match Call & Rematch Tracker
+**Learning:** Expanding Gen 3 support by surfacing hidden, dynamically changing state (like the obfuscated step-counter-driven Match Call rematch flags) provides players with highly actionable utilities. Transforming a tedious, scroll-heavy in-game UI into an optimized dashboard for EV and EXP farming perfectly leverages our offline-first programmatic parsing strengths, turning hidden state into a competitive advantage for the hardcore playerbase.


### PR DESCRIPTION
Generates an IDEA node proposing a Gen 3 Match Call & Rematch Tracker dashboard. The dashboard would read obfuscated save state (step-counter-driven Match Call flags) to surface actionable data about available rematches for EXP/EV farming. Also updates `.jules/visionary.md` with relevant learnings about the importance of surfacing dynamically changing hidden state to benefit the hardcore playerbase.

---
*PR created automatically by Jules for task [10686163853467740469](https://jules.google.com/task/10686163853467740469) started by @szubster*