### PR TITLE
🧱 Mason: VerticalDivider and NavigationTab extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -115,3 +115,12 @@
   - Always extend standard HTML attributes (e.g. `React.ButtonHTMLAttributes<HTMLButtonElement>`) and forward refs (`React.forwardRef`) to ensure callers can supply strict accessibility properties (`aria-label`, `title`) without redefining them on the props interface.
   - Set a default `type="button"` on the inner element to prevent accidental form submissions when the component is eventually utilized inside a `fieldset` or `form`.
   - Ensure the internal `className` explicitly allows for overriding absolute positioning and padding since icon-only buttons often serve as absolute-positioned decorators (like close buttons or input clear buttons).
+
+## AppHeader Refactoring - VerticalDivider and NavigationTab
+- **What**: Extracted repeated vertical dashed divider elements (`<div className="w-[1px] border-zinc-800 border-r border-dashed bg-zinc-800" />`) into a reusable `<VerticalDivider>` component.
+- **What**: Extracted repeated navigation link setups inside the main header (incorporating active/inactive tailwind states, corner crosshairs, and monospaced text) into `<NavigationTab>`.
+- **Why**: Cleaned up the heavily dense `AppHeader.tsx`. Consolidating `NavigationTab` ensures we do not have to copy-paste the extremely verbose Tailwind class list and `CornerCrosshairs` setup every time we add a new primary navigational route to the app.
+- **Key Learnings**:
+  - Utilizing `Omit<LinkProps, 'activeProps' | 'inactiveProps' | 'className'>` ensures the parent `<NavigationTab>` strictly governs the styling and routing state styles, preventing accidental overrides from callers while still allowing them to pass standard Tanstack `to` attributes.
+  - Exposing `className` on tiny, structural components like `<VerticalDivider>` using `cn()` is incredibly powerful, because we can trivially apply specific height classes (`className="h-8"`) contextually without rebuilding the component.
+  - To automatically fix formatting errors identified by the Biome linter, execute `pnpm biome check --write .`.

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -7,7 +7,9 @@ import { cn } from '../utils/cn';
 import { getGenerationConfig } from '../utils/generationConfig';
 import { CornerCrosshairs } from './CornerCrosshairs';
 import { InlineDataPoint } from './InlineDataPoint';
+import { NavigationTab } from './NavigationTab';
 import { TacticalButton } from './TacticalButton';
+import { VerticalDivider } from './VerticalDivider';
 
 interface AppHeaderProps {
   saveData: SaveData | null;
@@ -58,47 +60,11 @@ export function AppHeader({
         {saveData && (
           <nav className="mt-4 hidden lg:mt-0 lg:flex lg:flex-1 lg:justify-center">
             <div className="flex bg-zinc-900/30">
-              <Link
-                to="/"
-                activeProps={{
-                  className: 'bg-[var(--theme-primary)]/10 text-[var(--theme-primary)] border-b-[var(--theme-primary)]',
-                }}
-                inactiveProps={{
-                  className: 'border-b-transparent text-zinc-500 hover:text-zinc-300 hover:bg-white/5',
-                }}
-                className="group focus-visible:tactical-focus relative flex flex-col items-center gap-1 border-b-2 border-dashed px-8 py-3 font-black font-mono text-[10px] uppercase tracking-[0.2em] transition-all"
-              >
-                <CornerCrosshairs className="h-1 w-1 border-current opacity-50" />
-                <LayoutGrid size={14} className="mb-1" />[ SYS.DEX ]
-              </Link>
-              <div className="w-[1px] border-zinc-800 border-r border-dashed bg-zinc-800" />
-              <Link
-                to="/storage"
-                activeProps={{
-                  className: 'bg-[var(--theme-primary)]/10 text-[var(--theme-primary)] border-b-[var(--theme-primary)]',
-                }}
-                inactiveProps={{
-                  className: 'border-b-transparent text-zinc-500 hover:text-zinc-300 hover:bg-white/5',
-                }}
-                className="group focus-visible:tactical-focus relative flex flex-col items-center gap-1 border-b-2 border-dashed px-8 py-3 font-black font-mono text-[10px] uppercase tracking-[0.2em] transition-all"
-              >
-                <CornerCrosshairs className="h-1 w-1 border-current opacity-50" />
-                <Database size={14} className="mb-1" />[ SYS.STRG ]
-              </Link>
-              <div className="w-[1px] border-zinc-800 border-r border-dashed bg-zinc-800" />
-              <Link
-                to="/assistant"
-                activeProps={{
-                  className: 'bg-[var(--theme-primary)]/10 text-[var(--theme-primary)] border-b-[var(--theme-primary)]',
-                }}
-                inactiveProps={{
-                  className: 'border-b-transparent text-zinc-500 hover:text-zinc-300 hover:bg-white/5',
-                }}
-                className="group focus-visible:tactical-focus relative flex flex-col items-center gap-1 border-b-2 border-dashed px-8 py-3 font-black font-mono text-[10px] uppercase tracking-[0.2em] transition-all"
-              >
-                <CornerCrosshairs className="h-1 w-1 border-current opacity-50" />
-                <Sparkles size={14} className="mb-1" />[ SYS.ASST ]
-              </Link>
+              <NavigationTab to="/" icon={<LayoutGrid size={14} />} label="SYS.DEX" />
+              <VerticalDivider />
+              <NavigationTab to="/storage" icon={<Database size={14} />} label="SYS.STRG" />
+              <VerticalDivider />
+              <NavigationTab to="/assistant" icon={<Sparkles size={14} />} label="SYS.ASST" />
             </div>
           </nav>
         )}
@@ -118,7 +84,7 @@ export function AppHeader({
               />
             </div>
 
-            <div className="h-8 w-[1px] border-zinc-800 border-r border-dashed bg-zinc-800" />
+            <VerticalDivider className="h-8" />
 
             <div className="flex min-w-[100px] flex-col justify-center px-4">
               <InlineDataPoint
@@ -159,7 +125,7 @@ export function AppHeader({
               <div className="lcd-flicker absolute inset-0 bg-white/5 opacity-0 transition-opacity group-hover:opacity-100" />
             </button>
 
-            <div className="h-6 w-[1px] border-zinc-800 border-r border-dashed bg-zinc-800" />
+            <VerticalDivider className="h-6" />
 
             <TacticalButton
               onClick={() => setIsSettingsOpen(true)}

--- a/src/components/NavigationTab.tsx
+++ b/src/components/NavigationTab.tsx
@@ -1,0 +1,26 @@
+import { Link, type LinkProps } from '@tanstack/react-router';
+import type React from 'react';
+import { CornerCrosshairs } from './CornerCrosshairs';
+
+interface NavigationTabProps extends Omit<LinkProps, 'activeProps' | 'inactiveProps' | 'className'> {
+  icon: React.ReactNode;
+  label: string;
+}
+
+export function NavigationTab({ icon, label, ...props }: NavigationTabProps) {
+  return (
+    <Link
+      {...props}
+      activeProps={{
+        className: 'bg-[var(--theme-primary)]/10 text-[var(--theme-primary)] border-b-[var(--theme-primary)]',
+      }}
+      inactiveProps={{
+        className: 'border-b-transparent text-zinc-500 hover:text-zinc-300 hover:bg-white/5',
+      }}
+      className="group focus-visible:tactical-focus relative flex flex-col items-center gap-1 border-b-2 border-dashed px-8 py-3 font-black font-mono text-[10px] uppercase tracking-[0.2em] transition-all"
+    >
+      <CornerCrosshairs className="h-1 w-1 border-current opacity-50" />
+      <div className="mb-1">{icon}</div>[ {label} ]
+    </Link>
+  );
+}

--- a/src/components/VerticalDivider.tsx
+++ b/src/components/VerticalDivider.tsx
@@ -1,0 +1,8 @@
+import type React from 'react';
+import { cn } from '../utils/cn';
+
+interface VerticalDividerProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function VerticalDivider({ className, ...props }: VerticalDividerProps) {
+  return <div className={cn('w-[1px] border-zinc-800 border-r border-dashed bg-zinc-800', className)} {...props} />;
+}


### PR DESCRIPTION
🎯 What\nExtracted repeated vertical dashed divider elements into a reusable `<VerticalDivider>` component. Extracted repeated navigation link setups inside the main header into `<NavigationTab>`.\n\n💡 Why\nCleaned up the heavily dense `AppHeader.tsx`. Consolidating `NavigationTab` ensures we do not have to copy-paste the extremely verbose Tailwind class list and `CornerCrosshairs` setup every time we add a new primary navigational route to the app. \n\n✅ Verification\n- Tested build successfully (`pnpm test` and `pnpm test:e2e`).\n- Linter passed cleanly (`pnpm lint`).\n\n✨ Result\nCleaner `AppHeader` markup. Less duplicated Tailwind configuration. New `VerticalDivider` that cleanly handles additional classes through `cn()`.

---
*PR created automatically by Jules for task [9572185108729984277](https://jules.google.com/task/9572185108729984277) started by @szubster*