### PR TITLE
🎨 Palette: Improve loading state accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -62,3 +62,7 @@
 ## 2026-07-01 - Missing native indicators for custom select inputs
 **Learning:** When using `appearance-none` on native `<select>` elements to remove default browser styling (e.g., the dropdown arrow), developers must explicitly provide an alternative visual indicator (like a custom chevron icon) so users recognize the element as a dropdown menu. Simply styling it as a text box or button without an indicator reduces discoverability.
 **Action:** Wrapped the custom `<select>` component in a `relative` container and positioned a `ChevronDown` icon from the design system's icon library absolutely on the right to restore the dropdown affordance. Handled disabled states appropriately with `disabled:opacity-50 disabled:cursor-not-allowed`.
+
+## 2026-07-15 - ARIA Live Regions for Loading States
+**Learning:** When using dynamic loading components (like spinners) that replace content, screen readers are not inherently aware of the loading state unless they are explicitly marked as live regions.
+**Action:** Use `role="status"` and `aria-live="polite"` on loading spinner containers, and include a visually hidden text element (e.g., `<span className="sr-only">Loading...</span>`) to ensure the state is announced. Note that oxlint may complain about `jsx-a11y/prefer-tag-over-role` (suggesting `<output>` instead of `role="status"`); use `// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role` to suppress this when a `<div>` structure is required for layout.

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -131,9 +131,15 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
       </div>
 
       {isLoading ? (
-        <div className="relative flex items-center justify-center border border-zinc-800/50 bg-zinc-900/50 p-12">
+        <div
+          className="relative flex items-center justify-center border border-zinc-800/50 bg-zinc-900/50 p-12"
+          // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
+          role="status"
+          aria-live="polite"
+        >
           <CornerCrosshairs thickness={2} className="h-2 w-2 border-white/20" />
           <Loader2 className="animate-spin text-zinc-500" size={32} />
+          <span className="sr-only">Loading suggestions...</span>
         </div>
       ) : suggestions.length === 0 ? (
         <div className="relative flex flex-col items-center justify-center border border-zinc-800/50 bg-zinc-900/50 p-12 text-center">

--- a/src/components/SyncProgress.tsx
+++ b/src/components/SyncProgress.tsx
@@ -97,8 +97,13 @@ export function SyncProgress() {
               <div className="flex h-16 w-16 items-center justify-center border border-blue-500/20 bg-blue-500/10">
                 <Database className="text-blue-500/50" size={28} />
               </div>
-              <div className="absolute inset-0 flex items-center justify-center">
+              <div
+                className="absolute inset-0 flex items-center justify-center" // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
+                role="status"
+                aria-live="polite"
+              >
                 <Loader2 className="animate-spin text-blue-500/20" size={80} strokeWidth={0.5} />
+                <span className="sr-only">Syncing data...</span>
               </div>
             </>
           )}

--- a/src/components/dag/DagDashboard.tsx
+++ b/src/components/dag/DagDashboard.tsx
@@ -223,8 +223,13 @@ export function DagDashboard() {
 
   if (isLoading) {
     return (
-      <div className="flex h-full w-full items-center justify-center font-mono text-zinc-500">
-        [ SYSTEM.LOADING_DAG ]
+      <div
+        className="flex h-full w-full items-center justify-center font-mono text-zinc-500"
+        // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
+        role="status"
+        aria-live="polite"
+      >
+        <span aria-hidden="true">[ SYSTEM.LOADING_DAG ]</span> <span className="sr-only">Loading DAG...</span>
       </div>
     );
   }


### PR DESCRIPTION
Added `role="status"` and `aria-live="polite"` to `AssistantPanel`, `DagDashboard`, and `SyncProgress` components. Included visually hidden screen reader text to properly announce loading states to assistive technologies.

---
*PR created automatically by Jules for task [8425646300690520145](https://jules.google.com/task/8425646300690520145) started by @szubster*