### PR TITLE
Create tasks for Gen 3 contest error handling

### DIFF
--- a/.foundry/stories/story-065-141-gen3-contest-error-handling.md
+++ b/.foundry/stories/story-065-141-gen3-contest-error-handling.md
@@ -34,3 +34,7 @@ Derived from `epic-040-065-gen3-contest-data-integration`, this story ensures th
 ## 3. Acceptance Criteria
 - [ ] Implement graceful error handling (e.g., `RangeError` from `DataView`) for corrupted or incomplete save segments within contest data extraction.
 - [ ] Ensure that errors are appropriately handled upstream in `parseGen3` and do not cause application crashes.
+
+## 4. Tasks
+- [ ] task-141-209-gen3-contest-error-handling-impl
+- [ ] task-141-210-gen3-contest-error-handling-qa

--- a/.foundry/tasks/task-141-209-gen3-contest-error-handling-impl.md
+++ b/.foundry/tasks/task-141-209-gen3-contest-error-handling-impl.md
@@ -1,0 +1,43 @@
+---
+id: task-141-209-gen3-contest-error-handling-impl
+type: TASK
+title: Implement Gen 3 Contest Data Error Handling
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-065-141-gen3-contest-error-handling
+tags:
+  - feature
+  - gen3
+  - contests
+  - error-handling
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement Gen 3 Contest Data Error Handling
+
+## 1. Objective
+Implement error handling during Gen 3 contest data extraction (condition stats and ribbons) to gracefully manage out-of-bounds reads without crashing the application.
+
+## 2. Requirements
+- Modify `parseGen3ConditionStats` in `src/engine/saveParser/parsers/gen3.ts` to wrap its parsing logic in a `try...catch` block. If a `RangeError` is caught (from `DataView` out-of-bounds), re-throw it as `new Error('The save file is corrupted or incomplete.')`.
+- Modify `parseGen3Ribbons` in `src/engine/saveParser/parsers/gen3.ts` similarly to handle `RangeError`s gracefully.
+- Ensure `parseGen3` bubbles these errors up as expected.
+
+## 3. Reminders & Constraints
+- Explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## 4. Acceptance Criteria
+- [ ] `parseGen3ConditionStats` catches `RangeError` and throws a specific generic validation error.
+- [ ] `parseGen3Ribbons` catches `RangeError` and throws a specific generic validation error.
+- [ ] All tests for Gen 3 parsing pass.

--- a/.foundry/tasks/task-141-210-gen3-contest-error-handling-qa.md
+++ b/.foundry/tasks/task-141-210-gen3-contest-error-handling-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-141-210-gen3-contest-error-handling-qa
+type: TASK
+title: QA Gen 3 Contest Data Error Handling
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on:
+  - task-141-209-gen3-contest-error-handling-impl
+jules_session_id: null
+pr_number: null
+parent: story-065-141-gen3-contest-error-handling
+tags:
+  - feature
+  - gen3
+  - contests
+  - error-handling
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Gen 3 Contest Data Error Handling
+
+## 1. Objective
+Validate the Gen 3 contest data error handling modifications to ensure that `RangeError`s are properly caught and mapped to 'The save file is corrupted or incomplete.' validation errors.
+
+## 2. Requirements
+- Inspect the modifications in `src/engine/saveParser/parsers/gen3.ts` for `parseGen3ConditionStats` and `parseGen3Ribbons`.
+- Validate that the existing logic correctly encapsulates these error-handling mechanisms.
+- Run `pnpm run test -- src/engine/saveParser/parsers/gen3.test.ts` to ensure coverage for these branches.
+
+## 3. Reminders & Constraints
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## 4. Acceptance Criteria
+- [ ] Confirmed that `parseGen3ConditionStats` correctly handles `RangeError`.
+- [ ] Confirmed that `parseGen3Ribbons` correctly handles `RangeError`.
+- [ ] Confirmed that errors are handled upstream without application crashes.


### PR DESCRIPTION
Created child TASK nodes `task-141-209-gen3-contest-error-handling-impl` and `task-141-210-gen3-contest-error-handling-qa` for `story-065-141-gen3-contest-error-handling`, and appended them as unchecked tasks to the STORY node.

---
*PR created automatically by Jules for task [16665530269339498987](https://jules.google.com/task/16665530269339498987) started by @szubster*