### PR TITLE
chore: handle impossible loop for mirage island offset

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -53,3 +53,7 @@ Prevents silent failures and ensures backwards compatibility.
 
 - **Observation**: Standard documentation often lists Hall of Fame counts at fixed absolute offsets (e.g. `0x24EC` for GS). However, relying on these can be unreliable due to emulator artifacts or regional shifts, causing task failures.
 - **Action**: When drafting tasks for parsing variable save data, enforce the use of relative offsets based on known, stable anchor points within the player data block. For example, explicitly mapping the Hall of Fame count to `johtoBadgesOffset + 0xA8` ensures cross-version stability and prevents rigid absolute offset failures.
+## 2026-06-13: Verifying Save File Sections against Bulbapedia
+
+- **Observation**: When documenting Gen 3 save file offsets, simply finding the correct byte offset is insufficient. The offset must be mapped to the correct logical 4KB section boundary as defined by authoritative sources like Bulbapedia. For instance, the Mirage Island offset (`0x0408`/`0x0464`) was incorrectly attributed to "Section 3-4 - Game Specific Data" instead of the correct "Section 2 - Game State", leading to QA rejection.
+- **Action**: Always explicitly verify the logical section of any discovered offset against authoritative documentation before finalizing parsing specs to prevent incorrect data extraction by the orchestrator.

--- a/.foundry/research/research-098-171-investigate-mirage-island-offset.md
+++ b/.foundry/research/research-098-171-investigate-mirage-island-offset.md
@@ -1,0 +1,37 @@
+---
+id: research-098-171-investigate-mirage-island-offset
+type: RESEARCH
+title: Investigate Mirage Island Offset and Section
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-061-098-locate-mirage-island-data
+tags:
+  - gen3
+  - mirage-island
+  - save-parsing
+  - research
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Mirage Island Offset and Section
+
+## Context
+The QA validation failed for the Mirage Island offset documentation (`task-098-158-qa-mirage-island-offset`). The rejection reason states:
+> Validation FAILED: The documentation incorrectly attributes the offset to "Section 3-4 - Game Specific Data". According to Bulbapedia, 0x0408 and 0x0464 belong to "Section 2 - Game State". The target task has been failed and reverted for correction.
+
+## Requirements
+1. Investigate the Bulbapedia claims and cross-reference with authoritative sources (e.g., Pret decompilations) to determine the correct logical 4KB section boundaries for the Gen 3 save file.
+2. Determine if the offset `0x0408` (Ruby/Sapphire) and `0x0464` (Emerald) falls within "Section 2 - Game State" or "Section 3-4 - Game Specific Data".
+3. Provide a detailed summary of the findings so that the subsequent documentation task can record the correct offset and section information.
+
+## Acceptance Criteria
+- [ ] Determine the correct section (Section 2 or Section 3-4) for the Mirage Island daily value.
+- [ ] Document the findings and provide references to authoritative sources.

--- a/.foundry/stories/story-061-098-locate-mirage-island-data.md
+++ b/.foundry/stories/story-061-098-locate-mirage-island-data.md
@@ -33,3 +33,6 @@ As part of Epic `epic-038-061-mirage-island-save-parsing`, we need to locate the
 - [x] Tech Lead: Generate child tasks to locate and document the offset for the Mirage Island value.
 - [ ] .foundry/archive/tasks/task-098-157-locate-mirage-island-offset.md
 - [ ] .foundry/tasks/task-098-158-qa-mirage-island-offset.md
+- [ ] .foundry/research/research-098-171-investigate-mirage-island-offset.md
+- [ ] .foundry/tasks/task-098-172-locate-mirage-island-offset-retry.md
+- [ ] .foundry/tasks/task-098-173-qa-mirage-island-offset-retry.md

--- a/.foundry/tasks/task-098-158-qa-mirage-island-offset.md
+++ b/.foundry/tasks/task-098-158-qa-mirage-island-offset.md
@@ -41,3 +41,5 @@ The `coder` persona has documented the exact offset and data structure for the d
 
 ### QA Notes
 - Validation FAILED: The documentation incorrectly attributes the offset to "Section 3-4 - Game Specific Data". According to Bulbapedia, 0x0408 and 0x0464 belong to "Section 2 - Game State". The target task has been failed and reverted for correction.
+
+**Note:** This task is CANCELLED and has been replaced by `task-098-173-qa-mirage-island-offset-retry.md` due to incorrect Bulbapedia section documentation.

--- a/.foundry/tasks/task-098-172-locate-mirage-island-offset-retry.md
+++ b/.foundry/tasks/task-098-172-locate-mirage-island-offset-retry.md
@@ -1,0 +1,44 @@
+---
+id: task-098-172-locate-mirage-island-offset-retry
+type: TASK
+title: Locate Mirage Island Data Block Offset (Retry)
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - research-098-171-investigate-mirage-island-offset
+jules_session_id: null
+pr_number: null
+parent: story-061-098-locate-mirage-island-data
+tags:
+  - gen3
+  - mirage-island
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Locate Mirage Island Data Block Offset (Retry)
+
+## Context
+As part of the Mirage Island save parsing feature (Story `story-061-098-locate-mirage-island-data`), we need to identify the precise byte offset, section, and data structure for the random/daily variables block that contains the 2-byte Mirage Island value in Gen 3 save files (Ruby, Sapphire, Emerald). A previous attempt failed QA because the documented section was incorrect according to Bulbapedia.
+
+## Requirements
+1. Review the findings in `research-098-171-investigate-mirage-island-offset.md`.
+2. Determine the exact offset for the Mirage Island daily value within the Generation 3 save data structure based on the research.
+3. Determine the size and format of this data.
+4. Document these findings in a new file `.foundry/docs/knowledge_base/gen3_mirage_island_offsets.md`. Ensure you map the byte offsets to the correct logical 4KB section boundaries (e.g. "Section 2 - Game State").
+
+## Tech Lead Instructions for Coder
+- **Documentation format**: Provide the offsets, sections, and data sizes clearly in the new markdown file.
+- **Reminder**: Even if no application source code is changed and you only add the documentation file, you MUST use the `submit` tool to create the Pull Request. Do not leave the PR empty without updating the Acceptance Criteria checkboxes (`- [x]`) if you make an empty PR.
+- **Failure Condition**: If you cannot locate the offset or encounter permanent failures, you MUST update this node's YAML frontmatter to `status: FAILED` with a clear `rejection_reason`.
+
+## Acceptance Criteria
+- [ ] Document the exact byte offset(s) for the Mirage Island value in R/S/E.
+- [ ] Document the correct section containing the value.
+- [ ] Document the data structure size (expected to be a 16-bit integer).
+- [ ] Create or update `.foundry/docs/knowledge_base/gen3_mirage_island_offsets.md` with the findings.

--- a/.foundry/tasks/task-098-173-qa-mirage-island-offset-retry.md
+++ b/.foundry/tasks/task-098-173-qa-mirage-island-offset-retry.md
@@ -1,0 +1,41 @@
+---
+id: task-098-173-qa-mirage-island-offset-retry
+type: TASK
+title: QA - Verify Mirage Island Data Block Offset Documentation (Retry)
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - task-098-172-locate-mirage-island-offset-retry
+jules_session_id: null
+pr_number: null
+parent: story-061-098-locate-mirage-island-data
+tags:
+  - qa
+  - gen3
+  - mirage-island
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Verify Mirage Island Data Block Offset Documentation (Retry)
+
+## Context
+The `coder` persona has documented the exact offset, section, and data structure for the daily/random variables block containing the Mirage Island value in Gen 3 save files (Ruby, Sapphire, Emerald) in `task-098-172-locate-mirage-island-offset-retry`. We need to verify the accuracy of this documentation.
+
+## Requirements
+1. Review `.foundry/docs/knowledge_base/gen3_mirage_island_offsets.md`.
+2. Verify the documented offsets, sections, and data structure size match known Gen 3 save structures (e.g., from Bulbapedia, Pret repositories, etc.) and align with the findings from `research-098-171-investigate-mirage-island-offset.md`.
+
+## Tech Lead Instructions for QA
+- **Empty PR Reminder**: Since this is a QA verification task and you are unlikely to make code changes, you MUST check off the Acceptance Criteria (`- [x]`) in this node's markdown and use the `submit` tool to create an empty Pull Request.
+- **Failure Condition**: If the documentation is incorrect or missing, you MUST update this node's YAML frontmatter to `status: FAILED` with a clear `rejection_reason` so the tech lead can resurrect the work. Do NOT mark this task as FAILED if the task itself passes but you found a bug in the target; report bugs in the rejection_reason and FAILED status if necessary.
+
+## Acceptance Criteria
+- [ ] Verify the documented byte offsets for the Mirage Island value in R/S/E are correct.
+- [ ] Verify the documented section for the Mirage Island value is correct according to Bulbapedia.
+- [ ] Verify the data size is documented as a 16-bit integer.


### PR DESCRIPTION
This PR handles the Impossible Loop triggered by the permanent failure of the Mirage Island offset documentation tasks.

**Changes:**
1.  **Tech Lead Journal Update:** Recorded a lesson on verifying Gen 3 save file byte offsets against logical 4KB section boundaries defined by Bulbapedia.
2.  **Research Node Spawning:** Created `research-098-171-investigate-mirage-island-offset.md` to investigate the correct Bulbapedia sections.
3.  **Replacement Tasks:** Drafted `task-098-172-locate-mirage-island-offset-retry.md` and `task-098-173-qa-mirage-island-offset-retry.md` with proper DAG dependencies on the new research node.
4.  **DAG Cleanup:** Appended a `CANCELLED` note to the orphaned QA task (`task-098-158`) markdown body without modifying its frontmatter.
5.  **Story Update:** Appended the newly generated task nodes to `story-061-098-locate-mirage-island-data.md` as unchecked acceptance criteria.

---
*PR created automatically by Jules for task [9897316495401718692](https://jules.google.com/task/9897316495401718692) started by @szubster*