### PR TITLE
Cancel Orphaned QA Task 162

### DIFF
--- a/.foundry/tasks/task-108-162-gen3-roamer-dataview-extraction-qa.md
+++ b/.foundry/tasks/task-108-162-gen3-roamer-dataview-extraction-qa.md
@@ -43,3 +43,6 @@ If you submit an empty PR for a completed task, you MUST check off all Acceptanc
 
 ### CANCELLED
 This task has been cancelled due to the permanent failure of its dependency `task-108-161-gen3-roamer-dataview-extraction-impl`. It has been replaced by `task-108-193-gen3-roamer-dataview-extraction-qa` which will depend on the new implementation task.
+
+### Auditor Rejection
+This task is permanently cancelled and replaced by task-108-193-gen3-roamer-dataview-extraction-qa because the original dependency failed permanently.


### PR DESCRIPTION
Cancels the orphaned QA task for `task-108-162` by appending the cancellation message in the markdown body, adhering strictly to the YAML frontmatter rule. Leaves the parent Story's checkboxes unchanged to keep the DAG correctly pending.

---
*PR created automatically by Jules for task [11357818010190987801](https://jules.google.com/task/11357818010190987801) started by @szubster*