### PR TITLE
feat(foundry): break down epic-037-059-hidden-items-data-layer

### DIFF
--- a/.foundry/epics/epic-037-059-hidden-items-data-layer.md
+++ b/.foundry/epics/epic-037-059-hidden-items-data-layer.md
@@ -33,3 +33,5 @@ This Epic corresponds to the second requirement in the Missing Hidden Items Find
 ## 3. Acceptance Criteria
 - [ ] Data model accurately maps hidden items to location and type.
 - [ ] Data aggregation allows logical mapping and filtering of the parsed hidden item event flags.
+- [ ] .foundry/stories/story-059-125-hidden-items-data-model.md
+- [ ] .foundry/stories/story-059-126-hidden-items-aggregation-logic.md

--- a/.foundry/stories/story-059-125-hidden-items-data-model.md
+++ b/.foundry/stories/story-059-125-hidden-items-data-model.md
@@ -1,0 +1,34 @@
+---
+id: story-059-125-hidden-items-data-model
+type: STORY
+title: Hidden Items Data Model
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-059-hidden-items-data-layer
+tags:
+  - feature
+  - tool
+  - data
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Hidden Items Data Model
+
+## 1. Context & Background
+This Story addresses defining the structural representation of hidden items. The parser fetches flags; we now need a proper TypeScript structure defining how a hidden item interacts with its physical map location, item type, and flag acquisition state for runtime use.
+
+## 2. Product Requirements
+- Define `HiddenItemData` (or similar appropriate name) data model interfaces.
+- It must represent: the hidden item's event flag offset/bit, corresponding location details, the specific `Item` it contains, and whether it is acquired.
+- Follow ADR 015 convention of using readable property names for application data structures if exporting data.
+
+## 3. Acceptance Criteria
+- [ ] TypeScript interfaces for `HiddenItemData` are defined.
+- [ ] Technical implementation details for creating those interfaces are defined as child `TASK`s.

--- a/.foundry/stories/story-059-126-hidden-items-aggregation-logic.md
+++ b/.foundry/stories/story-059-126-hidden-items-aggregation-logic.md
@@ -1,0 +1,35 @@
+---
+id: story-059-126-hidden-items-aggregation-logic
+type: STORY
+title: Hidden Items Aggregation Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - story-059-125-hidden-items-data-model
+jules_session_id: null
+pr_number: null
+parent: epic-037-059-hidden-items-data-layer
+tags:
+  - feature
+  - tool
+  - data
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Hidden Items Aggregation Logic
+
+## 1. Context & Background
+Now that the data structure is defined (`story-059-125-hidden-items-data-model`) and we can parse event flags from save states, we need logic to map those boolean flags to the actual hidden item locations across the games and aggregate the results for UI consumption.
+
+## 2. Product Requirements
+- Implement the logical mapping connecting raw parsed boolean flags from the event save data to the structured `HiddenItemData` entities.
+- Implement filtering logic to quickly query remaining (unacquired) or collected hidden items.
+
+## 3. Acceptance Criteria
+- [ ] Logic correctly joins parsed event flags with hidden item source data.
+- [ ] Logic provides utility to filter items by acquisition status.
+- [ ] Technical tasks are drafted for the implementations.


### PR DESCRIPTION
Break down `epic-037-059-hidden-items-data-layer` into smaller, actionable STORY nodes.

Changes:
- Added `story-059-125-hidden-items-data-model` to define the TS interfaces.
- Added `story-059-126-hidden-items-aggregation-logic` to implement data extraction mapping logic.
- Updated the parent epic's markdown body to track the new stories via unchecked checkboxes.

---
*PR created automatically by Jules for task [12093153266034103900](https://jules.google.com/task/12093153266034103900) started by @szubster*