### PR TITLE
🧹 Remove unused HiddenItemData and ignore verify-dag-refs script in knip

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -35,3 +35,5 @@ Before deleting code flagged as dead, always check the status of Foundry tasks (
 ## 2026-06-07 - Verify Unused Code Removals
 **Learning:** Tools like `knip` can identify unused exports and dependencies, but they sometimes have blind spots or misinterpret usage (especially for global configurations, setup scripts, or exported test helpers/fixtures).
 **Action:** When using tools like `knip` to find unused exports or files, always verify potential implicit usage with a global repository search (e.g., `grep`) before removing them to ensure they aren't dynamically referenced by tests or CI scripts.
+## 2026-06-07 - Verify Unused Code Removals
+**Learning:** The project's biome config may be outdated. Do not attempt to run `biome migrate --write` as it could cause biome syntax errors.

--- a/knip.json
+++ b/knip.json
@@ -15,7 +15,8 @@
     ".github/scripts/extract-research.ts",
     "scripts/gen3-fetch-locations.ts",
     "functions/_middleware.ts",
-    "scripts/data/gen3/match_call/etl.ts"
+    "scripts/data/gen3/match_call/etl.ts",
+    ".github/scripts/verify-dag-refs.ts"
   ],
   "rules": {
     "files": "warn",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -140,14 +140,6 @@ export interface PokemonMetadata {
   det: CompactEvolutionDetail[]; // Evolutionary requirements to reach THIS pokemon from parent
 }
 
-export interface HiddenItemData {
-  flagOffset: number;
-  flagBit: number;
-  locationId: number;
-  itemId: number;
-  isAcquired?: boolean;
-}
-
 export interface PokeDataExport {
   poke: PokemonMetadata[];
   enc: LocationAreaEncounters[];


### PR DESCRIPTION
🎯 What
Removes unused code and silences a false positive in Knip.

💡 Why
`HiddenItemData` was not used anywhere in the codebase.
`.github/scripts/verify-dag-refs.ts` was being flagged by Knip as unused, but it's executed dynamically via a GitHub Actions workflow step (`verify:refs`), so it needs to be explicitly ignored to pass the linter.

✅ Verification
Ran `pnpm test`, `pnpm lint`, `pnpm test:e2e` locally, all passed.

✨ Result
Cleaner codebase and a warning-free `pnpm knip` run.

---
*PR created automatically by Jules for task [6574513760776147261](https://jules.google.com/task/6574513760776147261) started by @szubster*