### PR TITLE
feat: implement Gen 3 condition stats parsing logic

### DIFF
--- a/.foundry/tasks/task-101-157-gen3-condition-stats-parsing.md
+++ b/.foundry/tasks/task-101-157-gen3-condition-stats-parsing.md
@@ -34,9 +34,9 @@ This task implements the logic to extract Gen 3 contest condition statistics (Co
 4. **Error Handling**: Allow `DataView` to throw `RangeError` on out-of-bounds reads and handle them gracefully as required by ADR 010.
 
 ## Acceptance Criteria
-- [ ] Logic correctly parses Gen 3 Condition stats (Cool, Beauty, Cute, Smart, Tough).
-- [ ] The `DataView` API is exclusively used for all new parsing logic.
-- [ ] No regressions in Gen 1 and Gen 2 parsing interfaces.
+- [x] Logic correctly parses Gen 3 Condition stats (Cool, Beauty, Cute, Smart, Tough).
+- [x] The `DataView` API is exclusively used for all new parsing logic.
+- [x] No regressions in Gen 1 and Gen 2 parsing interfaces.
 
 ---
 

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -29,6 +29,7 @@ export interface PokemonInstance {
   currentHp?: number | undefined;
   dvs?: { hp: number; atk: number; def: number; spd: number; spc: number };
   statExp?: { hp: number; atk: number; def: number; spd: number; spc: number };
+  condition?: { cool: number; beauty: number; cute: number; smart: number; tough: number };
   caughtData?:
     | {
         time: 'Morning' | 'Day' | 'Night' | 'Unknown';

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isGen3Save, parseGen3, parseGen3PersonalityValue } from './gen3';
+import { isGen3Save, parseGen3, parseGen3ConditionStats, parseGen3PersonalityValue } from './gen3';
 
 describe('gen3 parser scaffolding', () => {
   it('isGen3Save should return false normally', () => {
@@ -79,6 +79,91 @@ describe('gen3 parser scaffolding', () => {
 
     // Restore
     view.getUint8 = originalGetUint8;
+  });
+});
+
+describe('parseGen3ConditionStats', () => {
+  it('should correctly decrypt and extract condition stats from substruct E', () => {
+    // 80 bytes is the size of the pokemon struct
+    const buffer = new ArrayBuffer(80);
+    const view = new DataView(buffer);
+
+    const pokemonOffset = 0;
+    const personalityValue = 0; // % 24 = 0 -> Substruct order: GAEM -> E is index 2
+    const otId = 0x12345678;
+    const decryptionKey = personalityValue ^ otId;
+
+    // Substruct E starts at pokemonOffset + 32 + (2 * 12) = 56
+    const substructStart = 56;
+
+    // We want cool=10, beauty=20, cute=30, smart=40, tough=50
+    // dword1 covers bytes 4-7. cool is at byte 2, beauty is at byte 3.
+    // So decrypted dword1 should be: (beauty << 24) | (cool << 16) = (20 << 24) | (10 << 16) = 0x140A0000
+    const decryptedDword1 = (20 << 24) | (10 << 16);
+
+    // dword2 covers bytes 8-11. cute is at byte 0, smart is at byte 1, tough is at byte 2.
+    // So decrypted dword2 should be: (tough << 16) | (smart << 8) | cute = (50 << 16) | (40 << 8) | 30 = 0x0032281E
+    const decryptedDword2 = (50 << 16) | (40 << 8) | 30;
+
+    // Encrypt the dwords
+    const encryptedDword1 = decryptedDword1 ^ decryptionKey;
+    const encryptedDword2 = decryptedDword2 ^ decryptionKey;
+
+    view.setUint32(substructStart + 4, encryptedDword1, true);
+    view.setUint32(substructStart + 8, encryptedDword2, true);
+
+    const result = parseGen3ConditionStats(view, pokemonOffset, personalityValue, otId);
+
+    expect(result).toEqual({
+      cool: 10,
+      beauty: 20,
+      cute: 30,
+      smart: 40,
+      tough: 50,
+    });
+  });
+
+  it('should correctly decrypt and extract from a different substruct order', () => {
+    const buffer = new ArrayBuffer(80);
+    const view = new DataView(buffer);
+
+    const pokemonOffset = 0;
+    const personalityValue = 12; // % 24 = 12 -> Substruct order: EGAM -> E is index 0
+    const otId = 0x87654321;
+    const decryptionKey = personalityValue ^ otId;
+
+    // Substruct E starts at pokemonOffset + 32 + (0 * 12) = 32
+    const substructStart = 32;
+
+    const decryptedDword1 = (255 << 24) | (128 << 16); // beauty=255, cool=128
+    const decryptedDword2 = (1 << 16) | (2 << 8) | 3; // tough=1, smart=2, cute=3
+
+    view.setUint32(substructStart + 4, decryptedDword1 ^ decryptionKey, true);
+    view.setUint32(substructStart + 8, decryptedDword2 ^ decryptionKey, true);
+
+    const result = parseGen3ConditionStats(view, pokemonOffset, personalityValue, otId);
+
+    expect(result).toEqual({
+      cool: 128,
+      beauty: 255,
+      cute: 3,
+      smart: 2,
+      tough: 1,
+    });
+  });
+
+  it('should throw corrupted file error on out of bounds read', () => {
+    // A buffer that is too small (less than 80 bytes)
+    const buffer = new ArrayBuffer(40);
+    const view = new DataView(buffer);
+
+    const pokemonOffset = 0;
+    const personalityValue = 0; // E is index 2, needs offset 56
+    const otId = 0;
+
+    expect(() => parseGen3ConditionStats(view, pokemonOffset, personalityValue, otId)).toThrowError(
+      'The save file is corrupted or incomplete.',
+    );
   });
 });
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -130,6 +130,70 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
 }
 
 /**
+ * Parses the Gen 3 condition stats (Cool, Beauty, Cute, Smart, Tough) for a Pokémon.
+ *
+ * @param view - The raw save file DataView.
+ * @param pokemonOffset - The start offset of the 80-byte Pokémon struct.
+ * @param personalityValue - The 32-bit Personality Value used for decryption and layout.
+ * @param otId - The 32-bit OT ID used for decryption.
+ * @returns An object containing the extracted condition stats.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3ConditionStats(
+  view: DataView,
+  pokemonOffset: number,
+  personalityValue: number,
+  otId: number,
+): { cool: number; beauty: number; cute: number; smart: number; tough: number } {
+  try {
+    const decryptionKey = personalityValue ^ otId;
+    const substructOrder = personalityValue % 24;
+
+    // The index (0-3) of the EVs/Condition substructure (Substruct E)
+    const evConditionSubstructIndex = [2, 3, 1, 1, 3, 2, 2, 3, 1, 1, 3, 2, 0, 0, 0, 0, 0, 0, 3, 2, 3, 2, 1, 1][
+      substructOrder
+    ];
+
+    if (evConditionSubstructIndex === undefined) {
+      throw new Error('Invalid substructOrder');
+    }
+
+    const dataBlockStart = pokemonOffset + 32;
+    const substructStart = dataBlockStart + evConditionSubstructIndex * 12;
+
+    // Conditions are stored starting at offset 6 within the 12-byte EV/Condition substructure.
+    // They are stored as:
+    // +6: cool, +7: beauty
+    // +8: cute, +9: smart
+    // +10: tough, +11: feel (ignored here)
+
+    // Decrypt the two 32-bit integers that span the Condition bytes (offsets 4-7 and 8-11 of the substructure).
+    const dword1 = view.getUint32(substructStart + 4, true) ^ decryptionKey;
+    const dword2 = view.getUint32(substructStart + 8, true) ^ decryptionKey;
+
+    // Extract the bytes from the decrypted dwords.
+    // dword1 (little-endian): [offset + 4] [offset + 5] [offset + 6] [offset + 7]
+    // cool is at offset + 6 (byte 2 of dword1), beauty is at offset + 7 (byte 3 of dword1)
+    const cool = (dword1 >> 16) & 0xff;
+    const beauty = (dword1 >> 24) & 0xff;
+
+    // dword2 (little-endian): [offset + 8] [offset + 9] [offset + 10] [offset + 11]
+    // cute is at offset + 8 (byte 0 of dword2), smart is at offset + 9 (byte 1 of dword2)
+    // tough is at offset + 10 (byte 2 of dword2)
+    const cute = dword2 & 0xff;
+    const smart = (dword2 >> 8) & 0xff;
+    const tough = (dword2 >> 16) & 0xff;
+
+    return { cool, beauty, cute, smart, tough };
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+/**
  * Parses the 32-bit Personality Value (PV) from a Gen 3 save file.
  *
  * @param view - The raw save file DataView.


### PR DESCRIPTION
Implemented Gen 3 condition stats parsing logic per requirements of `task-101-157`.

- Added optional `condition` object into `PokemonInstance`.
- Implemented `parseGen3ConditionStats` using `DataView` API directly.
- Used native `RangeError` capturing and gracefully throwing per ADR 010.
- Included full unit test coverage mimicking encrypted Gen 3 data structures in `gen3.test.ts`.

---
*PR created automatically by Jules for task [16654154222188426496](https://jules.google.com/task/16654154222188426496) started by @szubster*