### PR TITLE
feat: define impl task for palette persona documentation

### DIFF
--- a/.foundry/stories/story-077-114-document-palette-styling-ownership.md
+++ b/.foundry/stories/story-077-114-document-palette-styling-ownership.md
@@ -33,3 +33,6 @@ Update `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_po
 ## Acceptance Criteria
 - [ ] `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` is updated.
 - [ ] Documentation accurately reflects `palette` ownership of styling per ADR 024.
+
+## Child Tasks
+- [ ] task-114-201-document-palette-styling-ownership-impl

--- a/.foundry/tasks/task-114-201-document-palette-styling-ownership-impl.md
+++ b/.foundry/tasks/task-114-201-document-palette-styling-ownership-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-114-201-document-palette-styling-ownership-impl
+type: TASK
+title: Implement palette persona documentation updates
+status: PENDING
+owner_persona: coder
+created_at: "2026-06-18"
+updated_at: "2026-06-18"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-077-114-document-palette-styling-ownership
+tags:
+  - styling
+  - agents
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement palette persona documentation updates
+
+## Objective
+Update `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` to formally document this expanded styling ownership within the multi-agent pipeline.
+
+## Blueprint / Contract
+You are tasked with fulfilling the documentation update as requested by `story-077-114-document-palette-styling-ownership`. You must self-verify the documentation updates. There is no separate QA task for this story because it is a low-risk documentation change.
+
+1. Ensure the `palette` persona's responsibility over `src/index.css` and custom tactical `@utility` primitives in the relevant Foundry system definitions and policies is documented, aligning with ADR 024.
+2. In `schema.md`, you can add `palette` to the "Owner Persona Enum" table.
+3. In `core_policies.md`, you can create a new section for Palette guidelines if necessary, or styling ownership.
+
+**Important Reminders for Coder:**
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` is updated.
+- [ ] Documentation accurately reflects `palette` ownership of styling per ADR 024.


### PR DESCRIPTION
Breaks down `story-077-114-document-palette-styling-ownership` into `task-114-201-document-palette-styling-ownership-impl` without creating a separate QA task because it is a low-risk documentation change. Appends task reference to the story markdown body.

---
*PR created automatically by Jules for task [4855449069535802566](https://jules.google.com/task/4855449069535802566) started by @szubster*