### PR TITLE
🧭 Strategist: Prompt improvement - Ensure Canvas uses frontend_verification_instructions tool

### DIFF
--- a/.github/agents/canvas.md
+++ b/.github/agents/canvas.md
@@ -34,7 +34,7 @@ You have no memory between sessions. Your only persistence is what's committed t
 - Read your journal before starting — it's your only memory
 - Include a journal entry for the current change in every PR you open. Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability.
 - Run `pnpm lint` and `pnpm test` before pushing
-- Start the local dev server (`pnpm run dev`), write a temporary Python Playwright script to run a Core User Journey (CUJ), record a video to `/home/jules/verification/videos`, take a screenshot in `/home/jules/verification/screenshots`, and call the `frontend_verification_complete` tool to include before/after screenshots
+- Start the local dev server (`pnpm run dev`), then use the `frontend_verification_instructions` tool to get exact instructions on how to write a temporary Python Playwright script to verify your changes, capture screenshots/videos, and finalize verification using the `frontend_verification_complete` tool.
 - Keep changes to a single component or page — ambitious but scoped
 - Adhere to the project's tactical hardware/snooping aesthetic
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -244,3 +244,9 @@
 **Outcome:** Merged
 **Why:** The Agile Coach journal (`2026-06-14`) identified that the instructions for handling permanent failures (like reaching max rejection count) were inconsistent across the different agent personas. Some agents (like `coder` and `qa`) were instructed to use `CANCELLED` and explicitly warned not to use `FAILED` because it prevents the Orchestrator from formally dropping the node and waking up the parent for error recovery. Other agents (like `architect`, `epic_planner`, `product_manager`, `researcher`, `story_owner`, and `tech_lead`) were incorrectly instructed to use either `FAILED` or `CANCELLED`.
 **Pattern:** Codify system memory constraints regarding permanent node failures across all relevant agent prompts to ensure consistent error recovery behavior across the entire DAG hierarchy. When an execution node must gracefully exit the DAG because it is permanently failed or replaced, the agent responsible MUST update its status to `CANCELLED`, not `FAILED`.
+
+## 2026-07-12 - [Accepted] - Prompt improvement - Ensure Canvas uses frontend_verification_instructions tool
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The Canvas prompt instructed the agent to manually write Playwright scripts, but the system now provides the `frontend_verification_instructions` tool which provides exact, up-to-date headless environment instructions.
+**Pattern:** UI agents must explicitly use the `frontend_verification_instructions` tool instead of guessing Playwright setups in headless environments.


### PR DESCRIPTION
- Updated `.github/agents/canvas.md` to instruct the Canvas agent to use the `frontend_verification_instructions` tool instead of manually writing headless Playwright scripts.
- Added journal entry to `.jules/strategist.md`.

---
*PR created automatically by Jules for task [12409742528053366063](https://jules.google.com/task/12409742528053366063) started by @szubster*