### PR TITLE
Reject idea-079-automated-max-rejection-cancellation

### DIFF
--- a/.foundry/ideas/idea-079-automated-max-rejection-cancellation.md
+++ b/.foundry/ideas/idea-079-automated-max-rejection-cancellation.md
@@ -33,4 +33,8 @@ Refactor the Foundry Orchestrator (`foundry-orchestrator.ts`) to automatically t
 
 ## Acceptance Criteria
 - [x] Implement orchestrator logic to transition `FAILED` nodes to `CANCELLED` when `rejection_count` >= max threshold.
-- [x] Ensure this triggers the proper parent awakening logic.
+- [ ] Ensure this triggers the proper parent awakening logic.
+
+
+### Auditor Rejection
+While the nodes are transitioned to CANCELLED, they bypass the parent awakening logic in Phase 3.6 of `foundry-orchestrator.ts`. The condition `node.frontmatter.status === 'FAILED'` must be expanded to include `CANCELLED` nodes with a rejection reason (like max rejection reached).

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -74,3 +74,6 @@ This confirms the Gen 2 Pokerus parsing logic works and successfully covers the 
 
 **Recommendation/Learnings:**
 The extraction code correctly uses bitwise logic on the +28 offset raw byte (`rawPokerus >> 4` for strain, `rawPokerus & 0x0f` for days) and cleanly handles the differentiation between never infected (`0`) and cured. The tests cover these bounds accurately.
+
+### Lesson: Impossible Loop Awakening for CANCELLED Nodes
+When nodes are transitioned to CANCELLED (e.g. due to max rejection threshold), they must trigger the same Impossible Loop parent awakening logic as FAILED nodes, otherwise the DAG deadlocks. Parent awakening conditions must include CANCELLED status when a rejection reason is present.


### PR DESCRIPTION
Auditor verification rejection.

The orchestrator logic (`foundry-orchestrator.ts`, Phase 3.6) only triggers parent awakening for `FAILED` nodes. However, the requirement is to trigger it when `rejection_count >= MAX_REJECTION_THRESHOLD`, which transitions the node to `CANCELLED`. Thus, the parent awakening is currently bypassed.

- Unchecked the Acceptance Criteria in `idea-079`.
- Appended `### Auditor Rejection` to `idea-079`.
- Added a lesson in `.foundry/journals/auditor.md`.

---
*PR created automatically by Jules for task [9853881304709285025](https://jules.google.com/task/9853881304709285025) started by @szubster*