### PR TITLE
Foundry: Investigate TPM Journal Bloat

### DIFF
--- a/.foundry/ideas/idea-076-tpm-journal-bloat.md
+++ b/.foundry/ideas/idea-076-tpm-journal-bloat.md
@@ -36,5 +36,5 @@ The objective is to determine if the continuous logging into the TPM journal ind
 - [x] Analyze the research findings.
 - [x] Create a TASK node (if applicable) to implement the removal of the logging statements from the orchestrator.
 
-- [ ] .foundry/research/research-076-174-investigate-tpm-journal-bloat.md
-- [ ] .foundry/tasks/task-076-179-remove-tpm-logging-orchestrator.md
+- [ ] .foundry/research/research-076-189-investigate-tpm-journal-bloat.md
+- [ ] .foundry/tasks/task-076-194-remove-tpm-logging-orchestrator.md

--- a/.foundry/research/research-076-189-investigate-tpm-journal-bloat.md
+++ b/.foundry/research/research-076-189-investigate-tpm-journal-bloat.md
@@ -1,0 +1,31 @@
+---
+id: research-076-189-investigate-tpm-journal-bloat
+type: RESEARCH
+title: Investigate TPM Journal Bloat and Orchestrator Logging
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-076-tpm-journal-bloat
+tags:
+  - architecture
+  - logging
+  - orchestrator
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Investigate TPM Journal Bloat and Orchestrator Logging
+
+## Objective
+Investigate the Orchestrator script (`.github/scripts/foundry-orchestrator.ts`) and Foundry Engine GitHub Action to understand why and where it logs routine task verification and state transition updates to the TPM journal (`.foundry/journals/tpm.md`). Determine if this continuous logging indicates an underlying problem or if it's simply unnecessary logging that should be removed.
+
+## Acceptance Criteria
+- [ ] Identify the location(s) in the Orchestrator script or GitHub Action where logs are written to the TPM journal.
+- [ ] Analyze the purpose and necessity of these log statements.
+- [ ] Determine if the logging behavior is a symptom of a systemic issue or just unnecessary bloat.
+- [ ] Propose a solution (e.g., removing the logging statements) based on the findings.

--- a/.foundry/tasks/task-076-194-remove-tpm-logging-orchestrator.md
+++ b/.foundry/tasks/task-076-194-remove-tpm-logging-orchestrator.md
@@ -1,0 +1,32 @@
+---
+id: task-076-194-remove-tpm-logging-orchestrator
+type: TASK
+title: Remove TPM Journal Logging from Orchestrator
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on:
+  - research-076-189-investigate-tpm-journal-bloat
+jules_session_id: null
+pr_number: null
+parent: idea-076-tpm-journal-bloat
+tags:
+  - architecture
+  - logging
+  - orchestrator
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Remove TPM Journal Logging from Orchestrator
+
+## Objective
+Based on the findings from the RESEARCH node (`research-076-189-investigate-tpm-journal-bloat`), implement the proposed solution to remove unnecessary routine task verification and state transition logs from being written to the TPM journal (`.foundry/journals/tpm.md`) by the Orchestrator script (`.github/scripts/foundry-orchestrator.ts`) or the Foundry Engine GitHub Action.
+
+## Acceptance Criteria
+- [ ] Remove or update the logging statements identified in the research phase.
+- [ ] Ensure that no routine or unnecessary logs are written to the TPM journal during Orchestrator runs.
+- [ ] Verify that critical learnings or failures are still properly logged, if applicable according to the revised logging strategy.
+- [ ] Ensure all relevant tests pass.


### PR DESCRIPTION
- Add RESEARCH node to investigate TPM Journal Bloat in Orchestrator.
- Add TASK node to implement the findings.
- Update `idea-076-tpm-journal-bloat.md`'s acceptance criteria to include the new tasks.

---
*PR created automatically by Jules for task [5313855967279768764](https://jules.google.com/task/5313855967279768764) started by @szubster*