### PR TITLE
Implement Gen 3 Berry Tracker DataView Parsing Logic (Retry)

### DIFF
--- a/.foundry/tasks/task-095-183-gen3-berry-dataview-parsing-retry.md
+++ b/.foundry/tasks/task-095-183-gen3-berry-dataview-parsing-retry.md
@@ -36,7 +36,7 @@ Implement the extraction logic for Gen 3 berry patches using the native `DataVie
 - IMPORTANT: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement `DataView` reading logic for Gen 3 berry patches using correct relative offsets.
-- [ ] Implement graceful handling of bounds checking by throwing/catching `RangeError`.
-- [ ] Extract explicit data such as berry ID, current growth stage, regrowth count, and watering history booleans.
-- [ ] Ensure implicit data (map ID, time planted, last watered time) are NOT included in the extraction schema.
+- [x] Implement `DataView` reading logic for Gen 3 berry patches using correct relative offsets.
+- [x] Implement graceful handling of bounds checking by throwing/catching `RangeError`.
+- [x] Extract explicit data such as berry ID, current growth stage, regrowth count, and watering history booleans.
+- [x] Ensure implicit data (map ID, time planted, last watered time) are NOT included in the extraction schema.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -60,7 +60,6 @@ export interface PokemonInstance {
  */
 
 export interface Gen3BerryPatch {
-  mapId: number;
   berryId: number;
   stage: number;
   stopGrowth: boolean;

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -72,8 +72,8 @@ describe('gen3 parser scaffolding', () => {
     view.setUint32(section2Offset + 4088, 0x08012025, true);
     view.setUint32(section2Offset + 4092, 25, true);
 
-    // Write mock berry data at Section 1, offset 0x169C + (0 * 8)
-    const baseOffset = section1Offset + 0x169c;
+    // Write mock berry data at Section 1, offset 0x071c + (0 * 8)
+    const baseOffset = section1Offset + 0x071c;
 
     // Patch 0
     view.setUint8(baseOffset + 0, 15); // berryId
@@ -87,7 +87,7 @@ describe('gen3 parser scaffolding', () => {
     expect(saveData.gen3BerryPatches?.length).toBe(128);
 
     const patch0 = saveData.gen3BerryPatches?.[0];
-    expect(patch0?.mapId).toBe(0);
+    expect(patch0).not.toHaveProperty('mapId');
     expect(patch0?.berryId).toBe(15);
     expect(patch0?.stage).toBe(2);
     expect(patch0?.stopGrowth).toBe(true);
@@ -132,7 +132,7 @@ describe('gen3 parser scaffolding', () => {
 
     const originalGetUint8 = view.getUint8.bind(view);
     view.getUint8 = (offset: number) => {
-      if (offset >= section1Offset + 0x169c) {
+      if (offset >= section1Offset + 0x071c) {
         throw new RangeError('Out of bounds reading berry patch');
       }
       return originalGetUint8(offset);

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -63,7 +63,7 @@ function getLatestSectionOffset(view: DataView, targetSectionId: number): number
 
 function extractBerryPatches(view: DataView, saveBlock1Offset: number) {
   const patches: Gen3BerryPatch[] = [];
-  const baseOffset = saveBlock1Offset + 0x169c;
+  const baseOffset = saveBlock1Offset + 0x071c;
 
   for (let i = 0; i < 128; i++) {
     const offset = baseOffset + i * 8;
@@ -84,7 +84,6 @@ function extractBerryPatches(view: DataView, saveBlock1Offset: number) {
       const watered4 = (wateredByte & 0x80) !== 0;
 
       patches.push({
-        mapId: i, // We use the array index as the mapId, as researched.
         berryId,
         stage,
         stopGrowth,


### PR DESCRIPTION
This submission addresses task `task-095-183-gen3-berry-dataview-parsing-retry` by correcting the relative offset for Berry Patch extraction in Gen 3 `.sav` files (`0x169C` relative to SaveBlock1 is actually `0x071C` relative to Section 1 due to Section 0 payload size). It also strips out implicit data properties like `mapId` that don't belong in the strict explicit extraction schema per the ADRs.

- Fixed DataView indexing bugs that caused RangeErrors.
- Passed full test suite successfully.
- Code review approved.

---
*PR created automatically by Jules for task [208369059633576429](https://jules.google.com/task/208369059633576429) started by @szubster*