### PR TITLE
Fix: Create Gen 2 gender computation prerequisite tasks

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -71,3 +71,5 @@ Always use the exact, short ID slug for DAG references. Do not include directory
 ## 2026-06-18: Gen 3 Roamer Location Constraint
 - **Observation**: Extracting the exact current map location and location history of the roaming Pokémon from a Gen 3 `.sav` file is mathematically impossible. These values (`sRoamerLocation` and `sLocationHistory`) are kept dynamically in `EWRAM` and are never serialized into the static save file.
 - **Action**: The technical blueprint generation for extracting this data must be cancelled. An ADR was created to permanently document this architectural impossibility to prevent future wasted cycles.
+
+- [2026-06-20] Missing prerequisites for complex logic (like Gen 2 gender computation for breeding algorithms) cause downstream pipeline failures. Always proactively verify and create prerequisite tasks for foundational data schemas and utilities before drafting implementation logic.

--- a/.foundry/stories/story-044-084-breeding-pair-algorithm.md
+++ b/.foundry/stories/story-044-084-breeding-pair-algorithm.md
@@ -40,3 +40,8 @@ Develop an algorithm to suggest optimal breeding pairs by cross-referencing Egg 
 - [x] Tech Lead: Break down into backend Tasks.
 - [ ] .foundry/tasks/task-084-204-breeding-pair-algorithm-impl.md
 - [ ] .foundry/tasks/task-084-205-breeding-pair-algorithm-qa.md
+- [ ] .foundry/tasks/research-084-215-gen2-gender-computation.md
+- [ ] .foundry/tasks/task-084-211-gen2-gender-computation-impl.md
+- [ ] .foundry/tasks/task-084-212-gen2-gender-computation-qa.md
+- [ ] .foundry/tasks/task-084-213-breeding-pair-algorithm-impl.md
+- [ ] .foundry/tasks/task-084-214-breeding-pair-algorithm-qa.md

--- a/.foundry/tasks/research-084-215-gen2-gender-computation.md
+++ b/.foundry/tasks/research-084-215-gen2-gender-computation.md
@@ -1,0 +1,31 @@
+---
+id: research-084-215-gen2-gender-computation
+type: RESEARCH
+title: Investigate Gen 2 Gender Computation
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-044-084-breeding-pair-algorithm
+tags:
+  - research
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 2 Gender Computation
+
+## Objective
+Investigate and document the exact mechanics, memory offsets, and formulas for computing a Gen 2 Pokémon's gender based on its Attack DV and Gender Ratio.
+
+## Acceptance Criteria
+- [ ] Determine the exact mapping between Gender Ratio constants and Attack DV thresholds.
+- [ ] Document the bitwise logic for extracting the Attack DV from the Gen 2 Pokémon data structure.
+- [ ] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
+- [ ] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-084-204-breeding-pair-algorithm-impl.md
+++ b/.foundry/tasks/task-084-204-breeding-pair-algorithm-impl.md
@@ -2,7 +2,7 @@
 id: task-084-204-breeding-pair-algorithm-impl
 type: TASK
 title: Implement Shiny Carrier Breeding Pair Algorithm
-status: PENDING
+status: CANCELLED
 owner_persona: coder
 created_at: '2026-06-18'
 updated_at: '2026-06-18'
@@ -18,7 +18,7 @@ tags:
   - backend
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Missing prerequisite: utility to compute Gen 2 Pokemon gender based on Attack DV and Gender Ratio.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-084-205-breeding-pair-algorithm-qa.md
+++ b/.foundry/tasks/task-084-205-breeding-pair-algorithm-qa.md
@@ -45,3 +45,7 @@ Verify the correctness of the Shiny Carrier breeding algorithm implementation, e
 - [ ] All associated unit tests pass.
 - [ ] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
 - [ ] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### Auditor Rejection
+
+CANCELLED: Replaced by tasks with proper Gen 2 gender computation prerequisites.

--- a/.foundry/tasks/task-084-211-gen2-gender-computation-impl.md
+++ b/.foundry/tasks/task-084-211-gen2-gender-computation-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-084-211-gen2-gender-computation-impl
+type: TASK
+title: Implement Gen 2 Gender Computation Utility
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on:
+  - research-084-215-gen2-gender-computation
+jules_session_id: null
+pr_number: null
+parent: story-044-084-breeding-pair-algorithm
+tags:
+  - feature
+  - breeding
+  - gen2
+  - backend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 2 Gender Computation Utility
+
+## Objective
+Implement a pure utility function to compute a Gen 2 Pokémon's gender based on its Attack DV and Gender Ratio.
+
+## Technical Contract
+- Create a utility that accepts a Pokémon's Attack DV and its species' Gender Ratio.
+- Return the computed gender based on Gen 2 mechanics.
+- **Constraint**: Do not use inline magic numbers. Define memory offsets, lengths, bit locations, and shifts as reusable constants at the module level.
+
+## Acceptance Criteria
+- [ ] Utility correctly computes gender based on Gen 2 Attack DV and Gender Ratio.
+- [ ] No inline magic numbers are used.
+- [ ] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
+- [ ] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-084-212-gen2-gender-computation-qa.md
+++ b/.foundry/tasks/task-084-212-gen2-gender-computation-qa.md
@@ -1,0 +1,38 @@
+---
+id: task-084-212-gen2-gender-computation-qa
+type: TASK
+title: QA Gen 2 Gender Computation Utility
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on:
+  - task-084-211-gen2-gender-computation-impl
+jules_session_id: null
+pr_number: null
+parent: story-044-084-breeding-pair-algorithm
+tags:
+  - feature
+  - breeding
+  - gen2
+  - backend
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 2 Gender Computation Utility
+
+## Objective
+Verify the implementation of the Gen 2 gender computation utility.
+
+## Technical Contract
+- Write unit tests validating the utility correctly computes gender based on Gen 2 Attack DV and Gender Ratio.
+
+## Acceptance Criteria
+- [ ] Unit tests thoroughly verify gender computation logic.
+- [ ] Tests pass successfully.
+- [ ] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
+- [ ] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-084-213-breeding-pair-algorithm-impl.md
+++ b/.foundry/tasks/task-084-213-breeding-pair-algorithm-impl.md
@@ -1,0 +1,40 @@
+---
+id: task-084-213-breeding-pair-algorithm-impl
+type: TASK
+title: Implement Shiny Carrier Breeding Pair Algorithm
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on:
+  - story-044-083-pc-party-shiny-flag
+  - task-084-211-gen2-gender-computation-impl
+jules_session_id: null
+pr_number: null
+parent: story-044-084-breeding-pair-algorithm
+tags:
+  - feature
+  - breeding
+  - gen2
+  - backend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Shiny Carrier Breeding Pair Algorithm
+
+## Objective
+Implement the core backend algorithm to calculate valid breeding pairs prioritized by Shiny Carrier status, utilizing the new Gen 2 gender computation utility.
+
+## Technical Contract
+- Create a function to cross-reference Gen 2 Egg Groups, Genders, and Shiny Carrier status.
+- Prioritize pairs where at least one parent is a Shiny Carrier.
+- Use the new Gen 2 gender computation utility for accurate gender determination.
+
+## Acceptance Criteria
+- [ ] Algorithm correctly matches valid Gen 2 breeding pairs.
+- [ ] Output explicitly highlights/prioritizes pairs involving Shiny Carriers.
+- [ ] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
+- [ ] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-084-214-breeding-pair-algorithm-qa.md
+++ b/.foundry/tasks/task-084-214-breeding-pair-algorithm-qa.md
@@ -1,0 +1,38 @@
+---
+id: task-084-214-breeding-pair-algorithm-qa
+type: TASK
+title: QA Shiny Carrier Breeding Pair Algorithm
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on:
+  - task-084-213-breeding-pair-algorithm-impl
+jules_session_id: null
+pr_number: null
+parent: story-044-084-breeding-pair-algorithm
+tags:
+  - feature
+  - breeding
+  - gen2
+  - backend
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Shiny Carrier Breeding Pair Algorithm
+
+## Objective
+Verify the Shiny Carrier breeding pair algorithm implementation.
+
+## Technical Contract
+- Write unit tests validating that the algorithm correctly identifies valid breeding pairs and accurately prioritizes pairs involving Shiny Carriers.
+
+## Acceptance Criteria
+- [ ] Unit tests thoroughly verify breeding pair algorithm logic.
+- [ ] Tests pass successfully.
+- [ ] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
+- [ ] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR handles the permanent failure of the Breeding Pair Algorithm task due to missing prerequisites.

- Cancels the failed implementation task `task-084-204` and notes the prerequisite failure in its frontmatter.
- Cancels the orphaned QA task `task-084-205` by appending an Auditor Rejection notice to its markdown body (preserving frontmatter).
- Creates a new `RESEARCH` node to investigate Gen 2 Gender Computation.
- Creates new replacement prerequisite tasks `task-084-211` (impl) and `task-084-212` (qa) that depend on the `RESEARCH` node.
- Creates new replacement algorithm tasks `task-084-213` (impl) and `task-084-214` (qa) that depend on the prerequisite implementation.
- Appends the new child tasks to the parent story `story-044-084` without modifying its frontmatter.
- Updates the `tech_lead` journal with the learning regarding prerequisites for complex logic and strict DAG ID usage.

---
*PR created automatically by Jules for task [1344004403307567483](https://jules.google.com/task/1344004403307567483) started by @szubster*