### PR TITLE
🖼️ Canvas: Tactical Telemetry Datapoints Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -197,3 +197,9 @@
 **Outcome:** Accepted
 **Why:** Brings the fundamental app framing into the specialized hardware motif. The application no longer looks like a website occupying the browser window; it looks like a physical CRT terminal monitor displaying a war-room data grid.
 **Pattern:** Apply heavy, physical-looking frames and global screen-space overlays (vignettes, scanlines, hex grids) to the root application layout to permanently break the "web page" illusion and enforce the specialized device fantasy at the macro level.
+
+## 2026-07-21 - [Accepted] - 🖼️ Canvas: Tactical Telemetry Datapoints Redesign
+**What:** Redesigned the `DataPoint` and `InlineDataPoint` components to fully embrace the tactical "snooping" aesthetic. Added bracketed text (`[ LABEL ]`) for all telemetry headers, included LCD indicator dots and active scanning lines (hover states), and replaced generic flex layouts with rigid, segmented terminal block layouts (e.g. `bg-black/40 px-1 border-b border-dashed`).
+**Outcome:** Accepted
+**Why:** Brings the most granular, fundamental data readout components in line with the established specialized hardware motif. The previous datapoints were simple flex column text pairs, which broke the terminal simulation on dense screens (like the Header and Details Panel). Treating individual stats as active telemetry nodes reinforces the physical device fantasy.
+**Pattern:** Apply tactical aesthetics (bracketed telemetry labels, rigid block backgrounds, dashed borders acting as connection wires, and LCD indicator dots) even to the smallest, most atomic data display elements to maintain absolute visual coherence deep within complex data views.

--- a/src/components/DataPoint.tsx
+++ b/src/components/DataPoint.tsx
@@ -12,9 +12,21 @@ interface DataPointProps {
 
 export function DataPoint({ label, value, children, className, labelClassName, valueClassName }: DataPointProps) {
   return (
-    <div className={cn('relative flex flex-col border-zinc-800 border-l border-dashed pl-3', className)}>
-      <div className="absolute top-1.5 left-[-2px] h-1.5 w-1.5 border border-zinc-500 bg-zinc-950" />
-      <span className={cn('tactical-text mb-0.5 font-black text-[9px] text-zinc-500', labelClassName)}>{label}</span>
+    <div
+      className={cn(
+        'group relative flex flex-col border-zinc-800 border-l border-dashed pl-3 transition-colors hover:border-zinc-500 hover:bg-black/20',
+        className,
+      )}
+    >
+      <div className="absolute top-1.5 left-[-2px] h-1.5 w-1.5 border border-zinc-500 bg-zinc-950 transition-colors group-hover:border-[var(--theme-primary)] group-hover:bg-[var(--theme-primary)]" />
+      <span
+        className={cn(
+          'tactical-text mb-0.5 font-black text-[9px] text-zinc-500 tracking-widest transition-colors group-hover:text-zinc-400',
+          labelClassName,
+        )}
+      >
+        [ {label} ]
+      </span>
       <span className={cn('font-bold font-mono text-[11px] text-zinc-300 uppercase tracking-tight', valueClassName)}>
         {value || children}
       </span>

--- a/src/components/InlineDataPoint.tsx
+++ b/src/components/InlineDataPoint.tsx
@@ -19,11 +19,14 @@ export function InlineDataPoint({
   valueClassName,
 }: InlineDataPointProps) {
   return (
-    <div className={cn('flex items-center gap-2', className)}>
-      <span className={cn('tactical-text font-black text-[8px] text-zinc-500', labelClassName)}>{label}</span>
+    <div className={cn('relative flex items-center gap-2 border-zinc-800/50 border-b border-dashed pb-0.5', className)}>
+      <div className="absolute top-1.5 -left-1.5 h-0.5 w-0.5 bg-[var(--theme-primary)] opacity-50 shadow-[0_0_2px_var(--theme-primary)]" />
+      <span className={cn('tactical-text font-black text-[8px] text-zinc-500 tracking-widest', labelClassName)}>
+        [ {label} ]
+      </span>
       <span
         className={cn(
-          'font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-tight',
+          'bg-black/40 px-1 font-black font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-tight',
           valueClassName,
         )}
       >

--- a/src/components/__tests__/PokedexCard.test.tsx
+++ b/src/components/__tests__/PokedexCard.test.tsx
@@ -54,7 +54,7 @@ describe('PokedexCard', () => {
     await render(<RouterProvider router={router} />);
 
     // Test for ID styling
-    await expect.element(page.getByText('ID', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('[ ID ]', { exact: true })).toBeInTheDocument();
     await expect.element(page.getByText('001', { exact: true })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
- Updated `DataPoint` to have a darker hover block background and bracketed telemetry labels.
- Updated `InlineDataPoint` to have an absolute LCD indicator dot, dashed bottom border, segmented value background, and bracketed text.
- Fixed `PokedexCard.test.tsx` to match the new bracketed `[ ID ]` label.
- Logged new design pattern in `.jules/canvas.md`.

---
*PR created automatically by Jules for task [4945489111180710878](https://jules.google.com/task/4945489111180710878) started by @szubster*