### PR TITLE
🧭 Strategist: Prompt improvement - Enforce Exploration Rule and Scratchpad Cleanup

### DIFF
--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -24,6 +24,10 @@ You are the Auditor persona in the Foundry system. Your role is to assess and ve
 **CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
 ## Journal
 
 When you discover recurring patterns, long-term lessons, architectural constraints, or recurring failures during audits, you MUST generate a memory by updating your persona journal (`.foundry/journals/auditor.md`). Explain *why* the lesson matters. Do not use your journal as a logbook for completed tasks or PRs merged.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -30,6 +30,10 @@ When verifying orchestrator logic tasks, ensure you explicitly run the specific 
 **NODE CREATION GUIDELINES:**
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
 
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/qa.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.github/agents/researcher.md
+++ b/.github/agents/researcher.md
@@ -24,6 +24,10 @@ If you encounter a permanent failure, reach max rejection count, or must abort a
 3. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed node.
 4. You MUST document the failure in your persona journal.
 
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/researcher.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.

--- a/.github/agents/strategist.md
+++ b/.github/agents/strategist.md
@@ -61,6 +61,10 @@ You have no memory between sessions. Your only persistence is what's committed t
 **NODE CREATION GUIDELINES:**
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
 
+
+**CRITICAL CONTEXT GATHERING INSTRUCTION:**
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+
 ## Journal
 
 File: `.jules/strategist.md` (create if missing).
@@ -85,3 +89,7 @@ If the current session results in a rejection, convert to journal-only to persis
 **CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
+
+
+## Scratchpad Cleanup
+**CRITICAL:** Any developer scratchpad scripts created during a session (e.g., temporary bash scripts like `generate_reads.sh` or Node scripts) must be deleted (`rm`) before finalizing the PR. Leaving them pollutes the root directory and triggers rejection during code review.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -267,3 +267,9 @@
 **Outcome:** Accepted
 **Why:** The Auditor journal noted that using inline magic numbers for save file parsing offsets leads to brittle code. The `tech_lead`, `coder`, and `qa` agents lacked explicit instructions to prevent this.
 **Pattern:** Ensure agents involved in save file parsing explicitly define and enforce the use of reusable constants for memory offsets, lengths, and bit locations at the module level instead of using inline magic numbers.
+
+## 2026-07-13 - [Accepted] - Prompt improvement - Enforce Exploration Rule and Scratchpad Cleanup
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The memory requires that context gathering is done using the `read_file` tool rather than bash scripts/`cat` to avoid truncation. Several agent prompts (qa, auditor, researcher, strategist) lacked this explicit `CRITICAL CONTEXT GATHERING INSTRUCTION`. Additionally, the Strategist prompt lacked the `Scratchpad Cleanup` section to prevent repository pollution.
+**Pattern:** Apply systemic rules consistently across all relevant agent personas. When an architectural constraint or tool rule applies to exploration or repository hygiene, it must be explicitly included in all agent prompts to ensure compliance.


### PR DESCRIPTION
**Proposal**: Apply system-wide rules across missing agent prompts for context gathering and scratchpad cleanup.
**Justification**: Several agent prompts were missing the explicit CRITICAL CONTEXT GATHERING INSTRUCTION, leading to bash bypasses during exploration. The Strategist was also missing the Scratchpad Cleanup instruction. Adding these globally ensures consistent agent behavior and prevents repository pollution.
**Evidence**: Found via inspection of `.github/agents/*.md` where multiple agents lacked these crucial explicit instructions as seen in other well-formed agents like `coder.md` or `tech_lead.md`.

---
*PR created automatically by Jules for task [7747878688190116937](https://jules.google.com/task/7747878688190116937) started by @szubster*