### PR TITLE
test: implement Unown form parser unit tests

### DIFF
--- a/.foundry/tasks/task-096-179-unown-parser-tests-impl.md
+++ b/.foundry/tasks/task-096-179-unown-parser-tests-impl.md
@@ -37,6 +37,6 @@ The logic for determining the Unown form in Gen 2 uses a bitwise operation on th
 - If you submit an empty PR for a completed task (e.g., if the tests already exist), you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Unit tests written to verify the exact bitwise calculation against known DV combinations for Unown forms (A, Z, etc.).
-- [ ] Tests assert that `unownForm` is appended to the output structure when `speciesId` is 201.
-- [ ] Tests assert that `unownForm` is omitted or undefined for non-Unown Pokemon.
+- [x] Unit tests written to verify the exact bitwise calculation against known DV combinations for Unown forms (A, Z, etc.).
+- [x] Tests assert that `unownForm` is appended to the output structure when `speciesId` is 201.
+- [x] Tests assert that `unownForm` is omitted or undefined for non-Unown Pokemon.

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -324,6 +324,51 @@ describe('gen2 parsers', () => {
     });
   });
 
+  describe('parseGen2 - Unown Forms', () => {
+    it('should correctly parse Unown Form A', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x288a, 1);
+      view.setUint8(0x288b, 201); // Unown species
+      view.setUint8(0x288b + 7, 201); // speciesId inside struct
+
+      // Form A (value 0): DVs = 0
+      view.setUint16(0x288b + 7 + 21, 0, false);
+
+      const data = parseGen2(view, false);
+      expect(data.partyDetails[0]?.unownForm).toBe('A');
+    });
+
+    it('should correctly parse Unown Form Z', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x288a, 1);
+      view.setUint8(0x288b, 201); // Unown species
+      view.setUint8(0x288b + 7, 201); // speciesId inside struct
+
+      // Form Z (value 25): DVs = 578
+      view.setUint16(0x288b + 7 + 21, 578, false);
+
+      const data = parseGen2(view, false);
+      expect(data.partyDetails[0]?.unownForm).toBe('Z');
+    });
+
+    it('should not parse Unown form for non-Unown Pokemon even with same DVs', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x288a, 1);
+      view.setUint8(0x288b, 1); // Bulbasaur
+      view.setUint8(0x288b + 7, 1); // speciesId inside struct
+
+      // DVs = 578 (which would be Form Z for Unown)
+      view.setUint16(0x288b + 7 + 21, 578, false);
+
+      const data = parseGen2(view, false);
+      expect(data.partyDetails[0]?.speciesId).toBe(1);
+      expect(data.partyDetails[0]?.unownForm).toBeUndefined();
+    });
+  });
+
   describe('parseGen2 - PC Items', () => {
     it('should parse pcItems correctly for Gold/Silver', () => {
       const buffer = new ArrayBuffer(0x8000);


### PR DESCRIPTION
This PR implements unit tests for the Gen 2 Unown form parser logic to fulfill `task-096-179-unown-parser-tests-impl`.

The tests mock party data specifically for Unown (`speciesId = 201`) and assert that the bitwise calculations correctly identify Form A and Form Z. It also includes an edge case test for non-Unown Pokémon to ensure the `unownForm` property is not incorrectly assigned when DVs match Unown forms.

---
*PR created automatically by Jules for task [4888170178312897702](https://jules.google.com/task/4888170178312897702) started by @szubster*