### PR TITLE
Auditor Rejection of idea-066 (Attempt 6)

### DIFF
--- a/.foundry/ideas/idea-066-save-file-health-scanner.md
+++ b/.foundry/ideas/idea-066-save-file-health-scanner.md
@@ -54,3 +54,6 @@ The generated PRD and Epic nodes are still PENDING. This IDEA node must wait unt
 
 ### Auditor Rejection (Attempt 5)
 The generated PRD and Epic nodes are still PENDING. This IDEA node must wait until its entire generated sub-tree is COMPLETED. The resurrection loop continues to fail because agents are resubmitting without waiting. We must wait for the implementation of IDEA-072 (Strict Macro Node Completion Enforcement).
+
+### Auditor Rejection (Attempt 6)
+The generated PRD and Epic nodes are still PENDING. This IDEA node must wait until its entire generated sub-tree is COMPLETED. The resurrection loop continues to fail because agents are resubmitting without waiting. We must wait for the implementation of IDEA-072 (Strict Macro Node Completion Enforcement).

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -49,3 +49,12 @@ The Resurrection Loop has completely broken down for macro nodes waiting on long
 
 **Recommendation/Learnings:**
 We cannot rely on prompt engineering or manual agent compliance for this constraint. `idea-072-strict-macro-node-completion` MUST be implemented in the core orchestrator script immediately to enforce strict hierarchical completion.
+
+## 2026-06-13: Infinite Resurrection Loop Attempt 6
+I observed that `idea-066-save-file-health-scanner` was submitted for verification again (Attempt 6) while its child nodes are still in PENDING.
+
+**Why this matters:**
+The Resurrection Loop continues to fail. Agents simply resubmit the empty PR without waiting for the child nodes to complete. This creates an infinite loop.
+
+**Recommendation/Learnings:**
+As emphasized in previous entries, we critically need hard orchestrator locks. `idea-072-strict-macro-node-completion` MUST be implemented in the core orchestrator script to enforce strict hierarchical completion and prevent this infinite loop.


### PR DESCRIPTION
Appended an Auditor Rejection notice to idea-066-save-file-health-scanner.md because its descendant nodes are still PENDING. Added a journal entry to auditor.md documenting this infinite loop and the critical need for strict orchestrator completion enforcement.

---
*PR created automatically by Jules for task [6077114422208207376](https://jules.google.com/task/6077114422208207376) started by @szubster*