### PR TITLE
Epic 051-094: Friendship Data Extraction Breakdown

### DIFF
--- a/.foundry/epics/epic-051-094-friendship-data-extraction.md
+++ b/.foundry/epics/epic-051-094-friendship-data-extraction.md
@@ -36,3 +36,7 @@ Implement the core data extraction logic to read the Friendship (Happiness) valu
 - [ ] Gen 3 Party parsing extracts Friendship value (handling PV % 24 substructure permutation).
 - [ ] Gen 3 PC parsing extracts Friendship value.
 - [ ] Unit tests added/updated to verify Friendship extraction against known save fixtures.
+
+- [x] Break down into Tasks
+- [ ] story-094-151-gen2-friendship-extraction
+- [ ] story-094-152-gen3-friendship-extraction

--- a/.foundry/stories/story-094-151-gen2-friendship-extraction.md
+++ b/.foundry/stories/story-094-151-gen2-friendship-extraction.md
@@ -1,0 +1,29 @@
+---
+id: story-094-151-gen2-friendship-extraction
+type: STORY
+title: Gen 2 Friendship Data Extraction
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-051-094-friendship-data-extraction
+tags:
+  - gen2
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Friendship Data Extraction
+
+## Description
+Implement the logic to extract the Friendship (Happiness) value for Gen 2 Pokémon in both the active Party and PC Boxes.
+
+## Acceptance Criteria
+- [ ] Implement Gen 2 Party parsing to extract Friendship.
+- [ ] Implement Gen 2 PC parsing to extract Friendship.
+- [ ] Update Gen 2 unit tests to verify the extracted Friendship value.

--- a/.foundry/stories/story-094-152-gen3-friendship-extraction.md
+++ b/.foundry/stories/story-094-152-gen3-friendship-extraction.md
@@ -1,0 +1,31 @@
+---
+id: story-094-152-gen3-friendship-extraction
+type: STORY
+title: Gen 3 Friendship Data Extraction
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on:
+  - story-094-151-gen2-friendship-extraction
+jules_session_id: null
+pr_number: null
+parent: epic-051-094-friendship-data-extraction
+tags:
+  - gen3
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Friendship Data Extraction
+
+## Description
+Implement the logic to extract the Friendship (Happiness) value for Gen 3 Pokémon in both the active Party and PC Boxes. This must handle the 48-byte encrypted Data block and use `PV % 24` to locate the Growth (G) substructure.
+
+## Acceptance Criteria
+- [ ] Implement Gen 3 Party parsing to extract Friendship (handling PV % 24).
+- [ ] Implement Gen 3 PC parsing to extract Friendship.
+- [ ] Ensure `DataView` API is used for rigorous bounds checking (ADR 010).
+- [ ] Update Gen 3 unit tests to verify the extracted Friendship value.


### PR DESCRIPTION
This PR breaks down `epic-051-094-friendship-data-extraction` into two granular `STORY` nodes: one for Gen 2 and one for Gen 3 parsing logic. 

- The new stories (`story-094-151-gen2-friendship-extraction` and `story-094-152-gen3-friendship-extraction`) are added as unchecked items to the parent Epic's markdown body.
- The `Break down into Tasks` checklist item in the parent Epic is checked.
- Parent epic YAML frontmatter has deliberately not been modified (to keep it in READY/PENDING state, adhering to the late-binding constraints).
- Scratchpad scripts have been cleaned up and the workspace builds correctly.

---
*PR created automatically by Jules for task [7491662400131061486](https://jules.google.com/task/7491662400131061486) started by @szubster*