### PR TITLE
feat(gen3): implement Battle Frontier win streaks parsing

### DIFF
--- a/.foundry/tasks/task-121-171-gen3-parse-battle-frontier-win-streaks-impl.md
+++ b/.foundry/tasks/task-121-171-gen3-parse-battle-frontier-win-streaks-impl.md
@@ -49,6 +49,6 @@ Offsets (relative to start of `SaveBlock2`, `0x0000`):
 - `0x0E1E` - `pyramidRecordStreaks`
 
 ## Acceptance Criteria
-- [ ] Extract current win streaks for Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid.
-- [ ] Extract max win records for all 7 facilities.
-- [ ] Implement error handling for out-of-bounds reads.
+- [x] Extract current win streaks for Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid.
+- [x] Extract max win records for all 7 facilities.
+- [x] Implement error handling for out-of-bounds reads.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -92,6 +92,26 @@ export interface Gen3BerryPatch {
   watered4: boolean;
 }
 
+export interface Gen3BattleFrontierFacility2D {
+  winStreaks: number[][]; // [battleModes][levelModes]
+  recordWinStreaks: number[][]; // [battleModes][levelModes]
+}
+
+export interface Gen3BattleFrontierFacility1D {
+  winStreaks: number[]; // [levelModes]
+  recordWinStreaks: number[]; // [levelModes]
+}
+
+export interface Gen3BattleFrontier {
+  tower: Gen3BattleFrontierFacility2D; // [4][2]
+  dome: Gen3BattleFrontierFacility2D; // [2][2]
+  palace: Gen3BattleFrontierFacility2D; // [2][2]
+  arena: Gen3BattleFrontierFacility1D; // [2]
+  factory: Gen3BattleFrontierFacility2D; // [2][2]
+  pike: Gen3BattleFrontierFacility1D; // [2]
+  pyramid: Gen3BattleFrontierFacility1D; // [2]
+}
+
 export interface SaveData {
   /** The generation of the parsed save file (1 or 2). */
   generation: Generation;
@@ -166,6 +186,8 @@ export interface SaveData {
   }[];
   /** Gen 3 specific: The 16-bit daily Mirage Island random value. */
   mirageIslandValue?: number;
+  /** Gen 3 specific: Battle Frontier win streaks and records. */
+  gen3BattleFrontier?: Gen3BattleFrontier;
 }
 
 // Removed byte helper as DataView provides getUint8 natively.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -9,6 +9,7 @@ import {
   parseGen3PokeNews,
   parseGen3Ribbons,
   parseGen3Roamer,
+  parseGen3BattleFrontier,
 } from './gen3';
 
 describe('gen3 parser scaffolding', () => {
@@ -519,5 +520,62 @@ describe('parseGen3Roamer', () => {
     const view = new DataView(buffer);
 
     expect(() => parseGen3Roamer(view, 0, 'ruby')).toThrowError('The save file is corrupted or incomplete.');
+  });
+});
+
+describe('parseGen3BattleFrontier', () => {
+  it('should extract the Battle Frontier win streaks correctly', () => {
+    const buffer = new ArrayBuffer(8192); // Large enough to encompass saveblock offsets
+    const view = new DataView(buffer);
+    const offset = 0x1000; // Mock SaveBlock2 offset
+
+    // Set some sample values for Tower (2D array [4][2])
+    view.setUint16(offset + 0x0ce0, 10, true); // Tower mode 0, level 0
+    view.setUint16(offset + 0x0ce0 + 2, 20, true); // Tower mode 0, level 1
+    view.setUint16(offset + 0x0ce0 + 14, 80, true); // Tower mode 3, level 1
+
+    // Set some sample values for Tower records
+    view.setUint16(offset + 0x0cf0, 15, true);
+    view.setUint16(offset + 0x0cf0 + 14, 85, true);
+
+    // Set some sample values for Arena (1D array [2])
+    view.setUint16(offset + 0x0dda, 30, true); // Arena level 0
+    view.setUint16(offset + 0x0dda + 2, 40, true); // Arena level 1
+
+    // Set some sample values for Pyramid records
+    view.setUint16(offset + 0x0e1e, 50, true);
+    view.setUint16(offset + 0x0e1e + 2, 60, true);
+
+    const result = parseGen3BattleFrontier(view, offset);
+
+    // Assert Tower (2D)
+    expect(result.tower.winStreaks[0][0]).toBe(10);
+    expect(result.tower.winStreaks[0][1]).toBe(20);
+    expect(result.tower.winStreaks[3][1]).toBe(80);
+    expect(result.tower.recordWinStreaks[0][0]).toBe(15);
+    expect(result.tower.recordWinStreaks[3][1]).toBe(85);
+
+    // Assert Arena (1D)
+    expect(result.arena.winStreaks[0]).toBe(30);
+    expect(result.arena.winStreaks[1]).toBe(40);
+
+    // Assert Pyramid records (1D)
+    expect(result.pyramid.recordWinStreaks[0]).toBe(50);
+    expect(result.pyramid.recordWinStreaks[1]).toBe(60);
+
+    // Assert uninitialized values are 0
+    expect(result.dome.winStreaks[0][0]).toBe(0);
+    expect(result.palace.winStreaks[1][1]).toBe(0);
+    expect(result.factory.recordWinStreaks[1][0]).toBe(0);
+    expect(result.pike.winStreaks[0]).toBe(0);
+  });
+
+  it('should explicitly catch RangeError and throw corrupted file error on out-of-bounds reads', () => {
+    // A buffer that is too small for the required offsets
+    const buffer = new ArrayBuffer(0x0e1e + 1);
+    const view = new DataView(buffer);
+
+    // Using a large saveBlock2 offset that pushes the read out of bounds
+    expect(() => parseGen3BattleFrontier(view, 100)).toThrowError('The save file is corrupted or incomplete.');
   });
 });

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -18,7 +18,7 @@
  * is determined by `PV % 24`.
  */
 
-import type { GameVersion, Gen3BerryPatch, Gen3Ribbons, SaveData } from './common';
+import type { GameVersion, Gen3BerryPatch, Gen3Ribbons, SaveData, Gen3BattleFrontier } from './common';
 
 const SIGNATURE = 0x08012025;
 const SECTION_SIZE = 4096;
@@ -387,6 +387,8 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     const mirageIslandOffset = _forcedVersion === 'emerald' ? 0x0464 : 0x0408;
     const mirageIslandValue = parseGen3MirageIslandValue(view, section2Offset + mirageIslandOffset);
 
+    const gen3BattleFrontier = parseGen3BattleFrontier(view, section2Offset);
+
     // Dummy scaffold values for now until fully implemented
     return {
       generation: 3,
@@ -407,8 +409,92 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       gen3BerryPatches,
       hiddenItemFlags,
       mirageIslandValue,
+      gen3BattleFrontier,
       gen3PokeNews,
       gen3MixRecords,
+    };
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+const TOWER_WIN_STREAKS_OFFSET = 0x0ce0;
+const TOWER_RECORD_WIN_STREAKS_OFFSET = 0x0cf0;
+const DOME_WIN_STREAKS_OFFSET = 0x0d0c;
+const DOME_RECORD_WIN_STREAKS_OFFSET = 0x0d14;
+const PALACE_WIN_STREAKS_OFFSET = 0x0dc8;
+const PALACE_RECORD_WIN_STREAKS_OFFSET = 0x0dd0;
+const ARENA_WIN_STREAKS_OFFSET = 0x0dda;
+const ARENA_RECORD_STREAKS_OFFSET = 0x0dde;
+const FACTORY_WIN_STREAKS_OFFSET = 0x0de2;
+const FACTORY_RECORD_WIN_STREAKS_OFFSET = 0x0dea;
+const PIKE_WIN_STREAKS_OFFSET = 0x0e04;
+const PIKE_RECORD_STREAKS_OFFSET = 0x0e08;
+const PYRAMID_WIN_STREAKS_OFFSET = 0x0e1a;
+const PYRAMID_RECORD_STREAKS_OFFSET = 0x0e1e;
+
+/**
+ * Parses the Battle Frontier win streaks from a Gen 3 save file.
+ *
+ * @param view - The raw save file DataView.
+ * @param saveBlock2Offset - The offset within the buffer to the start of SaveBlock2.
+ * @returns The Battle Frontier win streaks data structure.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3BattleFrontier(view: DataView, saveBlock2Offset: number): Gen3BattleFrontier {
+  try {
+    const read1D = (baseOffset: number): number[] => {
+      const arr = [];
+      for (let lvl = 0; lvl < 2; lvl++) {
+        arr.push(view.getUint16(saveBlock2Offset + baseOffset + lvl * 2, true));
+      }
+      return arr;
+    };
+
+    const read2D = (baseOffset: number, battleModes: number): number[][] => {
+      const arr: number[][] = [];
+      for (let battle = 0; battle < battleModes; battle++) {
+        const lvlArr = [];
+        for (let lvl = 0; lvl < 2; lvl++) {
+          lvlArr.push(view.getUint16(saveBlock2Offset + baseOffset + (battle * 2 + lvl) * 2, true));
+        }
+        arr.push(lvlArr);
+      }
+      return arr;
+    };
+
+    return {
+      tower: {
+        winStreaks: read2D(TOWER_WIN_STREAKS_OFFSET, 4),
+        recordWinStreaks: read2D(TOWER_RECORD_WIN_STREAKS_OFFSET, 4),
+      },
+      dome: {
+        winStreaks: read2D(DOME_WIN_STREAKS_OFFSET, 2),
+        recordWinStreaks: read2D(DOME_RECORD_WIN_STREAKS_OFFSET, 2),
+      },
+      palace: {
+        winStreaks: read2D(PALACE_WIN_STREAKS_OFFSET, 2),
+        recordWinStreaks: read2D(PALACE_RECORD_WIN_STREAKS_OFFSET, 2),
+      },
+      arena: {
+        winStreaks: read1D(ARENA_WIN_STREAKS_OFFSET),
+        recordWinStreaks: read1D(ARENA_RECORD_STREAKS_OFFSET),
+      },
+      factory: {
+        winStreaks: read2D(FACTORY_WIN_STREAKS_OFFSET, 2),
+        recordWinStreaks: read2D(FACTORY_RECORD_WIN_STREAKS_OFFSET, 2),
+      },
+      pike: {
+        winStreaks: read1D(PIKE_WIN_STREAKS_OFFSET),
+        recordWinStreaks: read1D(PIKE_RECORD_STREAKS_OFFSET),
+      },
+      pyramid: {
+        winStreaks: read1D(PYRAMID_WIN_STREAKS_OFFSET),
+        recordWinStreaks: read1D(PYRAMID_RECORD_STREAKS_OFFSET),
+      },
     };
   } catch (error) {
     if (error instanceof RangeError) {


### PR DESCRIPTION
This PR implements the logic to extract current and max win streaks for the 7 Battle Frontier facilities from a Generation 3 SaveBlock2 structure. It aligns with the existing data format schemas by extracting 1D and 2D arrays directly utilizing the DataView API. Additionally, test coverage has been provided to assert correct parsing along with out-of-bounds safety checks.

---
*PR created automatically by Jules for task [3973873876007102154](https://jules.google.com/task/3973873876007102154) started by @szubster*