### PR TITLE
docs(foundry): check off gen 1 hof parser acceptance criteria

### DIFF
--- a/.foundry/tasks/task-111-165-gen1-hof-parser-impl.md
+++ b/.foundry/tasks/task-111-165-gen1-hof-parser-impl.md
@@ -38,6 +38,6 @@ Implement logic to extract the Hall of Fame data and count from Generation 1 (Re
 - If you submit an empty PR to verify a pre-existing target artifact, you MUST check off all Acceptance Criteria checkboxes before doing so.
 
 ## Acceptance Criteria
-- [ ] Implement Gen 1 Hall of Fame count parsing using `DataView.getUint8`.
-- [ ] Account for the `offsetShift` (`1` for Yellow, `0` for Red/Blue) from base offset `0x25B3`.
-- [ ] Treat a raw parsed value of `0xFF` as `0`.
+- [x] Implement Gen 1 Hall of Fame count parsing using `DataView.getUint8`.
+- [x] Account for the `offsetShift` (`1` for Yellow, `0` for Red/Blue) from base offset `0x25B3`.
+- [x] Treat a raw parsed value of `0xFF` as `0`.


### PR DESCRIPTION
Checks off acceptance criteria for Gen 1 Hall of Fame Data Parsing. Code was already fully implemented and unit tested.

---
*PR created automatically by Jules for task [2358782563801532452](https://jules.google.com/task/2358782563801532452) started by @szubster*