### PR TITLE
docs: update gen 3 roamer location research findings

### DIFF
--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -28,3 +28,8 @@ Agents must ensure actual structural integration and strict adherence to data sc
 
 ### Lesson: Save File Offsets Trust
 When performing research on save file offsets, never blindly trust task descriptions or previous documentation if it conflicts with the disassembly. In task-095-157, the PM/author confused the Party Data offsets (0x283E/0x281A) with Event Flag offsets. Always cross-reference the WRAM memory map directly and calculate offsets by subtracting relative to known anchors (e.g., wCurBox).
+
+### Gen 3 Roamer Location Memory Offset Investigation
+- **Date**: 2026-06-18
+- **Observation**: Roamer locations (`sRoamerLocation` and `sLocationHistory`) are kept in dynamic `EWRAM_DATA` and are not directly saved to the `.sav` file; they re-initialize dynamically upon startup.
+- **Pattern/Constraint**: It is mathematically impossible to extract the exact current route of a roaming Pokémon directly from a static Gen 3 `.sav` file unless the player saved while the roamer was active on their current route.

--- a/.foundry/research/research-108-187-gen3-roamer-location-offsets.md
+++ b/.foundry/research/research-108-187-gen3-roamer-location-offsets.md
@@ -31,4 +31,27 @@ Discover the exact memory offsets for the roamer's map group and map number for 
 During the implementation of `task-108-161-gen3-roamer-location-impl`, it was discovered that the previous research (`research-071-138-gen3-roamer-offsets`) identified that the roamer's current map group and map number are not stored within the primary 20-byte struct, but kept in separate variables loaded into EWRAM (`sRoamerLocation`). However, the exact byte offsets or structure for extracting these values via DataView were not provided.
 
 ## Acceptance Criteria
-- [ ] Determine the exact memory offset and structure for the roamer's map group and map number for Gen 3 saves.
+- [x] Determine the exact memory offset and structure for the roamer's map group and map number for Gen 3 saves.
+
+## Findings
+
+### sRoamerLocation and sLocationHistory
+
+Upon deeper investigation of the Gen 3 game decompilation repositories (`pret/pokeemerald`, `pret/pokeruby`, `pret/pokefirered`), it has been determined that the roamer's current map location (`sRoamerLocation`) and its location history (`sLocationHistory`) are **not stored within the `.sav` file at all.**
+
+These variables are defined as `EWRAM_DATA`:
+
+```c
+EWRAM_DATA static u8 sLocationHistory[3][2] = {0};
+EWRAM_DATA static u8 sRoamerLocation[2] = {0};
+```
+
+When the game boots or a save is loaded, these variables are re-initialized dynamically.
+
+- In `InitRoamer()`, the roamer is placed randomly into a valid starting map from `sRoamerLocations` array.
+- The `sLocationHistory` is updated dynamically as the player moves around, reading from the player's current location (`gSaveBlock1Ptr->location.mapGroup` / `gSaveBlock1Ptr->location.mapNum`).
+- `sRoamerLocation` is updated when the player encounters a map transition, relying on a random probability check and constraints matching the current map against the roamer's internal map array logic.
+
+### Conclusion
+
+Because the exact map location and location history of the roamer are strictly `EWRAM` state and are **never serialized into the save file**, it is mathematically impossible to extract the exact current route of a roaming Pokémon directly from a static Gen 3 `.sav` file, unless the player explicitly saved their game on the exact route while the roamer was active. Any companion app parsing the save file can only confirm the roamer's internal IVs, HP, status, and whether it is `active`, but not its immediate coordinates in the Game Boy's memory.


### PR DESCRIPTION
Updates the research node `research-108-187-gen3-roamer-location-offsets.md` to document the findings regarding Gen 3 roamer locations. Specifically, it clarifies that `sRoamerLocation` and `sLocationHistory` are stored in EWRAM and are not serialized into the save file, meaning it is impossible to extract their exact location from the static save.

---
*PR created automatically by Jules for task [9240626839193653308](https://jules.google.com/task/9240626839193653308) started by @szubster*