### PR TITLE
feat(foundry): generate blueprints for offline auth state management

### DIFF
--- a/.foundry/stories/story-038-076-offline-auth-state.md
+++ b/.foundry/stories/story-038-076-offline-auth-state.md
@@ -34,3 +34,7 @@ The application is designed to be offline-first. Therefore, the client needs to 
 - [ ] Ensure the UI reflects the authenticated state.
 - [ ] Ensure the authenticated state persists across page reloads and when the device goes offline.
 - [ ] Implement a logout mechanism that clears the client-side state.
+
+## Child Nodes
+- [ ] .foundry/tasks/task-076-199-offline-auth-state-impl.md
+- [ ] .foundry/tasks/task-076-200-offline-auth-state-qa.md

--- a/.foundry/tasks/task-076-199-offline-auth-state-impl.md
+++ b/.foundry/tasks/task-076-199-offline-auth-state-impl.md
@@ -1,0 +1,44 @@
+---
+id: task-076-199-offline-auth-state-impl
+type: TASK
+title: Implement Client-side Offline Auth State Management
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-17'
+updated_at: '2026-06-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-038-076-offline-auth-state
+tags:
+  - frontend
+  - authentication
+  - sso
+  - cloudflare
+  - offline
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Client-side Offline Auth State Management
+
+## Context
+Per ADR 019, the application relies on Cloudflare Access (Zero Trust) for Google SSO. While Cloudflare manages the actual session via an HttpOnly cookie, the offline-first React frontend needs an awareness of the authentication state.
+
+## Architectural Scaffolding
+- Define the Context layer (e.g., `AuthContext`) first before implementing UI components, to prevent tight coupling.
+- Store a lightweight session indicator locally (e.g. `isLoggedIn: true` in LocalStorage or IndexedDB) so the app knows it is authenticated even when offline.
+
+## Acceptance Criteria
+- [ ] Create an `AuthContext` to manage client-side authentication state.
+- [ ] Implement logic to store and retrieve the offline auth indicator securely.
+- [ ] Provide functions to initiate login (redirecting to Cloudflare Access) and logout (clearing local state and redirecting to Cloudflare logout).
+- [ ] Ensure the context provides the current authenticated state to consumer UI components.
+- [ ] Write tests ensuring context provider logic functions as expected (especially offline simulation).
+
+## Important Constraints
+- **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures:** If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-076-200-offline-auth-state-qa.md
+++ b/.foundry/tasks/task-076-200-offline-auth-state-qa.md
@@ -1,0 +1,41 @@
+---
+id: task-076-200-offline-auth-state-qa
+type: TASK
+title: QA Client-side Offline Auth State Management
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-17'
+updated_at: '2026-06-17'
+depends_on:
+  - task-076-199-offline-auth-state-impl
+jules_session_id: null
+pr_number: null
+parent: story-038-076-offline-auth-state
+tags:
+  - frontend
+  - authentication
+  - sso
+  - cloudflare
+  - offline
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Task: Client-side Offline Auth State Management
+
+## Context
+Verify the implementation of `task-076-199-offline-auth-state-impl`. The application needs to correctly handle offline auth state using Context and local storage.
+
+## Acceptance Criteria
+- [ ] Verify `AuthContext` provides the correct authentication state to the application.
+- [ ] Verify the offline auth indicator is correctly persisted across page reloads and when simulated offline.
+- [ ] Verify the login initiation and logout mechanisms work correctly with the application UI.
+- [ ] Ensure any automated tests pass and adequately cover edge cases (offline state).
+
+## Important Constraints
+- **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures:** If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Created the technical implementation and QA blueprints (TASK nodes) required to satisfy `story-038-076-offline-auth-state`.

The tasks outline the requirements for establishing an `AuthContext` to interact with Cloudflare Access and locally persist a lightweight authentication indicator for the offline-first application.

- Created `task-076-199-offline-auth-state-impl.md` (assigned to `coder`)
- Created `task-076-200-offline-auth-state-qa.md` (assigned to `qa`)
- Appended the new child nodes to `story-038-076-offline-auth-state.md`

---
*PR created automatically by Jules for task [9039517708020495839](https://jules.google.com/task/9039517708020495839) started by @szubster*