### PR TITLE
feat(gen3): implement mix record parsing

### DIFF
--- a/.foundry/tasks/task-124-172-gen3-mix-record-events-parser.md
+++ b/.foundry/tasks/task-124-172-gen3-mix-record-events-parser.md
@@ -27,10 +27,10 @@ notes: ''
 Implement the parsing logic to extract Mix Record flags/data from Gen 3 save files to identify inherited events. The parser MUST use the `DataView` API as mandated by ADR-010 to ensure bounds checking and prevent silent failures on corrupted saves.
 
 ## Acceptance Criteria
-- [ ] Implement `DataView`-based parser for Gen 3 Mix Record flags/data.
-- [ ] Parse data to identify if events were inherited from the "Mix Record" feature.
-- [ ] Handle potential out-of-bounds reads via `DataView` `RangeError` with graceful propagation.
-- [ ] Ensure backward compatibility with existing parsers as required by ADR-010.
+- [x] Implement `DataView`-based parser for Gen 3 Mix Record flags/data.
+- [x] Parse data to identify if events were inherited from the "Mix Record" feature.
+- [x] Handle potential out-of-bounds reads via `DataView` `RangeError` with graceful propagation.
+- [x] Ensure backward compatibility with existing parsers as required by ADR-010.
 
 ## Contract Reminders
 **To Coder / QA:**

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -74,6 +74,11 @@ export interface Gen3PokeNews {
   dayCountdown: number;
 }
 
+export interface Gen3MixRecord {
+  kind: number;
+  active: boolean;
+}
+
 export interface Gen3BerryPatch {
   berryId: number;
   stage: number;
@@ -144,6 +149,8 @@ export interface SaveData {
   gen3BerryPatches?: Gen3BerryPatch[];
   /** Gen 3 specific: Upcoming event schedule. */
   gen3PokeNews?: Gen3PokeNews[];
+  /** Gen 3 specific: Inherited Mix Record events. */
+  gen3MixRecords?: Gen3MixRecord[];
   /**
    * Information regarding currently roaming Legendaries (Gen 2: Raikou, Entei, Suicune. Gen 3: Latios, Latias).
    *

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -4,6 +4,7 @@ import {
   parseGen3,
   parseGen3ConditionStats,
   parseGen3MirageIslandValue,
+  parseGen3MixRecords,
   parseGen3PersonalityValue,
   parseGen3PokeNews,
   parseGen3Ribbons,
@@ -395,6 +396,46 @@ describe('parseGen3Ribbons', () => {
 
     // Attempting to read a 32-bit integer (4 bytes) starting at offset 2 will exceed the 4-byte buffer
     expect(() => parseGen3Ribbons(view, 2)).toThrowError('The save file is corrupted or incomplete.');
+  });
+});
+
+describe('parseGen3MixRecords', () => {
+  it('should extract active mix record events correctly', () => {
+    const buffer = new ArrayBuffer(900); // 25 shows * 36 bytes
+    const view = new DataView(buffer);
+
+    // Show 1: Normal show (kind 1, active) - should be ignored
+    view.setUint8(0, 1);
+    view.setUint8(1, 1);
+
+    // Show 2: Mix Record show (kind 22, active) - should be included
+    view.setUint8(36, 22);
+    view.setUint8(37, 1);
+
+    // Show 3: Mix Record show (kind 31, active) - should be included
+    view.setUint8(72, 31);
+    view.setUint8(73, 1);
+
+    // Show 4: Mix Record show (kind 33, inactive) - should be ignored
+    view.setUint8(108, 33);
+    view.setUint8(109, 0);
+
+    // Show 5: Outbreak show (kind 45, active) - should be ignored
+    view.setUint8(144, 45);
+    view.setUint8(145, 1);
+
+    const result = parseGen3MixRecords(view, 0);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ kind: 22, active: true });
+    expect(result[1]).toEqual({ kind: 31, active: true });
+  });
+
+  it('should explicitly catch RangeError on out-of-bounds reads and throw a corrupted file error', () => {
+    const buffer = new ArrayBuffer(800); // Not enough space for 25 items (900 bytes)
+    const view = new DataView(buffer);
+
+    expect(() => parseGen3MixRecords(view, 0)).toThrowError('The save file is corrupted or incomplete.');
   });
 });
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -121,6 +121,36 @@ export function isGen3Save(view: DataView): boolean {
 }
 
 /**
+ * Parses Mix Record events from a Gen 3 save file.
+ *
+ * @param view - The raw save file DataView.
+ * @param offset - The offset within the buffer to read the value from.
+ * @returns An array of inherited Mix Record events.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3MixRecords(view: DataView, offset: number) {
+  try {
+    const mixRecords = [];
+    for (let i = 0; i < 25; i++) {
+      const itemOffset = offset + i * 36;
+      const kind = view.getUint8(itemOffset);
+      const active = view.getUint8(itemOffset + 1) !== 0;
+
+      // Check if the show is a Mix Record event (21 to 40)
+      if (active && kind >= 21 && kind <= 40) {
+        mixRecords.push({ kind, active });
+      }
+    }
+    return mixRecords;
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+/**
  * Parses the 16-bit Mirage Island value from a Gen 3 save file.
  *
  * @param view - The raw save file DataView.
@@ -186,6 +216,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     const gen3BerryPatches = extractBerryPatches(view, section1Offset);
 
     const gen3PokeNews = parseGen3PokeNews(view, section1Offset + 0x2b50);
+    const gen3MixRecords = parseGen3MixRecords(view, section1Offset + 0x27cc);
 
     const flagsOffset = section2Offset + 0x02f0;
     const hiddenItemFlags = new Uint8Array(14);
@@ -220,6 +251,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       hiddenItemFlags,
       mirageIslandValue,
       gen3PokeNews,
+      gen3MixRecords,
     };
   } catch (error) {
     if (error instanceof RangeError) {


### PR DESCRIPTION
Implemented DataView-based parser for Gen 3 Mix Record TV shows logic. Correctly integrates with main parser checking for active events in the kinds 21 through 40 range, handles out of bounds natively as per ADR-010, and retains backward compatibility with existing tests. Checked off all tasks criteria in the node.

---
*PR created automatically by Jules for task [17002292908072378993](https://jules.google.com/task/17002292908072378993) started by @szubster*