### PR TITLE
🛠️ Infras: Synchronize Biome version and schema to 2.5.0

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: "2.4.16"
+          version: "2.5.0"
 
       - name: Run Biome
         run: biome ci --error-on-warnings .

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -26,7 +26,7 @@
       "types": "recommended"
     },
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "nursery": {
         "useSortedClasses": {
           "level": "error",
@@ -40,13 +40,13 @@
         "useSimpleNumberKeys": "off"
       },
       "correctness": {
-        "recommended": true
+        "preset": "recommended"
       },
       "style": {
         "useNodejsImportProtocol": "error"
       },
       "security": {
-        "recommended": true
+        "preset": "recommended"
       }
     }
   },


### PR DESCRIPTION
What: Updated Biome schema from 2.4.16 to 2.5.0 and updated deprecated schema properties in `biome.jsonc`. Synchronized the Biome version in `.github/workflows/biome.yml` to 2.5.0.

Why: The Biome version in `package.json` was 2.5.0, but `biome.jsonc` and the GitHub workflow `.github/workflows/biome.yml` were still using version 2.4.16, leading to a config drift and version mismatch warning during schema validation.

Impact on DX/CI: Prevents warnings and ensures local and CI environments both use the exact same up-to-date version of Biome for linting and formatting.

Setup notes: Run `pnpm install` to ensure the matching Biome CLI version is downloaded if missing locally.

---
*PR created automatically by Jules for task [11583521588440756637](https://jules.google.com/task/11583521588440756637) started by @szubster*