### PR TITLE
Scaffold tasks for Unown Dex Panel Data Integration

### DIFF
--- a/.foundry/stories/story-059-132-unown-dex-data-integration.md
+++ b/.foundry/stories/story-059-132-unown-dex-data-integration.md
@@ -31,4 +31,8 @@ Integrate the newly built UI panel with the parsed `unownForm` data.
 Determine which of the 26 Unown forms (A-Z) the player possesses in their active party or PC boxes by aggregating the `unownForm` properties from the save file data instances. Surface the missing/owned states to the Unown Dex Panel UI component.
 
 ## Acceptance Criteria
-- [ ] Task for mapping the unownForm property to the Unown Dex Panel UI component created.
+- [x] Task for mapping the unownForm property to the Unown Dex Panel UI component created.
+
+## Tasks
+- [ ] .foundry/tasks/task-132-206-unown-dex-data-integration-impl.md
+- [ ] .foundry/tasks/task-132-207-unown-dex-data-integration-qa.md

--- a/.foundry/tasks/task-132-206-unown-dex-data-integration-impl.md
+++ b/.foundry/tasks/task-132-206-unown-dex-data-integration-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-132-206-unown-dex-data-integration-impl
+type: TASK
+title: Unown Dex Panel Data Integration Implementation
+status: PENDING
+owner_persona: coder
+created_at: "2026-06-19"
+updated_at: "2026-06-19"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-059-132-unown-dex-data-integration
+tags:
+  - feature
+  - gen2
+  - tracking
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Unown Dex Panel Data Integration Implementation
+
+## Objective
+Implement the data integration logic for the Unown Dex Panel UI component as described in `story-059-132-unown-dex-data-integration`.
+
+## Logic
+Determine which of the 26 Unown forms (A-Z) the player possesses in their active party or PC boxes by aggregating the `unownForm` properties from the save file data instances. Surface the missing/owned states to the Unown Dex Panel UI component.
+
+## Constraints and Scaffolding
+- You must map the `unownForm` property from the save file data instances to the UI component.
+- Ensure the Unown Dex Panel UI component properly reflects the owned/missing states for the 26 Unown forms based on the save file data.
+- Integrate the newly built UI panel with the parsed `unownForm` data.
+
+## Important Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Data integration logic mapping the `unownForm` property to the Unown Dex Panel UI component is implemented.
+- [ ] The UI component correctly displays the owned/missing states for the 26 Unown forms.
+- [ ] Appropriate tests are added to verify the integration.

--- a/.foundry/tasks/task-132-207-unown-dex-data-integration-qa.md
+++ b/.foundry/tasks/task-132-207-unown-dex-data-integration-qa.md
@@ -1,0 +1,41 @@
+---
+id: task-132-207-unown-dex-data-integration-qa
+type: TASK
+title: Unown Dex Panel Data Integration QA
+status: PENDING
+owner_persona: qa
+created_at: "2026-06-19"
+updated_at: "2026-06-19"
+depends_on:
+  - task-132-206-unown-dex-data-integration-impl
+jules_session_id: null
+pr_number: null
+parent: story-059-132-unown-dex-data-integration
+tags:
+  - feature
+  - gen2
+  - tracking
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Unown Dex Panel Data Integration QA
+
+## Objective
+Verify the implementation of the Unown Dex Panel Data Integration.
+
+## Logic
+Verify the integration, ensuring the UI correctly displays the owned/missing states for the 26 Unown forms based on the save file data.
+
+## Important Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verified that the `unownForm` property is correctly mapped from the save file data instances to the UI component.
+- [ ] Verified that the Unown Dex Panel UI component correctly displays the owned/missing states for all 26 Unown forms.
+- [ ] Verified that appropriate tests are in place and passing.


### PR DESCRIPTION
This PR breaks down Story `story-059-132-unown-dex-data-integration` into actionable technical tasks.

1.  Created `task-132-206-unown-dex-data-integration-impl` for the `coder` to implement the logic that maps the `unownForm` property from save file data to the UI component.
2.  Created `task-132-207-unown-dex-data-integration-qa` for the `qa` persona to verify the integration correctly displays the owned/missing states for the 26 Unown forms.
3.  Updated the parent story (`story-059-132-unown-dex-data-integration.md`) to mark the original acceptance criteria as completed and append the new child nodes as unchecked tasks, ensuring the node does not prematurely transition to `VERIFYING`.

All node metadata adheres strictly to the Parent-Linked ID Schema and includes explicit persona reminders regarding transient failures and empty PR checks.

---
*PR created automatically by Jules for task [16425138245492939923](https://jules.google.com/task/16425138245492939923) started by @szubster*