### PR TITLE
Implement Unit Tests for Shared DAG Utilities

### DIFF
--- a/.foundry/tasks/task-106-159-dag-utils-unit-tests-impl.md
+++ b/.foundry/tasks/task-106-159-dag-utils-unit-tests-impl.md
@@ -37,7 +37,7 @@ This task was generated from `.foundry/stories/story-053-106-dag-utils-unit-test
 *   If submitting an empty PR for a completed task (e.g., if you realize the file already has complete tests), you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 4. Acceptance Criteria
-- [ ] `.github/scripts/dag-utils.test.ts` is created.
-- [ ] Comprehensive unit tests for `buildReverseDependencyGraph` are written and pass.
-- [ ] Comprehensive unit tests for `getOrphanedNodes` are written and pass.
-- [ ] Running `pnpm exec vitest run` passes without errors.
+- [x] `.github/scripts/dag-utils.test.ts` is created.
+- [x] Comprehensive unit tests for `buildReverseDependencyGraph` are written and pass.
+- [x] Comprehensive unit tests for `getOrphanedNodes` are written and pass.
+- [x] Running `pnpm exec vitest run` passes without errors.

--- a/.github/scripts/dag-utils.test.ts
+++ b/.github/scripts/dag-utils.test.ts
@@ -22,6 +22,25 @@ describe('dag-utils', () => {
     expect(graph.get('b')).toEqual(['d']);
   });
 
+  it('buildReverseDependencyGraph - empty graph', () => {
+    const graph = buildReverseDependencyGraph([], () => null);
+    expect(graph.size).toBe(0);
+  });
+
+  it('buildReverseDependencyGraph - missing dependencies & undefined depends_on', () => {
+    const nodes = [
+      { repoPath: 'a', frontmatter: { depends_on: ['missing', 'resolved'] } },
+      { repoPath: 'b', frontmatter: {} }, // no depends_on
+    ];
+
+    const resolveNodePath = (ref: string) => (ref === 'resolved' ? 'resolved_path' : null);
+
+    const graph = buildReverseDependencyGraph(nodes, resolveNodePath);
+    expect(graph.get('resolved_path')).toEqual(['a']);
+    expect(graph.get('missing')).toBeUndefined();
+    expect(graph.size).toBe(1);
+  });
+
   it('getOrphanedNodes', () => {
     const graph = new Map([
       ['a', ['b', 'c']],
@@ -38,5 +57,30 @@ describe('dag-utils', () => {
     expect(orphanedB.has('b')).toBe(true);
     expect(orphanedB.has('d')).toBe(true);
     expect(orphanedB.has('a')).toBe(false);
+  });
+
+  it('getOrphanedNodes - node with no dependents', () => {
+    const graph = new Map([
+      ['a', []]
+    ]);
+    const orphaned = getOrphanedNodes('a', graph);
+    expect(orphaned.has('a')).toBe(true);
+    expect(orphaned.size).toBe(1);
+  });
+
+  it('getOrphanedNodes - cycle/diamond dependency graph', () => {
+    const graph = new Map([
+      ['a', ['b', 'c']],
+      ['b', ['d']],
+      ['c', ['d']],
+      ['d', ['a']], // Cycle back to 'a'
+    ]);
+
+    const orphaned = getOrphanedNodes('a', graph);
+    expect(orphaned.has('a')).toBe(true);
+    expect(orphaned.has('b')).toBe(true);
+    expect(orphaned.has('c')).toBe(true);
+    expect(orphaned.has('d')).toBe(true);
+    expect(orphaned.size).toBe(4); // Ensure it didn't infinite loop and found all 4
   });
 });


### PR DESCRIPTION
Added comprehensive unit tests for `buildReverseDependencyGraph` and `getOrphanedNodes` in `.github/scripts/dag-utils.test.ts`. Also updated the corresponding task node markdown.

---
*PR created automatically by Jules for task [2206443533653804636](https://jules.google.com/task/2206443533653804636) started by @szubster*