### PR TITLE
Cancel Impossible Gen 3 Roamer Location Extraction Story

### DIFF
--- a/.foundry/docs/adrs/adr-108-027-gen3-roamer-location-impossible.md
+++ b/.foundry/docs/adrs/adr-108-027-gen3-roamer-location-impossible.md
@@ -1,0 +1,37 @@
+---
+id: adr-108-027-gen3-roamer-location-impossible
+type: ADR
+title: Impossibility of Gen 3 Roamer Location Extraction
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-06-18'
+updated_at: '2026-06-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-072-108-gen3-roamer-location-extraction
+tags:
+  - gen3
+  - roamer
+  - save-offsets
+research_references:
+  - research-108-187-gen3-roamer-location-offsets
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Impossibility of Gen 3 Roamer Location Extraction
+
+## Context
+As part of integrating the Gen 3 Roamer Location Radar feature, the task required parsing the roamer's current map group and map number from the `.sav` file.
+
+## Decision
+Do not attempt to extract `sRoamerLocation` or `sLocationHistory` for Generation 3 roaming Pokémon from the save file.
+
+## Consequences
+Research (`research-108-187-gen3-roamer-location-offsets`) revealed that in Generation 3 games, the roamer's location (`sRoamerLocation`) and its map history (`sLocationHistory`) are kept exclusively in dynamically allocated `EWRAM_DATA` during gameplay. When the game saves, these values are **never serialized into the save file**. Instead, they are dynamically re-initialized when the save is loaded, based on random starting maps and the player's current location.
+
+Therefore, it is mathematically impossible to statically extract the active roamer's immediate map coordinates from a Gen 3 `.sav` file, unless the save was taken at the exact moment the roamer was encountered. Any parsing logic for this data would result in a failure.
+
+The UI for tracking the Gen 3 roamer will need to rely on the active roamer flags and IVs, rather than plotting its exact map route.

--- a/.foundry/epics/epic-044-072-gen3-roamer-location-radar.md
+++ b/.foundry/epics/epic-044-072-gen3-roamer-location-radar.md
@@ -33,6 +33,6 @@ Determine the current map group and map number of the roaming Pokémon from the 
 - [ ] Map the location index to the correct route or area in the application.
 - [ ] Integrate this location data with the Route Radar map display.
 - [x] Story Owner: Break down this Epic into executable Stories.
-- [ ] .foundry/stories/story-072-108-gen3-roamer-location-extraction.md
+- [x] .foundry/stories/story-072-108-gen3-roamer-location-extraction.md
 - [ ] .foundry/stories/story-072-109-gen3-roamer-location-mapping.md
 - [ ] .foundry/stories/story-072-110-gen3-roamer-route-radar-ui.md

--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -88,3 +88,7 @@ Always use the exact, short ID slug for DAG references. Do not include directory
 ## 2026-06-18: Unexpected Artifact Existence
 - **Observation**: While processing `story-074-115-define-tactical-input-and-text.md`, it was discovered that its target artifacts (`task-115-165-implement-tactical-input-text.md` and `task-115-166-qa-tactical-input-text.md`) already unexpectedly existed in the `.foundry/tasks/` directory and were marked as `COMPLETED`.
 - **Action**: Followed the Empty PR Policy by checking off the acceptance criteria checkboxes in the story node's markdown body and proceeding with an Empty PR submission, logging this anomaly for the Agile Coach.
+
+## 2026-06-18: Gen 3 Roamer Location Constraint
+- **Observation**: Extracting the exact current map location and location history of the roaming Pokémon from a Gen 3 `.sav` file is mathematically impossible. These values (`sRoamerLocation` and `sLocationHistory`) are kept dynamically in `EWRAM` and are never serialized into the static save file.
+- **Action**: The technical blueprint generation for extracting this data must be cancelled. An ADR was created to permanently document this architectural impossibility to prevent future wasted cycles.

--- a/.foundry/stories/story-072-108-gen3-roamer-location-extraction.md
+++ b/.foundry/stories/story-072-108-gen3-roamer-location-extraction.md
@@ -2,7 +2,7 @@
 id: story-072-108-gen3-roamer-location-extraction
 type: STORY
 title: Gen 3 Roamer Location Data Extraction
-status: READY
+status: CANCELLED
 owner_persona: tech_lead
 created_at: '2026-06-10'
 updated_at: '2026-06-18'
@@ -17,7 +17,7 @@ tags:
 research_references:
   - research-071-138-gen3-roamer-offsets
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Extracting exact Gen 3 roamer map locations from save files is impossible as the data is stored in EWRAM, not the save file (see research-108-187-gen3-roamer-location-offsets).'
 notes: ''
 ---
 


### PR DESCRIPTION
Cancel `story-072-108-gen3-roamer-location-extraction` as Gen 3 roamer locations (`sRoamerLocation`, `sLocationHistory`) are kept in dynamically allocated `EWRAM_DATA` during gameplay and are never serialized into the static save file, making extraction impossible.

Updates:
- Checked off the cancelled story in `epic-044-072-gen3-roamer-location-radar.md`.
- Logged the constraint in the tech lead journal.
- Created `adr-108-027-gen3-roamer-location-impossible.md` to document the impossibility.

---
*PR created automatically by Jules for task [8499086342884173453](https://jules.google.com/task/8499086342884173453) started by @szubster*