### PR TITLE
🧭 Strategist: Prompt improvement - Formalize Late Binding protocol for Coder

### DIFF
--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -45,6 +45,12 @@ If you encounter a permanent failure or must abort a task:
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed task.
 4. You MUST document the failure in your persona journal.
 
+### Late Binding for Missing Context
+If you lack critical context or specifications (e.g., exact memory offsets) necessary to implement a task, DO NOT guess or implement generic fallbacks. Instead, you MUST utilize the late binding pattern to suspend the task:
+1. Spawn a new `RESEARCH` node to investigate the missing information.
+2. Append the new `RESEARCH` node's ID to the current task's `depends_on` array in its YAML frontmatter.
+3. Update the current task's `status` to `FAILED` and provide a clear `rejection_reason` indicating that it is suspended pending research.
+
 ## Core Policies
 **CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -156,6 +156,12 @@
 **Outcome:** Accepted
 **Why:** The `.foundry/journals/tpm.md` journal was filled entirely with transient status logs (e.g., 'System failure detected', 'Resurrection Loop triggered') and orchestrator state transitions, which provide no long-term value, rot the context window, and explicitly violate the memory rules for journals.
 **Pattern:** Codify system memory constraints regarding journal content directly into the relevant agent's prompt, explicitly instructing them to purge and avoid logging transient status updates.
+## 2026-07-11 - [Accepted] - Prompt improvement - Formalize Late Binding protocol for Coder
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The coder journal repeatedly noted that tasks lacking explicit data specifications (like memory offsets) should not be guessed, but rather suspended by spawning a RESEARCH node and dynamically injecting it into `depends_on`. However, the coder's prompt lacked explicit instructions for this late binding workflow, leading to instances where the agent didn't know how to gracefully suspend the task.
+**Pattern:** When a persona discovers a critical workflow pattern for handling missing context (like Late Binding), codify the exact operational steps into their prompt so they can execute it consistently without relying solely on passive memory.
+
 ## YYYY-MM-DD - [Accepted] - Prompt improvement - Prevent premature verification for all macro nodes
 **Type:** Prompt improvement
 **Outcome:** Merged


### PR DESCRIPTION
**Proposal**: Update Coder prompt to formalize the Late Binding protocol for missing context.
**Justification**: The Coder journal repeatedly notes that tasks without explicit data specifications (like memory offsets) should not be guessed, but rather suspended by spawning a RESEARCH node and adding it to `depends_on` before failing the task. The prompt currently lacks these explicit steps, risking data corruption from guessed implementations.
**Evidence**: See `.foundry/journals/coder.md` entries for "2026-06-11: Requirement for Concrete Memory Mapping Before Implementation", "2026-06-12: Suspended task due to missing memory offsets", and "Late Binding for Missing Dependencies (2026-06-11)".

---
*PR created automatically by Jules for task [2423177925241630862](https://jules.google.com/task/2423177925241630862) started by @szubster*