### PR TITLE
🧹 Clean up unused interface and correct knip config

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -35,3 +35,4 @@ Before deleting code flagged as dead, always check the status of Foundry tasks (
 ## 2026-06-07 - Verify Unused Code Removals
 **Learning:** Tools like `knip` can identify unused exports and dependencies, but they sometimes have blind spots or misinterpret usage (especially for global configurations, setup scripts, or exported test helpers/fixtures).
 **Action:** When using tools like `knip` to find unused exports or files, always verify potential implicit usage with a global repository search (e.g., `grep`) before removing them to ensure they aren't dynamically referenced by tests or CI scripts.
+When using `knip` or similar tools for dead code analysis, always verify implicit usage with a global repository search (`grep`) before deleting files or exports. Standalone generator or ETL scripts meant to be executed directly will often be flagged as unused; these must be added to the `knip.json` ignore array rather than being deleted.

--- a/knip.json
+++ b/knip.json
@@ -12,7 +12,7 @@
     "scripts/validate-foundry-schema.ts",
     ".github/scripts/extract-research.ts",
     "scripts/gen3-fetch-locations.ts",
-    "src/components/dashboard/DagContext.tsx"
+    "scripts/data/gen3/match_call/etl.ts"
   ],
   "rules": {
     "files": "warn",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -140,14 +140,6 @@ export interface PokemonMetadata {
   det: CompactEvolutionDetail[]; // Evolutionary requirements to reach THIS pokemon from parent
 }
 
-export interface HiddenItemData {
-  flagOffset: number;
-  flagBit: number;
-  locationId: number;
-  itemId: number;
-  isAcquired?: boolean;
-}
-
 export interface PokeDataExport {
   poke: PokemonMetadata[];
   enc: LocationAreaEncounters[];


### PR DESCRIPTION
🎯 What
Removed unused `HiddenItemData` interface from `src/db/schema.ts` and corrected the `knip.json` configuration to properly ignore the standalone `scripts/data/gen3/match_call/etl.ts` script.

💡 Why
`HiddenItemData` was dead code. `scripts/data/gen3/match_call/etl.ts` is an operational standalone script but was being flagged as an unused file by `knip`. Updating the config removes the false positive without destroying necessary tooling.

✅ Verification
Ran `pnpm knip` to verify no more unused exports or configuration hints.
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no regressions were introduced.

✨ Result
A cleaner codebase with zero `knip` warnings and no dead interfaces.

---
*PR created automatically by Jules for task [16037274851217920376](https://jules.google.com/task/16037274851217920376) started by @szubster*