### PR TITLE
🧭 Strategist: Prompt improvement - Standardize permanent failure handling across all agents

### DIFF
--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -25,8 +25,8 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 
 
 ### Handling Rejections & Aborts
-If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -43,8 +43,8 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 ### Handling Rejections & Aborts
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
 
-If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -37,8 +37,8 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 ### Handling Rejections & Aborts
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
 
-If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/researcher.md
+++ b/.github/agents/researcher.md
@@ -18,8 +18,8 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/004-resea
 - **Knowledge Base Contribution**: When your findings establish new, lasting facts or patterns about the project, update or create relevant documentation in `.foundry/docs/knowledge_base/`.
 
 ### Handling Rejections & Aborts
-If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -39,8 +39,8 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 ### Handling Rejections & Aborts
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
 
-If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -49,8 +49,8 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 ### Handling Rejections & Aborts
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
 
-If you encounter a permanent failure or must abort a node:
-1. You MUST update the target node's YAML frontmatter to `status: FAILED` or `status: CANCELLED`.
+If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:
+1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).
 2. You MUST provide a clear `rejection_reason` in the target node's YAML frontmatter.
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -238,3 +238,9 @@
 **Outcome:** Accepted
 **Why:** The Tech Lead journal ("2026-06-10") observed that temporary scratchpad scripts (like generate_reads.sh) left in the workspace pollute the repository and cause code review rejections.
 **Pattern:** Ensure all agents are explicitly instructed to clean up any temporary scripts or scratchpads they create before submitting their work to prevent repository pollution and PR rejections.
+
+## 2026-06-14 - [Accepted] - Prompt improvement - Standardize permanent failure handling across all agents
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The Agile Coach journal (`2026-06-14`) identified that the instructions for handling permanent failures (like reaching max rejection count) were inconsistent across the different agent personas. Some agents (like `coder` and `qa`) were instructed to use `CANCELLED` and explicitly warned not to use `FAILED` because it prevents the Orchestrator from formally dropping the node and waking up the parent for error recovery. Other agents (like `architect`, `epic_planner`, `product_manager`, `researcher`, `story_owner`, and `tech_lead`) were incorrectly instructed to use either `FAILED` or `CANCELLED`.
+**Pattern:** Codify system memory constraints regarding permanent node failures across all relevant agent prompts to ensure consistent error recovery behavior across the entire DAG hierarchy. When an execution node must gracefully exit the DAG because it is permanently failed or replaced, the agent responsible MUST update its status to `CANCELLED`, not `FAILED`.


### PR DESCRIPTION
The Agile Coach journal from 2026-06-14 noted that orchestrator nodes were ending up permanently orphaned in `status: FAILED` after reaching `MAX_REJECTION_THRESHOLD` because multiple agent prompts had confusing instructions (`status: FAILED or status: CANCELLED`).

This PR standardizes the permanent failure handling across the entire agent roster (`architect`, `epic_planner`, `product_manager`, `researcher`, `story_owner`, and `tech_lead`) to match the stricter instructions already used by `coder` and `qa`. When an execution node must gracefully exit the DAG because it is permanently failed or replaced, the agent responsible MUST update its status to `CANCELLED`, not `FAILED`. This ensures the orchestrator formally drops them and reliably wakes up their parent nodes for error recovery.

---
*PR created automatically by Jules for task [921239279934420359](https://jules.google.com/task/921239279934420359) started by @szubster*