### PR TITLE
feat: implement permanent failure dashboard ui

### DIFF
--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -59,3 +59,9 @@ The current system instructions were confusingly telling agents to set nodes to 
 To resolve this, I have:
 1. Updated `.github/agents/coder.md`, `.github/agents/qa.md`, `.github/agents/auditor.md`, and `.github/agents/tech_lead.md` to explicitly clarify the difference: `FAILED` is strictly for transient errors triggering a resurrection retry, while `CANCELLED` MUST be used for permanent failures (impossible tasks or max rejections reached) to formally drop them from the DAG and trigger parent recovery.
 2. Autonomously generated `idea-079-automated-max-rejection-cancellation.md` to propose updating the Foundry Orchestrator to automatically transition a node's status to `CANCELLED` when it hits its `MAX_REJECTION_THRESHOLD`.
+
+## 2026-06-15: Introduced Permanent Failures Dashboard View
+
+To improve visibility into system deadlocks (ADR 017), I have implemented a 'Permanent Failures' toggle on the DAG Dashboard. This filters and highlights nodes with a `rejection_count >= 3`, allowing the team to quickly spot orphaned tasks and 'Impossible Loops' without needing to manually inspect the repository structure.
+
+This required updating the `DagFilterPanel`, `DagDashboard`, and `DagNode` components to consume the already-parsed `rejection_count` property. Going forward, PMs and Tech Leads should check this view regularly.

--- a/src/components/dag/DagDashboard.tsx
+++ b/src/components/dag/DagDashboard.tsx
@@ -10,6 +10,10 @@ import { DagFilterPanel } from './DagFilterPanel';
 import { DagNode, type DagNodeData } from './DagNode';
 
 export function getMiniMapNodeColor(node: FlowNode<DagNodeData>): string {
+  if (node.data?.status === 'FAILED' && (node.data?.rejection_count ?? 0) >= 3) {
+    return '#dc2626'; // red-600
+  }
+
   switch (node.data?.status) {
     case 'COMPLETED':
       return '#10b981'; // emerald-500
@@ -79,6 +83,7 @@ export function DagDashboard() {
   const [activeStatuses, setActiveStatuses] = useState<Set<string>>(
     new Set(['PENDING', 'READY', 'ACTIVE', 'COMPLETED', 'FAILED', 'BLOCKED', 'CANCELLED']),
   );
+  const [showPermanentFailures, setShowPermanentFailures] = useState(false);
 
   const handleTypeToggle = (type: string) => {
     setActiveTypes((prev) => {
@@ -158,7 +163,13 @@ export function DagDashboard() {
       if (n) {
         const type = n.data.type;
         const status = n.data.status;
-        if (type && status && activeTypes.has(type) && activeStatuses.has(status)) {
+        let shouldInclude = type && status && activeTypes.has(type) && activeStatuses.has(status);
+
+        if (shouldInclude && showPermanentFailures) {
+          shouldInclude = n.data.status === 'FAILED' && n.data.rejection_count >= 3;
+        }
+
+        if (shouldInclude) {
           const isHighlighted = activeNodeId ? highlightSet.has(n.id) : false;
           const isDimmed = activeNodeId ? !highlightSet.has(n.id) : false;
           result.push({
@@ -173,7 +184,7 @@ export function DagDashboard() {
       }
     }
     return result;
-  }, [nodes, activeTypes, activeStatuses, activeNodeId, highlightSet]);
+  }, [nodes, activeTypes, activeStatuses, activeNodeId, highlightSet, showPermanentFailures]);
 
   const displayEdges = useMemo(() => {
     // ⚡ Bolt: Prevent array allocation in Set construction
@@ -239,8 +250,10 @@ export function DagDashboard() {
       <DagFilterPanel
         activeTypes={activeTypes}
         activeStatuses={activeStatuses}
+        showPermanentFailures={showPermanentFailures}
         onTypeToggle={handleTypeToggle}
         onStatusToggle={handleStatusToggle}
+        onTogglePermanentFailures={() => setShowPermanentFailures((prev) => !prev)}
       />
       <ReactFlow
         nodes={displayNodes}

--- a/src/components/dag/DagFilterPanel.tsx
+++ b/src/components/dag/DagFilterPanel.tsx
@@ -3,14 +3,23 @@ import { TacticalMultiSelectControl } from '../TacticalMultiSelectControl';
 export interface DagFilterPanelProps {
   activeTypes: Set<string>;
   activeStatuses: Set<string>;
+  showPermanentFailures: boolean;
   onTypeToggle: (type: string) => void;
   onStatusToggle: (status: string) => void;
+  onTogglePermanentFailures: () => void;
 }
 
 const ALL_TYPES = ['IDEA', 'PRD', 'EPIC', 'STORY', 'TASK'];
 const ALL_STATUSES = ['PENDING', 'READY', 'ACTIVE', 'COMPLETED', 'FAILED', 'BLOCKED', 'CANCELLED'];
 
-export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onStatusToggle }: DagFilterPanelProps) {
+export function DagFilterPanel({
+  activeTypes,
+  activeStatuses,
+  showPermanentFailures,
+  onTypeToggle,
+  onStatusToggle,
+  onTogglePermanentFailures,
+}: DagFilterPanelProps) {
   return (
     <div className="absolute top-4 left-4 z-10 flex flex-col gap-4 border border-zinc-800 border-dashed bg-zinc-950/90 p-4 font-mono text-xs text-zinc-400 backdrop-blur-sm">
       <TacticalMultiSelectControl
@@ -72,6 +81,17 @@ export function DagFilterPanel({ activeTypes, activeStatuses, onTypeToggle, onSt
           };
         })}
       />
+      <button
+        type="button"
+        className={`!border-dashed border px-2 py-1 text-xs focus-visible:ring-[var(--theme-primary)] ${
+          showPermanentFailures
+            ? 'border-red-500 bg-red-950/20 text-red-500 shadow-none'
+            : 'border-zinc-800 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-400'
+        }`}
+        onClick={onTogglePermanentFailures}
+      >
+        [ PERMANENT_FAILURES_ONLY ]
+      </button>
     </div>
   );
 }

--- a/src/components/dag/DagNode.tsx
+++ b/src/components/dag/DagNode.tsx
@@ -35,6 +35,9 @@ export function DagNode({ data }: { data: DagNodeData }) {
       statusColor = 'text-red-500';
       dotColor = 'text-red-500';
       bgClass = 'bg-red-950/20 border-red-500/50';
+      if (data.status === 'FAILED' && data.rejection_count >= 3) {
+        bgClass = 'bg-red-900/40 border-red-500 border-2 brightness-125';
+      }
       break;
     case 'READY':
       statusColor = 'text-amber-500';

--- a/src/components/dag/__tests__/DagDashboard.test.tsx
+++ b/src/components/dag/__tests__/DagDashboard.test.tsx
@@ -350,4 +350,11 @@ test('getMiniMapNodeColor returns correct color based on status', () => {
       import('../DagNode').DagNodeData
     >),
   ).toBe('#52525b');
+  expect(
+    getMiniMapNodeColor({
+      id: '1',
+      position: { x: 0, y: 0 },
+      data: { rejection_count: 3, status: 'FAILED', type: 'TASK', owner_persona: 'human' },
+    }),
+  ).toBe('#dc2626');
 });

--- a/src/components/dag/__tests__/DagFilterPanel.test.tsx
+++ b/src/components/dag/__tests__/DagFilterPanel.test.tsx
@@ -34,4 +34,7 @@ test('DagFilterPanel renders all types and statuses', async () => {
 
   await page.getByText('READY').click();
   expect(mockOnStatusToggle).toHaveBeenCalledWith('READY');
+
+  await page.getByText('[ PERMANENT_FAILURES_ONLY ]').click();
+  expect(mockOnTogglePermanentFailures).toHaveBeenCalled();
 });

--- a/src/components/dag/__tests__/DagFilterPanel.test.tsx
+++ b/src/components/dag/__tests__/DagFilterPanel.test.tsx
@@ -9,12 +9,16 @@ test('DagFilterPanel renders all types and statuses', async () => {
   const mockOnTypeToggle = vi.fn<(type: string) => void>();
   const mockOnStatusToggle = vi.fn<(status: string) => void>();
 
+  const mockOnTogglePermanentFailures = vi.fn<() => void>();
+
   await render(
     <DagFilterPanel
       activeTypes={activeTypes}
       activeStatuses={activeStatuses}
+      showPermanentFailures={false}
       onTypeToggle={mockOnTypeToggle}
       onStatusToggle={mockOnStatusToggle}
+      onTogglePermanentFailures={mockOnTogglePermanentFailures}
     />,
   );
 

--- a/src/components/dag/__tests__/DagNode.test.tsx
+++ b/src/components/dag/__tests__/DagNode.test.tsx
@@ -160,3 +160,33 @@ test('DagNode applies styles for other statuses', async () => {
   await expect.element(page.getByText('READY', { exact: true })).toBeInTheDocument();
   await expect.element(page.getByText('PENDING', { exact: true })).toBeInTheDocument();
 });
+
+test('DagNode applies permanent failure styles when rejection_count >= 3', async () => {
+  const data = {
+    id: 'test-task-001',
+    label: 'test-task-001',
+    type: 'TASK',
+    owner_persona: 'coder',
+    status: 'FAILED',
+    rejection_count: 3,
+  };
+
+  const nodes = [
+    {
+      id: 'test-task-001',
+      type: 'custom',
+      data,
+      position: { x: 0, y: 0 },
+    },
+  ];
+
+  await render(
+    <div style={{ width: '500px', height: '500px' }}>
+      <ReactFlow nodes={nodes} nodeTypes={nodeTypes} />
+    </div>,
+  );
+
+  const node = page.getByTestId('dag-node');
+  await expect.element(node).toHaveClass('border-red-500');
+  await expect.element(node).toHaveClass('border-2');
+});


### PR DESCRIPTION
This PR implements the Permanent Failure Dashboard UI as requested in ADR 017 and epic-034-047-permanent-failure-dashboard-ui.

It introduces a new filter toggle in the DAG Dashboard to highlight nodes that have permanently failed (status: FAILED and rejection_count >= 3). It leverages the existing DAG React Context. It updates the `DagFilterPanel` with a new toggle button, modifies the graph's `displayNodes` logic to filter based on this state, and adds distinct visual styling to the `DagNode` component for permanently failed nodes.

As Agile Coach, I also updated the journal to log the implementation of this feature to help Tech Leads spot 'Impossible Loops' easily.

---
*PR created automatically by Jules for task [5569012011001823316](https://jules.google.com/task/5569012011001823316) started by @szubster*