### PR TITLE
Foundry: Reject task-128-181 (Missing Implementation)

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -24,3 +24,6 @@ Learned to carefully verify relative vs. logical offsets in Gen 3 blocks. For ex
 
 ## 2026-06-14: Rejecting Task due to Max Rejections
 Permanently failed `task-095-157-gen3-berry-dataview-parsing` since it reached the maximum rejection count of 3. The task was initially rejected due to incorrect offset calculations and the inclusion of implicit/missing data in the acceptance criteria, as noted earlier. Its status has been updated to CANCELLED to prevent it from looping in the resurrection loop indefinitely. `task-095-158-gen3-berry-dataview-parsing-qa` checkboxes were ticked so it gracefully exits the DAG as per Empty PR policy (ADR 007).
+
+## 2026-06-16: Missing Implementation Validation
+Rejected task-128-181-move-data-extraction-impl because the implementation was completely absent. The agent marked the task as complete but failed to write any move data extraction logic to the required files, meaning `data/db/moves.jsonl` was never generated. When verifying tasks, we must always check that the files are actually created and populated.

--- a/.foundry/tasks/task-128-181-move-data-extraction-impl.md
+++ b/.foundry/tasks/task-128-181-move-data-extraction-impl.md
@@ -2,7 +2,7 @@
 id: task-128-181-move-data-extraction-impl
 type: TASK
 title: Implement Move Data Extraction
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-13'
 updated_at: '2026-06-16'
@@ -15,8 +15,8 @@ tags:
   - build
   - db
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'The implementation is completely missing. scripts/generate-pokedata.ts does not contain any logic for move data extraction, and data/db/moves.jsonl is not generated.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-128-182-move-data-extraction-qa.md
+++ b/.foundry/tasks/task-128-182-move-data-extraction-qa.md
@@ -41,3 +41,6 @@ The coder has implemented move data extraction in `scripts/generate-pokedata.ts`
 - [ ] The generated data structure strictly follows the ADR 025 schema constraints.
 - [ ] Compaction logic effectively omits default/empty values to minimize payload size.
 - [ ] The generated `moves.jsonl` file is successfully created and verified.
+
+## QA Failure Note (2026-06-16)
+Rejected target task due to missing implementation.


### PR DESCRIPTION
The target implementation task `task-128-181-move-data-extraction-impl` was marked as complete, but the actual code to implement the move data extraction logic in `scripts/generate-pokedata.ts` was entirely missing, and `data/db/moves.jsonl` was never created.

As the QA agent, I have:
1. Updated the target task's YAML frontmatter to explicitly set `status: FAILED`, incremented the `rejection_count` to 1, and provided a clear `rejection_reason`.
2. Documented the failure in my QA task node (`task-128-182-move-data-extraction-qa`).
3. Added a new entry to the QA journal (`.foundry/journals/qa.md`) highlighting the issue.

---
*PR created automatically by Jules for task [3121992045520011283](https://jules.google.com/task/3121992045520011283) started by @szubster*