### PR TITLE
docs(foundry): check off cancelled rtc extraction story in epic 047-081

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -43,7 +43,7 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [x] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
-- [ ] story-081-122-gen3-rtc-extraction
+- [x] story-081-122-gen3-rtc-extraction
 - [ ] story-081-123-gen3-active-swarm-parsing
 - [ ] story-081-124-gen3-event-forecast-schedule
 - [ ] research-081-144-gen3-rtc-strategy


### PR DESCRIPTION
Checked off the cancelled child node `story-081-122-gen3-rtc-extraction` in `.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md` to satisfy the Cancelled Child Node Checklist Rule, while leaving the other PENDING child nodes unchecked according to the Orchestrator Late-Binding Rule for Parent Nodes.

---
*PR created automatically by Jules for task [14392316925673278222](https://jules.google.com/task/14392316925673278222) started by @szubster*