### PR TITLE
chore(foundry): Break down Epic 050-089 into Stories

### DIFF
--- a/.foundry/epics/epic-050-089-zombie-node-detection-engine.md
+++ b/.foundry/epics/epic-050-089-zombie-node-detection-engine.md
@@ -44,4 +44,7 @@ This Epic focuses exclusively on the logic required to sweep `.foundry/` directo
 - [ ] Unit tests for the detection functions.
 
 ## 5. Next Steps
-- [ ] Break down into Stories.
+- [x] Break down into Stories
+- [ ] [Sweep Active Nodes](../stories/story-089-133-sweep-active-nodes.md)
+- [ ] [Session ID Validator](../stories/story-089-134-session-id-validator.md)
+- [ ] [Workflow Liveliness Check](../stories/story-089-135-workflow-liveliness-check.md)

--- a/.foundry/stories/story-089-133-sweep-active-nodes.md
+++ b/.foundry/stories/story-089-133-sweep-active-nodes.md
@@ -1,0 +1,39 @@
+---
+id: story-089-133-sweep-active-nodes
+type: STORY
+title: Sweep Active Nodes
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-050-089-zombie-node-detection-engine
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Sweep Active Nodes
+
+## 1. Context
+As part of the Zombie Node Detection Engine (Epic 050-089), we need a mechanism to scan the `.foundry/` directory to identify any node files that are currently marked as `ACTIVE`.
+
+## 2. Requirements
+- Write a sweeping utility function that recursively iterates through all markdown files in the `.foundry/` directory tree.
+- Parse the YAML frontmatter of each file.
+- Filter and return only the nodes where `status` is `ACTIVE`.
+
+## 3. Acceptance Criteria
+- [ ] Implement directory traversal logic for `.foundry/`.
+- [ ] Correctly parse node frontmatter and filter for `ACTIVE` status.
+- [ ] Create tests to verify the sweeping logic correctly identifies active nodes and ignores non-active ones.
+
+## 4. Next Steps
+- [ ] Break down into Tasks.

--- a/.foundry/stories/story-089-134-session-id-validator.md
+++ b/.foundry/stories/story-089-134-session-id-validator.md
@@ -1,0 +1,39 @@
+---
+id: story-089-134-session-id-validator
+type: STORY
+title: Session ID Validator
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-050-089-zombie-node-detection-engine
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Session ID Validator
+
+## 1. Context
+Following the identification of `ACTIVE` nodes, we need to extract and validate the `jules_session_id` associated with each node to verify if the session is legitimate or malfunctioning.
+
+## 2. Requirements
+- Write logic to extract the `jules_session_id` from the parsed frontmatter of `ACTIVE` nodes.
+- Implement validation checks to see if `jules_session_id` is null, empty, or malformed.
+- Nodes lacking a valid session ID while in the `ACTIVE` state indicate an immediate integrity error.
+
+## 3. Acceptance Criteria
+- [ ] Implement extraction logic for `jules_session_id`.
+- [ ] Implement format and existence validation for the extracted ID.
+- [ ] Create tests handling cases with valid, null, missing, or malformed session IDs.
+
+## 4. Next Steps
+- [ ] Break down into Tasks.

--- a/.foundry/stories/story-089-135-workflow-liveliness-check.md
+++ b/.foundry/stories/story-089-135-workflow-liveliness-check.md
@@ -1,0 +1,39 @@
+---
+id: story-089-135-workflow-liveliness-check
+type: STORY
+title: Workflow Liveliness Check
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-14'
+updated_at: '2026-06-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-050-089-zombie-node-detection-engine
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Workflow Liveliness Check
+
+## 1. Context
+To confirm if an `ACTIVE` node is truly a "zombie", we must cross-reference its validated `jules_session_id` against an external source of truth to check if the session is still running or has terminated (success, failure, or cancelled).
+
+## 2. Requirements
+- Implement an API integration (e.g., GitHub Actions API or equivalent) to query the status of a given `jules_session_id`.
+- Parse the API response to determine the session's liveliness state.
+- Define a clear set of statuses that classify the node's session as active or terminated.
+
+## 3. Acceptance Criteria
+- [ ] Implement API query logic using the provided `jules_session_id`.
+- [ ] Map the API response states to internal liveliness indicators.
+- [ ] Create tests to mock API responses and verify correct liveliness determination.
+
+## 4. Next Steps
+- [ ] Break down into Tasks.


### PR DESCRIPTION
This PR breaks down `epic-050-089-zombie-node-detection-engine` into three granular `STORY` nodes for implementation by the Tech Lead.

The stories are:
1. `story-089-133-sweep-active-nodes`
2. `story-089-134-session-id-validator`
3. `story-089-135-workflow-liveliness-check`

The Epic's Markdown body has been updated to reflect these new children as unchecked tasks, and its acceptance criteria for breakdown is checked off.

No application code changes were necessary; an empty PR is submitted to transition the work via the Foundry orchestrator.

---
*PR created automatically by Jules for task [14379556503952367981](https://jules.google.com/task/14379556503952367981) started by @szubster*