### PR TITLE
📜 Scribe: Documented Gen 3 Save Parser Architecture

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -174,3 +174,10 @@ Documenting this prevents developers from incorrectly refactoring offset lookups
 **Why:** The File System Access API (`window.showOpenFilePicker`) has non-obvious constraints regarding long-term file access.
 - **Permission Revocation:** Even when a `FileSystemFileHandle` is persisted perfectly in IndexedDB, the browser automatically revokes the *read permission* when the tab is closed for security reasons. Documenting this constraint explains *why* the `resumeSync` function exists (to re-request permission via `handle.requestPermission()`) and why the hook differentiates between having a stored handle and being in a 'live' state.
 - **Polling Loop:** The modern web lacks a standard `FileSystemObserver` API. Documenting this explains *why* a manual `setInterval` polling loop checking `file.lastModified` is required to detect emulator saves.
+
+## 2026-06-25 - Gen 3 Memory Architecture and Berry Patch Documentation
+
+**What:** Added comprehensive JSDoc to `getLatestSectionOffset` and `extractBerryPatches` in `src/engine/saveParser/parsers/gen3.ts`.
+**Why:** The Generation 3 save format uses a complex A/B bank flash memory architecture (unlike Gen 1/2 SRAM) where the game alternates writing between two 56KB blocks (`0x0000` and `0xE000`) to prevent data corruption during saves.
+- `getLatestSectionOffset`: I documented how this function scans both banks for the `0x08012025` signature and compares the `saveIndex` to determine which block contains the most recent, non-corrupted data. Without this documentation, developers might incorrectly assume a linear memory structure or rely on the first signature they find, leading to rollback bugs where outdated data is read.
+- `extractBerryPatches`: I documented the explicit binary structure of Hoenn's 128 berry patches. The growth stage and watering flags are densely packed into bitwise offsets (e.g., the top bit of the stage byte indicates if growth is stopped, and watering data is split across four specific bits). Explaining this dense packing prevents developers from misreading the offsets or overwriting flags during potential future save-editing features.

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -6,6 +6,24 @@ const NUM_SECTIONS = 14;
 const SAVE_BLOCK_A = 0x0000;
 const SAVE_BLOCK_B = 0xe000;
 
+/**
+ * Locates the most recent memory offset for a specific save section in Gen 3 flash memory.
+ *
+ * **A/B Bank Architecture:**
+ * Gen 3 games use flash memory divided into two 56KB blocks: Bank A (`0x0000`) and Bank B (`0xE000`).
+ * When saving, the game writes to whichever bank was NOT used previously, acting as a fail-safe
+ * against data corruption if the device powers off mid-save.
+ * Each bank is further divided into 14 4KB sections.
+ *
+ * This function scans both banks for the target section using the magic signature `0x08012025`.
+ * If the section exists in both banks, it compares their `saveIndex` values (the number of times
+ * the game has been saved) to return the offset of the most recent, non-corrupted write.
+ *
+ * @param view - The raw save file DataView.
+ * @param targetSectionId - The internal ID of the section to locate (e.g., 1 for SaveBlock1, 2 for SaveBlock2).
+ * @returns The memory offset of the most recent section.
+ * @throws Error if the section cannot be found or if neither bank contains a valid signature.
+ */
 function getLatestSectionOffset(view: DataView, targetSectionId: number): number {
   let saveIndexA = -1;
   let saveIndexB = -1;
@@ -61,6 +79,26 @@ function getLatestSectionOffset(view: DataView, targetSectionId: number): number
  * @returns True if the structure looks like a valid Gen 3 save.
  */
 
+/**
+ * Extracts the status and growth data of all 128 Berry Patches in Hoenn.
+ *
+ * **Binary Data Structure:**
+ * Each berry patch is represented by an 8-byte structure:
+ * - `Byte 0`: Berry ID (which berry is planted).
+ * - `Byte 1`: Growth Stage & Stop Flag. The lower 7 bits represent the current growth stage.
+ *   The highest bit (`0x80`) is a boolean flag indicating if growth has been stopped (e.g., fully grown).
+ * - `Bytes 2-3`: 16-bit timer indicating minutes until the next growth stage.
+ * - `Byte 4`: The total berry yield expected when harvested.
+ * - `Byte 5`: Regrowth Count & Watering Flags. The lower 4 bits track how many times the plant has
+ *   regrown after dropping its berries. The upper 4 bits are individual boolean flags indicating
+ *   if the plant was watered during each of its 4 growth stages (`0x10`, `0x20`, `0x40`, `0x80`).
+ * - `Bytes 6-7`: Padding / unused.
+ *
+ * @param view - The raw save file DataView.
+ * @param saveBlock1Offset - The base offset of SaveBlock1.
+ * @returns An array of parsed `Gen3BerryPatch` objects.
+ * @throws RangeError if the read goes out of bounds.
+ */
 function extractBerryPatches(view: DataView, saveBlock1Offset: number) {
   const patches: Gen3BerryPatch[] = [];
   const baseOffset = saveBlock1Offset + 0x071c;


### PR DESCRIPTION
Added comprehensive JSDoc to `getLatestSectionOffset` and `extractBerryPatches` in `src/engine/saveParser/parsers/gen3.ts`. This module manages the complex binary extraction from the Gen 3 A/B bank flash memory architecture. Documenting the signature validation and the specific bit-packed structures of the 128 Hoenn berry patches provides necessary context to prevent corruption issues in future parsing or save editing updates.

---
*PR created automatically by Jules for task [10243498466056455386](https://jules.google.com/task/10243498466056455386) started by @szubster*