### PR TITLE
docs: document gen3 mass outbreak memory offsets

### DIFF
--- a/.foundry/docs/knowledge_base/gen3_tv_shows_and_events.md
+++ b/.foundry/docs/knowledge_base/gen3_tv_shows_and_events.md
@@ -83,3 +83,25 @@ Shows with IDs between `TVGROUP_RECORD_MIX_START` (`21`) and `TVGROUP_RECORD_MIX
 - `33`: `TVSHOW_BATTLE_SEMINAR`
 
 By parsing these specific shows, the system can extract the original player's name and details of their actions, effectively acting as an asynchronous multiplayer history log.
+
+### `TVSHOW_MASS_OUTBREAK` Payload
+When the `kind` field of a `TVShow` struct indicates a mass outbreak event (e.g. ID `TVSHOW_MASS_OUTBREAK` or another appropriate outbreak constant), the remaining bytes are structured as follows:
+
+| Offset | Type | Name | Description |
+|---|---|---|---|
+| `0x00` | `u8` | `kind` | The ID of the TV show broadcast (common header). |
+| `0x01` | `bool8` | `active` | Boolean flag indicating if the show is actively in rotation (common header). |
+| `0x02` | `u8` | `unused1` | Unused byte. |
+| `0x03` | `u8` | `unused3` | Unused byte. |
+| `0x04` | `u16[4]` | `moves` | The 4 moves the mass outbreak Pokémon will have. |
+| `0x0C` | `u16` | `species` | The internal species ID of the swarming Pokémon. |
+| `0x0E` | `u16` | `unused2` | Unused half-word. |
+| `0x10` | `u8` | `locationMapNum` | The Map Num where the outbreak occurs. |
+| `0x11` | `u8` | `locationMapGroup` | The Map Group where the outbreak occurs. |
+| `0x12` | `u8` | `unused4` | Unused byte. |
+| `0x13` | `u8` | `probability` | Probability factor for the outbreak. |
+| `0x14` | `u8` | `level` | The level of the swarming Pokémon. |
+| `0x15` | `u8` | `unused5` | Unused byte. |
+| `0x16` | `u16` | `daysBeforeOutbreak` | Days remaining until the mass outbreak happens (if not already started). |
+| `0x18` | `u8` | `language` | The language of the broadcast. |
+| `0x19` | `padding` | `padding` | Padding bytes (struct total size 36 bytes / 0x24). |

--- a/.foundry/research/research-123-202-gen3-outbreak-offsets.md
+++ b/.foundry/research/research-123-202-gen3-outbreak-offsets.md
@@ -22,3 +22,42 @@ notes: ''
 # Research: Gen 3 Mass Outbreak Memory Offsets
 ## Objective
 Investigate the exact memory offsets inside the `massOutbreak` payload of the `TVShow` struct (within SaveBlock1) to extract the active swarm species, location (mapId/mapGroup), and days remaining. This is required for `task-123-183-gen3-active-swarm-parsing-impl`.
+
+## Findings
+Based on the `pret/pokeemerald` decompilation (`include/global.tv.h`), the `massOutbreak` struct within the `TVShow` union has the following memory layout:
+
+```c
+// TVSHOW_MASS_OUTBREAK
+struct {
+    /*0x00*/ u8 kind;
+    /*0x01*/ bool8 active;
+    /*0x02*/ u8 unused1;
+    /*0x03*/ u8 unused3;
+    /*0x04*/ u16 moves[4]; // MAX_MON_MOVES is 4
+    /*0x0C*/ u16 species;
+    /*0x0E*/ u16 unused2;
+    /*0x10*/ u8 locationMapNum;
+    /*0x11*/ u8 locationMapGroup;
+    /*0x12*/ u8 unused4;
+    /*0x13*/ u8 probability;
+    /*0x14*/ u8 level;
+    /*0x15*/ u8 unused5;
+    /*0x16*/ u16 daysBeforeOutbreak;
+    /*0x18*/ u8 language;
+    /*0x19*/ //u8 padding;
+} massOutbreak;
+```
+
+### Extracted Offsets
+Within the 36-byte (0x24) `TVShow` struct size, the `massOutbreak` payload contains the following offsets for the requested data fields:
+
+- **Active Swarm Species:** `0x0C` (12) - `u16` (2 bytes)
+- **Location (MapNum):** `0x10` (16) - `u8` (1 byte)
+- **Location (MapGroup):** `0x11` (17) - `u8` (1 byte)
+- **Days Remaining (`daysBeforeOutbreak`):** `0x16` (22) - `u16` (2 bytes)
+
+These offsets are relative to the start of each 36-byte TV show block within the `tvShows` array located at offset `0x27CC` in `SaveBlock1` (as documented in `.foundry/docs/knowledge_base/gen3_tv_shows_and_events.md`).
+
+- [x] Identify memory offset for mass outbreak species ID
+- [x] Identify memory offsets for mass outbreak location mapNum and mapGroup
+- [x] Identify memory offset for mass outbreak days remaining


### PR DESCRIPTION
- Identified `TVSHOW_MASS_OUTBREAK` payload offsets
- Extracted exact positions for species, map ID, and countdown
- Updated `.foundry/docs/knowledge_base/gen3_tv_shows_and_events.md`
- Added findings to `.foundry/research/research-123-202-gen3-outbreak-offsets.md`
- Met all ACs while strictly adhering to Empty PR policies

---
*PR created automatically by Jules for task [8393363084291567728](https://jules.google.com/task/8393363084291567728) started by @szubster*