### PR TITLE
chore: check off cancelled tasks in breeding algorithm story

### DIFF
--- a/.foundry/stories/story-044-084-breeding-pair-algorithm.md
+++ b/.foundry/stories/story-044-084-breeding-pair-algorithm.md
@@ -38,8 +38,8 @@ Develop an algorithm to suggest optimal breeding pairs by cross-referencing Egg 
 
 ## Next Steps
 - [x] Tech Lead: Break down into backend Tasks.
-- [ ] .foundry/tasks/task-084-204-breeding-pair-algorithm-impl.md
-- [ ] .foundry/tasks/task-084-205-breeding-pair-algorithm-qa.md
+- [x] .foundry/tasks/task-084-204-breeding-pair-algorithm-impl.md
+- [x] .foundry/tasks/task-084-205-breeding-pair-algorithm-qa.md
 - [ ] .foundry/research/research-084-209-egg-groups-missing.md
 - [ ] .foundry/tasks/task-084-210-breeding-pair-algorithm-impl.md
 - [ ] .foundry/tasks/task-084-211-breeding-pair-algorithm-qa.md


### PR DESCRIPTION
This PR updates the markdown checkboxes in the `story-044-084-breeding-pair-algorithm.md` node. The original implementation and QA tasks (`task-084-204` and `task-084-205`) were permanently cancelled due to missing Egg Groups data.

As per ADR 007 and the Cancelled Child Node Checklist Rule, the checkboxes for these permanently cancelled nodes have been checked off (`[x]`). The replacement nodes (`research-084-209`, `task-084-210`, and `task-084-211`) remain pending and unchecked (`[ ]`).

By submitting this PR, the Heartbeat script will properly evaluate the node and demote it back to `PENDING` due to the pending child nodes, enforcing the Orchestrator Late-Binding Rule.

---
*PR created automatically by Jules for task [16182434507915255576](https://jules.google.com/task/16182434507915255576) started by @szubster*