### PR TITLE
Fix late-binding orchestrator parent dependency validation

### DIFF
--- a/.foundry/tasks/task-116-169-verify-late-binding-impl.md
+++ b/.foundry/tasks/task-116-169-verify-late-binding-impl.md
@@ -37,6 +37,6 @@ Verify the late-binding logic in the orchestrator and add any missing test cases
 - Ensure test changes are robust and maintain current testing patterns. Do not modify global graph state tests without extreme caution.
 
 ## Acceptance Criteria
-- [ ] Review late-binding logic (`Late-Binding Parent` handling, exceptions for PENDING parents) in `.github/scripts/foundry-orchestrator.ts`.
-- [ ] Add or verify comprehensive test cases for late-binding logic in `.github/scripts/foundry-orchestrator.test.ts`.
-- [ ] Ensure `pnpm test` passes.
+- [x] Review late-binding logic (`Late-Binding Parent` handling, exceptions for PENDING parents) in `.github/scripts/foundry-orchestrator.ts`.
+- [x] Add or verify comprehensive test cases for late-binding logic in `.github/scripts/foundry-orchestrator.test.ts`.
+- [x] Ensure `pnpm test` passes.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1959,4 +1959,48 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     expect(epicContent).toContain('status: READY');
   });
 
+  test('Late-Binding: Child of PENDING parent should be blocked if parent dependencies are incomplete', () => {
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    createValidTestNode(tmpDir, '.foundry/epics/epic-002.md', {
+      id: "epic-002",
+      type: "EPIC",
+      title: "Epic 2",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/epics/epic-001.md"], // Parent depends on Epic 1
+      jules_session_id: null,
+    });
+
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/epics/epic-002.md",
+      jules_session_id: null,
+    });
+
+    main();
+
+    const storyResult = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-001.md'), 'utf-8');
+    expect(storyResult).toContain('status: PENDING'); // Should be blocked
+  });
+
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -696,7 +696,20 @@ function main(): void {
         const parentChildren = parentToChildren.get(currParent) || [];
         if (parentStatus === 'PENDING' && parentChildren.length > 0) {
           // Exception for Late-Binding: If parent is PENDING and has children,
-          // it is waiting for those children. Do not block the child.
+          // it is waiting for those children. Do not block the child...
+          // UNLESS the parent itself has incomplete dependencies.
+          let isParentDepIncomplete = false;
+          for (const depRef of parentNode.frontmatter.depends_on) {
+            const depPath = resolveNodePath(depRef)!;
+            if (isHierarchicallyIncomplete(depPath, node.repoPath)) {
+              isParentDepIncomplete = true;
+              break;
+            }
+          }
+          if (isParentDepIncomplete) {
+            blocked = true;
+            break;
+          }
         } else {
           blocked = true;
           break;


### PR DESCRIPTION
- Ensures children of PENDING late-binding parents are blocked if the parent itself has incomplete explicit dependencies.
- Added corresponding tests for late-binding parent dependency checking.

---
*PR created automatically by Jules for task [5356210822608745937](https://jules.google.com/task/5356210822608745937) started by @szubster*