### PR TITLE
fix: extract feebas seed memory offsets to constants

### DIFF
--- a/.foundry/epics/epic-036-058-feebas-backend-parsing.md
+++ b/.foundry/epics/epic-036-058-feebas-backend-parsing.md
@@ -25,7 +25,7 @@ notes: ''
 Create a utility module that reads the parsed save file's data at the identified offset to extract the Feebas seed, and implements the PRNG/math algorithm used by Gen 3 to translate the seed into the 6 specific tile coordinates on Route 119.
 
 ## Acceptance Criteria
-- [ ] Create a utility module for Feebas seed extraction.
+- [x] Create a utility module for Feebas seed extraction.
 - [x] Implement Gen 3 algorithm to calculate the 6 tile coordinates based on the seed.
 - [x] Ensure fast calculation concurrent with save file hydration.
 - [x] .foundry/stories/story-058-095-feebas-seed-extraction.md

--- a/src/engine/gen3/feebas.test.ts
+++ b/src/engine/gen3/feebas.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { calculateFeebasTiles, extractFeebasSeed, mapSpotIdsToCoordinates } from './feebas';
+import {
+  calculateFeebasTiles,
+  extractFeebasSeed,
+  FEEBAS_SEED_OFFSET_EMERALD,
+  FEEBAS_SEED_OFFSET_RS,
+  mapSpotIdsToCoordinates,
+} from './feebas';
 
 describe('extractFeebasSeed', () => {
   it('extracts the Feebas seed for Ruby/Sapphire', () => {
     // 0x2dd6 + 2 bytes = 11736 bytes
     const buffer = new ArrayBuffer(12000);
     const view = new DataView(buffer);
-    view.setUint16(0x2dd6, 0x1234, true);
+    view.setUint16(FEEBAS_SEED_OFFSET_RS, 0x1234, true);
 
     const seedRuby = extractFeebasSeed(view, 'ruby');
     expect(seedRuby).toBe(0x1234);
@@ -19,7 +25,7 @@ describe('extractFeebasSeed', () => {
     // 0x2e66 + 2 bytes = 11880 bytes
     const buffer = new ArrayBuffer(12000);
     const view = new DataView(buffer);
-    view.setUint16(0x2e66, 0x5678, true);
+    view.setUint16(FEEBAS_SEED_OFFSET_EMERALD, 0x5678, true);
 
     const seedEmerald = extractFeebasSeed(view, 'emerald');
     expect(seedEmerald).toBe(0x5678);

--- a/src/engine/gen3/feebas.ts
+++ b/src/engine/gen3/feebas.ts
@@ -1,5 +1,8 @@
 import type { GameVersion } from '../saveParser/parsers/common';
 
+export const FEEBAS_SEED_OFFSET_RS = 0x2dd6;
+export const FEEBAS_SEED_OFFSET_EMERALD = 0x2e66;
+
 /**
  * Extracts the 16-bit Feebas seed from Gen 3 save files using the native DataView API.
  *
@@ -13,9 +16,9 @@ export function extractFeebasSeed(saveData: DataView, gameVersion: GameVersion):
     let offset = 0;
 
     if (gameVersion === 'ruby' || gameVersion === 'sapphire') {
-      offset = 0x2dd6;
+      offset = FEEBAS_SEED_OFFSET_RS;
     } else if (gameVersion === 'emerald') {
-      offset = 0x2e66;
+      offset = FEEBAS_SEED_OFFSET_EMERALD;
     } else {
       throw new Error(`Unsupported game version for Feebas seed extraction: ${gameVersion}`);
     }


### PR DESCRIPTION
Extracts the Feebas seed memory offsets into explicit constants (`FEEBAS_SEED_OFFSET_RS` and `FEEBAS_SEED_OFFSET_EMERALD`) to resolve an auditor rejection. Also checks off the final acceptance criteria in the Epic's markdown body.

---
*PR created automatically by Jules for task [5028582062158954872](https://jules.google.com/task/5028582062158954872) started by @szubster*