### PR TITLE
Research: Gen 3 Battle Frontier Win Streak Data Types

### DIFF
--- a/.foundry/research/research-121-188-gen3-battle-frontier-win-streak-types.md
+++ b/.foundry/research/research-121-188-gen3-battle-frontier-win-streak-types.md
@@ -36,5 +36,33 @@ Determine the exact data size (e.g. 16-bit vs 32-bit integer) and structure (sin
 - `pyramidWinStreaks` / `pyramidRecordStreaks`
 
 ## Acceptance Criteria
-- [ ] Identify data types and byte sizes for all 7 facility win streaks and records.
-- [ ] Update this document with the exact structures.
+- [x] Identify data types and byte sizes for all 7 facility win streaks and records.
+- [x] Update this document with the exact structures.
+
+## Findings: Battle Frontier Win Streak Data Types
+
+Based on the `pret/pokeemerald` decompilation (specifically `include/global.h` and `include/constants/global.h`), the data types and array structures for the Battle Frontier facilities are as follows.
+
+All elements are **16-bit unsigned integers (`u16`)**, meaning each value takes exactly **2 bytes**. The size of the arrays varies by facility because they track different battle modes (Singles, Doubles, Multi, Link Multi). The constant `FRONTIER_LVL_MODE_COUNT` is defined as `2` (representing Level 50 and Open Level).
+
+*   **Battle Tower (`towerWinStreaks` / `towerRecordWinStreaks`)**:
+    *   Type: 2D Array `u16 [4][2]` (4 battle modes, 2 level modes)
+    *   Total size: 8 elements (16 bytes) each.
+*   **Battle Dome (`domeWinStreaks` / `domeRecordWinStreaks`)**:
+    *   Type: 2D Array `u16 [2][2]` (2 battle modes, 2 level modes)
+    *   Total size: 4 elements (8 bytes) each.
+*   **Battle Palace (`palaceWinStreaks` / `palaceRecordWinStreaks`)**:
+    *   Type: 2D Array `u16 [2][2]` (2 battle modes, 2 level modes)
+    *   Total size: 4 elements (8 bytes) each.
+*   **Battle Arena (`arenaWinStreaks` / `arenaRecordStreaks`)**:
+    *   Type: 1D Array `u16 [2]` (2 level modes)
+    *   Total size: 2 elements (4 bytes) each.
+*   **Battle Factory (`factoryWinStreaks` / `factoryRecordWinStreaks`)**:
+    *   Type: 2D Array `u16 [2][2]` (2 battle modes, 2 level modes)
+    *   Total size: 4 elements (8 bytes) each.
+*   **Battle Pike (`pikeWinStreaks` / `pikeRecordStreaks`)**:
+    *   Type: 1D Array `u16 [2]` (2 level modes)
+    *   Total size: 2 elements (4 bytes) each.
+*   **Battle Pyramid (`pyramidWinStreaks` / `pyramidRecordStreaks`)**:
+    *   Type: 1D Array `u16 [2]` (2 level modes)
+    *   Total size: 2 elements (4 bytes) each.


### PR DESCRIPTION
This PR finalizes the research on the data structures for the Gen 3 Battle Frontier save block win streaks, satisfying `research-121-188-gen3-battle-frontier-win-streak-types`. All acceptance criteria have been marked completed.

---
*PR created automatically by Jules for task [17333848215615577179](https://jules.google.com/task/17333848215615577179) started by @szubster*