### PR TITLE
chore(foundry): handle impossible loop for gen3 roamer location radar

### DIFF
--- a/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+++ b/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
@@ -36,3 +36,6 @@ Develop a dashboard view that presents the exact state of the roaming Pokémon, 
 - [ ] Implement a visual warning indicator for the IV Glitch.
 - [ ] Ensure seamless integration with the Route Radar UI component.
 - [ ] Story Owner: Break down this Epic into executable Stories.
+
+### Auditor Rejection
+**CANCELLED:** This Epic has been cancelled and replaced by `epic-044-097-gen3-roamer-dashboard-ui-v2.md` because its dependency on the cancelled `epic-044-072-gen3-roamer-location-radar` created an impossible loop deadlock. The replacement epic depends on a new research node (`research-044-210-investigate-location-radar-failure`) to determine how to proceed with the UI without the location radar.

--- a/.foundry/epics/epic-044-097-gen3-roamer-dashboard-ui-v2.md
+++ b/.foundry/epics/epic-044-097-gen3-roamer-dashboard-ui-v2.md
@@ -1,0 +1,38 @@
+---
+id: epic-044-097-gen3-roamer-dashboard-ui-v2
+type: EPIC
+title: Gen 3 Roamer Dashboard UI V2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on:
+  - epic-044-070-gen3-roamer-core-extraction
+  - epic-044-071-gen3-roamer-iv-glitch
+  - research-044-210-investigate-location-radar-failure
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Dashboard UI V2
+
+## Objective
+Create a user interface to display the comprehensive breakdown of the roaming legendary's internal state, adjusting for the lack of explicit map coordinates.
+
+## Description
+Develop a dashboard view that presents the exact state of the roaming Pokémon, utilizing the parsed data. It should clearly display the Pokémon's Nature, individual IVs, current HP, and status condition. It should provide a prominent warning if the IV Glitch has corrupted its stats. Since precise map locations cannot be extracted (as per `adr-108-027`), the UI must rely on the research from `research-044-210` to determine the best alternative visual representation (e.g. tracking "Active" status flags instead of map routes).
+
+## Acceptance Criteria
+- [ ] Build a UI component to display the roamer's Nature, IVs, HP, and Status.
+- [ ] Implement a visual warning indicator for the IV Glitch.
+- [ ] Implement alternative tracking indicators based on the findings from `research-044-210`.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -23,3 +23,11 @@ Additionally, when a PRD relies on its generated child Epics to be completed, it
 Furthermore, generated Epics MUST have their dependencies explicitly defined. For example, if an Epic is for Visual Regression Testing, its `depends_on` array must contain the IDs of the Epics that build the UI components it will test. Failure to set these dependencies allows the testing Epic to run concurrently with the UI Epic, resulting in immediate failures.
 ### Lessons Learned: Bash scripts using `printf` with numbers containing leading zeros (e.g., `091`) will fail due to invalid octal interpretation. Strip leading zeros before mathematical operations or use Python for accurate zero-padded sequence generation.
 ### Lessons Learned: Execution Plan Verification Rule: If files are generated or modified via custom scripts, the execution plan must include an explicit step to verify the exact contents of the resulting files using `read_file`, as well as a step to clean up any temporary scratchpad scripts using `rm`, before proceeding to testing or pre-commit.
+
+## 2026-06-20: Handling Impossibility Constraints & Node Failures
+When an Epic fails permanently (e.g., due to an architectural impossibility discovered by the Auditor, such as extracting Gen 3 roamer locations dynamically), and that Epic acts as a dependency for other pending Epics (e.g., the Dashboard UI Epic), this creates an impossible loop. The correct response is:
+1. Do not modify the YAML frontmatter of the stranded pending nodes (e.g. Dashboard UI).
+2. Append a `CANCELLED` notice inside their markdown body.
+3. Spawn a new `RESEARCH` node to investigate alternative solutions given the new constraint.
+4. Spawn replacement `EPIC` nodes (e.g., Dashboard UI V2) that depend on this new research node.
+5. Append these new generated child nodes (both the research and replacement epic) as unchecked tasks (`- [ ]`) in the parent PRD's markdown body.

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -36,3 +36,5 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
 - [ ] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
 - [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [ ] .foundry/research/research-044-210-investigate-location-radar-failure.md
+- [ ] .foundry/epics/epic-044-097-gen3-roamer-dashboard-ui-v2.md

--- a/.foundry/research/research-044-210-investigate-location-radar-failure.md
+++ b/.foundry/research/research-044-210-investigate-location-radar-failure.md
@@ -1,0 +1,37 @@
+---
+id: research-044-210-investigate-location-radar-failure
+type: RESEARCH
+title: Investigate Gen 3 Roamer Location Radar Epic Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - map
+research_references:
+  - .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
+  - .foundry/docs/adrs/adr-108-027-gen3-roamer-location-impossible.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 3 Roamer Location Radar Epic Failure
+
+## Objective
+Investigate the failure of the Gen 3 Roamer Location Radar epic (`epic-044-072-gen3-roamer-location-radar.md`) and determine the necessary adjustments to the dashboard UI requirements.
+
+## Context
+The Gen 3 Roamer Location Radar epic was permanently cancelled by the Auditor because, as established in `adr-108-027-gen3-roamer-location-impossible`, the active map coordinates for a roaming Pokémon are stored dynamically in EWRAM during gameplay and are never serialized to the static save file.
+
+Because `epic-044-073-gen3-roamer-dashboard-ui.md` was waiting on the location radar epic (which is now cancelled), it is stuck in a pending state with a permanently failed dependency.
+
+## Acceptance Criteria
+- [ ] Determine how the Gen 3 Roamer Dashboard UI should be redesigned or updated given that location tracking is impossible.
+- [ ] Document what alternative UI tracking indicators (if any) are viable using the available roamer flags and IVs.


### PR DESCRIPTION
Resolves the impossible loop deadlock caused by the permanently cancelled `epic-044-072-gen3-roamer-location-radar` dependency.

This change adheres to the Foundry system constraints by:
1. Not modifying the YAML frontmatter of the stranded `epic-044-073`.
2. Appending a `CANCELLED` notice inside its markdown body.
3. Spawning a new `RESEARCH` node to investigate alternative UI solutions given the new constraint.
4. Spawning a replacement `EPIC` node (Dashboard UI V2) that depends on this new research node.
5. Appending these new generated child nodes as unchecked tasks in the parent PRD's markdown body.
6. Recording this pattern in the Epic Planner's journal.

---
*PR created automatically by Jules for task [8639074659998454299](https://jules.google.com/task/8639074659998454299) started by @szubster*