### PR TITLE
feat: Gen 3 event schedule parser implementation

### DIFF
--- a/.foundry/tasks/task-124-171-gen3-event-schedule-parser.md
+++ b/.foundry/tasks/task-124-171-gen3-event-schedule-parser.md
@@ -27,9 +27,9 @@ notes: ''
 Implement the parsing logic to extract upcoming event schedule data (such as Energy Guru sales) from Gen 3 save files. The parser MUST use the `DataView` API as mandated by ADR-010 to ensure bounds checking and prevent silent failures on corrupted saves.
 
 ## Acceptance Criteria
-- [ ] Implement `DataView`-based parser for Gen 3 upcoming event schedule.
-- [ ] Handle potential out-of-bounds reads via `DataView` `RangeError` with graceful propagation.
-- [ ] Ensure backward compatibility with existing parsers as required by ADR-010.
+- [x] Implement `DataView`-based parser for Gen 3 upcoming event schedule.
+- [x] Handle potential out-of-bounds reads via `DataView` `RangeError` with graceful propagation.
+- [x] Ensure backward compatibility with existing parsers as required by ADR-010.
 
 ## Contract Reminders
 **To Coder / QA:**

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -68,6 +68,12 @@ export interface PokemonInstance {
  * This structure bridges the gap between binary memory blocks and the suggestion engine.
  */
 
+export interface Gen3PokeNews {
+  kind: number;
+  state: number;
+  dayCountdown: number;
+}
+
 export interface Gen3BerryPatch {
   berryId: number;
   stage: number;
@@ -136,6 +142,8 @@ export interface SaveData {
   daycareHasEgg?: boolean;
   /** Gen 3 specific: Information regarding the state of Berry Patches across Hoenn. */
   gen3BerryPatches?: Gen3BerryPatch[];
+  /** Gen 3 specific: Upcoming event schedule. */
+  gen3PokeNews?: Gen3PokeNews[];
   /**
    * Information regarding currently roaming Legendaries (Gen 2: Raikou, Entei, Suicune. Gen 3: Latios, Latias).
    *

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -5,6 +5,7 @@ import {
   parseGen3ConditionStats,
   parseGen3MirageIslandValue,
   parseGen3PersonalityValue,
+  parseGen3PokeNews,
   parseGen3Ribbons,
 } from './gen3';
 
@@ -99,6 +100,9 @@ describe('gen3 parser scaffolding', () => {
     expect(patch0?.watered2).toBe(false);
     expect(patch0?.watered3).toBe(true);
     expect(patch0?.watered4).toBe(false);
+
+    expect(saveData.gen3PokeNews).toBeDefined();
+    expect(saveData.gen3PokeNews?.length).toBe(16);
   });
 
   it('isGen3Save should catch RangeError and return false', () => {
@@ -391,5 +395,35 @@ describe('parseGen3Ribbons', () => {
 
     // Attempting to read a 32-bit integer (4 bytes) starting at offset 2 will exceed the 4-byte buffer
     expect(() => parseGen3Ribbons(view, 2)).toThrowError('The save file is corrupted or incomplete.');
+  });
+});
+
+describe('parseGen3PokeNews', () => {
+  it('should extract 16 news items correctly', () => {
+    const buffer = new ArrayBuffer(64);
+    const view = new DataView(buffer);
+
+    // Set up a news item at offset 0 (kind: 1, state: 2, countdown: 4)
+    view.setUint8(0, 1);
+    view.setUint8(1, 2);
+    view.setUint16(2, 4, true);
+
+    // Set up another news item at index 15 (offset 60)
+    view.setUint8(60, 3);
+    view.setUint8(61, 1);
+    view.setUint16(62, 10, true);
+
+    const result = parseGen3PokeNews(view, 0);
+
+    expect(result).toHaveLength(16);
+    expect(result[0]).toEqual({ kind: 1, state: 2, dayCountdown: 4 });
+    expect(result[15]).toEqual({ kind: 3, state: 1, dayCountdown: 10 });
+  });
+
+  it('should explicitly catch RangeError on out-of-bounds reads and throw a corrupted file error', () => {
+    const buffer = new ArrayBuffer(60); // Not enough space for 16 items (64 bytes)
+    const view = new DataView(buffer);
+
+    expect(() => parseGen3PokeNews(view, 0)).toThrowError('The save file is corrupted or incomplete.');
   });
 });

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -185,6 +185,8 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
 
     const gen3BerryPatches = extractBerryPatches(view, section1Offset);
 
+    const gen3PokeNews = parseGen3PokeNews(view, section1Offset + 0x2b50);
+
     const flagsOffset = section2Offset + 0x02f0;
     const hiddenItemFlags = new Uint8Array(14);
 
@@ -217,6 +219,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       gen3BerryPatches,
       hiddenItemFlags,
       mirageIslandValue,
+      gen3PokeNews,
     };
   } catch (error) {
     if (error instanceof RangeError) {
@@ -264,6 +267,33 @@ export function parseGen3Ribbons(view: DataView, offset: number): Gen3Ribbons {
     const tough = (bitfield >> 12) & 0x07;
 
     return { cool, beauty, cute, smart, tough };
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+/**
+ * Parses the upcoming event schedule (PokeNews) from a Gen 3 save file.
+ *
+ * @param view - The raw save file DataView.
+ * @param offset - The offset within the buffer to read the value from.
+ * @returns An array of news events.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3PokeNews(view: DataView, offset: number) {
+  try {
+    const news = [];
+    for (let i = 0; i < 16; i++) {
+      const itemOffset = offset + i * 4;
+      const kind = view.getUint8(itemOffset);
+      const state = view.getUint8(itemOffset + 1);
+      const dayCountdown = view.getUint16(itemOffset + 2, true);
+      news.push({ kind, state, dayCountdown });
+    }
+    return news;
   } catch (error) {
     if (error instanceof RangeError) {
       throw new Error('The save file is corrupted or incomplete.');


### PR DESCRIPTION
This commit implements the `parseGen3PokeNews` function to extract the upcoming event schedule (e.g., Energy Guru sales, Lilycove Department Store clearance sales) from Gen 3 save files. It strictly utilizes the native `DataView` API as mandated by ADR-010 to perform bounds checking and explicitly catches `RangeError` to throw a standardized "Corrupted Save File" exception, avoiding silent failures.

The new functionality is integrated into `parseGen3`, with the parsed schedule optionally added to the `SaveData` structure via the new `gen3PokeNews` property, ensuring full backward compatibility with existing parsers. Comprehensive unit tests and integration coverage have been added and verified to pass. All acceptance criteria for the task have been met and the corresponding Markdown checkboxes have been updated without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [3927667530971781843](https://jules.google.com/task/3927667530971781843) started by @szubster*