### PR TITLE
Foundry Orchestrator: Resolve Suspension Flip-Flop and Improve Mitigation

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -5,7 +5,7 @@ title: Gen 3 TV Broadcast and Swarm Tracker Data Extraction
 status: READY
 owner_persona: story_owner
 created_at: '2026-06-12'
-updated_at: '2026-06-17'
+updated_at: '2026-06-18'
 depends_on: []
 jules_session_id: null
 pr_number: null

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -574,10 +574,14 @@ function main(): void {
     let shouldSuspend = false;
 
     const children = parentToChildren.get(node.repoPath) || [];
+    let hasTerminalFailure = false;
     for (const child of children) {
+      if ((child.frontmatter.status === 'FAILED' || child.frontmatter.status === 'CANCELLED') && child.frontmatter.rejection_reason) {
+        hasTerminalFailure = true;
+        break;
+      }
       if (isHierarchicallyIncomplete(child.repoPath, [node.repoPath])) {
         shouldSuspend = true;
-        break;
       }
     }
 
@@ -601,6 +605,11 @@ function main(): void {
         break;
       }
 
+      if ((dep.frontmatter.status === 'FAILED' || dep.frontmatter.status === 'CANCELLED') && dep.frontmatter.rejection_reason) {
+        hasTerminalFailure = true;
+        break;
+      }
+
       // If it is an ancestor, we only care that it is status ACTIVE or COMPLETED.
       if (!isDescendant(node.repoPath, depPath!)) {
         if (isHierarchicallyIncomplete(depPath!, [node.repoPath])) {
@@ -613,6 +622,10 @@ function main(): void {
           break;
         }
       }
+    }
+
+    if (hasTerminalFailure) {
+      shouldSuspend = false;
     }
 
     if (shouldSuspend && (node.frontmatter.status === 'ACTIVE' || node.frontmatter.status === 'VERIFYING' || node.frontmatter.status === 'READY')) {
@@ -658,9 +671,23 @@ function main(): void {
           parentNode &&
           parentNode.frontmatter.status !== 'ACTIVE' &&
           parentNode.frontmatter.status !== 'READY' &&
+          parentNode.frontmatter.status !== 'VERIFYING' &&
           parentNode.frontmatter.status !== 'COMPLETED' &&
           parentNode.frontmatter.status !== 'CANCELLED'
         ) {
+          let isParentDepIncomplete = false;
+          for (const depRef of parentNode.frontmatter.depends_on) {
+            const depPath = resolveNodePath(depRef);
+            if (depPath && isHierarchicallyIncomplete(depPath, [parentNode.repoPath])) {
+              isParentDepIncomplete = true;
+              break;
+            }
+          }
+
+          if (isParentDepIncomplete) {
+            continue;
+          }
+
           info(`Impossible Loop: waking up parent ${parentNode.repoPath}`);
           if (parentNode.frontmatter.owner_persona === 'human') {
             promoteNodeStatus(parentNode, parentNode.frontmatter.status, 'ACTIVE');


### PR DESCRIPTION
This PR improves the robustness of the Foundry Engine orchestrator by addressing a specific "suspension vs. wakeup" flip-flop loop that caused orchestration failures. 

Key changes:
1. **Terminal Failure Protection:** Modified Phase 3.5 to prevent nodes from being suspended back to `PENDING` if any of their children or dependencies have already terminally failed (`FAILED` or `CANCELLED` with a `rejection_reason`). This ensures that the system doesn't enter an infinite loop of suspending a parent node while another phase tries to wake it up to handle the child's failure.
2. **Hierarchical Dependency Check:** Modified Phase 3.6 (Impossible Loop mitigation) to prevent waking up a parent node if that parent node is itself blocked by its own `depends_on` dependencies. This ensures that nodes only progress when they are actually ready to do so.
3. **Status Regression Prevention:** Added the `VERIFYING` status to the list of statuses that exclude a parent from being woken up in Phase 3.6, preventing unintended regressions from a verification state back to `READY` or `ACTIVE`.

These changes ensure DAG stability and prevent "orchestration failures" in complex dependency scenarios.

Fixes #2789

---
*PR created automatically by Jules for task [18422102109683582904](https://jules.google.com/task/18422102109683582904) started by @szubster*