### PR TITLE
chore(foundry): suspend gen3 roamer location task via late binding

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -74,3 +74,7 @@ When implementing `task-101-157-gen3-condition-stats-parsing`, the exact memory 
 
 ## Verifying Gen 3 Save File Sections
 When verifying save file documentation (e.g. Generation 3 save parsing), it is crucial to ensure that the stated offsets fall within the correct section headers as defined by authoritative sources like Bulbapedia. Failing to map byte offsets to the correct logical 4KB section boundaries can lead to incorrect data extraction in the orchestrator.
+
+## 2026-06-14: Late Binding for Unknown Offsets (Gen 3 sRoamerLocation)
+When attempting to implement `task-108-161-gen3-roamer-location-impl` to extract the Gen 3 roamer's active map group and map number, the previous research (`research-071-138-gen3-roamer-offsets`) only documented the 20-byte `struct Roamer` and noted that the location (`sRoamerLocation`) is stored separately in EWRAM/save block, but did not provide the exact offsets.
+Following the system's Late Binding pattern for missing context, rather than guessing offsets or hallucinating data limits, I suspended the implementation task (`status: FAILED` with a clear `rejection_reason`), spawned a new research node (`research-108-163-gen3-sroamerlocation-offsets`), and appended it to the task's `depends_on` array. This ensures the implementation is halted until precise memory offsets are discovered.

--- a/.foundry/research/research-108-163-gen3-sroamerlocation-offsets.md
+++ b/.foundry/research/research-108-163-gen3-sroamerlocation-offsets.md
@@ -1,0 +1,37 @@
+---
+id: research-108-163-gen3-sroamerlocation-offsets
+type: RESEARCH
+title: Investigate Gen 3 sRoamerLocation Save Offsets
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-108-161-gen3-roamer-location-impl
+tags:
+  - gen3
+  - roamer
+  - save-offsets
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 3 sRoamerLocation Save Offsets
+
+## Objective
+Find and document the exact save offsets or methods to extract the map group and map number for the active roaming Pokémon (`sRoamerLocation`) in Gen 3 (Ruby/Sapphire, Emerald, FireRed/LeafGreen).
+
+## Description
+The previous research (`research-071-138-gen3-roamer-offsets`) documented the primary 20-byte `struct Roamer`. However, it explicitly states that the roamer's current map group and map number are **not** stored within this struct and are kept in separate variables loaded into EWRAM (`sRoamerLocation` or similar).
+
+The implementation task (`task-108-161-gen3-roamer-location-impl`) requires extracting this map data using `DataView` API. Without the exact memory offsets or an understanding of how to reliably extract this location from the save blocks, the task cannot be completed.
+
+Your goal is to investigate how to locate and extract the active roamer's map group and map index from the Gen 3 save format.
+
+## Acceptance Criteria
+- [ ] Determine if the roamer location is deterministically saved to the SRAM/Flash in a specific block, and if so, document the exact offsets across different Gen 3 versions.
+- [ ] Document how the location shifts dynamically, and if it's feasible to track based purely on the static `.sav` file.

--- a/.foundry/tasks/task-108-161-gen3-roamer-location-impl.md
+++ b/.foundry/tasks/task-108-161-gen3-roamer-location-impl.md
@@ -2,12 +2,13 @@
 id: task-108-161-gen3-roamer-location-impl
 type: TASK
 title: Implement Gen 3 Roamer Location Data Extraction
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-11'
 updated_at: '2026-06-14'
 depends_on:
   - research-071-138-gen3-roamer-offsets
+  - research-108-163-gen3-sroamerlocation-offsets
 jules_session_id: '13009823998726891357'
 pr_number: null
 parent: story-072-108-gen3-roamer-location-extraction
@@ -18,7 +19,7 @@ tags:
 research_references:
   - research-071-138-gen3-roamer-offsets
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'The exact memory offsets for sRoamerLocation (map group and map number) are missing from the provided research context. Suspended task using Late Binding by spawning research-108-163-gen3-sroamerlocation-offsets.'
 notes: ''
 ---
 


### PR DESCRIPTION
Suspended task-108-161-gen3-roamer-location-impl because the exact memory offsets for `sRoamerLocation` (map group and map number) were missing from the provided research context. I utilized the Late Binding pattern by spawning `research-108-163-gen3-sroamerlocation-offsets` and appending it to the task's `depends_on` array. The task was marked as FAILED with a rejection reason, and the architectural constraint was documented in the coder journal.

---
*PR created automatically by Jules for task [13009823998726891357](https://jules.google.com/task/13009823998726891357) started by @szubster*