### PR TITLE
chore(orchestrator): check off completed tasks for story-070-108-orchestrator-hierarchical-completion-logic

### DIFF
--- a/.foundry/stories/story-070-108-orchestrator-hierarchical-completion-logic.md
+++ b/.foundry/stories/story-070-108-orchestrator-hierarchical-completion-logic.md
@@ -36,10 +36,10 @@ Update `.github/scripts/foundry-orchestrator.ts` to block `VERIFYING` and `COMPL
    - Ensure that `isHierarchicallyIncomplete` correctly considers the extended `parentToChildren` map.
 
 ## Acceptance Criteria
-- [ ] `foundry-orchestrator.ts` correctly extracts markdown body links and treats them as child relationships.
-- [ ] `childToParents` and `parentToChildren` maps are correctly populated.
-- [ ] `isDescendant` accurately traverses multiple parents using `childToParents`.
-- [ ] Hierarchical completion strictly blocks transition when either explicit or markdown-referenced children are incomplete.
+- [x] `foundry-orchestrator.ts` correctly extracts markdown body links and treats them as child relationships.
+- [x] `childToParents` and `parentToChildren` maps are correctly populated.
+- [x] `isDescendant` accurately traverses multiple parents using `childToParents`.
+- [x] Hierarchical completion strictly blocks transition when either explicit or markdown-referenced children are incomplete.
 
-- [ ] .foundry/tasks/task-108-189-hierarchical-completion-impl.md
-- [ ] .foundry/tasks/task-108-190-hierarchical-completion-qa.md
+- [x] .foundry/tasks/task-108-189-hierarchical-completion-impl.md
+- [x] .foundry/tasks/task-108-190-hierarchical-completion-qa.md


### PR DESCRIPTION
Checked off the already completed generated child task nodes (`task-108-189` and `task-108-190`) as well as the acceptance criteria in `story-070-108-orchestrator-hierarchical-completion-logic.md` because all the corresponding tasks have been completed. Left the YAML frontmatter entirely unmodified as per the rule. Also ran `pnpm test` and `pnpm exec vitest run --dir .github/scripts/` to confirm that the changes did not introduce regressions and that `foundry-orchestrator.test.ts` passes successfully.

---
*PR created automatically by Jules for task [16270194261313014339](https://jules.google.com/task/16270194261313014339) started by @szubster*