### PR TITLE
chore(foundry): generate tasks for move generation discrepancies

### DIFF
--- a/.foundry/stories/story-086-129-move-generation-discrepancies.md
+++ b/.foundry/stories/story-086-129-move-generation-discrepancies.md
@@ -34,3 +34,6 @@ Moves can have different stats (like PP, Power, Accuracy) across different gener
 - [ ] Identify generation discrepancies for moves relevant to Gen 1-3.
 - [ ] Apply necessary overrides to the extracted move data.
 - [ ] Verify that base PP is stored correctly according to the target generation.
+
+- [ ] task-129-206-move-generation-discrepancies-impl
+- [ ] task-129-207-move-generation-discrepancies-qa

--- a/.foundry/tasks/task-129-206-move-generation-discrepancies-impl.md
+++ b/.foundry/tasks/task-129-206-move-generation-discrepancies-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-129-206-move-generation-discrepancies-impl
+type: TASK
+title: Apply Move Generation Discrepancies
+status: READY
+owner_persona: coder
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-086-129-move-generation-discrepancies
+tags:
+  - build
+  - refactor
+  - impl
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Apply Move Generation Discrepancies (Implementation)
+
+## Background
+Moves can have different stats (like PP, Power, Accuracy) across different generations. The initial extraction gets the base data from PokeAPI, but we must account for historical generation differences, particularly relevant for Gen 1-3 support.
+
+## Goals
+1. Process the extracted move data in `scripts/generate-pokedata.ts` to apply generation-specific overrides where necessary.
+2. Ensure base PP values are accurately stored, leaving max PP calculations to the client runtime as per ADR 025.
+
+## Context and Constraints
+- Leverage `past_values` or `version_group_details` arrays from PokeAPI if using dynamic extraction.
+- Prioritize Gen 1-3 accurate stats where available, or fallback to the latest stats if historical data is missing or uniform.
+- As per ADR 025, base PP is what should be stored. Do not calculate max PP within the generation script.
+
+## Reminder for Coder/QA Personas
+- **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Identify generation discrepancies for moves relevant to Gen 1-3 within the generation script logic.
+- [ ] Apply necessary overrides to the extracted move data before saving to `moves.jsonl`.
+- [ ] Ensure that only base PP is stored for each move.

--- a/.foundry/tasks/task-129-207-move-generation-discrepancies-qa.md
+++ b/.foundry/tasks/task-129-207-move-generation-discrepancies-qa.md
@@ -1,0 +1,47 @@
+---
+id: task-129-207-move-generation-discrepancies-qa
+type: TASK
+title: Verify Move Generation Discrepancies
+status: READY
+owner_persona: qa
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on:
+  - task-129-206-move-generation-discrepancies-impl
+jules_session_id: null
+pr_number: null
+parent: story-086-129-move-generation-discrepancies
+tags:
+  - build
+  - db
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Verify Move Generation Discrepancies (QA)
+
+## Background
+Move data extraction has been updated to apply generation-specific overrides for historical discrepancies, particularly Gen 1-3 differences in PP, power, and accuracy.
+
+## Goals
+1. Verify that the generated `moves.jsonl` data accurately reflects these generation-specific overrides.
+2. Verify that base PP values are accurately stored instead of max PP.
+
+## Verification Steps
+1. Run the data generation script: `pnpm tsx scripts/generate-pokedata.ts`.
+2. Inspect the output `data/db/moves.jsonl`.
+3. Pick a few sample moves known to have changed (e.g., "Tackle" power/accuracy changes over generations, "Blizzard" accuracy changes, etc.).
+4. Confirm that the extracted stats for Gen 1-3 align with historical data (e.g., from Bulbapedia) rather than latest Gen 9 stats.
+5. Revert any uncommitted changes to the output directories (`git restore data/db/`) before finishing.
+
+## Reminder for Coder/QA Personas
+- **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Confirmed generation discrepancies are properly applied in `moves.jsonl` output for sample moves.
+- [ ] Confirmed that base PP is stored correctly instead of max PP.


### PR DESCRIPTION
Breaks down `story-086-129-move-generation-discrepancies` into atomic technical task nodes for Implementation and QA personas.

The goal is to apply generation-specific overrides to move data (e.g., PP values) extracted in `scripts/generate-pokedata.ts` for Gen 1-3.

---
*PR created automatically by Jules for task [9847015453033433408](https://jules.google.com/task/9847015453033433408) started by @szubster*