### PR TITLE
Check off cancelled child nodes in Gen 3 Roamer Tracker PRD

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -34,7 +34,7 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 
 - [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
 - [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
-- [ ] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
-- [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
+- [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
 - [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
 - [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
This PR checks off two cancelled Epic child nodes in the `prd-071-044-gen3-roamer-tracker.md` file.

The `epic-044-072-gen3-roamer-location-radar` and `epic-044-073-gen3-roamer-dashboard-ui` Epics were cancelled because the underlying feature (static roamer location map mapping) was found to be impossible, as documented in ADR 108.

By checking these off, the PRD satisfies the orchestrator requirements to ignore these tasks in the completeness calculation, while still keeping the PRD itself pending for the remaining active child nodes (like the replacement dashboard).

---
*PR created automatically by Jules for task [2143285072990530011](https://jules.google.com/task/2143285072990530011) started by @szubster*