### PR TITLE
chore(foundry): breakdown story-061-099 into tasks

### DIFF
--- a/.foundry/stories/story-061-099-implement-mirage-island-parser.md
+++ b/.foundry/stories/story-061-099-implement-mirage-island-parser.md
@@ -33,5 +33,5 @@ With the data offsets located, we need to implement the actual parser for the Ge
 
 ## Acceptance Criteria
 - [x] Tech Lead: Generate child tasks to implement the parsing logic and integrate it into the parser engine.
-- [ ] task-099-185-mirage-island-parser-impl
-- [ ] task-099-186-mirage-island-parser-qa
+- [ ] task-099-192-mirage-island-parser-impl
+- [ ] task-099-193-mirage-island-parser-qa

--- a/.foundry/tasks/task-099-192-mirage-island-parser-impl.md
+++ b/.foundry/tasks/task-099-192-mirage-island-parser-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-099-192-mirage-island-parser-impl
+type: TASK
+title: Implement Mirage Island Parser Engine Logic
+status: READY
+owner_persona: coder
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-061-099-implement-mirage-island-parser
+tags:
+  - feature
+  - gen3
+  - parser
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Mirage Island Parser Engine Logic
+
+## Context
+We need to implement the Gen 3 save parser logic for extracting the Mirage Island value. This is a technical blueprint for the coder to execute.
+
+## Requirements
+- Update the Gen 3 save parser engine to extract the Mirage Island value using the located offsets (0x0408 for RS, 0x0464 for Emerald).
+- Strictly adhere to ADR 010: Use the `DataView` API exclusively. Do not use raw `Uint8Array` manipulations.
+- Implement graceful error handling: Catch `RangeError` on out-of-bounds reads and propagate them as specific validation errors (e.g., "Corrupted Save File").
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement the Mirage Island parsing logic using `DataView`.
+- [ ] Ensure out-of-bounds `RangeError`s are caught and handled gracefully.
+- [ ] Update the parent story `.foundry/stories/story-061-099-implement-mirage-island-parser.md` by checking off this task's checkbox.

--- a/.foundry/tasks/task-099-193-mirage-island-parser-qa.md
+++ b/.foundry/tasks/task-099-193-mirage-island-parser-qa.md
@@ -1,0 +1,39 @@
+---
+id: task-099-193-mirage-island-parser-qa
+type: TASK
+title: QA - Mirage Island Parser Logic
+status: READY
+owner_persona: qa
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on:
+  - task-099-192-mirage-island-parser-impl
+jules_session_id: null
+pr_number: null
+parent: story-061-099-implement-mirage-island-parser
+tags:
+  - test
+  - gen3
+  - parser
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Mirage Island Parser Logic
+
+## Context
+We need to verify that the Gen 3 save parser logic for extracting the Mirage Island value is implemented correctly and safely.
+
+## Requirements
+- Write unit tests to confirm the Mirage Island value is parsed correctly using the `DataView` API.
+- Write tests to explicitly verify that out-of-bounds reads throw a `RangeError` and are handled gracefully by the parser.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify unit tests confirm successful parsing using `DataView`.
+- [ ] Verify unit tests confirm graceful error handling for `RangeError`.
+- [ ] Update the parent story `.foundry/stories/story-061-099-implement-mirage-island-parser.md` by checking off this task's checkbox.


### PR DESCRIPTION
This PR breaks down the `story-061-099-implement-mirage-island-parser` into actionable `TASK` nodes for the coder and QA personas, mapping the technical contracts outlined in the ADRs.

---
*PR created automatically by Jules for task [15307249867100214766](https://jules.google.com/task/15307249867100214766) started by @szubster*