### PR TITLE
Handle permanent failure of Gen 3 Roamer Location Radar

### DIFF
--- a/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+++ b/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
@@ -36,3 +36,6 @@ Develop a dashboard view that presents the exact state of the roaming Pokémon, 
 - [ ] Implement a visual warning indicator for the IV Glitch.
 - [ ] Ensure seamless integration with the Route Radar UI component.
 - [ ] Story Owner: Break down this Epic into executable Stories.
+
+### Epic Planner Update
+**CANCELLED:** This Epic has been permanently cancelled and replaced by `epic-044-096-gen3-roamer-dashboard-ui-v2` because it was incorrectly dependent on the permanently failed `epic-044-072-gen3-roamer-location-radar`. The YAML frontmatter is unmodified to prevent DAG deadlocks.

--- a/.foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md
+++ b/.foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md
@@ -1,0 +1,38 @@
+---
+id: epic-044-096-gen3-roamer-dashboard-ui-v2
+type: EPIC
+title: Gen 3 Roamer Dashboard UI (Without Radar)
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on:
+  - epic-044-070-gen3-roamer-core-extraction
+  - epic-044-071-gen3-roamer-iv-glitch
+  - research-044-207-investigate-roamer-location-failure
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Dashboard UI (Without Radar)
+
+## Objective
+Create a user interface to display the comprehensive breakdown of the roaming legendary's internal state, excluding the location radar.
+
+## Description
+Develop a dashboard view that presents the exact state of the roaming Pokémon, utilizing the parsed data. It should clearly display the Pokémon's Nature, individual IVs, current HP, and status condition, and provide a prominent warning if the IV Glitch has corrupted its stats. This node replaces the originally planned dashboard (`epic-044-073-gen3-roamer-dashboard-ui`) which incorrectly depended on the permanently failed location radar epic.
+
+## Acceptance Criteria
+- [ ] Build a UI component to display the roamer's Nature, IVs, HP, and Status.
+- [ ] Implement a visual warning indicator for the IV Glitch.
+- [ ] Ensure the dashboard functions correctly without location data, acting on the findings from the research node.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -23,3 +23,11 @@ Additionally, when a PRD relies on its generated child Epics to be completed, it
 Furthermore, generated Epics MUST have their dependencies explicitly defined. For example, if an Epic is for Visual Regression Testing, its `depends_on` array must contain the IDs of the Epics that build the UI components it will test. Failure to set these dependencies allows the testing Epic to run concurrently with the UI Epic, resulting in immediate failures.
 ### Lessons Learned: Bash scripts using `printf` with numbers containing leading zeros (e.g., `091`) will fail due to invalid octal interpretation. Strip leading zeros before mathematical operations or use Python for accurate zero-padded sequence generation.
 ### Lessons Learned: Execution Plan Verification Rule: If files are generated or modified via custom scripts, the execution plan must include an explicit step to verify the exact contents of the resulting files using `read_file`, as well as a step to clean up any temporary scratchpad scripts using `rm`, before proceeding to testing or pre-commit.
+
+## 2026-06-20: Cascading Cancellations and Orphaned Pending Nodes
+When a child node fails permanently (e.g., an Epic is proven technically impossible to implement and is cancelled by the Auditor), any sibling nodes that depend on the failed node must be handled carefully to avoid DAG deadlocks.
+If a sibling node is currently in the `PENDING` status waiting on the failed node:
+1.  **Do NOT update the YAML frontmatter** of the pending node to `CANCELLED`. Changing the status of a pending node can corrupt the Orchestrator's dependency graph resolution.
+2.  Instead, update the pending node's **Markdown body** explicitly stating that it is CANCELLED due to its dependency failing.
+3.  Spawn a new `RESEARCH` node to investigate the failure, and create a **new replacement node** that depends on the research and excludes the impossible features.
+4.  Append the new `RESEARCH` and replacement nodes to the parent's markdown body as unchecked tasks to ensure the macro node cannot prematurely transition to VERIFYING.

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -36,3 +36,5 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
 - [ ] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
 - [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [ ] .foundry/research/research-044-207-investigate-roamer-location-failure.md
+- [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md

--- a/.foundry/research/research-044-207-investigate-roamer-location-failure.md
+++ b/.foundry/research/research-044-207-investigate-roamer-location-failure.md
@@ -1,0 +1,33 @@
+---
+id: research-044-207-investigate-roamer-location-failure
+type: RESEARCH
+title: Investigate Gen 3 Roamer Location Radar Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - research
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 3 Roamer Location Radar Failure
+
+## Objective
+Investigate the root cause of the roamer location radar failure (`epic-044-072-gen3-roamer-location-radar`), specifically focusing on why extracting map locations from Gen 3 save files is impossible.
+
+## Description
+The implementation Epic for the Roamer Location Radar has failed permanently. This RESEARCH node is spawned to formally investigate the root cause, documenting the technical impossibility so that replacement nodes (like the UI dashboard without the radar component) can proceed confidently without attempting this feature.
+
+## Acceptance Criteria
+- [ ] Read and summarize the architectural decision regarding the impossibility of Gen 3 roamer location extraction (`adr-108-027-gen3-roamer-location-impossible.md`).
+- [ ] Confirm the behavior of EWRAM versus serialized save data for the Roamer's active map coordinates.


### PR DESCRIPTION
Handle permanent failure of Gen 3 Roamer Location Radar by:
1. Spawning RESEARCH node `research-044-207-investigate-roamer-location-failure.md`.
2. Creating a replacement EPIC `epic-044-096-gen3-roamer-dashboard-ui-v2.md` without the radar dependency.
3. Cancelling the orphaned pending EPIC `epic-044-073-gen3-roamer-dashboard-ui.md` via markdown body update to prevent DAG deadlock.
4. Appending generated nodes to parent PRD `prd-071-044-gen3-roamer-tracker.md`.
5. Logging the procedure for handling cascading cancellations in `.foundry/journals/epic_planner.md`.

---
*PR created automatically by Jules for task [15316292557837434681](https://jules.google.com/task/15316292557837434681) started by @szubster*