### PR TITLE
feat: Break down Global Ribbon Dashboard Scaffold into tasks

### DIFF
--- a/.foundry/stories/story-066-137-global-ribbon-dashboard-scaffold.md
+++ b/.foundry/stories/story-066-137-global-ribbon-dashboard-scaffold.md
@@ -35,3 +35,7 @@ Derived from `epic-041-066-global-ribbon-checklist-dashboard`, this story focuse
 - [ ] Scaffold `GlobalRibbonChecklistDashboard` React component.
 - [ ] Integrate with Living Dex / PC Box data store.
 - [ ] Render the basic ribbon display components for the aggregated data.
+
+## 4. Child Nodes
+- [ ] .foundry/tasks/task-137-209-global-ribbon-dashboard-scaffold-impl.md
+- [ ] .foundry/tasks/task-137-210-global-ribbon-dashboard-scaffold-qa.md

--- a/.foundry/tasks/task-137-209-global-ribbon-dashboard-scaffold-impl.md
+++ b/.foundry/tasks/task-137-209-global-ribbon-dashboard-scaffold-impl.md
@@ -1,0 +1,49 @@
+---
+id: task-137-209-global-ribbon-dashboard-scaffold-impl
+type: TASK
+title: Implement Global Ribbon Checklist Dashboard Scaffold
+status: READY
+owner_persona: coder
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-066-137-global-ribbon-dashboard-scaffold
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement Global Ribbon Checklist Dashboard Scaffold
+
+## Background
+We need to scaffold the `GlobalRibbonChecklistDashboard` component to provide a centralized aggregate view for checking Ribbons across the Living Dex or current PC boxes. This will leverage shared contest components from epic 064.
+
+## Goals
+1. Scaffold `GlobalRibbonChecklistDashboard` React component.
+2. Integrate with Living Dex / PC Box data store.
+3. Render the basic ribbon display components for the aggregated data.
+
+## Context and Constraints
+- The component must integrate with existing IndexedDB/state store structures to fetch Pokémon.
+- Ensure the integration steps and tests are included for rendering the new component so it isn't orphaned.
+- For complex logic or state, consider React Context or other architectural scaffolding to prevent tight coupling.
+- Ensure UI responsiveness and accessibility, handling large datasets efficiently.
+
+## Reminder for Coder/QA Personas
+- **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Scaffold `GlobalRibbonChecklistDashboard` component in the frontend.
+- [ ] Connect the component to read from Living Dex / PC Box data context.
+- [ ] Render a list or grid displaying basic ribbon availability for each Pokémon.
+- [ ] Add explicit integration tests or usage to verify rendering and prevent orphaned components.

--- a/.foundry/tasks/task-137-210-global-ribbon-dashboard-scaffold-qa.md
+++ b/.foundry/tasks/task-137-210-global-ribbon-dashboard-scaffold-qa.md
@@ -1,0 +1,43 @@
+---
+id: task-137-210-global-ribbon-dashboard-scaffold-qa
+type: TASK
+title: QA Global Ribbon Checklist Dashboard Scaffold
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-19'
+updated_at: '2026-06-19'
+depends_on:
+  - task-137-209-global-ribbon-dashboard-scaffold-impl
+jules_session_id: null
+pr_number: null
+parent: story-066-137-global-ribbon-dashboard-scaffold
+tags:
+  - feature
+  - gen3
+  - contests
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Global Ribbon Checklist Dashboard Scaffold
+
+## Background
+The coder has implemented the `GlobalRibbonChecklistDashboard` component for viewing aggregate Ribbon data. This needs to be thoroughly verified.
+
+## Goals
+1. Verify the `GlobalRibbonChecklistDashboard` component functions as designed.
+2. Ensure data from the Living Dex / PC Box is correctly aggregated and displayed.
+
+## Reminder for QA Persona
+- **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify `GlobalRibbonChecklistDashboard` accurately displays data from the PC/Living Dex.
+- [ ] Verify basic ribbon display components render correctly for the aggregated data.
+- [ ] Verify performance constraints (handling large datasets like hundreds of Pokémon).
+- [ ] Run and verify E2E tests for the new dashboard component.


### PR DESCRIPTION
Broke down the `story-066-137-global-ribbon-dashboard-scaffold` node into two specific tasks for the coder and qa personas.
1. `task-137-209-global-ribbon-dashboard-scaffold-impl`
2. `task-137-210-global-ribbon-dashboard-scaffold-qa`

The parent story has been updated with these tasks appended as unchecked items to leverage the orchestrator's late-binding pending wait state.

---
*PR created automatically by Jules for task [17297365825936881838](https://jules.google.com/task/17297365825936881838) started by @szubster*