### PR TITLE
Suspend breeding pair algorithm task due to missing Egg Groups data

### DIFF
--- a/.foundry/research/research-150-186-egg-groups-missing.md
+++ b/.foundry/research/research-150-186-egg-groups-missing.md
@@ -1,0 +1,32 @@
+---
+id: research-150-186-egg-groups-missing
+type: RESEARCH
+title: Investigate Missing Egg Groups Data for Breeding Algorithm
+status: READY
+owner_persona: researcher
+created_at: "2026-06-15"
+updated_at: "2026-06-15"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-084-150-breeding-pair-algorithm-impl
+tags:
+  - backend
+  - data
+  - breeding
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Investigate Missing Egg Groups Data for Breeding Algorithm
+
+## Context
+While implementing `task-084-150-breeding-pair-algorithm-impl`, it was discovered that `PokemonMetadata` inside `src/db/schema.ts` does not include `egg_groups`.
+In addition, there isn't a known utility to compute Gen 2 Pokemon gender based on Attack DV and Gender Ratio.
+
+## Objectives
+- Determine how to add Egg Groups to the DB schema (and update `scripts/generate-pokedata.ts`).
+- Determine how to calculate gender using DVs and Gender Ratio (`gr`).
+- Outline the necessary changes to supply this data to the Breeding Algorithm.

--- a/.foundry/tasks/task-084-150-breeding-pair-algorithm-impl.md
+++ b/.foundry/tasks/task-084-150-breeding-pair-algorithm-impl.md
@@ -2,11 +2,12 @@
 id: task-084-150-breeding-pair-algorithm-impl
 type: TASK
 title: Implement Gen 2 Breeding Pair Algorithm
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-08'
 updated_at: '2026-06-15'
-depends_on: []
+depends_on:
+  - research-150-186-egg-groups-missing
 jules_session_id: '7103759404911118140'
 pr_number: null
 parent: story-044-084-breeding-pair-algorithm
@@ -17,7 +18,7 @@ tags:
   - backend
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Late Binding: Missing Egg Groups in PokemonMetadata schema. Suspending task until research node is resolved.'
 notes: ''
 ---
 


### PR DESCRIPTION
The task `task-084-150-breeding-pair-algorithm-impl` has been suspended due to critical missing context: the `PokemonMetadata` schema in `src/db/schema.ts` lacks the `egg_groups` property, which is required to correctly implement Gen 2 Egg Group pairing rules. In addition, there is no available context or helper to reliably resolve Gen 2 gender from Attack DVs. A new `RESEARCH` node (`research-150-186-egg-groups-missing`) has been spawned to investigate this missing context and added to the task's `depends_on` array. The original task has been `FAILED` appropriately to allow for context resolution prior to implementation.

---
*PR created automatically by Jules for task [7103759404911118140](https://jules.google.com/task/7103759404911118140) started by @szubster*