### PR TITLE
Update ADR 001 with strict macro node completion rules

### DIFF
--- a/.foundry/stories/story-071-109-update-adr001-macro-node-completion.md
+++ b/.foundry/stories/story-071-109-update-adr001-macro-node-completion.md
@@ -36,3 +36,4 @@ Update `.foundry/docs/adrs/001-the-foundry-architecture.md` (ADR 001) to reflect
 
 ## Tasks
 - [ ] task-109-161-update-adr001-macro-node-completion-impl
+- [ ] .foundry/tasks/task-109-192-update-adr001-formatting-rules-impl.md

--- a/.foundry/tasks/task-109-192-update-adr001-formatting-rules-impl.md
+++ b/.foundry/tasks/task-109-192-update-adr001-formatting-rules-impl.md
@@ -1,0 +1,44 @@
+---
+id: task-109-192-update-adr001-formatting-rules-impl
+type: TASK
+title: Update ADR 001 with parent-child formatting rules for macro nodes
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on:
+  - task-109-161-update-adr001-macro-node-completion-impl
+jules_session_id: null
+pr_number: null
+parent: story-071-109-update-adr001-macro-node-completion
+tags:
+  - orchestrator
+  - adr
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update ADR 001 with parent-child formatting rules for macro nodes
+
+## Context
+Macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) cannot complete until all descendant nodes are `COMPLETED`. We must update our architectural documentation to instruct personas on how to correctly format these parent-child relationships.
+
+## Objective
+Update `.foundry/docs/adrs/001-the-foundry-architecture.md` (ADR 001) to detail how personas must format parent-child relationships to comply with macro node completion constraints.
+
+## Requirements
+1. Update `.foundry/docs/adrs/001-the-foundry-architecture.md` (ADR 001), specifically Section 7 ("System Invariants") or a related section, to state the following rules for generating child nodes:
+   - Append references to newly generated child nodes as unchecked tasks (`- [ ] <file_path>`) directly into the markdown body of the parent node.
+   - Do NOT modify the parent's YAML frontmatter.
+   - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+   - Do NOT submit an Empty PR to transition a macro node to VERIFYING until ALL of its generated child nodes have transitioned to COMPLETED.
+2. This is a low-risk documentation task, so the Coder is responsible for self-verifying. No separate QA task is required.
+3. Reminder for Coder/QA: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to status: FAILED with a rejection_reason.
+4. Reminder for Coder/QA: If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to status: CANCELLED with a rejection_reason.
+5. Reminder for Coder/QA: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Update `001-the-foundry-architecture.md` to detail how to format parent-child relationships for macro nodes.


### PR DESCRIPTION
This PR addresses the missing formatting requirements for Story 071-109. It introduces a new technical blueprint (Task 109-192) that explicitly directs the Coder to update ADR 001 with the macro node parent-child formatting rules.

The new task is sequenced sequentially to the existing `task-109-161` implementation using the `depends_on` array to prevent DAG conflicts. Mandatory error-handling and failure reporting reminders for Coder and QA personas have been included in the blueprint as required by Tech Lead guidelines.

---
*PR created automatically by Jules for task [17279393343569169577](https://jules.google.com/task/17279393343569169577) started by @szubster*