### PR TITLE
Research: Gen 3 Pokerus Memory Structure and Extraction

### DIFF
--- a/.foundry/docs/knowledge_base/gen3_pokemon_data_structure.md
+++ b/.foundry/docs/knowledge_base/gen3_pokemon_data_structure.md
@@ -1,0 +1,34 @@
+# Gen 3 Pokémon Data Structure
+
+## Overview
+In Generation 3 (Ruby, Sapphire, Emerald, FireRed, LeafGreen), a Pokémon's full data structure in the party is 100 bytes long. However, the core details are stored in a 48-byte encrypted Data block (bytes 32 through 79 of the 100-byte structure).
+
+## The 48-Byte Encrypted Data Block
+This block is divided into four 12-byte substructures:
+- **Growth (G):** Species, Item held, Experience, PP bonuses, Friendship.
+- **Attacks (A):** Move 1, Move 2, Move 3, Move 4, PP 1, PP 2, PP 3, PP 4.
+- **EVs & Condition (E):** HP EV, Attack EV, Defense EV, Speed EV, Special Attack EV, Special Defense EV, Coolness, Beauty, Cuteness, Smartness, Toughness, Feel.
+- **Miscellaneous (M):** Pokerus status, Met location, Origins info, IVs/Egg/Ability, Ribbons/Obedience.
+
+### Decryption
+The data is encrypted using a simple XOR cipher. The 32-bit decryption key is obtained by XORing the Pokémon's Personality Value (PV) with the Original Trainer ID (OT ID). The data is decrypted by XORing it with this key, 32 bits (4 bytes) at a time.
+
+### Substructure Order
+The order of the four 12-byte substructures within the 48-byte block is not static. It is determined by the Personality Value (PV) modulo 24 (`PV % 24`). This produces one of 24 possible permutations (e.g., GAEM, AGEM, MGAE, etc.).
+
+## Pokerus
+The Pokerus status is stored in the **first byte** (offset 0) of the **Miscellaneous (M)** substructure.
+
+Its bitwise structure is **identical to Generation 2**:
+- **Bits 0-3 (Lower 4 bits):** Days left until Pokérus is cured.
+- **Bits 4-7 (Upper 4 bits):** Pokérus "strain".
+
+Just like in Gen 2, if the strain is non-zero (i.e., the Pokémon was infected) but the days remaining is 0, the Pokémon is considered "cured" (immune).
+
+### Implementation Strategy
+To extract the Pokerus data in Gen 3, the engine must:
+1. Parse the 100-byte structure to obtain the PV and OT ID.
+2. Determine the permutation order using `PV % 24`.
+3. Locate the Miscellaneous (M) substructure within the 48-byte Data block.
+4. Decrypt the Data block (or specifically the M substructure).
+5. Read the first byte of the M substructure and apply the bitwise operations (`byte >> 4` for strain, `byte & 0x0f` for days).

--- a/.foundry/ideas/idea-080-gen3-pokerus-extraction.md
+++ b/.foundry/ideas/idea-080-gen3-pokerus-extraction.md
@@ -1,0 +1,40 @@
+---
+id: idea-080-gen3-pokerus-extraction
+type: IDEA
+title: Implement Gen 3 Pokerus Extraction
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - gen3
+  - save-engine
+  - pokerus
+research_references:
+  - .foundry/research/research-175-176-gen3-pokerus-extraction.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Implement Gen 3 Pokerus Extraction
+
+## Context
+Based on the findings in `.foundry/research/research-175-176-gen3-pokerus-extraction.md`, the memory structure and bitwise logic for Pokerus in Generation 3 have been fully documented. While the bitwise extraction logic (`>> 4` and `& 0x0f`) is identical to Gen 2, locating the Pokerus byte requires full decryption and parsing of the 48-byte Gen 3 Pokémon Data block and its four substructures (Growth, Attacks, EVs & Condition, Miscellaneous).
+
+## Proposal
+Implement the necessary infrastructure in `src/engine/saveParser/parsers/gen3.ts` to fully parse and decrypt the Gen 3 Pokémon data structures, and then extract the Pokerus state from the Miscellaneous (M) substructure.
+
+### Technical Requirements
+1. **Pokémon Data Extraction:** Build the core logic to locate and extract the 100-byte Pokémon structures from the active save Section.
+2. **Decryption Logic:** Implement the XOR decryption using the `PV XOR OT ID` key.
+3. **Substructure Resolution:** Implement the `PV % 24` logic to correctly map the decrypted 48-byte block into its four distinct substructures (G, A, E, M).
+4. **Pokerus Extraction:** Extract the Pokerus byte from the start of the M substructure and parse the strain and days remaining.
+5. **Data Mapping:** Map the parsed Pokerus data onto the corresponding Pokémon objects within the returned `SaveData` payload.
+
+## Value
+This is a required precursor for enabling the Pokerus Tracker and Infection Spread Assistant (idea-068-069-pokerus-tracker) for Generation 3 games, expanding feature parity across generations.

--- a/.foundry/research/research-175-176-gen3-pokerus-extraction.md
+++ b/.foundry/research/research-175-176-gen3-pokerus-extraction.md
@@ -33,3 +33,29 @@ During the audit of `epic-038-061-pokerus-state-exfiltration`, we verified the e
 
 ## Output
 Update this markdown body with the research findings and create a downstream IDEA or PRD node if actionable work is required to support Gen 3 Pokerus extraction.
+
+## Findings
+
+### Memory Structure and Location
+In Generation 3, a Pokémon's data is stored in a 100-byte structure. However, the core details are stored within a 48-byte encrypted Data block. This block consists of four 12-byte substructures: Growth (G), Attacks (A), EVs & Condition (E), and Miscellaneous (M).
+
+The order of these substructures within the 48-byte block is dynamic and determined by the formula: `Personality Value (PV) % 24`. The data is also encrypted via XOR. The 32-bit decryption key is the result of `PV XOR OT ID`.
+
+The Pokerus status is located in the **first byte (offset 0)** of the **Miscellaneous (M)** substructure.
+
+### Bitwise Structure
+The bitwise structure of the Pokerus byte in Generation 3 is **identical to Generation 2**:
+- **Lower 4 bits (0-3):** Days left until Pokérus is cured.
+- **Upper 4 bits (4-7):** Pokérus "strain".
+
+The logic for determining a "cured" status (strain is non-zero, but days remaining is 0) remains unchanged.
+
+### Technical Strategy & Blockers
+To implement Gen 3 Pokerus extraction in `src/engine/saveParser/parsers/gen3.ts`, the engine must first be capable of:
+1. Extracting the 100-byte structure for a given Pokémon.
+2. Reading the PV and OT ID to generate the decryption key.
+3. Calculating the substructure order (`PV % 24`) to locate the Miscellaneous (M) substructure.
+4. Decrypting the 48-byte Data block.
+5. Reading the first byte of the M substructure and applying the bitwise operators (`>> 4` and `& 0x0f`).
+
+**Blocker:** Currently, `src/engine/saveParser/parsers/gen3.ts` is mostly a scaffold. It lacks the core logic to parse, decrypt, and construct the Pokémon data substructures. We cannot implement Pokerus extraction until the foundational Gen 3 Pokémon extraction and decryption logic is implemented. An IDEA node has been created to track this dependency.


### PR DESCRIPTION
Completes the Research task `research-175-176-gen3-pokerus-extraction`. The structural details and implementation blockers for Gen 3 Pokérus were documented. An IDEA node was created to spawn the implementation work once the foundational parsing is built.

---
*PR created automatically by Jules for task [16329644812449438361](https://jules.google.com/task/16329644812449438361) started by @szubster*