### PR TITLE
feat: define HiddenItemData interface

### DIFF
--- a/.foundry/tasks/task-125-177-define-hidden-item-data-model.md
+++ b/.foundry/tasks/task-125-177-define-hidden-item-data-model.md
@@ -37,5 +37,5 @@ This task defines the data model for Hidden Items based on the requirements of `
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 4. Acceptance Criteria
-- [ ] TypeScript interfaces for `HiddenItemData` are defined and exported.
-- [ ] The properties strictly follow the ADR 015 naming convention.
+- [x] TypeScript interfaces for `HiddenItemData` are defined and exported.
+- [x] The properties strictly follow the ADR 015 naming convention.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -140,6 +140,14 @@ export interface PokemonMetadata {
   det: CompactEvolutionDetail[]; // Evolutionary requirements to reach THIS pokemon from parent
 }
 
+export interface HiddenItemData {
+  flagOffset: number;
+  flagBit: number;
+  locationId: number;
+  itemId: number;
+  isAcquired?: boolean;
+}
+
 export interface PokeDataExport {
   poke: PokemonMetadata[];
   enc: LocationAreaEncounters[];


### PR DESCRIPTION
This PR defines the `HiddenItemData` TypeScript interface in `src/db/schema.ts` as requested by task-125-177. It includes properties for the flag offset, flag bit, location ID, item ID, and an optional acquisition state flag, adhering to the full readable naming convention specified in ADR 015. Acceptance criteria have been checked off in the markdown task.

---
*PR created automatically by Jules for task [6287487391234914636](https://jules.google.com/task/6287487391234914636) started by @szubster*