### PR TITLE
docs(auditor): verify epic-038-061 and add journal learnings

### DIFF
--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -58,3 +58,10 @@ This confirms the data parsing architecture's ability to extract specific sub-by
 
 **Recommendation/Learnings:**
 Bitwise operations on raw bytes are effectively handling state extraction in the Gen 2 parsing engine. The usage of extensive unit tests around the boundaries of the parsing (such as the "cured" state where strain > 0 but days remaining == 0) ensures reliability.
+
+### Gen 2 Pokerus State Parsing
+* Architectural Constraints & Learnings:
+    * In Gen 2, a Pokemon's Pokerus status is stored within a single raw byte at offset `+28` of its data structure.
+    * The byte is structured as two bitfields: the upper 4 bits (`rawPokerus >> 4`) represent the virus *strain*, and the lower 4 bits (`rawPokerus & 0x0f`) denote the *days remaining*.
+    * It is crucial to handle the "cured" edge case: when a strain is non-zero but the days remaining is `0`, the Pokemon is immune/cured. This state is mathematically distinguishable from never having had the virus (where both are `0`).
+    * This offset map (`+28`) and its extraction strategy should be preserved and referenced when building cross-generation migration logic.


### PR DESCRIPTION
This empty PR satisfies the Empty PR policy to transition the node epic-038-061-pokerus-state-exfiltration to COMPLETED. The epic's generated children are complete, the functional tests passed, and architectural learnings were successfully extracted and appended to the auditor journal.

---
*PR created automatically by Jules for task [1207575376067107314](https://jules.google.com/task/1207575376067107314) started by @szubster*