### PR TITLE
QA: Verify updates to palette agent prompt

### DIFF
--- a/.foundry/tasks/task-113-168-update-palette-persona-qa.md
+++ b/.foundry/tasks/task-113-168-update-palette-persona-qa.md
@@ -37,8 +37,8 @@ The coder was tasked with updating the `palette` agent prompt to assign ownershi
 4. Verify that the constraint prohibiting adding custom CSS has been removed or modified to allow for `@utility` definitions.
 
 ## Acceptance Criteria
-- [ ] Confirmed `.github/agents/palette.md` asserts `palette` ownership of `src/index.css`.
-- [ ] Confirmed `.github/agents/palette.md` tasks `palette` with enforcing tactical hardware aesthetic and managing custom `@utility` primitives.
+- [x] Confirmed `.github/agents/palette.md` asserts `palette` ownership of `src/index.css`.
+- [x] Confirmed `.github/agents/palette.md` tasks `palette` with enforcing tactical hardware aesthetic and managing custom `@utility` primitives.
 
 ## Critical Reminders
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.


### PR DESCRIPTION
Checked off the acceptance criteria for the QA task verifying updates to the palette agent prompt.

* `.github/agents/palette.md` was already confirmed to explicitly grant ownership of `src/index.css`.
* `.github/agents/palette.md` was confirmed to task `palette` with enforcing the tactical hardware aesthetic.
* `.github/agents/palette.md` was confirmed to permit custom `@utility` primitives management per ADR 024.

---
*PR created automatically by Jules for task [13569959418337710833](https://jules.google.com/task/13569959418337710833) started by @szubster*