### PR TITLE
QA: Verify API query for jules_session_id liveliness

### DIFF
--- a/.foundry/tasks/task-135-192-session-api-integration-qa.md
+++ b/.foundry/tasks/task-135-192-session-api-integration-qa.md
@@ -32,9 +32,9 @@ Verify the implementation of the API query used to check the liveliness of a \`j
 - Test error scenarios (network failure, missing authentication, run not found).
 
 ## 3. Acceptance Criteria
-- [ ] Create tests to mock API responses and verify correct liveliness determination.
-- [ ] Ensure all mock scenarios (active, terminated, error) are covered.
-- [ ] Run tests to ensure they pass correctly.
+- [x] Create tests to mock API responses and verify correct liveliness determination.
+- [x] Ensure all mock scenarios (active, terminated, error) are covered.
+- [x] Run tests to ensure they pass correctly.
 
 ## 4. Notes
 - If a transient failure occurs, transition this node to \`FAILED\` with a \`rejection_reason\`. If permanent, \`CANCELLED\`.

--- a/.github/scripts/session-api.test.ts
+++ b/.github/scripts/session-api.test.ts
@@ -1,0 +1,109 @@
+import { test, expect, vi, describe, beforeEach, afterEach } from 'vitest';
+import { checkSessionLiveliness } from './session-api';
+
+describe('checkSessionLiveliness', () => {
+    const MOCK_JULES_KEY = 'test_jules_key';
+    const MOCK_SESSION_ID = 'test_session_id';
+
+    let stderrWriteSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        // Suppress expected error logs during tests
+        stderrWriteSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test('returns TERMINATED on HTTP 404', async () => {
+        // @ts-ignore
+        global.fetch = vi.fn<any>(() => Promise.resolve({
+            status: 404,
+            ok: false
+        }));
+
+        const result = await checkSessionLiveliness(MOCK_SESSION_ID, MOCK_JULES_KEY);
+        expect(result).toBe('TERMINATED');
+        expect(global.fetch).toHaveBeenCalledWith(`https://jules.googleapis.com/v1alpha/sessions/${MOCK_SESSION_ID}`, {
+            headers: { 'X-Goog-Api-Key': MOCK_JULES_KEY }
+        });
+        expect(stderrWriteSpy).not.toHaveBeenCalled();
+    });
+
+    test('returns TERMINATED on HTTP non-ok status (e.g. 500)', async () => {
+        // @ts-ignore
+        global.fetch = vi.fn<any>(() => Promise.resolve({
+            status: 500,
+            ok: false
+        }));
+
+        const result = await checkSessionLiveliness(MOCK_SESSION_ID, MOCK_JULES_KEY);
+        expect(result).toBe('TERMINATED');
+        expect(stderrWriteSpy).toHaveBeenCalledWith('[session-api] Jules API error: received status 500\n');
+    });
+
+    test('returns TERMINATED on network fetch error', async () => {
+        // @ts-ignore
+        global.fetch = vi.fn<any>(() => Promise.reject(new Error('Network failure')));
+
+        const result = await checkSessionLiveliness(MOCK_SESSION_ID, MOCK_JULES_KEY);
+        expect(result).toBe('TERMINATED');
+        expect(stderrWriteSpy).toHaveBeenCalledWith('[session-api] Jules API fetch error: Error: Network failure\n');
+    });
+
+    const activeStates = [
+        'STATE_UNSPECIFIED',
+        'QUEUED',
+        'PLANNING',
+        'AWAITING_PLAN_APPROVAL',
+        'AWAITING_USER_FEEDBACK',
+        'IN_PROGRESS',
+        'PAUSED'
+    ];
+
+    for (const state of activeStates) {
+        test(`returns ACTIVE for state: ${state}`, async () => {
+            // @ts-ignore
+            global.fetch = vi.fn<any>(() => Promise.resolve({
+                status: 200,
+                ok: true,
+                json: () => Promise.resolve({ state })
+            }));
+
+            const result = await checkSessionLiveliness(MOCK_SESSION_ID, MOCK_JULES_KEY);
+            expect(result).toBe('ACTIVE');
+        });
+    }
+
+    const terminatedStates = [
+        'FAILED',
+        'COMPLETED'
+    ];
+
+    for (const state of terminatedStates) {
+        test(`returns TERMINATED for state: ${state}`, async () => {
+            // @ts-ignore
+            global.fetch = vi.fn<any>(() => Promise.resolve({
+                status: 200,
+                ok: true,
+                json: () => Promise.resolve({ state })
+            }));
+
+            const result = await checkSessionLiveliness(MOCK_SESSION_ID, MOCK_JULES_KEY);
+            expect(result).toBe('TERMINATED');
+        });
+    }
+
+    test('returns TERMINATED for unrecognized state', async () => {
+        // @ts-ignore
+        global.fetch = vi.fn<any>(() => Promise.resolve({
+            status: 200,
+            ok: true,
+            json: () => Promise.resolve({ state: 'SOME_UNKNOWN_STATE' })
+        }));
+
+        const result = await checkSessionLiveliness(MOCK_SESSION_ID, MOCK_JULES_KEY);
+        expect(result).toBe('TERMINATED');
+    });
+});


### PR DESCRIPTION
This PR completes the QA task to verify the API query used to check the liveliness of a `jules_session_id`.

I created unit tests using `vitest` in `.github/scripts/session-api.test.ts` to mock the Google API `fetch` call and process standard scenarios outlined by `checkSessionLiveliness`. This includes assertions for `ACTIVE` states (e.g. `IN_PROGRESS`, `PLANNING`), `TERMINATED` states (`FAILED`, `COMPLETED`), HTTP 404/500 errors, and network failures.

I also checked off the acceptance criteria checkboxes in `.foundry/tasks/task-135-192-session-api-integration-qa.md`. All workspace tests pass successfully.

---
*PR created automatically by Jules for task [15446818260624168936](https://jules.google.com/task/15446818260624168936) started by @szubster*