### PR TITLE
fix: Gen 2 event flag dataview extraction

### DIFF
--- a/.foundry/tasks/task-095-157-gen2-event-flag-impl.md
+++ b/.foundry/tasks/task-095-157-gen2-event-flag-impl.md
@@ -32,5 +32,5 @@ As requested in Story `story-061-095-gen2-event-flag-extraction`, you are to imp
 4. **Permanent Failure Policy (ADR 017):** If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a specific `rejection_reason`.
 
 ## Acceptance Criteria
-- [ ] Implement Gen 2 event flag extraction logic using the `DataView` API.
-- [ ] Add unit tests demonstrating successful extraction and bounds checking (`RangeError` scenarios).
+- [x] Implement Gen 2 event flag extraction logic using the `DataView` API.
+- [x] Add unit tests demonstrating successful extraction and bounds checking (`RangeError` scenarios).

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -322,6 +322,22 @@ describe('gen2 parsers', () => {
       expect(data.eventFlags?.length).toBe(0x100);
       expect(data.hiddenItemFlags).toBe(data.eventFlags);
     });
+
+    it('should throw "Corrupted Save File" if reading event flags out of bounds', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x2865, 1);
+      view.setUint8(0x2866, 1);
+      view.setUint8(0x2866 + 7, 1);
+
+      const originalGetUint8 = view.getUint8.bind(view);
+      view.getUint8 = (offset: number) => {
+        if (offset === 0x2600) throw new RangeError('Out of bounds');
+        return originalGetUint8(offset);
+      };
+
+      expect(() => parseGen2(view, true)).toThrow('Corrupted Save File');
+    });
   });
 
   describe('parseGen2 - Unown Forms', () => {

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -589,7 +589,17 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
   const roamingLegendaries = parseRoamingLegendaries(view, isCrystal);
 
   const eventFlagsOffset = isCrystal ? 0x2600 : 0x2624;
-  const eventFlags = new Uint8Array(view.buffer, view.byteOffset + eventFlagsOffset, 0x100);
+  const eventFlags = new Uint8Array(0x100);
+  try {
+    for (let i = 0; i < 0x100; i++) {
+      eventFlags[i] = view.getUint8(eventFlagsOffset + i);
+    }
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('Corrupted Save File');
+    }
+    throw error;
+  }
   const hiddenItemFlags = eventFlags;
 
   return {


### PR DESCRIPTION
Implemented Gen 2 event flag extraction logic using the DataView API per task-095-157-gen2-event-flag-impl requirements. Removed direct Uint8Array instantiation from buffer and correctly iterated via DataView getUint8, wrapping it in a try-catch to propagate RangeErrors into graceful validation errors. Updated task markdown acceptance criteria.

---
*PR created automatically by Jules for task [2023761918715979577](https://jules.google.com/task/2023761918715979577) started by @szubster*