### PR TITLE
chore: tech lead blueprint for individual contest sheen ui

### DIFF
--- a/.foundry/stories/story-065-138-individual-contest-sheen-ui.md
+++ b/.foundry/stories/story-065-138-individual-contest-sheen-ui.md
@@ -31,3 +31,7 @@ This story implements a requirement for `epic-041-065-individual-contest-stats-v
 
 ## 3. Acceptance Criteria
 - [ ] Integrate the Sheen display into the detailed Pokémon view.
+
+## Child Tasks
+- [ ] .foundry/tasks/task-138-209-individual-contest-sheen-ui-impl.md
+- [ ] .foundry/tasks/task-138-210-individual-contest-sheen-ui-qa.md

--- a/.foundry/tasks/task-138-209-individual-contest-sheen-ui-impl.md
+++ b/.foundry/tasks/task-138-209-individual-contest-sheen-ui-impl.md
@@ -1,0 +1,51 @@
+---
+id: task-138-209-individual-contest-sheen-ui-impl
+type: TASK
+title: Implement Contest Sheen UI Integration
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-065-138-individual-contest-sheen-ui
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Contest Sheen UI Integration
+
+## 1. Context
+This task integrates the `ContestSheenDisplay` component into the detailed Pokémon view (`PokemonCaughtDetails.tsx`) to display a Pokémon's Sheen value when applicable (Generation 3).
+
+## 2. Technical Blueprint
+- **File**: `src/components/pokemon/details/PokemonCaughtDetails.tsx`
+- **Instructions**:
+  - Import `ContestSheenDisplay` from `./ContestSheenDisplay`.
+  - Inside the rendering map for each Pokémon instance (`yourPokemon.map`), check if the `generation` is `3` and if the Pokémon instance (`p`) has a `condition` object (`p.condition`).
+  - If the conditions are met, render the `ContestSheenDisplay` component.
+  - Pass `p.condition.sheen` as the `sheen` prop to the `ContestSheenDisplay`.
+  - Position the display appropriately within the `TacticalPanel`, likely as a new block after the caught data/origin point.
+
+- **File**: `src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx`
+- **Instructions**:
+  - Update the tests to verify that the `ContestSheenDisplay` renders correctly when a Gen 3 Pokémon has contest condition stats.
+  - You can spy on or mock `ContestSheenDisplay` if needed, or simply assert on the text/bar output.
+
+## 3. Important Reminders for Coder & QA Personas
+- **Transient Failures**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures**: If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the YAML frontmatter on successful completion.
+
+## 4. Acceptance Criteria
+- [ ] Integrate `ContestSheenDisplay` into `PokemonCaughtDetails.tsx` for Gen 3 Pokémon with condition stats.
+- [ ] Ensure the component renders beautifully and fits the tactical UI aesthetic.
+- [ ] Add tests to verify the integration.

--- a/.foundry/tasks/task-138-210-individual-contest-sheen-ui-qa.md
+++ b/.foundry/tasks/task-138-210-individual-contest-sheen-ui-qa.md
@@ -1,0 +1,45 @@
+---
+id: task-138-210-individual-contest-sheen-ui-qa
+type: TASK
+title: QA Contest Sheen UI Integration
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on:
+  - task-138-209-individual-contest-sheen-ui-impl
+jules_session_id: null
+pr_number: null
+parent: story-065-138-individual-contest-sheen-ui
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Contest Sheen UI Integration
+
+## 1. Context
+This QA task verifies the integration of the `ContestSheenDisplay` component into the detailed Pokémon view (`PokemonCaughtDetails.tsx`) as implemented in `task-138-209-individual-contest-sheen-ui-impl`.
+
+## 2. Testing Blueprint
+- Verify that `ContestSheenDisplay` is imported and used in `PokemonCaughtDetails.tsx`.
+- Verify that the display only appears when `generation === 3` and `p.condition` is present.
+- Verify that the `sheen` prop passed is correct (`p.condition.sheen`).
+- Review the aesthetic layout to ensure it fits nicely within the `TacticalPanel` and maintains the "tactical hardware" design system (e.g., proper spacing, use of mono font, borders).
+- Verify that the automated tests added in `__tests__/PokemonCaughtDetails.test.tsx` adequately cover the new logic.
+
+## 3. Important Reminders for QA
+- **Transient Failures**: If you experience a transient failure requiring retry or test failure, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures**: If the implementation is fundamentally flawed or impossible, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the YAML frontmatter on successful completion.
+
+## 4. Acceptance Criteria
+- [ ] Verify `ContestSheenDisplay` is correctly integrated for Gen 3 Pokémon in `PokemonCaughtDetails.tsx`.
+- [ ] Verify unit tests cover the new component rendering.
+- [ ] Verify aesthetic fit.


### PR DESCRIPTION
As the Tech Lead, I have transformed the `story-065-138-individual-contest-sheen-ui` into granular technical blueprints (Tasks). I have:
1. Created an implementation task (`task-138-209`) instructing the Coder on how to integrate the `ContestSheenDisplay` component.
2. Created a corresponding QA verification task (`task-138-210`) properly linked in the dependency graph.
3. Added the necessary reminders concerning failures and empty PRs in the generated tasks.
4. Appended the generated child tasks to the markdown body of the parent story, intentionally leaving the Acceptance Criteria unchecked per DAG completion invariants.

---
*PR created automatically by Jules for task [3732961425735845984](https://jules.google.com/task/3732961425735845984) started by @szubster*