### PR TITLE
chore(qa): Complete Gen 1 Hidden Coin Event Flags Parsing QA

### DIFF
--- a/.foundry/tasks/task-095-168-gen1-hidden-coin-parsing-qa.md
+++ b/.foundry/tasks/task-095-168-gen1-hidden-coin-parsing-qa.md
@@ -27,10 +27,10 @@ notes: ''
 This task verifies the implementation of the `task-095-167-gen1-hidden-coin-parsing-impl` task, ensuring the `SaveData` interface and Gen 1 save parser correctly handle hidden coin event flags.
 
 ## QA Verification Criteria
-- [ ] Verify that `hiddenCoinFlags?: Uint8Array` has been added to the `SaveData` interface in `src/engine/saveParser/parsers/common.ts`.
-- [ ] Verify that the `parseGen1` function correctly calculates the offset and extracts the hidden coin flags.
-- [ ] Verify that the implementation correctly uses the `offsetShift` when calculating the hidden coin flags offset to ensure Pokemon Yellow compatibility.
-- [ ] Verify that unit tests were added or updated in `src/engine/saveParser/parsers/gen1.test.ts` and that they cover the extraction logic, injecting mock data and verifying it is correctly extracted.
+- [x] Verify that `hiddenCoinFlags?: Uint8Array` has been added to the `SaveData` interface in `src/engine/saveParser/parsers/common.ts`.
+- [x] Verify that the `parseGen1` function correctly calculates the offset and extracts the hidden coin flags.
+- [x] Verify that the implementation correctly uses the `offsetShift` when calculating the hidden coin flags offset to ensure Pokemon Yellow compatibility.
+- [x] Verify that unit tests were added or updated in `src/engine/saveParser/parsers/gen1.test.ts` and that they cover the extraction logic, injecting mock data and verifying it is correctly extracted.
 
 ## IMPORTANT REMINDERS
 - **If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.**


### PR DESCRIPTION
## What
Checked off the acceptance criteria checkboxes in `.foundry/tasks/task-095-168-gen1-hidden-coin-parsing-qa.md` to transition the completed validation task. 

## Why
The implementation task (`task-095-167-gen1-hidden-coin-parsing-impl`) passed QA verification constraints (e.g. `hiddenCoinFlags` in `SaveData`, correct tests and offsets logic verified). To advance the node state to `COMPLETED`, the acceptance criteria must be checked inside the Markdown body without mutating the YAML frontmatter.

## Testing
- Verified `pnpm lint` and `pnpm test`.
- Validated Foundry schema via `node --experimental-strip-types scripts/validate-foundry-schema.ts`.

---
*PR created automatically by Jules for task [11895561284791136716](https://jules.google.com/task/11895561284791136716) started by @szubster*