### PR TITLE
🧩 Story Owner: Break down Gen 3 Match Call Static Data Epic

### DIFF
--- a/.foundry/epics/epic-048-084-gen3-match-call-static-data.md
+++ b/.foundry/epics/epic-048-084-gen3-match-call-static-data.md
@@ -38,4 +38,6 @@ This epic focuses on building the static dataset necessary to enrich the raw Mat
 - Integrate the dataset into the IndexedDB persistence layer (`PokeDB.ts`) for quick runtime hydration.
 
 ## Next Steps
-- [ ] Story Owner: Break this Epic down into actionable Stories (e.g., ETL Scripting, EV Calculation Logic, MsgPack Integration).
+- [x] Story Owner: Break this Epic down into actionable Stories (e.g., ETL Scripting, EV Calculation Logic, MsgPack Integration).
+- [ ] story-084-125-match-call-etl
+- [ ] story-084-126-match-call-msgpack

--- a/.foundry/stories/story-084-125-match-call-etl.md
+++ b/.foundry/stories/story-084-125-match-call-etl.md
@@ -1,0 +1,33 @@
+---
+id: story-084-125-match-call-etl
+type: STORY
+title: 'Story: Gen 3 Match Call Static Data ETL'
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-048-084-gen3-match-call-static-data
+tags:
+  - feature
+  - gen3
+  - data-generation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Match Call Static Data ETL
+
+## Overview
+As part of building the static dataset for Match Call tracking, we need an ETL (Extract, Transform, Load) script to process and compile the data for the 69 Match Call trainers.
+
+## Description
+Extract the 69 Match Call trainers from game data sources, structure them with trainer Name, Location (Route/Cave), and their 5 possible team tiers, and implement EV (Effort Value) calculation logic for defeating each specific team at each tier.
+
+## Acceptance Criteria
+- [ ] Implement ETL script to process trainer match call data.
+- [ ] Calculate and aggregate the total EV yield for defeating each team.

--- a/.foundry/stories/story-084-126-match-call-msgpack.md
+++ b/.foundry/stories/story-084-126-match-call-msgpack.md
@@ -1,0 +1,35 @@
+---
+id: story-084-126-match-call-msgpack
+type: STORY
+title: 'Story: Gen 3 Match Call MsgPack Integration'
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - story-084-125-match-call-etl
+jules_session_id: null
+pr_number: null
+parent: epic-048-084-gen3-match-call-static-data
+tags:
+  - feature
+  - gen3
+  - data-generation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Match Call MsgPack Integration
+
+## Overview
+Following the static data ETL generation for Match Call tracking, the dataset needs to be exported using MsgPack serialization to adhere to Gen 3 data optimization strategies.
+
+## Description
+Export the static match call dataset using the highly-compacted MsgPack serialization format (`msgpackr`) to minimize bundle size impact.
+Integrate the dataset into the IndexedDB persistence layer (`PokeDB.ts`) for quick runtime hydration.
+
+## Acceptance Criteria
+- [ ] Export match call dataset to MsgPack format.
+- [ ] Integrate into `PokeDB.ts` for runtime hydration.


### PR DESCRIPTION
Breaks down `epic-048-084-gen3-match-call-static-data` into `story-084-125-match-call-etl` and `story-084-126-match-call-msgpack` following the Foundry strict schema node generation rules.

---
*PR created automatically by Jules for task [6869000542714863980](https://jules.google.com/task/6869000542714863980) started by @szubster*