### PR TITLE
chore: verify and mark story 078-118 complete

### DIFF
--- a/.foundry/stories/story-078-118-refactor-parser-for-rejection-count.md
+++ b/.foundry/stories/story-078-118-refactor-parser-for-rejection-count.md
@@ -31,5 +31,5 @@ As required by ADR 017, we need to extract the `rejection_count` to display perm
 - [x] Break down into Tasks
 
 ### Generated Tasks
-- [ ] task-118-168-impl-extract-rejection-count
-- [ ] task-118-169-qa-extract-rejection-count
+- [x] task-118-168-impl-extract-rejection-count
+- [x] task-118-169-qa-extract-rejection-count


### PR DESCRIPTION
Checked off the generated tasks under Acceptance Criteria for `story-078-118-refactor-parser-for-rejection-count` after confirming their completion. The implementation (`task-118-168`) and QA (`task-118-169`) are both marked COMPLETED. No frontmatter modifications were made, per core policies.

---
*PR created automatically by Jules for task [9612697177018592385](https://jules.google.com/task/9612697177018592385) started by @szubster*