### PR TITLE
Implement Gen 3 Mirage Island Value Parsing

### DIFF
--- a/.foundry/tasks/task-098-175-mirage-island-parsing-impl.md
+++ b/.foundry/tasks/task-098-175-mirage-island-parsing-impl.md
@@ -36,5 +36,5 @@ As defined in Story `story-061-098-parse-mirage-island-value` and ADR 010, we ne
 - **Empty PR Constraint:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] `parseGen3MirageIslandValue` reads a 16-bit unsigned integer using `DataView`.
-- [ ] It catches `RangeError` and throws a specific corruption error message.
+- [x] `parseGen3MirageIslandValue` reads a 16-bit unsigned integer using `DataView`.
+- [x] It catches `RangeError` and throws a specific corruption error message.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -125,6 +125,8 @@ export interface SaveData {
     mapGroup: number;
     mapId: number;
   }[];
+  /** Gen 3 specific: The 16-bit daily Mirage Island random value. */
+  mirageIslandValue?: number;
 }
 
 // Removed byte helper as DataView provides getUint8 natively.

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -131,6 +131,7 @@ export function isGen3Save(view: DataView): boolean {
  */
 export function parseGen3MirageIslandValue(view: DataView, offset: number): number {
   try {
+    // Read the 16-bit little-endian value using the DataView API
     return view.getUint16(offset, true);
   } catch (error) {
     if (error instanceof RangeError) {
@@ -176,6 +177,9 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       hiddenItemFlags[i] = ((currentByte >> 4) | ((nextByte & 0x0f) << 4)) & 0xff;
     }
 
+    const mirageIslandOffset = _forcedVersion === 'emerald' ? 0x0464 : 0x0408;
+    const mirageIslandValue = parseGen3MirageIslandValue(view, section2Offset + mirageIslandOffset);
+
     // Dummy scaffold values for now until fully implemented
     return {
       generation: 3,
@@ -195,6 +199,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       hallOfFameCount: 0,
       gen3BerryPatches,
       hiddenItemFlags,
+      mirageIslandValue,
     };
   } catch (error) {
     if (error instanceof RangeError) {


### PR DESCRIPTION
Implemented Gen 3 Mirage Island Value parsing according to ADR 010.

- `mirageIslandValue` was added as an optional number to the `SaveData` interface.
- `parseGen3` now correctly computes the Section 2 offset based on the game version (`0x0464` for Emerald, `0x0408` for Ruby/Sapphire).
- `parseGen3MirageIslandValue` successfully uses the `DataView` API `getUint16(offset, true)` to extract the value and traps `RangeError` with the mandated corruption error message.
- Acceptance criteria for `task-098-175` checked off. All test suites pass.

---
*PR created automatically by Jules for task [6132386693860857510](https://jules.google.com/task/6132386693860857510) started by @szubster*