### PR TITLE
feat: Implement Hidden Items Aggregation Logic

### DIFF
--- a/.foundry/tasks/task-126-194-hidden-items-aggregation-impl.md
+++ b/.foundry/tasks/task-126-194-hidden-items-aggregation-impl.md
@@ -35,6 +35,6 @@ We need to implement the logic that maps raw parsed boolean flags from the event
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 4. Acceptance Criteria
-- [ ] Aggregation utility correctly maps parsed event flags to `HiddenItemData` items.
-- [ ] Filtering utilities return correct subsets of items based on acquisition status.
-- [ ] Unit tests verify the logic against expected behavior.
+- [x] Aggregation utility correctly maps parsed event flags to `HiddenItemData` items.
+- [x] Filtering utilities return correct subsets of items based on acquisition status.
+- [x] Unit tests verify the logic against expected behavior.

--- a/src/engine/saveParser/utils/hiddenItems.test.ts
+++ b/src/engine/saveParser/utils/hiddenItems.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { HiddenItemData } from '../../../db/schema';
+import { getAcquiredHiddenItems, getRemainingHiddenItems, mergeHiddenItemFlags } from './hiddenItems';
+
+describe('Hidden Items Utilities', () => {
+  const mockItems: HiddenItemData[] = [
+    { flagOffset: 0, flagBit: 0, locationId: 1, itemId: 1 },
+    { flagOffset: 0, flagBit: 1, locationId: 2, itemId: 2 },
+    { flagOffset: 1, flagBit: 7, locationId: 3, itemId: 3 },
+  ];
+
+  describe('mergeHiddenItemFlags', () => {
+    it('returns false for all items if flags is undefined', () => {
+      const result = mergeHiddenItemFlags(undefined, mockItems);
+      expect(result).toHaveLength(3);
+      expect(result[0]?.isAcquired).toBe(false);
+      expect(result[1]?.isAcquired).toBe(false);
+      expect(result[2]?.isAcquired).toBe(false);
+    });
+
+    it('throws a RangeError if the offset goes out of bounds', () => {
+      const buffer = new ArrayBuffer(1); // Only 1 byte long
+      const view = new DataView(buffer);
+
+      expect(() => {
+        mergeHiddenItemFlags(view, mockItems);
+      }).toThrowError(RangeError);
+    });
+
+    it('correctly maps flags based on matching bits', () => {
+      const buffer = new ArrayBuffer(2);
+      const view = new DataView(buffer);
+
+      // Set byte 0: 0000 0001 (bit 0 is 1)
+      view.setUint8(0, 1);
+      // Set byte 1: 1000 0000 (bit 7 is 1)
+      view.setUint8(1, 128);
+
+      const result = mergeHiddenItemFlags(view, mockItems);
+      expect(result[0]?.isAcquired).toBe(true);
+      expect(result[1]?.isAcquired).toBe(false); // bit 1 of byte 0 is 0
+      expect(result[2]?.isAcquired).toBe(true);
+    });
+
+    it('correctly maps flags when some bits do not match', () => {
+      const buffer = new ArrayBuffer(2);
+      const view = new DataView(buffer);
+
+      // Set byte 0: 0000 0010 (bit 1 is 1)
+      view.setUint8(0, 2);
+      view.setUint8(1, 0);
+
+      const result = mergeHiddenItemFlags(view, mockItems);
+      expect(result[0]?.isAcquired).toBe(false);
+      expect(result[1]?.isAcquired).toBe(true);
+      expect(result[2]?.isAcquired).toBe(false);
+    });
+  });
+
+  describe('Filtering utilities', () => {
+    const mixedItems: HiddenItemData[] = [
+      { flagOffset: 0, flagBit: 0, locationId: 1, itemId: 1, isAcquired: true },
+      { flagOffset: 0, flagBit: 1, locationId: 2, itemId: 2, isAcquired: false },
+      { flagOffset: 1, flagBit: 7, locationId: 3, itemId: 3 }, // isAcquired undefined
+    ];
+
+    describe('getAcquiredHiddenItems', () => {
+      it('returns only items where isAcquired is true', () => {
+        const result = getAcquiredHiddenItems(mixedItems);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.itemId).toBe(1);
+      });
+    });
+
+    describe('getRemainingHiddenItems', () => {
+      it('returns items where isAcquired is false or undefined', () => {
+        const result = getRemainingHiddenItems(mixedItems);
+        expect(result).toHaveLength(2);
+        expect(result[0]?.itemId).toBe(2);
+        expect(result[1]?.itemId).toBe(3);
+      });
+    });
+  });
+});

--- a/src/engine/saveParser/utils/hiddenItems.ts
+++ b/src/engine/saveParser/utils/hiddenItems.ts
@@ -1,0 +1,46 @@
+import type { HiddenItemData } from '../../../db/schema';
+
+export const BITMASK_ACQUIRED = 1;
+
+/**
+ * Merges raw parsed event flags with statically defined hidden items.
+ *
+ * @param flags - The raw binary data of the event flags, or undefined.
+ * @param items - The statically defined HiddenItemData objects.
+ * @returns A new array of HiddenItemData with `isAcquired` populated.
+ * @throws RangeError if a flagOffset goes out of bounds.
+ */
+export function mergeHiddenItemFlags(flags: DataView | undefined, items: HiddenItemData[]): HiddenItemData[] {
+  return items.map((item) => {
+    let isAcquired = false;
+    if (flags) {
+      try {
+        const byte = flags.getUint8(item.flagOffset);
+        isAcquired = ((byte >> item.flagBit) & BITMASK_ACQUIRED) === BITMASK_ACQUIRED;
+      } catch (error) {
+        if (error instanceof RangeError) {
+          throw new RangeError(`Out of bounds read for HiddenItemData at offset ${item.flagOffset}`);
+        }
+        throw error;
+      }
+    }
+    return {
+      ...item,
+      isAcquired,
+    };
+  });
+}
+
+/**
+ * Returns a filtered array of HiddenItemData containing only the items that have been acquired.
+ */
+export function getAcquiredHiddenItems(items: HiddenItemData[]): HiddenItemData[] {
+  return items.filter((item) => item.isAcquired === true);
+}
+
+/**
+ * Returns a filtered array of HiddenItemData containing only the items that have NOT been acquired.
+ */
+export function getRemainingHiddenItems(items: HiddenItemData[]): HiddenItemData[] {
+  return items.filter((item) => item.isAcquired === false || item.isAcquired === undefined);
+}


### PR DESCRIPTION
Implemented hidden items aggregation utilities in \`src/engine/saveParser/utils/hiddenItems.ts\` based on \`task-126-194-hidden-items-aggregation-impl\`. The utilities use \`DataView\` to parse the binary payload, prevent magic numbers, and explicitly handle out of bounds \`RangeError\`. Tests are included in \`src/engine/saveParser/utils/hiddenItems.test.ts\`. Checked off all the task acceptance criteria checkboxes.

---
*PR created automatically by Jules for task [14065136062561741134](https://jules.google.com/task/14065136062561741134) started by @szubster*