### PR TITLE
chore(story): Mark move data extraction story as completed

### DIFF
--- a/.foundry/stories/story-086-128-move-data-extraction.md
+++ b/.foundry/stories/story-086-128-move-data-extraction.md
@@ -31,9 +31,9 @@ As part of the EPIC to dynamically generate move PP PokeData, we need to first e
 2. Focus on extracting `id`, `name`, `type`, `power`, `accuracy`, `pp`, `damage_class`, and `effect_chance` as defined in ADR 025.
 
 ## Acceptance Criteria
-- [ ] Determine how to fetch move data efficiently during the build.
-- [ ] Implement the extraction logic to capture the necessary fields for each move.
-- [ ] Ensure that default values and nulls are appropriately handled at the extraction boundary.
+- [x] Determine how to fetch move data efficiently during the build.
+- [x] Implement the extraction logic to capture the necessary fields for each move.
+- [x] Ensure that default values and nulls are appropriately handled at the extraction boundary.
 
-- [ ] task-128-181-move-data-extraction-impl
-- [ ] task-128-182-move-data-extraction-qa
+- [x] task-128-181-move-data-extraction-impl
+- [x] task-128-182-move-data-extraction-qa


### PR DESCRIPTION
As requested by the Tech Lead persona instructions for verifying a STORY macro node, all underlying generated tasks (`task-128-181-move-data-extraction-impl` and `task-128-182-move-data-extraction-qa`) have been verified to be `COMPLETED`. 

Consequently, all acceptance criteria and child task checkboxes in `.foundry/stories/story-086-128-move-data-extraction.md` have been updated to checked `[x]`. The YAML frontmatter has been deliberately left untouched as per the Empty PR Policy and ADR 007/009 constraints.

Tests and linting run cleanly after these changes.

---
*PR created automatically by Jules for task [9537391178265902714](https://jules.google.com/task/9537391178265902714) started by @szubster*