### PR TITLE
Update palette agent prompt to define ownership of Tailwind styling

### DIFF
--- a/.foundry/tasks/task-113-167-update-palette-persona-impl.md
+++ b/.foundry/tasks/task-113-167-update-palette-persona-impl.md
@@ -34,8 +34,8 @@ As per `story-077-113-update-palette-persona` and `ADR 024`, the Tailwind v4 mig
 4. Modify the boundary "Use existing design system classes — don't add custom CSS" to reflect that `palette` CAN and SHOULD maintain custom `@utility` primitives in `src/index.css` for the design system.
 
 ## Acceptance Criteria
-- [ ] `.github/agents/palette.md` is updated to define `palette` ownership of `src/index.css`.
-- [ ] `.github/agents/palette.md` explicitly tasks the `palette` persona with enforcing the tactical hardware aesthetic and managing custom `@utility` primitives via ADR 024.
+- [x] `.github/agents/palette.md` is updated to define `palette` ownership of `src/index.css`.
+- [x] `.github/agents/palette.md` explicitly tasks the `palette` persona with enforcing the tactical hardware aesthetic and managing custom `@utility` primitives via ADR 024.
 
 ## Critical Reminders
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/.github/agents/palette.md
+++ b/.github/agents/palette.md
@@ -1,9 +1,11 @@
 # Palette — UX & Accessibility
 
 Find and implement ONE micro-UX improvement that makes the interface more intuitive, accessible, or pleasant.
+You are the designated owner of `src/index.css`.
 
 ## Focus Areas
 
+- Enforcing the tactical hardware aesthetic (sharp edges `rounded-none`, dashed borders `border-dashed`, monospaced telemetry fonts `font-mono`)
 - Missing ARIA labels, roles, or descriptions on interactive elements
 - Insufficient color contrast or missing focus-visible states
 - Missing loading, empty, error, or disabled states
@@ -16,7 +18,7 @@ Find and implement ONE micro-UX improvement that makes the interface more intuit
 **Always:**
 - Run `pnpm lint` and `pnpm test` before opening a PR
 - Add ARIA attributes where appropriate
-- Use existing design system classes — don't add custom CSS
+- Use existing design system classes, but you CAN and SHOULD maintain custom `@utility` primitives in `src/index.css` for the design system per ADR 024
 - Keep changes under 50 lines
 
 **Ask first:**

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -26,7 +26,7 @@
       "types": "recommended"
     },
     "rules": {
-      "preset": "recommended",
+      "recommended": true,
       "nursery": {
         "useSortedClasses": {
           "level": "error",
@@ -40,13 +40,13 @@
         "useSimpleNumberKeys": "off"
       },
       "correctness": {
-        "preset": "recommended"
+        "recommended": true
       },
       "style": {
         "useNodejsImportProtocol": "error"
       },
       "security": {
-        "preset": "recommended"
+        "recommended": true
       }
     }
   },

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -26,7 +26,7 @@
       "types": "recommended"
     },
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "nursery": {
         "useSortedClasses": {
           "level": "error",
@@ -40,13 +40,13 @@
         "useSimpleNumberKeys": "off"
       },
       "correctness": {
-        "recommended": true
+        "preset": "recommended"
       },
       "style": {
         "useNodejsImportProtocol": "error"
       },
       "security": {
-        "recommended": true
+        "preset": "recommended"
       }
     }
   },


### PR DESCRIPTION
Updates the `palette` scheduled agent persona to assign ownership of `src/index.css`, enforce strict tactical aesthetic constraints (sharp edges, dashed borders, monospaced telemetry fonts), and clarify its boundary guidelines to allow maintenance of custom `@utility` primitives in accordance with ADR 024. Also marks the corresponding task node acceptance criteria as completed.

---
*PR created automatically by Jules for task [900870093737595506](https://jules.google.com/task/900870093737595506) started by @szubster*