### PR TITLE
docs(tasks): forbid magic numbers in gen3 roamer parsing

### DIFF
--- a/.foundry/tasks/task-108-192-gen3-roamer-dataview-extraction-impl.md
+++ b/.foundry/tasks/task-108-192-gen3-roamer-dataview-extraction-impl.md
@@ -33,6 +33,7 @@ This task involves writing the core extraction logic for the Gen 3 roamer data. 
 - [ ] Implement a `DataView`-based reader for the 20-byte Gen 3 roamer structure.
 - [ ] Implement parsing logic to extract IVs, HP, and Level.
 - [ ] Ensure `DataView` native API is used exclusively for reading bytes (e.g., `getUint8`, `getUint16`, `getUint32`).
+- [ ] Ensure all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
 
 ## Execution Constraints
 - **CRITICAL**: If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/.foundry/tasks/task-108-193-gen3-roamer-dataview-extraction-qa.md
+++ b/.foundry/tasks/task-108-193-gen3-roamer-dataview-extraction-qa.md
@@ -33,6 +33,7 @@ Validate that the `DataView` API is used correctly and exclusively for reading t
 - [ ] Verify `DataView` native API is used exclusively for reading the 20-byte structure.
 - [ ] Verify the parsing logic accurately extracts IVs, HP, and Level.
 - [ ] Write tests confirming accurate parsing for edge cases and known data structures.
+- [ ] Verify that no inline magic numbers were used for memory offsets, lengths, bit locations, or shifts, ensuring they are defined as reusable constants at the module level.
 
 ## Execution Constraints
 - **CRITICAL**: If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Appends acceptance criteria to `task-108-192-gen3-roamer-dataview-extraction-impl.md` and `task-108-193-gen3-roamer-dataview-extraction-qa.md` to explicitly forbid inline magic numbers for memory offsets and require reusable module-level constants. Submits an empty PR with pending child tasks remaining unchecked in the parent `story-070-108` per the Late Binding Orchestrator Heartbeat Rule.

---
*PR created automatically by Jules for task [4350292950788017666](https://jules.google.com/task/4350292950788017666) started by @szubster*