### PR TITLE
feat: implement Contest Ribbons UI component

### DIFF
--- a/.foundry/tasks/task-103-157-contest-ribbons-ui-impl.md
+++ b/.foundry/tasks/task-103-157-contest-ribbons-ui-impl.md
@@ -38,6 +38,6 @@ This task is derived from `story-064-103-contest-ribbons-display-ui` and involve
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement the `ContestRibbonBadge` React component(s).
-- [ ] Ensure proper styling matching the project's aesthetics.
-- [ ] Add rendering tests to verify various Ribbon combinations display correctly.
+- [x] Implement the `ContestRibbonBadge` React component(s).
+- [x] Ensure proper styling matching the project's aesthetics.
+- [x] Add rendering tests to verify various Ribbon combinations display correctly.

--- a/src/components/pokemon/details/ContestRibbonBadge.tsx
+++ b/src/components/pokemon/details/ContestRibbonBadge.tsx
@@ -1,0 +1,53 @@
+import { Award } from 'lucide-react';
+import React from 'react';
+import { cn } from '../../../utils/cn';
+
+export type ContestConditionType = 'Cool' | 'Beauty' | 'Cute' | 'Smart' | 'Tough';
+export type ContestRibbonRank = 'Normal' | 'Super' | 'Hyper' | 'Master';
+
+export interface ContestRibbonBadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  type: ContestConditionType;
+  rank: ContestRibbonRank;
+}
+
+const typeColorMap: Record<ContestConditionType, string> = {
+  Cool: 'text-red-500 border-red-500/50 bg-red-500/10',
+  Beauty: 'text-blue-500 border-blue-500/50 bg-blue-500/10',
+  Cute: 'text-pink-500 border-pink-500/50 bg-pink-500/10',
+  Smart: 'text-emerald-500 border-emerald-500/50 bg-emerald-500/10',
+  Tough: 'text-amber-500 border-amber-500/50 bg-amber-500/10',
+};
+
+const rankColorMap: Record<ContestRibbonRank, string> = {
+  Normal: 'text-zinc-400',
+  Super: 'text-zinc-200',
+  Hyper: 'text-yellow-400',
+  Master: 'text-purple-400',
+};
+
+const getTooltipText = (type: ContestConditionType, rank: ContestRibbonRank) => {
+  return `${type} Contest - ${rank} Rank Ribbon`;
+};
+
+export const ContestRibbonBadge = React.forwardRef<HTMLDivElement, ContestRibbonBadgeProps>(
+  ({ type, rank, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        title={getTooltipText(type, rank)}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-none border border-dashed px-2 py-1 font-mono text-xs uppercase tracking-widest',
+          typeColorMap[type],
+          className,
+        )}
+        {...props}
+      >
+        <Award className={cn('h-3.5 w-3.5', rankColorMap[rank])} aria-hidden="true" />
+        <span className="font-bold">{type}</span>
+        <span className="text-[10px] opacity-80">{rank}</span>
+      </div>
+    );
+  },
+);
+
+ContestRibbonBadge.displayName = 'ContestRibbonBadge';

--- a/src/components/pokemon/details/__tests__/ContestRibbonBadge.test.tsx
+++ b/src/components/pokemon/details/__tests__/ContestRibbonBadge.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { ContestRibbonBadge } from '../ContestRibbonBadge';
+
+describe('ContestRibbonBadge', () => {
+  it('renders correctly with Cool type and Normal rank', async () => {
+    await render(<ContestRibbonBadge type="Cool" rank="Normal" />);
+
+    const container = page.getByTitle('Cool Contest - Normal Rank Ribbon');
+    await expect.element(container).toBeVisible();
+    await expect.element(container).toHaveClass('border-dashed');
+    await expect.element(container).toHaveClass('rounded-none');
+    await expect.element(page.getByText('Cool')).toBeVisible();
+    await expect.element(page.getByText('Normal')).toBeVisible();
+  });
+
+  it('renders correctly with Beauty type and Super rank', async () => {
+    await render(<ContestRibbonBadge type="Beauty" rank="Super" />);
+
+    const container = page.getByTitle('Beauty Contest - Super Rank Ribbon');
+    await expect.element(container).toBeVisible();
+    await expect.element(page.getByText('Beauty')).toBeVisible();
+    await expect.element(page.getByText('Super')).toBeVisible();
+  });
+
+  it('renders correctly with Cute type and Hyper rank', async () => {
+    await render(<ContestRibbonBadge type="Cute" rank="Hyper" />);
+
+    const container = page.getByTitle('Cute Contest - Hyper Rank Ribbon');
+    await expect.element(container).toBeVisible();
+    await expect.element(page.getByText('Cute')).toBeVisible();
+    await expect.element(page.getByText('Hyper')).toBeVisible();
+  });
+
+  it('renders correctly with Smart type and Master rank', async () => {
+    await render(<ContestRibbonBadge type="Smart" rank="Master" />);
+
+    const container = page.getByTitle('Smart Contest - Master Rank Ribbon');
+    await expect.element(container).toBeVisible();
+    await expect.element(page.getByText('Smart')).toBeVisible();
+    await expect.element(page.getByText('Master')).toBeVisible();
+  });
+
+  it('renders correctly with Tough type and Normal rank', async () => {
+    await render(<ContestRibbonBadge type="Tough" rank="Normal" />);
+
+    const container = page.getByTitle('Tough Contest - Normal Rank Ribbon');
+    await expect.element(container).toBeVisible();
+    await expect.element(page.getByText('Tough')).toBeVisible();
+    await expect.element(page.getByText('Normal')).toBeVisible();
+  });
+});


### PR DESCRIPTION
This pull request implements the Contest Ribbons UI Component to display the ribbons a Pokémon has earned.

**Changes Included:**
- The new `ContestRibbonBadge.tsx` component
- Unit tests validating the visual style, types, and ranks in `ContestRibbonBadge.test.tsx`
- Fully checked task markdown

All visual changes were successfully run and tested with playwright verifying the new tactical ui guidelines.

---
*PR created automatically by Jules for task [11592345276044395445](https://jules.google.com/task/11592345276044395445) started by @szubster*