### PR TITLE
QA: Gen 2 Event Flag Extraction Verification

### DIFF
--- a/.foundry/tasks/task-095-158-gen2-event-flag-qa.md
+++ b/.foundry/tasks/task-095-158-gen2-event-flag-qa.md
@@ -33,5 +33,5 @@ Verify the work completed in `task-095-157-gen2-event-flag-impl`.
 4. **Permanent Failure Policy (ADR 017):** If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a specific `rejection_reason`.
 
 ## Acceptance Criteria
-- [ ] Verify that the extraction logic uses the `DataView` API exclusively.
-- [ ] Verify the implementation has robust unit tests and handles bounds checking correctly (`RangeError`).
+- [x] Verify that the extraction logic uses the `DataView` API exclusively.
+- [x] Verify the implementation has robust unit tests and handles bounds checking correctly (`RangeError`).


### PR DESCRIPTION
This PR completes the QA verification for the Gen 2 Event Flag Extraction implementation.

- Verified that `src/engine/saveParser/parsers/gen2.ts` exclusively uses the `DataView` API.
- Verified that robust unit tests exist in `src/engine/saveParser/parsers/gen2.test.ts` and handle bounds checking correctly (`RangeError`).
- Checked off all acceptance criteria checkboxes in `.foundry/tasks/task-095-158-gen2-event-flag-qa.md`.
- Ran `pnpm test` and `pnpm lint` to ensure no regressions.

---
*PR created automatically by Jules for task [18067792966618578876](https://jules.google.com/task/18067792966618578876) started by @szubster*