### PR TITLE
🎨 Palette: Add missing aria-label to Clear Filters button

### DIFF
--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -68,6 +68,7 @@ export function SearchAndFilters() {
                 onClick={() => setFilters([])}
                 aria-pressed={filtersSet.size === 0}
                 title="Clear filters"
+                aria-label="Clear filters"
                 className={`tactical-text focus-visible:tactical-focus min-w-[100px] flex-1 border-zinc-800 border-r border-dashed px-2 py-3 font-black text-[10px] transition-all ${
                   filtersSet.size === 0
                     ? 'bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_10px_rgba(var(--theme-primary-rgb),0.3)]'


### PR DESCRIPTION
Added `aria-label="Clear filters"` to the 'ALL' clear filters button in `src/components/SearchAndFilters.tsx` to ensure proper accessibility for screen readers, addressing the gap where only a `title` attribute was present. All tests and linters pass.

---
*PR created automatically by Jules for task [11515426608415941493](https://jules.google.com/task/11515426608415941493) started by @szubster*