### PR TITLE
🧭 Strategist: Prompt improvement - Prevent magic numbers in save file parsing

### DIFF
--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -17,6 +17,9 @@ When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.t
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
 
+## Save File Parsing & Magic Numbers
+When implementing save file parsing or data definitions, you MUST explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Strictly avoid using inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions. This ensures robustness against version-specific shifts and prevents brittle code.
+
 ## UI Aesthetic Constraints (ADR 008)
 When implementing UI components, you MUST adhere strictly to the "tactical hardware/snooping" aesthetic outlined in ADR 008.
 - Explicitly use sharp edges (`rounded-none`).

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -17,7 +17,7 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/001-the-f
 
 ## Responsibilities
 
-1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria.
+1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria. You MUST explicitly reject tasks that use inline magic numbers (e.g., `0x2dd6`, `>> 4`) for save file data extraction instead of defined reusable constants at the module level.
 2. **Review**: Ensure implemented code follows architectural constraints (especially ADR 001).
 3. **Approval/Rejection**: If the implementation is valid, approve it. If not, detail what is missing or incorrect according to the contract and architecture.
 4. **Specify Results**: Explicitly specify the results of your validation work. Depending on the scope and need for further analysis, this output can include new tests, documentation updates, or the creation of new tasks, stories, PRDs, or ideas.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -11,6 +11,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
     - If they experience a transient failure requiring retry, they MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
     - If they must abort or permanently fail a task (impossible or max rejections reached), they MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
     - If they submit an empty PR for a completed task, they MUST check off all Acceptance Criteria checkboxes before submitting.
+    - When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
 5.  **Intelligent Verification Protocol**: Intelligently decide when a STORY requires a separate QA verification task:
     - If a story involves complex logic or risk, create a matching TASK for the `qa` persona to verify the `coder`'s work.
     - If simple/low-risk, designate the `coder` to self-verify (documented in the task journal).

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -261,3 +261,9 @@
 **Outcome:** Merged
 **Why:** The Strategist prompt was missing the explicit instruction about checking unchecked Acceptance Criteria checkboxes when submitting an empty PR, which is present in other persona prompts and required by ADR 007 and ADR 009.
 **Pattern:** Codify system memory constraints into agent prompts to avoid regressions and ensure consistency across personas.
+
+## 2026-06-20 - [Accepted] - Prompt improvement - Prevent magic numbers in save file parsing
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The Auditor journal noted that using inline magic numbers for save file parsing offsets leads to brittle code. The `tech_lead`, `coder`, and `qa` agents lacked explicit instructions to prevent this.
+**Pattern:** Ensure agents involved in save file parsing explicitly define and enforce the use of reusable constants for memory offsets, lengths, and bit locations at the module level instead of using inline magic numbers.


### PR DESCRIPTION
Proposal: Explicitly forbid inline magic numbers for binary/save file parsing across the developer, reviewer, and architect prompts.

Justification: The Auditor journal highlighted a repeating pattern of brittle code due to implementers using hardcoded offsets (`0x2dd6`, `>> 4`) directly in parsing functions. The existing `coder.md`, `qa.md`, and `tech_lead.md` lacked explicit constraints preventing this. This prompt improvement ensures all involved agents define and enforce module-level constants.

Evidence: `.foundry/journals/auditor.md` logged: "I rejected the Epic epic-036-058-feebas-backend-parsing because the implementer used inline magic numbers (e.g., 0x2dd6) directly in the parsing functions instead of explicitly defined constants."

---
*PR created automatically by Jules for task [10089583466558407215](https://jules.google.com/task/10089583466558407215) started by @szubster*