### PR TITLE
QA: Verify Mirage Island offset documentation (Retry)

### DIFF
--- a/.foundry/tasks/task-098-173-qa-mirage-island-offset-retry.md
+++ b/.foundry/tasks/task-098-173-qa-mirage-island-offset-retry.md
@@ -36,6 +36,6 @@ The `coder` persona has documented the exact offset, section, and data structure
 - **Failure Condition**: If the documentation is incorrect or missing, you MUST update this node's YAML frontmatter to `status: FAILED` with a clear `rejection_reason` so the tech lead can resurrect the work. Do NOT mark this task as FAILED if the task itself passes but you found a bug in the target; report bugs in the rejection_reason and FAILED status if necessary.
 
 ## Acceptance Criteria
-- [ ] Verify the documented byte offsets for the Mirage Island value in R/S/E are correct.
-- [ ] Verify the documented section for the Mirage Island value is correct according to Bulbapedia.
-- [ ] Verify the data size is documented as a 16-bit integer.
+- [x] Verify the documented byte offsets for the Mirage Island value in R/S/E are correct.
+- [x] Verify the documented section for the Mirage Island value is correct according to Bulbapedia.
+- [x] Verify the data size is documented as a 16-bit integer.


### PR DESCRIPTION
QA has verified the `coder`'s updated offset documentation for Mirage Island in Gen 3 (`task-098-172-locate-mirage-island-offset-retry`). The offsets and sections match the findings from `research-098-171-investigate-mirage-island-offset.md` and authoritative sources. Acceptance criteria have been checked off. Tests, linting, and schema validation have passed.

---
*PR created automatically by Jules for task [13888584630131910429](https://jules.google.com/task/13888584630131910429) started by @szubster*