### PR TITLE
auditor: Verify Pokerus State Exfiltration Epic and Extract Bitwise Learnings

### DIFF
--- a/.foundry/docs/adrs/adr-061-026-bitwise-state-extraction.md
+++ b/.foundry/docs/adrs/adr-061-026-bitwise-state-extraction.md
@@ -1,0 +1,45 @@
+---
+id: adr-061-026-bitwise-state-extraction
+type: ADR
+title: 'ADR 026: Bitwise State Extraction and Cured Boundaries'
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-038-061-pokerus-state-exfiltration
+tags:
+  - architecture
+  - save-engine
+  - parsing
+  - bitwise
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# ADR 026: Bitwise State Extraction and Cured Boundaries
+
+## Context
+When extracting state from Pokémon save files, data is frequently compressed into single bytes via bitwise flags (e.g., the Pokerus status byte, which combines the "strain" and "days remaining" into a single 8-bit integer).
+In previous generations, parsing these bytes directly into boolean or simple numeric states led to regressions when scaling, specifically because these bitfields contain specific combinations of bits that represent distinct edge case states (e.g., the game engine treating a non-zero strain with zero days remaining differently than an absolute zero state).
+
+## Decision
+We formally standardize the pattern for bitwise state extraction across the parsing engine:
+1.  **Explicit Bitwise Logic**: Parsers MUST use explicit bitwise shifting (`>>`) and masking (`&`) to isolate multi-value bitfields into discrete properties rather than evaluating the entire byte.
+2.  **Cured State Enforcement**: Any bitwise data structure representing a "condition" that degrades or changes over time (like Pokerus or Contest conditions) MUST explicitly define and test its boundary states (such as the "cured" state where the identity/strain is non-zero but the duration is zero).
+3.  **Comprehensive Boundary Testing**: All parsing logic involving bitwise extraction MUST be accompanied by extensive unit tests that explicitly cover:
+    -   Absolute zero state (uninfected/uninitialized).
+    -   Boundary states (cured/expired).
+    -   Max boundary values (e.g., max strain and max days remaining).
+
+## Consequences
+-   **Positive**: This guarantees parsing regressions will not occur when migrating logic to Gen 3 or Gen 4, where bitwise structures become increasingly dense.
+-   **Positive**: Distinguishing accurately between states like "uninfected" and "cured" enables richer UI logic (e.g., showing a Pokerus dot icon for cured Pokémon).
+-   **Negative**: Requires additional boilerplate testing around bitwise masking logic for data fields that might seem trivially numeric.
+
+## Acceptance Criteria
+- [x] Standardize bitwise extraction and cured boundary testing rules.

--- a/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
+++ b/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
@@ -31,3 +31,6 @@ Read the specific byte flags for Pokerus for every Pokemon in the party and PC f
 - [x] .foundry/stories/story-061-096-pokerus-tests.md
 
 <!-- Tech Lead: Verified complete. Pokerus bitwise logic is thoroughly tested including cured state boundaries. -->
+
+## Follow-up Nodes
+- [ ] .foundry/docs/adrs/adr-061-026-bitwise-state-extraction.md

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -125,7 +125,7 @@ The usage of specific bitwise operators (`>> 4` and `& 0x0f`) accompanied by tar
 When implementing save file parsing, strictly use dynamic relative offset calculations (anchored to known base offsets) instead of absolute hardcoded offsets for extracting dynamic data blocks to ensure robustness against version-specific shifts and prevent regressions.
 
 ### Lesson: Pokerus Bitwise Parsing and Cured State
-When extracting Pokerus state from an 8-bit integer, relying on bitwise operations requires explicitly handling boundary conditions like the "cured" state (where strain is non-zero but days remaining is 0). This is critical to distinguish from a completely uninfected state (all zeros) and prevents state regressions across generations.
+When extracting Pokerus state from an 8-bit integer, relying on bitwise operations requires explicitly handling boundary conditions like the "cured" state (where strain is non-zero but days remaining is 0). This is critical to distinguish from a completely uninfected state (all zeros) and prevents state regressions across generations. We have formally documented this requirement in `ADR 026: Bitwise State Extraction and Cured Boundaries` to act as an architectural constraint for future Gens.
 ## 2026-06-19: Enforcing Reusable Constants for Memory Offsets
 I rejected the Epic `epic-036-058-feebas-backend-parsing` because the implementer used inline magic numbers (e.g., `0x2dd6`) directly in the parsing functions instead of explicitly defined constants.
 


### PR DESCRIPTION
As the Auditor persona, verified that Epic `epic-038-061-pokerus-state-exfiltration` and its child tasks have fully transitioned to `COMPLETED`. Extracted lessons learned regarding the boundary testing of bitwise extracted states (specifically the "cured" boundary of Pokerus, where strain is non-zero but duration is zero) into a new architectural decision record `adr-061-026-bitwise-state-extraction.md`. Updated the Auditor journal to propagate this parsing constraint to future generations. Submitted an empty PR to transition the Epic to `COMPLETED` without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [410547163798522046](https://jules.google.com/task/410547163798522046) started by @szubster*