### PR TITLE
Foundry: Verify epic-071-074-define-tailwind-v4-utilities

### DIFF
--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -155,3 +155,10 @@ While generally QA tasks verify implementations, the coder is always responsible
 
 **Recommendation/Learnings:**
 Do not strictly enforce QA task pairing for every single implementation task if the Tech Lead has deemed the complexity low enough to bypass it.
+
+## 2026-06-21: Verification of Tailwind v4 Tactical Utilities Epic
+
+I verified `epic-071-074-define-tailwind-v4-utilities` and its child stories and tasks.
+
+### Strict Hierarchical Verification for Macro Nodes
+When verifying macro nodes like EPICs, it's critical to recursively check that all spawned descendant nodes (down to the TASK level) have fully transitioned to the COMPLETED state before submitting an empty PR. Relying solely on the parent node's acceptance criteria checkboxes or immediate child nodes can prematurely transition the node to VERIFYING, leading to system inconsistency as the actual implementation might not yet be merged into the codebase. This applies to all deep levels of the spawned sub-tree.


### PR DESCRIPTION
Verified the Epic `epic-071-074-define-tailwind-v4-utilities`.
All `tactical-*` utilities have been appropriately defined using Tailwind v4's `@utility` directive in `src/index.css`.
All Acceptance Criteria and generated stories have been marked as completed in the node's markdown body.

Recorded learnings in `.foundry/journals/auditor.md` regarding the necessity to recursively check the complete tree of spawned descendant tasks before verification, and noting that QA task pairing is flexible at the Tech Lead's discretion.

---
*PR created automatically by Jules for task [7310110675991709257](https://jules.google.com/task/7310110675991709257) started by @szubster*