### PR TITLE
Foundry: Complete story-070-108 tasks breakdown

### DIFF
--- a/.foundry/stories/story-070-108-gen3-roamer-dataview-extraction.md
+++ b/.foundry/stories/story-070-108-gen3-roamer-dataview-extraction.md
@@ -34,8 +34,8 @@ This story handles the base extraction logic in the save parser for Gen 3. The `
 - [x] Tech Lead: Break down this Story into executable Tasks.
 
 ## Generated Tasks
-- [ ] task-108-161-gen3-roamer-dataview-extraction-impl
-- [ ] task-108-162-gen3-roamer-dataview-extraction-qa
+- [x] task-108-161-gen3-roamer-dataview-extraction-impl
+- [x] task-108-162-gen3-roamer-dataview-extraction-qa
 - [ ] task-108-192-gen3-roamer-dataview-extraction-impl
 - [ ] task-108-193-gen3-roamer-dataview-extraction-qa
 - [ ] research-108-194-gen3-roamer-iv-bitfield


### PR DESCRIPTION
Completed the tech lead breakdown for `story-070-108-gen3-roamer-dataview-extraction.md`. Checked off the failed and cancelled tasks (`task-108-161` and `task-108-162`). The replacement tasks `task-108-192`, `task-108-193`, and `research-108-194` were previously generated and their corresponding unchecked boxes correctly indicate pending statuses in the story markdown.

---
*PR created automatically by Jules for task [15319994012878694722](https://jules.google.com/task/15319994012878694722) started by @szubster*