### PR TITLE
docs(foundry): Handle PV extraction permanent child failures

### DIFF
--- a/.foundry/research/research-098-189-investigate-pv-extraction-failure.md
+++ b/.foundry/research/research-098-189-investigate-pv-extraction-failure.md
@@ -1,0 +1,34 @@
+---
+id: research-098-189-investigate-pv-extraction-failure
+type: RESEARCH
+title: Investigate PV extraction failures
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-062-098-gen3-parse-32bit-pv
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Investigate PV extraction failures
+
+## Context
+The Gen 3 PV extraction tasks (e.g. 169, 183) keep resulting in permanent child failures, causing a retry loop. We need to investigate why the implementation of `DataView` parsing for the 32-bit PV is failing.
+
+## Requirements
+1. Investigate the root cause of the previous implementation and QA failures.
+2. Provide a detailed summary of what needs to change to successfully implement the `DataView` parsing.
+3. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+
+## Acceptance Criteria
+- [ ] Root cause of PV extraction failures identified.
+- [ ] Proposed solution documented for the next iteration of the implementation task.

--- a/.foundry/stories/story-062-098-gen3-parse-32bit-pv.md
+++ b/.foundry/stories/story-062-098-gen3-parse-32bit-pv.md
@@ -37,3 +37,6 @@ As part of the Mirage Island checking feature (Epic `epic-038-062-personality-va
 - [ ] task-098-170-extract-32bit-pv-qa
 - [ ] task-098-183-extract-32bit-pv-impl
 - [ ] task-098-184-extract-32bit-pv-qa
+- [ ] .foundry/research/research-098-189-investigate-pv-extraction-failure.md
+- [ ] .foundry/tasks/task-098-192-extract-32bit-pv-impl.md
+- [ ] .foundry/tasks/task-098-193-extract-32bit-pv-qa.md

--- a/.foundry/tasks/task-098-170-extract-32bit-pv-qa.md
+++ b/.foundry/tasks/task-098-170-extract-32bit-pv-qa.md
@@ -36,3 +36,6 @@ The coder has implemented the extraction of the 32-bit personality value (PV) fo
 - [x] Verify Gen 3 PV extraction uses `DataView`.
 - [x] Verify `RangeError` propagation for out-of-bounds reads.
 - [x] Verify Gen 1 and 2 handlers are functional.
+
+### Auditor Rejection
+This task is CANCELLED and replaced by new tasks due to permanent child failures.

--- a/.foundry/tasks/task-098-192-extract-32bit-pv-impl.md
+++ b/.foundry/tasks/task-098-192-extract-32bit-pv-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-098-192-extract-32bit-pv-impl
+type: TASK
+title: Extract 32-bit PV using DataView
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on:
+  - research-098-189-investigate-pv-extraction-failure
+jules_session_id: null
+pr_number: null
+parent: story-062-098-gen3-parse-32bit-pv
+tags:
+  - feature
+  - gen3
+  - mirage-island
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extract 32-bit PV using DataView
+
+## Context
+As part of the Mirage Island checking feature, we need to parse the full 32-bit personality value (PV) for Gen 3 Pokémon. This requires adhering to ADR 010 by using the native `DataView` API.
+
+## Requirements
+1. **DataView Usage:** The parser MUST use the `DataView` API (e.g., `getUint32`) to safely extract the 32-bit PV instead of raw array access.
+2. **Bounds Checking:** Ensure the parser propagates the `RangeError` thrown by `DataView` when attempting out-of-bounds reads. Catch the error, and either throw a clear error message (e.g., "Corrupted Save File") or propagate it up.
+3. **Backwards Compatibility:** Ensure that Gen 1 and Gen 2 legacy handlers continue to work without modification.
+4. **Resilience Contract:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+5. **Completion Contract:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement `DataView` extraction for the Gen 3 32-bit PV.
+- [ ] Explicitly propagate `RangeError` from out-of-bounds reads.
+- [ ] Ensure Gen 1 and Gen 2 legacy parsing remains functional.

--- a/.foundry/tasks/task-098-193-extract-32bit-pv-qa.md
+++ b/.foundry/tasks/task-098-193-extract-32bit-pv-qa.md
@@ -1,13 +1,13 @@
 ---
-id: task-098-184-extract-32bit-pv-qa
+id: task-098-193-extract-32bit-pv-qa
 type: TASK
 title: QA - Extract 32-bit PV using DataView
-status: COMPLETED
+status: PENDING
 owner_persona: qa
-created_at: '2026-06-14'
+created_at: '2026-06-16'
 updated_at: '2026-06-16'
 depends_on:
-  - task-098-183-extract-32bit-pv-impl
+  - task-098-192-extract-32bit-pv-impl
 jules_session_id: null
 pr_number: null
 parent: story-062-098-gen3-parse-32bit-pv
@@ -34,9 +34,6 @@ The coder has implemented the extraction logic for the 32-bit personality value 
 5. **Completion Contract:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [x] Verify `DataView` is used for Gen 3 PV extraction.
-- [x] Verify `RangeError` is propagated on out-of-bounds reads.
-- [x] Verify Gen 1 and Gen 2 parsing handlers are fully functional.
-
-### Auditor Rejection
-This task is CANCELLED and replaced by new tasks due to permanent child failures.
+- [ ] Verify `DataView` is used for Gen 3 PV extraction.
+- [ ] Verify `RangeError` is propagated on out-of-bounds reads.
+- [ ] Verify Gen 1 and Gen 2 parsing handlers are fully functional.


### PR DESCRIPTION
The Gen 3 PV extraction tasks (`task-098-169`, `task-098-183`) and their respective QA tasks have been failing permanently. This PR implements the mandated protocol for "Permanent Child Failures (The Impossible Loop)":
1. Created a `RESEARCH` node (`research-098-189-investigate-pv-extraction-failure`) to investigate the root cause.
2. Created a replacement implementation task (`task-098-192-extract-32bit-pv-impl`) that explicitly depends on the research node.
3. Created a replacement QA task (`task-098-193-extract-32bit-pv-qa`) that depends on the new impl task.
4. Appended the new nodes as unchecked tasks to the parent story `story-062-098-gen3-parse-32bit-pv`.
5. Updated the orphaned QA tasks (`170` and `184`) with an `### Auditor Rejection` block to indicate they are CANCELLED. YAML frontmatter was left untouched per the strict instructions.

---
*PR created automatically by Jules for task [18418332371483025447](https://jules.google.com/task/18418332371483025447) started by @szubster*