### PR TITLE
QA: Verify Sweep Active Nodes Utility

### DIFF
--- a/.foundry/tasks/task-133-188-sweep-active-nodes-qa.md
+++ b/.foundry/tasks/task-133-188-sweep-active-nodes-qa.md
@@ -34,6 +34,6 @@ The implementation task (task-133-187-sweep-active-nodes-impl) has built the uti
 - **Reminder**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 3. Acceptance Criteria
-- [ ] Implementations correctly traverses `.foundry/`.
-- [ ] Parsing correctly uses `gray-matter` and filters for `ACTIVE`.
-- [ ] Tests successfully verify the functionality.
+- [x] Implementations correctly traverses `.foundry/`.
+- [x] Parsing correctly uses `gray-matter` and filters for `ACTIVE`.
+- [x] Tests successfully verify the functionality.


### PR DESCRIPTION
This PR verifies the functionality implemented in `task-133-187-sweep-active-nodes-impl`.

- Verified that the utility function recursively iterates through all markdown files in the `.foundry/` directory tree.
- Verified that the YAML frontmatter is parsed using `gray-matter`.
- Verified that the utility correctly filters and returns only the nodes where `status` is `ACTIVE`.
- Ensured that the tests cover both active and non-active nodes.
- Run `pnpm test` successfully.

---
*PR created automatically by Jules for task [16030383422897987893](https://jules.google.com/task/16030383422897987893) started by @szubster*