### PR TITLE
Draft Gen 3 Parse Battle Frontier Win Streaks Tasks

### DIFF
--- a/.foundry/stories/story-078-121-gen3-parse-battle-frontier-win-streaks.md
+++ b/.foundry/stories/story-078-121-gen3-parse-battle-frontier-win-streaks.md
@@ -31,3 +31,6 @@ Based on the offset research in `research-046-140-gen3-battle-frontier`, extract
 - [ ] Extract current win streaks for Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid.
 - [ ] Extract max win records for all 7 facilities.
 - [ ] Implement error handling for out-of-bounds reads.
+
+- [ ] task-121-171-gen3-parse-battle-frontier-win-streaks-impl
+- [ ] task-121-172-gen3-parse-battle-frontier-win-streaks-qa

--- a/.foundry/tasks/task-121-171-gen3-parse-battle-frontier-win-streaks-impl.md
+++ b/.foundry/tasks/task-121-171-gen3-parse-battle-frontier-win-streaks-impl.md
@@ -1,0 +1,53 @@
+---
+id: task-121-171-gen3-parse-battle-frontier-win-streaks-impl
+type: TASK
+title: Implement Gen 3 Parse Battle Frontier Win Streaks
+status: PENDING
+owner_persona: coder
+created_at: "2026-06-13"
+updated_at: "2026-06-13"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-078-121-gen3-parse-battle-frontier-win-streaks
+tags:
+  - feature
+  - gen3
+  - endgame
+research_references:
+  - research-046-140-gen3-battle-frontier
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement Gen 3 Parse Battle Frontier Win Streaks
+
+## Context
+Based on the offset research in `research-046-140-gen3-battle-frontier`, extract the current and max win streaks for the 7 Battle Frontier facilities from SaveBlock2 using `DataView`.
+
+**Note:** If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Requirements
+Extract current win streaks and max win records for all 7 facilities (Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid) and implement error handling for out-of-bounds reads.
+
+Offsets (relative to start of `SaveBlock2`, `0x0000`):
+- `0x0CE0` - `towerWinStreaks`
+- `0x0CF0` - `towerRecordWinStreaks`
+- `0x0D0C` - `domeWinStreaks`
+- `0x0D14` - `domeRecordWinStreaks`
+- `0x0DC8` - `palaceWinStreaks`
+- `0x0DD0` - `palaceRecordWinStreaks`
+- `0x0DDA` - `arenaWinStreaks`
+- `0x0DDE` - `arenaRecordStreaks`
+- `0x0DE2` - `factoryWinStreaks`
+- `0x0DEA` - `factoryRecordWinStreaks`
+- `0x0E04` - `pikeWinStreaks`
+- `0x0E08` - `pikeRecordStreaks`
+- `0x0E1A` - `pyramidWinStreaks`
+- `0x0E1E` - `pyramidRecordStreaks`
+
+## Acceptance Criteria
+- [ ] Extract current win streaks for Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid.
+- [ ] Extract max win records for all 7 facilities.
+- [ ] Implement error handling for out-of-bounds reads.

--- a/.foundry/tasks/task-121-172-gen3-parse-battle-frontier-win-streaks-qa.md
+++ b/.foundry/tasks/task-121-172-gen3-parse-battle-frontier-win-streaks-qa.md
@@ -1,0 +1,38 @@
+---
+id: task-121-172-gen3-parse-battle-frontier-win-streaks-qa
+type: TASK
+title: QA Gen 3 Parse Battle Frontier Win Streaks
+status: PENDING
+owner_persona: qa
+created_at: "2026-06-13"
+updated_at: "2026-06-13"
+depends_on:
+  - task-121-171-gen3-parse-battle-frontier-win-streaks-impl
+jules_session_id: null
+pr_number: null
+parent: story-078-121-gen3-parse-battle-frontier-win-streaks
+tags:
+  - testing
+  - gen3
+  - endgame
+research_references:
+  - research-046-140-gen3-battle-frontier
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA Gen 3 Parse Battle Frontier Win Streaks
+
+## Context
+Validate the implementation of the Battle Frontier win streak parsing functionality developed in `task-121-171-gen3-parse-battle-frontier-win-streaks-impl`.
+
+**Note:** If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Requirements
+Verify that current win streaks and max win records for all 7 facilities (Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid) are correctly extracted and that error handling for out-of-bounds reads functions properly. Add corresponding unit tests.
+
+## Acceptance Criteria
+- [ ] Verify unit tests correctly parse current win streaks.
+- [ ] Verify unit tests correctly parse max win records.
+- [ ] Verify unit tests handle out-of-bounds read errors.


### PR DESCRIPTION
# Gen 3 Battle Frontier Win Streaks Blueprints

Breaks down `story-078-121-gen3-parse-battle-frontier-win-streaks` into two actionable tasks:
- `task-121-171-gen3-parse-battle-frontier-win-streaks-impl`: Coder task to extract current and max win streaks for the 7 Battle Frontier facilities using the researched SaveBlock2 offsets.
- `task-121-172-gen3-parse-battle-frontier-win-streaks-qa`: QA task to verify the implementation handles parsing and out-of-bounds reads correctly.

The parent story's markdown body has been updated to reference these child tasks without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [8408414113669936455](https://jules.google.com/task/8408414113669936455) started by @szubster*