### PR TITLE
chore(research): investigate and correct gen 2 event flag offsets

### DIFF
--- a/.foundry/docs/knowledge_base/engine/save_parsing/gen2_generic_structure.md
+++ b/.foundry/docs/knowledge_base/engine/save_parsing/gen2_generic_structure.md
@@ -39,7 +39,17 @@ This document catalogs the save file offsets for Pokémon Gold, Silver, and Crys
 | **Owned Flags** | `0x2A4C` | `0x29CE` |
 | **Seen Flags** | `0x2A6C` | `0x29EE` |
 
-## 4. Item Inventory (Bank 1)
+## 4. Event Flags (Bank 1)
+
+| Field | GS (Standard) | Crystal (Standard) | Size | Notes |
+| :--- | :--- | :--- | :--- | :--- |
+| **English Event Flags** | `0x2624` | `0x2600` | 256 | 2048 flags. Offset is 0x100 bytes before Current PC Box. |
+| **Japanese Event Flags**| `0x2600` | `0x25E2` | 256 | Shifted back due to Japanese string encodings. |
+
+> [!NOTE]
+> Previous documentation falsely claimed `0x283E` (GS) and `0x281A` (Crystal) for Event Flags. Those offsets actually correspond to **Party Data** for English Crystal and Japanese Crystal respectively. `wEventFlags` is consistently located exactly 256 bytes prior to `wCurBox`.
+
+## 5. Item Inventory (Bank 1)
 
 | Pocket | GS (Standard) | Crystal (Standard) |
 | :--- | :--- | :--- |

--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -25,3 +25,6 @@ When implementing new pipeline states that involve temporary ownership handoffs 
   1.  **Missing Architectural Integration (ADR 018)**: `RouteRadarController` was created as an isolated class but was never integrated into the application's data flow (`Save State -> suggestionEngine -> RouteRadarController -> Heatmap State`) nor passed as props to the Map UI component.
   2.  **Data Schema Violation (ADR 015)**: The implementation continued to use the shortened data property `aid` (as seen in `encounter.aid`) instead of the fully expanded `areaId` property mandated by ADR 015 ("Revert Data Format Optimizations").
 Agents must ensure actual structural integration and strict adherence to data schema ADRs, not just isolated utility completion.
+
+### Lesson: Save File Offsets Trust
+When performing research on save file offsets, never blindly trust task descriptions or previous documentation if it conflicts with the disassembly. In task-095-157, the PM/author confused the Party Data offsets (0x283E/0x281A) with Event Flag offsets. Always cross-reference the WRAM memory map directly and calculate offsets by subtracting relative to known anchors (e.g., wCurBox).

--- a/.foundry/research/research-095-157-gen2-event-flag-offsets.md
+++ b/.foundry/research/research-095-157-gen2-event-flag-offsets.md
@@ -28,7 +28,19 @@ During the implementation of `task-095-157-gen2-event-flag-impl`, the exact memo
 To successfully extract the correct event flag bytes using the `DataView` API, we need precise offset mapping and to ensure the extracted bounds match what is required by the `eventFlags` property in `SaveData`.
 
 ## Tasks
-1. Investigate and document the exact start offset for event flags in both GS and Crystal saves.
-2. Determine the exact length of the event flags block.
-3. Confirm if any additional shifts occur depending on the specific locale version of the game or other variables.
-4. Update `.foundry/docs/knowledge_base/engine/save_parsing/gen2_generic_structure.md` with the verified offsets.
+- [x] 1. Investigate and document the exact start offset for event flags in both GS and Crystal saves.
+- [x] 2. Determine the exact length of the event flags block.
+- [x] 3. Confirm if any additional shifts occur depending on the specific locale version of the game or other variables.
+- [x] 4. Update `.foundry/docs/knowledge_base/engine/save_parsing/gen2_generic_structure.md` with the verified offsets.
+
+## Research Conclusion
+After analyzing the `pokecrystal` disassembly and cross-referencing with Bulbapedia's Generation II save structure:
+1. The initial assumption that event flags might be at `0x283E` (GS) or `0x281A` (Crystal) was incorrect. Those offsets actually correspond to the **Party Pokémon Data** for English Crystal and Japanese Crystal, respectively.
+2. The `wEventFlags` block is located exactly 256 bytes (`0x100`) before `wCurBox` (Current PC Box).
+3. The exact start offsets are:
+   - English Gold/Silver: `0x2624`
+   - English Crystal: `0x2600`
+   - Japanese Gold/Silver: `0x2600`
+   - Japanese Crystal: `0x25E2`
+4. The exact length of the event flags block is 256 bytes (representing 2048 flags/bits).
+5. Shifts do indeed occur based on the locale version of the game (Japanese versions are shifted backwards due to shorter string allocations for names and PC box names).


### PR DESCRIPTION
This PR completes `research-095-157-gen2-event-flag-offsets`. The investigation successfully discovered that previous assumptions about Gen 2 Event Flag offsets (e.g., `0x283E`) were actually pointing to Party Data. The true event flag offsets are correctly identified relative to the `wCurBox` anchor, and the `gen2_generic_structure.md` documentation has been updated to reflect these accurate offsets for both English and Japanese locales.

---
*PR created automatically by Jules for task [13234401548499381552](https://jules.google.com/task/13234401548499381552) started by @szubster*