### PR TITLE
feat(foundry): Epic Breakdown for Zombie Node GC PRD

### DIFF
--- a/.foundry/epics/epic-050-089-zombie-node-detection-engine.md
+++ b/.foundry/epics/epic-050-089-zombie-node-detection-engine.md
@@ -1,0 +1,47 @@
+---
+id: epic-050-089-zombie-node-detection-engine
+type: EPIC
+title: Zombie Node Detection Engine
+status: READY
+owner_persona: story_owner
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-079-050-foundry-zombie-node-cleanup
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Zombie Node Detection Engine
+
+## 1. Context and Problem Statement
+To implement the Foundry Zombie Node Garbage Collection, we first need a robust mechanism to identify "zombie" nodes. These are nodes stuck in an `ACTIVE` state because their assigned session silently failed or the workflow completed without transitioning the node's state.
+
+## 2. Scope
+This Epic focuses exclusively on the logic required to sweep `.foundry/` directories and detect zombie nodes. It does not handle the actual remediation (changing state to `FAILED`), which is covered in a separate Epic.
+
+## 3. High-Level Requirements
+1. **Sweep mechanism**: Logic to iterate through all markdown files in the `.foundry/` directory tree.
+2. **Detection Logic**:
+   - Identify nodes with `status: ACTIVE`.
+   - Extract their `jules_session_id` from the frontmatter.
+3. **Liveliness Verification**:
+   - Check if `jules_session_id` is null or malformed.
+   - Cross-reference the `jules_session_id` with the GitHub Actions API (or an equivalent verification source) to determine if the session is still active or has terminated (success, failure, cancelled).
+
+## 4. Acceptance Criteria
+- [ ] Implement directory sweeping to identify all `ACTIVE` nodes.
+- [ ] Implement logic to validate `jules_session_id` format and existence.
+- [ ] Implement GitHub API integration (or equivalent) to check workflow liveliness.
+- [ ] Unit tests for the detection functions.
+
+## 5. Next Steps
+- [ ] Break down into Stories.

--- a/.foundry/epics/epic-050-090-zombie-node-remediation-and-gc.md
+++ b/.foundry/epics/epic-050-090-zombie-node-remediation-and-gc.md
@@ -1,0 +1,46 @@
+---
+id: epic-050-090-zombie-node-remediation-and-gc
+type: EPIC
+title: Zombie Node Remediation and GC Logic
+status: READY
+owner_persona: story_owner
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on:
+  - epic-050-089-zombie-node-detection-engine
+jules_session_id: null
+pr_number: null
+parent: prd-079-050-foundry-zombie-node-cleanup
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Zombie Node Remediation and GC Logic
+
+## 1. Context and Problem Statement
+Following the detection of "zombie" nodes (nodes incorrectly stuck in the `ACTIVE` state), the system must auto-remediate them to prevent DAG deadlocks. This involves transitioning their state to `FAILED` so the existing Resurrection Loop can pick them up and retry.
+
+## 2. Scope
+This Epic handles the remediation logic (state transitions) and the integration of the Garbage Collection (GC) workflow (either as a standalone TPM script or within the main orchestrator script). It depends on the detection engine to identify the target nodes.
+
+## 3. High-Level Requirements
+1. **Remediation Logic**: Functionality to safely update the YAML frontmatter of identified zombie nodes, changing `status: ACTIVE` to `status: FAILED`.
+2. **Integration Decision & Implementation**:
+   - Determine whether this GC process runs synchronously within `.github/scripts/foundry-orchestrator.ts` or as an independent scheduled script.
+   - Implement the chosen integration pattern, ensuring it accurately utilizes the detection engine.
+3. **Resurrection Hand-off**: Ensure that the remediated nodes (`FAILED` state) are correctly processed by the existing resurrection loop on the subsequent cycle without manual intervention.
+
+## 4. Acceptance Criteria
+- [ ] Determine the integration approach (standalone script vs. direct orchestrator integration).
+- [ ] Implement state transition logic (modifying `status` to `FAILED` in the markdown files).
+- [ ] Implement the integration of detection and remediation logic.
+- [ ] Ensure unit test coverage for the remediation functionality.
+
+## 5. Next Steps
+- [ ] Break down into Stories.

--- a/.foundry/prds/prd-079-050-foundry-zombie-node-cleanup.md
+++ b/.foundry/prds/prd-079-050-foundry-zombie-node-cleanup.md
@@ -51,4 +51,6 @@ The mechanism will:
 - [ ] Unit tests for the new GC logic.
 
 ## 5. Next Steps
-- [ ] Break down into Epics.
+- [x] Break down into Epics.
+  - [ ] epic-050-089-zombie-node-detection-engine
+  - [ ] epic-050-090-zombie-node-remediation-and-gc


### PR DESCRIPTION
This PR translates the PRD `prd-079-050-foundry-zombie-node-cleanup` into granular Epics (`epic-089` and `epic-090`) to manage the detection and remediation of zombie Foundry DAG nodes, setting the stage for downstream execution.

---
*PR created automatically by Jules for task [12465921032678961216](https://jules.google.com/task/12465921032678961216) started by @szubster*