### PR TITLE
chore: update epic 047-081 to check off cancelled story

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -43,7 +43,7 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [x] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
-- [ ] story-081-122-gen3-rtc-extraction
+- [x] story-081-122-gen3-rtc-extraction
 - [ ] story-081-123-gen3-active-swarm-parsing
 - [ ] story-081-124-gen3-event-forecast-schedule
 - [ ] research-081-144-gen3-rtc-strategy


### PR DESCRIPTION
This PR updates `epic-047-081-gen3-tv-swarm-data-extraction` by checking off the `story-081-122-gen3-rtc-extraction` which has been cancelled. The remaining generated child nodes have been left unchecked because they are still `PENDING` or `READY`, ensuring the parent node remains `PENDING` per the Orchestrator Late-Binding Rule.

---
*PR created automatically by Jules for task [9397996188939520698](https://jules.google.com/task/9397996188939520698) started by @szubster*