### PR TITLE
chore(story-096): mark child tasks as complete for pokerus parsing tests

### DIFF
--- a/.foundry/stories/story-061-096-pokerus-tests.md
+++ b/.foundry/stories/story-061-096-pokerus-tests.md
@@ -28,6 +28,6 @@ notes: ''
 Implement tests for the Pokerus byte parsing logic.
 
 ## Acceptance Criteria
-- [ ] Add tests for Pokerus parsing.
-- [ ] task-096-169-pokerus-tests-impl
-- [ ] task-096-170-pokerus-tests-qa
+- [x] Add tests for Pokerus parsing.
+- [x] task-096-169-pokerus-tests-impl
+- [x] task-096-170-pokerus-tests-qa


### PR DESCRIPTION
As the Tech Lead, I have verified that all generated child TASK nodes (`task-096-169-pokerus-tests-impl` and `task-096-170-pokerus-tests-qa`) have fully transitioned to `COMPLETED`. In accordance with the Empty PR Policy and ADR-009, I have explicitly checked off the Acceptance Criteria checkboxes (`- [x]`) in the markdown body of `story-061-096-pokerus-tests.md` without modifying its YAML frontmatter. This allows the orchestrator to advance the DAG without violating state constraints.

---
*PR created automatically by Jules for task [13944507925220079262](https://jules.google.com/task/13944507925220079262) started by @szubster*