### PR TITLE
chore: retry gen 3 berry dataview parsing logic

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -59,3 +59,7 @@ Prevents silent failures and ensures backwards compatibility.
 - **Action**: Always explicitly verify the logical section of any discovered offset against authoritative documentation before finalizing parsing specs to prevent incorrect data extraction by the orchestrator.
 ## 2026-06-13: Handling Cancelled QA Tasks from Missing Integrations
 When a coder task fails permanently due to missing architectural integration (like missing context/props), resulting in a resurrection loop and a RESEARCH node, it is critical that the orphaned QA task from the previous failed run is marked as CANCELLED in its markdown body. If left un-cancelled, the orchestrator will assign an agent to verify the failed task, leading to deadlocks. The parent macro node must be updated with the newly generated child tasks, and the orphaned QA task must be explicitly replaced.
+
+## 2026-06-14: Handling Research Findings for Missing/Implicit Data
+- **Observation**: When a `RESEARCH` node reveals that originally requested data fields are implicit or simply not present in the game's data structures (e.g., Gen 3 Berry Tracker missing explicit "time planted" and "map ID" fields), the subsequent retry `TASK` nodes must explicitly instruct the coder to omit these fields from explicit extraction.
+- **Action**: Do not attempt to force parsers to extract non-existent data. Update the technical blueprints to explicitly reflect the research findings and omit the missing fields, ensuring the QA constraints match the newly established physical reality of the data structure.

--- a/.foundry/stories/story-055-095-gen3-berry-data-parsing.md
+++ b/.foundry/stories/story-055-095-gen3-berry-data-parsing.md
@@ -33,3 +33,6 @@ Implement the extraction logic for Gen 3 berry patches using the native `DataVie
 
 - [ ] .foundry/tasks/task-095-157-gen3-berry-dataview-parsing.md
 - [ ] .foundry/tasks/task-095-158-gen3-berry-dataview-parsing-qa.md
+- [ ] .foundry/research-095-158-gen3-berry-missing-offsets.md
+- [ ] .foundry/tasks/task-095-183-gen3-berry-dataview-parsing-retry-impl.md
+- [ ] .foundry/tasks/task-095-184-gen3-berry-dataview-parsing-retry-qa.md

--- a/.foundry/tasks/task-095-183-gen3-berry-dataview-parsing-retry-impl.md
+++ b/.foundry/tasks/task-095-183-gen3-berry-dataview-parsing-retry-impl.md
@@ -1,0 +1,43 @@
+---
+id: task-095-183-gen3-berry-dataview-parsing-retry-impl
+type: TASK
+title: Implement Gen 3 Berry Tracker DataView Parsing Logic Retry
+status: PENDING
+owner_persona: coder
+created_at: 2026-06-14
+updated_at: 2026-06-14
+depends_on:
+  - research-095-158-gen3-berry-missing-offsets
+jules_session_id: null
+pr_number: null
+parent: story-055-095-gen3-berry-data-parsing
+tags:
+  - feature
+  - gen3
+  - berries
+  - engine
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Task: Implement Gen 3 Berry Tracker DataView Parsing Logic Retry
+
+## Overview
+Implement the extraction logic for Gen 3 berry patches using the native `DataView` API. This is a retry task incorporating research findings on missing explicit fields.
+
+## Constraints & Architecture
+- Follow ADR 010: Exclusively use the native `DataView` API (e.g., `getUint8`, `getUint16`) instead of raw `Uint8Array` manipulations.
+- Implement graceful handling of bounds checking by throwing and explicitly catching `RangeError` within the parser engine. Propagate these as specific validation errors (e.g., "Corrupted Save File").
+- Extract `berry ID`, `stage`, `stopGrowth`, `minutesUntilNextStage`, `berryYield`, `regrowthCount`, and `watered` stages as defined in the `gen3_berry_patch_offsets.md` document.
+- IMPORTANT: `map ID`, `time planted`, and `last watered time` are implicit and should NOT be explicitly extracted, to avoid incorrect calculations as detailed in `.foundry/research-095-158-gen3-berry-missing-offsets.md`.
+- Seek to offset `0x169C` in `SaveBlock1` (taking into account the relative offset `0x071C` within Section 1) and iterate 128 times, advancing by 8 bytes per iteration.
+- IMPORTANT: If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- IMPORTANT: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement `DataView` reading logic for Gen 3 berry patches using offset `0x169C` in `SaveBlock1`.
+- [ ] Implement graceful handling of bounds checking by throwing/catching `RangeError`.
+- [ ] Extract `berry ID`, `stage`, `stopGrowth`, `minutesUntilNextStage`, `berryYield`, `regrowthCount`, and watering history bitflags.
+- [ ] Ensure `map ID`, `time planted`, and `last watered time` are omitted from extraction logic since they are implicit.

--- a/.foundry/tasks/task-095-184-gen3-berry-dataview-parsing-retry-qa.md
+++ b/.foundry/tasks/task-095-184-gen3-berry-dataview-parsing-retry-qa.md
@@ -1,13 +1,13 @@
 ---
-id: task-095-158-gen3-berry-dataview-parsing-qa
+id: task-095-184-gen3-berry-dataview-parsing-retry-qa
 type: TASK
-title: QA Verification for Gen 3 Berry Tracker DataView Parsing Logic
-status: READY
+title: QA Verification for Gen 3 Berry Tracker DataView Parsing Logic Retry
+status: PENDING
 owner_persona: qa
-created_at: '2026-06-10'
-updated_at: '2026-06-14'
+created_at: 2026-06-14
+updated_at: 2026-06-14
 depends_on:
-  - task-095-157-gen3-berry-dataview-parsing
+  - task-095-183-gen3-berry-dataview-parsing-retry-impl
 jules_session_id: null
 pr_number: null
 parent: story-055-095-gen3-berry-data-parsing
@@ -18,20 +18,21 @@ tags:
   - engine
   - qa
 research_references: []
-rejection_count: 1
-rejection_reason: ''
-notes: ''
+rejection_count: 0
+rejection_reason: ""
+notes: ""
 ---
 
-# Task: QA Verification for Gen 3 Berry Tracker DataView Parsing Logic
+# Task: QA Verification for Gen 3 Berry Tracker DataView Parsing Logic Retry
 
 ## Overview
-Verify the implementation of the extraction logic for Gen 3 berry patches.
+Verify the implementation of the extraction logic for Gen 3 berry patches, ensuring that missing/implicit data is not erroneously extracted.
 
 ## Constraints & Verification Steps
 - Verify that the implementation uses the `DataView` API exclusively, avoiding raw `Uint8Array` manipulations.
 - Verify that bounds checking is gracefully handled by catching `RangeError` exceptions and raising proper errors (e.g., "Corrupted Save File").
-- Verify that map ID, berry ID, current growth stage, time planted, and last watered time are extracted correctly.
+- Verify that `berry ID`, `stage`, `stopGrowth`, `minutesUntilNextStage`, `berryYield`, `regrowthCount`, and `watered` stages are extracted correctly according to the documented structures in `.foundry/docs/knowledge_base/gen3_berry_patch_offsets.md`.
+- Ensure that `map ID`, `time planted`, and `last watered time` are properly omitted from the extraction as per research findings.
 - Ensure that the tests correctly mock range bounds and corrupted save files without crashing the process.
 - IMPORTANT: If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
 - IMPORTANT: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
@@ -39,8 +40,5 @@ Verify the implementation of the extraction logic for Gen 3 berry patches.
 ## Acceptance Criteria
 - [ ] Verify `DataView` reading logic for Gen 3 berry patches implementation is correct.
 - [ ] Verify graceful handling of bounds checking (throwing/catching `RangeError`) without process crash.
-- [ ] Verify correct extraction of map ID, berry ID, current growth stage, time planted, and last watered time.
-
-**Note**: The implementation `task-095-157-gen3-berry-dataview-parsing` has been rejected due to incorrect offset calculations and the inclusion of implicit/missing data in the acceptance criteria.
-
-**CANCELLED**: This QA task is cancelled and has been replaced by `task-095-184-gen3-berry-dataview-parsing-retry-qa` due to the permanent failure of the underlying implementation task.
+- [ ] Verify correct extraction of `berry ID`, `stage`, `stopGrowth`, `minutesUntilNextStage`, `berryYield`, `regrowthCount`, and watering history bitflags.
+- [ ] Verify that `map ID`, `time planted`, and `last watered time` are omitted.


### PR DESCRIPTION
Handled the permanent failure of the Gen 3 Berry DataView parsing task by creating replacement implementation and QA tasks that incorporate the research findings on missing implicit fields. Updated the parent story, canceled the orphaned QA task properly, and updated the persona journal.

---
*PR created automatically by Jules for task [9252666072392972351](https://jules.google.com/task/9252666072392972351) started by @szubster*