### PR TITLE
chore(epic): uncheck cancelled story-081-122 in epic-047-081

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -43,7 +43,7 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [x] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
-- [x] story-081-122-gen3-rtc-extraction
+- [ ] story-081-122-gen3-rtc-extraction
 - [ ] story-081-123-gen3-active-swarm-parsing
 - [ ] story-081-124-gen3-event-forecast-schedule
 - [ ] research-081-144-gen3-rtc-strategy


### PR DESCRIPTION
Unchecks the cancelled story (`story-081-122-gen3-rtc-extraction`) in `epic-047-081-gen3-tv-swarm-data-extraction.md`. No new files were created because all necessary stories already exist in the codebase. Tests and linters ran successfully.

---
*PR created automatically by Jules for task [7960494157153894637](https://jules.google.com/task/7960494157153894637) started by @szubster*