### PR TITLE
🧱 Mason: InlineDataPoint extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -100,3 +100,10 @@
 - **Key Learnings**:
   - Reusing existing components like `TacticalBadge` is crucial for code modularity and adherence to the project's aesthetic constraints (e.g., sharp edges, dashed borders).
   - Always verify that the extracted component matches the exact styling variants (e.g., `emerald`, `red`, `zinc`, `primary`) needed by the specific contexts.
+
+## InlineDataPoint Extraction
+- **What**: Extracted a repeated JSX pattern in `AppHeader.tsx` consisting of a side-by-side uppercase tracking label and a bold value into an `InlineDataPoint` reusable component.
+- **Why**: Reduced duplication of the verbose tactical utility classes `font-black font-mono text-[8px] text-zinc-500 uppercase tracking-widest` and allowed for standard horizontal metrics presentation.
+- **Key Learnings**:
+  - Distinguishing between vertical representations (like the existing `DataPoint` component) and horizontal ones (`InlineDataPoint`) is necessary since the layout structures (`flex-col` vs `items-center`) dictate the context of the data.
+  - Using `valueClassName` and `labelClassName` gives flexibility for minor styling tweaks like making values bold or specific colors (like `text-zinc-300`) without breaking the core pattern.

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -6,6 +6,7 @@ import { useFileSyncController } from '../hooks/useFileSyncController';
 import { cn } from '../utils/cn';
 import { getGenerationConfig } from '../utils/generationConfig';
 import { CornerCrosshairs } from './CornerCrosshairs';
+import { InlineDataPoint } from './InlineDataPoint';
 import { TacticalButton } from './TacticalButton';
 
 interface AppHeaderProps {
@@ -114,29 +115,23 @@ export function AppHeader({
           <div className="zoom-in-95 fade-in relative flex animate-in items-center bg-zinc-900/50 p-2 duration-500">
             <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700" />
             <div className="flex flex-col pr-4 pl-2">
-              <div className="flex items-center gap-2">
-                <span className="font-black font-mono text-[8px] text-zinc-500 uppercase tracking-widest">TRNR</span>
-                <span className="font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-tight">
-                  {saveData.trainerName || 'UNKNOWN'}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="font-black font-mono text-[8px] text-zinc-500 uppercase tracking-widest">ID</span>
-                <span className="font-bold font-mono text-[10px] text-zinc-300">
-                  {String(saveData.trainerId).padStart(5, '0')}
-                </span>
-              </div>
+              <InlineDataPoint label="TRNR" value={saveData.trainerName || 'UNKNOWN'} />
+              <InlineDataPoint
+                label="ID"
+                value={String(saveData.trainerId).padStart(5, '0')}
+                valueClassName="font-bold text-[10px] text-zinc-300"
+              />
             </div>
 
             <div className="h-8 w-[1px] border-zinc-800 border-r border-dashed bg-zinc-800" />
 
             <div className="flex min-w-[100px] flex-col justify-center px-4">
-              <div className="mb-1 flex items-center justify-between">
-                <span className="font-black font-mono text-[8px] text-zinc-500 uppercase tracking-widest">L-DEX</span>
-                <span className="font-black font-mono text-[9px] text-[var(--theme-primary)]">
-                  {Math.floor(progressPercentage)}%
-                </span>
-              </div>
+              <InlineDataPoint
+                label="L-DEX"
+                value={`${Math.floor(progressPercentage)}%`}
+                className="mb-1 justify-between"
+                valueClassName="text-[9px]"
+              />
               <div className="relative h-1 overflow-hidden border border-white/10 bg-black/50">
                 <div
                   style={{

--- a/src/components/InlineDataPoint.tsx
+++ b/src/components/InlineDataPoint.tsx
@@ -1,0 +1,36 @@
+import type React from 'react';
+import { cn } from '../utils/cn';
+
+interface InlineDataPointProps {
+  label: React.ReactNode;
+  value?: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+  labelClassName?: string;
+  valueClassName?: string;
+}
+
+export function InlineDataPoint({
+  label,
+  value,
+  children,
+  className,
+  labelClassName,
+  valueClassName,
+}: InlineDataPointProps) {
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <span className={cn('font-black font-mono text-[8px] text-zinc-500 uppercase tracking-widest', labelClassName)}>
+        {label}
+      </span>
+      <span
+        className={cn(
+          'font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-tight',
+          valueClassName,
+        )}
+      >
+        {value || children}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
🎯 What
Extracted a repeated JSX pattern in `AppHeader.tsx` consisting of a side-by-side uppercase tracking label and a bold value into an `InlineDataPoint` reusable component.

💡 Why
Reduced duplication of the verbose tactical utility classes (`font-black font-mono text-[8px] text-zinc-500 uppercase tracking-widest`) and standardized horizontal metrics presentation.

✅ Verification
Ran `pnpm check:fix`, `pnpm lint`, `pnpm test`, and `pnpm test:e2e`. All tests passed with no regressions.

✨ Result
Improved modularity and consistent application of styling for horizontal data labels.

---
*PR created automatically by Jules for task [7428735233853486999](https://jules.google.com/task/7428735233853486999) started by @szubster*