### PR TITLE
feat: Define tactical-panel and tactical-card utilities

### DIFF
--- a/.foundry/tasks/task-113-165-define-tactical-utilities-impl.md
+++ b/.foundry/tasks/task-113-165-define-tactical-utilities-impl.md
@@ -47,5 +47,5 @@ Based on analysis of `TacticalPanel` and `TacticalCard` in `src/components/`, th
 * **CRITICAL**: If the target artifacts are already completely implemented, you MUST check all Acceptance Criteria checkboxes (`- [x]`) before submitting an empty PR. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009.
 
 ## Acceptance Criteria
-- [ ] Appropriate `@utility tactical-panel` and `@utility tactical-card` primitives are defined in `src/index.css`.
-- [ ] Tailwind v4 formatting and structure is respected.
+- [x] Appropriate `@utility tactical-panel` and `@utility tactical-card` primitives are defined in `src/index.css`.
+- [x] Tailwind v4 formatting and structure is respected.

--- a/src/index.css
+++ b/src/index.css
@@ -124,3 +124,16 @@ body {
 .lcd-flicker {
   animation: screen-flicker 0.1s infinite;
 }
+
+
+/* =========================================
+   Tactical Primitives (@utility definitions)
+   ========================================= */
+
+@utility tactical-panel {
+  @apply overflow-hidden rounded-none border border-dashed bg-zinc-900/50 text-zinc-100 font-mono transition-all duration-300;
+}
+
+@utility tactical-card {
+  @apply flex flex-col rounded-none border border-dashed bg-zinc-950 p-4 font-mono transition-all duration-500 hover:scale-[1.02] active:scale-[0.98];
+}


### PR DESCRIPTION
This PR defines the base Tailwind v4 utility classes `tactical-panel` and `tactical-card` in `src/index.css` to consolidate common styling related to the "tactical hardware" aesthetic as dictated by ADR 024 and PRD 071. It also updates the task completion checklist.

---
*PR created automatically by Jules for task [7599354570018371525](https://jules.google.com/task/7599354570018371525) started by @szubster*