### PR TITLE
Generate tasks for Gen 3 Match Call Offsets

### DIFF
--- a/.foundry/stories/story-083-125-gen3-match-call-memory-offset-discovery.md
+++ b/.foundry/stories/story-083-125-gen3-match-call-memory-offset-discovery.md
@@ -31,3 +31,5 @@ Determine the exact memory offsets in Pokémon Emerald `.sav` files for the Matc
 - [ ] Find rematch readiness bitflags
 - [ ] Determine rematch tier states offsets
 - [ ] research-125-173-gen3-match-call-offsets
+- [ ] task-125-183-match-call-offsets-impl
+- [ ] task-125-184-match-call-offsets-qa

--- a/.foundry/tasks/task-125-183-match-call-offsets-impl.md
+++ b/.foundry/tasks/task-125-183-match-call-offsets-impl.md
@@ -1,0 +1,47 @@
+---
+id: task-125-183-match-call-offsets-impl
+type: TASK
+title: Implement Gen 3 Match Call Offset Definitions
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on:
+  - research-125-173-gen3-match-call-offsets
+jules_session_id: null
+pr_number: null
+parent: story-083-125-gen3-match-call-memory-offset-discovery
+tags:
+  - feature
+  - gen3
+  - tracking
+  - save-parsing
+research_references:
+  - .foundry/research/research-125-173-gen3-match-call-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Match Call Offset Definitions
+
+## Overview
+Implement the memory offset constants and type definitions for the Match Call data block in Gen 3 Pokémon Emerald `.sav` files.
+
+## Technical Details
+Refer to the findings in `research-125-173-gen3-match-call-offsets.md`.
+- Implement constants for the starting offset and length of the Match Call memory block.
+- Define byte mapping and exact bitwise locations for rematch readiness flags.
+- Define memory locations and structure of rematch tier states.
+
+## Acceptance Criteria
+- [ ] Implement offset constants for the Match Call data block.
+- [ ] Implement offset constants for rematch readiness flags.
+- [ ] Implement offset constants for rematch tier states.
+- [ ] Conform to ADR 010.
+
+## Instructions
+- Ensure you read the associated research node.
+- Only mark this node as FAILED if you encounter a transient failure requiring retry.
+- Only mark this node as CANCELLED if you must abort or permanently fail.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-125-184-match-call-offsets-qa.md
+++ b/.foundry/tasks/task-125-184-match-call-offsets-qa.md
@@ -1,0 +1,47 @@
+---
+id: task-125-184-match-call-offsets-qa
+type: TASK
+title: QA - Verify Gen 3 Match Call Offset Definitions
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on:
+  - task-125-183-match-call-offsets-impl
+jules_session_id: null
+pr_number: null
+parent: story-083-125-gen3-match-call-memory-offset-discovery
+tags:
+  - feature
+  - gen3
+  - tracking
+  - save-parsing
+  - qa
+research_references:
+  - .foundry/research/research-125-173-gen3-match-call-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Verify Gen 3 Match Call Offset Definitions
+
+## Overview
+Verify the coder's implementation of the memory offset constants and type definitions for the Match Call data block in Gen 3 Pokémon Emerald `.sav` files.
+
+## Verification Details
+Ensure the coder correctly implemented the offsets discovered in `research-125-173-gen3-match-call-offsets.md` in `task-125-183-match-call-offsets-impl`.
+- Verify the constants for the starting offset and length of the Match Call memory block.
+- Verify byte mapping and exact bitwise locations for rematch readiness flags.
+- Verify memory locations and structure of rematch tier states.
+- Ensure the implementation strictly adheres to ADR 010 (bounds checking).
+
+## Acceptance Criteria
+- [ ] Verify offset constants for the Match Call data block.
+- [ ] Verify offset constants for rematch readiness flags.
+- [ ] Verify offset constants for rematch tier states.
+- [ ] Verify adherence to ADR 010.
+
+## Instructions
+- If the implementation is incorrect, mark the target node `task-125-183-match-call-offsets-impl` as FAILED, provide a `rejection_reason`, and increment its `rejection_count`. DO NOT change this QA task's status to FAILED.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR creates two technical TASK nodes (`task-125-183-match-call-offsets-impl` and `task-125-184-match-call-offsets-qa`) based on the research findings for Gen 3 Match Call save data offsets. It also updates the parent STORY node (`story-083-125-gen3-match-call-memory-offset-discovery`) to track these new child tasks without prematurely altering its frontmatter.

---
*PR created automatically by Jules for task [4247984994830806741](https://jules.google.com/task/4247984994830806741) started by @szubster*