### PR TITLE
🧪 Sentinel: Add visual regression tests to pokemon-details E2E test

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -146,3 +146,13 @@ When writing E2E tests, do not import helper methods like `argosScreenshot` dire
 * `test:e2e` Playwright tests must be run during verification to fulfill the repo mandate.
 * If testing environments fail with `browserType.launch: Executable doesn't exist`, use `pnpm exec playwright install`.
 * Use explicit type casts (`as unknown as import('../strategies/types').AssistantStrategy`) when constructing partial mocks for strategies with specific methods like `getSpecialSuggestions` to satisfy strict checking in `test-coverage.test.ts`.
+
+## 2026-06-20 - Visual Regression coverage in E2E
+**What:** Added visual regression tests () to .
+**Why:** Fulfills the boundary to cover untested visual flows.
+**Learning:** When writing E2E tests for visual components, ensure  is imported directly from  as per instructions, avoiding local wrappers unless specifically told otherwise.
+
+## 2026-06-20 - Visual Regression coverage in E2E
+**What:** Added visual regression tests (`argosScreenshot`) to `tests/e2e/pokemon-details.spec.ts`.
+**Why:** Fulfills the boundary to cover untested visual flows.
+**Learning:** When writing E2E tests for visual components, ensure `argosScreenshot` is imported directly from `@argos-ci/playwright` as per instructions, avoiding local wrappers unless specifically told otherwise.

--- a/tests/e2e/pokemon-details.spec.ts
+++ b/tests/e2e/pokemon-details.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { argosScreenshot } from '@argos-ci/playwright';
 import { expect, test } from '@playwright/test';
 import { initializeWithSave } from './test-utils';
 
@@ -29,6 +30,8 @@ test.describe('Pokemon Details Modal', () => {
     await page.getByRole('button', { name: 'RAICHU' }).first().click();
     await expect(page.getByText(/\[ SUBJECT_ID: 026 \]/i)).toBeVisible();
     await expect(page.getByText('Raichu', { exact: true }).nth(0)).toBeVisible();
+
+    await argosScreenshot(page, 'pokemon-details-modal');
   });
 
   test('should show correct locations for the version', async ({ page }) => {
@@ -49,5 +52,7 @@ test.describe('Pokemon Details Modal', () => {
     const locationList = page.getByTestId('location-list');
     await expect(locationList).toBeVisible({ timeout: 15000 });
     await expect(locationList.getByText('ROUTE 1', { exact: true })).toBeVisible({ timeout: 10000 });
+
+    await argosScreenshot(page, 'pokemon-details-locations');
   });
 });


### PR DESCRIPTION
🎯 What
Added missing visual regression tests to `tests/e2e/pokemon-details.spec.ts` using `@argos-ci/playwright`.

📊 Coverage
Covers the detailed information and location list visual states of the Pokemon Details Modal in the E2E test suite.

✨ Result
Enhanced visual regression testing for critical user flows without modifying application source code.

---
*PR created automatically by Jules for task [12646697067941767168](https://jules.google.com/task/12646697067941767168) started by @szubster*