### PR TITLE
Foundry: Break down Mirage Island parser story into tasks

### DIFF
--- a/.foundry/stories/story-061-099-implement-mirage-island-parser.md
+++ b/.foundry/stories/story-061-099-implement-mirage-island-parser.md
@@ -32,4 +32,6 @@ With the data offsets located, we need to implement the actual parser for the Ge
 - Implement graceful error handling by catching `RangeError` on out-of-bounds reads and propagating them as validation errors.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Generate child tasks to implement the parsing logic and integrate it into the parser engine.
+- [x] Tech Lead: Generate child tasks to implement the parsing logic and integrate it into the parser engine.
+- [ ] task-099-185-mirage-island-parser-impl
+- [ ] task-099-186-mirage-island-parser-qa

--- a/.foundry/tasks/task-099-185-mirage-island-parser-impl.md
+++ b/.foundry/tasks/task-099-185-mirage-island-parser-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-099-185-mirage-island-parser-impl
+type: TASK
+title: Implement Gen 3 Mirage Island Parser
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-061-099-implement-mirage-island-parser
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Mirage Island Parser
+
+## Context
+With the data offsets located, we need to implement the actual parser for the Gen 3 Mirage Island value.
+The Mirage Island value is stored as a random value within the "Section 2 - Game State" of the save file structure. It is a 16-bit integer (2 bytes) in Little-endian.
+
+## Requirements
+1.  **Parse Mirage Island Value**: Update the Gen 3 save parser engine (`src/engine/saveParser/parsers/gen3.ts`) to extract the 16-bit Mirage Island value using the following offsets depending on the game version:
+    - **Ruby / Sapphire**: Section 2, Offset `0x0408`.
+    - **Emerald**: Section 2, Offset `0x0464`.
+2.  **Use DataView API**: You MUST strictly use the native `DataView` API (e.g., `getUint16`) for safe data parsing as mandated by ADR 010.
+3.  **Graceful Error Handling**: Do not crash on out-of-bounds reads. Rely on `DataView` throwing `RangeError` and handle it gracefully by propagating specific validation errors.
+4.  **Unit Tests**: Add unit tests in `src/engine/saveParser/parsers/gen3.test.ts` to verify correct parsing.
+
+## Acceptance Criteria
+- [ ] Implement Gen 3 Mirage Island value parsing logic using `DataView`.
+- [ ] Ensure `RangeError` is caught and handled gracefully as per ADR 010.
+- [ ] Add unit tests covering Ruby/Sapphire and Emerald offset logic.
+
+## Coder Persona Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the YAML frontmatter.

--- a/.foundry/tasks/task-099-186-mirage-island-parser-qa.md
+++ b/.foundry/tasks/task-099-186-mirage-island-parser-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-099-186-mirage-island-parser-qa
+type: TASK
+title: QA Gen 3 Mirage Island Parser
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on:
+  - task-099-185-mirage-island-parser-impl
+jules_session_id: null
+pr_number: null
+parent: story-061-099-implement-mirage-island-parser
+tags:
+  - feature
+  - gen3
+  - mirage-island
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 Mirage Island Parser
+
+## Context
+The Coder has implemented the Gen 3 Mirage Island Parser. This QA task ensures the implementation is correct, handles edge cases gracefully, and strictly adheres to our architecture guidelines.
+
+## Verification Requirements
+1.  **Code Review**: Verify that the Coder correctly implemented the 16-bit Mirage Island value extraction logic in `src/engine/saveParser/parsers/gen3.ts` using the documented offsets (0x0408 for RS, 0x0464 for Emerald).
+2.  **Architecture Compliance**: Verify strict adherence to ADR 010. The Coder MUST use the native `DataView` API. Ensure that no raw `Uint8Array` manipulations are used for this logic.
+3.  **Error Handling**: Confirm that `RangeError` is properly caught and handled by propagating validation errors, rather than causing application crashes.
+4.  **Test Coverage**: Review the added unit tests in `src/engine/saveParser/parsers/gen3.test.ts`. Verify they sufficiently cover both Ruby/Sapphire and Emerald variations, and edge cases. Run `pnpm test` to ensure all tests pass.
+
+## Acceptance Criteria
+- [ ] Code properly extracts Mirage Island value using documented offsets.
+- [ ] Code strictly follows ADR 010 (DataView API).
+- [ ] `RangeError` is handled gracefully without crashing.
+- [ ] Unit tests are complete and passing.
+
+## QA Persona Reminders
+- If you find defects or architecture violations, you MUST update the YAML frontmatter to `status: FAILED` with a clear `rejection_reason` so the Coder can fix it.
+- If you submit an empty PR for a passed QA task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the YAML frontmatter on success.


### PR DESCRIPTION
This PR creates the necessary child tasks (`task-099-185-mirage-island-parser-impl` and `task-099-186-mirage-island-parser-qa`) to implement and verify the Gen 3 Mirage Island parsing logic, and updates the parent `story-061-099-implement-mirage-island-parser` accordingly.

---
*PR created automatically by Jules for task [10589188629985343644](https://jules.google.com/task/10589188629985343644) started by @szubster*