### PR TITLE
chore: trigger resurrection loop for epic-044-070-hof-data-parsing

### DIFF
--- a/.foundry/epics/epic-044-070-hof-data-parsing.md
+++ b/.foundry/epics/epic-044-070-hof-data-parsing.md
@@ -27,7 +27,10 @@ notes: ''
 This epic covers the implementation details for extracting Hall of Fame data from Generation 1 and Generation 2 save files. This includes properly reading the offset in Gen 2 (0xA8 from Johto badges).
 
 ## Acceptance Criteria
-- [x] Break down into Stories
+- [ ] Break down into Stories
 
 - [x] story-070-111-parse-gen1-hof-data
 - [x] story-070-112-parse-gen2-hof-data
+
+### Auditor Rejection
+The implementation only parses the `hallOfFameCount` and does not parse the actual Hall of Fame data blocks. The PRD requires that the engine "Extract Pokémon species, levels, and the player's name for past League victories." We need new stories and tasks to properly parse the data structures representing the Hall of Fame records themselves.


### PR DESCRIPTION
The actual Hall of Fame data blocks containing pokemon, levels and player name was not extracted. Only the count was parsed. I added an auditor rejection block and unchecked the acceptance criteria box to send it back.

---
*PR created automatically by Jules for task [2817665166289914492](https://jules.google.com/task/2817665166289914492) started by @szubster*