### PR TITLE
docs(research): Investigate missing egg groups and gen 2 gender mechanics

### DIFF
--- a/.foundry/docs/knowledge_base/engine/gen2-breeding.md
+++ b/.foundry/docs/knowledge_base/engine/gen2-breeding.md
@@ -1,0 +1,30 @@
+# Gen 2 Breeding Mechanics
+
+## Gender and Attack DVs
+In Pokémon Gold, Silver, and Crystal (Gen 2), a Pokémon's gender is intrinsically linked to its Attack Determinant Value (DV, ranging from 0-15).
+
+PokeAPI provides a `gender_rate` value for each Pokémon species, which represents the chance of the Pokémon being female in eighths (e.g., `1` means 1/8 Female, `4` means 1/2 Female).
+- `0` means 100% Male
+- `8` means 100% Female
+- `-1` means Genderless
+
+The female Attack DV threshold in Gen 2 is simply `gender_rate * 2`. A Pokémon is female if its Attack DV is strictly less than this threshold.
+
+### Formula
+```typescript
+function getGen2Gender(attackDV: number, genderRate: number): 'Male' | 'Female' | 'Genderless' {
+    if (genderRate === -1) return 'Genderless';
+    if (genderRate === 0) return 'Male';
+    if (genderRate === 8) return 'Female';
+    const femaleThreshold = genderRate * 2;
+    return attackDV < femaleThreshold ? 'Female' : 'Male';
+}
+```
+
+This mechanical constraint means that female Pokémon of species with a low female ratio (like Starters, which have `gender_rate = 1`) can never have a high Attack DV.
+
+## Egg Groups
+When determining if two Pokémon can breed:
+- If either Pokémon has the 'no-eggs' (15) egg group, they are incompatible.
+- If either is Ditto (13), they are compatible with any non-'no-eggs' Pokémon. (Note: Two Dittos cannot breed with each other).
+- If neither is Ditto, the two Pokémon must share at least one egg group and must be of opposite genders.

--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -39,3 +39,9 @@ When performing research on save file offsets, never blindly trust task descript
 **Lesson**: When investigating recurring task failures for code that appears to be fully functional, check if the root cause is a pipeline violation rather than a code defect.
 - **Example (research-098-189)**: The Gen 3 PV extraction tasks were stuck in a failure/retry loop despite `parseGen3PersonalityValue` already existing and passing tests. The failures were caused by implementers violating the strict Empty PR Policy (ADR 007 and ADR 009) — they submitted empty PRs without checking off the Acceptance Criteria checkboxes in the task markdown, leading to automated rejection and continuous resurrection.
 - **Action**: Always adhere strictly to Empty PR protocols. If the code exists, only update the task markdown to check off the boxes and submit an empty PR. Do not modify the YAML frontmatter.
+
+## Gen 2 Breeding Mechanics
+In Gen 2, gender is intrinsically linked to the Attack DV. The `gender_rate` from PokeAPI represents the female ratio in eighths. The female Attack DV threshold in Gen 2 is simply `gender_rate * 2`. A Pokemon is female if its Attack DV is less than this threshold. This means a Pokemon with a high Attack DV is more likely to be male, creating interesting constraints when trying to breed physical attackers.
+
+## PokeAPI Egg Groups
+Egg groups are retrieved from the `pokemon-species` endpoint. They must be mapped to integer constants to fit within DexHelper's memory-optimized schemas.

--- a/.foundry/research/research-192-209-egg-groups-missing-data.md
+++ b/.foundry/research/research-192-209-egg-groups-missing-data.md
@@ -27,6 +27,52 @@ While implementing `task-084-192-breeding-pair-algorithm-impl`, it was discovere
 In addition, there isn't a known utility to compute Gen 2 Pokemon gender based on Attack DV and Gender Ratio.
 
 ## Objectives
-- Determine how to add Egg Groups to the DB schema (and update `scripts/generate-pokedata.ts`).
-- Determine how to calculate gender using DVs and Gender Ratio (`gr`).
-- Outline the necessary changes to supply this data to the Breeding Algorithm.
+- [x] Determine how to add Egg Groups to the DB schema (and update `scripts/generate-pokedata.ts`).
+- [x] Determine how to calculate gender using DVs and Gender Ratio (`gr`).
+- [x] Outline the necessary changes to supply this data to the Breeding Algorithm.
+
+
+## Findings
+
+### 1. DB Schema & ETL Updates for Egg Groups
+To store egg groups compactly, we can define an `EGG_GROUP_MAP` enum in `src/db/schema.ts`:
+```typescript
+export const EGG_GROUP_MAP: Record<string, number> = {
+  monster: 1, water1: 2, bug: 3, flying: 4, ground: 5, fairy: 6, plant: 7, humanshape: 8,
+  water3: 9, mineral: 10, indeterminate: 11, water2: 12, ditto: 13, dragon: 14, 'no-eggs': 15,
+};
+```
+Then, update `PokemonMetadata` to include `eg?: number[]`.
+In `scripts/generate-pokedata.ts`, we need to parse the `egg_groups` array from the `pokemon-species` API response:
+```typescript
+const eggGroups = sData.egg_groups.map((eg: any) => EGG_GROUP_MAP[eg.name]).filter(Boolean);
+if (eggGroups.length > 0) {
+    pokemonData.eg = eggGroups;
+}
+```
+This ensures the egg group data is properly extracted, transformed, and loaded into the optimized DB.
+
+### 2. Calculating Gender from Gen 2 DVs
+In PokeAPI, `gender_rate` represents the chance of a Pokémon being female in eighths (e.g., `1` = 1/8 Female, `4` = 1/2 Female). `0` means 100% Male, `8` means 100% Female, and `-1` means Genderless.
+In Gen 2, gender is determined directly by comparing the Attack DV (0-15) to a threshold. The threshold is exactly `gender_rate * 2`.
+If `Attack DV < threshold`, the Pokémon is Female. Otherwise, it is Male.
+
+```typescript
+function getGen2Gender(attackDV: number, genderRate: number): 'Male' | 'Female' | 'Genderless' {
+    if (genderRate === -1) return 'Genderless';
+    if (genderRate === 0) return 'Male';
+    if (genderRate === 8) return 'Female';
+    const femaleThreshold = genderRate * 2;
+    return attackDV < femaleThreshold ? 'Female' : 'Male';
+}
+```
+
+### 3. Supplying Data to the Breeding Algorithm
+To integrate this into the Breeding Algorithm:
+1. Ensure both parents have their `PokemonMetadata` loaded to access `eg` (Egg Groups) and `gr` (Gender Rate).
+2. Calculate the gender of both parents using their Attack DVs (from their stats/save data) and the `getGen2Gender` utility.
+3. Check compatibility:
+   - If either Pokémon has the 'no-eggs' (15) egg group, they are incompatible.
+   - If either is Ditto (13), they are compatible with any non-'no-eggs' Pokémon. (Note: Two Dittos cannot breed with each other in Gen 2).
+   - If not Ditto, the two Pokémon must share at least one egg group (array intersection of `eg` > 0).
+   - If they share an egg group, they must be opposite genders (one 'Male' and one 'Female').


### PR DESCRIPTION
This PR concludes the research on `research-192-209-egg-groups-missing-data`. It updates the research node with concrete findings on how to map PokeAPI's `egg_groups` to our integer-based `EGG_GROUP_MAP` enum, defines the mathematical relationship between Gen 2 Attack DVs and PokeAPI's `gender_rate`, and outlines the exact conditions needed for the Breeding Algorithm. The knowledge base has been updated, and the researcher journal has successfully appended the new mechanical constraints without deleting historical memory.

---
*PR created automatically by Jules for task [12323051297088765958](https://jules.google.com/task/12323051297088765958) started by @szubster*