### PR TITLE
feat(ui): implement contest ribbons panel for Gen 3 pokemon

### DIFF
--- a/.foundry/tasks/task-139-209-individual-contest-ribbons-impl.md
+++ b/.foundry/tasks/task-139-209-individual-contest-ribbons-impl.md
@@ -47,7 +47,7 @@ This task implements the UI integration required for `story-065-139-individual-c
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Create a `ContestRibbonsPanel` component to wrap and display the earned ribbons.
-- [ ] Correctly map numeric ribbon values (1-4) to their string equivalents.
-- [ ] Integrate the ribbon display into `PokemonCaughtDetails.tsx` when `p.ribbons` is present.
-- [ ] Add rendering tests (e.g., using Vitest/Playwright) to verify the integration.
+- [x] Create a `ContestRibbonsPanel` component to wrap and display the earned ribbons.
+- [x] Correctly map numeric ribbon values (1-4) to their string equivalents.
+- [x] Integrate the ribbon display into `PokemonCaughtDetails.tsx` when `p.ribbons` is present.
+- [x] Add rendering tests (e.g., using Vitest/Playwright) to verify the integration.

--- a/src/components/pokemon/details/ContestRibbonsPanel.tsx
+++ b/src/components/pokemon/details/ContestRibbonsPanel.tsx
@@ -1,0 +1,45 @@
+import { Award } from 'lucide-react';
+import type { Gen3Ribbons } from '../../../engine/saveParser/parsers/common';
+import { type ContestConditionType, ContestRibbonBadge, type ContestRibbonRank } from './ContestRibbonBadge';
+
+interface ContestRibbonsPanelProps {
+  ribbons: Gen3Ribbons;
+}
+
+const rankMap: Record<number, ContestRibbonRank> = {
+  1: 'Normal',
+  2: 'Super',
+  3: 'Hyper',
+  4: 'Master',
+};
+
+const conditionMap: Record<keyof Gen3Ribbons, ContestConditionType> = {
+  cool: 'Cool',
+  beauty: 'Beauty',
+  cute: 'Cute',
+  smart: 'Smart',
+  tough: 'Tough',
+};
+
+export function ContestRibbonsPanel({ ribbons }: ContestRibbonsPanelProps) {
+  const hasRibbons = Object.values(ribbons).some((rank) => rank > 0);
+
+  if (!hasRibbons) {
+    return null;
+  }
+
+  return (
+    <div className="relative z-10 space-y-2 border-white/5 border-t pt-4">
+      <span className="flex items-center gap-1 font-black text-[8px] text-zinc-500 uppercase tracking-widest">
+        <Award size={8} /> Contest Ribbons
+      </span>
+      <div className="flex flex-wrap gap-2">
+        {(Object.entries(ribbons) as [keyof Gen3Ribbons, number][]).map(([key, rank]) => {
+          if (rank === 0 || !rankMap[rank]) return null;
+
+          return <ContestRibbonBadge key={key} type={conditionMap[key]} rank={rankMap[rank]} />;
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pokemon/details/PokemonCaughtDetails.tsx
+++ b/src/components/pokemon/details/PokemonCaughtDetails.tsx
@@ -7,6 +7,7 @@ import { DataPoint } from '../../DataPoint';
 import { SectionHeader } from '../../SectionHeader';
 import { TacticalBadge } from '../../TacticalBadge';
 import { TacticalPanel } from '../../TacticalPanel';
+import { ContestRibbonsPanel } from './ContestRibbonsPanel';
 
 interface PokemonCaughtDetailsProps {
   yourPokemon: (PokemonInstance & { location: string })[];
@@ -111,6 +112,8 @@ export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps)
                 </div>
               </div>
             )}
+
+            {p.ribbons && generation === 3 && <ContestRibbonsPanel ribbons={p.ribbons} />}
           </TacticalPanel>
         ))}
       </div>

--- a/src/components/pokemon/details/__tests__/ContestRibbonsPanel.test.tsx
+++ b/src/components/pokemon/details/__tests__/ContestRibbonsPanel.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import type { Gen3Ribbons } from '../../../../engine/saveParser/parsers/common';
+import { ContestRibbonsPanel } from '../ContestRibbonsPanel';
+
+describe('ContestRibbonsPanel', () => {
+  it('renders badges when ribbons are present', async () => {
+    const ribbons: Gen3Ribbons = {
+      cool: 1, // Normal
+      beauty: 2, // Super
+      cute: 3, // Hyper
+      smart: 4, // Master
+      tough: 0, // None
+    };
+
+    await render(<ContestRibbonsPanel ribbons={ribbons} />);
+
+    // Renders the header
+    await expect.element(page.getByText('Contest Ribbons')).toBeInTheDocument();
+
+    // Renders the badges with correct type and rank texts based on mappings
+    await expect.element(page.getByText('Cool')).toBeInTheDocument();
+    await expect.element(page.getByText('Normal')).toBeInTheDocument();
+
+    await expect.element(page.getByText('Beauty')).toBeInTheDocument();
+    await expect.element(page.getByText('Super')).toBeInTheDocument();
+
+    await expect.element(page.getByText('Cute')).toBeInTheDocument();
+    await expect.element(page.getByText('Hyper')).toBeInTheDocument();
+
+    await expect.element(page.getByText('Smart')).toBeInTheDocument();
+    await expect.element(page.getByText('Master')).toBeInTheDocument();
+
+    // Does not render a badge if rank is 0
+    await expect.element(page.getByText('Tough')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing if all ribbons are 0', async () => {
+    const ribbons: Gen3Ribbons = {
+      cool: 0,
+      beauty: 0,
+      cute: 0,
+      smart: 0,
+      tough: 0,
+    };
+
+    const result = await render(<ContestRibbonsPanel ribbons={ribbons} />);
+    expect(result.container.firstChild).toBeNull();
+  });
+});

--- a/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
+++ b/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
@@ -74,4 +74,32 @@ describe('PokemonCaughtDetails', () => {
 
     await expect.element(page.getByText('INVALID: Gen 2 Species')).toBeInTheDocument();
   });
+
+  it('renders ContestRibbonsPanel for Gen 3 pokemon with ribbons', async () => {
+    (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
+      (selector: unknown) =>
+        (selector as (state: unknown) => unknown)({
+          saveData: {
+            generation: 3,
+          },
+        }),
+    );
+
+    const gen3PokemonWithRibbons = {
+      ...mockPokemon,
+      ribbons: {
+        cool: 4,
+        beauty: 0,
+        cute: 0,
+        smart: 0,
+        tough: 0,
+      },
+    };
+
+    await render(<PokemonCaughtDetails yourPokemon={[gen3PokemonWithRibbons]} />);
+
+    await expect.element(page.getByText('Contest Ribbons')).toBeInTheDocument();
+    await expect.element(page.getByText('Cool')).toBeInTheDocument();
+    await expect.element(page.getByText('Master')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Implements `ContestRibbonsPanel` and integrates it into `PokemonCaughtDetails` for Gen 3 Pokémon. Includes rendering tests and complies with the tactical UI constraints (ADR 008, 024).

Resolves `.foundry/tasks/task-139-209-individual-contest-ribbons-impl.md`.

---
*PR created automatically by Jules for task [9644346473755975277](https://jules.google.com/task/9644346473755975277) started by @szubster*