### PR TITLE
chore(foundry): abort task-108-163-gen3-secret-base-parser and spawn research

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -88,3 +88,7 @@ Following the Late Binding for Missing Context pattern, rather than making assum
 When implementing save parser logic, research handoffs occasionally identify bitfields (e.g., Gen 3 Roamer IVs) without specifying the exact bit shifts or field sizes required for correct extraction. It's critical to avoid hallucinating these exact mathematical formulas to comply with groundedness rules. When this occurs, always spawn a late-bound `RESEARCH` node to determine the exact parsing formula and suspend the implementation task until the data is verified.
 
 - **Gen 3 Contest Ribbons**: Added `parseGen3Ribbons` utilizing `getUint32` to parse the 32-bit ribbon bitfields to correctly extract Cool, Beauty, Cute, Smart, and Tough contest ranks using bitwise isolation.
+
+## 2026-06-15: Late Binding for Missing Context
+
+When implementing tasks that require specific data offsets (e.g., Gen 3 Secret Base memory offsets), and that information is missing from the provided `.foundry/docs/knowledge_base/` files or the task context, I must suspend the task using the "Late Binding" pattern. I should create a `RESEARCH` node to investigate the missing context, append the new exact node ID to the current task's `depends_on` array, update the current task's `status` to `FAILED`, and provide a clear `rejection_reason` in the YAML frontmatter. This ensures the orchestrator pauses the task until the prerequisite research is complete.

--- a/.foundry/research/research-108-187-gen3-secret-base-offsets.md
+++ b/.foundry/research/research-108-187-gen3-secret-base-offsets.md
@@ -1,0 +1,38 @@
+---
+id: research-108-187-gen3-secret-base-offsets
+type: RESEARCH
+title: Investigate Gen 3 Secret Base Memory Offsets
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-15'
+updated_at: '2026-06-15'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-108-163-gen3-secret-base-parser
+tags:
+  - research
+  - gen3
+  - secret-base
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# RESEARCH: Investigate Gen 3 Secret Base Memory Offsets
+
+## Objective
+To successfully implement the Gen 3 Secret Base Parser (`task-108-163-gen3-secret-base-parser`), we need to identify the exact memory offsets and data structures for Secret Bases in Gen 3 save files (Ruby, Sapphire, Emerald).
+
+## Questions to Answer
+1. In which save block and at what specific offsets is the Secret Base data located?
+2. What is the layout of the Secret Base data structure (e.g., size per entry, total number of entries)?
+3. How is the map/location ID represented within this structure?
+4. Are there version differences (Ruby/Sapphire vs. Emerald) for these offsets?
+
+## Action Plan
+- Research documentation on Gen 3 save file structures.
+- Analyze decompilation repositories like `pret/pokeemerald` if necessary.
+- Document findings in `.foundry/docs/knowledge_base/gen3_secret_base_offsets.md`.

--- a/.foundry/tasks/task-108-163-gen3-secret-base-parser.md
+++ b/.foundry/tasks/task-108-163-gen3-secret-base-parser.md
@@ -2,11 +2,12 @@
 id: task-108-163-gen3-secret-base-parser
 type: TASK
 title: Implement Gen 3 Secret Base Parser
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-11'
 updated_at: '2026-06-15'
-depends_on: []
+depends_on:
+  - research-108-187-gen3-secret-base-offsets
 jules_session_id: '1097762190059818453'
 pr_number: null
 parent: story-070-108-parse-secret-base-locations
@@ -17,7 +18,7 @@ tags:
   - save-parsing
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Late binding: suspended pending research for Gen 3 Secret Base memory offsets.'
 notes: ''
 ---
 


### PR DESCRIPTION
This PR implements the Late Binding pattern to gracefully abort and suspend the implementation of the Gen 3 Secret Base parser (`task-108-163-gen3-secret-base-parser`) due to missing memory offsets.

It performs the following:
- Creates a new `RESEARCH` node (`research-108-187-gen3-secret-base-offsets.md`) to investigate the required memory offsets.
- Updates the original task's `status` to `FAILED` and sets a `rejection_reason`.
- Adds the new research node to the original task's `depends_on` array.
- Documents the usage of the late binding pattern in the coder's journal for future reference.

---
*PR created automatically by Jules for task [1097762190059818453](https://jules.google.com/task/1097762190059818453) started by @szubster*