### PR TITLE
chore: cancel failed child nodes in story-044-084-breeding-pair-algorithm

### DIFF
--- a/.foundry/stories/story-044-084-breeding-pair-algorithm.md
+++ b/.foundry/stories/story-044-084-breeding-pair-algorithm.md
@@ -38,8 +38,8 @@ Develop an algorithm to suggest optimal breeding pairs by cross-referencing Egg 
 
 ## Next Steps
 - [x] Tech Lead: Break down into backend Tasks.
-- [ ] .foundry/tasks/task-084-204-breeding-pair-algorithm-impl.md
-- [ ] .foundry/tasks/task-084-205-breeding-pair-algorithm-qa.md
+- [x] .foundry/tasks/task-084-204-breeding-pair-algorithm-impl.md
+- [x] .foundry/tasks/task-084-205-breeding-pair-algorithm-qa.md
 - [ ] .foundry/research/research-084-209-egg-groups-missing.md
 - [ ] .foundry/tasks/task-084-210-breeding-pair-algorithm-impl.md
 - [ ] .foundry/tasks/task-084-211-breeding-pair-algorithm-qa.md


### PR DESCRIPTION
- Checked off the checkboxes for the permanently failed/cancelled child nodes (`task-084-204-breeding-pair-algorithm-impl.md` and `task-084-205-breeding-pair-algorithm-qa.md`) inside the `.foundry/stories/story-044-084-breeding-pair-algorithm.md` to properly handle the impossible loop and prevent the orchestrator from blocking on cancelled tasks.
- Leaving the active/pending child tasks' (`task-084-210`, `task-084-211`) checkboxes unchecked to enforce the orchestrator late-binding rule.

---
*PR created automatically by Jules for task [9074682132413017245](https://jules.google.com/task/9074682132413017245) started by @szubster*