### PR TITLE
chore(foundry): verify tactical-button and tactical-focus utilities in story 114

### DIFF
--- a/.foundry/stories/story-074-114-define-tactical-button-and-focus.md
+++ b/.foundry/stories/story-074-114-define-tactical-button-and-focus.md
@@ -30,6 +30,6 @@ Extract and consolidate common, repetitive Tailwind class patterns used for butt
 3. **Verify Compliance**: Ensure custom utilities correctly use `@apply` or raw CSS to define the desired baseline "tactical hardware" aesthetic as dictated by ADR 024. Ensure hover and focus states can be correctly inherited natively through v4's directive structure.
 
 ## Acceptance Criteria
-- [ ] Appropriate `@utility tactical-button` and `@utility tactical-focus` primitives are defined in `src/index.css`.
-- [ ] Tailwind v4 formatting and structure is respected.
-- [ ] task-114-165-tactical-button-focus-impl
+- [x] Appropriate `@utility tactical-button` and `@utility tactical-focus` primitives are defined in `src/index.css`.
+- [x] Tailwind v4 formatting and structure is respected.
+- [x] task-114-165-tactical-button-focus-impl


### PR DESCRIPTION
Checked off the acceptance criteria for `story-074-114-define-tactical-button-and-focus.md` as its child task `task-114-165-tactical-button-focus-impl` has already implemented the required utilities (`tactical-button` and `tactical-focus`) in `src/index.css`. Following the Empty PR policy, zero implementation files were modified and no YAML frontmatter was altered.

---
*PR created automatically by Jules for task [513592357775963530](https://jules.google.com/task/513592357775963530) started by @szubster*