### PR TITLE
chore: Check off cancelled task nodes in story 084

### DIFF
--- a/.foundry/stories/story-044-084-breeding-pair-algorithm.md
+++ b/.foundry/stories/story-044-084-breeding-pair-algorithm.md
@@ -38,8 +38,8 @@ Develop an algorithm to suggest optimal breeding pairs by cross-referencing Egg 
 
 ## Next Steps
 - [x] Tech Lead: Break down into backend Tasks.
-- [ ] .foundry/tasks/task-084-204-breeding-pair-algorithm-impl.md
-- [ ] .foundry/tasks/task-084-205-breeding-pair-algorithm-qa.md
+- [x] .foundry/tasks/task-084-204-breeding-pair-algorithm-impl.md
+- [x] .foundry/tasks/task-084-205-breeding-pair-algorithm-qa.md
 - [ ] .foundry/research/research-084-209-egg-groups-missing.md
 - [ ] .foundry/tasks/task-084-210-breeding-pair-algorithm-impl.md
 - [ ] .foundry/tasks/task-084-211-breeding-pair-algorithm-qa.md


### PR DESCRIPTION
This PR checks off `task-084-204-breeding-pair-algorithm-impl` and `task-084-205-breeding-pair-algorithm-qa` in their parent story `story-044-084-breeding-pair-algorithm.md`. These tasks were previously marked as `CANCELLED` and replaced by new tasks, but were left unchecked in the parent node, leading to a blocked/invalid DAG state where the orchestrator couldn't correctly resolve the tree.

---
*PR created automatically by Jules for task [13166828553964977102](https://jules.google.com/task/13166828553964977102) started by @szubster*