### PR TITLE
feat(gen3): implement contest recommendation algorithm

### DIFF
--- a/.foundry/tasks/task-102-183-gen3-contest-recommendation-algorithm-impl.md
+++ b/.foundry/tasks/task-102-183-gen3-contest-recommendation-algorithm-impl.md
@@ -48,10 +48,10 @@ This task implements the core recommendation logic for advising players on the b
 - Ensure the types for Condition stats and Nature match existing project schemas.
 
 ## Acceptance Criteria
-- [ ] Implement the recommendation algorithm matching the requirements.
-- [ ] Write unit tests verifying the algorithm recommends the correct category for a Pokémon with a preferred nature and matching high stats.
-- [ ] Write unit tests for max Sheen scenarios (where remaining potential is 0).
-- [ ] Write unit tests handling conflicting Natures and edge cases (e.g., all stats equal).
+- [x] Implement the recommendation algorithm matching the requirements.
+- [x] Write unit tests verifying the algorithm recommends the correct category for a Pokémon with a preferred nature and matching high stats.
+- [x] Write unit tests for max Sheen scenarios (where remaining potential is 0).
+- [x] Write unit tests handling conflicting Natures and edge cases (e.g., all stats equal).
 
 ## Important Reminder for the Coder
 - **Transient Failure**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/engine/gen3/contests/recommendation.test.ts
+++ b/src/engine/gen3/contests/recommendation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getContestRecommendations } from './recommendation';
+
+describe('getContestRecommendations', () => {
+  it('recommends the preferred condition when stats are high', () => {
+    // Adamant prefers Cool
+    const conditions = {
+      cool: 200,
+      beauty: 50,
+      cute: 50,
+      smart: 50,
+      tough: 50,
+    };
+    const recommendations = getContestRecommendations('adamant', conditions, 200);
+    expect(recommendations[0]?.category).toBe('cool');
+    expect(recommendations[0]?.score).toBeGreaterThan(200); // Because of the 1.1x multiplier
+  });
+
+  it('handles max Sheen scenario correctly', () => {
+    // Sheen is 255, so remaining potential is 0. Base score should just be the condition value.
+    const conditions = {
+      cool: 100,
+      beauty: 150,
+      cute: 50,
+      smart: 50,
+      tough: 50,
+    };
+    // Modest prefers Beauty
+    const recommendations = getContestRecommendations('modest', conditions, 255);
+    expect(recommendations[0]?.category).toBe('beauty');
+    expect(recommendations[0]?.score).toBe(150 * 1.1); // 165
+  });
+
+  it('handles conflicting natures and resolves ties based on preference', () => {
+    // All stats equal
+    const conditions = {
+      cool: 100,
+      beauty: 100,
+      cute: 100,
+      smart: 100,
+      tough: 100,
+    };
+    // Bold prefers Tough, dislikes Cool
+    const recommendations = getContestRecommendations('bold', conditions, 100);
+    expect(recommendations[0]?.category).toBe('tough');
+
+    // Check that cool is penalized and not in the top 2
+    const coolScore = recommendations.find((r) => r.category === 'cool');
+    expect(coolScore).toBeUndefined(); // It shouldn't be in the top 2
+  });
+
+  it('breaks ties on zero stats based on nature preference', () => {
+    const conditions = {
+      cool: 0,
+      beauty: 0,
+      cute: 0,
+      smart: 0,
+      tough: 0,
+    };
+    // Timid prefers Cute
+    const recommendations = getContestRecommendations('timid', conditions, 0);
+    expect(recommendations[0]?.category).toBe('cute');
+    expect(recommendations[0]?.score).toBe(255 * 1.1); // Max potential * multiplier
+  });
+});

--- a/src/engine/gen3/contests/recommendation.ts
+++ b/src/engine/gen3/contests/recommendation.ts
@@ -1,0 +1,42 @@
+import { getDislikedCondition, getPreferredCondition } from './natureMapping';
+import type { ContestCondition, Nature } from './types';
+
+export type Conditions = Record<ContestCondition, number>;
+
+export interface ContestRecommendation {
+  category: ContestCondition;
+  score: number;
+}
+
+export function getContestRecommendations(
+  nature: Nature,
+  conditions: Conditions,
+  sheen: number,
+): ContestRecommendation[] {
+  const preferred = getPreferredCondition(nature);
+  const disliked = getDislikedCondition(nature);
+
+  const recommendations: ContestRecommendation[] = [];
+
+  const categories: ContestCondition[] = ['cool', 'beauty', 'cute', 'smart', 'tough'];
+
+  for (const category of categories) {
+    const conditionValue = conditions[category] ?? 0;
+    // Calculate remaining potential. Caps at 255 for condition and sheen.
+    const remainingPotential = Math.max(0, Math.min(255 - conditionValue, 255 - sheen));
+
+    let score = conditionValue + remainingPotential;
+
+    if (category === preferred) {
+      score *= 1.1;
+    } else if (category === disliked) {
+      score *= 0.9;
+    }
+
+    recommendations.push({ category, score });
+  }
+
+  recommendations.sort((a, b) => b.score - a.score);
+
+  return recommendations.slice(0, 2);
+}


### PR DESCRIPTION
Implemented the core recommendation logic for advising players on the best Contest categories for their Gen 3 Pokémon. 

- Calculates theoretical remaining growth potential based on current condition value and Sheen cap (255).
- Applies Nature preference bonuses (`1.1x`) and penalties (`0.9x`) to the base score.
- Returns the top 2 recommended categories.
- Includes full unit test coverage for various scenarios including edge cases like max Sheen and conflicting Natures.
- Updates the Foundry task node to mark acceptance criteria as completed.

---
*PR created automatically by Jules for task [11486449279622046484](https://jules.google.com/task/11486449279622046484) started by @szubster*