### PR TITLE
feat(foundry): Break down update TPM/Agile Coach journal story into task

### DIFF
--- a/.foundry/stories/story-049-117-update-tpm-agile-coach-journal.md
+++ b/.foundry/stories/story-049-117-update-tpm-agile-coach-journal.md
@@ -30,4 +30,6 @@ Process changes related to the orchestrator's handling of late-binding (where a 
 Ensure the TPM and Agile Coach personas are aware of the new late-binding process by updating their journals.
 
 ## Acceptance Criteria
-- [ ] Break down into TASK nodes to append process change notes regarding late-binding to the TPM or Agile Coach journal.
+- [x] Break down into TASK nodes to append process change notes regarding late-binding to the TPM or Agile Coach journal.
+
+- [ ] task-117-201-update-tpm-agile-coach-journals

--- a/.foundry/tasks/task-117-201-update-tpm-agile-coach-journals.md
+++ b/.foundry/tasks/task-117-201-update-tpm-agile-coach-journals.md
@@ -1,0 +1,38 @@
+---
+id: task-117-201-update-tpm-agile-coach-journals
+type: TASK
+title: Update TPM/Agile Coach Journal with Late-Binding Process
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-17'
+updated_at: '2026-06-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-049-117-update-tpm-agile-coach-journal
+tags:
+  - foundry
+  - process
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update TPM/Agile Coach Journal with Late-Binding Process
+
+## Context
+Process changes related to the orchestrator's handling of late-binding (where a `PENDING` parent node does not block its children from starting if it already has children, to avoid circular dependencies) need to be formally logged in the appropriate persona journals.
+
+## Goal
+Ensure the TPM and Agile Coach personas are aware of the new late-binding process by updating their journals.
+
+## Acceptance Criteria
+- [ ] Append process change notes regarding late-binding to the `.foundry/journals/tpm.md` journal.
+- [ ] Append process change notes regarding late-binding to the `.foundry/journals/agile_coach.md` journal.
+
+## Developer Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR transitions the STORY node `story-049-117-update-tpm-agile-coach-journal` into technical execution by creating a new TASK node `task-117-201-update-tpm-agile-coach-journals.md`. The task instructs the Coder persona to append process change notes regarding late-binding to the `.foundry/journals/tpm.md` and `.foundry/journals/agile_coach.md` journals. It also updates the parent story node by checking off the acceptance criteria and appending a reference to the newly generated task.

---
*PR created automatically by Jules for task [4923136477116559521](https://jules.google.com/task/4923136477116559521) started by @szubster*