### PR TITLE
Foundry: Breakdown epic-040-065-gen3-contest-data-integration into explicit stories

### DIFF
--- a/.foundry/epics/epic-040-065-gen3-contest-data-integration.md
+++ b/.foundry/epics/epic-040-065-gen3-contest-data-integration.md
@@ -37,3 +37,7 @@ As derived from PRD `prd-070-040-gen3-contest-data-parsing`, this Epic handles i
 - [ ] Map the extracted Condition, Sheen, and Ribbon data to appropriate fields in the internal Pokémon data structure.
 - [ ] Confirm all existing Gen 1 and Gen 2 save parsing tests pass without modification.
 - [ ] Write integration tests confirming the parsing engine successfully processes full Gen 3 save files and maps contest data correctly.
+
+- [ ] .foundry/stories/story-065-141-gen3-contest-error-handling.md
+- [ ] .foundry/stories/story-065-142-gen3-contest-data-mapping.md
+- [ ] .foundry/stories/story-065-143-gen3-contest-integration-tests.md

--- a/.foundry/stories/story-065-141-gen3-contest-error-handling.md
+++ b/.foundry/stories/story-065-141-gen3-contest-error-handling.md
@@ -1,0 +1,36 @@
+---
+id: story-065-141-gen3-contest-error-handling
+type: STORY
+title: Gen 3 Contest Data Error Handling
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-040-065-gen3-contest-data-integration
+tags:
+  - feature
+  - gen3
+  - contests
+  - error-handling
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Gen 3 Contest Data Error Handling
+
+## 1. Context
+Derived from `epic-040-065-gen3-contest-data-integration`, this story ensures that out-of-bounds reads during contest data extraction propagate as specific validation errors. This is crucial for avoiding application crashes when encountering corrupted or incomplete save files.
+
+## 2. Requirements
+- Ensure that `parseGen3ConditionStats` and `parseGen3Ribbons` (or equivalent data extraction functions) properly catch `RangeError` from the `DataView` API.
+- Re-throw these `RangeError`s as descriptive validation errors (e.g., 'The save file is corrupted or incomplete.').
+- Validate that the existing logic correctly encapsulates these error-handling mechanisms without breaking the application state.
+
+## 3. Acceptance Criteria
+- [ ] Implement graceful error handling (e.g., `RangeError` from `DataView`) for corrupted or incomplete save segments within contest data extraction.
+- [ ] Ensure that errors are appropriately handled upstream in `parseGen3` and do not cause application crashes.

--- a/.foundry/stories/story-065-142-gen3-contest-data-mapping.md
+++ b/.foundry/stories/story-065-142-gen3-contest-data-mapping.md
@@ -1,0 +1,37 @@
+---
+id: story-065-142-gen3-contest-data-mapping
+type: STORY
+title: Gen 3 Contest Data Mapping
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on:
+  - story-065-141-gen3-contest-error-handling
+jules_session_id: null
+pr_number: null
+parent: epic-040-065-gen3-contest-data-integration
+tags:
+  - feature
+  - gen3
+  - contests
+  - mapping
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Gen 3 Contest Data Mapping
+
+## 1. Context
+Derived from `epic-040-065-gen3-contest-data-integration`, this story focuses on mapping the extracted contest data to the internal Pokémon instance structures (`PokemonInstance`).
+
+## 2. Requirements
+- Integrate the extracted `Gen3ConditionStats` and `Gen3Ribbons` into the `PokemonInstance` structure for Gen 3 saves.
+- When generating the `PokemonInstance` list for the `partyDetails` and `pcDetails` in `parseGen3`, ensure the correct data extraction logic for contest stats and ribbons is invoked and assigned to the respective Pokémon instances.
+- Ensure backwards compatibility: Gen 1 and Gen 2 parsing interfaces must remain unmodified and fully functional.
+
+## 3. Acceptance Criteria
+- [ ] Map the extracted Condition, Sheen, and Ribbon data to the appropriate `condition` and `ribbons` fields in the internal Pokémon data structure (`PokemonInstance`).
+- [ ] Confirm all existing Gen 1 and Gen 2 save parsing tests pass without modification.

--- a/.foundry/stories/story-065-143-gen3-contest-integration-tests.md
+++ b/.foundry/stories/story-065-143-gen3-contest-integration-tests.md
@@ -1,0 +1,35 @@
+---
+id: story-065-143-gen3-contest-integration-tests
+type: STORY
+title: Gen 3 Contest Integration Tests
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on:
+  - story-065-142-gen3-contest-data-mapping
+jules_session_id: null
+pr_number: null
+parent: epic-040-065-gen3-contest-data-integration
+tags:
+  - tests
+  - gen3
+  - contests
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Gen 3 Contest Integration Tests
+
+## 1. Context
+Derived from `epic-040-065-gen3-contest-data-integration`, this story is responsible for validating that the end-to-end extraction and mapping of contest data for Gen 3 works flawlessly.
+
+## 2. Requirements
+- Write integration tests in the save parser suite that validate full Gen 3 save files correctly map contest data (Conditions, Sheen, Ribbons) to `PokemonInstance` objects.
+- Ensure tests verify both successful parsing and correct extraction mapping for contest stats.
+
+## 3. Acceptance Criteria
+- [ ] Write integration tests confirming the parsing engine successfully processes full Gen 3 save files and maps contest data correctly.


### PR DESCRIPTION
This PR fulfills the responsibilities of the `story_owner` persona by evaluating `epic-040-065-gen3-contest-data-integration` and scheduling its concrete implementation steps.

Three distinct stories have been created to encapsulate error propagation, data mapping to the PokeData struct, and integration testing for Gen 3 Contest parsing:
- `story-065-141-gen3-contest-error-handling`
- `story-065-142-gen3-contest-data-mapping`
- `story-065-143-gen3-contest-integration-tests`

The parent EPIC node has been updated to track these children while remaining in the active DAG loop.

---
*PR created automatically by Jules for task [13736269028627570356](https://jules.google.com/task/13736269028627570356) started by @szubster*