### PR TITLE
chore(foundry): Cancel breeding pair algorithm task due to missing context and max rejections

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -101,3 +101,6 @@ Implemented Unown Dex Panel using tactical hardware styling constraints (ADR 008
 2. Append the exact ID of the newly created node to the current implementation task's `depends_on` array.
 3. Submit the empty PR with unchecked acceptance criteria to gracefully suspend the task. The orchestrator will automatically pause the task until the prerequisite research is complete.
 4. It is *not* necessary to manually mark the current task as `FAILED` or provide a `rejection_reason` in the YAML frontmatter. Adding the new RESEARCH node to the `depends_on` array and submitting with unchecked acceptance criteria is sufficient for the orchestrator to keep the task suspended.
+
+## 2026-06-18: Rejecting Task due to Max Rejections & Missing Dependencies
+Permanently failed `task-084-150-breeding-pair-algorithm-impl` since it reached the maximum rejection count of 3. The task lacked critical context (Gen 2 Egg Groups data and gender calculation logic), and its dependency `research-150-186-egg-groups-missing` was already CANCELLED via cascading cancellation. Its status has been updated to CANCELLED in the frontmatter, with a descriptive `rejection_reason`. Crucially, its acceptance criteria checkboxes were left unchecked, ensuring it does not mistakenly masquerade as successfully completed, correctly triggering its exit from the DAG.

--- a/.foundry/tasks/task-084-150-breeding-pair-algorithm-impl.md
+++ b/.foundry/tasks/task-084-150-breeding-pair-algorithm-impl.md
@@ -2,7 +2,7 @@
 id: task-084-150-breeding-pair-algorithm-impl
 type: TASK
 title: Implement Gen 2 Breeding Pair Algorithm
-status: ACTIVE
+status: CANCELLED
 owner_persona: coder
 created_at: '2026-06-08'
 updated_at: '2026-06-18'
@@ -18,7 +18,7 @@ tags:
   - backend
 research_references: []
 rejection_count: 3
-rejection_reason: ''
+rejection_reason: 'Aborted: Task reached maximum rejection count of 3. Missing critical context regarding Egg Groups and Gen 2 gender computation. Dependency research-150-186-egg-groups-missing is also cancelled.'
 notes: ''
 ---
 


### PR DESCRIPTION
This PR aborts `task-084-150-breeding-pair-algorithm-impl` because it reached the maximum rejection count of 3 and its dependency (`research-150-186-egg-groups-missing`) was also cancelled. The task has been safely moved to a `CANCELLED` status with a proper rejection reason, and the Acceptance Criteria checkboxes have deliberately been left unchecked so it can gracefully exit the DAG. The reasoning has been logged in the Coder journal.

---
*PR created automatically by Jules for task [359040412850573257](https://jules.google.com/task/359040412850573257) started by @szubster*