### PR TITLE
feat: implement ContestSheenDisplay component

### DIFF
--- a/.foundry/tasks/task-102-157-contest-sheen-display-impl.md
+++ b/.foundry/tasks/task-102-157-contest-sheen-display-impl.md
@@ -39,6 +39,6 @@ This task is part of `story-064-102-contest-sheen-display-ui`, which aims to cre
 - Do NOT modify the YAML frontmatter unless permanently failing or cancelling the task. Only check off the markdown boxes below when completing the work.
 
 ## Acceptance Criteria
-- [ ] Implement `ContestSheenDisplay` React component in `src/components/pokemon/details/`.
-- [ ] Ensure the component properly handles values from 0 to 255, filling up a visual meter/bar.
-- [ ] Ensure styles follow the tactical hardware aesthetic.
+- [x] Implement `ContestSheenDisplay` React component in `src/components/pokemon/details/`.
+- [x] Ensure the component properly handles values from 0 to 255, filling up a visual meter/bar.
+- [x] Ensure styles follow the tactical hardware aesthetic.

--- a/src/components/pokemon/details/ContestSheenDisplay.tsx
+++ b/src/components/pokemon/details/ContestSheenDisplay.tsx
@@ -1,0 +1,34 @@
+import type React from 'react';
+import { cn } from '../../../utils/cn';
+import { TacticalPanel } from '../../TacticalPanel';
+
+interface ContestSheenDisplayProps {
+  sheen: number;
+  className?: string;
+}
+
+export const ContestSheenDisplay: React.FC<ContestSheenDisplayProps> = ({ sheen, className }) => {
+  const maxSheen = 255;
+  const percentage = Math.min(Math.max((sheen / maxSheen) * 100, 0), 100);
+  const isMaxed = sheen >= maxSheen;
+
+  return (
+    <TacticalPanel
+      variant={isMaxed ? 'emerald' : 'blue'}
+      className={cn('flex flex-col gap-2 p-4 font-mono', className)}
+    >
+      <div className="flex items-center justify-between font-semibold text-xs uppercase tracking-wider">
+        <span className="text-zinc-400">Sheen</span>
+        <span className={cn(isMaxed ? 'text-emerald-400' : 'text-zinc-300')}>
+          {sheen} / {maxSheen} {isMaxed && '(MAX)'}
+        </span>
+      </div>
+      <div className="h-2 w-full bg-zinc-800/50 outline outline-1 outline-zinc-700">
+        <div
+          className={cn('h-full transition-all duration-500', isMaxed ? 'bg-emerald-500' : 'bg-blue-500')}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </TacticalPanel>
+  );
+};

--- a/src/components/pokemon/details/ContestSheenDisplay.tsx
+++ b/src/components/pokemon/details/ContestSheenDisplay.tsx
@@ -23,9 +23,9 @@ export const ContestSheenDisplay: React.FC<ContestSheenDisplayProps> = ({ sheen,
           {sheen} / {maxSheen} {isMaxed && '(MAX)'}
         </span>
       </div>
-      <div className="h-2 w-full bg-zinc-800/50 outline outline-1 outline-zinc-700">
+      <div className="h-2 w-full rounded-none border border-zinc-700 border-dashed bg-zinc-800/50">
         <div
-          className={cn('h-full transition-all duration-500', isMaxed ? 'bg-emerald-500' : 'bg-blue-500')}
+          className={cn('h-full rounded-none transition-all duration-500', isMaxed ? 'bg-emerald-500' : 'bg-blue-500')}
           style={{ width: `${percentage}%` }}
         />
       </div>

--- a/src/components/pokemon/details/__tests__/ContestSheenDisplay.test.tsx
+++ b/src/components/pokemon/details/__tests__/ContestSheenDisplay.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { ContestSheenDisplay } from '../ContestSheenDisplay';
+
+describe('ContestSheenDisplay', () => {
+  it('renders correctly with 0 sheen', async () => {
+    await render(<ContestSheenDisplay sheen={0} />);
+
+    await expect.element(page.getByText('Sheen')).toBeVisible();
+    await expect.element(page.getByText('0 / 255')).toBeVisible();
+  });
+
+  it('renders correctly with max sheen', async () => {
+    await render(<ContestSheenDisplay sheen={255} />);
+
+    await expect.element(page.getByText('Sheen')).toBeVisible();
+    await expect.element(page.getByText('255 / 255 (MAX)')).toBeVisible();
+  });
+
+  it('renders correctly with partial sheen', async () => {
+    await render(<ContestSheenDisplay sheen={127} />);
+
+    await expect.element(page.getByText('Sheen')).toBeVisible();
+    await expect.element(page.getByText('127 / 255')).toBeVisible();
+  });
+});


### PR DESCRIPTION
- Implemented `ContestSheenDisplay` React component in `src/components/pokemon/details/`.
- Ensure the component properly handles values from 0 to 255, filling up a visual meter/bar.
- Ensure styles follow the tactical hardware aesthetic.

---
*PR created automatically by Jules for task [4303746179125692537](https://jules.google.com/task/4303746179125692537) started by @szubster*