### PR TITLE
docs: Update TPM and Agile Coach journals with late-binding process

### DIFF
--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -65,3 +65,7 @@ To resolve this, I have:
 To improve visibility into system deadlocks (ADR 017), I have implemented a 'Permanent Failures' toggle on the DAG Dashboard. This filters and highlights nodes with a `rejection_count >= 3`, allowing the team to quickly spot orphaned tasks and 'Impossible Loops' without needing to manually inspect the repository structure.
 
 This required updating the `DagFilterPanel`, `DagDashboard`, and `DagNode` components to consume the already-parsed `rejection_count` property. Going forward, PMs and Tech Leads should check this view regularly.
+
+## 2026-06-17: Late-Binding Hierarchy Orchestrator Exception
+
+Added formal notes regarding the Late-Binding process to clarify orchestrator deadlock prevention. A `PENDING` parent node will not block its children from starting *if* the parent node already has children. This exception to the normal hierarchical completion rule avoids circular dependency deadlocks where a parent waits for children that are inherently waiting for their parent to become active.

--- a/.foundry/journals/tpm.md
+++ b/.foundry/journals/tpm.md
@@ -1,3 +1,7 @@
 # TPM Journal
 
 No critical learnings logged yet.
+
+## Process Change: Late-Binding Hierarchy
+A new process change regarding late-binding hierarchical dependencies has been documented.
+In the orchestrator, a `PENDING` parent node will not block its children from starting *if* the parent node already has children. This exception to the normal hierarchical completion rule avoids circular dependency deadlocks where a parent waits for children that are waiting for the parent to become active.

--- a/.foundry/tasks/task-117-201-update-tpm-agile-coach-journals.md
+++ b/.foundry/tasks/task-117-201-update-tpm-agile-coach-journals.md
@@ -29,8 +29,8 @@ Process changes related to the orchestrator's handling of late-binding (where a 
 Ensure the TPM and Agile Coach personas are aware of the new late-binding process by updating their journals.
 
 ## Acceptance Criteria
-- [ ] Append process change notes regarding late-binding to the `.foundry/journals/tpm.md` journal.
-- [ ] Append process change notes regarding late-binding to the `.foundry/journals/agile_coach.md` journal.
+- [x] Append process change notes regarding late-binding to the `.foundry/journals/tpm.md` journal.
+- [x] Append process change notes regarding late-binding to the `.foundry/journals/agile_coach.md` journal.
 
 ## Developer Reminders
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Appended process change notes regarding late-binding to `.foundry/journals/tpm.md` and `.foundry/journals/agile_coach.md` as per task 117-201. Checked off the acceptance criteria checkboxes in `.foundry/tasks/task-117-201-update-tpm-agile-coach-journals.md`.

---
*PR created automatically by Jules for task [17954604461018051065](https://jules.google.com/task/17954604461018051065) started by @szubster*