### PR TITLE
chore(foundry): transform story-137 to tech blueprint

### DIFF
--- a/.foundry/stories/story-065-137-individual-contest-stats-ui.md
+++ b/.foundry/stories/story-065-137-individual-contest-stats-ui.md
@@ -30,4 +30,6 @@ This story implements a requirement for `epic-041-065-individual-contest-stats-v
 - Integrate numerical contest stats into the detailed Pokémon view.
 
 ## 3. Acceptance Criteria
-- [ ] Integrate numerical contest stats into the detailed Pokémon view.
+- [x] Integrate numerical contest stats into the detailed Pokémon view.
+- [ ] .foundry/tasks/task-137-209-individual-contest-stats-ui-impl.md
+- [ ] .foundry/tasks/task-137-210-individual-contest-stats-ui-qa.md

--- a/.foundry/tasks/task-137-209-individual-contest-stats-ui-impl.md
+++ b/.foundry/tasks/task-137-209-individual-contest-stats-ui-impl.md
@@ -1,0 +1,37 @@
+---
+id: task-137-209-individual-contest-stats-ui-impl
+type: TASK
+title: "Implement Individual Contest Stats UI"
+status: PENDING
+owner_persona: "coder"
+created_at: "2026-06-19"
+updated_at: "2026-06-19"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-065-137-individual-contest-stats-ui
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement Individual Contest Stats UI
+
+## 1. Context
+This task implements the UI required to show individual contest stats for a specific Pokémon inside `PokemonCaughtDetails.tsx`. The goal is to surface accurate numeric condition values (Cool, Beauty, Cute, Smart, Tough) and the total sheen.
+
+## 2. Requirements
+1. Update `src/components/pokemon/details/PokemonCaughtDetails.tsx`.
+2. Check if the incoming `p.condition` object is available. If it is, display the values using `ContestConditionStats`.
+3. Check if `p.condition.sheen` is available. If it is, display the value using `ContestSheenDisplay`.
+4. Update `src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx` to include testing for these new visual components.
+
+## 3. Acceptance Criteria
+- [ ] `ContestConditionStats` renders correctly within `PokemonCaughtDetails` if `condition` data is passed.
+- [ ] `ContestSheenDisplay` renders correctly within `PokemonCaughtDetails` if `condition` data contains `sheen`.
+- [ ] Tests in `PokemonCaughtDetails.test.tsx` cover the rendering of these new condition stat displays.
+- [ ] If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- [ ] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-137-210-individual-contest-stats-ui-qa.md
+++ b/.foundry/tasks/task-137-210-individual-contest-stats-ui-qa.md
@@ -1,0 +1,35 @@
+---
+id: task-137-210-individual-contest-stats-ui-qa
+type: TASK
+title: "QA Individual Contest Stats UI"
+status: PENDING
+owner_persona: "qa"
+created_at: "2026-06-19"
+updated_at: "2026-06-19"
+depends_on:
+  - task-137-209-individual-contest-stats-ui-impl
+jules_session_id: null
+pr_number: null
+parent: story-065-137-individual-contest-stats-ui
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA Individual Contest Stats UI
+
+## 1. Context
+This task verifies the implementation of the individual contest stats display within the Pokémon details view, ensuring that `PokemonCaughtDetails` correctly uses `ContestConditionStats` and `ContestSheenDisplay`.
+
+## 2. Verification Steps
+1. Verify `src/components/pokemon/details/PokemonCaughtDetails.tsx` correctly renders `ContestConditionStats` and `ContestSheenDisplay` when given a mocked Pokemon object containing `condition` properties.
+2. Verify test cases were written in `PokemonCaughtDetails.test.tsx` and that they pass.
+
+## 3. Acceptance Criteria
+- [ ] `PokemonCaughtDetails` successfully renders the new stats visually.
+- [ ] Unit tests pass cleanly.
+- [ ] If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- [ ] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR fulfills the Tech Lead persona requirement for `story-065-137-individual-contest-stats-ui`. 

It creates the necessary implementation and QA `TASK` nodes in `.foundry/tasks/` representing the technical blueprint, correctly linking them via the `depends_on` array. Finally, it checks off the parent story's acceptance criteria and appends the new tasks as unchecked list items inside the markdown body, ensuring the DAG engine interprets the hierarchy successfully without breaking formatting constraints.

---
*PR created automatically by Jules for task [16334513204868356582](https://jules.google.com/task/16334513204868356582) started by @szubster*