### PR TITLE
Tech Lead: Blueprint tasks for dynamic item list parsing

### DIFF
--- a/.foundry/stories/story-087-128-dynamic-item-list-parsing.md
+++ b/.foundry/stories/story-087-128-dynamic-item-list-parsing.md
@@ -34,4 +34,6 @@ To eliminate manually maintained static item lists in the repository, we need to
 - [ ] Implement parsing logic in `scripts/generate-pokedata.ts` to extract item data from PokeAPI resources.
 - [ ] Perform compaction to omit nulls and default values.
 - [ ] Output the final structure to `data/db/items.jsonl`.
-- [ ] Break down this STORY into concrete TASK nodes for implementation.
+- [x] Break down this STORY into concrete TASK nodes for implementation.
+- [ ] task-128-181-implement-item-list-parsing
+- [ ] task-128-182-qa-item-list-parsing

--- a/.foundry/tasks/task-128-181-implement-item-list-parsing.md
+++ b/.foundry/tasks/task-128-181-implement-item-list-parsing.md
@@ -1,0 +1,50 @@
+---
+id: task-128-181-implement-item-list-parsing
+type: TASK
+title: Implement Dynamic Item List Parsing in scripts/generate-pokedata.ts
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-087-128-dynamic-item-list-parsing
+tags:
+  - refactor
+  - build
+  - db
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement Dynamic Item List Parsing in scripts/generate-pokedata.ts
+
+## Context & Background
+We need to transition from statically defined item lists to dynamically generated ones. Based on ADR-049-025, the existing ETL pipeline in `scripts/generate-pokedata.ts` needs to be updated to fetch and parse `item` resources from our local PokeAPI dataset, generating a compact `items.jsonl` output file inside `data/db/`.
+
+## Architecture & Constraints (ADR-049-025)
+The new item list will be generated as `items.jsonl`. We must perform a compaction pass to minimize payload size by stripping out defaults, nulls, and undefined values.
+The items must be structured with the following fields:
+*   `id`: `number` (The PokeAPI ID of the item)
+*   `name`: `string` (The display name of the item)
+*   `cost`: `number | undefined` (Cost in PokeMarts; omitted if 0)
+*   `category`: `number` (Item category ID, mapped from `category.name`)
+*   `fling_p` (fling_power): `number | undefined` (Power when used with Fling)
+*   `effect`: `string | undefined` (Short effect description, if applicable)
+*   `sprite`: `string | undefined` (Item sprite filename/URL, if applicable)
+
+Ensure the generation logic leverages generation-specific datasets (e.g., `past_values` or `version_group_details`) when mapping past generation properties, falling back to Gen 1-3 accurate stats or latest stats as available.
+
+## Acceptance Criteria
+- [ ] Implement parsing logic in `scripts/generate-pokedata.ts` to extract item data from the local PokeAPI dataset.
+- [ ] Apply compaction to remove nulls, default values, and zeros (like a cost of 0).
+- [ ] Ensure the generated structure matches the specification in ADR-049-025.
+- [ ] Output the processed data as `data/db/items.jsonl`.
+- [ ] Run the updated script to generate the initial `items.jsonl` file.
+
+## Critical Instructions for Coder
+- **Failure Policy**: If you must abort this task or it fails permanently, you MUST update the YAML frontmatter to `status: FAILED` and provide a `rejection_reason`. Do NOT check off any Acceptance Criteria in the event of failure.
+- **Empty PR Policy**: If you find that the artifacts are already complete and no code changes are necessary, you MUST check off all Acceptance Criteria checkboxes (`- [x]`) and then explicitly call the `submit` tool to create an Empty PR. Do NOT end your session without calling `submit`.

--- a/.foundry/tasks/task-128-182-qa-item-list-parsing.md
+++ b/.foundry/tasks/task-128-182-qa-item-list-parsing.md
@@ -1,0 +1,49 @@
+---
+id: task-128-182-qa-item-list-parsing
+type: TASK
+title: QA - Verify Dynamic Item List Parsing
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-13'
+updated_at: '2026-06-13'
+depends_on:
+  - task-128-181-implement-item-list-parsing
+jules_session_id: null
+pr_number: null
+parent: story-087-128-dynamic-item-list-parsing
+tags:
+  - qa
+  - db
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA - Verify Dynamic Item List Parsing
+
+## Context & Background
+The coder has implemented logic in `scripts/generate-pokedata.ts` to fetch and parse item data from the local PokeAPI dataset dynamically (task-128-181-implement-item-list-parsing), per ADR-049-025. This task serves as the QA step to verify the generation logic and the resulting payload.
+
+## Verification Requirements
+You need to verify that the item parser extracts the right fields, properly compacts data, and writes the output correctly:
+1. Verify `data/db/items.jsonl` contains the dynamically generated item list payload.
+2. Ensure the output strictly follows the schema defined in ADR-049-025:
+    *   `id`: `number` (The PokeAPI ID of the item)
+    *   `name`: `string` (The display name of the item)
+    *   `cost`: `number | undefined` (Cost in PokeMarts; omitted if 0)
+    *   `category`: `number` (Item category ID, mapped from `category.name`)
+    *   `fling_p` (fling_power): `number | undefined` (Power when used with Fling)
+    *   `effect`: `string | undefined` (Short effect description, if applicable)
+    *   `sprite`: `string | undefined` (Item sprite filename/URL, if applicable)
+3. Ensure compaction effectively stripped out zero-value costs and empty effects/sprites.
+
+## Acceptance Criteria
+- [ ] Review the updated code in `scripts/generate-pokedata.ts` to ensure it parses the `item` resource.
+- [ ] Inspect the generated `data/db/items.jsonl` to ensure all fields align with the schema.
+- [ ] Confirm compaction logic works accurately.
+- [ ] Test that the build process succeeds and `items.jsonl` is correctly integrated by the Vite plugin.
+
+## Critical Instructions for QA
+- **Failure Policy**: If the coder's implementation is flawed and you must reject it, you MUST update the YAML frontmatter of the target task (`task-128-181-implement-item-list-parsing`) to `status: FAILED`, provide a `rejection_reason`, and increment its `rejection_count`. Do NOT modify your own task's YAML frontmatter (it remains ACTIVE) and do NOT check off any Acceptance Criteria. Document the failure in your QA journal.
+- **Empty PR Policy**: Since this is a verification task that may involve no code changes, you MUST check off all Acceptance Criteria checkboxes (`- [x]`) and explicitly call the `submit` tool to create an Empty PR when the validation is successful. Do NOT end your session without calling `submit`.


### PR DESCRIPTION
This PR implements the Tech Lead's task for STORY `story-087-128-dynamic-item-list-parsing`. It creates two TASK nodes (`task-128-181-implement-item-list-parsing` and `task-128-182-qa-item-list-parsing`) to implement and verify the dynamic generation of item lists in `items.jsonl`, following the specs outlined in ADR-049-025. It correctly appends these as uncompleted tasks to the parent story and checks off the "Break down" acceptance criteria.

Testing/Verification:
- Tasks depend correctly (`QA` depends on `Implement`).
- Parent is completely excluded from `depends_on`.
- Frontmatter schemas validated using `npx vite-node scripts/validate-foundry-schema.ts`.
- Repository tests (`pnpm test`) run and passed.

---
*PR created automatically by Jules for task [10764763298277439634](https://jules.google.com/task/10764763298277439634) started by @szubster*