### PR TITLE
chore: create unown dex panel UI stories

### DIFF
--- a/.foundry/epics/epic-037-059-unown-tracker-ui.md
+++ b/.foundry/epics/epic-037-059-unown-tracker-ui.md
@@ -37,5 +37,9 @@ It should visually represent which of the 26 Gen 2 forms are currently owned by 
 Must adhere strictly to the "tactical hardware/snooping" aesthetic (`rounded-none`, dashed borders, monospace fonts) as defined in ADR 008.
 
 ## Acceptance Criteria
-- [ ] Story for Unown Dex panel UI created.
-- [ ] Story for Unown Dex panel data integration created.
+- [x] Story for Unown Dex panel UI created.
+- [x] Story for Unown Dex panel data integration created.
+
+## Generated Stories
+- [ ] `story-059-131-unown-dex-panel-ui`
+- [ ] `story-059-132-unown-dex-data-integration`

--- a/.foundry/stories/story-059-131-unown-dex-panel-ui.md
+++ b/.foundry/stories/story-059-131-unown-dex-panel-ui.md
@@ -1,0 +1,36 @@
+---
+id: story-059-131-unown-dex-panel-ui
+type: STORY
+title: Unown Dex Panel UI
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-059-unown-tracker-ui
+tags:
+  - feature
+  - gen2
+  - tracking
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Unown Dex Panel UI
+
+## Objective
+Build a UI component to display the 26 forms (A-Z) of Unown.
+
+## Logic
+Create a new panel or filter UI that visually represents the Unown checklist.
+
+## Design Constraints
+Must observe the "tactical hardware/snooping" styling requirements defined in ADR 008 and ADR 024 (e.g. sharp edges, dashed borders, monospace fonts, using the new `tactical-*` utility classes).
+
+## Acceptance Criteria
+- [ ] Task for creating the Unown Dex Panel UI component created.

--- a/.foundry/stories/story-059-132-unown-dex-data-integration.md
+++ b/.foundry/stories/story-059-132-unown-dex-data-integration.md
@@ -1,0 +1,34 @@
+---
+id: story-059-132-unown-dex-data-integration
+type: STORY
+title: Unown Dex Panel Data Integration
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on:
+  - story-059-131-unown-dex-panel-ui
+jules_session_id: null
+pr_number: null
+parent: epic-037-059-unown-tracker-ui
+tags:
+  - feature
+  - gen2
+  - tracking
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Unown Dex Panel Data Integration
+
+## Objective
+Integrate the newly built UI panel with the parsed `unownForm` data.
+
+## Logic
+Determine which of the 26 Unown forms (A-Z) the player possesses in their active party or PC boxes by aggregating the `unownForm` properties from the save file data instances. Surface the missing/owned states to the Unown Dex Panel UI component.
+
+## Acceptance Criteria
+- [ ] Task for mapping the unownForm property to the Unown Dex Panel UI component created.


### PR DESCRIPTION
Creates `story-059-131-unown-dex-panel-ui` and `story-059-132-unown-dex-data-integration` under `epic-037-059-unown-tracker-ui`. Updates the Epic acceptance criteria to reflect the creation of these stories. Ensures strict DAG ID formatting and avoids circular dependencies.

---
*PR created automatically by Jules for task [15642423677990061424](https://jules.google.com/task/15642423677990061424) started by @szubster*