### PR TITLE
chore(qa): Complete Unown Form Parser Unit Tests QA

### DIFF
--- a/.foundry/tasks/task-096-180-unown-parser-tests-qa.md
+++ b/.foundry/tasks/task-096-180-unown-parser-tests-qa.md
@@ -39,6 +39,6 @@ The logic for determining the Unown form in Gen 2 uses a bitwise operation on th
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verified that tests for the exact bitwise calculation against known DV combinations for Unown forms (A, Z, etc.) exist and pass.
-- [ ] Verified tests assert that `unownForm` is appended to the output structure when `speciesId` is 201.
-- [ ] Verified tests assert that `unownForm` is omitted or undefined for non-Unown Pokemon.
+- [x] Verified that tests for the exact bitwise calculation against known DV combinations for Unown forms (A, Z, etc.) exist and pass.
+- [x] Verified tests assert that `unownForm` is appended to the output structure when `speciesId` is 201.
+- [x] Verified tests assert that `unownForm` is omitted or undefined for non-Unown Pokemon.


### PR DESCRIPTION
This empty PR signifies the successful completion of QA for the Unown Form Parser Unit Tests task. Tests were confirmed to run cleanly (`pnpm test`), accurately assert the Gen 2 DV bitwise calculation for Unown forms (A and Z), and properly gate the append logic to `speciesId === 201`. The task node `task-096-180-unown-parser-tests-qa.md` has had its acceptance criteria updated.

---
*PR created automatically by Jules for task [2620565461797190132](https://jules.google.com/task/2620565461797190132) started by @szubster*