### PR TITLE
[Coder] Implement Unown Dex Panel UI

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -100,3 +100,6 @@ When implementing `task-121-171-gen3-tv-block-parser-impl`, the exact memory off
 ## 2026-06-17: Cloudflare Pages Integration
 When creating or modifying `functions/_middleware.ts` to implement `@cloudflare/pages-plugin-cloudflare-access`, ensure that both `@cloudflare/pages-plugin-cloudflare-access` and `@cloudflare/workers-types` are installed to the workspace root using the `-w` flag.
 Furthermore, the `functions/_middleware.ts` file and these dependencies must be properly ignored in `knip.json` to avoid unused exports warnings, as Knip does not natively understand Cloudflare Pages Functions directory structure without custom configuration.
+
+## Unown Dex Panel Implementation
+Implemented Unown Dex Panel using tactical hardware styling constraints (ADR 008, 024). Verification was self-performed via local Playwright script taking a screenshot of the panel. The component dynamically derives owned forms by looping through the `yourPokemon` property, checking `speciesId === 201` and extracting the `unownForm` field.

--- a/.foundry/tasks/task-131-185-implement-unown-dex-panel-ui.md
+++ b/.foundry/tasks/task-131-185-implement-unown-dex-panel-ui.md
@@ -48,6 +48,6 @@ Since this is a straightforward UI implementation without highly complex risk, t
 - **Node Modification Rule:** DO NOT modify this YAML frontmatter upon successful completion. Only update the markdown body (e.g., check off acceptance criteria). Modifying YAML is ONLY allowed for FAILED or CANCELLED status updates.
 
 ## Acceptance Criteria
-- [ ] Create the Unown Dex Panel UI component using `tactical-*` classes.
-- [ ] Integrate the component into the main application view hierarchy.
-- [ ] Self-verify the component rendering and document it in the coder journal.
+- [x] Create the Unown Dex Panel UI component using `tactical-*` classes.
+- [x] Integrate the component into the main application view hierarchy.
+- [x] Self-verify the component rendering and document it in the coder journal.

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -16,6 +16,7 @@ import { PokemonCaughtDetails } from './pokemon/details/PokemonCaughtDetails';
 import { PokemonEvolutions } from './pokemon/details/PokemonEvolutions';
 import { PokemonLocations } from './pokemon/details/PokemonLocations';
 import { PokemonSprite } from './pokemon/PokemonSprite';
+import { UnownDexPanel } from './pokemon/unown/UnownDexPanel';
 import { ScanlineOverlay } from './ScanlineOverlay';
 import { TacticalIconButton } from './TacticalIconButton';
 import { TacticalModal } from './TacticalModal';
@@ -300,6 +301,7 @@ export function PokemonDetails({
           {/* Right Column: Details & Locations */}
           <div className="space-y-12 lg:col-span-7">
             <PokemonCaughtDetails yourPokemon={yourPokemon} />
+            {pokemonId === 201 && saveData?.generation === 2 && <UnownDexPanel yourPokemon={yourPokemon} />}
 
             <PokemonEvolutions
               evoReq={evoReq}

--- a/src/components/pokemon/unown/UnownDexPanel.tsx
+++ b/src/components/pokemon/unown/UnownDexPanel.tsx
@@ -1,0 +1,51 @@
+import { CheckCircle2, X } from 'lucide-react';
+import React from 'react';
+import type { PokemonInstance } from '../../../engine/saveParser/index';
+
+interface UnownDexPanelProps {
+  yourPokemon: (PokemonInstance & { location: string })[];
+}
+
+const UNOWN_FORMS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+export function UnownDexPanel({ yourPokemon }: UnownDexPanelProps) {
+  // A set of owned unown forms extracted from the list of the player's Pokémon
+  const ownedForms = React.useMemo(() => {
+    const set = new Set<string>();
+    for (const p of yourPokemon) {
+      if (p.speciesId === 201 && p.unownForm) {
+        set.add(p.unownForm);
+      }
+    }
+    return set;
+  }, [yourPokemon]);
+
+  return (
+    <div className="tactical-panel mt-8 p-4 sm:p-6">
+      <div className="mb-6 flex flex-col justify-between border-zinc-800 border-b border-dashed pb-4 sm:flex-row sm:items-center">
+        <h3 className="font-bold font-mono text-sm text-zinc-400 uppercase tracking-widest">Unown Database</h3>
+        <div className="mt-2 font-mono text-xs text-zinc-500 sm:mt-0">
+          <span className="text-emerald-400">{ownedForms.size}</span> / 26 Forms Discovered
+        </div>
+      </div>
+      <div className="grid grid-cols-5 gap-3 sm:grid-cols-7">
+        {UNOWN_FORMS.map((form) => {
+          const isOwned = ownedForms.has(form);
+          return (
+            <div
+              key={form}
+              className={`flex aspect-square flex-col items-center justify-center rounded-none border border-dashed p-1 font-mono transition-colors duration-300 ${
+                isOwned
+                  ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)]/10 text-[var(--theme-primary)] shadow-[0_0_10px_rgba(var(--theme-primary-rgb),0.2)]'
+                  : 'border-zinc-800 bg-black/40 text-zinc-700'
+              }`}
+            >
+              <div className="font-black text-2xl">{form}</div>
+              {isOwned ? <CheckCircle2 size={12} className="mt-1" /> : <X size={12} className="mt-1 opacity-50" />}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Creates a specific panel for Gen 2 saves to track the 26 discovered forms of Unown. Uses strict tactical hardware UI aesthetic (`rounded-none`, `font-mono`, `border-dashed`) natively supported via Tailwind v4's `@utility` directive. Verified via frontend snapshot testing.

---
*PR created automatically by Jules for task [16340658292464697030](https://jules.google.com/task/16340658292464697030) started by @szubster*