### PR TITLE
🧠 Trainer: Group Nearby Catch Suggestions by Location

### DIFF
--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -322,10 +322,10 @@ describe('generateSuggestions', () => {
 
     const { suggestions } = generateSuggestions(mockSaveData, false, 'red', mockApiData, mockStrategy);
 
-    const nearbySuggestion = suggestions.find((s) => s.id === 'catch-nearby-19');
+    const nearbySuggestion = suggestions.find((s) => s.id === 'catch-nearby-2'); // Note aid is 2
     expect(nearbySuggestion).toBeDefined();
-    expect(nearbySuggestion?.title).toBe('Nearby: #19');
-    expect(nearbySuggestion?.pokemonId).toBe(19);
+    expect(nearbySuggestion?.title).toBe('Nearby: Route 1');
+    expect(nearbySuggestion?.pokemonIds).toContain(19);
     // Best distance is 1. Math.max(10, 110 - 1 * 12) = 110 - 12 = 98
     expect(nearbySuggestion?.priority).toBe(98);
   });

--- a/src/engine/assistant/generators/catchGenerator.ts
+++ b/src/engine/assistant/generators/catchGenerator.ts
@@ -103,6 +103,17 @@ export function generateCatchSuggestions(
   // A2. Nearby logic (1-8 areas away)
   // Distance is calculated via graph traversal in the generation's strategy.
   // Priority dynamically scales inversely with distance (closer = higher priority).
+  const nearbyGroups = new Map<
+    number,
+    {
+      aid: number;
+      areaName: string;
+      distance: number;
+      pids: number[];
+      encounterInfo: Record<number, EncounterDetail[]>;
+    }
+  >();
+
   for (const pid of queryTargets) {
     if (localPids.has(pid)) continue;
 
@@ -142,15 +153,45 @@ export function generateCatchSuggestions(
         });
       }
 
-      suggestions.push({
-        id: `catch-nearby-${pid}`,
-        category: 'Catch',
-        title: `Nearby: #${pid}`,
-        description: `Found at ${bestAreaName} (${bestDist === 0 ? 'very close' : `${bestDist} areas away`}).`,
-        pokemonId: pid,
-        priority: Math.max(10, 110 - bestDist * 12),
-        encounterInfo: { [pid]: bestDetails },
-      });
+      let group = nearbyGroups.get(aid);
+      if (!group) {
+        group = {
+          aid,
+          areaName: bestAreaName,
+          distance: bestDist,
+          pids: [],
+          encounterInfo: {},
+        };
+        nearbyGroups.set(aid, group);
+      }
+      group.pids.push(pid);
+      group.encounterInfo[pid] = bestDetails;
     }
+  }
+
+  for (const group of nearbyGroups.values()) {
+    const pidZero = group.pids[0];
+    const suggestion: import('../strategies/types').CatchSuggestion =
+      group.pids.length === 1 && pidZero !== undefined
+        ? {
+            id: `catch-nearby-${group.aid}`,
+            category: 'Catch',
+            title: `Nearby: ${group.areaName}`,
+            description: `Found 1 missing Pokémon at ${group.areaName} (${group.distance === 0 ? 'very close' : `${group.distance} areas away`}).`,
+            pokemonId: pidZero,
+            pokemonIds: group.pids,
+            priority: Math.max(10, 110 - group.distance * 12),
+            encounterInfo: group.encounterInfo,
+          }
+        : {
+            id: `catch-nearby-${group.aid}`,
+            category: 'Catch',
+            title: `Nearby: ${group.areaName}`,
+            description: `Found ${group.pids.length} missing Pokémon at ${group.areaName} (${group.distance === 0 ? 'very close' : `${group.distance} areas away`}).`,
+            pokemonIds: group.pids,
+            priority: Math.max(10, 110 - group.distance * 12),
+            encounterInfo: group.encounterInfo,
+          };
+    suggestions.push(suggestion);
   }
 }


### PR DESCRIPTION
This PR updates `generateCatchSuggestions` to group "Nearby Catch" suggestions by location (`aid`). Previously, each missing Pokemon found nearby generated its own suggestion card. Now, they are aggregated into a single card per location (e.g. "Found 2 missing Pokémon at Route 1").

**Impact:**
- Significantly reduces UI clutter when many missing Pokemon are clustered in nearby early-game routes.
- Fully backwards compatible with the `CatchSuggestion` type (`pokemonId` vs `pokemonIds`).
- E2E tests and type checks pass.

---
*PR created automatically by Jules for task [1376007356346782375](https://jules.google.com/task/1376007356346782375) started by @szubster*