### PR TITLE
Add Gen 2 event data layer tasks

### DIFF
--- a/.foundry/stories/story-061-096-gen2-event-data-layer.md
+++ b/.foundry/stories/story-061-096-gen2-event-data-layer.md
@@ -28,3 +28,7 @@ Expose the extracted event flags from the save file cleanly to the frontend UI c
 ## Acceptance Criteria
 - [ ] Implement data layer integration for Gen 2 event flags.
 - [ ] Add tests for data layer integration.
+
+### Implementation Tasks
+- [ ] .foundry/tasks/task-096-202-gen2-event-data-layer-impl.md
+- [ ] .foundry/tasks/task-096-203-gen2-event-data-layer-qa.md

--- a/.foundry/tasks/task-096-202-gen2-event-data-layer-impl.md
+++ b/.foundry/tasks/task-096-202-gen2-event-data-layer-impl.md
@@ -1,0 +1,36 @@
+---
+id: task-096-202-gen2-event-data-layer-impl
+type: TASK
+title: Gen 2 Event Data Layer - Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-17'
+updated_at: '2026-06-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-061-096-gen2-event-data-layer
+tags:
+  - gen2
+  - frontend
+  - data-layer
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 2 Event Data Layer - Implementation
+
+## Blueprint
+As requested in `story-061-096-gen2-event-data-layer`, you are to expose the extracted event flags from the Gen 2 save file to the frontend UI components via the data layer.
+- `STATIC_GIFT_DATA` in `src/engine/data/gen2/assistantData.ts` currently lacks `eventFlag` definitions for the static gifts (e.g., Togepi, Eevee, Shuckle, Dratini, Tyrogue). You need to add the correct `eventFlag` offsets. You might need to spawn a RESEARCH node if you lack the exact flag offsets.
+- Ensure the strategy/generators (like `src/engine/assistant/generators/tradeGenerator.ts` and `src/engine/assistant/strategies/gen2Strategy.ts`) correctly consume these flags to filter out already-claimed gifts for Gen 2.
+- Reminders:
+  - If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+  - If you must abort or permanently fail, update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+  - If you submit an empty PR for a completed task, check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Add `eventFlag` mappings to Gen 2 static gifts and trades.
+- [ ] Ensure frontend suggestion generation respects Gen 2 event flags.
+- [ ] Add unit tests verifying the data layer integration for Gen 2 event flags.

--- a/.foundry/tasks/task-096-203-gen2-event-data-layer-qa.md
+++ b/.foundry/tasks/task-096-203-gen2-event-data-layer-qa.md
@@ -1,0 +1,36 @@
+---
+id: task-096-203-gen2-event-data-layer-qa
+type: TASK
+title: Gen 2 Event Data Layer - QA Verification
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-17'
+updated_at: '2026-06-17'
+depends_on:
+  - task-096-202-gen2-event-data-layer-impl
+jules_session_id: null
+pr_number: null
+parent: story-061-096-gen2-event-data-layer
+tags:
+  - gen2
+  - frontend
+  - data-layer
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 2 Event Data Layer - QA Verification
+
+## Blueprint
+Verify the implementation of `task-096-202-gen2-event-data-layer-impl`.
+- Ensure tests verify that Gen 2 suggestion generation correctly hides claimed gifts when the respective event flag is set.
+- Check that no regressions were introduced to Gen 1 logic.
+- Reminders:
+  - If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+  - If you must abort or permanently fail, update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+  - If you submit an empty PR for a completed task, check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Run test suite to verify Gen 2 event data layer integration.
+- [ ] Confirm no regressions in the strategy engine test coverage.


### PR DESCRIPTION
Added new technical blueprint tasks for implementing and verifying the Gen 2 event data layer. The tasks specify updating `src/engine/data/gen2/assistantData.ts` to include missing `eventFlag` numbers, ensuring strategy logic checks them, and performing QA verification.

---
*PR created automatically by Jules for task [16506502738905096627](https://jules.google.com/task/16506502738905096627) started by @szubster*