### PR TITLE
Research: Investigate TPM Journal Bloat and Orchestrator Logging

### DIFF
--- a/.foundry/research/research-076-189-investigate-tpm-journal-bloat.md
+++ b/.foundry/research/research-076-189-investigate-tpm-journal-bloat.md
@@ -25,7 +25,12 @@ notes: ''
 Investigate the Orchestrator script (`.github/scripts/foundry-orchestrator.ts`) and Foundry Engine GitHub Action to understand why and where it logs routine task verification and state transition updates to the TPM journal (`.foundry/journals/tpm.md`). Determine if this continuous logging indicates an underlying problem or if it's simply unnecessary logging that should be removed.
 
 ## Acceptance Criteria
-- [ ] Identify the location(s) in the Orchestrator script or GitHub Action where logs are written to the TPM journal.
-- [ ] Analyze the purpose and necessity of these log statements.
-- [ ] Determine if the logging behavior is a symptom of a systemic issue or just unnecessary bloat.
-- [ ] Propose a solution (e.g., removing the logging statements) based on the findings.
+- [x] Identify the location(s) in the Orchestrator script or GitHub Action where logs are written to the TPM journal.
+- [x] Analyze the purpose and necessity of these log statements.
+- [x] Determine if the logging behavior is a symptom of a systemic issue or just unnecessary bloat.
+- [x] Propose a solution (e.g., removing the logging statements) based on the findings.
+
+## Findings
+- **Investigation Results**: Extensive search within the `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts` scripts revealed that they no longer contain any calls to the `logToJournal` function or any logic that writes to `.foundry/journals/tpm.md`.
+- **Systemic Purpose vs. Bloat**: The logging behavior previously seen was unnecessary bloat, but this issue has already been resolved in a prior task (`task-076-179-remove-tpm-logging-orchestrator.md`).
+- **Proposed Solution**: No further action is required regarding the Orchestrator scripts as the logging statements have already been removed. The current logging in the Orchestrator is limited to stdout (`info()` and `warn()`), which is correct.


### PR DESCRIPTION
This PR fulfills the RESEARCH node `research-076-189-investigate-tpm-journal-bloat` by providing the findings regarding the TPM journal bloat.

The investigation confirmed that the Orchestrator and Heartbeat scripts no longer contain calls to `logToJournal`, and their logging is correctly limited to stdout (`info()` and `warn()`). This was resolved in a prior task. No further modifications to the scripts are needed.

The Acceptance Criteria checkboxes in the research node have been checked, and the findings have been appended. The YAML frontmatter remains unmodified as required.

---
*PR created automatically by Jules for task [17896782057739072735](https://jules.google.com/task/17896782057739072735) started by @szubster*