### PR TITLE
Cancel impossible task-105-197 (Gen 3 roamer map extraction)

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -110,3 +110,6 @@ Permanently failed \`task-108-161-gen3-roamer-location-impl\`. As discovered in 
 
 ## 2026-06-19: Late Binding for Breeding Algorithm
 Following the Late Binding pattern, `task-084-192-breeding-pair-algorithm-impl` was suspended (marked `FAILED` with a `rejection_reason` and unchecked checkboxes). A new `RESEARCH` node `research-192-209-egg-groups-missing-data` was spawned and appended to the `depends_on` array because the `PokemonMetadata` schema is missing `egg_groups` data and Gen 2 gender calculation logic (based on DVs and gender ratios) is unknown, making the algorithm impossible to implement safely.
+
+## 2026-06-21: Gen 3 Roamer Location Parsing Limitation
+When assigned a task to extract Gen 3 roamer map coordinates (`mapId` and `mapGroup`) from a save file, the task MUST be cancelled or failed. Per `adr-108-027-gen3-roamer-location-impossible`, the exact map coordinates are exclusively stored in dynamic `EWRAM_DATA` during gameplay and are never serialized into the `.sav` battery save file. Any attempt to parse this data statically is mathematically impossible and will result in failure.

--- a/.foundry/tasks/task-105-197-gen3-roamer-parser-impl.md
+++ b/.foundry/tasks/task-105-197-gen3-roamer-parser-impl.md
@@ -2,7 +2,7 @@
 id: task-105-197-gen3-roamer-parser-impl
 type: TASK
 title: Implement Gen 3 Roamer Parse Logic
-status: ACTIVE
+status: CANCELLED
 owner_persona: coder
 created_at: '2026-06-17'
 updated_at: '2026-06-21'
@@ -18,7 +18,7 @@ tags:
   - parsing
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Extraction of Gen 3 roamer mapId and mapGroup is impossible as they are not serialized in the save file per adr-108-027-gen3-roamer-location-impossible'
 notes: ''
 ---
 


### PR DESCRIPTION
Cancel `task-105-197-gen3-roamer-parser-impl` because it requires extracting Gen 3 roamer map coordinates (`mapGroup` and `mapId`) which are stored dynamically in EWRAM and are not serialized into the save file. This makes static extraction from the `.sav` file mathematically impossible, as defined in `adr-108-027-gen3-roamer-location-impossible`. The coder journal has been updated to reflect this limitation.

---
*PR created automatically by Jules for task [11037981089361676713](https://jules.google.com/task/11037981089361676713) started by @szubster*