### PR TITLE
chore: break down feebas tile calculation story into tasks

### DIFF
--- a/.foundry/tasks/task-096-183-feebas-tile-calculation-impl.md
+++ b/.foundry/tasks/task-096-183-feebas-tile-calculation-impl.md
@@ -1,26 +1,26 @@
 ---
-id: story-058-096-feebas-tile-calculation
-type: STORY
-title: Feebas Tile Calculation Algorithm
-status: READY
-owner_persona: tech_lead
-created_at: '2026-06-08'
+id: task-096-183-feebas-tile-calculation-impl
+type: TASK
+title: Implement Feebas Tile Calculation Algorithm
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-14'
 updated_at: '2026-06-14'
-depends_on:
-  - story-058-095-feebas-seed-extraction
+depends_on: []
 jules_session_id: null
 pr_number: null
-parent: epic-036-058-feebas-backend-parsing
+parent: story-058-096-feebas-tile-calculation
 tags:
   - gen3
   - backend
   - algorithm
+research_references: []
 rejection_count: 0
 rejection_reason: ''
 notes: ''
 ---
 
-# Feebas Tile Calculation Algorithm
+# Implement Feebas Tile Calculation Algorithm
 
 ## Objective
 Implement the Gen 3 Linear Congruential Generator (LCG) algorithm to translate the 16-bit Feebas seed into the 6 specific valid spot IDs on Route 119, and map those spot IDs to physical map coordinates.
@@ -32,8 +32,8 @@ Implement the Gen 3 Linear Congruential Generator (LCG) algorithm to translate t
 - [ ] Implement spot rejection for values `< 4` (inaccessible spots), looping until 6 valid spot IDs are selected.
 - [ ] Add `mapSpotIdsToCoordinates(spotIds: number[])` to map 1D spot IDs to `(x, y)` relative grid coordinates.
 - [ ] Write unit tests verifying the exact 6 spots generated for a set of known seeds.
-- [x] Break down into Tasks
 
-## Tasks
-- [ ] .foundry/tasks/task-096-183-feebas-tile-calculation-impl.md
-- [ ] .foundry/tasks/task-096-184-feebas-tile-calculation-qa.md
+## Rules & Constraints
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-096-184-feebas-tile-calculation-qa.md
+++ b/.foundry/tasks/task-096-184-feebas-tile-calculation-qa.md
@@ -1,0 +1,40 @@
+---
+id: task-096-184-feebas-tile-calculation-qa
+type: TASK
+title: QA Feebas Tile Calculation Algorithm
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on:
+  - task-096-183-feebas-tile-calculation-impl
+jules_session_id: null
+pr_number: null
+parent: story-058-096-feebas-tile-calculation
+tags:
+  - gen3
+  - backend
+  - algorithm
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Feebas Tile Calculation Algorithm
+
+## Objective
+Verify the Gen 3 Linear Congruential Generator (LCG) algorithm implementation correctly translates the 16-bit Feebas seed into 6 specific valid spot IDs on Route 119 and maps them to coordinates.
+
+## Acceptance Criteria
+- [ ] Verify `calculateFeebasTiles(seed: number)` exists in `src/engine/gen3/feebas.ts` and uses the correct LCG formula (`1103515245 * sFeebasRngValue + 12345`).
+- [ ] Verify spot selection modulo math `(sFeebasRngValue >> 16) % 447` and force `0` to `447` are implemented correctly.
+- [ ] Verify spot rejection logic correctly rejects values `< 4` and guarantees 6 valid spot IDs are generated.
+- [ ] Verify `mapSpotIdsToCoordinates(spotIds: number[])` correctly maps 1D spot IDs to `(x, y)` relative grid coordinates.
+- [ ] Verify unit tests pass and explicitly test known seeds to verify the exact 6 spots generated.
+
+## Rules & Constraints
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Breaks down story-058-096-feebas-tile-calculation into granular implementation and QA tasks.

- Created `task-096-183-feebas-tile-calculation-impl.md` (coder).
- Created `task-096-184-feebas-tile-calculation-qa.md` (qa).
- Properly formatted `depends_on` in the QA node to use the exact node ID per DAG rules.
- Appended child task references and checked off acceptance criteria in the parent story body.

---
*PR created automatically by Jules for task [15160987497054339941](https://jules.google.com/task/15160987497054339941) started by @szubster*