### PR TITLE
feat: implement tactical-button and tactical-focus utilities

### DIFF
--- a/.foundry/tasks/task-114-165-tactical-button-focus-impl.md
+++ b/.foundry/tasks/task-114-165-tactical-button-focus-impl.md
@@ -35,5 +35,5 @@ Define the custom utilities in `src/index.css` leveraging `@apply` to enforce th
 - If an empty PR is submitted for a completed task, the Coder MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Appropriate `@utility tactical-button` and `@utility tactical-focus` primitives are defined in `src/index.css`.
-- [ ] Tailwind v4 formatting and structure is respected.
+- [x] Appropriate `@utility tactical-button` and `@utility tactical-focus` primitives are defined in `src/index.css`.
+- [x] Tailwind v4 formatting and structure is respected.

--- a/src/index.css
+++ b/src/index.css
@@ -124,3 +124,24 @@ body {
 .lcd-flicker {
   animation: screen-flicker 0.1s infinite;
 }
+
+
+/* =========================================
+   Tactical Primitives (@utility definitions)
+   ========================================= */
+
+@utility tactical-button {
+  @apply rounded-none border-dashed font-mono bg-[var(--theme-surface)] border border-[var(--theme-border)] text-white px-4 py-2 text-sm transition-all;
+
+  &:hover {
+    @apply bg-[rgba(var(--theme-primary-rgb),0.2)] border-[var(--theme-primary)] text-[var(--theme-primary)];
+  }
+
+  &:active {
+    @apply scale-95;
+  }
+}
+
+@utility tactical-focus {
+  @apply outline-dashed outline-1 outline-[var(--theme-primary)] outline-offset-1 rounded-none;
+}


### PR DESCRIPTION
This PR implements `@utility tactical-button` and `@utility tactical-focus` in `src/index.css` to consolidate repetitive styling based on Tailwind v4 and the "tactical hardware" aesthetic.

Changes:
- Added `@utility tactical-button` and `@utility tactical-focus` in `src/index.css`.
- Fixed the CSS theme variables usage in `@apply` statements.
- Checked off the Acceptance Criteria in `.foundry/tasks/task-114-165-tactical-button-focus-impl.md`.

---
*PR created automatically by Jules for task [10402501446780179862](https://jules.google.com/task/10402501446780179862) started by @szubster*