### PR TITLE
💡 Visionary: Hidden Power Type and Base Power Exposer

### DIFF
--- a/.foundry/ideas/idea-085-hidden-power-calculator.md
+++ b/.foundry/ideas/idea-085-hidden-power-calculator.md
@@ -1,0 +1,38 @@
+---
+id: idea-085-hidden-power-calculator
+type: IDEA
+title: Exact Hidden Power Type and Base Power Exposer
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - feature
+  - gen2
+  - gen3
+  - mechanics
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Exact Hidden Power Type and Base Power Exposer
+
+## Context
+"Hidden Power" is a widely used move introduced in Generation 2 whose exact Type and Base Power are determined entirely by a Pokémon's hidden Determinant Values (DVs) in Gen 2, and Individual Values (IVs) in Gen 3 onwards. Because DVs and IVs are not directly visible to the player in these generations, the exact properties of a Pokémon's Hidden Power remain completely obscured, forcing players to either guess, use tedious trial-and-error in battles against specific types, or calculate it manually if they know the DVs/IVs.
+
+## Proposal
+Since DexHelper already parses and extracts a Pokémon's exact DVs (Gen 2) and IVs (Gen 3) from the save state, we can run the math directly to determine their Hidden Power.
+- **Hidden Power Calculation Engine:** Implement the generation-specific algorithms for calculating Hidden Power Type and Base Power based on the extracted values.
+- **UI Exposure:** Directly display the exact Type and Base Power on the Pokémon's detail view, removing the guesswork entirely.
+
+## Value Proposition
+This transforms a completely opaque and crucial competitive game mechanic into a highly visible, actionable data point. It leverages our core strength of programmatic offline save parsing to provide "superpower" utility that the original games lacked, saving hardcore players and competitive battlers significant time and frustration.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD to define the implementation for the Gen 2 and Gen 3 calculation engines and the UI updates required to display it.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -112,3 +112,7 @@
 ## 2026-06-17
 **Idea:** Daycare Status and Exact Egg Hatch Tracker
 **Learning:** Targeting opaque, heavily-utilized progression mechanics like breeding (Daycare status and Egg steps) for actionable QoL improvements perfectly aligns with the app's offline-first programmatic save parsing strengths. Extracting exact cycle counts transforms vague in-game text into precise data, removing tedious guesswork for hardcore players.
+
+## 2026-06-20
+**Idea:** Exact Hidden Power Type and Base Power Exposer
+**Learning:** Expanding the app's capability to calculate derived stats from base hidden values (like computing Hidden Power from DVs/IVs) is a natural evolution of our core value proposition. Since we already parse the difficult-to-reach hidden state, adding a computation layer on top of it to expose complex, highly sought-after mechanics (like competitive move properties) provides immense utility without needing to parse new areas of the save file. This reinforces the idea that we can create new features purely by recombining or running calculations on data we already have.


### PR DESCRIPTION
Create IDEA node for Hidden Power Type and Base Power ExposernnAdds a new IDEA node proposing an engine expansion to calculate and UI to expose the exact Type and Base Power of a Pokémon's Hidden Power based on its extracted DVs/IVs for Gen 2 and Gen 3. Updates the visionary journal with the corresponding learning entry.

---
*PR created automatically by Jules for task [12682286565427346180](https://jules.google.com/task/12682286565427346180) started by @szubster*