### PR TITLE
Reject palette persona styling update task

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -24,3 +24,6 @@ Learned to carefully verify relative vs. logical offsets in Gen 3 blocks. For ex
 
 ## 2026-06-14: Rejecting Task due to Max Rejections
 Permanently failed `task-095-157-gen3-berry-dataview-parsing` since it reached the maximum rejection count of 3. The task was initially rejected due to incorrect offset calculations and the inclusion of implicit/missing data in the acceptance criteria, as noted earlier. Its status has been updated to CANCELLED to prevent it from looping in the resurrection loop indefinitely. `task-095-158-gen3-berry-dataview-parsing-qa` checkboxes were ticked so it gracefully exits the DAG as per Empty PR policy (ADR 007).
+
+## Missing Persona Prompt Updates (2026-06-16)
+Rejected `task-113-167-update-palette-persona-impl` because the coder completely failed to update the `.github/agents/palette.md` prompt file with the required changes (ownership of `src/index.css`, enforcing tactical hardware aesthetic, and managing custom `@utility` primitives via ADR 024). Agents must actually modify the files they are tasked with updating.

--- a/.foundry/tasks/task-113-167-update-palette-persona-impl.md
+++ b/.foundry/tasks/task-113-167-update-palette-persona-impl.md
@@ -2,7 +2,7 @@
 id: task-113-167-update-palette-persona-impl
 type: TASK
 title: Update palette agent prompt to define ownership of Tailwind styling
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-12'
 updated_at: '2026-06-16'
@@ -14,8 +14,8 @@ tags:
   - styling
   - agents
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'The palette persona prompt (.github/agents/palette.md) was not updated with the required changes (ownership of src/index.css, enforcing tactical hardware aesthetic, and managing custom @utility primitives via ADR 024).'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-113-168-update-palette-persona-qa.md
+++ b/.foundry/tasks/task-113-168-update-palette-persona-qa.md
@@ -25,6 +25,7 @@ notes: ''
 
 ## Objective
 Verify the changes implemented in `task-113-167-update-palette-persona-impl` to `.github/agents/palette.md`.
+**Validation Failed**: The implementation task failed to update .github/agents/palette.md with the required changes.
 
 ## Context
 The coder was tasked with updating the `palette` agent prompt to assign ownership of `src/index.css`, enforce the tactical hardware aesthetic, and manage custom `@utility` primitives via ADR 024. This verification task ensures those requirements were met.


### PR DESCRIPTION
The coder for `task-113-167-update-palette-persona-impl` completely failed to actually modify `.github/agents/palette.md` to establish ownership of `src/index.css` or manage custom `@utility` primitives via ADR 024.

Therefore, this QA task correctly identifies the failure and rejects the implementation task by updating its YAML frontmatter to FAILED, incrementing the rejection count, and recording the error in the QA journal.

---
*PR created automatically by Jules for task [16579330967875513179](https://jules.google.com/task/16579330967875513179) started by @szubster*