### PR TITLE
feat: implement route radar heatmap density logic

### DIFF
--- a/.foundry/tasks/task-089-165-radar-heatmap-density-logic-impl.md
+++ b/.foundry/tasks/task-089-165-radar-heatmap-density-logic-impl.md
@@ -42,10 +42,10 @@ Implement the data transformation pipeline inside the `RouteRadarController` in 
 - Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs in `src/engine/radar/__tests__/RouteRadarController.test.ts`.
 
 ## Acceptance Criteria
-- [ ] Implement the aggregation method in `RouteRadarController`.
-- [ ] Ensure the density score correctly maps `areaId`s to their corresponding missing species counts.
-- [ ] Ensure it accurately processes edge cases (e.g., areas with 0 missing encounters should not be present in the output or have a score of 0).
-- [ ] Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs.
+- [x] Implement the aggregation method in `RouteRadarController`.
+- [x] Ensure the density score correctly maps `areaId`s to their corresponding missing species counts.
+- [x] Ensure it accurately processes edge cases (e.g., areas with 0 missing encounters should not be present in the output or have a score of 0).
+- [x] Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs.
 
 **Important Persona Instructions:**
 - **CODER**: If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the frontmatter otherwise.


### PR DESCRIPTION
This PR checks off the acceptance criteria for `task-089-165-radar-heatmap-density-logic-impl`. The actual logic for `calculateHeatmap` and its tests are already present in the codebase. This empty PR (only modifying checkboxes) fulfills the Empty PR Policy to allow the DAG to progress.

---
*PR created automatically by Jules for task [13847775808189432125](https://jules.google.com/task/13847775808189432125) started by @szubster*