### PR TITLE
chore(foundry): Propose Egg Groups DB addition and cancel stale blocked ideas

### DIFF
--- a/.foundry/ideas/idea-021-unified-scheduled-agent-policies.md
+++ b/.foundry/ideas/idea-021-unified-scheduled-agent-policies.md
@@ -2,7 +2,7 @@
 id: idea-021-unified-scheduled-agent-policies
 type: IDEA
 title: Unified Scheduled Agent Policies Module
-status: BLOCKED
+status: CANCELLED
 owner_persona: tpm
 created_at: '2026-05-14'
 updated_at: '2026-05-14'

--- a/.foundry/ideas/idea-056-living-dex-tracker.md
+++ b/.foundry/ideas/idea-056-living-dex-tracker.md
@@ -2,7 +2,7 @@
 id: idea-056-living-dex-tracker
 type: IDEA
 title: Specialized "Living Dex" Organization Tracker UI
-status: BLOCKED
+status: CANCELLED
 owner_persona: tpm
 created_at: '2026-05-18'
 updated_at: '2026-05-18'
@@ -14,7 +14,7 @@ tags:
   - ui
   - living-dex
 notes: ''
-rejection_reason: ACTIVE node missing session ID
+rejection_reason: ''
 rejection_count: 0
 ---
 

--- a/.foundry/ideas/idea-066-enforce-gray-matter-linter.md
+++ b/.foundry/ideas/idea-066-enforce-gray-matter-linter.md
@@ -2,7 +2,7 @@
 id: idea-066-enforce-gray-matter-linter
 type: IDEA
 title: Enforce Gray-Matter Linter for Scripts
-status: BLOCKED
+status: CANCELLED
 owner_persona: tpm
 created_at: '2026-05-25'
 updated_at: '2026-06-17'

--- a/.foundry/ideas/idea-066-save-state-history.md
+++ b/.foundry/ideas/idea-066-save-state-history.md
@@ -2,7 +2,7 @@
 id: idea-066-save-state-history
 type: IDEA
 title: Save State Version History and Metadata Inference
-status: BLOCKED
+status: CANCELLED
 owner_persona: tpm
 created_at: '2026-05-24'
 updated_at: '2026-05-28'
@@ -17,7 +17,7 @@ tags:
   - indexeddb
 research_references: []
 rejection_count: 0
-rejection_reason: ACTIVE node missing session ID
+rejection_reason: ''
 notes: ''
 ---
 

--- a/.foundry/ideas/idea-082-gen3-secret-id-shiny-rng.md
+++ b/.foundry/ideas/idea-082-gen3-secret-id-shiny-rng.md
@@ -2,7 +2,7 @@
 id: idea-082-gen3-secret-id-shiny-rng
 type: IDEA
 title: Gen 3 Secret ID Viewer and Shiny RNG Assistant
-status: BLOCKED
+status: CANCELLED
 owner_persona: tpm
 created_at: '2026-06-16'
 updated_at: '2026-06-17'

--- a/.foundry/ideas/idea-086-add-egg-groups-to-db.md
+++ b/.foundry/ideas/idea-086-add-egg-groups-to-db.md
@@ -1,0 +1,33 @@
+---
+id: idea-086-add-egg-groups-to-db
+type: IDEA
+title: Add Egg Groups and Gender Derivation to DB Schema
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-06-21'
+updated_at: '2026-06-21'
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - database
+  - breeding
+notes: 'Generated autonomously by agile_coach based on repeated task failures (task-084-150, task-084-204).'
+---
+
+# Idea: Add Egg Groups and Gender Derivation to DB Schema
+
+## Context
+Recent implementations for breeding algorithms (`task-084-150-breeding-pair-algorithm-impl`, `task-084-204-breeding-pair-algorithm-impl`) were repeatedly rejected and permanently failed. The rejection reasons indicated missing critical context regarding "Egg Groups" and "Gender derivation logic" in the existing DB schema and PokeAPI ETL scripts. The current offline database schema lacks this fundamental data needed to accurately determine if two Pokémon can breed.
+
+## Proposal
+Extend the global application data schema (`PokeData` / `.jsonl` files) to include breeding metadata.
+1. Extract "Egg Groups" for each Pokémon species during the `scripts/generate-pokedata.ts` ETL phase.
+2. Implement and store the specific Gender derivation values (such as the gender ratio byte or percentage) required to calculate a Pokémon's gender from its DVs (in Gen 2) or PID (in Gen 3).
+3. Ensure this new metadata is integrated into the IndexedDB schema and passed efficiently to the frontend.
+
+## Value Proposition
+This foundational data is an absolute prerequisite for any features related to Daycare tracking, breeding suggestions, or egg move calculators. Providing it natively in the offline DB unblocks the permanently failed breeding UI features and prevents future `coder` and `qa` deadlocks.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD to define the schema additions and the required ETL pipeline changes.


### PR DESCRIPTION
- Created `idea-086-add-egg-groups-to-db.md` to formally request adding missing breeding schema data to the IndexedDB, addressing the root cause of multiple breeding algorithm failures.
- Transitioned several stale `IDEA` nodes incorrectly stuck in `BLOCKED` status to `CANCELLED` and cleared their rejection reasons (e.g. `idea-066-save-state-history`, `idea-056-living-dex-tracker`, `idea-082`, `idea-066-linter`, `idea-021`).

---
*PR created automatically by Jules for task [2021775811155258648](https://jules.google.com/task/2021775811155258648) started by @szubster*