### PR TITLE
Break down zombie node remediation epic into stories

### DIFF
--- a/.foundry/epics/epic-050-090-zombie-node-remediation-and-gc.md
+++ b/.foundry/epics/epic-050-090-zombie-node-remediation-and-gc.md
@@ -43,4 +43,8 @@ This Epic handles the remediation logic (state transitions) and the integration 
 - [ ] Ensure unit test coverage for the remediation functionality.
 
 ## 5. Next Steps
-- [ ] Break down into Stories.
+- [x] Break down into Stories.
+
+### Generated Stories
+- [ ] story-090-133-remediation-state-transition-logic
+- [ ] story-090-134-garbage-collection-integration

--- a/.foundry/stories/story-090-133-remediation-state-transition-logic.md
+++ b/.foundry/stories/story-090-133-remediation-state-transition-logic.md
@@ -1,0 +1,36 @@
+---
+id: story-090-133-remediation-state-transition-logic
+type: STORY
+title: Remediation State Transition Logic for Zombie Nodes
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on:
+  - epic-050-089-zombie-node-detection-engine
+jules_session_id: null
+pr_number: null
+parent: epic-050-090-zombie-node-remediation-and-gc
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Remediation State Transition Logic for Zombie Nodes
+
+## Objective
+Implement functionality to safely update the YAML frontmatter of identified zombie nodes, changing `status: ACTIVE` to `status: FAILED`.
+
+## Context
+Following the detection of "zombie" nodes (nodes incorrectly stuck in the `ACTIVE` state) by the engine developed in `epic-050-089-zombie-node-detection-engine`, the system must remediate them by transitioning their state to `FAILED`. This allows the existing Resurrection Loop to pick them up and retry them.
+
+## Acceptance Criteria
+- [ ] Create task breakdown.
+
+### Next Steps
+- [ ] Break down into Tasks.

--- a/.foundry/stories/story-090-134-garbage-collection-integration.md
+++ b/.foundry/stories/story-090-134-garbage-collection-integration.md
@@ -1,0 +1,36 @@
+---
+id: story-090-134-garbage-collection-integration
+type: STORY
+title: Garbage Collection Integration and Execution
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on:
+  - story-090-133-remediation-state-transition-logic
+jules_session_id: null
+pr_number: null
+parent: epic-050-090-zombie-node-remediation-and-gc
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Garbage Collection Integration and Execution
+
+## Objective
+Determine the integration approach for the GC process and implement it using the detection and remediation logic.
+
+## Context
+With the zombie node detection engine and state transition logic implemented, the final step is to integrate these pieces. We need to decide whether the GC process runs synchronously within the main orchestrator (`.github/scripts/foundry-orchestrator.ts`) or as an independent scheduled script, and then execute that integration. This will ensure that remediated nodes (`FAILED` state) are correctly processed by the existing resurrection loop.
+
+## Acceptance Criteria
+- [ ] Create task breakdown.
+
+### Next Steps
+- [ ] Break down into Tasks.


### PR DESCRIPTION
This PR fulfills the Story Owner's task of dynamically breaking down the "Zombie Node Remediation and GC Logic" epic (`epic-050-090-zombie-node-remediation-and-gc`) into two atomic `STORY` nodes for the `tech_lead` persona. The parent epic's markdown body has been updated to reflect this breakdown by appending the child stories as unchecked tasks and marking the related acceptance criteria as complete, strictly adhering to the Foundry node schema and the Empty PR policies.

---
*PR created automatically by Jules for task [11685995354736408843](https://jules.google.com/task/11685995354736408843) started by @szubster*