### PR TITLE
Suspend Gen 3 Roamer Location Task pending research

### DIFF
--- a/.foundry/research/research-108-187-gen3-roamer-location-offsets.md
+++ b/.foundry/research/research-108-187-gen3-roamer-location-offsets.md
@@ -1,0 +1,34 @@
+---
+id: research-108-187-gen3-roamer-location-offsets
+type: RESEARCH
+title: Investigate Gen 3 Roamer Location Save Offsets
+status: READY
+owner_persona: researcher
+created_at: '2026-06-15'
+updated_at: '2026-06-15'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-108-161-gen3-roamer-location-impl
+tags:
+  - gen3
+  - roamer
+  - save-offsets
+  - research
+research_references:
+  - research-071-138-gen3-roamer-offsets
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 3 Roamer Location Save Offsets
+
+## Objective
+Discover the exact memory offsets for the roamer's map group and map number for Gen 3 save files.
+
+## Context
+During the implementation of `task-108-161-gen3-roamer-location-impl`, it was discovered that the previous research (`research-071-138-gen3-roamer-offsets`) identified that the roamer's current map group and map number are not stored within the primary 20-byte struct, but kept in separate variables loaded into EWRAM (`sRoamerLocation`). However, the exact byte offsets or structure for extracting these values via DataView were not provided.
+
+## Acceptance Criteria
+- [ ] Determine the exact memory offset and structure for the roamer's map group and map number for Gen 3 saves.

--- a/.foundry/tasks/task-108-161-gen3-roamer-location-impl.md
+++ b/.foundry/tasks/task-108-161-gen3-roamer-location-impl.md
@@ -2,12 +2,13 @@
 id: task-108-161-gen3-roamer-location-impl
 type: TASK
 title: Implement Gen 3 Roamer Location Data Extraction
-status: READY
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-11'
 updated_at: '2026-06-14'
 depends_on:
   - research-071-138-gen3-roamer-offsets
+  - research-108-187-gen3-roamer-location-offsets
 jules_session_id: null
 pr_number: null
 parent: story-072-108-gen3-roamer-location-extraction
@@ -18,7 +19,7 @@ tags:
 research_references:
   - research-071-138-gen3-roamer-offsets
 rejection_count: 1
-rejection_reason: ''
+rejection_reason: 'Suspended pending research for exact memory offsets of Gen 3 roamer map group and map number.'
 notes: ''
 ---
 


### PR DESCRIPTION
Suspends task-108-161-gen3-roamer-location-impl using late binding pattern because exact memory offsets for the roamer's map group and map number were not provided in prior research. Spawned research-108-187 to investigate these offsets.

---
*PR created automatically by Jules for task [11454315226701866301](https://jules.google.com/task/11454315226701866301) started by @szubster*