### PR TITLE
Suspend Gen 3 roamer dataview extraction pending research

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -74,3 +74,6 @@ When implementing `task-101-157-gen3-condition-stats-parsing`, the exact memory 
 
 ## Verifying Gen 3 Save File Sections
 When verifying save file documentation (e.g. Generation 3 save parsing), it is crucial to ensure that the stated offsets fall within the correct section headers as defined by authoritative sources like Bulbapedia. Failing to map byte offsets to the correct logical 4KB section boundaries can lead to incorrect data extraction in the orchestrator.
+
+## 2026-06-14: Missing Bitfield Formulas in Research
+When implementing save parser logic, research handoffs occasionally identify bitfields (e.g., Gen 3 Roamer IVs) without specifying the exact bit shifts or field sizes required for correct extraction. It's critical to avoid hallucinating these exact mathematical formulas to comply with groundedness rules. When this occurs, always spawn a late-bound `RESEARCH` node to determine the exact parsing formula and suspend the implementation task until the data is verified.

--- a/.foundry/tasks/research-108-163-gen3-roamer-iv-bitfield.md
+++ b/.foundry/tasks/research-108-163-gen3-roamer-iv-bitfield.md
@@ -1,0 +1,35 @@
+---
+id: research-108-163-gen3-roamer-iv-bitfield
+type: RESEARCH
+title: Investigate Gen 3 Roamer IVs Bitfield Parsing Formula
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-108-161-gen3-roamer-dataview-extraction-impl
+tags:
+  - gen3
+  - roamer
+  - save-parsing
+  - research
+research_references:
+  - .foundry/archive/research/research-071-138-gen3-roamer-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 3 Roamer IVs Bitfield Parsing Formula
+
+## Objective
+Discover the exact IVs bitfield parsing formula for Gen 3 roamers, including the size of each stat field and the specific bit shifts required.
+
+## Context
+During the implementation of `task-108-161-gen3-roamer-dataview-extraction-impl`, it was discovered that the previous research (`research-071-138-gen3-roamer-offsets.md`) identified the IVs field as a 32-bit integer at offset `0x00` in the roamer data structure, containing the HP, Atk, Def, Spd, SpAtk, and SpDef stats. However, the explicit sizes of these fields (e.g., 5-bit vs other) and the exact bitwise operations (shifts and masks) needed to extract each individual stat were not provided. To adhere to groundedness and prevent hallucinated math, we need explicit confirmation of how to parse this bitfield.
+
+## Acceptance Criteria
+- [ ] Determine the exact bit size for each of the 6 IV stats within the 32-bit field.
+- [ ] Document the precise bitwise shift (`>>`) and mask (`&`) required to extract HP, Attack, Defense, Speed, Special Attack, and Special Defense from the 32-bit IV integer.

--- a/.foundry/tasks/task-108-161-gen3-roamer-dataview-extraction-impl.md
+++ b/.foundry/tasks/task-108-161-gen3-roamer-dataview-extraction-impl.md
@@ -2,11 +2,12 @@
 id: task-108-161-gen3-roamer-dataview-extraction-impl
 type: TASK
 title: Implement Gen 3 Roamer DataView Extraction and Core Parsing
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-11'
 updated_at: '2026-06-14'
-depends_on: []
+depends_on:
+  - research-108-163-gen3-roamer-iv-bitfield
 jules_session_id: '5479315469961816095'
 pr_number: null
 parent: story-070-108-gen3-roamer-dataview-extraction
@@ -16,7 +17,7 @@ tags:
   - save-parsing
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Suspended pending research on exact Gen 3 IV bitfield sizes (research-108-163-gen3-roamer-iv-bitfield).'
 notes: ''
 ---
 


### PR DESCRIPTION
# Suspend Gen 3 roamer dataview extraction pending research

- Created a new RESEARCH node `research-108-163-gen3-roamer-iv-bitfield` to determine the exact IVs bitfield parsing formula for Gen 3 roamers.
- Updated the target task (`task-108-161-gen3-roamer-dataview-extraction-impl`) to append the RESEARCH node to its `depends_on` array and marked the task's status as `FAILED` with a `rejection_reason` as per the late-binding protocol.
- Documented this recurring pattern of missing bitfield formulas in research handoffs within the coder journal to prevent hallucinating formulas.

---
*PR created automatically by Jules for task [5479315469961816095](https://jules.google.com/task/5479315469961816095) started by @szubster*