### PR TITLE
chore: check off cancelled child nodes in PRD

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -34,7 +34,7 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 
 - [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
 - [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
-- [ ] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
-- [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
+- [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
 - [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
 - [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
Checked off the permanently cancelled `epic-044-072` and `epic-044-073` in the markdown body of `prd-071-044-gen3-roamer-tracker.md` to satisfy the Cancelled Child Node Checklist Rule, while leaving the remaining active child nodes unchecked to ensure the Orchestrator Late-Binding Rule demotes the parent node to PENDING.

---
*PR created automatically by Jules for task [619482143980431229](https://jules.google.com/task/619482143980431229) started by @szubster*