### PR TITLE
Check off CANCELLED child story in epic

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -43,7 +43,7 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [x] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
-- [ ] story-081-122-gen3-rtc-extraction
+- [x] story-081-122-gen3-rtc-extraction
 - [ ] story-081-123-gen3-active-swarm-parsing
 - [ ] story-081-124-gen3-event-forecast-schedule
 - [ ] research-081-144-gen3-rtc-strategy


### PR DESCRIPTION
Checked off the CANCELLED child story `story-081-122-gen3-rtc-extraction` in the parent Epic `epic-047-081-gen3-tv-swarm-data-extraction.md` to satisfy DAG constraints and allow progression once the remaining active stories complete.

---
*PR created automatically by Jules for task [13375080902080305168](https://jules.google.com/task/13375080902080305168) started by @szubster*