### PR TITLE
chore: Mark ADR-026 Follow-up as complete

### DIFF
--- a/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
+++ b/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
@@ -33,4 +33,4 @@ Read the specific byte flags for Pokerus for every Pokemon in the party and PC f
 <!-- Tech Lead: Verified complete. Pokerus bitwise logic is thoroughly tested including cured state boundaries. -->
 
 ## Follow-up Nodes
-- [ ] .foundry/docs/adrs/adr-061-026-bitwise-state-extraction.md
+- [x] .foundry/docs/adrs/adr-061-026-bitwise-state-extraction.md


### PR DESCRIPTION
Checked off the follow-up task checkbox in `epic-038-061-pokerus-state-exfiltration.md` for the ADR-026 file, which has been completed.

---
*PR created automatically by Jules for task [2153722328432767725](https://jules.google.com/task/2153722328432767725) started by @szubster*