### PR TITLE
chore(qa): check off acceptance criteria for hierarchical completion logic

### DIFF
--- a/.foundry/tasks/task-108-162-hierarchical-completion-qa.md
+++ b/.foundry/tasks/task-108-162-hierarchical-completion-qa.md
@@ -40,6 +40,6 @@ Verify that the `foundry-orchestrator.ts` correctly blocks node transitions when
    - If you submit an empty PR for this completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] `foundry-orchestrator.ts` parses markdown links and adds them to `parentToChildren` and `childToParents`.
-- [ ] Multiple parents are correctly traversed.
-- [ ] Tests pass verifying hierarchical completion blocks `VERIFYING` or `COMPLETED` when any explicit or markdown child is not `COMPLETED`.
+- [x] `foundry-orchestrator.ts` parses markdown links and adds them to `parentToChildren` and `childToParents`.
+- [x] Multiple parents are correctly traversed.
+- [x] Tests pass verifying hierarchical completion blocks `VERIFYING` or `COMPLETED` when any explicit or markdown child is not `COMPLETED`.


### PR DESCRIPTION
Checked off acceptance criteria for the hierarchical completion logic QA task.

The implementation in `foundry-orchestrator.ts` satisfies the following:
- Parses markdown links and adds them to `parentToChildren` and `childToParents`.
- Navigates multiple parents correctly via BFS over `childToParents`.
- Passes tests verifying hierarchical completion blocks `VERIFYING` or `COMPLETED` when any explicit or markdown child is not `COMPLETED`.

---
*PR created automatically by Jules for task [2470953843234020873](https://jules.google.com/task/2470953843234020873) started by @szubster*