### PR TITLE
chore(foundry): complete QA task for Gen 2 Hall of Fame parsing

### DIFF
--- a/.foundry/tasks/task-112-166-qa-gen2-hof-parsing.md
+++ b/.foundry/tasks/task-112-166-qa-gen2-hof-parsing.md
@@ -33,9 +33,9 @@ A coder has implemented the parsing logic for extracting the Hall of Fame count 
 - Confirm that unit tests adequately cover this specific Gen 2 parsing logic.
 
 ## Acceptance Criteria
-- [ ] Code properly calculates the relative offset.
-- [ ] Code extracts the unsigned 8-bit integer.
-- [ ] Unit tests pass and provide sufficient coverage.
+- [x] Code properly calculates the relative offset.
+- [x] Code extracts the unsigned 8-bit integer.
+- [x] Unit tests pass and provide sufficient coverage.
 
 > **IMPORTANT REMINDER**:
 > - If you permanently fail or abort this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.


### PR DESCRIPTION
This PR marks the QA task for Gen 2 Hall of Fame parsing as completed.

The implemented logic correctly uses a relative offset of `0xA8` after the `johtoBadgesOffset` and parses it as an 8-bit unsigned integer. The unit tests in `src/engine/saveParser/parsers/gen2.test.ts` provide sufficient coverage for both Gold/Silver and Crystal versions. All acceptance criteria checkboxes have been checked off.

---
*PR created automatically by Jules for task [3819104371184660541](https://jules.google.com/task/3819104371184660541) started by @szubster*