### PR TITLE
🧹 chore: mark stories as completed in epic-044-070

### DIFF
--- a/.foundry/epics/epic-044-070-hof-data-parsing.md
+++ b/.foundry/epics/epic-044-070-hof-data-parsing.md
@@ -29,5 +29,5 @@ This epic covers the implementation details for extracting Hall of Fame data fro
 ## Acceptance Criteria
 - [x] Break down into Stories
 
-- [ ] story-070-111-parse-gen1-hof-data
-- [ ] story-070-112-parse-gen2-hof-data
+- [x] story-070-111-parse-gen1-hof-data
+- [x] story-070-112-parse-gen2-hof-data


### PR DESCRIPTION
Checked off the accepted criteria checkboxes in `.foundry/epics/epic-044-070-hof-data-parsing.md` for stories `story-070-111-parse-gen1-hof-data` and `story-070-112-parse-gen2-hof-data` because these stories have already been marked as `COMPLETED`. Since the target artifacts already existed, submitted via Empty PR Policy.

---
*PR created automatically by Jules for task [14316212376036294405](https://jules.google.com/task/14316212376036294405) started by @szubster*