### PR TITLE
Implement tactical-input and tactical-text utilities

### DIFF
--- a/.foundry/tasks/task-115-165-implement-tactical-input-text.md
+++ b/.foundry/tasks/task-115-165-implement-tactical-input-text.md
@@ -47,7 +47,7 @@ As per ADR 024, we are enforcing a strict "tactical hardware" aesthetic characte
    - If you submit an Empty PR because the target artifacts are already completely implemented, you MUST check off all Acceptance Criteria checkboxes (`- [x]`) below before submitting, as per ADR 007 and ADR 009.
 
 ## Acceptance Criteria
-- [ ] `@utility tactical-input` is defined in `src/index.css` using Tailwind v4 syntax.
-- [ ] `@utility tactical-text` is defined in `src/index.css` using Tailwind v4 syntax.
-- [ ] Repetitive inline classes in `src/components/` (especially inputs and text blocks) have been replaced with the new utilities.
-- [ ] No visual regressions are introduced; the tactical aesthetic remains unchanged.
+- [x] `@utility tactical-input` is defined in `src/index.css` using Tailwind v4 syntax.
+- [x] `@utility tactical-text` is defined in `src/index.css` using Tailwind v4 syntax.
+- [x] Repetitive inline classes in `src/components/` (especially inputs and text blocks) have been replaced with the new utilities.
+- [x] No visual regressions are introduced; the tactical aesthetic remains unchanged.

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -52,9 +52,7 @@ export function AppHeader({
               <span className="font-retro text-[8px] text-zinc-500 uppercase tracking-[0.3em]">
                 {saveData ? getGenerationConfig(saveData.generation).label : 'Protocol X'}
               </span>
-              <span className="font-mono text-[8px] text-[var(--theme-primary)] uppercase tracking-widest">
-                [ ONLINE ]
-              </span>
+              <span className="tactical-text text-[8px] text-[var(--theme-primary)]">[ ONLINE ]</span>
             </div>
           </div>
         </Link>
@@ -264,7 +262,7 @@ export function AppHeader({
             type="button"
             aria-label="Upload Save File"
             onClick={() => document.getElementById('init-save-input')?.click()}
-            className="group slide-in-from-bottom-2 fade-in relative inline-flex w-full animate-in cursor-pointer items-center justify-center gap-4 rounded-none border border-[var(--theme-primary)]/50 border-dashed bg-[var(--theme-primary)]/10 px-10 py-4 font-black font-mono text-[11px] text-[var(--theme-primary)] uppercase tracking-widest transition-all duration-300 hover:bg-[var(--theme-primary)] hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-95 sm:w-auto"
+            className="group slide-in-from-bottom-2 fade-in tactical-text relative inline-flex w-full animate-in cursor-pointer items-center justify-center gap-4 rounded-none border border-[var(--theme-primary)]/50 border-dashed bg-[var(--theme-primary)]/10 px-10 py-4 font-black text-[11px] text-[var(--theme-primary)] transition-all duration-300 hover:bg-[var(--theme-primary)] hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-95 sm:w-auto"
           >
             <CornerCrosshairs className="h-2 w-2 border-current" />
             <Upload size={20} />[ UPLOAD.SYS ]
@@ -284,7 +282,7 @@ export function AppHeader({
               type="button"
               aria-label="Start Live Sync"
               onClick={requestSync}
-              className="group slide-in-from-bottom-2 fade-in relative inline-flex w-full animate-in cursor-pointer items-center justify-center gap-4 rounded-none border border-[var(--theme-primary)]/50 border-dashed bg-[var(--theme-primary)]/10 px-10 py-4 font-black font-mono text-[11px] text-[var(--theme-primary)] uppercase tracking-widest transition-all duration-300 hover:bg-[var(--theme-primary)] hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-95 sm:w-auto"
+              className="group slide-in-from-bottom-2 fade-in tactical-text relative inline-flex w-full animate-in cursor-pointer items-center justify-center gap-4 rounded-none border border-[var(--theme-primary)]/50 border-dashed bg-[var(--theme-primary)]/10 px-10 py-4 font-black text-[11px] text-[var(--theme-primary)] transition-all duration-300 hover:bg-[var(--theme-primary)] hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-95 sm:w-auto"
             >
               <CornerCrosshairs className="h-2 w-2 border-current" />
               <Activity size={20} />[ LIVE_SYNC.SYS ]

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -81,12 +81,10 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         <div className="absolute inset-0 border-[26px] border-black/80" />
 
         {/* Hardware details in bezel */}
-        <div className="absolute top-2 left-6 font-black font-mono text-[8px] text-zinc-700 uppercase tracking-widest">
+        <div className="tactical-text absolute top-2 left-6 font-black text-[8px] text-zinc-700">
           [ MODEL: DEX-OS V2 ]
         </div>
-        <div className="absolute right-6 bottom-2 font-black font-mono text-[8px] text-zinc-700 uppercase tracking-widest">
-          POWER: ONLINE
-        </div>
+        <div className="tactical-text absolute right-6 bottom-2 font-black text-[8px] text-zinc-700">POWER: ONLINE</div>
 
         {/* Physical Screws */}
         <div className="absolute top-2 left-2 flex h-2 w-2 items-center justify-center rounded-full border border-zinc-800 bg-zinc-900 shadow-[inset_0_1px_1px_rgba(0,0,0,1)]">

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -103,7 +103,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
       <div className="relative flex flex-col justify-between gap-4 border border-zinc-800/80 bg-zinc-900/50 p-6 sm:flex-row sm:items-center">
         <CornerCrosshairs thickness={2} className="h-2 w-2 border-white/20" />
         <div className="absolute top-0 left-0 h-[2px] w-full bg-gradient-to-r from-emerald-500/50 via-amber-500/50 to-purple-500/50" />
-        <div className="pointer-events-none absolute -top-2.5 left-4 bg-zinc-950 px-1 font-mono text-[9px] text-[var(--theme-primary)] uppercase tracking-widest">
+        <div className="tactical-text pointer-events-none absolute -top-2.5 left-4 bg-zinc-950 px-1 text-[9px] text-[var(--theme-primary)]">
           SYS.ASST
         </div>
 
@@ -124,7 +124,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
               <Bug size={18} />
             </button>
           </div>
-          <p className="mt-1 font-mono text-[10px] text-zinc-500 uppercase tracking-widest">
+          <p className="tactical-text mt-1 text-[10px] text-zinc-500">
             [ SMART SUGGESTIONS GENERATED FROM SAVE TELEMETRY ]
           </p>
         </div>
@@ -180,13 +180,13 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
                       <div
                         className={`flex items-center gap-3 border border-zinc-800 border-dashed bg-zinc-900/80 px-4 py-2`}
                       >
-                        <div className="absolute -top-2 left-2 bg-zinc-950 px-1 font-mono text-[8px] text-zinc-500 uppercase tracking-widest">
+                        <div className="tactical-text absolute -top-2 left-2 bg-zinc-950 px-1 text-[8px] text-zinc-500">
                           SYS.CAT
                         </div>
                         <div className={`${catStyle.bg} ${catStyle.color.replace('border-', 'text-')} p-1`}>
                           {catStyle.icon}
                         </div>
-                        <h3 className="font-black font-mono text-lg text-white uppercase tracking-widest">
+                        <h3 className="tactical-text font-black text-lg text-white">
                           [{' '}
                           {category === 'Catch'
                             ? 'WILD ENCOUNTERS'

--- a/src/components/ContestConditionStats.tsx
+++ b/src/components/ContestConditionStats.tsx
@@ -56,7 +56,7 @@ export const ContestConditionStats = React.forwardRef<HTMLDivElement, ContestCon
     return (
       <TacticalPanel ref={ref} variant="default" className={cn('flex flex-col gap-4 p-4', className)} {...props}>
         <div className="flex items-center gap-2 border-white/20 border-b border-dashed pb-2">
-          <span className="font-bold font-mono text-sm text-white uppercase tracking-widest">Contest Conditions</span>
+          <span className="tactical-text font-bold text-sm text-white">Contest Conditions</span>
         </div>
 
         <div className="flex flex-col gap-3">

--- a/src/components/DataPoint.tsx
+++ b/src/components/DataPoint.tsx
@@ -14,11 +14,7 @@ export function DataPoint({ label, value, children, className, labelClassName, v
   return (
     <div className={cn('relative flex flex-col border-zinc-800 border-l border-dashed pl-3', className)}>
       <div className="absolute top-1.5 left-[-2px] h-1.5 w-1.5 border border-zinc-500 bg-zinc-950" />
-      <span
-        className={cn('mb-0.5 font-black font-mono text-[9px] text-zinc-500 uppercase tracking-widest', labelClassName)}
-      >
-        {label}
-      </span>
+      <span className={cn('tactical-text mb-0.5 font-black text-[9px] text-zinc-500', labelClassName)}>{label}</span>
       <span className={cn('font-bold font-mono text-[11px] text-zinc-300 uppercase tracking-tight', valueClassName)}>
         {value || children}
       </span>

--- a/src/components/DiagnosticCard.tsx
+++ b/src/components/DiagnosticCard.tsx
@@ -28,7 +28,7 @@ export function DiagnosticCard({ label, value, subValue, valueClassName }: Diagn
 
       <div className="relative z-10 flex flex-1 flex-col p-4 pl-6">
         <div className="mb-3 flex items-center justify-between border-zinc-800/50 border-b border-dashed pb-2">
-          <p className="font-black font-mono text-[9px] text-zinc-500 uppercase tracking-widest transition-colors group-hover:text-[var(--theme-primary)]">
+          <p className="tactical-text font-black text-[9px] text-zinc-500 transition-colors group-hover:text-[var(--theme-primary)]">
             [ {label} ]
           </p>
           <Activity size={10} className="text-zinc-600 transition-colors group-hover:text-[var(--theme-primary)]" />

--- a/src/components/InlineDataPoint.tsx
+++ b/src/components/InlineDataPoint.tsx
@@ -20,9 +20,7 @@ export function InlineDataPoint({
 }: InlineDataPointProps) {
   return (
     <div className={cn('flex items-center gap-2', className)}>
-      <span className={cn('font-black font-mono text-[8px] text-zinc-500 uppercase tracking-widest', labelClassName)}>
-        {label}
-      </span>
+      <span className={cn('tactical-text font-black text-[8px] text-zinc-500', labelClassName)}>{label}</span>
       <span
         className={cn(
           'font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-tight',

--- a/src/components/LocationSuggestions.tsx
+++ b/src/components/LocationSuggestions.tsx
@@ -64,7 +64,7 @@ export function LocationSuggestions() {
   if (selectedLocationId) {
     return (
       <div className="fade-in slide-in-from-top-1 flex animate-in items-center gap-2 px-4 pb-4">
-        <div className="relative flex items-center gap-2 border border-[var(--theme-primary)]/30 border-dashed bg-[var(--theme-primary)]/10 px-4 py-2 font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-widest">
+        <div className="tactical-text relative flex items-center gap-2 border border-[var(--theme-primary)]/30 border-dashed bg-[var(--theme-primary)]/10 px-4 py-2 font-black text-[10px] text-[var(--theme-primary)]">
           <div className="absolute top-0 left-0 h-full w-1 bg-[var(--theme-primary)]" />
           <CornerCrosshairs
             corners={['top-right', 'bottom-right']}
@@ -98,9 +98,7 @@ export function LocationSuggestions() {
       <CornerCrosshairs thickness={2} className="h-2 w-2 border-white/40" />
       <div className="scanline-overlay pointer-events-none absolute inset-0 opacity-10" />
       <div className="relative z-10 space-y-1 p-2">
-        <div className="px-3 py-2 font-black font-mono text-[9px] text-zinc-600 uppercase tracking-widest">
-          [ SCAN RESULTS ]
-        </div>
+        <div className="tactical-text px-3 py-2 font-black text-[9px] text-zinc-600">[ SCAN RESULTS ]</div>
         {suggestions.map((loc) => (
           <button
             type="button"
@@ -124,9 +122,7 @@ export function LocationSuggestions() {
                 <div className="font-black font-mono text-[11px] text-white uppercase tracking-wider transition-colors group-hover:text-[var(--theme-primary)]">
                   {loc.n}
                 </div>
-                <div className="font-bold font-mono text-[9px] text-zinc-500 uppercase tracking-widest">
-                  [{loc.count} DETECTED]
-                </div>
+                <div className="tactical-text font-bold text-[9px] text-zinc-500">[{loc.count} DETECTED]</div>
               </div>
             </div>
           </button>

--- a/src/components/PokedexGrid.tsx
+++ b/src/components/PokedexGrid.tsx
@@ -120,7 +120,7 @@ export function PokedexGrid({ pokemonList }: { pokemonList: PokemonListItem[] })
             useStore.getState().setFilters([]);
             useStore.getState().setSelectedLocationId(null);
           }}
-          className="mt-6 rounded-none border border-[var(--theme-primary)]/50 border-dashed bg-[var(--theme-primary)]/10 px-6 py-2.5 font-black font-mono text-[11px] text-[var(--theme-primary)] uppercase tracking-widest transition-all duration-300 hover:bg-[var(--theme-primary)] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+          className="tactical-text mt-6 rounded-none border border-[var(--theme-primary)]/50 border-dashed bg-[var(--theme-primary)]/10 px-6 py-2.5 font-black text-[11px] text-[var(--theme-primary)] transition-all duration-300 hover:bg-[var(--theme-primary)] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
         >
           Clear Filters
         </button>

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -244,7 +244,7 @@ export function PokemonDetails({
                 </h2>
                 <div className="flex flex-wrap justify-center gap-2 sm:justify-start">
                   {stadiumReward && (
-                    <div className="flex items-center gap-1.5 rounded-none border border-blue-500/50 border-dashed bg-blue-500/10 px-3 py-1 font-mono text-[10px] text-blue-400 uppercase tracking-widest backdrop-blur-md">
+                    <div className="tactical-text flex items-center gap-1.5 rounded-none border border-blue-500/50 border-dashed bg-blue-500/10 px-3 py-1 text-[10px] text-blue-400 backdrop-blur-md">
                       <Monitor size={12} /> Stadium Reward
                     </div>
                   )}

--- a/src/components/RetroBackground.tsx
+++ b/src/components/RetroBackground.tsx
@@ -46,7 +46,7 @@ export function RetroBackground(_props: RetroBackgroundProps) {
           SYS.TER
         </div>
 
-        <div className="absolute top-10 left-10 origin-top-left rotate-90 font-black font-mono text-4xl text-white/[0.02] uppercase tracking-widest">
+        <div className="tactical-text absolute top-10 left-10 origin-top-left rotate-90 font-black text-4xl text-white/[0.02]">
           [ DEPLOYED ]
         </div>
       </div>

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -68,7 +68,7 @@ export function SearchAndFilters() {
                 onClick={() => setFilters([])}
                 aria-pressed={filtersSet.size === 0}
                 title="Clear filters"
-                className={`min-w-[100px] flex-1 border-zinc-800 border-r border-dashed px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
+                className={`tactical-text min-w-[100px] flex-1 border-zinc-800 border-r border-dashed px-2 py-3 font-black text-[10px] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
                   filtersSet.size === 0
                     ? 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'
                     : 'bg-zinc-950/50 text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400'

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -49,9 +49,7 @@ export function SettingsModal() {
       <div className="flex items-center justify-between border-zinc-800 border-b border-dashed p-8 pt-10">
         <div>
           <h2 className="font-black font-mono text-2xl uppercase tracking-tighter">SYS.CONFIG</h2>
-          <p className="mt-1 font-bold font-mono text-[10px] text-zinc-500 uppercase tracking-widest">
-            Configure your experience
-          </p>
+          <p className="tactical-text mt-1 font-bold text-[10px] text-zinc-500">Configure your experience</p>
         </div>
         <TacticalButton
           onClick={() => setIsSettingsOpen(false)}

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -168,7 +168,7 @@ export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: 
                   <div className="flex items-center gap-4">
                     {/* Capacity Segmented Bar */}
                     <div className="flex items-center gap-2">
-                      <span className="min-w-[40px] text-right font-black font-mono text-[9px] text-zinc-500 uppercase tracking-widest">
+                      <span className="tactical-text min-w-[40px] text-right font-black text-[9px] text-zinc-500">
                         {pokemonInLocation.length} /{' '}
                         {location === 'Party' ? 6 : location === 'Daycare' ? 2 : genConfig.boxCapacity}
                       </span>

--- a/src/components/SyncProgress.tsx
+++ b/src/components/SyncProgress.tsx
@@ -114,13 +114,13 @@ export function SyncProgress() {
             <h3 className="font-black font-mono text-white text-xl uppercase tracking-tighter">
               {isComplete ? 'SYSTEM PRIMED' : 'INITIALIZING DATA'}
             </h3>
-            <p className="font-bold font-mono text-[10px] text-zinc-500 uppercase tracking-widest">
+            <p className="tactical-text font-bold text-[10px] text-zinc-500">
               {isComplete ? 'DATABASE HANDSHAKE SUCCESSFUL' : `PROCESSING ${progress?.stage}...`}
             </p>
           </div>
 
           <div className="w-full space-y-2">
-            <div className="flex justify-between font-black font-mono text-[10px] uppercase tracking-widest">
+            <div className="tactical-text flex justify-between font-black text-[10px]">
               <span className="text-zinc-500">TRANSFER</span>
               <span className={isComplete ? 'text-emerald-500' : 'text-blue-500'}>{percentage}%</span>
             </div>

--- a/src/components/TacticalButton.tsx
+++ b/src/components/TacticalButton.tsx
@@ -14,7 +14,7 @@ export const TacticalButton = React.forwardRef<HTMLButtonElement, TacticalButton
       <button
         ref={ref}
         className={cn(
-          'group relative inline-flex shrink-0 items-center justify-center gap-3 overflow-hidden rounded-none border border-dashed font-black font-mono uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:pointer-events-none disabled:opacity-50',
+          'group tactical-text relative inline-flex shrink-0 items-center justify-center gap-3 overflow-hidden rounded-none border border-dashed font-black transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:pointer-events-none disabled:opacity-50',
           {
             // Variants
             'border-white/20 bg-zinc-900/50 text-zinc-500 hover:border-white/40 hover:bg-zinc-800/80 hover:text-white focus-visible:ring-[var(--theme-primary)]':

--- a/src/components/TacticalInput.tsx
+++ b/src/components/TacticalInput.tsx
@@ -30,7 +30,7 @@ export const TacticalInput = React.forwardRef<HTMLInputElement, TacticalInputPro
           ref={ref}
           value={value}
           className={cn(
-            'w-full rounded-none border border-white/20 border-dashed bg-zinc-900/50 py-4 font-black font-mono text-white text-xs uppercase tracking-[0.2em] outline-none transition-all placeholder:text-zinc-600 focus:border-[var(--theme-primary)] focus:bg-zinc-900/80',
+            'tactical-input w-full',
             icon ? 'pl-14' : 'pl-4',
             onClear && value ? 'pr-12' : 'pr-4',
             className,
@@ -39,7 +39,7 @@ export const TacticalInput = React.forwardRef<HTMLInputElement, TacticalInputPro
         />
 
         {label && (
-          <div className="pointer-events-none absolute -top-2 left-4 bg-zinc-950 px-1 font-mono text-[9px] text-zinc-500 uppercase tracking-widest transition-colors group-focus-within:text-[var(--theme-primary)]">
+          <div className="tactical-text pointer-events-none absolute -top-2 left-4 bg-zinc-950 px-1 text-[9px] text-zinc-500 transition-colors group-focus-within:text-[var(--theme-primary)]">
             {label}
           </div>
         )}

--- a/src/components/TacticalMultiSelectControl.tsx
+++ b/src/components/TacticalMultiSelectControl.tsx
@@ -41,7 +41,7 @@ export function TacticalMultiSelectControl<T extends string | number | readonly 
       {legendLabel && (
         <>
           <legend className="sr-only">{ariaLabel || legendLabel}</legend>
-          <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">{legendLabel}</span>
+          <span className="tactical-text text-[9px] text-zinc-500">{legendLabel}</span>
         </>
       )}
       {!legendLabel && ariaLabel && <legend className="sr-only">{ariaLabel}</legend>}
@@ -65,7 +65,7 @@ export function TacticalMultiSelectControl<T extends string | number | readonly 
               data-testid={item.testId}
               title={typeof item.label === 'string' ? `${item.label} filter` : undefined}
               className={cn(
-                'flex-1 px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+                'tactical-text flex-1 px-2 py-3 font-black text-[10px] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
                 !isLast && 'border-zinc-800 border-r border-dashed',
                 isActive ? activeClass : inactiveClass,
                 buttonBaseClassName,

--- a/src/components/TacticalSegmentedControl.tsx
+++ b/src/components/TacticalSegmentedControl.tsx
@@ -39,7 +39,7 @@ export function TacticalSegmentedControl<T extends string | number | readonly st
       {legendLabel && (
         <>
           <legend className="sr-only">{ariaLabel || legendLabel}</legend>
-          <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">{legendLabel}</span>
+          <span className="tactical-text text-[9px] text-zinc-500">{legendLabel}</span>
         </>
       )}
       {!legendLabel && ariaLabel && <legend className="sr-only">{ariaLabel}</legend>}
@@ -68,7 +68,7 @@ export function TacticalSegmentedControl<T extends string | number | readonly st
               disabled={item.disabled}
               data-testid={item.testId}
               className={cn(
-                'flex-1 px-2 py-3 font-black font-mono text-[10px] uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+                'tactical-text flex-1 px-2 py-3 font-black text-[10px] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
                 !isLast && 'border-zinc-800 border-r border-dashed',
                 isActive ? activeClass : inactiveClass,
                 buttonBaseClassName,

--- a/src/components/TacticalSelect.tsx
+++ b/src/components/TacticalSelect.tsx
@@ -13,7 +13,7 @@ export const TacticalSelect = React.forwardRef<HTMLSelectElement, TacticalSelect
         <select
           ref={ref}
           className={cn(
-            'w-full appearance-none rounded-none border border-zinc-800 border-dashed bg-zinc-950 px-3 py-2 pr-8 font-black font-mono text-[9px] text-zinc-500 uppercase tracking-widest transition-all hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:opacity-50',
+            'tactical-text w-full appearance-none rounded-none border border-zinc-800 border-dashed bg-zinc-950 px-3 py-2 pr-8 font-black text-[9px] text-zinc-500 transition-all hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:opacity-50',
             className,
           )}
           {...props}

--- a/src/components/VersionModal.tsx
+++ b/src/components/VersionModal.tsx
@@ -41,7 +41,7 @@ export function VersionModal() {
           <AlertTriangle className="text-amber-500" size={24} />
         </div>
         <h2 className="font-black font-mono text-2xl text-white uppercase tracking-tighter">SYS.VERSION_CONFLICT</h2>
-        <p className="mt-1 font-bold font-mono text-[10px] text-zinc-500 uppercase leading-relaxed tracking-widest">
+        <p className="tactical-text mt-1 font-bold text-[10px] text-zinc-500 uppercase leading-relaxed">
           Game version detection failed. Manual override required.
         </p>
       </div>

--- a/src/components/assistant/AssistantDebugView.tsx
+++ b/src/components/assistant/AssistantDebugView.tsx
@@ -21,9 +21,7 @@ export function AssistantDebugView({ rejected, getPokemonName, saveData }: Assis
         <div className="rounded-none border border-zinc-700 border-dashed bg-zinc-800 p-2 text-zinc-400">
           <Bug size={16} />
         </div>
-        <h3 className="font-black font-mono text-[14px] text-[var(--theme-primary)] uppercase tracking-widest">
-          [ SYS.DIAGNOSTICS ]
-        </h3>
+        <h3 className="tactical-text font-black text-[14px] text-[var(--theme-primary)]">[ SYS.DIAGNOSTICS ]</h3>
       </div>
 
       <TacticalPanel variant="default" className="space-y-4 rounded-none border-dashed p-6 shadow-inner">
@@ -54,9 +52,7 @@ export function AssistantDebugView({ rejected, getPokemonName, saveData }: Assis
           <div className="rounded-none border border-amber-500/30 border-dashed bg-amber-500/10 p-2 text-amber-400">
             <AlertCircle size={16} />
           </div>
-          <h4 className="font-black font-mono text-[12px] text-amber-500 uppercase tracking-widest">
-            [ REJECTED_LOGS ]
-          </h4>
+          <h4 className="tactical-text font-black text-[12px] text-amber-500">[ REJECTED_LOGS ]</h4>
         </div>
       )}
 

--- a/src/components/assistant/AssistantSuggestionCard.tsx
+++ b/src/components/assistant/AssistantSuggestionCard.tsx
@@ -73,7 +73,7 @@ export function AssistantSuggestionCard({
             </div>
             {s.pokemonId && (
               <div className="flex items-center gap-2">
-                <span className="flex items-center gap-1 font-black font-mono text-[8px] text-[var(--theme-primary)] tracking-widest">
+                <span className="tactical-text flex items-center gap-1 font-black text-[8px] text-[var(--theme-primary)]">
                   <span className="h-1.5 w-1.5 animate-pulse bg-[var(--theme-primary)]" />[ TARGET ACQUIRED ]
                 </span>
                 <TacticalBadge className="px-1 py-0.5 font-mono text-[10px]">
@@ -98,9 +98,7 @@ export function AssistantSuggestionCard({
 
           {s.warning && (
             <div className="mt-2 flex w-max items-center gap-1.5 border border-amber-500/30 border-dashed bg-amber-500/10 px-2 py-1">
-              <span className="font-black font-mono text-[9px] text-amber-400 uppercase tracking-widest">
-                [ WARNING: {s.warning} ]
-              </span>
+              <span className="tactical-text font-black text-[9px] text-amber-400">[ WARNING: {s.warning} ]</span>
             </div>
           )}
         </div>

--- a/src/components/pokemon/PokemonStatusBadge.tsx
+++ b/src/components/pokemon/PokemonStatusBadge.tsx
@@ -22,12 +22,7 @@ export const PokemonStatusBadge = React.memo(function PokemonStatusBadge({
           isShiny ? 'border-amber-500/50 bg-amber-500/10' : 'border-emerald-500/50 bg-emerald-500/10',
         )}
       >
-        <span
-          className={cn(
-            'font-black font-mono text-[8px] uppercase tracking-widest',
-            isShiny ? 'text-amber-400' : 'text-emerald-400',
-          )}
-        >
+        <span className={cn('tactical-text font-black text-[8px]', isShiny ? 'text-amber-400' : 'text-emerald-400')}>
           [ SECURED ]
         </span>
       </div>
@@ -37,7 +32,7 @@ export const PokemonStatusBadge = React.memo(function PokemonStatusBadge({
   if (isOwnedInDex) {
     return (
       <div className="flex w-full items-center justify-center border-amber-500/50 border-t border-dashed bg-amber-500/10 py-1.5">
-        <span className="font-black font-mono text-[8px] text-amber-400 uppercase tracking-widest">[ DEX_ONLY ]</span>
+        <span className="tactical-text font-black text-[8px] text-amber-400">[ DEX_ONLY ]</span>
       </div>
     );
   }
@@ -45,14 +40,14 @@ export const PokemonStatusBadge = React.memo(function PokemonStatusBadge({
   if (isSeenInDex) {
     return (
       <div className="flex w-full items-center justify-center border-rose-500/50 border-t border-dashed bg-rose-500/10 py-1.5">
-        <span className="font-black font-mono text-[8px] text-rose-400 uppercase tracking-widest">[ SEEN ]</span>
+        <span className="tactical-text font-black text-[8px] text-rose-400">[ SEEN ]</span>
       </div>
     );
   }
 
   return (
     <div className="flex w-full items-center justify-center border-zinc-700 border-t border-dashed bg-white/5 py-1.5">
-      <span className="font-black font-mono text-[8px] text-zinc-600 uppercase tracking-widest">[ UNKNOWN ]</span>
+      <span className="tactical-text font-black text-[8px] text-zinc-600">[ UNKNOWN ]</span>
     </div>
   );
 });

--- a/src/components/pokemon/details/ContestRibbonBadge.tsx
+++ b/src/components/pokemon/details/ContestRibbonBadge.tsx
@@ -36,7 +36,7 @@ export const ContestRibbonBadge = React.forwardRef<HTMLDivElement, ContestRibbon
         ref={ref}
         title={getTooltipText(type, rank)}
         className={cn(
-          'inline-flex items-center gap-1.5 rounded-none border border-dashed px-2 py-1 font-mono text-xs uppercase tracking-widest',
+          'tactical-text inline-flex items-center gap-1.5 rounded-none border border-dashed px-2 py-1 text-xs',
           typeColorMap[type],
           className,
         )}

--- a/src/components/run/AliveTeamView.tsx
+++ b/src/components/run/AliveTeamView.tsx
@@ -48,7 +48,7 @@ export function AliveTeamView({ team, generation }: AliveTeamViewProps) {
                 </span>
 
                 <div className="mt-2 w-full space-y-1">
-                  <div className="flex items-center justify-between px-1 font-mono text-[9px] uppercase tracking-widest">
+                  <div className="tactical-text flex items-center justify-between px-1 text-[9px]">
                     <span className="text-zinc-500">LVL {pokemon.level}</span>
                     <span className="font-bold text-emerald-400">{pokemon.currentHp} HP</span>
                   </div>
@@ -87,7 +87,7 @@ export function AliveTeamView({ team, generation }: AliveTeamViewProps) {
               <span className="font-black font-mono text-red-500 text-xl uppercase tracking-[0.3em] drop-shadow-md">
                 CRITICAL_FAILURE
               </span>
-              <span className="mt-2 font-black font-mono text-[10px] text-red-400/80 uppercase tracking-widest">
+              <span className="tactical-text mt-2 font-black text-[10px] text-red-400/80">
                 [ TEAM_WIPE_DETECTED ] No vital signs found
               </span>
             </TacticalPanel>

--- a/src/components/run/GraveyardView.tsx
+++ b/src/components/run/GraveyardView.tsx
@@ -46,9 +46,7 @@ export function GraveyardView({ graveyard, generation }: GraveyardViewProps) {
           <div className="relative col-span-full flex flex-col items-center justify-center border border-zinc-800/50 border-dashed bg-zinc-950/20 p-8 text-center">
             <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700/50" />
             <Ghost className="mb-3 h-8 w-8 text-zinc-600" />
-            <span className="font-bold font-mono text-sm text-zinc-500 uppercase tracking-widest">
-              NO CASUALTIES RECORDED
-            </span>
+            <span className="tactical-text font-bold text-sm text-zinc-500">NO CASUALTIES RECORDED</span>
           </div>
         )}
       </div>

--- a/src/components/run/VisitedRoutesChecklist.tsx
+++ b/src/components/run/VisitedRoutesChecklist.tsx
@@ -38,7 +38,7 @@ export function VisitedRoutesChecklist({ visited, unvisited }: VisitedRoutesChec
                 <span className="truncate font-bold text-xs text-zinc-300 uppercase tracking-wider">
                   {route.locationName}
                 </span>
-                <span className="font-mono text-[10px] text-zinc-500 uppercase tracking-widest">
+                <span className="tactical-text text-[10px] text-zinc-500">
                   {route.encounters.length} ENCOUNTER{route.encounters.length !== 1 ? 'S' : ''}
                 </span>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -153,3 +153,11 @@ body {
 @utility tactical-card {
   @apply flex flex-col rounded-none border border-dashed bg-zinc-950 p-4 font-mono transition-all duration-500 hover:scale-[1.02] active:scale-[0.98];
 }
+
+@utility tactical-input {
+  @apply rounded-none border border-white/20 border-dashed bg-zinc-900/50 py-4 font-black font-mono text-white text-xs uppercase tracking-[0.2em] outline-none transition-all placeholder:text-zinc-600 focus:border-[var(--theme-primary)] focus:bg-zinc-900/80;
+}
+
+@utility tactical-text {
+  @apply font-mono uppercase tracking-widest;
+}


### PR DESCRIPTION
Implemented the `@utility tactical-input` and `@utility tactical-text` directives within Tailwind v4 syntax in `src/index.css` to consolidate repetitive styling constraints outlined by ADR 024. Applied these utilities globally across `src/components/` and refactored away from manual `font-mono uppercase tracking-widest` strings into explicit `tactical-text` utility classes to fulfill the project's 'tactical hardware' aesthetic directive natively.

Ensured visual parity via playwright headless testing against the web-server execution.
Accepted and updated markdown checkboxes to pass compliance.

---
*PR created automatically by Jules for task [14471850506295913779](https://jules.google.com/task/14471850506295913779) started by @szubster*