### PR TITLE
test: reject gen3 berry dataview parsing implementation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -18,3 +18,6 @@ When an implementation task only creates standalone UI components but fails to i
 
 ### Lesson Learned: Verifying Gen 3 Save File Sections
 When verifying save file documentation (e.g. Generation 3 save parsing), it is crucial to ensure that the stated offsets fall within the correct section headers as defined by authoritative sources like Bulbapedia. Failing to map byte offsets to the correct logical 4KB section boundaries can lead to incorrect data extraction in the orchestrator.
+
+## 2026-06-13: Gen 3 Save Parsing and Implicit Data
+Learned to carefully verify relative vs. logical offsets in Gen 3 blocks. For example, Gen 3 Berry Trees at logical offset `0x169C` are located in Section 1 of `SaveBlock1`, so we must calculate the relative offset into Section 1 using the Section 0 payload size (`0x0F80`), making the correct relative offset `0x071C`. Additionally, we must firmly reject tasks whose acceptance criteria require extraction of implicit/missing data like "Time Planted" or "Last Watered Time" when research findings explicitly show they are not stored.

--- a/.foundry/tasks/task-095-157-gen3-berry-dataview-parsing.md
+++ b/.foundry/tasks/task-095-157-gen3-berry-dataview-parsing.md
@@ -2,7 +2,7 @@
 id: task-095-157-gen3-berry-dataview-parsing
 type: TASK
 title: Implement Gen 3 Berry Tracker DataView Parsing Logic
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-10'
 updated_at: '2026-06-13'
@@ -17,8 +17,8 @@ tags:
   - berries
   - engine
 research_references: []
-rejection_count: 1
-rejection_reason: ''
+rejection_count: 2
+rejection_reason: 'Offset calculation is incorrect (must be relative to Section 1 payload size 0x0F80, so 0x071C instead of 0x169C). Also, Time Planted and Last Watered cannot be extracted as per research findings.'
 notes: ''
 ---
 
@@ -34,6 +34,6 @@ Implement the extraction logic for Gen 3 berry patches using the native `DataVie
 - IMPORTANT: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [x] Implement `DataView` reading logic for Gen 3 berry patches.
-- [x] Implement graceful handling of bounds checking by throwing/catching `RangeError`.
-- [x] Extract map ID, berry ID, current growth stage, time planted, and last watered time.
+- [ ] Implement `DataView` reading logic for Gen 3 berry patches.
+- [ ] Implement graceful handling of bounds checking by throwing/catching `RangeError`.
+- [ ] Extract map ID, berry ID, current growth stage, time planted, and last watered time.

--- a/.foundry/tasks/task-095-158-gen3-berry-dataview-parsing-qa.md
+++ b/.foundry/tasks/task-095-158-gen3-berry-dataview-parsing-qa.md
@@ -40,3 +40,5 @@ Verify the implementation of the extraction logic for Gen 3 berry patches.
 - [ ] Verify `DataView` reading logic for Gen 3 berry patches implementation is correct.
 - [ ] Verify graceful handling of bounds checking (throwing/catching `RangeError`) without process crash.
 - [ ] Verify correct extraction of map ID, berry ID, current growth stage, time planted, and last watered time.
+
+**Note**: The implementation `task-095-157-gen3-berry-dataview-parsing` has been rejected due to incorrect offset calculations and the inclusion of implicit/missing data in the acceptance criteria.


### PR DESCRIPTION
The implementation of `task-095-157-gen3-berry-dataview-parsing` incorrectly used logical offsets instead of calculating the relative offset into Section 1 of `SaveBlock1`. Additionally, the task's acceptance criteria required extracting "Time Planted" and "Last Watered Time," which research shows are not explicitly stored in the Gen 3 save format.

The target task has been transitioned to `FAILED`, the `rejection_count` incremented, and an appropriate `rejection_reason` provided. The QA journal has been updated with these learnings.

---
*PR created automatically by Jules for task [12714644709529663939](https://jules.google.com/task/12714644709529663939) started by @szubster*