### PR TITLE
Tech Lead: Implement DagContext and Provider Tasks

### DIFF
--- a/.foundry/stories/story-078-119-implement-dag-context-provider.md
+++ b/.foundry/stories/story-078-119-implement-dag-context-provider.md
@@ -29,4 +29,6 @@ Establish the `DagContext` React Context and `DagProvider` component to host the
 As mandated by ADR 013, the DAG Kanban Board and the React Flow visualizer must share the same underlying data without redundant fetching or parsing. This story implements the shared context structure that provides this single source of truth.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks
+- [x] Break down into Tasks
+- [ ] task-119-204-dag-context-provider-impl
+- [ ] task-119-205-dag-context-provider-qa

--- a/.foundry/tasks/task-119-204-dag-context-provider-impl.md
+++ b/.foundry/tasks/task-119-204-dag-context-provider-impl.md
@@ -1,0 +1,37 @@
+---
+id: task-119-204-dag-context-provider-impl
+type: TASK
+title: Implement DagContext and Provider Impl
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-18'
+updated_at: '2026-06-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-078-119-implement-dag-context-provider
+tags:
+  - architecture
+  - dashboard
+  - state-management
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement DagContext and Provider Impl
+
+## Overview
+Implement the `DagContext` React Context and `DagProvider` component to host the shared DAG data state globally.
+
+**Notice for Coder**: This component is already mostly implemented in `src/components/dashboard/DagContext.tsx` but we need to ensure it meets the requirements of ADR 013 (Kanban Board State Management) and ADR 017 (Permanent Failure Dashboard). You should verify and fix the implementation if needed. Please follow the Empty PR Policy: check off all Acceptance Criteria checkboxes and submit an empty PR if the code is already correct.
+
+## Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify that `DagContext` and `DagProvider` manage `nodes` and `edges` state.
+- [ ] Verify that `DagNodeData` includes `rejection_count` (ADR 017).
+- [ ] Verify that `DagProvider` provides state correctly.

--- a/.foundry/tasks/task-119-205-dag-context-provider-qa.md
+++ b/.foundry/tasks/task-119-205-dag-context-provider-qa.md
@@ -1,0 +1,37 @@
+---
+id: task-119-205-dag-context-provider-qa
+type: TASK
+title: Implement DagContext and Provider QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-18'
+updated_at: '2026-06-18'
+depends_on:
+  - task-119-204-dag-context-provider-impl
+jules_session_id: null
+pr_number: null
+parent: story-078-119-implement-dag-context-provider
+tags:
+  - architecture
+  - dashboard
+  - state-management
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement DagContext and Provider QA
+
+## Overview
+QA the `DagContext` and `DagProvider` implementation for the shared DAG state.
+
+**Notice for QA**: The test suite for this component already exists in `src/components/dashboard/__tests__/DagContext.test.tsx`. Verify that all tests pass and ensure the implementation aligns with ADR 013 and ADR 017. If no changes are needed, follow the Empty PR Policy by checking off all Acceptance Criteria and submitting an empty PR.
+
+## Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Run and verify that tests for `DagContext` exist and pass.
+- [ ] Verify `DagProvider` aligns with the single source of truth and error reporting principles outlined in ADR 013 and ADR 017.


### PR DESCRIPTION
Creates downstream task blueprints for the implementation of the `DagContext` and `DagProvider` components, complying with the Kanban Board State Management and Permanent Failure Dashboard ADRs. The PR includes the requisite reminders regarding transient and permanent task failure protocols for both the implementation and QA personas.

---
*PR created automatically by Jules for task [14944188106378842573](https://jules.google.com/task/14944188106378842573) started by @szubster*