### PR TITLE
chore(task): suspend battle frontier UI impl pending data research

### DIFF
--- a/.foundry/tasks/research-116-204-gen3-battle-frontier-data.md
+++ b/.foundry/tasks/research-116-204-gen3-battle-frontier-data.md
@@ -1,0 +1,35 @@
+---
+id: research-116-204-gen3-battle-frontier-data
+type: RESEARCH
+title: Investigate Gen 3 Battle Frontier Data Structures
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-18'
+updated_at: '2026-06-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-116-169-battle-frontier-dashboard-impl
+tags:
+  - research
+  - gen3
+  - battle-frontier
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Investigate Gen 3 Battle Frontier Data Structures
+
+## Description
+We need to implement the Battle Frontier Dashboard UI for Gen 3 saves, but currently lack the specific specifications. Please investigate the Gen 3 game logic, save files, or existing extraction scripts to find out:
+1. The exact names of the 7 facilities in the Battle Frontier.
+2. The data structure and save offsets for the BP (Battle Points) wallet.
+3. The metrics, states, or offsets needed to visualize progress towards the next Frontier Brain encounter for each facility.
+
+## Acceptance Criteria
+- [ ] Determine the 7 facility names and their representation in the data layer.
+- [ ] Determine how to extract BP wallet balance from the save file.
+- [ ] Determine the progress metrics required to display Frontier Brain encounter progress.
+- [ ] Update the knowledge base with the findings or output a data schema that can be consumed by the dashboard UI.

--- a/.foundry/tasks/task-116-169-battle-frontier-dashboard-impl.md
+++ b/.foundry/tasks/task-116-169-battle-frontier-dashboard-impl.md
@@ -2,11 +2,12 @@
 id: task-116-169-battle-frontier-dashboard-impl
 type: TASK
 title: Implement Gen 3 Battle Frontier Dashboard UI
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-13'
 updated_at: '2026-06-18'
-depends_on: []
+depends_on:
+  - research-116-204-gen3-battle-frontier-data
 jules_session_id: '14792903690927096036'
 pr_number: null
 parent: story-079-116-battle-frontier-dashboard-ui
@@ -17,7 +18,7 @@ tags:
   - frontend
 research_references: []
 rejection_count: 1
-rejection_reason: ''
+rejection_reason: 'Suspended pending research on Battle Frontier facility data and BP wallet offsets due to lack of specification in the knowledge base.'
 notes: ''
 ---
 


### PR DESCRIPTION
Applies the Late Binding pattern to suspend Task 116-169 pending research. The task requires Gen 3 Battle Frontier facility names, BP wallet structure, and UI progress metrics, none of which exist in the `knowledge_base` or task description. To prevent hallucination, a new `RESEARCH` node (`research-116-204-gen3-battle-frontier-data`) was spawned. The task frontmatter was updated to `status: FAILED` with a clear `rejection_reason` and the new dependency added.

---
*PR created automatically by Jules for task [14792903690927096036](https://jules.google.com/task/14792903690927096036) started by @szubster*