### PR TITLE
feat(saveParser): implement Gen 3 roamer data extraction

### DIFF
--- a/.foundry/tasks/task-108-161-gen3-roamer-dataview-extraction-impl.md
+++ b/.foundry/tasks/task-108-161-gen3-roamer-dataview-extraction-impl.md
@@ -32,13 +32,13 @@ Implement the logic to extract the 20-byte hidden roamer data structure from Gen
 Following ADR 010, the base extraction logic in the save parser for Gen 3 must safely read the 20-byte roamer structure exclusively using the `DataView` API. After extraction, correctly parse the IVs, HP, and Level of the roamer from this raw byte structure. Ensure that any out-of-bounds reads result in a `RangeError` that is caught and handled gracefully by propagating a validation error (e.g., "Corrupted Save File").
 
 ## Acceptance Criteria
-- [ ] Read the 20-byte Gen 3 roamer structure strictly using the `DataView` API.
-- [ ] Parse IVs, HP, and Level correctly from the extracted structure.
-- [ ] Handle `RangeError` on out-of-bounds reads gracefully and throw a clear validation error.
-- [ ] Tests and lint must pass.
+- [x] Read the 20-byte Gen 3 roamer structure strictly using the `DataView` API.
+- [x] Parse IVs, HP, and Level correctly from the extracted structure.
+- [x] Handle `RangeError` on out-of-bounds reads gracefully and throw a clear validation error.
+- [x] Tests and lint must pass.
 
 **Important Instructions:**
 If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
 If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
-- [ ] .foundry/research/research-161-186-gen3-roamer-iv-bitfield.md
+- [x] .foundry/research/research-161-186-gen3-roamer-iv-bitfield.md

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -8,6 +8,7 @@ import {
   parseGen3PersonalityValue,
   parseGen3PokeNews,
   parseGen3Ribbons,
+  parseGen3Roamer,
 } from './gen3';
 
 describe('gen3 parser scaffolding', () => {
@@ -466,5 +467,57 @@ describe('parseGen3PokeNews', () => {
     const view = new DataView(buffer);
 
     expect(() => parseGen3PokeNews(view, 0)).toThrowError('The save file is corrupted or incomplete.');
+  });
+});
+
+describe('parseGen3Roamer', () => {
+  it('should parse Gen 3 roamer data', () => {
+    const buffer = new ArrayBuffer(0x3144 + 20);
+    const view = new DataView(buffer);
+    const offset = 0x3144;
+
+    // Set ivs: HP=31, Atk=10, Def=15, Spd=20, SpAtk=25, SpDef=30
+    // 31 = 0x1F, 10 = 0x0A, 15 = 0x0F, 20 = 0x14, 25 = 0x19, 30 = 0x1E
+    // ivs = 31 | (10 << 5) | (15 << 10) | (20 << 15) | (25 << 20) | (30 << 25)
+    // ivs = 31 | 320 | 15360 | 655360 | 26214400 | 1006632960 = 1033518431 (0x3D9A3D5F)
+    view.setUint32(offset, 0x3d9a3d5f, true);
+
+    // Set personalityValue
+    view.setUint32(offset + 4, 0x12345678, true);
+
+    // Set speciesId (e.g. 380 for Latias)
+    view.setUint16(offset + 8, 380, true);
+
+    // Set hp
+    view.setUint16(offset + 10, 150, true);
+
+    // Set level
+    view.setUint8(offset + 12, 40);
+
+    // Set statusCondition (e.g. 1 for Sleep)
+    view.setUint8(offset + 13, 1);
+
+    // Set active
+    view.setUint8(offset + 19, 1);
+
+    const result = parseGen3Roamer(view, 0, 'ruby');
+
+    expect(result).toEqual({
+      ivs: { hp: 31, atk: 10, def: 15, spd: 20, spAtk: 25, spDef: 30 },
+      personalityValue: 0x12345678,
+      speciesId: 380,
+      hp: 150,
+      level: 40,
+      statusCondition: 1,
+      active: true,
+    });
+  });
+
+  it('should explicitly catch RangeError and throw corrupted file error on out-of-bounds reads', () => {
+    // A buffer that is not large enough to hold the 20-byte roamer struct at the correct offset
+    const buffer = new ArrayBuffer(0x3144 + 10);
+    const view = new DataView(buffer);
+
+    expect(() => parseGen3Roamer(view, 0, 'ruby')).toThrowError('The save file is corrupted or incomplete.');
   });
 });

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -121,6 +121,61 @@ export function isGen3Save(view: DataView): boolean {
 }
 
 /**
+ * Parses the Gen 3 Roamer data from the save file.
+ *
+ * @param view - The raw save file DataView.
+ * @param saveBlock1Offset - The offset where SaveBlock1 starts.
+ * @param gameVersion - The version of the Gen 3 game.
+ * @returns An object containing the extracted roamer data.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3Roamer(view: DataView, saveBlock1Offset: number, gameVersion: string) {
+  let offset = saveBlock1Offset;
+  if (gameVersion === 'ruby' || gameVersion === 'sapphire') {
+    offset += 0x3144;
+  } else if (gameVersion === 'emerald') {
+    offset += 0x31dc;
+  } else if (gameVersion === 'firered' || gameVersion === 'leafgreen') {
+    offset += 0x30d0;
+  } else {
+    // Defaulting to ruby offset if unknown
+    offset += 0x3144;
+  }
+
+  try {
+    const ivs = view.getUint32(offset, true);
+    const personalityValue = view.getUint32(offset + 4, true);
+    const speciesId = view.getUint16(offset + 8, true);
+    const hp = view.getUint16(offset + 10, true);
+    const level = view.getUint8(offset + 12);
+    const statusCondition = view.getUint8(offset + 13);
+    const active = view.getUint8(offset + 19) !== 0;
+
+    const ivHp = ivs & 0x1f;
+    const atk = (ivs >> 5) & 0x1f;
+    const def = (ivs >> 10) & 0x1f;
+    const spd = (ivs >> 15) & 0x1f;
+    const spAtk = (ivs >> 20) & 0x1f;
+    const spDef = (ivs >> 25) & 0x1f;
+
+    return {
+      ivs: { hp: ivHp, atk, def, spd, spAtk, spDef },
+      personalityValue,
+      speciesId,
+      hp,
+      level,
+      statusCondition,
+      active,
+    };
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+/**
  * Parses Mix Record events from a Gen 3 save file.
  *
  * @param view - The raw save file DataView.


### PR DESCRIPTION
Adds the logic to extract the 20-byte hidden roamer data structure from Gen 3 save files using the `DataView` API and accurately parse the IVs, HP, and Level. 
Follows ADR 010. Ensures out-of-bounds reads throw a clear "Corrupted Save File" validation error. 
Tests were successfully added and passing.

---
*PR created automatically by Jules for task [11679163152443792366](https://jules.google.com/task/11679163152443792366) started by @szubster*