### PR TITLE
Generate epic for visual regression and accessibility tests

### DIFF
--- a/.foundry/epics/epic-041-091-visual-regression-accessibility.md
+++ b/.foundry/epics/epic-041-091-visual-regression-accessibility.md
@@ -1,0 +1,40 @@
+---
+id: epic-041-091-visual-regression-accessibility
+type: EPIC
+title: Visual Regression and Accessibility Checks
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-15'
+updated_at: '2026-06-15'
+depends_on:
+  - epic-041-065-individual-contest-stats-view
+  - epic-041-066-global-ribbon-checklist-dashboard
+jules_session_id: null
+pr_number: null
+parent: prd-070-041-gen3-contest-ui-viewer
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Visual Regression and Accessibility Checks
+
+## 1. Context
+To satisfy the final acceptance criteria of the PRD, this epic ensures that all newly created UI components for the Gen 3 Contest Condition and Ribbon Viewer pass visual regression and accessibility checks.
+
+## 2. Requirements
+- Implement visual regression tests using Playwright.
+- Run accessibility checks on the detailed view and global dashboard.
+
+## 3. Acceptance Criteria
+- [ ] Pass visual regression tests.
+- [ ] Pass accessibility checks.
+
+## 4. Child Nodes

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -15,3 +15,9 @@ When executing the Empty PR Policy for tasks where target artifacts are already 
 
 ## 2026-06-13: DAG Linkage Requirement for Epics
 When breaking down a PRD into Epic nodes, if an architectural document is required, do NOT create a `TASK` node for the Architect and make the Epics depend on it. This violates the Foundry DAG execution hierarchy (`IDEA -> PRD -> ADR -> EPIC -> STORY -> TASK`). Instead, dynamically create an `ADR` node (`type: ADR`) directly in `.foundry/docs/adrs/` and set the Epics to depend on that ADR node. Furthermore, ensure that all `depends_on` array references strictly use the exact Node IDs (e.g., `adr-049-025-dynamic-pokedata-parsing`) and never repo-relative file paths to prevent DAG resolution deadlocks.
+
+## 2026-06-16: Parent Node Strict DAG Dependency & PRD Completion
+When breaking down a PRD into Epics, it is crucial to ensure every functional requirement maps to at least one Epic.
+Additionally, when a PRD relies on its generated child Epics to be completed, it acts as a "Late-Binding Parent". To correctly keep the parent node in `PENDING` mode while it waits for children, its acceptance criteria boxes MUST remain unchecked (`- [ ]`). Submitting an empty PR with checked boxes transitions it prematurely to `VERIFYING`, violating the dependency graph.
+
+Furthermore, generated Epics MUST have their dependencies explicitly defined. For example, if an Epic is for Visual Regression Testing, its `depends_on` array must contain the IDs of the Epics that build the UI components it will test. Failure to set these dependencies allows the testing Epic to run concurrently with the UI Epic, resulting in immediate failures.

--- a/.foundry/prds/prd-070-041-gen3-contest-ui-viewer.md
+++ b/.foundry/prds/prd-070-041-gen3-contest-ui-viewer.md
@@ -53,3 +53,4 @@ Following the data extraction phase, DexHelper must present the extracted Gen 3 
 - [ ] .foundry/archive/epics/epic-041-064-contest-ui-shared-components.md
 - [ ] .foundry/epics/epic-041-065-individual-contest-stats-view.md
 - [ ] .foundry/epics/epic-041-066-global-ribbon-checklist-dashboard.md
+- [ ] .foundry/epics/epic-041-091-visual-regression-accessibility.md


### PR DESCRIPTION
Breaks down the visual regression and accessibility criteria of the Gen 3 Contest UI PRD into a new epic, and sets the proper dependencies so testing waits on UI development. Leaves the parent PRD boxes unchecked to respect the Wait and Wake dependency constraints.

---
*PR created automatically by Jules for task [3197885195207899979](https://jules.google.com/task/3197885195207899979) started by @szubster*