### PR TITLE
QA verify gen3 berry data parsing logic

### DIFF
--- a/.foundry/tasks/task-095-184-gen3-berry-dataview-parsing-retry-qa.md
+++ b/.foundry/tasks/task-095-184-gen3-berry-dataview-parsing-retry-qa.md
@@ -38,7 +38,7 @@ Verify the implementation of the extraction logic for Gen 3 berry patches, ensur
 - IMPORTANT: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verify `DataView` reading logic for Gen 3 berry patches implementation uses the correct relative offset.
-- [ ] Verify graceful handling of bounds checking (throwing/catching `RangeError`) without process crash.
-- [ ] Verify explicit data is extracted correctly.
-- [ ] Verify implicit data (map ID, time planted, last watered time) are NOT included in the extraction schema.
+- [x] Verify `DataView` reading logic for Gen 3 berry patches implementation uses the correct relative offset.
+- [x] Verify graceful handling of bounds checking (throwing/catching `RangeError`) without process crash.
+- [x] Verify explicit data is extracted correctly.
+- [x] Verify implicit data (map ID, time planted, last watered time) are NOT included in the extraction schema.


### PR DESCRIPTION
QA verify that `src/engine/saveParser/parsers/gen3.ts` extraction logic adheres to specifications (e.g. usage of `DataView`, handling `RangeError` bounds gracefully without crashing, correctly using the relative offset `0x071C`, and accurately omitting implicit data like Map ID or planted times while getting explicit fields). Tests cover these requirements as seen passing smoothly. Also complete the task acceptance criteria checkboxes in `.foundry/tasks/task-095-184-gen3-berry-dataview-parsing-retry-qa.md`.

---
*PR created automatically by Jules for task [3223297852091900288](https://jules.google.com/task/3223297852091900288) started by @szubster*