### PR TITLE
docs(qa): mark late-binding qa task as verified

### DIFF
--- a/.foundry/tasks/task-116-170-verify-late-binding-qa.md
+++ b/.foundry/tasks/task-116-170-verify-late-binding-qa.md
@@ -36,6 +36,6 @@ Verify the test coverage added by the coder for the late-binding logic in `found
 - **CRITICAL**: If you submit an empty PR because the logic is already sound and tests are adequate, you MUST check off all Acceptance Criteria checkboxes before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009.
 
 ## Acceptance Criteria
-- [ ] Review the PR or changes made by the coder for `foundry-orchestrator.test.ts`.
-- [ ] Ensure that tests adequately cover the late-binding specific logic, including exceptions for children of PENDING parents and waking up PENDING parents.
-- [ ] Confirm that running `pnpm test` successfully executes the new tests without failures.
+- [x] Review the PR or changes made by the coder for `foundry-orchestrator.test.ts`.
+- [x] Ensure that tests adequately cover the late-binding specific logic, including exceptions for children of PENDING parents and waking up PENDING parents.
+- [x] Confirm that running `pnpm test` successfully executes the new tests without failures.


### PR DESCRIPTION
Completed the QA verification for the late-binding logic test coverage. The coder has implemented adequate tests in `foundry-orchestrator.test.ts` for late-binding behavior. All tests pass successfully and all acceptance criteria in the QA task node have been marked as complete.

---
*PR created automatically by Jules for task [6276965857860026590](https://jules.google.com/task/6276965857860026590) started by @szubster*