### PR TITLE
Remove Unnecessary TPM Journal Logging from Orchestrator

### DIFF
--- a/.foundry/tasks/task-076-179-remove-tpm-logging-orchestrator.md
+++ b/.foundry/tasks/task-076-179-remove-tpm-logging-orchestrator.md
@@ -31,5 +31,5 @@ Implement the removal of unnecessary logging statements from the orchestrator, a
 If you must abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
 
 ## Acceptance Criteria
-- [ ] Remove routine state transition and verification logging to the TPM journal from `.github/scripts/foundry-heartbeat.ts` and related files.
-- [ ] Ensure tests pass after removing the logging.
+- [x] Remove routine state transition and verification logging to the TPM journal from `.github/scripts/foundry-heartbeat.ts` and related files.
+- [x] Ensure tests pass after removing the logging.

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -68,11 +68,6 @@ ok: true,
     expect(writeCall[0]).toBe(mockNode.filePath);
     expect(writeCall[1]).toContain('status: READY');
     expect(writeCall[1]).toContain('jules_session_id: null');
-
-    expect(fs.appendFileSync).toHaveBeenCalled();
-    const appendCall = vi.mocked(fs.appendFileSync).mock.calls[0];
-    expect(appendCall[0]).toBe(path.join(mockRepoRoot, '.foundry', 'journals', 'tpm.md'));
-    expect(appendCall[1]).toContain('System failure detected for `task-1`');
   });
 
   it('should transition a node to FAILED if its Jules session is NOT_FOUND (404)', async () => {
@@ -159,7 +154,6 @@ ok: true,
     await main();
 
     expect(fs.writeFileSync).not.toHaveBeenCalled();
-    expect(fs.appendFileSync).not.toHaveBeenCalled();
   });
 
 
@@ -595,12 +589,6 @@ Body`;
     expect(fs.writeFileSync).toHaveBeenCalled();
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
     expect(writeCall[1]).toContain('status: FAILED');
-
-    // Also check the logToJournal call to make sure the message is correct
-    const appendCall = vi.mocked(fs.appendFileSync).mock.calls.find(call =>
-      typeof call[1] === 'string' && call[1].includes('PR #0 merged with unchecked tasks. `task-1` is now FAILED.')
-    );
-    expect(appendCall).toBeTruthy();
   });
 
     it('should transition leaf task with unchecked boxes to FAILED and set rejection_reason', async () => {
@@ -878,12 +866,6 @@ status: ACTIVE
       const deleteCalls = calls.filter(call => call[1]?.method === 'DELETE');
       expect(deleteCalls.length).toBe(1);
       expect(deleteCalls[0][0]).toContain('refs/heads/branch-delete');
-
-      expect(fs.appendFileSync).toHaveBeenCalled();
-      const appendCall = vi.mocked(fs.appendFileSync).mock.calls.find(call =>
-        typeof call[1] === 'string' && call[1].includes('Cleanup Loop deleted remote branch')
-      );
-      expect(appendCall).toBeTruthy();
 
       process.argv = originalArgv;
     });

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -10,7 +10,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import matter from 'gray-matter';
 import { discoverNodeFiles, parseNodeFile } from './foundry-orchestrator.ts';
-import { todayISO, logToJournal } from './dag-utils.ts';
+import { todayISO } from './dag-utils.ts';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -42,7 +42,6 @@ export async function transitionNodeToFailed(node: any, repoRoot: string, reject
 
   if (!DRY_RUN) {
     fs.writeFileSync(node.filePath, newContent, 'utf-8');
-    logToJournal(repoRoot, `\n- **${dateStr}**: Heartbeat detected zombie session for \`${node.frontmatter.id}\`. Transitioned to FAILED.\n`);
   }
   info(`${dryTag}Transitioned ACTIVE → FAILED: ${node.repoPath}`);
 }
@@ -85,7 +84,6 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
 
        if (!DRY_RUN) {
          fs.writeFileSync(node.filePath, newContent, 'utf-8');
-         logToJournal(repoRoot, `\n- **${dateStr}**: PR #${prNumber} merged but has unchecked tasks (parent node). \`${node.frontmatter.id}\` is now PENDING.\n`);
        }
        info(`${dryTag}Transitioned ACTIVE → PENDING: ${node.repoPath} (PR #${prNumber})`);
        return;
@@ -99,7 +97,6 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
 
        if (!DRY_RUN) {
          fs.writeFileSync(node.filePath, newContent, 'utf-8');
-         logToJournal(repoRoot, `\n- **${dateStr}**: PR #${prNumber} merged with unchecked tasks. \`${node.frontmatter.id}\` is now FAILED.\n`);
        }
        info(`${dryTag}Transitioned ACTIVE → FAILED: ${node.repoPath} (PR #${prNumber})`);
        return;
@@ -117,7 +114,6 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
 
     if (!DRY_RUN) {
       fs.writeFileSync(node.filePath, newContent, 'utf-8');
-      logToJournal(repoRoot, `\n- **${dateStr}**: PR #${prNumber} merged. \`${node.frontmatter.id}\` is now VERIFYING.\n`);
     }
     info(`${dryTag}Transitioned ACTIVE → VERIFYING: ${node.repoPath} (PR #${prNumber})`);
   } else {
@@ -130,7 +126,6 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
 
     if (!DRY_RUN) {
       fs.writeFileSync(node.filePath, newContent, 'utf-8');
-      logToJournal(repoRoot, `\n- **${dateStr}**: PR #${prNumber} merged. \`${node.frontmatter.id}\` is now COMPLETED.\n`);
     }
     info(`${dryTag}Transitioned ACTIVE → COMPLETED: ${node.repoPath} (PR #${prNumber})`);
   }
@@ -152,7 +147,6 @@ export async function transitionNodeToReady(node: any, repoRoot: string, reason:
     const newContent = matter.stringify(parsed.content, parsed.data);
     if (!DRY_RUN) {
       fs.writeFileSync(node.filePath, newContent, 'utf-8');
-      logToJournal(repoRoot, `\n- **${dateStr}**: Max rejection count reached for \`${node.frontmatter.id}\`. Reason: ${reason}. Transitioned to FAILED.\n`);
     }
     info(`${dryTag}Max rejection count reached → FAILED: ${node.repoPath} (${reason})`);
   } else {
@@ -165,7 +159,6 @@ export async function transitionNodeToReady(node: any, repoRoot: string, reason:
 
       if (!DRY_RUN) {
         fs.writeFileSync(node.filePath, newContent, 'utf-8');
-        logToJournal(repoRoot, `\n- **${dateStr}**: Resurrection Loop triggered for \`${node.frontmatter.id}\`. Reason: ${reason}. Transitioned back to VERIFYING.\n`);
       }
       info(`${dryTag}Resurrected → VERIFYING: ${node.repoPath} (${reason})`);
     } else {
@@ -176,7 +169,6 @@ export async function transitionNodeToReady(node: any, repoRoot: string, reason:
 
       if (!DRY_RUN) {
         fs.writeFileSync(node.filePath, newContent, 'utf-8');
-        logToJournal(repoRoot, `\n- **${dateStr}**: Resurrection Loop triggered for \`${node.frontmatter.id}\`. Reason: ${reason}. Transitioned back to READY.\n`);
       }
       info(`${dryTag}Resurrected → READY: ${node.repoPath} (${reason})`);
     }
@@ -202,7 +194,6 @@ export async function transitionNodeToReadyWithoutPenalty(node: any, repoRoot: s
 
     if (!DRY_RUN) {
       fs.writeFileSync(node.filePath, newContent, 'utf-8');
-      logToJournal(repoRoot, `\n- **${dateStr}**: System failure detected for \`${node.frontmatter.id}\`. Reason: ${reason}. Transitioned back to VERIFYING without penalty.\n`);
     }
     info(`${dryTag}System failure detected → VERIFYING: ${node.repoPath} (${reason})`);
   } else {
@@ -215,7 +206,6 @@ export async function transitionNodeToReadyWithoutPenalty(node: any, repoRoot: s
 
     if (!DRY_RUN) {
       fs.writeFileSync(node.filePath, newContent, 'utf-8');
-      logToJournal(repoRoot, `\n- **${dateStr}**: System failure detected for \`${node.frontmatter.id}\`. Reason: ${reason}. Transitioned back to READY without penalty.\n`);
     }
     info(`${dryTag}System failure detected → READY: ${node.repoPath} (${reason})`);
   }
@@ -473,7 +463,6 @@ export async function cleanupRemoteBranches(repoRoot: string, repoFullName: stri
     }
 
     // 4. Delete branches
-    const dateStr = todayISO();
     for (const branch of branchesToDelete) {
       if (DRY_RUN) {
         info(`[DRY-RUN] Would delete remote branch: ${branch}`);
@@ -485,7 +474,6 @@ export async function cleanupRemoteBranches(repoRoot: string, repoFullName: stri
 
         if (deleteRes.ok || deleteRes.status === 404 /* already deleted? */) {
           info(`Deleted remote branch: ${branch}`);
-          logToJournal(repoRoot, `\n- **${dateStr}**: Cleanup Loop deleted remote branch \`${branch}\`.\n`);
         } else {
           warn(`Failed to delete remote branch ${branch}: ${deleteRes.status} ${deleteRes.statusText}`);
         }


### PR DESCRIPTION
Removed routine state transition and verification logging to the TPM journal from `.github/scripts/foundry-heartbeat.ts` to prevent journal bloat, as per task `task-076-179-remove-tpm-logging-orchestrator`.

Changes:
- Removed `logToJournal` import and calls from `.github/scripts/foundry-heartbeat.ts`.
- Removed `fs.appendFileSync` assertions from `.github/scripts/foundry-heartbeat.test.ts`.
- Updated task markdown `.foundry/tasks/task-076-179-remove-tpm-logging-orchestrator.md` acceptance criteria checkboxes.

---
*PR created automatically by Jules for task [10031438533348375144](https://jules.google.com/task/10031438533348375144) started by @szubster*