### PR TITLE
feat: implement checkSessionLiveliness utility

### DIFF
--- a/.foundry/tasks/task-135-191-session-api-integration-impl.md
+++ b/.foundry/tasks/task-135-191-session-api-integration-impl.md
@@ -31,9 +31,9 @@ We need to determine if a given \`jules_session_id\` is truly active or if it ha
 - If the API call fails or the run is not found, classify it appropriately (e.g. assume it is dead/terminated).
 
 ## 3. Acceptance Criteria
-- [ ] Implement an async function \`checkSessionLiveliness(sessionId: string): Promise<string>\` or similar that queries the API.
-- [ ] Map the API response states to internal liveliness indicators.
-- [ ] Ensure the function falls back gracefully if the API fails or rate limits.
+- [x] Implement an async function \`checkSessionLiveliness(sessionId: string): Promise<string>\` or similar that queries the API.
+- [x] Map the API response states to internal liveliness indicators.
+- [x] Ensure the function falls back gracefully if the API fails or rate limits.
 
 ## 4. Notes
 - Remember that if a transient failure occurs, you must transition this node to \`FAILED\` with a \`rejection_reason\`. If permanent, \`CANCELLED\`.

--- a/.github/scripts/session-api.ts
+++ b/.github/scripts/session-api.ts
@@ -1,0 +1,50 @@
+/**
+ * session-api.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Utility functions for interacting with the Jules API regarding session state.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+export async function checkSessionLiveliness(sessionId: string, julesKey: string): Promise<string> {
+  try {
+    const res = await fetch(`https://jules.googleapis.com/v1alpha/sessions/${sessionId}`, {
+      headers: { 'X-Goog-Api-Key': julesKey }
+    });
+
+    if (res.status === 404) {
+      return 'TERMINATED';
+    }
+
+    if (!res.ok) {
+      process.stderr.write(`[session-api] Jules API error: received status ${res.status}\n`);
+      return 'TERMINATED';
+    }
+
+    const data = await res.json() as any;
+    const state = data.state;
+
+    const activeStates = [
+      'STATE_UNSPECIFIED',
+      'QUEUED',
+      'PLANNING',
+      'AWAITING_PLAN_APPROVAL',
+      'AWAITING_USER_FEEDBACK',
+      'IN_PROGRESS',
+      'PAUSED'
+    ];
+
+    if (state === 'FAILED' || state === 'COMPLETED') {
+      return 'TERMINATED';
+    }
+
+    if (activeStates.includes(state)) {
+      return 'ACTIVE';
+    }
+
+    // Fallback if state is unrecognized but request was ok
+    return 'TERMINATED';
+  } catch (err) {
+    process.stderr.write(`[session-api] Jules API fetch error: ${String(err)}\n`);
+    return 'TERMINATED';
+  }
+}


### PR DESCRIPTION
Implemented the API utility `checkSessionLiveliness` as requested by task-135-191-session-api-integration-impl to evaluate session liveliness.

---
*PR created automatically by Jules for task [12153661677902076613](https://jules.google.com/task/12153661677902076613) started by @szubster*