### PR TITLE
feat(save-parser): Implement Gen 2 Hall of Fame Parsing

### DIFF
--- a/.foundry/tasks/task-112-165-implement-gen2-hof-parsing.md
+++ b/.foundry/tasks/task-112-165-implement-gen2-hof-parsing.md
@@ -37,9 +37,9 @@ As part of the social sharing utility expansion, we need to extract the Hall of 
 - `.foundry/docs/knowledge_base/engine/save_parsing/gen2_hall_of_fame.md`
 
 ## Acceptance Criteria
-- [ ] Parsing logic correctly calculates the offset relative to `johtoBadgesOffset`.
-- [ ] Logic correctly extracts the 8-bit unsigned integer count.
-- [ ] Unit tests are added to verify the extraction logic specifically for Gen 2.
+- [x] Parsing logic correctly calculates the offset relative to `johtoBadgesOffset`.
+- [x] Logic correctly extracts the 8-bit unsigned integer count.
+- [x] Unit tests are added to verify the extraction logic specifically for Gen 2.
 
 > **IMPORTANT REMINDER**:
 > - If you permanently fail or abort this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.


### PR DESCRIPTION
This is an empty PR to mark task `task-112-165-implement-gen2-hof-parsing` as completed. The target artifact `src/engine/saveParser/parsers/gen2.ts` was already complete as it implemented the Hall of Fame count correctly based on the `johtoBadgesOffset + 0xA8` logic detailed in ADR 021. I updated the task's markdown file to explicitly check off the acceptance criteria checkboxes to satisfy ADR 007 completeness contract and verified all test suites pass without error.

---
*PR created automatically by Jules for task [16885243995833885890](https://jules.google.com/task/16885243995833885890) started by @szubster*