### PR TITLE
💡 Visionary: Gen 3 Secret ID Viewer and Shiny RNG Assistant

### DIFF
--- a/.foundry/ideas/idea-082-gen3-secret-id-shiny-rng.md
+++ b/.foundry/ideas/idea-082-gen3-secret-id-shiny-rng.md
@@ -2,7 +2,7 @@
 id: idea-082-gen3-secret-id-shiny-rng
 type: IDEA
 title: Gen 3 Secret ID Viewer and Shiny RNG Assistant
-status: PENDING
+status: CANCELLED
 owner_persona: product_manager
 created_at: '2026-06-16'
 updated_at: '2026-06-16'
@@ -16,6 +16,7 @@ tags:
   - rng
   - shiny-hunting
 research_references: []
+rejection_reason: 'Abandoned by maintainer.'
 notes: ''
 ---
 

--- a/.foundry/ideas/idea-082-gen3-secret-id-shiny-rng.md
+++ b/.foundry/ideas/idea-082-gen3-secret-id-shiny-rng.md
@@ -1,0 +1,38 @@
+---
+id: idea-082-gen3-secret-id-shiny-rng
+type: IDEA
+title: Gen 3 Secret ID Viewer and Shiny RNG Assistant
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - feature
+  - gen3
+  - rng
+  - shiny-hunting
+research_references: []
+notes: ''
+---
+
+# Idea: Gen 3 Secret ID Viewer and Shiny RNG Assistant
+
+## Context
+In Generation 3, every trainer has a Trainer ID (TID) which is visible, and a Secret ID (SID) which is permanently hidden from the player. The combination of TID and SID determines which Pokémon are "shiny" (alternate color). Because games like Pokémon Emerald have a fixed initial random seed, and games like Ruby/Sapphire with dry batteries also have fixed initial seeds, the "RNG Manipulation" meta is extremely popular. However, manipulating shiny encounters is impossible without knowing the SID.
+
+Players currently have to rely on external, complex tools or capturing an already-shiny Pokémon to calculate their SID.
+
+## Proposal
+Leverage DexHelper's programmatic save parsing to extract and display the player's Secret ID (SID) directly from their Gen 3 save file.
+- **Trainer Card Expansion:** Add a view displaying the exact SID next to the standard TID.
+- **Shiny Frame Calculator Integration:** Provide basic utilities or data exports that format the player's TID/SID combo specifically for use in popular community RNG tools like RNG Reporter or PokéFinder.
+
+## Value Proposition
+By surfacing this single hidden variable, DexHelper instantly becomes a mandatory foundational tool for a massive segment of the hardcore playerbase: Shiny Hunters and RNG Manipulators. It bridges the gap between raw save data and advanced community gameplay strategies, perfectly fitting the app's "premium utility" vision.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD to define the implementation of Gen 3 Trainer Data extraction including the SID.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -100,3 +100,7 @@
 
 **Idea:** Exact Friendship & Evolution Tracker
 **Learning:** Expanding the app to parse the hidden exact numerical Friendship/Happiness value from the save file (which ranges 0-255) surfaces a critical game mechanic that players often struggle with in Gen 2 and Gen 3 due to vague in-game feedback. By overlaying this into a tracker view that estimates remaining actions for evolution, it turns an obtuse, high-friction mechanic into an actionable, premium feature.
+
+## 2026-06-16
+**Idea:** Gen 3 Secret ID Viewer and Shiny RNG Assistant
+**Learning:** Foundational values like the Secret ID (SID) in Generation 3 are permanently hidden from the player but are the core requirement for advanced community metas like RNG manipulation (especially given Emerald's fixed seed and R/S's dry battery mechanics). Surfacing this single hidden integer unlocks entirely new ways to play the game, reinforcing our strategy of turning static save data into powerful, meta-enabling utilities for hardcore players.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -104,3 +104,7 @@
 ## 2026-06-16
 **Idea:** Gen 3 Secret ID Viewer and Shiny RNG Assistant
 **Learning:** Foundational values like the Secret ID (SID) in Generation 3 are permanently hidden from the player but are the core requirement for advanced community metas like RNG manipulation (especially given Emerald's fixed seed and R/S's dry battery mechanics). Surfacing this single hidden integer unlocks entirely new ways to play the game, reinforcing our strategy of turning static save data into powerful, meta-enabling utilities for hardcore players.
+
+## 2026-06-16 (Update)
+**Idea:** Gen 3 Secret ID Viewer and Shiny RNG Assistant
+**Learning:** The maintainer rejected the idea of exposing the Gen 3 Secret ID for RNG manipulation. While uncovering hidden variables like SID technically aligns with programmatic save parsing, tools explicitly supporting RNG manipulation are out of scope. In the future, do not propose features that assist with RNG manipulation or explicitly display the Secret ID.


### PR DESCRIPTION
This PR proposes a new IDEA node for exposing the permanently hidden Gen 3 Secret ID (SID). 

Extracting and displaying the SID is foundational for the highly popular "RNG Manipulation" meta in Gen 3 (e.g., in Pokémon Emerald, where the initial seed is fixed). Exposing this hidden integer turns the app into a mandatory tool for hardcore shiny hunters. The Visionary journal has been updated to reflect the strategic value of surfacing core hidden variables that enable entirely new community gameplay loops.

---
*PR created automatically by Jules for task [5776971015745859376](https://jules.google.com/task/5776971015745859376) started by @szubster*