### PR TITLE
QA task-098-170: Validate Gen 3 32-bit PV extraction via DataView

### DIFF
--- a/.foundry/tasks/task-098-170-extract-32bit-pv-qa.md
+++ b/.foundry/tasks/task-098-170-extract-32bit-pv-qa.md
@@ -33,6 +33,6 @@ The coder has implemented the extraction of the 32-bit personality value (PV) fo
 5. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verify Gen 3 PV extraction uses `DataView`.
-- [ ] Verify `RangeError` propagation for out-of-bounds reads.
-- [ ] Verify Gen 1 and 2 handlers are functional.
+- [x] Verify Gen 3 PV extraction uses `DataView`.
+- [x] Verify `RangeError` propagation for out-of-bounds reads.
+- [x] Verify Gen 1 and 2 handlers are functional.


### PR DESCRIPTION
Verified that `parseGen3PersonalityValue` utilizes the `DataView` API and propagates out-of-bounds reads as explicit `RangeError` (catching them and throwing "corrupted file" errors). Also successfully ran legacy Gen 1 and Gen 2 handlers and checked off the task's Acceptance Criteria.

---
*PR created automatically by Jules for task [3195307807357317649](https://jules.google.com/task/3195307807357317649) started by @szubster*