### PR TITLE
feat(gen3): implement Mirage Island value parsing

### DIFF
--- a/.foundry/tasks/task-098-157-mirage-island-parsing-impl.md
+++ b/.foundry/tasks/task-098-157-mirage-island-parsing-impl.md
@@ -34,8 +34,8 @@ This must adhere strictly to ADR 010:
 - Catch the `RangeError` and handle it gracefully (e.g. by throwing a specific validation error like "Corrupted Save File" or returning a designated safe error state, depending on the parser's existing error handling patterns).
 
 ## Acceptance Criteria
-- [ ] Logic implemented to extract the Mirage Island random value using `DataView.getUint16`.
-- [ ] Out-of-bounds reads (`RangeError`) are caught and handled gracefully as per ADR 010.
+- [x] Logic implemented to extract the Mirage Island random value using `DataView.getUint16`.
+- [x] Out-of-bounds reads (`RangeError`) are caught and handled gracefully as per ADR 010.
 
 ## Important Note for Coder
 If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isGen3Save, parseGen3, parseGen3PersonalityValue } from './gen3';
+import { isGen3Save, parseGen3, parseGen3MirageIslandValue, parseGen3PersonalityValue } from './gen3';
 
 describe('gen3 parser scaffolding', () => {
   it('isGen3Save should return false normally', () => {
@@ -79,6 +79,30 @@ describe('gen3 parser scaffolding', () => {
 
     // Restore
     view.getUint8 = originalGetUint8;
+  });
+});
+
+describe('parseGen3MirageIslandValue', () => {
+  it('should extract a 16-bit little-endian value correctly', () => {
+    const buffer = new ArrayBuffer(4);
+    const view = new DataView(buffer);
+
+    // Set up a 16-bit value at offset 2: 0x1234 (little endian)
+    // 0x34, 0x12
+    view.setUint8(2, 0x34);
+    view.setUint8(3, 0x12);
+
+    const result = parseGen3MirageIslandValue(view, 2);
+
+    expect(result).toBe(0x1234);
+  });
+
+  it('should explicitly catch RangeError on out-of-bounds reads and throw a corrupted file error', () => {
+    const buffer = new ArrayBuffer(2);
+    const view = new DataView(buffer);
+
+    // Attempting to read a 16-bit integer (2 bytes) starting at offset 2 will exceed the 2-byte buffer
+    expect(() => parseGen3MirageIslandValue(view, 2)).toThrowError('The save file is corrupted or incomplete.');
   });
 });
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -76,6 +76,25 @@ export function isGen3Save(view: DataView): boolean {
 }
 
 /**
+ * Parses the 16-bit Mirage Island value from a Gen 3 save file.
+ *
+ * @param view - The raw save file DataView.
+ * @param offset - The offset within the buffer to read the value from.
+ * @returns The 16-bit unsigned integer representing the Mirage Island value.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3MirageIslandValue(view: DataView, offset: number): number {
+  try {
+    return view.getUint16(offset, true);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+/**
  * Extracts all relevant game data from a Gen 3 save.
  * Placeholder implementation for scaffolding.
  *


### PR DESCRIPTION
Implemented `parseGen3MirageIslandValue` to extract the 16-bit daily random value for Mirage Island. This uses the `DataView` API directly and gracefully handles out-of-bounds reads as per ADR 010. Added unit tests for valid value extraction and `RangeError` bounds checking. Updated `task-098-157-mirage-island-parsing-impl.md` checkboxes.

---
*PR created automatically by Jules for task [268641716910362386](https://jules.google.com/task/268641716910362386) started by @szubster*