### PR TITLE
feat: implement move data extraction pipeline

### DIFF
--- a/.foundry/tasks/task-128-181-move-data-extraction-impl.md
+++ b/.foundry/tasks/task-128-181-move-data-extraction-impl.md
@@ -45,7 +45,7 @@ As per ADR 025 and Story 128, we need to extract move data from PokeAPI and writ
 - If you submit an empty PR for a completed task (which shouldn't be the case here, as code changes are expected), you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Logic is added to `scripts/generate-pokedata.ts` to parse move data from the PokeAPI dataset.
-- [ ] The generated move structures conform strictly to the ADR 025 schema (with abbreviations `p`, `acc`, `pp`, `dmg_class`).
-- [ ] Values matching defaults (e.g., accuracy 100) are explicitly omitted via the existing compaction logic.
-- [ ] The data is written to `moves.jsonl` in the `data/db` directory.
+- [x] Logic is added to `scripts/generate-pokedata.ts` to parse move data from the PokeAPI dataset.
+- [x] The generated move structures conform strictly to the ADR 025 schema (with abbreviations `p`, `acc`, `pp`, `dmg_class`).
+- [x] Values matching defaults (e.g., accuracy 100) are explicitly omitted via the existing compaction logic.
+- [x] The data is written to `moves.jsonl` in the `data/db` directory.

--- a/data/db/metadata.json
+++ b/data/db/metadata.json
@@ -1,4 +1,4 @@
 {
   "sourceSha": "",
-  "generatedAt": "2026-06-09T02:20:16.318Z"
+  "generatedAt": "2026-06-17T17:50:29.443Z"
 }

--- a/data/db/moves.jsonl
+++ b/data/db/moves.jsonl
@@ -1,0 +1,354 @@
+{"id":1,"name":"Pound","type":1,"p":40,"pp":35,"dmg_class":1}
+{"id":2,"name":"Karate Chop","type":2,"p":50,"pp":25,"dmg_class":1}
+{"id":3,"name":"Double Slap","type":1,"p":15,"acc":85,"pp":10,"dmg_class":1}
+{"id":4,"name":"Comet Punch","type":1,"p":18,"acc":85,"pp":15,"dmg_class":1}
+{"id":5,"name":"Mega Punch","type":1,"p":80,"acc":85,"pp":20,"dmg_class":1}
+{"id":6,"name":"Pay Day","type":1,"p":40,"pp":20,"dmg_class":1}
+{"id":7,"name":"Fire Punch","type":10,"p":75,"pp":15,"dmg_class":1,"effect":10}
+{"id":8,"name":"Ice Punch","type":15,"p":75,"pp":15,"dmg_class":1,"effect":10}
+{"id":9,"name":"Thunder Punch","type":13,"p":75,"pp":15,"dmg_class":1,"effect":10}
+{"id":10,"name":"Scratch","type":1,"p":40,"pp":35,"dmg_class":1}
+{"id":11,"name":"Vise Grip","type":1,"p":55,"pp":30,"dmg_class":1}
+{"id":12,"name":"Guillotine","type":1,"acc":30,"pp":5,"dmg_class":1}
+{"id":13,"name":"Razor Wind","type":1,"p":80,"pp":10,"dmg_class":2}
+{"id":14,"name":"Swords Dance","type":1,"pp":20,"dmg_class":3}
+{"id":15,"name":"Cut","type":1,"p":50,"acc":95,"pp":30,"dmg_class":1}
+{"id":16,"name":"Gust","type":3,"p":40,"pp":35,"dmg_class":2}
+{"id":17,"name":"Wing Attack","type":3,"p":60,"pp":35,"dmg_class":1}
+{"id":18,"name":"Whirlwind","type":1,"pp":20,"dmg_class":3}
+{"id":19,"name":"Fly","type":3,"p":90,"acc":95,"pp":15,"dmg_class":1}
+{"id":20,"name":"Bind","type":1,"p":15,"acc":85,"pp":20,"dmg_class":1,"effect":100}
+{"id":21,"name":"Slam","type":1,"p":80,"acc":75,"pp":20,"dmg_class":1}
+{"id":22,"name":"Vine Whip","type":12,"p":45,"pp":25,"dmg_class":1}
+{"id":23,"name":"Stomp","type":1,"p":65,"pp":20,"dmg_class":1,"effect":30}
+{"id":24,"name":"Double Kick","type":2,"p":30,"pp":30,"dmg_class":1}
+{"id":25,"name":"Mega Kick","type":1,"p":120,"acc":75,"pp":5,"dmg_class":1}
+{"id":26,"name":"Jump Kick","type":2,"p":100,"acc":95,"pp":10,"dmg_class":1}
+{"id":27,"name":"Rolling Kick","type":2,"p":60,"acc":85,"pp":15,"dmg_class":1,"effect":30}
+{"id":28,"name":"Sand Attack","type":5,"pp":15,"dmg_class":3}
+{"id":29,"name":"Headbutt","type":1,"p":70,"pp":15,"dmg_class":1,"effect":30}
+{"id":30,"name":"Horn Attack","type":1,"p":65,"pp":25,"dmg_class":1}
+{"id":31,"name":"Fury Attack","type":1,"p":15,"acc":85,"pp":20,"dmg_class":1}
+{"id":32,"name":"Horn Drill","type":1,"acc":30,"pp":5,"dmg_class":1}
+{"id":33,"name":"Tackle","type":1,"p":40,"pp":35,"dmg_class":1}
+{"id":34,"name":"Body Slam","type":1,"p":85,"pp":15,"dmg_class":1,"effect":30}
+{"id":35,"name":"Wrap","type":1,"p":15,"acc":90,"pp":20,"dmg_class":1,"effect":100}
+{"id":36,"name":"Take Down","type":1,"p":90,"acc":85,"pp":20,"dmg_class":1}
+{"id":37,"name":"Thrash","type":1,"p":120,"pp":10,"dmg_class":1}
+{"id":38,"name":"Double-Edge","type":1,"p":120,"pp":15,"dmg_class":1}
+{"id":39,"name":"Tail Whip","type":1,"pp":30,"dmg_class":3}
+{"id":40,"name":"Poison Sting","type":4,"p":15,"pp":35,"dmg_class":1,"effect":30}
+{"id":41,"name":"Twineedle","type":7,"p":25,"pp":20,"dmg_class":1,"effect":20}
+{"id":42,"name":"Pin Missile","type":7,"p":25,"acc":95,"pp":20,"dmg_class":1}
+{"id":43,"name":"Leer","type":1,"pp":30,"dmg_class":3,"effect":100}
+{"id":44,"name":"Bite","type":17,"p":60,"pp":25,"dmg_class":1,"effect":30}
+{"id":45,"name":"Growl","type":1,"pp":40,"dmg_class":3}
+{"id":46,"name":"Roar","type":1,"pp":20,"dmg_class":3}
+{"id":47,"name":"Sing","type":1,"acc":55,"pp":15,"dmg_class":3,"effect":2}
+{"id":48,"name":"Supersonic","type":1,"acc":55,"pp":20,"dmg_class":3,"effect":6}
+{"id":49,"name":"Sonic Boom","type":1,"acc":90,"pp":20,"dmg_class":2}
+{"id":50,"name":"Disable","type":1,"pp":20,"dmg_class":3,"effect":13}
+{"id":51,"name":"Acid","type":4,"p":40,"pp":30,"dmg_class":2,"effect":10}
+{"id":52,"name":"Ember","type":10,"p":40,"pp":25,"dmg_class":2,"effect":10}
+{"id":53,"name":"Flamethrower","type":10,"p":90,"pp":15,"dmg_class":2,"effect":10}
+{"id":54,"name":"Mist","type":15,"pp":30,"dmg_class":3}
+{"id":55,"name":"Water Gun","type":11,"p":40,"pp":25,"dmg_class":2}
+{"id":56,"name":"Hydro Pump","type":11,"p":110,"acc":80,"pp":5,"dmg_class":2}
+{"id":57,"name":"Surf","type":11,"p":90,"pp":15,"dmg_class":2}
+{"id":58,"name":"Ice Beam","type":15,"p":90,"pp":10,"dmg_class":2,"effect":10}
+{"id":59,"name":"Blizzard","type":15,"p":110,"acc":70,"pp":5,"dmg_class":2,"effect":10}
+{"id":60,"name":"Psybeam","type":14,"p":65,"pp":20,"dmg_class":2,"effect":10}
+{"id":61,"name":"Bubble Beam","type":11,"p":65,"pp":20,"dmg_class":2,"effect":10}
+{"id":62,"name":"Aurora Beam","type":15,"p":65,"pp":20,"dmg_class":2,"effect":10}
+{"id":63,"name":"Hyper Beam","type":1,"p":150,"acc":90,"pp":5,"dmg_class":2}
+{"id":64,"name":"Peck","type":3,"p":35,"pp":35,"dmg_class":1}
+{"id":65,"name":"Drill Peck","type":3,"p":80,"pp":20,"dmg_class":1}
+{"id":66,"name":"Submission","type":2,"p":80,"acc":80,"pp":20,"dmg_class":1}
+{"id":67,"name":"Low Kick","type":2,"pp":20,"dmg_class":1}
+{"id":68,"name":"Counter","type":2,"pp":20,"dmg_class":1}
+{"id":69,"name":"Seismic Toss","type":2,"pp":20,"dmg_class":1}
+{"id":70,"name":"Strength","type":1,"p":80,"pp":15,"dmg_class":1}
+{"id":71,"name":"Absorb","type":12,"p":20,"pp":25,"dmg_class":2}
+{"id":72,"name":"Mega Drain","type":12,"p":40,"pp":15,"dmg_class":2}
+{"id":73,"name":"Leech Seed","type":12,"acc":90,"pp":10,"dmg_class":3,"effect":18}
+{"id":74,"name":"Growth","type":1,"pp":20,"dmg_class":3}
+{"id":75,"name":"Razor Leaf","type":12,"p":55,"acc":95,"pp":25,"dmg_class":1}
+{"id":76,"name":"Solar Beam","type":12,"p":120,"pp":10,"dmg_class":2}
+{"id":77,"name":"Poison Powder","type":4,"acc":75,"pp":35,"dmg_class":3,"effect":5}
+{"id":78,"name":"Stun Spore","type":12,"acc":75,"pp":30,"dmg_class":3,"effect":1}
+{"id":79,"name":"Sleep Powder","type":12,"acc":75,"pp":15,"dmg_class":3,"effect":2}
+{"id":80,"name":"Petal Dance","type":12,"p":120,"pp":10,"dmg_class":2}
+{"id":81,"name":"String Shot","type":7,"acc":95,"pp":40,"dmg_class":3}
+{"id":82,"name":"Dragon Rage","type":16,"pp":10,"dmg_class":2}
+{"id":83,"name":"Fire Spin","type":10,"p":35,"acc":85,"pp":15,"dmg_class":2,"effect":100}
+{"id":84,"name":"Thunder Shock","type":13,"p":40,"pp":30,"dmg_class":2,"effect":10}
+{"id":85,"name":"Thunderbolt","type":13,"p":90,"pp":15,"dmg_class":2,"effect":10}
+{"id":86,"name":"Thunder Wave","type":13,"acc":90,"pp":20,"dmg_class":3,"effect":1}
+{"id":87,"name":"Thunder","type":13,"p":110,"acc":70,"pp":10,"dmg_class":2,"effect":30}
+{"id":88,"name":"Rock Throw","type":6,"p":50,"acc":90,"pp":15,"dmg_class":1}
+{"id":89,"name":"Earthquake","type":5,"p":100,"pp":10,"dmg_class":1}
+{"id":90,"name":"Fissure","type":5,"acc":30,"pp":5,"dmg_class":1}
+{"id":91,"name":"Dig","type":5,"p":80,"pp":10,"dmg_class":1}
+{"id":92,"name":"Toxic","type":4,"acc":90,"pp":10,"dmg_class":3,"effect":5}
+{"id":93,"name":"Confusion","type":14,"p":50,"pp":25,"dmg_class":2,"effect":10}
+{"id":94,"name":"Psychic","type":14,"p":90,"pp":10,"dmg_class":2,"effect":10}
+{"id":95,"name":"Hypnosis","type":14,"acc":60,"pp":20,"dmg_class":3,"effect":2}
+{"id":96,"name":"Meditate","type":14,"pp":40,"dmg_class":3}
+{"id":97,"name":"Agility","type":14,"pp":30,"dmg_class":3}
+{"id":98,"name":"Quick Attack","type":1,"p":40,"pp":30,"dmg_class":1}
+{"id":99,"name":"Rage","type":1,"p":20,"pp":20,"dmg_class":1}
+{"id":100,"name":"Teleport","type":14,"pp":20,"dmg_class":3}
+{"id":101,"name":"Night Shade","type":8,"pp":15,"dmg_class":2}
+{"id":102,"name":"Mimic","type":1,"pp":10,"dmg_class":3}
+{"id":103,"name":"Screech","type":1,"acc":85,"pp":40,"dmg_class":3}
+{"id":104,"name":"Double Team","type":1,"pp":15,"dmg_class":3}
+{"id":105,"name":"Recover","type":1,"pp":5,"dmg_class":3}
+{"id":106,"name":"Harden","type":1,"pp":30,"dmg_class":3}
+{"id":107,"name":"Minimize","type":1,"pp":10,"dmg_class":3}
+{"id":108,"name":"Smokescreen","type":1,"pp":20,"dmg_class":3}
+{"id":109,"name":"Confuse Ray","type":8,"pp":10,"dmg_class":3,"effect":6}
+{"id":110,"name":"Withdraw","type":11,"pp":40,"dmg_class":3}
+{"id":111,"name":"Defense Curl","type":1,"pp":40,"dmg_class":3}
+{"id":112,"name":"Barrier","type":14,"pp":20,"dmg_class":3}
+{"id":113,"name":"Light Screen","type":14,"pp":30,"dmg_class":3}
+{"id":114,"name":"Haze","type":15,"pp":30,"dmg_class":3}
+{"id":115,"name":"Reflect","type":14,"pp":20,"dmg_class":3}
+{"id":116,"name":"Focus Energy","type":1,"pp":30,"dmg_class":3}
+{"id":117,"name":"Bide","type":1,"pp":10,"dmg_class":1}
+{"id":118,"name":"Metronome","type":1,"pp":10,"dmg_class":3}
+{"id":119,"name":"Mirror Move","type":3,"pp":20,"dmg_class":3}
+{"id":120,"name":"Self-Destruct","type":1,"p":200,"pp":5,"dmg_class":1}
+{"id":121,"name":"Egg Bomb","type":1,"p":100,"acc":75,"pp":10,"dmg_class":1}
+{"id":122,"name":"Lick","type":8,"p":30,"pp":30,"dmg_class":1,"effect":30}
+{"id":123,"name":"Smog","type":4,"p":30,"acc":70,"pp":20,"dmg_class":2,"effect":40}
+{"id":124,"name":"Sludge","type":4,"p":65,"pp":20,"dmg_class":2,"effect":30}
+{"id":125,"name":"Bone Club","type":5,"p":65,"acc":85,"pp":20,"dmg_class":1,"effect":10}
+{"id":126,"name":"Fire Blast","type":10,"p":110,"acc":85,"pp":5,"dmg_class":2,"effect":10}
+{"id":127,"name":"Waterfall","type":11,"p":80,"pp":15,"dmg_class":1,"effect":20}
+{"id":128,"name":"Clamp","type":11,"p":35,"acc":85,"pp":15,"dmg_class":1,"effect":100}
+{"id":129,"name":"Swift","type":1,"p":60,"pp":20,"dmg_class":2}
+{"id":130,"name":"Skull Bash","type":1,"p":130,"pp":10,"dmg_class":1,"effect":100}
+{"id":131,"name":"Spike Cannon","type":1,"p":20,"pp":15,"dmg_class":1}
+{"id":132,"name":"Constrict","type":1,"p":10,"pp":35,"dmg_class":1,"effect":10}
+{"id":133,"name":"Amnesia","type":14,"pp":20,"dmg_class":3}
+{"id":134,"name":"Kinesis","type":14,"acc":80,"pp":15,"dmg_class":3}
+{"id":135,"name":"Soft-Boiled","type":1,"pp":5,"dmg_class":3}
+{"id":136,"name":"High Jump Kick","type":2,"p":130,"acc":90,"pp":10,"dmg_class":1}
+{"id":137,"name":"Glare","type":1,"pp":30,"dmg_class":3,"effect":1}
+{"id":138,"name":"Dream Eater","type":14,"p":100,"pp":15,"dmg_class":2}
+{"id":139,"name":"Poison Gas","type":4,"acc":90,"pp":40,"dmg_class":3,"effect":5}
+{"id":140,"name":"Barrage","type":1,"p":15,"acc":85,"pp":20,"dmg_class":1}
+{"id":141,"name":"Leech Life","type":7,"p":80,"pp":10,"dmg_class":1}
+{"id":142,"name":"Lovely Kiss","type":1,"acc":75,"pp":10,"dmg_class":3,"effect":2}
+{"id":143,"name":"Sky Attack","type":3,"p":140,"acc":90,"pp":5,"dmg_class":1,"effect":30}
+{"id":144,"name":"Transform","type":1,"pp":10,"dmg_class":3}
+{"id":145,"name":"Bubble","type":11,"p":40,"pp":30,"dmg_class":2,"effect":10}
+{"id":146,"name":"Dizzy Punch","type":1,"p":70,"pp":10,"dmg_class":1,"effect":20}
+{"id":147,"name":"Spore","type":12,"pp":15,"dmg_class":3,"effect":2}
+{"id":148,"name":"Flash","type":1,"pp":20,"dmg_class":3}
+{"id":149,"name":"Psywave","type":14,"pp":15,"dmg_class":2}
+{"id":150,"name":"Splash","type":1,"pp":40,"dmg_class":3}
+{"id":151,"name":"Acid Armor","type":4,"pp":20,"dmg_class":3}
+{"id":152,"name":"Crabhammer","type":11,"p":100,"acc":90,"pp":10,"dmg_class":1}
+{"id":153,"name":"Explosion","type":1,"p":250,"pp":5,"dmg_class":1}
+{"id":154,"name":"Fury Swipes","type":1,"p":18,"acc":80,"pp":15,"dmg_class":1}
+{"id":155,"name":"Bonemerang","type":5,"p":50,"acc":90,"pp":10,"dmg_class":1}
+{"id":156,"name":"Rest","type":14,"pp":5,"dmg_class":3}
+{"id":157,"name":"Rock Slide","type":6,"p":75,"acc":90,"pp":10,"dmg_class":1,"effect":30}
+{"id":158,"name":"Hyper Fang","type":1,"p":80,"acc":90,"pp":15,"dmg_class":1,"effect":10}
+{"id":159,"name":"Sharpen","type":1,"pp":30,"dmg_class":3}
+{"id":160,"name":"Conversion","type":1,"pp":30,"dmg_class":3}
+{"id":161,"name":"Tri Attack","type":1,"p":80,"pp":10,"dmg_class":2,"effect":20}
+{"id":162,"name":"Super Fang","type":1,"acc":90,"pp":10,"dmg_class":1}
+{"id":163,"name":"Slash","type":1,"p":70,"pp":20,"dmg_class":1}
+{"id":164,"name":"Substitute","type":1,"pp":10,"dmg_class":3}
+{"id":165,"name":"Struggle","type":1,"p":50,"pp":1,"dmg_class":1}
+{"id":166,"name":"Sketch","type":1,"pp":1,"dmg_class":3}
+{"id":167,"name":"Triple Kick","type":2,"p":10,"acc":90,"pp":10,"dmg_class":1}
+{"id":168,"name":"Thief","type":17,"p":60,"pp":25,"dmg_class":1}
+{"id":169,"name":"Spider Web","type":7,"pp":10,"dmg_class":3}
+{"id":170,"name":"Mind Reader","type":1,"pp":5,"dmg_class":3}
+{"id":171,"name":"Nightmare","type":8,"pp":15,"dmg_class":3,"effect":9}
+{"id":172,"name":"Flame Wheel","type":10,"p":60,"pp":25,"dmg_class":1,"effect":10}
+{"id":173,"name":"Snore","type":1,"p":50,"pp":15,"dmg_class":2,"effect":30}
+{"id":174,"name":"Curse","type":8,"pp":10,"dmg_class":3}
+{"id":175,"name":"Flail","type":1,"pp":15,"dmg_class":1}
+{"id":176,"name":"Conversion 2","type":1,"pp":30,"dmg_class":3}
+{"id":177,"name":"Aeroblast","type":3,"p":100,"acc":95,"pp":5,"dmg_class":2}
+{"id":178,"name":"Cotton Spore","type":12,"pp":40,"dmg_class":3}
+{"id":179,"name":"Reversal","type":2,"pp":15,"dmg_class":1}
+{"id":180,"name":"Spite","type":8,"pp":10,"dmg_class":3}
+{"id":181,"name":"Powder Snow","type":15,"p":40,"pp":25,"dmg_class":2,"effect":10}
+{"id":182,"name":"Protect","type":1,"pp":10,"dmg_class":3}
+{"id":183,"name":"Mach Punch","type":2,"p":40,"pp":30,"dmg_class":1}
+{"id":184,"name":"Scary Face","type":1,"pp":10,"dmg_class":3}
+{"id":185,"name":"Feint Attack","type":17,"p":60,"pp":20,"dmg_class":1}
+{"id":186,"name":"Sweet Kiss","type":18,"acc":75,"pp":10,"dmg_class":3,"effect":6}
+{"id":187,"name":"Belly Drum","type":1,"pp":10,"dmg_class":3}
+{"id":188,"name":"Sludge Bomb","type":4,"p":90,"pp":10,"dmg_class":2,"effect":30}
+{"id":189,"name":"Mud-Slap","type":5,"p":20,"pp":10,"dmg_class":2,"effect":100}
+{"id":190,"name":"Octazooka","type":11,"p":65,"acc":85,"pp":10,"dmg_class":2,"effect":50}
+{"id":191,"name":"Spikes","type":5,"pp":20,"dmg_class":3}
+{"id":192,"name":"Zap Cannon","type":13,"p":120,"acc":50,"pp":5,"dmg_class":2,"effect":100}
+{"id":193,"name":"Foresight","type":1,"pp":40,"dmg_class":3,"effect":17}
+{"id":194,"name":"Destiny Bond","type":8,"pp":5,"dmg_class":3}
+{"id":195,"name":"Perish Song","type":1,"pp":5,"dmg_class":3,"effect":20}
+{"id":196,"name":"Icy Wind","type":15,"p":55,"acc":95,"pp":15,"dmg_class":2,"effect":100}
+{"id":197,"name":"Detect","type":2,"pp":5,"dmg_class":3}
+{"id":198,"name":"Bone Rush","type":5,"p":25,"acc":90,"pp":10,"dmg_class":1}
+{"id":199,"name":"Lock-On","type":1,"pp":5,"dmg_class":3}
+{"id":200,"name":"Outrage","type":16,"p":120,"pp":10,"dmg_class":1}
+{"id":201,"name":"Sandstorm","type":6,"pp":10,"dmg_class":3}
+{"id":202,"name":"Giga Drain","type":12,"p":75,"pp":10,"dmg_class":2}
+{"id":203,"name":"Endure","type":1,"pp":10,"dmg_class":3}
+{"id":204,"name":"Charm","type":18,"pp":20,"dmg_class":3}
+{"id":205,"name":"Rollout","type":6,"p":30,"acc":90,"pp":20,"dmg_class":1}
+{"id":206,"name":"False Swipe","type":1,"p":40,"pp":40,"dmg_class":1}
+{"id":207,"name":"Swagger","type":1,"acc":85,"pp":15,"dmg_class":3,"effect":6}
+{"id":208,"name":"Milk Drink","type":1,"pp":5,"dmg_class":3}
+{"id":209,"name":"Spark","type":13,"p":65,"pp":20,"dmg_class":1,"effect":30}
+{"id":210,"name":"Fury Cutter","type":7,"p":40,"acc":95,"pp":20,"dmg_class":1}
+{"id":211,"name":"Steel Wing","type":9,"p":70,"acc":90,"pp":25,"dmg_class":1,"effect":10}
+{"id":212,"name":"Mean Look","type":1,"pp":5,"dmg_class":3}
+{"id":213,"name":"Attract","type":1,"pp":15,"dmg_class":3,"effect":7}
+{"id":214,"name":"Sleep Talk","type":1,"pp":10,"dmg_class":3}
+{"id":215,"name":"Heal Bell","type":1,"pp":5,"dmg_class":3}
+{"id":216,"name":"Return","type":1,"pp":20,"dmg_class":1}
+{"id":217,"name":"Present","type":1,"acc":90,"pp":15,"dmg_class":1}
+{"id":218,"name":"Frustration","type":1,"pp":20,"dmg_class":1}
+{"id":219,"name":"Safeguard","type":1,"pp":25,"dmg_class":3}
+{"id":220,"name":"Pain Split","type":1,"pp":20,"dmg_class":3}
+{"id":221,"name":"Sacred Fire","type":10,"p":100,"acc":95,"pp":5,"dmg_class":1,"effect":50}
+{"id":222,"name":"Magnitude","type":5,"pp":30,"dmg_class":1}
+{"id":223,"name":"Dynamic Punch","type":2,"p":100,"acc":50,"pp":5,"dmg_class":1,"effect":100}
+{"id":224,"name":"Megahorn","type":7,"p":120,"acc":85,"pp":10,"dmg_class":1}
+{"id":225,"name":"Dragon Breath","type":16,"p":60,"pp":20,"dmg_class":2,"effect":30}
+{"id":226,"name":"Baton Pass","type":1,"pp":40,"dmg_class":3}
+{"id":227,"name":"Encore","type":1,"pp":5,"dmg_class":3}
+{"id":228,"name":"Pursuit","type":17,"p":40,"pp":20,"dmg_class":1}
+{"id":229,"name":"Rapid Spin","type":1,"p":50,"pp":40,"dmg_class":1,"effect":100}
+{"id":230,"name":"Sweet Scent","type":1,"pp":20,"dmg_class":3}
+{"id":231,"name":"Iron Tail","type":9,"p":100,"acc":75,"pp":15,"dmg_class":1,"effect":30}
+{"id":232,"name":"Metal Claw","type":9,"p":50,"acc":95,"pp":35,"dmg_class":1,"effect":10}
+{"id":233,"name":"Vital Throw","type":2,"p":70,"pp":10,"dmg_class":1}
+{"id":234,"name":"Morning Sun","type":1,"pp":5,"dmg_class":3}
+{"id":235,"name":"Synthesis","type":12,"pp":5,"dmg_class":3}
+{"id":236,"name":"Moonlight","type":18,"pp":5,"dmg_class":3}
+{"id":237,"name":"Hidden Power","type":1,"p":60,"pp":15,"dmg_class":2}
+{"id":238,"name":"Cross Chop","type":2,"p":100,"acc":80,"pp":5,"dmg_class":1}
+{"id":239,"name":"Twister","type":16,"p":40,"pp":20,"dmg_class":2,"effect":20}
+{"id":240,"name":"Rain Dance","type":11,"pp":5,"dmg_class":3}
+{"id":241,"name":"Sunny Day","type":10,"pp":5,"dmg_class":3}
+{"id":242,"name":"Crunch","type":17,"p":80,"pp":15,"dmg_class":1,"effect":20}
+{"id":243,"name":"Mirror Coat","type":14,"pp":20,"dmg_class":2}
+{"id":244,"name":"Psych Up","type":1,"pp":10,"dmg_class":3}
+{"id":245,"name":"Extreme Speed","type":1,"p":80,"pp":5,"dmg_class":1}
+{"id":246,"name":"Ancient Power","type":6,"p":60,"pp":5,"dmg_class":2,"effect":10}
+{"id":247,"name":"Shadow Ball","type":8,"p":80,"pp":15,"dmg_class":2,"effect":20}
+{"id":248,"name":"Future Sight","type":14,"p":120,"pp":10,"dmg_class":2}
+{"id":249,"name":"Rock Smash","type":2,"p":40,"pp":15,"dmg_class":1,"effect":50}
+{"id":250,"name":"Whirlpool","type":11,"p":35,"acc":85,"pp":15,"dmg_class":2,"effect":100}
+{"id":251,"name":"Beat Up","type":17,"pp":10,"dmg_class":1}
+{"id":252,"name":"Fake Out","type":1,"p":40,"pp":10,"dmg_class":1,"effect":100}
+{"id":253,"name":"Uproar","type":1,"p":90,"pp":10,"dmg_class":2}
+{"id":254,"name":"Stockpile","type":1,"pp":20,"dmg_class":3}
+{"id":255,"name":"Spit Up","type":1,"pp":10,"dmg_class":2}
+{"id":256,"name":"Swallow","type":1,"pp":10,"dmg_class":3}
+{"id":257,"name":"Heat Wave","type":10,"p":95,"acc":90,"pp":10,"dmg_class":2,"effect":10}
+{"id":258,"name":"Hail","type":15,"pp":10,"dmg_class":3}
+{"id":259,"name":"Torment","type":17,"pp":15,"dmg_class":3,"effect":12}
+{"id":260,"name":"Flatter","type":17,"pp":15,"dmg_class":3,"effect":6}
+{"id":261,"name":"Will-O-Wisp","type":10,"acc":85,"pp":15,"dmg_class":3,"effect":4}
+{"id":262,"name":"Memento","type":17,"pp":10,"dmg_class":3}
+{"id":263,"name":"Facade","type":1,"p":70,"pp":20,"dmg_class":1}
+{"id":264,"name":"Focus Punch","type":2,"p":150,"pp":20,"dmg_class":1}
+{"id":265,"name":"Smelling Salts","type":1,"p":70,"pp":10,"dmg_class":1}
+{"id":266,"name":"Follow Me","type":1,"pp":20,"dmg_class":3}
+{"id":267,"name":"Nature Power","type":1,"pp":20,"dmg_class":3}
+{"id":268,"name":"Charge","type":13,"pp":20,"dmg_class":3}
+{"id":269,"name":"Taunt","type":17,"pp":20,"dmg_class":3}
+{"id":270,"name":"Helping Hand","type":1,"pp":20,"dmg_class":3}
+{"id":271,"name":"Trick","type":14,"pp":10,"dmg_class":3}
+{"id":272,"name":"Role Play","type":14,"pp":10,"dmg_class":3}
+{"id":273,"name":"Wish","type":1,"pp":10,"dmg_class":3}
+{"id":274,"name":"Assist","type":1,"pp":20,"dmg_class":3}
+{"id":275,"name":"Ingrain","type":12,"pp":20,"dmg_class":3,"effect":21}
+{"id":276,"name":"Superpower","type":2,"p":120,"pp":5,"dmg_class":1,"effect":100}
+{"id":277,"name":"Magic Coat","type":14,"pp":15,"dmg_class":3}
+{"id":278,"name":"Recycle","type":1,"pp":10,"dmg_class":3}
+{"id":279,"name":"Revenge","type":2,"p":60,"pp":10,"dmg_class":1}
+{"id":280,"name":"Brick Break","type":2,"p":75,"pp":15,"dmg_class":1}
+{"id":281,"name":"Yawn","type":1,"pp":10,"dmg_class":3,"effect":14}
+{"id":282,"name":"Knock Off","type":17,"p":65,"pp":20,"dmg_class":1}
+{"id":283,"name":"Endeavor","type":1,"pp":5,"dmg_class":1}
+{"id":284,"name":"Eruption","type":10,"p":150,"pp":5,"dmg_class":2}
+{"id":285,"name":"Skill Swap","type":14,"pp":10,"dmg_class":3}
+{"id":286,"name":"Imprison","type":14,"pp":10,"dmg_class":3}
+{"id":287,"name":"Refresh","type":1,"pp":20,"dmg_class":3}
+{"id":288,"name":"Grudge","type":8,"pp":5,"dmg_class":3}
+{"id":289,"name":"Snatch","type":17,"pp":10,"dmg_class":3}
+{"id":290,"name":"Secret Power","type":1,"p":70,"pp":20,"dmg_class":1,"effect":30}
+{"id":291,"name":"Dive","type":11,"p":80,"pp":10,"dmg_class":1}
+{"id":292,"name":"Arm Thrust","type":2,"p":15,"pp":20,"dmg_class":1}
+{"id":293,"name":"Camouflage","type":1,"pp":20,"dmg_class":3}
+{"id":294,"name":"Tail Glow","type":7,"pp":20,"dmg_class":3}
+{"id":295,"name":"Luster Purge","type":14,"p":95,"pp":5,"dmg_class":2,"effect":50}
+{"id":296,"name":"Mist Ball","type":14,"p":95,"pp":5,"dmg_class":2,"effect":50}
+{"id":297,"name":"Feather Dance","type":3,"pp":15,"dmg_class":3}
+{"id":298,"name":"Teeter Dance","type":1,"pp":20,"dmg_class":3,"effect":6}
+{"id":299,"name":"Blaze Kick","type":10,"p":85,"acc":90,"pp":10,"dmg_class":1,"effect":10}
+{"id":300,"name":"Mud Sport","type":5,"pp":15,"dmg_class":3}
+{"id":301,"name":"Ice Ball","type":15,"p":30,"acc":90,"pp":20,"dmg_class":1}
+{"id":302,"name":"Needle Arm","type":12,"p":60,"pp":15,"dmg_class":1,"effect":30}
+{"id":303,"name":"Slack Off","type":1,"pp":5,"dmg_class":3}
+{"id":304,"name":"Hyper Voice","type":1,"p":90,"pp":10,"dmg_class":2}
+{"id":305,"name":"Poison Fang","type":4,"p":50,"pp":15,"dmg_class":1,"effect":50}
+{"id":306,"name":"Crush Claw","type":1,"p":75,"acc":95,"pp":10,"dmg_class":1,"effect":50}
+{"id":307,"name":"Blast Burn","type":10,"p":150,"acc":90,"pp":5,"dmg_class":2}
+{"id":308,"name":"Hydro Cannon","type":11,"p":150,"acc":90,"pp":5,"dmg_class":2}
+{"id":309,"name":"Meteor Mash","type":9,"p":90,"acc":90,"pp":10,"dmg_class":1,"effect":20}
+{"id":310,"name":"Astonish","type":8,"p":30,"pp":15,"dmg_class":1,"effect":30}
+{"id":311,"name":"Weather Ball","type":1,"p":50,"pp":10,"dmg_class":2}
+{"id":312,"name":"Aromatherapy","type":12,"pp":5,"dmg_class":3}
+{"id":313,"name":"Fake Tears","type":17,"pp":20,"dmg_class":3}
+{"id":314,"name":"Air Cutter","type":3,"p":60,"acc":95,"pp":25,"dmg_class":2}
+{"id":315,"name":"Overheat","type":10,"p":130,"acc":90,"pp":5,"dmg_class":2,"effect":100}
+{"id":316,"name":"Odor Sleuth","type":1,"pp":40,"dmg_class":3,"effect":17}
+{"id":317,"name":"Rock Tomb","type":6,"p":60,"acc":95,"pp":15,"dmg_class":1,"effect":100}
+{"id":318,"name":"Silver Wind","type":7,"p":60,"pp":5,"dmg_class":2,"effect":10}
+{"id":319,"name":"Metal Sound","type":9,"acc":85,"pp":40,"dmg_class":3}
+{"id":320,"name":"Grass Whistle","type":12,"acc":55,"pp":15,"dmg_class":3,"effect":2}
+{"id":321,"name":"Tickle","type":1,"pp":20,"dmg_class":3}
+{"id":322,"name":"Cosmic Power","type":14,"pp":20,"dmg_class":3}
+{"id":323,"name":"Water Spout","type":11,"p":150,"pp":5,"dmg_class":2}
+{"id":324,"name":"Signal Beam","type":7,"p":75,"pp":15,"dmg_class":2,"effect":10}
+{"id":325,"name":"Shadow Punch","type":8,"p":60,"pp":20,"dmg_class":1}
+{"id":326,"name":"Extrasensory","type":14,"p":80,"pp":20,"dmg_class":2,"effect":10}
+{"id":327,"name":"Sky Uppercut","type":2,"p":85,"acc":90,"pp":15,"dmg_class":1}
+{"id":328,"name":"Sand Tomb","type":5,"p":35,"acc":85,"pp":15,"dmg_class":1,"effect":100}
+{"id":329,"name":"Sheer Cold","type":15,"acc":30,"pp":5,"dmg_class":2}
+{"id":330,"name":"Muddy Water","type":11,"p":90,"acc":85,"pp":10,"dmg_class":2,"effect":30}
+{"id":331,"name":"Bullet Seed","type":12,"p":25,"pp":30,"dmg_class":1}
+{"id":332,"name":"Aerial Ace","type":3,"p":60,"pp":20,"dmg_class":1}
+{"id":333,"name":"Icicle Spear","type":15,"p":25,"pp":30,"dmg_class":1}
+{"id":334,"name":"Iron Defense","type":9,"pp":15,"dmg_class":3}
+{"id":335,"name":"Block","type":1,"pp":5,"dmg_class":3}
+{"id":336,"name":"Howl","type":1,"pp":40,"dmg_class":3}
+{"id":337,"name":"Dragon Claw","type":16,"p":80,"pp":15,"dmg_class":1}
+{"id":338,"name":"Frenzy Plant","type":12,"p":150,"acc":90,"pp":5,"dmg_class":2}
+{"id":339,"name":"Bulk Up","type":2,"pp":20,"dmg_class":3}
+{"id":340,"name":"Bounce","type":3,"p":85,"acc":85,"pp":5,"dmg_class":1,"effect":30}
+{"id":341,"name":"Mud Shot","type":5,"p":55,"acc":95,"pp":15,"dmg_class":2,"effect":100}
+{"id":342,"name":"Poison Tail","type":4,"p":50,"pp":25,"dmg_class":1,"effect":10}
+{"id":343,"name":"Covet","type":1,"p":60,"pp":25,"dmg_class":1}
+{"id":344,"name":"Volt Tackle","type":13,"p":120,"pp":15,"dmg_class":1,"effect":10}
+{"id":345,"name":"Magical Leaf","type":12,"p":60,"pp":20,"dmg_class":2}
+{"id":346,"name":"Water Sport","type":11,"pp":15,"dmg_class":3}
+{"id":347,"name":"Calm Mind","type":14,"pp":20,"dmg_class":3}
+{"id":348,"name":"Leaf Blade","type":12,"p":90,"pp":15,"dmg_class":1}
+{"id":349,"name":"Dragon Dance","type":16,"pp":20,"dmg_class":3}
+{"id":350,"name":"Rock Blast","type":6,"p":25,"acc":90,"pp":10,"dmg_class":1}
+{"id":351,"name":"Shock Wave","type":13,"p":60,"pp":20,"dmg_class":2}
+{"id":352,"name":"Water Pulse","type":11,"p":60,"pp":20,"dmg_class":2,"effect":20}
+{"id":353,"name":"Doom Desire","type":9,"p":140,"pp":5,"dmg_class":2}
+{"id":354,"name":"Psycho Boost","type":14,"p":140,"acc":90,"pp":5,"dmg_class":2,"effect":100}

--- a/scripts/generate-pokedata.ts
+++ b/scripts/generate-pokedata.ts
@@ -604,6 +604,54 @@ for (const cid of uniqueChainIds) {
   registerChain(fullChain, []);
 }
 
+console.log('\nProcessing Moves...');
+const moves: any[] = [];
+// We primarily care about moves present up to Gen 3
+const MAX_MOVE_ID = 354;
+for (let i = 1; i <= MAX_MOVE_ID; i++) {
+  const mDataPath = path.join(dataPath, `move/${i}/index.json`);
+  const mData = readJson(mDataPath);
+  if (!mData) continue;
+
+  const typeId = parseInt(mData.type.url.split('/').filter(Boolean).pop() || '0', 10);
+
+  let dmgClass = 0;
+  if (mData.damage_class) {
+    const dcId = parseInt(mData.damage_class.url.split('/').filter(Boolean).pop() || '0', 10);
+    // PokeAPI: 1=status, 2=physical, 3=special
+    // Our DB: 1=physical, 2=special, 3=status
+    if (dcId === 2) dmgClass = 1;
+    else if (dcId === 3) dmgClass = 2;
+    else if (dcId === 1) dmgClass = 3;
+  }
+
+  let effect: number | undefined;
+  if (mData.effect_chance !== null && mData.effect_chance > 0) {
+    effect = mData.effect_chance;
+  } else if (mData.meta && mData.meta.ailment && mData.meta.ailment.url) {
+    const ailmentId = parseInt(mData.meta.ailment.url.split('/').filter(Boolean).pop() || '0', 10);
+    if (ailmentId > 0) {
+      effect = ailmentId;
+    }
+  }
+
+  const move: any = {
+    id: mData.id,
+    name: mData.names.find((n: PokeApiName) => n.language.name === 'en')?.name || mData.name,
+    type: typeId,
+    p: mData.power,
+    acc: mData.accuracy,
+    pp: mData.pp,
+    dmg_class: dmgClass,
+  };
+
+  if (effect !== undefined) {
+    move.effect = effect;
+  }
+
+  moves.push(move);
+}
+
 /**
  * Recursively strips nulls, undefined values, default falsy states, and empty arrays from an object.
  *
@@ -644,6 +692,11 @@ function compact(obj: any): any {
       // Omit max if same as min (encounter levels)
       if (key === 'max' && value === obj.min) continue;
 
+      // Omit move power p if 0 or null
+      if (key === 'p' && (value === 0 || value === null)) continue;
+      // Omit move acc if 100 or null
+      if (key === 'acc' && (value === 100 || value === null)) continue;
+
       result[key] = compact(value);
     }
     return result;
@@ -660,6 +713,7 @@ writeJsonl(path.join(OUTPUT_DIR, 'encounters.jsonl'), Array.from(pokemonEncounte
   enc: encs.map(compact)
 })));
 writeJsonl(path.join(OUTPUT_DIR, 'locations.jsonl'), Array.from(locationMap.values()).map(compact).sort((a, b) => a.id - b.id));
+writeJsonl(path.join(OUTPUT_DIR, 'moves.jsonl'), moves.map(compact));
 
   // Write metadata
   fs.writeFileSync(path.join(OUTPUT_DIR, 'metadata.json'), JSON.stringify({


### PR DESCRIPTION
Implements the move data extraction phase in the Pokédex data generation pipeline (`scripts/generate-pokedata.ts`) as defined in ADR 025. This extracts properties such as base power, accuracy, PP, damage class, type, and specific effects for all moves up to Generation 3, applying compaction rules to save space. Output is written to `data/db/moves.jsonl`.

---
*PR created automatically by Jules for task [15883840592792390280](https://jules.google.com/task/15883840592792390280) started by @szubster*