### PR TITLE
feat: Implement `sweepActiveNodes` utility

### DIFF
--- a/.foundry/tasks/task-133-187-sweep-active-nodes-impl.md
+++ b/.foundry/tasks/task-133-187-sweep-active-nodes-impl.md
@@ -33,6 +33,6 @@ As part of the Zombie Node Detection Engine (Epic 050-089) and Story 089-133, we
 - **Reminder**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 3. Acceptance Criteria
-- [ ] Implement directory traversal logic for `.foundry/`.
-- [ ] Correctly parse node frontmatter using `gray-matter` and filter for `ACTIVE` status.
-- [ ] Create tests to verify the sweeping logic.
+- [x] Implement directory traversal logic for `.foundry/`.
+- [x] Correctly parse node frontmatter using `gray-matter` and filter for `ACTIVE` status.
+- [x] Create tests to verify the sweeping logic.

--- a/.github/scripts/sweep-active-nodes.test.ts
+++ b/.github/scripts/sweep-active-nodes.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { sweepActiveNodes } from './sweep-active-nodes.ts';
+import { createValidTestNode } from './foundry-test-utils.ts';
+
+describe('sweepActiveNodes', () => {
+  let testEnvPath: string;
+
+  beforeEach(() => {
+    testEnvPath = path.join(process.cwd(), 'temp-test-dir-' + Math.random().toString(36).substring(7));
+    fs.mkdirSync(testEnvPath, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testEnvPath)) {
+      fs.rmSync(testEnvPath, { recursive: true, force: true });
+    }
+  });
+
+  it('should return empty array if .foundry does not exist', () => {
+    const result = sweepActiveNodes(path.join(testEnvPath, 'non-existent'));
+    expect(result).toEqual([]);
+  });
+
+  it('should find active nodes within .foundry', () => {
+    createValidTestNode(testEnvPath, '.foundry/ideas/active-node.md', { status: 'ACTIVE', type: 'IDEA' });
+    createValidTestNode(testEnvPath, '.foundry/ideas/pending-node.md', { status: 'PENDING', type: 'IDEA' });
+
+    // Invalid node
+    fs.writeFileSync(path.join(testEnvPath, '.foundry/ideas/invalid-node.md'), 'not a valid frontmatter', 'utf-8');
+
+    const result = sweepActiveNodes(testEnvPath);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(path.join('.foundry', 'ideas', 'active-node.md'));
+  });
+
+  it('should find nested active nodes', () => {
+    createValidTestNode(testEnvPath, '.foundry/tasks/nested/active-task.md', { status: 'ACTIVE', type: 'TASK' });
+
+    const result = sweepActiveNodes(testEnvPath);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(path.join('.foundry', 'tasks', 'nested', 'active-task.md'));
+  });
+});

--- a/.github/scripts/sweep-active-nodes.ts
+++ b/.github/scripts/sweep-active-nodes.ts
@@ -1,0 +1,51 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createRequire } from 'node:module';
+
+const _require = createRequire(import.meta.url);
+const matter = _require('gray-matter') as typeof import('gray-matter');
+
+export function sweepActiveNodes(repoRoot: string): string[] {
+  const foundryDir = path.join(repoRoot, '.foundry');
+  if (!fs.existsSync(foundryDir)) {
+    return [];
+  }
+
+  const results: string[] = [];
+
+  function walk(current: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        walk(path.join(current, e.name));
+      } else if (e.isFile() && e.name.endsWith('.md')) {
+        results.push(path.join(current, e.name));
+      }
+    }
+  }
+
+  walk(foundryDir);
+
+  const activeNodes: string[] = [];
+
+  for (const fp of results) {
+    try {
+      const content = fs.readFileSync(fp, 'utf-8');
+      const parsed = matter(content);
+      if (parsed.data && parsed.data['status'] === 'ACTIVE') {
+        const relativePath = path.relative(repoRoot, fp);
+        activeNodes.push(relativePath);
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  return activeNodes;
+}


### PR DESCRIPTION
This PR implements the `sweepActiveNodes` utility function to scan the `.foundry/` directory, parse markdown files with `gray-matter`, and return the repository-relative paths of all files with an `ACTIVE` status. 
It also adds full test coverage for this function.

---
*PR created automatically by Jules for task [10726551524848580115](https://jules.google.com/task/10726551524848580115) started by @szubster*