### PR TITLE
chore: check off acceptance criteria for task-106-159

### DIFF
--- a/.foundry/tasks/task-106-159-dag-utils-unit-tests-impl.md
+++ b/.foundry/tasks/task-106-159-dag-utils-unit-tests-impl.md
@@ -33,7 +33,7 @@ This task implements unit tests for the shared DAG utility functions located in 
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] `.github/scripts/dag-utils.test.ts` is created.
-- [ ] Unit tests for `buildReverseDependencyGraph` are implemented.
-- [ ] Unit tests for `getOrphanedNodes` are implemented.
-- [ ] All tests pass successfully (`pnpm install && npx vitest run`).
+- [x] `.github/scripts/dag-utils.test.ts` is created.
+- [x] Unit tests for `buildReverseDependencyGraph` are implemented.
+- [x] Unit tests for `getOrphanedNodes` are implemented.
+- [x] All tests pass successfully (`pnpm install && npx vitest run`).


### PR DESCRIPTION
Closes task-106-159-dag-utils-unit-tests-impl. The target artifact `.github/scripts/dag-utils.test.ts` was already completed, along with passing tests. Submitted an empty PR in accordance with ADR 009 (Enforce Acceptance Criteria Checkboxes Before Empty PR Auto-Merge) by checking off the necessary boxes.

---
*PR created automatically by Jules for task [9565618731398937782](https://jules.google.com/task/9565618731398937782) started by @szubster*