### PR TITLE
Create stories for Gen 3 Contest Advisor UI

### DIFF
--- a/.foundry/epics/epic-042-065-gen3-contest-advisor-ui.md
+++ b/.foundry/epics/epic-042-065-gen3-contest-advisor-ui.md
@@ -47,3 +47,8 @@ Derived from `prd-070-042-gen3-contest-optimization-advisor`, this epic handles 
 - [ ] Integrate components into the Pokémon detail view.
 - [ ] Implement clear reasoning copy for recommendations.
 - [ ] Implement and test visual warning states for maxed Sheen scenarios.
+
+### Stories
+- [ ] .foundry/stories/story-065-149-contest-recommendation-ui-components.md
+- [ ] .foundry/stories/story-065-150-contest-warning-states-ui.md
+- [ ] .foundry/stories/story-065-151-contest-advisor-ui-integration.md

--- a/.foundry/stories/story-065-149-contest-recommendation-ui-components.md
+++ b/.foundry/stories/story-065-149-contest-recommendation-ui-components.md
@@ -1,0 +1,34 @@
+---
+id: story-065-149-contest-recommendation-ui-components
+type: STORY
+title: Contest Recommendation UI Components
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on:
+  - epic-042-064-gen3-contest-advisor-algorithm
+jules_session_id: null
+pr_number: null
+parent: epic-042-065-gen3-contest-advisor-ui
+tags:
+  - feature
+  - gen3
+  - contests
+  - advisor
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Contest Recommendation UI Components
+
+## Description
+Design and build reusable UI components to display Contest recommendations, consuming outputs from the algorithm epic (`epic-042-064-gen3-contest-advisor-algorithm`). The component needs to clearly display the top 1-2 recommended Contest categories and provide a brief, generated explanation for *why* a category was chosen.
+
+## Acceptance Criteria
+- [ ] Develop reusable UI components for Contest recommendations.
+- [ ] Clearly display the top 1-2 recommended Contest categories.
+- [ ] Implement clear reasoning copy for recommendations (e.g. highlighting favorable Nature or high existing stat).

--- a/.foundry/stories/story-065-150-contest-warning-states-ui.md
+++ b/.foundry/stories/story-065-150-contest-warning-states-ui.md
@@ -1,0 +1,33 @@
+---
+id: story-065-150-contest-warning-states-ui
+type: STORY
+title: Contest Warning States UI
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on:
+  - story-065-149-contest-recommendation-ui-components
+jules_session_id: null
+pr_number: null
+parent: epic-042-065-gen3-contest-advisor-ui
+tags:
+  - feature
+  - gen3
+  - contests
+  - advisor
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Contest Warning States UI
+
+## Description
+Implement visual warning states for edge cases identified by the Gen 3 Contest Optimization Advisor algorithm. Specifically, alert users when a Pokémon has maxed out its Sheen but lacks the requisite stats for Master Rank contests, indicating a dead-end for optimization.
+
+## Acceptance Criteria
+- [ ] Implement visual warnings for edge cases.
+- [ ] Alert users when a Pokémon has maxed out its Sheen but lacks stats for Master Rank contests.

--- a/.foundry/stories/story-065-151-contest-advisor-ui-integration.md
+++ b/.foundry/stories/story-065-151-contest-advisor-ui-integration.md
@@ -1,0 +1,34 @@
+---
+id: story-065-151-contest-advisor-ui-integration
+type: STORY
+title: Contest Advisor UI Integration
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on:
+  - story-065-149-contest-recommendation-ui-components
+  - story-065-150-contest-warning-states-ui
+jules_session_id: null
+pr_number: null
+parent: epic-042-065-gen3-contest-advisor-ui
+tags:
+  - feature
+  - gen3
+  - contests
+  - advisor
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Contest Advisor UI Integration
+
+## Description
+Integrate the newly developed Contest Recommendation and Warning UI components into the individual Pokémon detail view, alongside the existing Contest Stats.
+
+## Acceptance Criteria
+- [ ] Integrate Contest Recommendation UI into the individual Pokémon detail view.
+- [ ] Integrate Contest Warning States UI into the individual Pokémon detail view.


### PR DESCRIPTION
Broke down epic-042-065-gen3-contest-advisor-ui into 3 granular story nodes:
- story-065-149-contest-recommendation-ui-components
- story-065-150-contest-warning-states-ui
- story-065-151-contest-advisor-ui-integration
Appended references to the new stories into the parent epic.

---
*PR created automatically by Jules for task [4151748229226601021](https://jules.google.com/task/4151748229226601021) started by @szubster*