### PR TITLE
test(gen2): implement pokerus parser edge-case tests

### DIFF
--- a/.foundry/tasks/task-096-169-pokerus-tests-impl.md
+++ b/.foundry/tasks/task-096-169-pokerus-tests-impl.md
@@ -30,8 +30,8 @@ The Pokerus byte parsing logic in Gen 2 currently has a happy-path test in `src/
 3. Validating the fallback handling if needed.
 
 ## Acceptance Criteria
-- [ ] Add extensive Pokerus parsing tests in `src/engine/saveParser/parsers/gen2.test.ts`.
-- [ ] Ensure edge cases like 0 days remaining with non-zero strain (cured state) are explicitly tested.
-- [ ] Ensure all tests pass.
-- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
-- [ ] If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- [x] Add extensive Pokerus parsing tests in `src/engine/saveParser/parsers/gen2.test.ts`.
+- [x] Ensure edge cases like 0 days remaining with non-zero strain (cured state) are explicitly tested.
+- [x] Ensure all tests pass.
+- [x] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- [x] If you abort or permanently fail a task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -132,17 +132,29 @@ describe('gen2 parsers', () => {
     it('should parse pokerus byte correctly', () => {
       const buffer = new ArrayBuffer(32768);
       const view = new DataView(buffer);
-      view.setUint8(0x288a, 2); // 2 in party
+      view.setUint8(0x288a, 4); // 4 in party
       view.setUint8(0x288b, 1);
       view.setUint8(0x288c, 2);
+      view.setUint8(0x288d, 3);
+      view.setUint8(0x288e, 4);
+
       view.setUint8(0x288b + 7, 1); // p1
       view.setUint8(0x288b + 7 + 28, 0x00); // 0 pokerus
+
       view.setUint8(0x288b + 7 + 48, 2); // p2
       view.setUint8(0x288b + 7 + 48 + 28, 0x1a); // pokerus: strain 1, days 10
+
+      view.setUint8(0x288b + 7 + 96, 3); // p3
+      view.setUint8(0x288b + 7 + 96 + 28, 0x50); // pokerus: strain 5, days 0 (cured state)
+
+      view.setUint8(0x288b + 7 + 144, 4); // p4
+      view.setUint8(0x288b + 7 + 144 + 28, 0xff); // pokerus: strain 15, days 15 (max boundary)
 
       const data = parseGen2(view, false);
       expect(data.partyDetails[0]?.pokerus).toBeUndefined();
       expect(data.partyDetails[1]?.pokerus).toEqual({ strain: 1, daysRemaining: 10 });
+      expect(data.partyDetails[2]?.pokerus).toEqual({ strain: 5, daysRemaining: 0 }); // cured state
+      expect(data.partyDetails[3]?.pokerus).toEqual({ strain: 15, daysRemaining: 15 }); // max boundary
     });
 
     it('should correctly detect silver/gold using pokedex seen/owned', () => {


### PR DESCRIPTION
Implemented edge-case tests for the Generation 2 Pokerus parsing logic. Specifically added assertions for parsing the "cured" state (`0x50` where strain is 5 and days remaining is 0) and the maximum bounds (`0xff` where strain is 15 and days remaining is 15). All tests are passing.

Fixes `#task-096-169-pokerus-tests-impl`

---
*PR created automatically by Jules for task [1237814858030854352](https://jules.google.com/task/1237814858030854352) started by @szubster*