### PR TITLE
docs: document RTC strategy findings and ADR

### DIFF
--- a/.foundry/docs/adrs/adr-078-025-rtc-strategy.md
+++ b/.foundry/docs/adrs/adr-078-025-rtc-strategy.md
@@ -27,8 +27,19 @@ notes: ""
 RTC (Real-Time Clock) data is highly problematic in Generation 3 save files, often being emulator-dependent or completely missing from cartridge dumps. We need to formalize a unified approach across the application for handling time-dependent events to prevent brittle features that rely on accurate RTC blocks.
 
 ## Decision
-*(This decision will be finalized after the completion of the `research-078-172-rtc-strategy-investigation` node. The researcher's findings will dictate whether we use system time, prompt users for overrides, or implement a hybrid approach.)*
+Based on the findings from `research-078-172-rtc-strategy-investigation`, we will adopt an **RTC-Independent Fallback Strategy** across the entire application for all generations.
+
+Because RTC data formatting is highly fragmented depending on the emulator (e.g., VBA-M appending bytes vs. mGBA using separate `.rtc` files) and is entirely absent in physical cartridge dumps, attempting to decode the game's internal RTC state directly from `.sav` files is unreliable.
+
+Instead, the application will use a hybrid approach:
+1. **System Time Fallback**: By default, time-dependent events (such as Gen 2 Day/Night cycles or Gen 3 time-based encounters/events) will use the host device's current system time.
+2. **Manual UI Overrides**: We will implement manual toggles in the application UI that allow users to override the time state explicitly. For example, a user playing a Gen 2 game during the day in the real world can toggle a "Night" mode in the UI to see nocturnal encounter suggestions.
+
+## Consequences
+- **Positive:** Our features will no longer be brittle or emulator-dependent. The application will work consistently whether the user provides a VBA-M save, an mGBA save, or a clean hardware cartridge dump.
+- **Positive:** Improved user experience via manual time-of-day overrides, allowing users to plan ahead for encounters without waiting for real-world time to pass.
+- **Parsing Constraints:** The save parsing engine must be updated to ensure it gracefully handles `.sav` files that are larger than the standard sizes (e.g., ignoring the trailing 44/48 bytes appended by VBA-M) without throwing validation or size mismatch errors.
 
 ## Acceptance Criteria
-- [ ] Based on research findings, detail the final architecture decision for handling RTC across generations.
-- [ ] Describe the consequences of this decision on UI components and save parsing logic.
+- [x] Based on research findings, detail the final architecture decision for handling RTC across generations.
+- [x] Describe the consequences of this decision on UI components and save parsing logic.

--- a/.foundry/research/research-078-172-rtc-strategy-investigation.md
+++ b/.foundry/research/research-078-172-rtc-strategy-investigation.md
@@ -28,9 +28,34 @@ Investigate the viability, alternatives, and emulator dependencies of Real-Time 
 ## Context
 RTC data is known to be problematic, particularly in Generation 3, where emulator dependencies or direct cartridge dumps can result in missing or inaccurate RTC block data. We need to formulate a robust strategy for handling time-dependent events.
 
+## Findings
+
+### 1. Emulator Handling of Gen 2 and Gen 3 RTC Data
+Emulators implement RTC features differently, leading to inconsistent `.sav` file formats:
+- **VBA-M**: Appends RTC data (typically 44 or 48 bytes) directly to the end of the standard save file. This makes the file size larger than standard (e.g., 128KB + 44 bytes).
+- **mGBA**: Creates a completely separate `.rtc` file next to the `.sav` file, keeping the `.sav` file at exactly the expected cartridge size.
+- **Physical Cartridge Dumps**: When dumping physical cartridges using standard readers, RTC data is usually omitted entirely, as it's tracked by a separate component on the cartridge that standard dumpers don't extract.
+
+### 2. Structure of RTC Blocks
+- **Gen 2 (GSC)**: The standard save file is 32 KB. For cartridges with MBC3 chips containing RTC, the RTC state is stored separately. Emulators handle this discrepancy via appending to the file or keeping separate files.
+- **Gen 3 (RSE)**: The standard save file is exactly 128 KB (Flash RAM). Emulators that append data (like VBA-M) will produce a file of size `131,116` bytes (131,072 + 44) or similar.
+
+### 3. Failure Modes
+- **Parsing Crashes**: Strict parsing logic that expects exactly 32 KB or 128 KB save files may throw errors or crash when presented with an emulator-appended `.sav` file.
+- **Missing Data**: Attempting to extract RTC data will fail completely on clean dumps or mGBA `.sav` files, as the data physically does not exist inside the `.sav` file.
+- **Data Corruption**: Relying on emulator-appended data offsets may lead to corrupt state parsing if different emulator versions use different appending formats (e.g., 44 vs 48 bytes in VBA).
+
+### 4. Proposed Alternatives
+Because assuming the presence of a valid, accurate RTC block in the `.sav` file leads to brittle features:
+- **System Time Fallback**: By default, use the host device's current system time (browser/OS time) to evaluate time-dependent events.
+- **Manual UI Overrides**: Provide explicit manual toggles within the application UI, allowing users to override the time (e.g., forcing Day/Night in Gen 2 or a specific time-of-day in Gen 3) for the purpose of checking encounter tables and events.
+
+### 5. Conclusion
+Given the extreme fragmentation of RTC data formatting, we must adopt an **RTC-Independent Strategy**. The parsing engine must gracefully accept `.sav` files with appended emulator data without failing, but the application must rely on host system time or manual user input for time-dependent logic rather than attempting to decode the save's internal RTC state.
+
 ## Tasks
-- [ ] Determine how different emulators handle Gen 2 and Gen 3 RTC data.
-- [ ] Investigate the structure of RTC blocks in `.sav` files across generations.
-- [ ] Identify the failure modes when RTC data is absent or corrupted.
-- [ ] Propose alternatives for handling time-dependent features if RTC extraction is deemed unreliable.
-- [ ] Document findings to support an Architecture Decision Record (ADR) on the final RTC strategy.
+- [x] Determine how different emulators handle Gen 2 and Gen 3 RTC data.
+- [x] Investigate the structure of RTC blocks in `.sav` files across generations.
+- [x] Identify the failure modes when RTC data is absent or corrupted.
+- [x] Propose alternatives for handling time-dependent features if RTC extraction is deemed unreliable.
+- [x] Document findings to support an Architecture Decision Record (ADR) on the final RTC strategy.


### PR DESCRIPTION
Documents findings from the RTC strategy investigation (node `research-078-172-rtc-strategy-investigation.md`) and updates the final decision in `adr-078-025-rtc-strategy.md` based on those findings. Adopts an RTC-Independent Strategy.

---
*PR created automatically by Jules for task [14011111358112477414](https://jules.google.com/task/14011111358112477414) started by @szubster*