### PR TITLE
docs: update ADR 001 with parent-child formatting rules for macro nodes

### DIFF
--- a/.foundry/docs/adrs/001-the-foundry-architecture.md
+++ b/.foundry/docs/adrs/001-the-foundry-architecture.md
@@ -113,5 +113,11 @@ The `.foundry/` monofolder has been scaffolded at the repository root. All 9 fil
 ## 7. System Invariants (Macro Node Completion)
 Macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) MUST NOT transition to `COMPLETED` until all of their descendant nodes in the DAG have reached the `COMPLETED` or `CANCELLED` status. A macro node with pending, active, or failed descendants is inherently incomplete.
 
+To comply with the above constraints, personas generating new child nodes MUST adhere to the following formatting rules:
+- Append references to newly generated child nodes as unchecked tasks (`- [ ] <file_path>`) directly into the markdown body of the parent node.
+- Do NOT modify the parent's YAML frontmatter.
+- Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+- Do NOT submit an Empty PR to transition a macro node to VERIFYING until ALL of its generated child nodes have transitioned to COMPLETED.
+
 ## 8. EMPTY PR POLICY
 Empty PRs (0 files changed) are submitted when a persona determines that the target artifact already exists and is complete. These PRs are automatically merged to allow the Foundry DAG to progress, while the persona documents the outcome in its journal.

--- a/.foundry/tasks/task-109-192-update-adr001-formatting-rules-impl.md
+++ b/.foundry/tasks/task-109-192-update-adr001-formatting-rules-impl.md
@@ -41,4 +41,4 @@ Update `.foundry/docs/adrs/001-the-foundry-architecture.md` (ADR 001) to detail 
 5. Reminder for Coder/QA: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Update `001-the-foundry-architecture.md` to detail how to format parent-child relationships for macro nodes.
+- [x] Update `001-the-foundry-architecture.md` to detail how to format parent-child relationships for macro nodes.


### PR DESCRIPTION
Updates ADR 001 to detail how to format parent-child relationships for macro nodes to comply with macro node completion constraints. Also updates the task markdown body to check off the acceptance criteria.

---
*PR created automatically by Jules for task [411723853960272582](https://jules.google.com/task/411723853960272582) started by @szubster*