### PR TITLE
Fix Mirage Island Offset Size Documentation

### DIFF
--- a/.foundry/docs/knowledge_base/gen3_mirage_island_offsets.md
+++ b/.foundry/docs/knowledge_base/gen3_mirage_island_offsets.md
@@ -5,7 +5,7 @@ This document outlines the byte offsets and data structure size for the daily/ra
 ## Data Structure
 The Mirage Island value is stored as a random value within the "Section 2 - Game State" of the save file structure.
 
-- **Size**: 16-bit integer (2 bytes). Only the low two bytes of the value are used.
+- **Size**: 16-bit integer (2 bytes).
 - **Endianness**: Little-endian.
 
 ## Offsets
@@ -13,8 +13,8 @@ The exact offsets depend on the game version:
 
 | Game Version | Section | Offset | Size | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| **Ruby / Sapphire** | Section 2 | `0x0408` | 4 bytes (only low 2 bytes used) | Mirage Island value |
-| **Emerald** | Section 2 | `0x0464` | 4 bytes (only low 2 bytes used) | Mirage Island value |
+| **Ruby / Sapphire** | Section 2 | `0x0408` | 2 bytes | Mirage Island value |
+| **Emerald** | Section 2 | `0x0464` | 2 bytes | Mirage Island value |
 
 ## Parsing Requirements
 As per ADR 010, any extraction logic must use the `DataView` API (e.g., `getUint16`) to read this value and handle out-of-bounds reads gracefully.

--- a/.foundry/tasks/task-098-172-locate-mirage-island-offset-retry.md
+++ b/.foundry/tasks/task-098-172-locate-mirage-island-offset-retry.md
@@ -38,7 +38,7 @@ As part of the Mirage Island save parsing feature (Story `story-061-098-locate-m
 - **Failure Condition**: If you cannot locate the offset or encounter permanent failures, you MUST update this node's YAML frontmatter to `status: FAILED` with a clear `rejection_reason`.
 
 ## Acceptance Criteria
-- [ ] Document the exact byte offset(s) for the Mirage Island value in R/S/E.
-- [ ] Document the correct section containing the value.
-- [ ] Document the data structure size (expected to be a 16-bit integer).
-- [ ] Create or update `.foundry/docs/knowledge_base/gen3_mirage_island_offsets.md` with the findings.
+- [x] Document the exact byte offset(s) for the Mirage Island value in R/S/E.
+- [x] Document the correct section containing the value.
+- [x] Document the data structure size (expected to be a 16-bit integer).
+- [x] Create or update `.foundry/docs/knowledge_base/gen3_mirage_island_offsets.md` with the findings.


### PR DESCRIPTION
Fixes an inaccuracy in the Mirage Island documentation where the data size was listed as 4 bytes instead of the correct 16-bit (2 bytes) integer format.

---
*PR created automatically by Jules for task [11731261898899691522](https://jules.google.com/task/11731261898899691522) started by @szubster*