### PR TITLE
Draft technical tasks for macro node completion ADR updates

### DIFF
--- a/.foundry/stories/story-071-109-update-adr001-macro-node-completion.md
+++ b/.foundry/stories/story-071-109-update-adr001-macro-node-completion.md
@@ -37,3 +37,5 @@ Update `.foundry/docs/adrs/001-the-foundry-architecture.md` (ADR 001) to reflect
 ## Tasks
 - [ ] task-109-161-update-adr001-macro-node-completion-impl
 - [ ] .foundry/tasks/task-109-192-update-adr001-formatting-rules-impl.md
+- [ ] .foundry/tasks/task-109-212-update-adr001-macro-node-completion-impl.md
+- [ ] .foundry/tasks/task-109-213-update-adr001-formatting-rules-impl.md

--- a/.foundry/tasks/task-109-212-update-adr001-macro-node-completion-impl.md
+++ b/.foundry/tasks/task-109-212-update-adr001-macro-node-completion-impl.md
@@ -1,0 +1,40 @@
+---
+id: task-109-212-update-adr001-macro-node-completion-impl
+type: TASK
+title: Implement macro node completion rules in ADR 001
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-071-109-update-adr001-macro-node-completion
+tags:
+  - orchestrator
+  - adr
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement macro node completion rules in ADR 001
+
+## Context
+With the introduction of strict hierarchical completion in the orchestrator, macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) cannot complete until all descendant nodes are `COMPLETED` or `CANCELLED`. Our system documentation needs to reflect these new constraints.
+
+## Objective
+Update `.foundry/docs/adrs/001-the-foundry-architecture.md` to detail the new macro node completion rules.
+
+## Requirements
+1. Update `.foundry/docs/adrs/001-the-foundry-architecture.md` (ADR 001) to reflect the strict completion checks.
+2. Specifically, add a rule to Section 7 ("System Invariants") or an appropriate section stating that macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) MUST NOT transition to `COMPLETED` until all of their descendant nodes in the DAG have reached the `COMPLETED` or `CANCELLED` status. A macro node with pending, active, or failed descendants is inherently incomplete.
+3. This task is low risk (documentation only), so the coder is responsible for self-verifying the changes. No separate QA task has been created.
+4. Reminder: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+5. Reminder: If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+6. Reminder: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior of macro nodes completion.

--- a/.foundry/tasks/task-109-213-update-adr001-formatting-rules-impl.md
+++ b/.foundry/tasks/task-109-213-update-adr001-formatting-rules-impl.md
@@ -1,0 +1,44 @@
+---
+id: task-109-213-update-adr001-formatting-rules-impl
+type: TASK
+title: Update ADR 001 with parent-child formatting rules for macro nodes
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-20'
+updated_at: '2026-06-20'
+depends_on:
+  - task-109-212-update-adr001-macro-node-completion-impl
+jules_session_id: null
+pr_number: null
+parent: story-071-109-update-adr001-macro-node-completion
+tags:
+  - orchestrator
+  - adr
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update ADR 001 with parent-child formatting rules for macro nodes
+
+## Context
+Macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) cannot complete until all descendant nodes are `COMPLETED`. We must update our architectural documentation to instruct personas on how to correctly format these parent-child relationships.
+
+## Objective
+Update `.foundry/docs/adrs/001-the-foundry-architecture.md` (ADR 001) to detail how personas must format parent-child relationships to comply with macro node completion constraints.
+
+## Requirements
+1. Update `.foundry/docs/adrs/001-the-foundry-architecture.md` (ADR 001), specifically Section 7 ("System Invariants") or a related section, to state the following rules for generating child nodes:
+   - Append references to newly generated child nodes as unchecked tasks (`- [ ] <file_path>`) directly into the markdown body of the parent node.
+   - Do NOT modify the parent's YAML frontmatter.
+   - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
+   - Do NOT submit an Empty PR to transition a macro node to VERIFYING until ALL of its generated child nodes have transitioned to COMPLETED.
+2. This is a low-risk documentation task, so the Coder is responsible for self-verifying. No separate QA task is required.
+3. Reminder for Coder/QA: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to status: FAILED with a rejection_reason.
+4. Reminder for Coder/QA: If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to status: CANCELLED with a rejection_reason.
+5. Reminder for Coder/QA: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Update `001-the-foundry-architecture.md` to detail how to format parent-child relationships for macro nodes.


### PR DESCRIPTION
Drafted two new TASK nodes for the coder to update ADR 001 with the strict macro node completion constraints and parent-child formatting rules. Appended these new tasks to the story markdown body as unchecked items.

---
*PR created automatically by Jules for task [16067376261874940412](https://jules.google.com/task/16067376261874940412) started by @szubster*