### PR TITLE
feat(orchestrator): sort matrix output chronologically by created_at

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -991,7 +991,19 @@ function main(): void {
       ...n.frontmatter,
       repo_path: n.repoPath,
       owner_persona: n.frontmatter.status === 'VERIFYING' ? 'auditor' : n.frontmatter.owner_persona,
-    }));
+    }))
+    .sort((a, b) => {
+      const dateA = new Date(a.created_at).getTime();
+      const dateB = new Date(b.created_at).getTime();
+
+      // Sort by created_at ascending (oldest first)
+      if (!Number.isNaN(dateA) && !Number.isNaN(dateB) && dateA !== dateB) {
+        return dateA - dateB;
+      }
+
+      // Fallback: sort by numeric id ascending
+      return a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: 'base' });
+    });
 
   info(`Total READY nodes: ${readyNodes.length}`);
 


### PR DESCRIPTION
This PR updates the GitHub Action foundry orchestrator to sort outputted nodes (tasks/ready items) chronologically based on their `created_at` timestamp in ascending order (from oldest to newest). If two nodes share the same exact creation date, it falls back to sorting by `id` numerically in ascending order. This guarantees older, existing items are processed before more newly generated items.

- Parses `created_at` fields safely using standard JS `Date`.
- Implements numerical `localeCompare` for `id` tiebreaking.

---
*PR created automatically by Jules for task [7865455064266181649](https://jules.google.com/task/7865455064266181649) started by @szubster*