### PR TITLE
chore: verify unown tracker epic completion

### DIFF
--- a/.foundry/epics/epic-037-058-unown-tracker-engine.md
+++ b/.foundry/epics/epic-037-058-unown-tracker-engine.md
@@ -37,5 +37,5 @@ Requires unit tests verifying the exact bitwise calculation against known DV com
 ## Acceptance Criteria
 - [x] Story for parser logic created.
 - [x] Story for parser unit tests created.
-- [ ] .foundry/stories/story-058-095-unown-parser-logic.md
-- [ ] .foundry/stories/story-058-096-unown-parser-tests.md
+- [x] .foundry/stories/story-058-095-unown-parser-logic.md
+- [x] .foundry/stories/story-058-096-unown-parser-tests.md


### PR DESCRIPTION
This submits an Empty PR for epic-037-058-unown-tracker-engine since its child story nodes are completely implemented. It updates the Acceptance Criteria checkboxes to `- [x]` as required by ADR 007 and ADR 009 before verification.

---
*PR created automatically by Jules for task [5543846165981562251](https://jules.google.com/task/5543846165981562251) started by @szubster*