### PR TITLE
Implement Gen 3 Sheen Value Parsing

### DIFF
--- a/.foundry/tasks/task-102-157-impl-gen3-sheen-parsing.md
+++ b/.foundry/tasks/task-102-157-impl-gen3-sheen-parsing.md
@@ -32,7 +32,7 @@ As part of `story-064-102-gen3-sheen-value-parsing`, we need to implement logic 
 - **Strict DataView API Usage**: All parsing logic for contest data MUST exclusively use the native `DataView` API (e.g., `getUint8`) as mandated by ADR 010.
 
 ## 3. Acceptance Criteria
-- [ ] Implement Sheen value extraction logic using the `DataView` API.
-- [ ] Ensure unit tests are added or updated to verify the extracted Sheen value.
-- [ ] **Important:** If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
-- [ ] **Important:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- [x] Implement Sheen value extraction logic using the `DataView` API.
+- [x] Ensure unit tests are added or updated to verify the extracted Sheen value.
+- [x] **Important:** If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
+- [x] **Important:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -23,7 +23,7 @@ export interface Gen3ConditionStats {
   cute: number;
   smart: number;
   tough: number;
-  feel: number;
+  sheen: number;
 }
 
 export interface PokemonInstance {

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -214,7 +214,7 @@ describe('parseGen3ConditionStats', () => {
       cute: 30,
       smart: 40,
       tough: 50,
-      feel: 60,
+      sheen: 60,
     });
   });
 
@@ -238,7 +238,7 @@ describe('parseGen3ConditionStats', () => {
       cute: 35,
       smart: 45,
       tough: 55,
-      feel: 65,
+      sheen: 65,
     });
   });
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -136,9 +136,9 @@ export function parseGen3ConditionStats(view: DataView, offset: number) {
     const cute = view.getUint8(offset + 0x08);
     const smart = view.getUint8(offset + 0x09);
     const tough = view.getUint8(offset + 0x0a);
-    const feel = view.getUint8(offset + 0x0b);
+    const sheen = view.getUint8(offset + 0x0b);
 
-    return { cool, beauty, cute, smart, tough, feel };
+    return { cool, beauty, cute, smart, tough, sheen };
   } catch (error) {
     if (error instanceof RangeError) {
       throw new Error('The save file is corrupted or incomplete.');


### PR DESCRIPTION
Implements Sheen value parsing for Gen 3 save files in accordance with `task-102-157-impl-gen3-sheen-parsing`. Replaced the ambiguous `feel` internal property with `sheen`. Uses the native DataView API as mandated by ADR 010. Unit tests have been updated and passing.

---
*PR created automatically by Jules for task [8658511175428237817](https://jules.google.com/task/8658511175428237817) started by @szubster*