### PR TITLE
feat: implement strict jules_session_id validation in heartbeat

### DIFF
--- a/.foundry/tasks/task-134-187-session-id-validator-impl.md
+++ b/.foundry/tasks/task-134-187-session-id-validator-impl.md
@@ -33,6 +33,6 @@ As part of the Zombie Node Detection Engine (Epic 050), we need to extract and s
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 3. Acceptance Criteria
-- [ ] Implement robust extraction logic for `jules_session_id`.
-- [ ] Implement format and existence validation for the extracted ID.
-- [ ] Create or update tests handling cases with valid, null, missing, or malformed session IDs.
+- [x] Implement robust extraction logic for `jules_session_id`.
+- [x] Implement format and existence validation for the extracted ID.
+- [x] Create or update tests handling cases with valid, null, missing, or malformed session IDs.

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -172,7 +172,6 @@ ok: true,
     vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
     vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
 
-    // Mock API requests done in the cleanup phase to prevent them from failing the mock verification
     globalFetch.mockResolvedValue({
       ok: true,
       status: 200,
@@ -208,8 +207,110 @@ ok: true,
 
     await main();
 
-    // we need to filter out the cleanup fetch calls before ensuring the regular global fetch wasn't called.
-    // Github list PRs is called for remote branch cleanup
+    expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('should transition a node to FAILED if jules_session_id is empty string', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: ""
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: ""\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    globalFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => []
+    } as unknown as Response);
+
+    await main();
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('should transition a node to FAILED if jules_session_id is whitespace only', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: "   "
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: "   "\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    globalFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => []
+    } as unknown as Response);
+
+    await main();
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('should transition a node to FAILED if jules_session_id is literal "null"', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: "null"
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: "null"\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    globalFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => []
+    } as unknown as Response);
+
+    await main();
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('should transition a node to FAILED if jules_session_id is literal "undefined"', async () => {
+    const mockNode = {
+      filePath: '/mock/repo/.foundry/tasks/task-1.md',
+      repoPath: '.foundry/tasks/task-1.md',
+      frontmatter: {
+        id: 'task-1',
+        status: 'ACTIVE',
+        jules_session_id: "undefined"
+      },
+      rawContent: '---\nstatus: ACTIVE\njules_session_id: "undefined"\nupdated_at: "2023-01-01"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/tasks/task-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockReturnValue(mockNode as any);
+
+    globalFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => []
+    } as unknown as Response);
+
+    await main();
+
     expect(fs.writeFileSync).toHaveBeenCalled();
   });
 

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -25,6 +25,15 @@ function info(msg: string): void {
 
 const TERMINAL_STATES = ['FAILED', 'COMPLETED'];
 
+/** Extracts and strictly validates jules_session_id from a node */
+function getSessionId(node: any): string | null {
+  const rawId = node.frontmatter.jules_session_id;
+  if (typeof rawId !== 'string') return null;
+  const trimmed = rawId.trim();
+  if (!trimmed || trimmed === 'null' || trimmed === 'undefined') return null;
+  return trimmed;
+}
+
 /** Surgical mutation to FAILED */
 export async function transitionNodeToFailed(node: any, repoRoot: string, rejectionReason?: string): Promise<void> {
   const dateStr = todayISO();
@@ -317,12 +326,12 @@ export async function main() {
 
   // --- Pass 1: Check ACTIVE Nodes ---
   for (const node of activeNodes) {
-    const sessionId = node.frontmatter.jules_session_id;
+    const sessionId = getSessionId(node);
     const isHuman = node.frontmatter.owner_persona === 'human';
 
-    if (!isHuman && (!sessionId || sessionId === 'null') && (node.frontmatter.status === 'ACTIVE' || node.frontmatter.status === 'VERIFYING')) {
+    if (!isHuman && !sessionId && (node.frontmatter.status === 'ACTIVE' || node.frontmatter.status === 'VERIFYING')) {
       warn(`Node ${node.repoPath} is ${node.frontmatter.status} but missing session ID. Failing.`);
-      await transitionNodeToFailed(node, repoRoot, `${node.frontmatter.status} node missing session ID`);
+      await transitionNodeToFailed(node, repoRoot, `${node.frontmatter.status} node missing or malformed session ID`);
       continue;
     }
 
@@ -502,9 +511,9 @@ export async function identifyBranchesForCleanup(repoRoot: string, remoteBranche
     if (!node) continue;
 
     const status = node.frontmatter.status;
-    const sessionId = node.frontmatter.jules_session_id;
+    const sessionId = getSessionId(node);
 
-    if (!sessionId || sessionId === 'null') {
+    if (!sessionId) {
       continue;
     }
 


### PR DESCRIPTION
This PR implements the requirements for TASK `task-134-187-session-id-validator-impl`.

It adds robust extraction logic for `jules_session_id` within the `foundry-heartbeat.ts` script. Previously, nodes could bypass validation if `jules_session_id` was misconfigured or parsed in an unexpected format by `gray-matter` (e.g., empty strings, whitespace, literal string `"null"`). 

This update introduces a `getSessionId` helper that explicitly checks for and handles these invalid states, safely transitioning the associated node to `FAILED` instead of causing runtime errors or missed validations.

New tests have been added to `.github/scripts/foundry-heartbeat.test.ts` to explicitly cover these edge cases, and all tests pass successfully. Acceptance criteria have been marked complete in the task markdown file.

---
*PR created automatically by Jules for task [1943286251563558064](https://jules.google.com/task/1943286251563558064) started by @szubster*