### PR TITLE
chore(foundry): check off cancelled child nodes in prd-071-044

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -34,7 +34,7 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 
 - [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
 - [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
-- [ ] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
-- [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
+- [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
 - [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
 - [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
This PR resolves the impossible loop rejection by explicitly checking off the `[x]` checkboxes for the permanently cancelled child nodes (`epic-044-072-gen3-roamer-location-radar.md` and `epic-044-073-gen3-roamer-dashboard-ui.md`) within the markdown body of `prd-071-044-gen3-roamer-tracker.md`. 

This satisfies the Cancelled Child Node Checklist Rule and ADR 007, ensuring the PRD's dependencies accurately reflect the cancellation of the impossible features without prematurely marking the entire PRD as VERIFYING (since other child epics are still `PENDING`). The Empty PR allows the Orchestrator's late-binding logic to gracefully demote the PRD node back to `PENDING` until the remaining epics are resolved.

---
*PR created automatically by Jules for task [16134862479437648211](https://jules.google.com/task/16134862479437648211) started by @szubster*