### PR TITLE
Complete QA for Gen 3 Mirage Island Parser

### DIFF
--- a/.foundry/tasks/task-099-186-mirage-island-parser-qa.md
+++ b/.foundry/tasks/task-099-186-mirage-island-parser-qa.md
@@ -34,10 +34,10 @@ The Coder has implemented the Gen 3 Mirage Island Parser. This QA task ensures t
 4.  **Test Coverage**: Review the added unit tests in `src/engine/saveParser/parsers/gen3.test.ts`. Verify they sufficiently cover both Ruby/Sapphire and Emerald variations, and edge cases. Run `pnpm test` to ensure all tests pass.
 
 ## Acceptance Criteria
-- [ ] Code properly extracts Mirage Island value using documented offsets.
-- [ ] Code strictly follows ADR 010 (DataView API).
-- [ ] `RangeError` is handled gracefully without crashing.
-- [ ] Unit tests are complete and passing.
+- [x] Code properly extracts Mirage Island value using documented offsets.
+- [x] Code strictly follows ADR 010 (DataView API).
+- [x] `RangeError` is handled gracefully without crashing.
+- [x] Unit tests are complete and passing.
 
 ## QA Persona Reminders
 - If you find defects or architecture violations, you MUST update the YAML frontmatter to `status: FAILED` with a clear `rejection_reason` so the Coder can fix it.


### PR DESCRIPTION
This PR completes the QA task for the Gen 3 Mirage Island parser by checking off all the acceptance criteria checkboxes in `.foundry/tasks/task-099-186-mirage-island-parser-qa.md`. Tests successfully cover the 16-bit little-endian reading behavior and the `RangeError` bounds checking using `DataView` API. No actual code changes are introduced, this simply validates the implementation.

---
*PR created automatically by Jules for task [1077307730495745622](https://jules.google.com/task/1077307730495745622) started by @szubster*