### PR TITLE
Create PRDs for Daycare and Egg Hatch Tracking

### DIFF
--- a/.foundry/ideas/idea-083-daycare-egg-tracker.md
+++ b/.foundry/ideas/idea-083-daycare-egg-tracker.md
@@ -36,3 +36,7 @@ Leverage DexHelper's offline-first programmatic save parsing to extract and disp
 ## Value Proposition
 
 By surfacing these highly opaque, heavily utilized mechanics, DexHelper immediately solves a massive pain point for competitive breeders and completionists. Transforming vague in-game hints into exact, actionable data points perfectly aligns with the app's mission to be the ultimate premium companion tool for retro Pokémon.
+
+## Generated PRDs
+- [ ] .foundry/prds/prd-083-053-daycare-status-dashboard.md
+- [ ] .foundry/prds/prd-083-054-exact-egg-tracker.md

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -54,3 +54,8 @@ When generating a child node from a parent, ensure the new child node is added a
 
 ## 2026-06-16: Parent Node Awakening and Generated Nodes
 When transforming an `IDEA` to a `PRD`, and there are existing acceptance criteria on the `IDEA` that cannot be fulfilled before all generated child nodes are complete, the `IDEA` node MUST NOT have all its acceptance criteria checked off. Check off only what is fulfilled, and always append the newly generated nodes as unchecked checkboxes (`- [ ] <filepath>`) in the markdown body. Checking all acceptance criteria prematurely causes the empty PR submission to be verified before children complete, violating the strict pipeline graph.
+
+## 2026-06-20
+- **Execution Plan Strictness**: Ensure that Execution Plans do not contain internal monologues or deliberations (e.g. "Wait, the rule says..."). Plans must contain concrete, direct, and actionable steps.
+- **Sequence Verification**: Ensure you do not guess the highest sequence number when generating node IDs if `ls` output is truncated. Use `tail` explicitly (e.g. `ls -1 | sort -n | tail -n 5`) to confirm sequence numbers.
+- **Node Handoff Strictness**: The pipeline handoff order (IDEA -> PRD -> ADR -> EPIC) strictly maps to personas (PM -> PM -> Architect -> Epic Planner). When generating PRDs from an IDEA, the next target in the DAG is an ADR, meaning the generated PRDs must be assigned `owner_persona: architect` (not epic planner).

--- a/.foundry/prds/prd-083-053-daycare-status-dashboard.md
+++ b/.foundry/prds/prd-083-053-daycare-status-dashboard.md
@@ -1,0 +1,36 @@
+---
+id: prd-083-053-daycare-status-dashboard
+type: PRD
+title: Daycare Status Dashboard
+status: PENDING
+owner_persona: architect
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-083-daycare-egg-tracker
+tags:
+  - feature
+  - gen2
+  - gen3
+  - breeding
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Daycare Status Dashboard
+
+## Objective
+Provide an offline-first, real-time dashboard displaying the status of the Pokémon Daycare based on the player's `.sav` file. This will eliminate the tedious in-game process of repeatedly visiting the Daycare to check for Eggs or accumulated EXP.
+
+## Features & Requirements
+1. **Deposited Pokémon Display**: Extract and display the Pokémon currently left in the Daycare slots. Show their species, level at time of deposit (if possible), and accumulated EXP/levels gained.
+2. **Gen 2 & Gen 3 Support**: The dashboard must accurately parse and present daycare data for Generation 2 (GSC) and Generation 3 (RSE, FRLG) save files.
+3. **Egg Waiting Indicator**: Specifically expose the hidden "Egg is waiting" flag from the save file so players know exactly when a new Egg is ready to be picked up.
+4. **Integration**: The dashboard should be accessible from the main UI (e.g., as a new tab or section alongside Party/PC storage), maintaining the project's tactical hardware aesthetic (ADR 008, ADR 024).
+
+## Acceptance Criteria
+- [ ] Break down into Epics (e.g., Engine Parsing Epic, UI/Component Epic).

--- a/.foundry/prds/prd-083-054-exact-egg-tracker.md
+++ b/.foundry/prds/prd-083-054-exact-egg-tracker.md
@@ -1,0 +1,36 @@
+---
+id: prd-083-054-exact-egg-tracker
+type: PRD
+title: Exact Egg Tracker
+status: PENDING
+owner_persona: architect
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-083-daycare-egg-tracker
+tags:
+  - feature
+  - gen2
+  - gen3
+  - breeding
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Exact Egg Tracker
+
+## Objective
+Convert the vague in-game hints regarding an Egg's hatch progress into exact, numerical step counts by extracting and parsing the relevant save data.
+
+## Features & Requirements
+1. **Target Population**: Identify and track all Eggs currently in the player's Party or PC storage.
+2. **Cycle Extraction**: Parse the friendship/egg cycles remaining byte for each Egg.
+3. **Step Calculation**: Multiply the remaining cycle count by the specific generation's cycle length (e.g., 256 steps) to calculate and display the exact numerical step count remaining until the Egg hatches.
+4. **Integration**: Display this precise information within the Pokémon Details view or Storage grids when an Egg is selected, replacing or augmenting the standard flavor text.
+
+## Acceptance Criteria
+- [ ] Break down into Epics (e.g., Cycle Calculation/Parsing Epic, UI Update Epic).


### PR DESCRIPTION
Generated granular PRDs `prd-083-053-daycare-status-dashboard` and `prd-083-054-exact-egg-tracker` based on `idea-083-daycare-egg-tracker`.
Appended the references as unchecked tasks to the parent IDEA node to avoid premature hierarchical completion.

---
*PR created automatically by Jules for task [7515775365673356720](https://jules.google.com/task/7515775365673356720) started by @szubster*