### PR TITLE
🧹 Clean up unused types and fix Node.js strip-types execution flags

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -14,7 +14,7 @@
  *   8. EXIT      — 0 on success; 1 if unresolvable deps found in --strict mode
  *
  * Usage:
- *   node --strip-types foundry-orchestrator.ts [--dry-run] [--strict]
+ *   node --experimental-strip-types foundry-orchestrator.ts [--dry-run] [--strict]
  *
  * Flags:
  *   --dry-run   Log what would be promoted; do NOT write any files.

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -4,10 +4,10 @@
   "description": "Foundry DAG orchestration scripts — run with Node 24 native TypeScript support.",
   "type": "module",
   "scripts": {
-    "orchestrate": "node --strip-types foundry-orchestrator.ts",
-    "orchestrate:dry": "node --strip-types foundry-orchestrator.ts --dry-run",
-    "orchestrate:strict": "node --strip-types foundry-orchestrator.ts --strict",
-    "verify:refs": "node --strip-types verify-dag-refs.ts",
+    "orchestrate": "node --experimental-strip-types foundry-orchestrator.ts",
+    "orchestrate:dry": "node --experimental-strip-types foundry-orchestrator.ts --dry-run",
+    "orchestrate:strict": "node --experimental-strip-types foundry-orchestrator.ts --strict",
+    "verify:refs": "node --experimental-strip-types verify-dag-refs.ts",
     "test": "vitest run"
   },
   "dependencies": {

--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version-file: ".nvmrc" # Required for --strip-types
+          node-version-file: ".nvmrc" # Required for --experimental-strip-types
           cache: "pnpm"
 
       - name: Install dependencies
@@ -49,7 +49,7 @@ jobs:
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          node --strip-types .github/scripts/foundry-heartbeat.ts
+          node --experimental-strip-types .github/scripts/foundry-heartbeat.ts
 
       - name: Verify DAG References
         run: |
@@ -59,7 +59,7 @@ jobs:
         id: set-matrix
         run: |
           set +e
-          output=$(node --strip-types .github/scripts/foundry-orchestrator.ts --strict 2> orchestrator-err.log | tail -n 1)
+          output=$(node --experimental-strip-types .github/scripts/foundry-orchestrator.ts --strict 2> orchestrator-err.log | tail -n 1)
           exit_code=${PIPESTATUS[0]}
           set -e
           cat orchestrator-err.log >&2
@@ -193,7 +193,7 @@ jobs:
             fi
 
             # 1.5 Extract research_references from parent chain safely
-            research_context_str=$(node --strip-types .github/scripts/extract-research.ts "${{ matrix.node.repo_path }}")
+            research_context_str=$(node --experimental-strip-types .github/scripts/extract-research.ts "${{ matrix.node.repo_path }}")
 
             if [[ -n "$research_context_str" ]]; then
               agent_context="${agent_context}\n\n### RESEARCH REFERENCES\nThe following research context paths have been automatically injected from the node dependency chain. You may use the read_file tool to read their contents if necessary:\n${research_context_str}"
@@ -250,7 +250,7 @@ jobs:
         run: |
           set -o pipefail
           # Transition the file to ACTIVE state and inject the real Jules ID
-          node --strip-types .github/scripts/foundry-active.ts "${{ matrix.node.repo_path }}" "$SESSION_ID" 2>&1 | tee active-transition.log
+          node --experimental-strip-types .github/scripts/foundry-active.ts "${{ matrix.node.repo_path }}" "$SESSION_ID" 2>&1 | tee active-transition.log
 
       - name: Commit State Change
         run: |

--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -35,3 +35,8 @@ Before deleting code flagged as dead, always check the status of Foundry tasks (
 ## 2026-06-07 - Verify Unused Code Removals
 **Learning:** Tools like `knip` can identify unused exports and dependencies, but they sometimes have blind spots or misinterpret usage (especially for global configurations, setup scripts, or exported test helpers/fixtures).
 **Action:** When using tools like `knip` to find unused exports or files, always verify potential implicit usage with a global repository search (e.g., `grep`) before removing them to ensure they aren't dynamically referenced by tests or CI scripts.
+
+## 2026-06-25 - Node v22 native TypeScript flags & Knip ignore lists
+
+**Learning:** Node.js v22+ requires the `--experimental-strip-types` flag instead of `--strip-types` to execute TypeScript natively. Additionally, `knip` natively understands GitHub Actions workflow files (`.github/workflows/`), meaning scripts executed within those workflows are automatically tracked and do not need to be manually added to the `ignore` array in `knip.json`.
+**Action:** Always verify that script execution commands align with the Node.js version, and rely on `knip`'s automatic GitHub Actions integration before manually ignoring files.

--- a/knip.json
+++ b/knip.json
@@ -12,7 +12,6 @@
   "ignore": [
     "src/test-setup.ts",
     "scripts/validate-foundry-schema.ts",
-    ".github/scripts/extract-research.ts",
     "scripts/gen3-fetch-locations.ts",
     "functions/_middleware.ts",
     "scripts/data/gen3/match_call/etl.ts"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -140,14 +140,6 @@ export interface PokemonMetadata {
   det: CompactEvolutionDetail[]; // Evolutionary requirements to reach THIS pokemon from parent
 }
 
-export interface HiddenItemData {
-  flagOffset: number;
-  flagBit: number;
-  locationId: number;
-  itemId: number;
-  isAcquired?: boolean;
-}
-
 export interface PokeDataExport {
   poke: PokemonMetadata[];
   enc: LocationAreaEncounters[];

--- a/src/engine/gen3/matchCall/offsets.ts
+++ b/src/engine/gen3/matchCall/offsets.ts
@@ -14,4 +14,3 @@ export const MATCH_CALL_UNLOCK_FLAG_BIT = 7;
 // Rematch readiness and tier states
 export const MATCH_CALL_REMATCH_NOT_READY = 0;
 // Where 0 is not ready, >0 means ready and represents the internal tier index
-export type MatchCallRematchEntry = number;


### PR DESCRIPTION
🎯 What
- Cleaned up unused exported types (`MatchCallRematchEntry` and `HiddenItemData`).
- Updated the Node.js TypeScript execution flag from `--strip-types` to `--experimental-strip-types` across all `.github/scripts/package.json` and workflow scripts.
- Removed `.github/scripts/extract-research.ts` from the `knip.json` ignore array.

💡 Why
- `knip` flagged `MatchCallRematchEntry` and `HiddenItemData` as dead types.
- Node.js versions <= 22.22.x require the `--experimental-strip-types` flag (not `--strip-types`), which was causing the `verify:refs` job in `.github/workflows/foundry-engine.yml` to fail.
- `knip` natively parses GitHub Actions workflows, so `.github/scripts/extract-research.ts` did not need an explicit manual ignore configuration.

✅ Verification
- Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure the codebase remains healthy and regression-free.

✨ Result
- Less dead code, a leaner configuration file, and fixing the failing `verify:refs` job in the Foundry Orchestrator engine.

---
*PR created automatically by Jules for task [15181974962427720215](https://jules.google.com/task/15181974962427720215) started by @szubster*