### PR TITLE
docs: update styling ownership documentation for palette persona

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -30,3 +30,9 @@ When creating implementation tasks for UI components, explicit integration steps
 
 ## Transient Logs
 System failures, node state transitions (e.g. from FAILED to READY), and "is now COMPLETED" status log entries in Foundry journals add zero value to future runs and unnecessarily expand the context window. Such logs belong in orchestrator execution logs or PR history, not long-term agent journals.
+
+## Styling Ownership (Palette Persona)
+The `palette` persona is the master of the Tailwind and styling ecosystem. This includes:
+1. Maintaining custom primitives in `src/index.css` using the `@utility` directive.
+2. Consolidating repeating utility combinations.
+3. Ensuring styling adherence to the tactical hardware aesthetic guidelines (e.g., `rounded-none`, `border-dashed`, monospaced fonts) as defined in ADR 024.

--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -149,6 +149,7 @@ No persona should ever manually set `status: READY`. The orchestrator calculates
 
 | Value | Role |
 |---|---|
+| `palette` | Master of Tailwind and styling ecosystem. Maintains `src/index.css` and custom tactical `@utility` primitives as per ADR 024. |
 | `product_manager` | Transforms `IDEA` → `PRD`. |
 | `epic_planner` | Transforms `PRD` → `EPIC` breakdown. |
 | `story_owner` | Monitors active epics; writes `STORY` nodes dynamically (late-binding). |

--- a/.foundry/tasks/task-114-201-document-palette-styling-ownership-impl.md
+++ b/.foundry/tasks/task-114-201-document-palette-styling-ownership-impl.md
@@ -38,5 +38,5 @@ You are tasked with fulfilling the documentation update as requested by `story-0
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` is updated.
-- [ ] Documentation accurately reflects `palette` ownership of styling per ADR 024.
+- [x] `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` is updated.
+- [x] Documentation accurately reflects `palette` ownership of styling per ADR 024.


### PR DESCRIPTION
Updates `schema.md` and `core_policies.md` to officially document the `palette` persona's responsibility over styling and Tailwind utilities, referencing ADR 024.

---
*PR created automatically by Jules for task [1910259929368199347](https://jules.google.com/task/1910259929368199347) started by @szubster*