### PR TITLE
Draft tasks for Gen 3 Event Forecasting and Mix Records parsing

### DIFF
--- a/.foundry/stories/story-081-124-gen3-event-forecast-schedule.md
+++ b/.foundry/stories/story-081-124-gen3-event-forecast-schedule.md
@@ -28,3 +28,7 @@ Extract the forecasting schedule for upcoming events (e.g., Energy Guru sales) a
 ## Acceptance Criteria
 - [ ] Extract upcoming event schedule data from the save file.
 - [ ] Extract Mix Record flags/data to identify inherited events.
+- [ ] task-124-171-gen3-event-schedule-parser
+- [ ] task-124-172-gen3-mix-record-events-parser
+- [ ] task-124-173-qa-gen3-event-schedule-parser
+- [ ] task-124-174-qa-gen3-mix-record-events-parser

--- a/.foundry/tasks/task-124-171-gen3-event-schedule-parser.md
+++ b/.foundry/tasks/task-124-171-gen3-event-schedule-parser.md
@@ -1,0 +1,36 @@
+---
+id: task-124-171-gen3-event-schedule-parser
+type: TASK
+title: Gen 3 Event Schedule Parser Implementation
+status: PENDING
+owner_persona: coder
+created_at: "2026-06-13"
+updated_at: "2026-06-13"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-081-124-gen3-event-forecast-schedule
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen 3 Event Schedule Parser Implementation
+
+## Description
+Implement the parsing logic to extract upcoming event schedule data (such as Energy Guru sales) from Gen 3 save files. The parser MUST use the `DataView` API as mandated by ADR-010 to ensure bounds checking and prevent silent failures on corrupted saves.
+
+## Acceptance Criteria
+- [ ] Implement `DataView`-based parser for Gen 3 upcoming event schedule.
+- [ ] Handle potential out-of-bounds reads via `DataView` `RangeError` with graceful propagation.
+- [ ] Ensure backward compatibility with existing parsers as required by ADR-010.
+
+## Contract Reminders
+**To Coder / QA:**
+- If you must abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the YAML frontmatter on successful completion.

--- a/.foundry/tasks/task-124-172-gen3-mix-record-events-parser.md
+++ b/.foundry/tasks/task-124-172-gen3-mix-record-events-parser.md
@@ -1,0 +1,38 @@
+---
+id: task-124-172-gen3-mix-record-events-parser
+type: TASK
+title: Gen 3 Mix Record Events Parser Implementation
+status: PENDING
+owner_persona: coder
+created_at: "2026-06-13"
+updated_at: "2026-06-13"
+depends_on:
+  - task-124-171-gen3-event-schedule-parser
+jules_session_id: null
+pr_number: null
+parent: story-081-124-gen3-event-forecast-schedule
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen 3 Mix Record Events Parser Implementation
+
+## Description
+Implement the parsing logic to extract Mix Record flags/data from Gen 3 save files to identify inherited events. The parser MUST use the `DataView` API as mandated by ADR-010 to ensure bounds checking and prevent silent failures on corrupted saves.
+
+## Acceptance Criteria
+- [ ] Implement `DataView`-based parser for Gen 3 Mix Record flags/data.
+- [ ] Parse data to identify if events were inherited from the "Mix Record" feature.
+- [ ] Handle potential out-of-bounds reads via `DataView` `RangeError` with graceful propagation.
+- [ ] Ensure backward compatibility with existing parsers as required by ADR-010.
+
+## Contract Reminders
+**To Coder / QA:**
+- If you must abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the YAML frontmatter on successful completion.

--- a/.foundry/tasks/task-124-173-qa-gen3-event-schedule-parser.md
+++ b/.foundry/tasks/task-124-173-qa-gen3-event-schedule-parser.md
@@ -1,0 +1,39 @@
+---
+id: task-124-173-qa-gen3-event-schedule-parser
+type: TASK
+title: QA Gen 3 Event Schedule Parser
+status: PENDING
+owner_persona: qa
+created_at: "2026-06-13"
+updated_at: "2026-06-13"
+depends_on:
+  - task-124-171-gen3-event-schedule-parser
+jules_session_id: null
+pr_number: null
+parent: story-081-124-gen3-event-forecast-schedule
+tags:
+  - feature
+  - gen3
+  - data-parsing
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA Gen 3 Event Schedule Parser
+
+## Description
+Verify the implementation of the Gen 3 upcoming event schedule parser (`task-124-171-gen3-event-schedule-parser`).
+
+## Acceptance Criteria
+- [ ] Verify that the parser extracts upcoming event schedule data from Gen 3 save files correctly.
+- [ ] Verify that the parser exclusively uses the `DataView` API for all new Gen 3 save parsing logic.
+- [ ] Verify that out-of-bounds reads via `DataView` throw `RangeError` and are caught/handled gracefully.
+- [ ] Verify backward compatibility with existing parsers is maintained.
+
+## Contract Reminders
+**To Coder / QA:**
+- If you must abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the YAML frontmatter on successful completion.

--- a/.foundry/tasks/task-124-174-qa-gen3-mix-record-events-parser.md
+++ b/.foundry/tasks/task-124-174-qa-gen3-mix-record-events-parser.md
@@ -1,0 +1,39 @@
+---
+id: task-124-174-qa-gen3-mix-record-events-parser
+type: TASK
+title: QA Gen 3 Mix Record Events Parser
+status: PENDING
+owner_persona: qa
+created_at: "2026-06-13"
+updated_at: "2026-06-13"
+depends_on:
+  - task-124-172-gen3-mix-record-events-parser
+jules_session_id: null
+pr_number: null
+parent: story-081-124-gen3-event-forecast-schedule
+tags:
+  - feature
+  - gen3
+  - data-parsing
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA Gen 3 Mix Record Events Parser
+
+## Description
+Verify the implementation of the Gen 3 Mix Record events parser (`task-124-172-gen3-mix-record-events-parser`).
+
+## Acceptance Criteria
+- [ ] Verify that the parser correctly extracts Mix Record flags/data to identify inherited events.
+- [ ] Verify that the parser exclusively uses the `DataView` API for all new Gen 3 save parsing logic.
+- [ ] Verify that out-of-bounds reads via `DataView` throw `RangeError` and are caught/handled gracefully.
+- [ ] Verify backward compatibility with existing parsers is maintained.
+
+## Contract Reminders
+**To Coder / QA:**
+- If you must abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the YAML frontmatter on successful completion.


### PR DESCRIPTION
This PR breaks down `story-081-124-gen3-event-forecast-schedule` into four distinct tasks:
1. `task-124-171-gen3-event-schedule-parser`: Implement `DataView`-based parser for Gen 3 upcoming event schedule.
2. `task-124-172-gen3-mix-record-events-parser`: Implement `DataView`-based parser for Gen 3 Mix Record inheritance flags.
3. `task-124-173-qa-gen3-event-schedule-parser`: QA task for event schedule parser.
4. `task-124-174-qa-gen3-mix-record-events-parser`: QA task for Mix Record parser.

The parent story node's markdown body has been updated to include these child tasks as unchecked checkboxes, preventing premature verification. All schema constraints and ADR-010 architectural requirements are embedded within the tasks.

---
*PR created automatically by Jules for task [14300013428284532281](https://jules.google.com/task/14300013428284532281) started by @szubster*