### PR TITLE
Tech Lead: Draft Tasks for Gen 3 TV Block DataView Parser

### DIFF
--- a/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
+++ b/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
@@ -28,3 +28,7 @@ Implement the foundational logic to locate and read the TV broadcast data block 
 ## Acceptance Criteria
 - [ ] Implement parser logic using `DataView` to read the TV event block.
 - [ ] Handle bounds checking and corrupted reads gracefully.
+
+## Child Tasks
+- [ ] task-121-171-gen3-tv-block-parser-impl
+- [ ] task-121-172-gen3-tv-block-parser-qa

--- a/.foundry/tasks/task-121-171-gen3-tv-block-parser-impl.md
+++ b/.foundry/tasks/task-121-171-gen3-tv-block-parser-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-121-171-gen3-tv-block-parser-impl
+type: TASK
+title: Implement Gen 3 TV Block DataView Parser
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-081-121-gen3-tv-block-dataview-parser
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Gen 3 TV Block DataView Parser
+
+## Description
+This task requires you to implement the foundational logic to locate and read the TV broadcast data block from the Gen 3 save file structure.
+As mandated by **ADR 010**, you MUST strictly utilize the `DataView` API for all new Gen 3 data parsing logic to ensure robustness and safety.
+You must avoid legacy `Uint8Array` manual read methods and instead use `DataView` methods such as `getUint8`, `getUint16`, etc., to enforce native bounds checking.
+
+Any out-of-bounds reads or structurally corrupt states within the TV block MUST trigger a gracefully caught `RangeError` which the parser translates into a descriptive structural error, rather than crashing the application.
+
+## Acceptance Criteria
+- [ ] The TV block extraction logic is built entirely using `DataView`.
+- [ ] Explicit error handling is in place to catch `RangeError` exceptions natively thrown by `DataView` on malformed saves.
+- [ ] New parsing functions conform to the existing Gen 1 and Gen 2 backward-compatible parsing interfaces without breaking them.
+
+## Important Protocols (For Coder)
+- **Empty PR Protocol:** If the required logic is already implemented and the criteria are satisfied by existing code, you MUST still submit an empty Pull Request (with 0 file changes). However, before submitting an empty PR, you MUST check off all Acceptance Criteria checkboxes above (`- [x]`).
+- **Failure Protocol:** If you encounter a deadlock or a fundamental impossibility to complete this task, you MUST NOT check off the acceptance criteria. Instead, modify the YAML frontmatter to set `status: FAILED` and provide a clear `rejection_reason`. You must also document the failure in your persona journal.

--- a/.foundry/tasks/task-121-172-gen3-tv-block-parser-qa.md
+++ b/.foundry/tasks/task-121-172-gen3-tv-block-parser-qa.md
@@ -1,0 +1,38 @@
+---
+id: task-121-172-gen3-tv-block-parser-qa
+type: TASK
+title: QA Gen 3 TV Block DataView Parser
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - task-121-171-gen3-tv-block-parser-impl
+jules_session_id: null
+pr_number: null
+parent: story-081-121-gen3-tv-block-dataview-parser
+tags:
+  - qa
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Gen 3 TV Block DataView Parser
+
+## Description
+This QA task ensures the completion of the implementation defined in `task-121-171-gen3-tv-block-parser-impl`.
+You must verify that the Gen 3 TV broadcast data block parsing logic strictly utilizes the `DataView` API according to **ADR 010**.
+You must test that the parsing gracefully handles out-of-bounds reads and malformed files by catching `RangeError` exceptions natively thrown by `DataView`.
+
+## Acceptance Criteria
+- [ ] Verified that `DataView` API is used exclusively in the new TV block parsing code.
+- [ ] Verified that out-of-bounds reads are successfully caught and mapped to a structured parsing error instead of crashing.
+- [ ] Confirmed that backward compatibility with Gen 1 and Gen 2 parsing functions remains unbroken.
+
+## Important Protocols (For QA)
+- **Empty PR Protocol:** Once you have manually run tests and verified the code is correct, you MUST submit an empty Pull Request (with 0 file changes). However, before submitting the empty PR, you MUST check off all Acceptance Criteria checkboxes above (`- [x]`).
+- **Failure Protocol:** If the implementation failed to meet the ADR requirements or fails testing, you MUST NOT check off the acceptance criteria. Instead, modify the YAML frontmatter to set `status: FAILED` and provide a detailed `rejection_reason`. You must also document the failure in your persona journal.


### PR DESCRIPTION
Drafted tasks to implement and QA the Gen 3 TV block parser logic in accordance with ADR 010.

- Created `task-121-171-gen3-tv-block-parser-impl.md` for the coder to use `DataView` for native bounds checking.
- Created `task-121-172-gen3-tv-block-parser-qa.md` to enforce the testing contract.
- Updated `story-081-121-gen3-tv-block-dataview-parser.md` to include child task references without incorrectly transitioning its state.

---
*PR created automatically by Jules for task [11046393225282005077](https://jules.google.com/task/11046393225282005077) started by @szubster*