### PR TITLE
docs: Update schema.md with explicit parent-child formatting constraints

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -196,6 +196,10 @@ These are the hard rules the orchestrator, heartbeat, and resurrection loop rely
 13. **Composite Nodes are an anti-pattern.** Do not create "Composite Nodes". They bundle multiple lifecycle states or responsibilities that conflict with the strict Directed Acyclic Graph orchestrator. This leads to circular dependencies or unresolved `depends_on` chains, causing DAG deadlocks.
 14. **Sibling Dependency Recommendations.** If multiple sibling nodes (e.g. TASK nodes from the same STORY) are created with sequential implementation dependencies, their `depends_on` field SHOULD explicitly point to the prerequisite task to prevent DAG deadlocks. This is the responsibility of the tech lead and is not enforced by the orchestrator.
 15. **Macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) cannot complete until all of their descendant nodes are `COMPLETED`.**
+    - When creating downstream/child nodes, personas MUST append references to newly generated child nodes as unchecked tasks (`- [ ]`) directly into the markdown body of the parent node.
+    - You must check off your specific acceptance criteria checkboxes in the parent node WITHOUT modifying its YAML frontmatter.
+    - Do NOT submit an Empty PR to transition a parent node to VERIFYING (by checking off its own acceptance criteria) until ALL of its generated child nodes have transitioned to COMPLETED.
+    - If a parent node has incomplete children, you must leave its own acceptance criteria checkboxes unchecked to keep it in PENDING status.
 
 ---
 

--- a/.foundry/tasks/task-108-191-update-schema-parent-child-formatting-impl.md
+++ b/.foundry/tasks/task-108-191-update-schema-parent-child-formatting-impl.md
@@ -44,4 +44,4 @@ Update rule 15 in `.foundry/docs/schema.md` to include these exact instructions:
 This is a low-risk documentation task. The `coder` is designated to self-verify.
 
 ## Acceptance Criteria
-- [ ] Ensure `.foundry/docs/schema.md` rule 15 fully explains parent-child formatting constraints.
+- [x] Ensure `.foundry/docs/schema.md` rule 15 fully explains parent-child formatting constraints.


### PR DESCRIPTION
Updates `.foundry/docs/schema.md` to include explicit rules for parent-child relationship formatting, ensuring nodes don't prematurely complete while children are still pending. Checked off acceptance criteria in task node.

---
*PR created automatically by Jules for task [14643769167712650168](https://jules.google.com/task/14643769167712650168) started by @szubster*