### PR TITLE
Foundry: Remove TPM Journal Logging from Orchestrator

### DIFF
--- a/.foundry/tasks/task-076-194-remove-tpm-logging-orchestrator.md
+++ b/.foundry/tasks/task-076-194-remove-tpm-logging-orchestrator.md
@@ -26,7 +26,7 @@ notes: ''
 Based on the findings from the RESEARCH node (`research-076-189-investigate-tpm-journal-bloat`), implement the proposed solution to remove unnecessary routine task verification and state transition logs from being written to the TPM journal (`.foundry/journals/tpm.md`) by the Orchestrator script (`.github/scripts/foundry-orchestrator.ts`) or the Foundry Engine GitHub Action.
 
 ## Acceptance Criteria
-- [ ] Remove or update the logging statements identified in the research phase.
-- [ ] Ensure that no routine or unnecessary logs are written to the TPM journal during Orchestrator runs.
-- [ ] Verify that critical learnings or failures are still properly logged, if applicable according to the revised logging strategy.
-- [ ] Ensure all relevant tests pass.
+- [x] Remove or update the logging statements identified in the research phase.
+- [x] Ensure that no routine or unnecessary logs are written to the TPM journal during Orchestrator runs.
+- [x] Verify that critical learnings or failures are still properly logged, if applicable according to the revised logging strategy.
+- [x] Ensure all relevant tests pass.

--- a/.github/scripts/dag-utils.ts
+++ b/.github/scripts/dag-utils.ts
@@ -1,5 +1,3 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 
 export function todayISO(): string {
   const d = new Date();
@@ -7,12 +5,6 @@ export function todayISO(): string {
   const mm = String(d.getMonth() + 1).padStart(2, '0');
   const dd = String(d.getDate()).padStart(2, '0');
   return `${yyyy}-${mm}-${dd}`;
-}
-
-export function logToJournal(repoRoot: string, entry: string): void {
-  const journalDir = path.join(repoRoot, '.foundry', 'journals');
-  if (!fs.existsSync(journalDir)) fs.mkdirSync(journalDir, { recursive: true });
-  fs.appendFileSync(path.join(journalDir, 'tpm.md'), entry, 'utf-8');
 }
 
 export function buildReverseDependencyGraph(nodes: any[], resolveNodePath: (ref: string) => string | null): Map<string, string[]> {


### PR DESCRIPTION
Foundry: Remove TPM Journal Logging from Orchestrator

Removed the unused `logToJournal` function from `.github/scripts/dag-utils.ts` and checked off the Acceptance Criteria in `.foundry/tasks/task-076-194-remove-tpm-logging-orchestrator.md`.

---
*PR created automatically by Jules for task [12753237476386690884](https://jules.google.com/task/12753237476386690884) started by @szubster*