### PR TITLE
Research: Investigate Orchestrator TPM Journal Logging Mechanism

### DIFF
--- a/.foundry/research/research-076-174-investigate-tpm-journal-bloat.md
+++ b/.foundry/research/research-076-174-investigate-tpm-journal-bloat.md
@@ -27,5 +27,9 @@ The TPM journal (`.foundry/journals/tpm.md`) is heavily bloated with routine tas
 Investigate the Orchestrator script and Foundry Engine GitHub Action to understand why and where it logs these routine updates.
 
 ## Acceptance Criteria
-- [ ] Identify the exact files and lines of code responsible for logging to the TPM journal.
-- [ ] Determine if the logging behavior serves a systemic purpose or if it's unnecessary bloat.
+- [x] Identify the exact files and lines of code responsible for logging to the TPM journal.
+- [x] Determine if the logging behavior serves a systemic purpose or if it's unnecessary bloat.
+
+## Findings
+- **Files and lines of code**: The `.github/scripts/dag-utils.ts` script handles appending messages to the `tpm.md` journal via the `logToJournal` function. The orchestrator script `.github/scripts/foundry-heartbeat.ts` calls `logToJournal` excessively across multiple lines (e.g., 45, 88, 102, 120, 133, 155, 168, 179, 205, 218, 488) to log routine state transitions, system failures, node cleanup, etc.
+- **Systemic Purpose vs. Bloat**: This logging behavior is unnecessary bloat. According to the TPM persona documentation (`.foundry/docs/knowledge_base/agents/core_policies.md` and `.github/agents/tpm.md`), the `tpm.md` file is strictly for logging long-term lessons, architectural constraints, and recurring failures, not as a ledger to record completed tasks or step transitions. The orchestrator and PR history already track what happened. Routine task verification logs in this journal degrade long-term memory context and waste context tokens without serving any functional orchestrator purpose.


### PR DESCRIPTION
This PR adds the findings for the research task `research-076-174-investigate-tpm-journal-bloat.md`.

It identifies the exact files (`.github/scripts/dag-utils.ts` and `.github/scripts/foundry-heartbeat.ts`) responsible for logging to the TPM journal.
It determines that the logging behavior is unnecessary bloat, as the `tpm.md` file is intended for critical learnings and architectural constraints, not routine task verification.

It checks off the acceptance criteria.

---
*PR created automatically by Jules for task [15918807968795082903](https://jules.google.com/task/15918807968795082903) started by @szubster*