### PR TITLE
chore(foundry): Generate tasks for individual contest ribbons UI

### DIFF
--- a/.foundry/stories/story-065-139-individual-contest-ribbons-ui.md
+++ b/.foundry/stories/story-065-139-individual-contest-ribbons-ui.md
@@ -31,3 +31,7 @@ This story implements a requirement for `epic-041-065-individual-contest-stats-v
 
 ## 3. Acceptance Criteria
 - [ ] Integrate Ribbons for a single Pokémon.
+
+## Child Tasks
+- [ ] .foundry/tasks/task-139-209-individual-contest-ribbons-impl.md
+- [ ] .foundry/tasks/task-139-210-individual-contest-ribbons-qa.md

--- a/.foundry/tasks/task-139-209-individual-contest-ribbons-impl.md
+++ b/.foundry/tasks/task-139-209-individual-contest-ribbons-impl.md
@@ -1,0 +1,53 @@
+---
+id: task-139-209-individual-contest-ribbons-impl
+type: TASK
+title: Implement Individual Contest Ribbons Integration
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-065-139-individual-contest-ribbons-ui
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Individual Contest Ribbons Integration
+
+## Context
+This task implements the UI integration required for `story-065-139-individual-contest-ribbons-ui`. We need to display the Contest Ribbons a Pokémon has earned in the `PokemonCaughtDetails` view.
+
+## Requirements
+1. Implement a new component (e.g. `ContestRibbonsPanel`) that uses the existing `ContestRibbonBadge` component to render all ribbons a Pokémon has earned.
+2. Integrate `ContestRibbonsPanel` into `PokemonCaughtDetails.tsx` (found in `src/components/pokemon/details/`). It should only render for Gen 3 Pokémon (or when `p.ribbons` is defined).
+
+## Architectural Scaffolding
+- The `PokemonInstance` object has an optional `ribbons` property of type `Gen3Ribbons`, which contains the ranks (0-4) for each condition (`cool`, `beauty`, `cute`, `smart`, `tough`).
+- A value of `0` means no ribbon was earned for that condition category. Do not render a badge for `0`.
+- The `ContestRibbonBadge` component expects a `ContestRibbonRank` string (`'Normal' | 'Super' | 'Hyper' | 'Master'`).
+- You must map the numeric ranks to these strings:
+  - `1` -> `'Normal'`
+  - `2` -> `'Super'`
+  - `3` -> `'Hyper'`
+  - `4` -> `'Master'`
+- Group these badges nicely using a `TacticalPanel` (or similar section grouping) next to the other stats (e.g. Contest Condition Stats, Sheen).
+
+## Contract
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Create a `ContestRibbonsPanel` component to wrap and display the earned ribbons.
+- [ ] Correctly map numeric ribbon values (1-4) to their string equivalents.
+- [ ] Integrate the ribbon display into `PokemonCaughtDetails.tsx` when `p.ribbons` is present.
+- [ ] Add rendering tests (e.g., using Vitest/Playwright) to verify the integration.

--- a/.foundry/tasks/task-139-210-individual-contest-ribbons-qa.md
+++ b/.foundry/tasks/task-139-210-individual-contest-ribbons-qa.md
@@ -1,0 +1,46 @@
+---
+id: task-139-210-individual-contest-ribbons-qa
+type: TASK
+title: QA Individual Contest Ribbons Integration
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-16'
+updated_at: '2026-06-16'
+depends_on:
+  - task-139-209-individual-contest-ribbons-impl
+jules_session_id: null
+pr_number: null
+parent: story-065-139-individual-contest-ribbons-ui
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Individual Contest Ribbons Integration
+
+## Context
+This task is to verify the implementation of `task-139-209-individual-contest-ribbons-impl` which integrates the display of Contest Ribbons into the individual Pokémon details view (`PokemonCaughtDetails`).
+
+## Requirements
+1. Verify that `ContestRibbonsPanel` (or similar) was created and correctly integrated into `PokemonCaughtDetails.tsx`.
+2. Verify that the numerical ribbon ranks (`1` through `4`) are correctly mapped to their respective strings (`Normal`, `Super`, `Hyper`, `Master`).
+3. Verify that a rank of `0` results in no badge being displayed for that specific condition.
+4. Verify that unit/rendering tests have been added and properly cover the mapping and display logic.
+5. Verify that the UI follows the global tactical UI guidelines.
+
+## Contract
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify `ContestRibbonsPanel` renders correctly inside `PokemonCaughtDetails` only when `p.ribbons` is defined.
+- [ ] Verify the numerical rank mapping logic (1=Normal, 2=Super, 3=Hyper, 4=Master, 0=Hidden).
+- [ ] Verify proper test coverage for the new component and integration.


### PR DESCRIPTION
This PR generates the implementation and QA task blueprints for `story-065-139-individual-contest-ribbons-ui`.

Tasks generated:
- `task-139-209-individual-contest-ribbons-impl`: Implements the `ContestRibbonsPanel` component and integrates it into `PokemonCaughtDetails.tsx` utilizing `ContestRibbonBadge`. Includes required UI and architectural instructions.
- `task-139-210-individual-contest-ribbons-qa`: Validates the implementation and test coverage.

The parent story has been updated with these tasks as unchecked child nodes.

No production code changes were made.

---
*PR created automatically by Jules for task [2069001233643904042](https://jules.google.com/task/2069001233643904042) started by @szubster*