### PR TITLE
🧭 Strategist: Prompt improvement - Enforce Permanent Child Failure Protocol for Tech Lead

### DIFF
--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -44,7 +44,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 1. Spawn a `RESEARCH` node to investigate the root cause of the failure.
 2. Create a new set of replacement implementation and/or QA tasks that explicitly depend on the `RESEARCH` node being completed.
 3. Append these new nodes to your own markdown body.
-4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending `QA` task nodes associated with the failed implementation. Instead, update the orphaned QA task's Markdown body indicating that it is CANCELLED and replaced by the new tasks.
+4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending `QA` task nodes associated with the failed implementation. Instead, update the orphaned QA task's Markdown body indicating that it is CANCELLED and replaced by the new tasks, and append an `### Auditor Rejection` section.
 
 ### Handling Rejections & Aborts
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -250,3 +250,8 @@
 **Outcome:** Accepted
 **Why:** The Canvas prompt instructed the agent to manually write Playwright scripts, but the system now provides the `frontend_verification_instructions` tool which provides exact, up-to-date headless environment instructions.
 **Pattern:** UI agents must explicitly use the `frontend_verification_instructions` tool instead of guessing Playwright setups in headless environments.
+## 2026-06-17 - [Accepted] - Prompt improvement - Enforce Permanent Child Failure Protocol for Tech Lead
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The memory requires appending an '### Auditor Rejection' section to orphaned QA tasks during a permanent child failure to properly cancel it, which the Tech Lead prompt lacked.
+**Pattern:** Codify system memory constraints regarding permanent node failures across all relevant agent prompts to ensure consistent error recovery behavior across the entire DAG hierarchy.


### PR DESCRIPTION
**Proposal**: Require Tech Lead to append an `### Auditor Rejection` section to orphaned QA tasks during the Impossible Loop.

**Justification**: The Tech Lead is responsible for handling the impossible loop, but was missing the instruction to add the auditor rejection section to the markdown.

**Evidence**: Memory explicitly states: "append an '### Auditor Rejection' section to the orphaned QA task's markdown body indicating it is CANCELLED without altering its YAML frontmatter."

---
*PR created automatically by Jules for task [3158185979797738873](https://jules.google.com/task/3158185979797738873) started by @szubster*