### PR TITLE
Update PRD to check off cancelled epics

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -34,7 +34,7 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 
 - [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
 - [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
-- [ ] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
-- [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
+- [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
 - [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
 - [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
Updated the PRD `.foundry/prds/prd-071-044-gen3-roamer-tracker.md` to check off the two cancelled child epic nodes (`epic-044-072-gen3-roamer-location-radar` and `epic-044-073-gen3-roamer-dashboard-ui`). This will allow the Orchestrator to correctly handle the PRD node state.

---
*PR created automatically by Jules for task [3505826357804039841](https://jules.google.com/task/3505826357804039841) started by @szubster*