### PR TITLE
Break down PRD 077-049 into dynamic pokedata Epics and ADR

### DIFF
--- a/.foundry/docs/adrs/025-dynamic-pokedata-parsing.md
+++ b/.foundry/docs/adrs/025-dynamic-pokedata-parsing.md
@@ -1,0 +1,38 @@
+---
+id: adr-049-025-dynamic-pokedata-parsing
+type: ADR
+title: Dynamic PokeData Parsing Architecture
+status: PENDING
+owner_persona: architect
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-077-049-dynamic-pokedata-parsing
+tags:
+  - refactor
+  - build
+  - db
+  - adr
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# ADR: Dynamic PokeData Parsing Architecture
+
+## Background
+We are moving away from manually compiled data tables for move PPs and valid item lists. The goal is to generate this data dynamically at build time (e.g., via `scripts/generate-pokedata.ts`) and store it as `.jsonl` files (e.g., `items.jsonl`, `moves.jsonl`). This task is to write the Architectural Decision Record (ADR) that will guide this transition.
+
+## Goals
+Write an ADR that details:
+1. The exact data structures (schema) for the generated `moves.jsonl` and `items.jsonl` files.
+2. The architectural approach for integrating this dynamic generation into the existing build pipeline (`scripts/generate-pokedata.ts`).
+3. How the Vite plugin will securely and efficiently bundle these `.jsonl` files for the client side.
+4. Any constraints or potential issues regarding differences across generations (e.g., Gen 1 vs. Gen 2 PP limits).
+
+## Acceptance Criteria
+- [ ] Determine and document the precise data structure for the `moves.jsonl` and `items.jsonl` records.
+- [ ] Document how generation logic will handle generation discrepancies (e.g. PP limits).

--- a/.foundry/epics/epic-049-086-dynamic-move-pp-parsing.md
+++ b/.foundry/epics/epic-049-086-dynamic-move-pp-parsing.md
@@ -1,0 +1,38 @@
+---
+id: epic-049-086-dynamic-move-pp-parsing
+type: EPIC
+title: Dynamic Generation of Moves PP PokeData
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - adr-049-025-dynamic-pokedata-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-077-049-dynamic-pokedata-parsing
+tags:
+  - refactor
+  - build
+  - db
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Dynamic Generation of Moves PP PokeData
+
+## Background
+Currently, data such as move PPs are either manually maintained or fetched ad-hoc. Managing these static tables directly in the repository is a maintenance burden. To solve this, we will parse this data dynamically at build time using `scripts/generate-pokedata.ts`.
+
+## Goals
+1. Extract move parameters (specifically Move PPs) by parsing existing repository data at build time.
+2. Ensure generation logic properly handles generational discrepancies (e.g., Gen 1 vs. Gen 2 PP limits).
+3. Store the extracted data in a scalable format (`moves.jsonl`).
+4. Replace manual/hardcoded tables for move data.
+
+## Acceptance Criteria
+- [ ] Implement parsing logic in `scripts/generate-pokedata.ts` to extract moves data (including PPs).
+- [ ] Handle any discrepancies between generations for moves.
+- [ ] Output the correct `moves.jsonl` data payload.

--- a/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
+++ b/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
@@ -1,0 +1,38 @@
+---
+id: epic-049-087-dynamic-item-list-parsing
+type: EPIC
+title: Dynamic Generation of Items PokeData
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - adr-049-025-dynamic-pokedata-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-077-049-dynamic-pokedata-parsing
+tags:
+  - refactor
+  - build
+  - db
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Dynamic Generation of Items PokeData
+
+## Background
+Currently, valid item lists are either manually maintained or fetched ad-hoc. Managing these static tables directly in the repository is a maintenance burden. To solve this, we will parse this data dynamically at build time using `scripts/generate-pokedata.ts`.
+
+## Goals
+1. Extract item lists by parsing existing repository data at build time.
+2. Ensure generation logic properly categorizes and validates item structures.
+3. Store the extracted data in a scalable format (`items.jsonl`).
+4. Replace manual/hardcoded tables for item data.
+
+## Acceptance Criteria
+- [ ] Implement parsing logic in `scripts/generate-pokedata.ts` to extract item lists.
+- [ ] Handle any validation required for items (e.g. mapping across generations, PokeAPI IDs to internal ROM IDs).
+- [ ] Output the correct `items.jsonl` data payload.

--- a/.foundry/epics/epic-049-088-vite-plugin-jsonl-integration.md
+++ b/.foundry/epics/epic-049-088-vite-plugin-jsonl-integration.md
@@ -1,0 +1,38 @@
+---
+id: epic-049-088-vite-plugin-jsonl-integration
+type: EPIC
+title: Vite Plugin Integration for JSONL Data
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - epic-049-086-dynamic-move-pp-parsing
+  - epic-049-087-dynamic-item-list-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-077-049-dynamic-pokedata-parsing
+tags:
+  - refactor
+  - build
+  - db
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Vite Plugin Integration for JSONL Data
+
+## Background
+We have successfully extracted moves and items data into `moves.jsonl` and `items.jsonl`. We now need to update the Vite plugin so that this data can be packaged appropriately and securely consumed by the client side.
+
+## Goals
+1. Update the Vite plugin to properly bundle the generated `moves.jsonl` and `items.jsonl` files.
+2. Ensure the loading is efficient and performant.
+3. Verify that the client can correctly parse and utilize the new data structures.
+
+## Acceptance Criteria
+- [ ] Update Vite configuration/plugin to package `.jsonl` files for moves and items.
+- [ ] Update application runtime (e.g. `src/db/`) to load and map the newly generated dynamic lists.
+- [ ] Ensure backward compatibility or smooth transition for UI that relies on this data.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -12,3 +12,6 @@ When executing the Empty PR Policy for tasks where target artifacts are already 
 
 ## 2026-06-12
 - Scope Strictness Warning: Keep git patches strictly scoped. When working on feature branches, DO NOT manually fix schema or frontmatter errors in completely unrelated files (like Gen 2 tasks) just because the schema validator flagged them. Fixing out-of-scope errors creates major regressions and pollutes the dependency graph. Rely solely on checking out or reverting the unrelated files to restore the pristine state.
+
+## 2026-06-13: DAG Linkage Requirement for Epics
+When breaking down a PRD into Epic nodes, if an architectural document is required, do NOT create a `TASK` node for the Architect and make the Epics depend on it. This violates the Foundry DAG execution hierarchy (`IDEA -> PRD -> ADR -> EPIC -> STORY -> TASK`). Instead, dynamically create an `ADR` node (`type: ADR`) directly in `.foundry/docs/adrs/` and set the Epics to depend on that ADR node. Furthermore, ensure that all `depends_on` array references strictly use the exact Node IDs (e.g., `adr-049-025-dynamic-pokedata-parsing`) and never repo-relative file paths to prevent DAG resolution deadlocks.

--- a/.foundry/prds/prd-077-049-dynamic-pokedata-parsing.md
+++ b/.foundry/prds/prd-077-049-dynamic-pokedata-parsing.md
@@ -40,3 +40,9 @@ Currently, data such as move PPs and valid item lists are either manually mainta
 - [ ] Determine the precise data structure for the `moves.jsonl` and `items.jsonl` records.
 - [ ] Ensure the generation logic handles any discrepancies between the generations (e.g., Gen 1 vs. Gen 2 PP limits).
 - [ ] Write an ADR detailing the architectural approach for integrating this dynamic generation into the existing data pipeline.
+
+### Epic Breakdown
+- [ ] .foundry/docs/adrs/025-dynamic-pokedata-parsing.md
+- [ ] .foundry/epics/epic-049-086-dynamic-move-pp-parsing.md
+- [ ] .foundry/epics/epic-049-087-dynamic-item-list-parsing.md
+- [ ] .foundry/epics/epic-049-088-vite-plugin-jsonl-integration.md


### PR DESCRIPTION
This PR breaks down `prd-077-049-dynamic-pokedata-parsing` into an `ADR` node and three actionable `EPIC` nodes to handle dynamic parsing of Move PPs and Items, and integrating the generated JSONL files into Vite. The parent PRD has been updated to include these child nodes.

---
*PR created automatically by Jules for task [15710274444595008829](https://jules.google.com/task/15710274444595008829) started by @szubster*