### PR TITLE
Fix Foundry Orchestration Link Failures

### DIFF
--- a/.foundry/archive/epics/epic-010-oxlint-config.md
+++ b/.foundry/archive/epics/epic-010-oxlint-config.md
@@ -33,4 +33,4 @@ In response to CEO feedback (PR comment 4303644512), we need to schedule work in
 - [.foundry/stories/story-010-014-implement-oxlint-config.md](../stories/story-010-014-implement-oxlint-config.md)
 - [.foundry/stories/story-010-016-enable-expensive-oxlint-checks.md](../stories/story-010-016-enable-expensive-oxlint-checks.md)
 - [.foundry/stories/story-010-017-fix-jest-rules.md](../stories/story-010-017-fix-jest-rules.md)
-- [.foundry/archive/stories/story-010-028-verify-jest-tests.md](../archive/stories/story-010-028-verify-jest-tests.md)
+- [.foundry/archive/stories/story-010-028-verify-jest-tests.md](../stories/story-010-028-verify-jest-tests.md)

--- a/.foundry/archive/epics/epic-035-048-implicit-dependency-enforcement.md
+++ b/.foundry/archive/epics/epic-035-048-implicit-dependency-enforcement.md
@@ -33,5 +33,5 @@ Update the `foundry-orchestrator.ts` to enforce implicit dependency. A node cann
 - [x] Ensure unit tests in `.github/scripts/foundry-orchestrator.test.ts` are updated or added.
 
 ### Implementation Stories
-- [.foundry/stories/story-048-086-implement-implicit-dependency-check.md](.foundry/stories/story-048-086-implement-implicit-dependency-check.md)
-- [.foundry/stories/story-048-087-update-orchestrator-tests.md](.foundry/stories/story-048-087-update-orchestrator-tests.md)
+- [.foundry/archive/stories/story-048-086-implement-implicit-dependency-check.md](../stories/story-048-086-implement-implicit-dependency-check.md)
+- [.foundry/stories/story-048-087-update-orchestrator-tests.md](../../stories/story-048-087-update-orchestrator-tests.md)

--- a/.foundry/archive/ideas/idea-053-gen3-support.md
+++ b/.foundry/archive/ideas/idea-053-gen3-support.md
@@ -33,6 +33,6 @@ Currently, the application supports Gen 1 and Gen 2. We should expand the scope 
 - [x] Gen3 encounters, locations, and Pokemon are integrated.
 
 ## References
-- [.foundry/prds/prd-053-022-gen3-data-parsing.md](.foundry/archive/prds/prd-053-022-gen3-data-parsing.md)
-- [.foundry/prds/prd-053-023-gen3-map-graph.md](.foundry/archive/prds/prd-053-023-gen3-map-graph.md)
-- [.foundry/prds/prd-053-024-gen3-encounters.md](.foundry/prds/prd-053-024-gen3-encounters.md)
+- [.foundry/archive/prds/prd-053-022-gen3-data-parsing.md](../prds/prd-053-022-gen3-data-parsing.md)
+- [.foundry/archive/prds/prd-053-023-gen3-map-graph.md](../prds/prd-053-023-gen3-map-graph.md)
+- [.foundry/archive/prds/prd-053-024-gen3-encounters.md](../prds/prd-053-024-gen3-encounters.md)

--- a/.foundry/archive/stories/story-005-013-tpm-archiving-logic.md
+++ b/.foundry/archive/stories/story-005-013-tpm-archiving-logic.md
@@ -23,4 +23,4 @@ Implement logic in the TPM agent (`.github/agents/tpm.md` or a related task/scri
 **Note:** The TPM agent should be designed to be conservative when archiving. Even if a node is marked `COMPLETED`, if the TPM determines it might still be relevant or needed, it should retain it. It's better to leave more nodes unarchived than to aggressively remove nodes that might still have value.
 
 ## Generated Tasks
-- [.foundry/tasks/task-013-024-update-tpm-prompt.md](../../.foundry/tasks/task-013-024-update-tpm-prompt.md)
+- [.foundry/archive/tasks/task-013-024-update-tpm-prompt.md](../tasks/task-013-024-update-tpm-prompt.md)

--- a/.foundry/archive/stories/story-010-015-enforce-strict-oxlint-rules.md
+++ b/.foundry/archive/stories/story-010-015-enforce-strict-oxlint-rules.md
@@ -28,5 +28,5 @@ All disabled oxlint rules should be enabled back. The tech lead should create a 
 2. Ensure each task focuses strictly on enabling that rule in `.oxlintrc.json` and fixing all corresponding violations across the codebase.
 
 ## Generated Tasks
-- [.foundry/archive/tasks/task-015-033-oxlint-require-mock-type-parameters.md](../../.foundry/archive/tasks/task-015-033-oxlint-require-mock-type-parameters.md)
+- [.foundry/archive/tasks/task-015-033-oxlint-require-mock-type-parameters.md](../tasks/task-015-033-oxlint-require-mock-type-parameters.md)
 - [.foundry/tasks/task-015-034-oxlint-expect-expect.md](../tasks/task-015-034-oxlint-expect-expect.md)

--- a/.foundry/archive/stories/story-010-017-fix-jest-rules.md
+++ b/.foundry/archive/stories/story-010-017-fix-jest-rules.md
@@ -28,4 +28,4 @@ Even though we use vitest, oxlint uses the jest plugin to lint test files. We tu
 
 ## Generated Tasks
 - [.foundry/tasks/task-017-041-fix-jest-standalone-expect.md](../tasks/task-017-041-fix-jest-standalone-expect.md)
-- [.foundry/archive/tasks/task-017-042-fix-jest-disabled-tests.md](../archive/tasks/task-017-042-fix-jest-disabled-tests.md)
+- [.foundry/archive/tasks/task-017-042-fix-jest-disabled-tests.md](../tasks/task-017-042-fix-jest-disabled-tests.md)

--- a/.foundry/archive/stories/story-010-028-verify-jest-tests.md
+++ b/.foundry/archive/stories/story-010-028-verify-jest-tests.md
@@ -26,4 +26,4 @@ Even though we resolved the jest rules, we still have FAILED statuses in previou
 - [x] `pnpm exec oxlint .` passes with these rules completely enabled.
 
 ## Generated Tasks
-- [.foundry/archive/tasks/task-028-046-verify-jest-rules-resolution.md](../../.foundry/archive/tasks/task-028-046-verify-jest-rules-resolution.md)
+- [.foundry/archive/tasks/task-028-046-verify-jest-rules-resolution.md](../tasks/task-028-046-verify-jest-rules-resolution.md)

--- a/.foundry/archive/stories/story-029-052-implement-graph-filtering.md
+++ b/.foundry/archive/stories/story-029-052-implement-graph-filtering.md
@@ -40,5 +40,5 @@ Following the implementation of the core graph visualization for the DAG Dashboa
 - [x] Verify that the styling of the filter controls matches the project's strict design system requirements.
 
 ## Tasks
-- [.foundry/tasks/task-052-090-implement-graph-filtering.md](../../.foundry/tasks/task-052-090-implement-graph-filtering.md)
-- [.foundry/tasks/task-052-091-qa-graph-filtering.md](../../.foundry/tasks/task-052-091-qa-graph-filtering.md)
+- [.foundry/archive/tasks/task-052-090-implement-graph-filtering.md](../tasks/task-052-090-implement-graph-filtering.md)
+- [.foundry/archive/tasks/task-052-091-qa-graph-filtering.md](../tasks/task-052-091-qa-graph-filtering.md)

--- a/.foundry/archive/stories/story-041-079-ui-sync-status.md
+++ b/.foundry/archive/stories/story-041-079-ui-sync-status.md
@@ -27,5 +27,5 @@ notes: ''
 - [x] Implement a UI gesture (like a "Resume Sync" button) if the browser needs a user interaction to re-grant permission.
 
 ## Generated Tasks
-- [x] [.foundry/tasks/task-079-144-ui-sync-status-impl.md](.foundry/tasks/task-079-144-ui-sync-status-impl.md)
-- [x] [.foundry/tasks/task-079-145-ui-sync-status-qa.md](.foundry/tasks/task-079-145-ui-sync-status-qa.md)
+- [x] [.foundry/archive/tasks/task-079-144-ui-sync-status-impl.md](../tasks/task-079-144-ui-sync-status-impl.md)
+- [x] [.foundry/archive/tasks/task-079-145-ui-sync-status-qa.md](../tasks/task-079-145-ui-sync-status-qa.md)

--- a/.foundry/archive/stories/story-053-090-extract-dag-utilities.md
+++ b/.foundry/archive/stories/story-053-090-extract-dag-utilities.md
@@ -36,8 +36,8 @@ This story details the technical steps for extracting shared DAG utility functio
 
 ## Next Steps
 - [x] Tech Lead: Write Tasks to implement the file creation, extraction, test writing, and test updates.
-  - [.foundry/tasks/task-090-148-extract-dag-utils-impl.md](.foundry/tasks/task-090-148-extract-dag-utils-impl.md)
-  - [.foundry/tasks/task-090-149-extract-dag-utils-qa.md](.foundry/tasks/task-090-149-extract-dag-utils-qa.md)
+  - [.foundry/archive/tasks/task-090-148-extract-dag-utils-impl.md](../tasks/task-090-148-extract-dag-utils-impl.md)
+  - [.foundry/archive/tasks/task-090-149-extract-dag-utils-qa.md](../tasks/task-090-149-extract-dag-utils-qa.md)
 
 ## Acceptance Criteria
 - [x] `dag-utils.ts` is created containing `todayISO`, `logToJournal`, `buildReverseDependencyGraph`, and `getOrphanedNodes`.

--- a/.foundry/archive/stories/story-053-090-health-scanner-diagnostic-models.md
+++ b/.foundry/archive/stories/story-053-090-health-scanner-diagnostic-models.md
@@ -35,4 +35,4 @@ Before implementing the actual validation logic for the Health Scanner Core Engi
 - [x] All child tasks are COMPLETED.
 
 ## Child Tasks
-* [.foundry/tasks/task-090-148-health-scanner-models-impl.md](.foundry/tasks/task-090-148-health-scanner-models-impl.md)
+* [.foundry/archive/tasks/task-090-148-health-scanner-models-impl.md](../tasks/task-090-148-health-scanner-models-impl.md)

--- a/.foundry/prds/prd-065-035-epic-verification-timing.md
+++ b/.foundry/prds/prd-065-035-epic-verification-timing.md
@@ -53,5 +53,5 @@ This ensures that "Epic implementation is done" is semantically accurate.
 
 
 ## Generated Epics
-- [.foundry/archive/epics/epic-035-048-implicit-dependency-enforcement.md](./../epics/epic-035-048-implicit-dependency-enforcement.md)
+- [.foundry/archive/epics/epic-035-048-implicit-dependency-enforcement.md](../archive/epics/epic-035-048-implicit-dependency-enforcement.md)
 - [.foundry/epics/epic-035-049-late-binding-accommodation.md](./../epics/epic-035-049-late-binding-accommodation.md)

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -28,6 +28,22 @@ function resolveNodeIdToPath(nodeId: string): string {
   if (fs.existsSync(basePath)) {
     return basePath;
   }
+
+  // Handle ADRs that might not have the adr- prefix in the filename (e.g. adr-001 -> 001-...)
+  if (type === 'adr') {
+    const adrDir = path.join(process.cwd(), '.foundry/docs/adrs');
+    if (fs.existsSync(adrDir)) {
+      const adrFiles = fs.readdirSync(adrDir);
+      const numericPart = nodeId.split('-')[1];
+      if (numericPart) {
+        const match = adrFiles.find(f => f.startsWith(numericPart + '-'));
+        if (match) {
+          return `.foundry/docs/adrs/${match}`;
+        }
+      }
+    }
+  }
+
   const archivePath = `.foundry/archive/${folder}/${nodeId}.md`;
   if (fs.existsSync(archivePath)) {
     return archivePath;


### PR DESCRIPTION
I have resolved the orchestration failure by improving the `check-links.ts` script and fixing numerous broken links in the Foundry metadata system. The script now correctly resolves ADR IDs and avoids crashes by checking for directory existence. I also performed a comprehensive cleanup of broken relative links in both active and archived nodes, ensuring consistent paths and matching labels. Global link verification now passes.

Fixes #2820

---
*PR created automatically by Jules for task [15402780048681385105](https://jules.google.com/task/15402780048681385105) started by @szubster*