### PR TITLE
Auditor Rejection: epic-036-058-feebas-backend-parsing

### DIFF
--- a/.foundry/epics/epic-036-058-feebas-backend-parsing.md
+++ b/.foundry/epics/epic-036-058-feebas-backend-parsing.md
@@ -25,8 +25,11 @@ notes: ''
 Create a utility module that reads the parsed save file's data at the identified offset to extract the Feebas seed, and implements the PRNG/math algorithm used by Gen 3 to translate the seed into the 6 specific tile coordinates on Route 119.
 
 ## Acceptance Criteria
-- [x] Create a utility module for Feebas seed extraction.
+- [ ] Create a utility module for Feebas seed extraction.
 - [x] Implement Gen 3 algorithm to calculate the 6 tile coordinates based on the seed.
 - [x] Ensure fast calculation concurrent with save file hydration.
 - [x] .foundry/stories/story-058-095-feebas-seed-extraction.md
 - [x] .foundry/stories/story-058-096-feebas-tile-calculation.md
+
+### Auditor Rejection
+Inline magic numbers are used for memory offsets (0x2dd6, 0x2e66) in `src/engine/gen3/feebas.ts` instead of explicitly defined and reusable constants, violating the memory rule.

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -123,3 +123,12 @@ This confirms the architecture accurately scales bitwise state extractions, reli
 The usage of specific bitwise operators (`>> 4` and `& 0x0f`) accompanied by targeted edge-case unit tests ensures regressions are caught early in core data structures. This pattern of boundary testing for custom bit fields is crucial and should be propagated to other similar bit-level extraction systems in Gen 3/4.
 ## Save File Parsing Strategy
 When implementing save file parsing, strictly use dynamic relative offset calculations (anchored to known base offsets) instead of absolute hardcoded offsets for extracting dynamic data blocks to ensure robustness against version-specific shifts and prevent regressions.
+
+## 2026-06-19: Enforcing Reusable Constants for Memory Offsets
+I rejected the Epic `epic-036-058-feebas-backend-parsing` because the implementer used inline magic numbers (e.g., `0x2dd6`) directly in the parsing functions instead of explicitly defined constants.
+
+**Why this matters:**
+Scattering magic numbers across the codebase makes maintaining version-specific parsing offsets difficult and brittle. The memory rule mandates that when implementing save file parsing or data definitions, explicitly define and use reusable constants for memory offsets, lengths, and bit locations.
+
+**Recommendation/Learnings:**
+Always enforce the rule against inline magic numbers during verification. All memory offsets, bit lengths, and shifts must be defined as reusable, descriptive constants at the module level.


### PR DESCRIPTION
Rejected `epic-036-058-feebas-backend-parsing` because the implementation (`src/engine/gen3/feebas.ts`) used inline magic numbers for memory offsets instead of explicitly defined constants, violating the rule recorded in the Auditor journal.
Added learning to Auditor journal.

---
*PR created automatically by Jules for task [16841401977057460420](https://jules.google.com/task/16841401977057460420) started by @szubster*