### PR TITLE
feat: add tests for time capsule UI indicators

### DIFF
--- a/.foundry/tasks/task-118-181-time-capsule-ui-indicators-impl.md
+++ b/.foundry/tasks/task-118-181-time-capsule-ui-indicators-impl.md
@@ -47,8 +47,8 @@ Implement UI indicators for Time Capsule readiness in the DexHelper application,
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Time Capsule validation utility implemented and uses `isGen1Species` and `hasGen2ExclusiveMove`.
-- [ ] Visual indicator added to the Storage View for Gen 2 saves.
-- [ ] Detailed Pokémon view displays Time Capsule status and highlights validation failures.
-- [ ] Unit tests implemented and passing.
-- [ ] `pnpm type-check` passes.
+ - [x] Time Capsule validation utility implemented and uses `isGen1Species` and `hasGen2ExclusiveMove`.
+ - [x] Visual indicator added to the Storage View for Gen 2 saves.
+ - [x] Detailed Pokémon view displays Time Capsule status and highlights validation failures.
+ - [x] Unit tests implemented and passing.
+ - [x] `pnpm type-check` passes.

--- a/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
+++ b/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import type { PokemonInstance } from '../../../../engine/saveParser/index';
+import { useStore } from '../../../../store';
+import { PokemonCaughtDetails } from '../PokemonCaughtDetails';
+
+vi.mock('../../../../store', () => ({
+  useStore: vi.fn<() => void>(),
+}));
+
+describe('PokemonCaughtDetails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockPokemon: PokemonInstance & { location: string } = {
+    speciesId: 1, // Bulbasaur
+    level: 5,
+    isShiny: false,
+    otName: 'ASH',
+    storageLocation: 'Party',
+    slot: 1,
+    location: 'Party',
+    moves: [1, 2],
+    currentHp: 20,
+    condition: { cool: 0, beauty: 0, cute: 0, smart: 0, tough: 0, sheen: 0 },
+    friendship: 100,
+    item: 0,
+  };
+
+  it('renders correctly', async () => {
+    (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
+      (selector: unknown) =>
+        (selector as (state: unknown) => unknown)({
+          saveData: {
+            generation: 1,
+          },
+        }),
+    );
+
+    await render(<PokemonCaughtDetails yourPokemon={[mockPokemon]} />);
+
+    await expect.element(page.getByText('LV.5')).toBeInTheDocument();
+    await expect.element(page.getByText('Party')).toBeInTheDocument();
+  });
+
+  it('renders Gen 2 specific info and Time Capsule validation', async () => {
+    (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
+      (selector: unknown) =>
+        (selector as (state: unknown) => unknown)({
+          saveData: {
+            generation: 2,
+          },
+        }),
+    );
+
+    await render(<PokemonCaughtDetails yourPokemon={[mockPokemon]} />);
+
+    await expect.element(page.getByText('[ TIME CAPSULE READY ]')).toBeInTheDocument();
+  });
+
+  it('renders Gen 2 specific info and Time Capsule validation with error', async () => {
+    (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
+      (selector: unknown) =>
+        (selector as (state: unknown) => unknown)({
+          saveData: {
+            generation: 2,
+          },
+        }),
+    );
+
+    await render(<PokemonCaughtDetails yourPokemon={[{ ...mockPokemon, speciesId: 152 }]} />);
+
+    await expect.element(page.getByText('INVALID: Gen 2 Species')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
The PR includes unit tests for `PokemonCaughtDetails` and checks off acceptance criteria for time capsule UI indicators. The actual implementation code was already present but unchecked in the task frontmatter.

---
*PR created automatically by Jules for task [5271476438252027635](https://jules.google.com/task/5271476438252027635) started by @szubster*