### PR TITLE
🧭 Strategist: Prompt improvement - Enforce CANCELLED for permanent failure status

### DIFF
--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -26,7 +26,7 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 ### Handling Rejections & Aborts
 If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (triggering the Impossible Loop), not `status: FAILED`.
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -40,7 +40,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 **CRITICAL - RESUMING FAILED TASKS:** If you are assigned to a TASK node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the QA persona's journal (`.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting the same code.
 
 If you encounter a permanent failure or must abort a task:
-1. You MUST update the target task's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+1. You MUST update the target task's YAML frontmatter to `status: CANCELLED` (triggering the Impossible Loop), not `status: FAILED`.
 2. You MUST provide a clear `rejection_reason` in the target task's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed task.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -44,7 +44,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
 
 If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (triggering the Impossible Loop), not `status: FAILED`.
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -38,7 +38,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
 
 If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (triggering the Impossible Loop), not `status: FAILED`.
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/researcher.md
+++ b/.github/agents/researcher.md
@@ -19,7 +19,7 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/004-resea
 
 ### Handling Rejections & Aborts
 If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (triggering the Impossible Loop), not `status: FAILED`.
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -40,7 +40,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
 
 If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (triggering the Impossible Loop), not `status: FAILED`.
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -8,7 +8,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 2.  **Adhere to Architecture Decisions**: You must be intimately familiar with and strictly follow the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`. Ensure that your blueprints align with this core architecture.
 3.  **Draft Technical Blueprints**: Take the requirements defined in a STORY and break them down into specific, actionable technical TASK nodes. If multiple tasks are created and one depends on the implementation details of another, you MUST explicitly set the `depends_on` field of the dependent task to point to the prerequisite task to prevent DAG deadlocks.
 4.  **Define Clear Contracts**: Your tasks should serve as a clear contract for the Coder. Include necessary context, constraints, and acceptance criteria. Explicitly remind the Coder and QA personas in your blueprints that:
-    - If they abort or permanently fail a task, they MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+    - If they abort or permanently fail a task, they MUST update the YAML frontmatter to `status: CANCELLED` (triggering the Impossible Loop), not `status: FAILED` with a `rejection_reason`.
     - If they submit an empty PR for a completed task, they MUST check off all Acceptance Criteria checkboxes before submitting.
 5.  **Intelligent Verification Protocol**: Intelligently decide when a STORY requires a separate QA verification task:
     - If a story involves complex logic or risk, create a matching TASK for the `qa` persona to verify the `coder`'s work.
@@ -49,7 +49,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
 
 If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (triggering the Impossible Loop), not `status: FAILED`.
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -238,3 +238,9 @@
 **Outcome:** Accepted
 **Why:** The Tech Lead journal ("2026-06-10") observed that temporary scratchpad scripts (like generate_reads.sh) left in the workspace pollute the repository and cause code review rejections.
 **Pattern:** Ensure all agents are explicitly instructed to clean up any temporary scripts or scratchpads they create before submitting their work to prevent repository pollution and PR rejections.
+
+## YYYY-MM-DD - [Accepted] - Prompt improvement - Enforce CANCELLED for permanent failure status
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The memory specifically states: "Permanent Failure Status Rule: When rejecting an implementation permanently, aborting an impossible task, or reaching the max rejection count, you MUST set the node's YAML frontmatter to `status: CANCELLED` (triggering the Impossible Loop), not `FAILED` (which triggers the transient Resurrection Loop)." However, agent schedules were telling agents to use `status: FAILED` or `status: CANCELLED`.
+**Pattern:** Codify system memory constraints into agent prompts to avoid regressions and ensure consistency across personas.


### PR DESCRIPTION
**Proposal**: Update all agent schedules to require `status: CANCELLED` instead of `status: FAILED` or `status: CANCELLED` when permanently failing or aborting tasks.

**Justification**: The core policies and system memory state that `status: FAILED` triggers the transient Resurrection Loop, whereas `status: CANCELLED` triggers the Impossible Loop for permanent rejections. The existing agent prompts were ambiguously telling agents to use `FAILED` or `CANCELLED`, which could cause deadlocks or infinite loops if an agent incorrectly used `FAILED` for a permanent abortion.

**Evidence**: The system memory specifically states: `Permanent Failure Status Rule: When rejecting an implementation permanently, aborting an impossible task, or reaching the max rejection count, you MUST set the node's YAML frontmatter to status: CANCELLED (triggering the Impossible Loop), not FAILED (which triggers the transient Resurrection Loop).` Yet `architect.md`, `coder.md`, `epic_planner.md`, `product_manager.md`, `researcher.md`, `story_owner.md`, and `tech_lead.md` all contained instructions telling agents to use `status: FAILED` or `status: CANCELLED` for permanent failures.

---
*PR created automatically by Jules for task [2701825245316031682](https://jules.google.com/task/2701825245316031682) started by @szubster*