### PR TITLE
Fix: Check off cancelled child story in epic-047-081

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -43,7 +43,7 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [x] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
-- [ ] story-081-122-gen3-rtc-extraction
+- [x] story-081-122-gen3-rtc-extraction
 - [ ] story-081-123-gen3-active-swarm-parsing
 - [ ] story-081-124-gen3-event-forecast-schedule
 - [ ] research-081-144-gen3-rtc-strategy


### PR DESCRIPTION
Checked off the cancelled `story-081-122-gen3-rtc-extraction` child story in the Acceptance Criteria of `.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md`. The replacement story `story-081-144` was already present. This fulfills the `story_owner` requirement to track cancelled stories in the parent Epic while submitting an empty PR to allow the orchestrator's late-binding demotion mechanism to reset the Epic to PENDING since other children are still pending.

---
*PR created automatically by Jules for task [6416057016550280047](https://jules.google.com/task/6416057016550280047) started by @szubster*