### PR TITLE
QA Individual Contest Ribbons Integration

### DIFF
--- a/.foundry/tasks/task-139-210-individual-contest-ribbons-qa.md
+++ b/.foundry/tasks/task-139-210-individual-contest-ribbons-qa.md
@@ -41,6 +41,6 @@ This task is to verify the implementation of `task-139-209-individual-contest-ri
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verify `ContestRibbonsPanel` renders correctly inside `PokemonCaughtDetails` only when `p.ribbons` is defined.
-- [ ] Verify the numerical rank mapping logic (1=Normal, 2=Super, 3=Hyper, 4=Master, 0=Hidden).
-- [ ] Verify proper test coverage for the new component and integration.
+- [x] Verify `ContestRibbonsPanel` renders correctly inside `PokemonCaughtDetails` only when `p.ribbons` is defined.
+- [x] Verify the numerical rank mapping logic (1=Normal, 2=Super, 3=Hyper, 4=Master, 0=Hidden).
+- [x] Verify proper test coverage for the new component and integration.


### PR DESCRIPTION
Checked off acceptance criteria in task-139-210-individual-contest-ribbons-qa.md to complete the QA task after verifying that the component integrates and handles ranks correctly with adequate tests.

---
*PR created automatically by Jules for task [16164931986732063545](https://jules.google.com/task/16164931986732063545) started by @szubster*