### PR TITLE
docs: update SaveData.roamingLegendaries interface for Gen 3

### DIFF
--- a/.foundry/tasks/task-104-159-gen3-roamer-interface-impl.md
+++ b/.foundry/tasks/task-104-159-gen3-roamer-interface-impl.md
@@ -33,7 +33,7 @@ We need to ensure the `roamingLegendaries` type signature in the `SaveData` inte
   - Gen 3: Utilizes the unified Map Group / Map Index architecture.
 
 ## Acceptance Criteria
-- [ ] `roamingLegendaries` documentation in `SaveData` explicitly states support for Gen 2 and Gen 3 roamers.
-- [ ] Interface comments explain the map group/id differences between the generations.
-- [ ] If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
-- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- [x] `roamingLegendaries` documentation in `SaveData` explicitly states support for Gen 2 and Gen 3 roamers.
+- [x] Interface comments explain the map group/id differences between the generations.
+- [x] If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- [x] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -116,9 +116,15 @@ export interface SaveData {
   daycare?: PokemonInstance[];
   /** Gen 2 specific: Indicates if an Egg is currently waiting to be picked up from the Daycare. */
   daycareHasEgg?: boolean;
-  /** Gen 2 specific: Information regarding currently roaming Legendary beasts (Raikou, Entei, Suicune). */
+  /** Gen 3 specific: Information regarding the state of Berry Patches across Hoenn. */
   gen3BerryPatches?: Gen3BerryPatch[];
-  /** Gen 2 specific: Information regarding currently roaming Legendary beasts (Raikou, Entei, Suicune). */
+  /**
+   * Information regarding currently roaming Legendaries (Gen 2: Raikou, Entei, Suicune. Gen 3: Latios, Latias).
+   *
+   * Generation differences for map identification:
+   * - Gen 2: `mapGroup` and `mapId` are read as separate distinct bytes from the save file.
+   * - Gen 3: Utilizes the unified Map Group / Map Index architecture. `mapGroup` and `mapId` can be conceptually derived from a 16-bit Map ID `(GroupIndex << 8) | MapIndex` (though often stored as separate bytes or fields internally, they form a single coordinate).
+   */
   roamingLegendaries?: {
     speciesId: number;
     level: number;


### PR DESCRIPTION
This PR addresses the requirements for task `task-104-159-gen3-roamer-interface-impl`.

### Changes Made:
- Updated the documentation for the `roamingLegendaries` property in the `SaveData` interface in `src/engine/saveParser/parsers/common.ts` to reflect support for Gen 3 roamers (Latios, Latias).
- Clarified the generation-specific mapping structures for `mapGroup` and `mapId` (separate bytes in Gen 2 vs. unified 16-bit format in Gen 3).
- Corrected a pre-existing documentation typo on the adjacent `gen3BerryPatches` property.
- Checked off all acceptance criteria in `.foundry/tasks/task-104-159-gen3-roamer-interface-impl.md`.

All linting, project tests, and schema validations passed successfully.

---
*PR created automatically by Jules for task [15972724275597505462](https://jules.google.com/task/15972724275597505462) started by @szubster*