### PR TITLE
docs: Verify DAG data parsing for rejection count

### DIFF
--- a/.foundry/tasks/task-118-169-qa-extract-rejection-count.md
+++ b/.foundry/tasks/task-118-169-qa-extract-rejection-count.md
@@ -35,9 +35,9 @@ This is a verification task for `task-118-168-impl-extract-rejection-count`. In 
 3. Verify context layer broadcasts `rejection_count` correctly, per ADR 013 and ADR 017.
 
 ## Acceptance Criteria
-- [ ] QA: Verify parser extracts `rejection_count`.
-- [ ] QA: Verify models are updated.
-- [ ] QA: Verify context layer broadcasts `rejection_count`.
+- [x] QA: Verify parser extracts `rejection_count`.
+- [x] QA: Verify models are updated.
+- [x] QA: Verify context layer broadcasts `rejection_count`.
 
 ## Reminders
 - If QA validation fails, you MUST update the target implementation task's YAML frontmatter (set `status: FAILED`, provide `rejection_reason`, increment `rejection_count`), leave its Acceptance Criteria unchecked, and document the failure in `.foundry/journals/qa.md`, while leaving this QA task's frontmatter completely untouched.


### PR DESCRIPTION
Verified the DAG data parsing logic correctly extracts the `rejection_count` property from YAML frontmatter and that it properly flows into the React Context (`DagContext`) as implemented in the upstream task. Checked off all acceptance criteria in `task-118-169-qa-extract-rejection-count.md`. No code changes were needed as the implementation was verified correct.

---
*PR created automatically by Jules for task [1547014858441964513](https://jules.google.com/task/1547014858441964513) started by @szubster*