### PR TITLE
Settle RTC Strategy Once and For All

### DIFF
--- a/.foundry/docs/adrs/adr-078-025-rtc-strategy.md
+++ b/.foundry/docs/adrs/adr-078-025-rtc-strategy.md
@@ -1,0 +1,34 @@
+---
+id: adr-078-025-rtc-strategy
+type: ADR
+title: RTC Strategy Architecture Decision
+status: PENDING
+owner_persona: architect
+created_at: "2026-06-13"
+updated_at: "2026-06-13"
+depends_on:
+  - research-078-172-rtc-strategy-investigation
+jules_session_id: null
+pr_number: null
+parent: idea-078-settle-rtc-strategy
+tags:
+  - rtc
+  - gen3
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# ADR 025: RTC Strategy Architecture Decision
+
+## Context
+RTC (Real-Time Clock) data is highly problematic in Generation 3 save files, often being emulator-dependent or completely missing from cartridge dumps. We need to formalize a unified approach across the application for handling time-dependent events to prevent brittle features that rely on accurate RTC blocks.
+
+## Decision
+*(This decision will be finalized after the completion of the `research-078-172-rtc-strategy-investigation` node. The researcher's findings will dictate whether we use system time, prompt users for overrides, or implement a hybrid approach.)*
+
+## Acceptance Criteria
+- [ ] Based on research findings, detail the final architecture decision for handling RTC across generations.
+- [ ] Describe the consequences of this decision on UI components and save parsing logic.

--- a/.foundry/ideas/idea-078-settle-rtc-strategy.md
+++ b/.foundry/ideas/idea-078-settle-rtc-strategy.md
@@ -31,3 +31,5 @@ We need to settle the RTC strategy once and for all to establish a unified appro
 - Spawn a `RESEARCH` node to investigate the viability, alternatives, and emulator dependencies of RTC data across generations (especially Gen 2 and Gen 3).
 - Based on the research, author an `ADR` (Architecture Decision Record) defining exactly how the application should handle time-dependent events. This might mean always using the system's current time, building RTC-independent event suggestions, or prompting the user for manual overrides.
 - No immediate feature implementation is expected under this idea unless the research explicitly dictates a necessary structural change. This is primarily a discovery and standardization effort.
+- [ ] .foundry/research/research-078-172-rtc-strategy-investigation.md
+- [ ] .foundry/docs/adrs/adr-078-025-rtc-strategy.md

--- a/.foundry/research/research-078-172-rtc-strategy-investigation.md
+++ b/.foundry/research/research-078-172-rtc-strategy-investigation.md
@@ -1,0 +1,36 @@
+---
+id: research-078-172-rtc-strategy-investigation
+type: RESEARCH
+title: RTC Strategy and Viability Investigation
+status: PENDING
+owner_persona: researcher
+created_at: "2026-06-13"
+updated_at: "2026-06-13"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-078-settle-rtc-strategy
+tags:
+  - rtc
+  - gen3
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Research: RTC Strategy and Viability Investigation
+
+## Objective
+Investigate the viability, alternatives, and emulator dependencies of Real-Time Clock (RTC) data across Pokémon generations, specifically focusing on Generation 2 and Generation 3.
+
+## Context
+RTC data is known to be problematic, particularly in Generation 3, where emulator dependencies or direct cartridge dumps can result in missing or inaccurate RTC block data. We need to formulate a robust strategy for handling time-dependent events.
+
+## Tasks
+- [ ] Determine how different emulators handle Gen 2 and Gen 3 RTC data.
+- [ ] Investigate the structure of RTC blocks in `.sav` files across generations.
+- [ ] Identify the failure modes when RTC data is absent or corrupted.
+- [ ] Propose alternatives for handling time-dependent features if RTC extraction is deemed unreliable.
+- [ ] Document findings to support an Architecture Decision Record (ADR) on the final RTC strategy.


### PR DESCRIPTION
This PR addresses the `idea-078-settle-rtc-strategy` node by spawning the necessary child nodes to research and document the RTC strategy for Generation 3 and beyond.

- **RESEARCH Node:** `research-078-172-rtc-strategy-investigation.md` created to investigate emulator dependencies and failure modes of RTC data.
- **ADR Node:** `adr-078-025-rtc-strategy.md` created to document the final architectural decision, dependent on the research completion.
- The parent IDEA node has been updated to reference these new child nodes.

---
*PR created automatically by Jules for task [2060025323897284855](https://jules.google.com/task/2060025323897284855) started by @szubster*