### PR TITLE
chore: suspend task pending research on gen3 battle frontier data types

### DIFF
--- a/.foundry/research/research-121-188-gen3-battle-frontier-win-streak-types.md
+++ b/.foundry/research/research-121-188-gen3-battle-frontier-win-streak-types.md
@@ -1,0 +1,40 @@
+---
+id: research-121-188-gen3-battle-frontier-win-streak-types
+type: RESEARCH
+title: Gen 3 Battle Frontier Win Streak Data Types
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-121-171-gen3-parse-battle-frontier-win-streaks-impl
+tags:
+  - research
+  - gen3
+  - endgame
+research_references:
+  - research-046-140-gen3-battle-frontier
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Gen 3 Battle Frontier Win Streak Data Types
+
+## Context
+The previous offset research (`research-046-140-gen3-battle-frontier`) provided the memory offsets for the Battle Frontier win streaks but did not specify the exact data types, byte sizes, or if these are single integers or arrays.
+
+## Requirements
+Determine the exact data size (e.g. 16-bit vs 32-bit integer) and structure (single value or array) for each of the 7 Battle Frontier facility win streaks and records:
+- `towerWinStreaks` / `towerRecordWinStreaks`
+- `domeWinStreaks` / `domeRecordWinStreaks`
+- `palaceWinStreaks` / `palaceRecordWinStreaks`
+- `arenaWinStreaks` / `arenaRecordStreaks`
+- `factoryWinStreaks` / `factoryRecordWinStreaks`
+- `pikeWinStreaks` / `pikeRecordStreaks`
+- `pyramidWinStreaks` / `pyramidRecordStreaks`
+
+## Acceptance Criteria
+- [ ] Identify data types and byte sizes for all 7 facility win streaks and records.
+- [ ] Update this document with the exact structures.

--- a/.foundry/tasks/task-121-171-gen3-parse-battle-frontier-win-streaks-impl.md
+++ b/.foundry/tasks/task-121-171-gen3-parse-battle-frontier-win-streaks-impl.md
@@ -2,11 +2,12 @@
 id: task-121-171-gen3-parse-battle-frontier-win-streaks-impl
 type: TASK
 title: Implement Gen 3 Parse Battle Frontier Win Streaks
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-13'
 updated_at: '2026-06-16'
-depends_on: []
+depends_on:
+  - research-121-188-gen3-battle-frontier-win-streak-types
 jules_session_id: '18094982712372041976'
 pr_number: null
 parent: story-078-121-gen3-parse-battle-frontier-win-streaks
@@ -17,7 +18,7 @@ tags:
 research_references:
   - research-046-140-gen3-battle-frontier
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Suspended pending research on exact data types and sizes for battle frontier win streaks'
 notes: ''
 ---
 


### PR DESCRIPTION
chore: suspend task pending research on gen3 battle frontier data types

Applied the Late Binding Protocol to spawn a research node for the
exact data types and byte sizes for the Gen 3 Battle Frontier win
streaks, as this context was missing from the offset research.
Updated the task frontmatter to FAILED and appended the research
dependency.

---
*PR created automatically by Jules for task [18094982712372041976](https://jules.google.com/task/18094982712372041976) started by @szubster*