### PR TITLE
chore(foundry): replace cancelled epic-044-073 with research and v2 epic

### DIFF
--- a/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+++ b/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
@@ -25,6 +25,9 @@ notes: ''
 
 # Gen 3 Roamer Dashboard UI
 
+### Auditor Rejection
+**CANCELLED:** This epic has been cancelled and replaced due to the impossibility of extracting static map locations from save files.
+
 ## Objective
 Create a user interface to display the comprehensive breakdown of the roaming legendary's internal state.
 

--- a/.foundry/epics/epic-044-212-gen3-roamer-dashboard-ui-v2.md
+++ b/.foundry/epics/epic-044-212-gen3-roamer-dashboard-ui-v2.md
@@ -1,0 +1,38 @@
+---
+id: epic-044-212-gen3-roamer-dashboard-ui-v2
+type: EPIC
+title: Gen 3 Roamer Dashboard UI V2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on:
+  - research-044-211-gen3-roamer-ui-alternatives
+  - epic-044-070-gen3-roamer-core-extraction
+  - epic-044-071-gen3-roamer-iv-glitch
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Dashboard UI V2
+
+## Objective
+Create a user interface to display the comprehensive breakdown of the roaming legendary's internal state, omitting map-based tracking.
+
+## Description
+Develop a dashboard view that presents the exact state of the roaming Pokémon, utilizing the parsed data. It should clearly display the Pokémon's Nature, individual IVs, current HP, status condition, and provide a prominent warning if the IV Glitch has corrupted its stats. This replaces the previous UI Epic that incorrectly included Route Radar integration, as extracting the exact map location is impossible.
+
+## Acceptance Criteria
+- [ ] Build a UI component to display the roamer's Nature, IVs, HP, and Status.
+- [ ] Implement a visual warning indicator for the IV Glitch.
+- [ ] Ensure the design reflects the findings from `research-044-211-gen3-roamer-ui-alternatives` and does not include map locations.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -23,3 +23,13 @@ Additionally, when a PRD relies on its generated child Epics to be completed, it
 Furthermore, generated Epics MUST have their dependencies explicitly defined. For example, if an Epic is for Visual Regression Testing, its `depends_on` array must contain the IDs of the Epics that build the UI components it will test. Failure to set these dependencies allows the testing Epic to run concurrently with the UI Epic, resulting in immediate failures.
 ### Lessons Learned: Bash scripts using `printf` with numbers containing leading zeros (e.g., `091`) will fail due to invalid octal interpretation. Strip leading zeros before mathematical operations or use Python for accurate zero-padded sequence generation.
 ### Lessons Learned: Execution Plan Verification Rule: If files are generated or modified via custom scripts, the execution plan must include an explicit step to verify the exact contents of the resulting files using `read_file`, as well as a step to clean up any temporary scratchpad scripts using `rm`, before proceeding to testing or pre-commit.
+
+## 2026-06-20: Handling Permanent Failures and Cascading Cancellations
+**Context:** I was dispatched to a node (`prd-071-044-gen3-roamer-tracker`) where a child epic (`epic-044-072`) was permanently cancelled. The cancellation was due to mathematical impossibility discovered during research: Gen 3 roamer active map coordinates are stored dynamically in EWRAM and are not serialized into the `.sav` file.
+**Pattern / Action Taken:** Because `epic-044-072` was cancelled, its dependent sibling epic (`epic-044-073-gen3-roamer-dashboard-ui`) also needed to be replaced, as its acceptance criteria explicitly required Route Radar integration.
+**Resolution:**
+1. I left the YAML frontmatter of the orphaned `epic-044-073` intact but updated its markdown body with a cancellation notice.
+2. I spawned a new `RESEARCH` node (`research-044-211-gen3-roamer-ui-alternatives`) to investigate UI alternatives that omit the impossible map tracking.
+3. I created a replacement epic (`epic-044-212-gen3-roamer-dashboard-ui-v2`) that explicitly depends on the new research.
+4. I checked off the cancelled child epics in the parent PRD markdown body to ensure the macro node doesn't get blocked indefinitely, and appended the new nodes.
+**Lesson:** When a core technical assumption fails (e.g., data availability in save files), it's crucial to not just cancel the failing node but also proactively cancel and replace dependent nodes (like UI integrations) and spawn new research to find viable alternatives, keeping the macro feature unblocked.

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -34,5 +34,7 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 
 - [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
 - [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
-- [ ] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
-- [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
+- [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [ ] .foundry/research/research-044-211-gen3-roamer-ui-alternatives.md
+- [ ] .foundry/epics/epic-044-212-gen3-roamer-dashboard-ui-v2.md

--- a/.foundry/research/research-044-211-gen3-roamer-ui-alternatives.md
+++ b/.foundry/research/research-044-211-gen3-roamer-ui-alternatives.md
@@ -1,0 +1,37 @@
+---
+id: research-044-211-gen3-roamer-ui-alternatives
+type: RESEARCH
+title: Investigate Gen 3 Roamer Tracker UI Alternatives
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - ui
+  - map
+research_references:
+  - research-108-187-gen3-roamer-location-offsets
+  - research-108-206-gen3-roamer-ewram-investigation
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 3 Roamer Tracker UI Alternatives
+
+## Objective
+Propose an alternative UI design for the Gen 3 Roamer Tracker that does not rely on static map locations.
+
+## Description
+Since ADR 108-027 establishes that extracting the roamer's immediate map coordinates from the `.sav` file is mathematically impossible, the original design of plotting the roamer on a Route Radar cannot be implemented. We need a new UI approach that effectively presents the available roamer data (Nature, IVs, HP, status, and activity state) without misleading the user about map location.
+
+## Acceptance Criteria
+- [ ] Review available roamer data (from core extraction).
+- [ ] Propose an alternative UI layout/concept to present this data to the user without the Route Radar map.
+- [ ] Document findings and recommendations for the Story Owner to translate into the Dashboard UI implementation.


### PR DESCRIPTION
Replaces the permanently failed `epic-044-073-gen3-roamer-dashboard-ui.md` due to impossible map extraction requirements. Leaves the original YAML intact but updates the body. Spawns `research-044-211-gen3-roamer-ui-alternatives.md` and `epic-044-212-gen3-roamer-dashboard-ui-v2.md` to unblock the feature.

---
*PR created automatically by Jules for task [14891346410681879206](https://jules.google.com/task/14891346410681879206) started by @szubster*