### PR TITLE
docs: Update ADR 001 with macro node completion rules

### DIFF
--- a/.foundry/docs/adrs/001-the-foundry-architecture.md
+++ b/.foundry/docs/adrs/001-the-foundry-architecture.md
@@ -110,5 +110,8 @@ The `.foundry/` monofolder has been scaffolded at the repository root. All 9 fil
 1. Technical implementation of the GitHub Actions engine (`task-001`).
 2. Draft initial Persona `.md` frameworks inside `.github/agents/`.
 
-## 7. EMPTY PR POLICY
+## 7. System Invariants (Macro Node Completion)
+Macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) MUST NOT transition to `COMPLETED` until all of their descendant nodes in the DAG have reached the `COMPLETED` or `CANCELLED` status. A macro node with pending, active, or failed descendants is inherently incomplete.
+
+## 8. EMPTY PR POLICY
 Empty PRs (0 files changed) are submitted when a persona determines that the target artifact already exists and is complete. These PRs are automatically merged to allow the Foundry DAG to progress, while the persona documents the outcome in its journal.

--- a/.foundry/tasks/task-109-161-update-adr001-macro-node-completion-impl.md
+++ b/.foundry/tasks/task-109-161-update-adr001-macro-node-completion-impl.md
@@ -36,4 +36,4 @@ Update `.foundry/docs/adrs/001-the-foundry-architecture.md` to detail the new ma
 5. Reminder: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior of macro nodes completion.
+- [x] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior of macro nodes completion.


### PR DESCRIPTION
This PR updates ADR 001 to explicitly document the strict completion rules for macro nodes (IDEA, PRD, EPIC, STORY) in the Foundry architecture. It also checks off the related acceptance criteria in the task node.

---
*PR created automatically by Jules for task [350837188325313940](https://jules.google.com/task/350837188325313940) started by @szubster*