### PR TITLE
chore: update cancelled child tasks in story 108

### DIFF
--- a/.foundry/stories/story-070-108-gen3-roamer-dataview-extraction.md
+++ b/.foundry/stories/story-070-108-gen3-roamer-dataview-extraction.md
@@ -36,9 +36,9 @@ This story handles the base extraction logic in the save parser for Gen 3. The `
 ## Generated Tasks
 - [x] task-108-161-gen3-roamer-dataview-extraction-impl
 - [x] task-108-162-gen3-roamer-dataview-extraction-qa
-- [ ] task-108-192-gen3-roamer-dataview-extraction-impl
-- [ ] task-108-193-gen3-roamer-dataview-extraction-qa
-- [ ] research-108-194-gen3-roamer-iv-bitfield
+- [x] task-108-192-gen3-roamer-dataview-extraction-impl
+- [x] task-108-193-gen3-roamer-dataview-extraction-qa
+- [x] research-108-194-gen3-roamer-iv-bitfield
 - [ ] research-108-209-gen3-roamer-iv-bitfield
 - [ ] task-108-210-gen3-roamer-dataview-extraction-impl
 - [ ] task-108-211-gen3-roamer-dataview-extraction-qa


### PR DESCRIPTION
Update cancelled child tasks to checked off state in story 108. The replacement child tasks were already present in the list, so they were left unchecked as per the system rules to allow the late-binding completion logic to hold the parent node in `PENDING` state until the newly created child nodes are completed.

---
*PR created automatically by Jules for task [7672965534426267997](https://jules.google.com/task/7672965534426267997) started by @szubster*