### PR TITLE
chore: check off cancelled rtc extraction story in epic

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -43,7 +43,7 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [x] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
-- [ ] story-081-122-gen3-rtc-extraction
+- [x] story-081-122-gen3-rtc-extraction
 - [ ] story-081-123-gen3-active-swarm-parsing
 - [ ] story-081-124-gen3-event-forecast-schedule
 - [ ] research-081-144-gen3-rtc-strategy


### PR DESCRIPTION
Checks off the `story-081-122-gen3-rtc-extraction` checkbox in the epic markdown body, as the story was permanently CANCELLED and replaced. The child story nodes already exist.

---
*PR created automatically by Jules for task [10690501529724626189](https://jules.google.com/task/10690501529724626189) started by @szubster*