### PR TITLE
chore(foundry): check off cancelled story in epic 047 081

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -43,7 +43,7 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [x] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
-- [ ] story-081-122-gen3-rtc-extraction
+- [x] story-081-122-gen3-rtc-extraction
 - [ ] story-081-123-gen3-active-swarm-parsing
 - [ ] story-081-124-gen3-event-forecast-schedule
 - [ ] research-081-144-gen3-rtc-strategy


### PR DESCRIPTION
This PR updates `epic-047-081-gen3-tv-swarm-data-extraction.md` to check off the `story-081-122-gen3-rtc-extraction` child story, which was permanently cancelled due to architectural changes (ADR 025). 

Following the **Cancelled Child Node Checklist Rule**, this satisfies ADR 007 while leaving the YAML frontmatter intact. The remaining pending stories are deliberately left unchecked, complying with the **Orchestrator Late-Binding Rule for Parent Nodes** to ensure this Epic is properly demoted back to `PENDING` rather than prematurely transitioning to `VERIFYING`.

---
*PR created automatically by Jules for task [13840326053036111943](https://jules.google.com/task/13840326053036111943) started by @szubster*