### PR TITLE
feat: break down unown form parser tests into tasks

### DIFF
--- a/.foundry/stories/story-058-096-unown-parser-tests.md
+++ b/.foundry/stories/story-058-096-unown-parser-tests.md
@@ -35,4 +35,8 @@ The logic for determining the Unown form in Gen 2 uses a bitwise operation on th
 - Ensure the property is omitted or undefined for non-Unown Pokemon.
 
 ## Acceptance Criteria
-- [ ] Task created for implementing unit tests for the unown form parser logic.
+- [x] Task created for implementing unit tests for the unown form parser logic.
+
+## Generated Tasks
+- [ ] `task-096-179-unown-parser-tests-impl`
+- [ ] `task-096-180-unown-parser-tests-qa`

--- a/.foundry/tasks/task-096-179-unown-parser-tests-impl.md
+++ b/.foundry/tasks/task-096-179-unown-parser-tests-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-096-179-unown-parser-tests-impl
+type: TASK
+title: Implement Unown Form Parser Unit Tests
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-058-096-unown-parser-tests
+tags:
+  - testing
+  - gen2
+  - tracking
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Unown Form Parser Unit Tests
+
+## Context
+The logic for determining the Unown form in Gen 2 uses a bitwise operation on the Attack, Defense, Speed, and Special DVs. This logic is implemented in the `story-058-095-unown-parser-logic` story. We need to write unit tests to ensure the exact bitwise calculation works and covers all known DV combinations for Unown forms (A, Z, edge cases).
+
+## Instructions for Coder
+1. Locate the Unown parsing logic in the Gen 2 parsing utilities.
+2. Write unit tests explicitly mocking different DV combinations (Attack, Defense, Speed, and Special DVs).
+3. Test edge cases where the DVs generate the lowest and highest boundary values for Unown forms (Forms A and Z, assuming standard Gen 2 form math).
+4. Verify that `unownForm` is properly appended to the result object only when `speciesId` is 201.
+5. Verify that `unownForm` is missing/undefined when `speciesId` is NOT 201, even if the DVs would otherwise calculate a valid form.
+
+## Contract Reminders
+- If you must abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
+- If you submit an empty PR for a completed task (e.g., if the tests already exist), you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Unit tests written to verify the exact bitwise calculation against known DV combinations for Unown forms (A, Z, etc.).
+- [ ] Tests assert that `unownForm` is appended to the output structure when `speciesId` is 201.
+- [ ] Tests assert that `unownForm` is omitted or undefined for non-Unown Pokemon.

--- a/.foundry/tasks/task-096-180-unown-parser-tests-qa.md
+++ b/.foundry/tasks/task-096-180-unown-parser-tests-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-096-180-unown-parser-tests-qa
+type: TASK
+title: QA - Unown Form Parser Unit Tests
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - task-096-179-unown-parser-tests-impl
+jules_session_id: null
+pr_number: null
+parent: story-058-096-unown-parser-tests
+tags:
+  - testing
+  - gen2
+  - tracking
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA - Unown Form Parser Unit Tests
+
+## Context
+The logic for determining the Unown form in Gen 2 uses a bitwise operation on the Attack, Defense, Speed, and Special DVs. A coder has written unit tests to verify this logic. Your job is to verify that the unit tests are comprehensive and correct.
+
+## Instructions for QA
+1. Ensure the unit tests actually run and pass (e.g. `pnpm test`).
+2. Review the unit tests to ensure they cover the edge cases of Unown form calculation (specifically checking extreme DV combinations that yield Form A and Form Z).
+3. Confirm there is a test guaranteeing `unownForm` is appended when `speciesId === 201`.
+4. Confirm there is a test guaranteeing `unownForm` is omitted/undefined when `speciesId !== 201`.
+
+## Contract Reminders
+- If you reject the implementation, you MUST update the target implementation task's YAML frontmatter to `status: FAILED`, provide a `rejection_reason`, increment `rejection_count`, and leave its acceptance criteria unchecked. DO NOT modify your own YAML frontmatter (this task remains `ACTIVE`). Document the failure in your own markdown body.
+- If you must abort or permanently fail your own QA task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verified that tests for the exact bitwise calculation against known DV combinations for Unown forms (A, Z, etc.) exist and pass.
+- [ ] Verified tests assert that `unownForm` is appended to the output structure when `speciesId` is 201.
+- [ ] Verified tests assert that `unownForm` is omitted or undefined for non-Unown Pokemon.


### PR DESCRIPTION
This PR transforms the `story-058-096-unown-parser-tests` into actionable technical blueprint tasks for the coder and qa personas, adhering strictly to the Foundry DAG architecture.

---
*PR created automatically by Jules for task [12736298741286988768](https://jules.google.com/task/12736298741286988768) started by @szubster*