### PR TITLE
💡 Visionary: Hidden Power Type and Base Power Calculator

### DIFF
--- a/.foundry/ideas/idea-085-hidden-power-calculator.md
+++ b/.foundry/ideas/idea-085-hidden-power-calculator.md
@@ -3,7 +3,7 @@ id: idea-085-hidden-power-calculator
 type: IDEA
 title: Hidden Power Type and Base Power Calculator
 status: READY
-owner_persona: product_manager
+owner_persona: human
 created_at: '2026-06-25'
 updated_at: '2026-06-25'
 depends_on: []

--- a/.foundry/ideas/idea-085-hidden-power-calculator.md
+++ b/.foundry/ideas/idea-085-hidden-power-calculator.md
@@ -1,0 +1,40 @@
+---
+id: idea-085-hidden-power-calculator
+type: IDEA
+title: Hidden Power Type and Base Power Calculator
+status: READY
+owner_persona: product_manager
+created_at: '2026-06-25'
+updated_at: '2026-06-25'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - feature
+  - mechanics
+  - gen2
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Hidden Power Type and Base Power Calculator
+
+## Context
+Hidden Power is a notoriously opaque mechanic introduced in Gen 2 and expanded in Gen 3. The move's Type and Base Power are determined entirely by the Pokémon's hidden IVs (DVs in Gen 2). Players have absolutely no way of knowing a Pokémon's Hidden Power Type or Power in-game without tedious trial and error against various Pokémon types or using external calculators. Since DexHelper already extracts these exact IVs/DVs from the save file, we are in a perfect position to solve this.
+
+## Proposal
+Add a "Hidden Power Calculator" view directly into the Pokémon details screen.
+- Instantly calculate and display the exact Type and Base Power of Hidden Power for every single Pokémon in the player's Party and PC boxes.
+- For Gen 2, use the DV-based formula.
+- For Gen 3, use the IV-based formula.
+- Potentially add a filter/search function in the PC box view to find Pokémon with specific Hidden Power types (e.g., "Find all Pokémon in my PC with Hidden Power Grass").
+
+## Value Proposition
+This directly leverages DexHelper's core strength: extracting hidden state from the save file and making it actionable. Hidden Power optimization is crucial for competitive play, battle facilities (like the Battle Frontier), and Nuzlocke challenge runs. By surfacing this data automatically, we eliminate the need for manual IV calculation and external tools, providing immediate, high-value utility to serious players.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -112,3 +112,7 @@
 ## 2026-06-17
 **Idea:** Daycare Status and Exact Egg Hatch Tracker
 **Learning:** Targeting opaque, heavily-utilized progression mechanics like breeding (Daycare status and Egg steps) for actionable QoL improvements perfectly aligns with the app's offline-first programmatic save parsing strengths. Extracting exact cycle counts transforms vague in-game text into precise data, removing tedious guesswork for hardcore players.
+
+## 2026-06-25
+**Idea:** Hidden Power Type and Base Power Calculator
+**Learning:** Hidden Power is a highly sought-after mechanic for competitive battling and challenge runs (like Nuzlockes), especially in Gens 2 and 3. Since the move's attributes are determined entirely by the Pokémon's hidden IVs/DVs—which players cannot easily see in-game without trial and error or external calculators—automatically extracting and calculating this information from the save file provides immediate, immense value. This perfectly fits the "premium companion app" ethos: taking opaque, hidden data and rendering it directly actionable.


### PR DESCRIPTION
Generates a new IDEA node for adding a Hidden Power Type and Base Power Calculator. This addresses a common pain point in Gen 2 and Gen 3 where players have no way of knowing a Pokémon's Hidden Power stats in-game. By extracting the exact IVs/DVs from the save file, we can instantly calculate and display this information, providing immense value to serious players. Also updates the Visionary persona's journal with this learning.

---
*PR created automatically by Jules for task [287483041115720981](https://jules.google.com/task/287483041115720981) started by @szubster*