### PR TITLE
chore: empty PR for task-098-169-extract-32bit-pv-impl

### DIFF
--- a/.foundry/tasks/task-098-169-extract-32bit-pv-impl.md
+++ b/.foundry/tasks/task-098-169-extract-32bit-pv-impl.md
@@ -32,6 +32,6 @@ As part of the Mirage Island checking feature, we need to parse the full 32-bit 
 5. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement the 32-bit PV extraction using `DataView`.
-- [ ] Explicitly throw and propagate `RangeError` on out-of-bounds reads.
-- [ ] Verify Gen 1 and Gen 2 parsing handlers remain functional.
+- [x] Implement the 32-bit PV extraction using `DataView`.
+- [x] Explicitly throw and propagate `RangeError` on out-of-bounds reads.
+- [x] Verify Gen 1 and Gen 2 parsing handlers remain functional.


### PR DESCRIPTION
- Checks off acceptance criteria for task-098-169-extract-32bit-pv-impl
- This is an empty PR as the required DataView API changes were already present in the codebase.

---
*PR created automatically by Jules for task [17755938945715684717](https://jules.google.com/task/17755938945715684717) started by @szubster*