### PR TITLE
Break down story-061-096-pokerus-tests into TASK nodes

### DIFF
--- a/.foundry/stories/story-061-096-pokerus-tests.md
+++ b/.foundry/stories/story-061-096-pokerus-tests.md
@@ -29,3 +29,5 @@ Implement tests for the Pokerus byte parsing logic.
 
 ## Acceptance Criteria
 - [ ] Add tests for Pokerus parsing.
+- [ ] task-096-169-pokerus-tests-impl
+- [ ] task-096-170-pokerus-tests-qa

--- a/.foundry/tasks/task-096-169-pokerus-tests-impl.md
+++ b/.foundry/tasks/task-096-169-pokerus-tests-impl.md
@@ -1,0 +1,37 @@
+---
+id: task-096-169-pokerus-tests-impl
+type: TASK
+title: Implement Pokerus Parser Edge-Case Tests
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-061-096-pokerus-tests
+tags:
+  - gen2
+  - save-engine
+  - pokerus
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Pokerus Parser Edge-Case Tests
+
+## Description
+The Pokerus byte parsing logic in Gen 2 currently has a happy-path test in `src/engine/saveParser/parsers/gen2.test.ts`, but it needs comprehensive tests for edge cases. Implement tests that cover the boundaries of the Pokerus extraction logic (bit shifts and masking) such as:
+1. When strain is non-zero but daysRemaining is zero (cured state).
+2. When the parsed value contains specific bounds for `daysRemaining` and `strain`.
+3. Validating the fallback handling if needed.
+
+## Acceptance Criteria
+- [ ] Add extensive Pokerus parsing tests in `src/engine/saveParser/parsers/gen2.test.ts`.
+- [ ] Ensure edge cases like 0 days remaining with non-zero strain (cured state) are explicitly tested.
+- [ ] Ensure all tests pass.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- [ ] If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/.foundry/tasks/task-096-170-pokerus-tests-qa.md
+++ b/.foundry/tasks/task-096-170-pokerus-tests-qa.md
@@ -1,0 +1,35 @@
+---
+id: task-096-170-pokerus-tests-qa
+type: TASK
+title: QA Pokerus Parser Edge-Case Tests
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - task-096-169-pokerus-tests-impl
+jules_session_id: null
+pr_number: null
+parent: story-061-096-pokerus-tests
+tags:
+  - gen2
+  - save-engine
+  - pokerus
+  - testing
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Pokerus Parser Edge-Case Tests
+
+## Description
+Verify the implementation of Pokerus parsing edge-case tests in `src/engine/saveParser/parsers/gen2.test.ts`.
+
+## Acceptance Criteria
+- [ ] Verify that Pokerus parsing tests cover boundary values such as non-zero strain with 0 days remaining.
+- [ ] Verify that the test suite runs correctly (`pnpm test`) and passes successfully.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- [ ] If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.


### PR DESCRIPTION
Broke down the product story into granular TASK nodes for the coder and qa personas.

---
*PR created automatically by Jules for task [11487988009605969593](https://jules.google.com/task/11487988009605969593) started by @szubster*