### PR TITLE
🧹 Remove dead types HiddenItemData and MatchCallRematchEntry

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -35,3 +35,6 @@ Before deleting code flagged as dead, always check the status of Foundry tasks (
 ## 2026-06-07 - Verify Unused Code Removals
 **Learning:** Tools like `knip` can identify unused exports and dependencies, but they sometimes have blind spots or misinterpret usage (especially for global configurations, setup scripts, or exported test helpers/fixtures).
 **Action:** When using tools like `knip` to find unused exports or files, always verify potential implicit usage with a global repository search (e.g., `grep`) before removing them to ensure they aren't dynamically referenced by tests or CI scripts.
+
+## 2026-06-25 - Handling Knip False Positives in CI Scripts
+**Learning:** When using `knip` or similar tools to find dead code, be extremely careful of false positives for files implicitly required by tests or CI (e.g., scripts in `.github/scripts/`, `test-setup.ts`, or `fake-indexeddb`). Always manually verify usage with `grep` before deleting files or removing exports.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -140,14 +140,6 @@ export interface PokemonMetadata {
   det: CompactEvolutionDetail[]; // Evolutionary requirements to reach THIS pokemon from parent
 }
 
-export interface HiddenItemData {
-  flagOffset: number;
-  flagBit: number;
-  locationId: number;
-  itemId: number;
-  isAcquired?: boolean;
-}
-
 export interface PokeDataExport {
   poke: PokemonMetadata[];
   enc: LocationAreaEncounters[];

--- a/src/engine/gen3/matchCall/offsets.ts
+++ b/src/engine/gen3/matchCall/offsets.ts
@@ -13,5 +13,3 @@ export const MATCH_CALL_UNLOCK_FLAG_BIT = 7;
 
 // Rematch readiness and tier states
 export const MATCH_CALL_REMATCH_NOT_READY = 0;
-// Where 0 is not ready, >0 means ready and represents the internal tier index
-export type MatchCallRematchEntry = number;


### PR DESCRIPTION
🎯 What
Removed unused type declarations `HiddenItemData` from `src/db/schema.ts` and `MatchCallRematchEntry` from `src/engine/gen3/matchCall/offsets.ts`.

💡 Why
Clean up dead code and reduce technical debt as identified by `knip` tooling, improving the overall codebase health and maintainability.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and pre-commit checks locally which confirmed that these types are not used implicitly by configuration files or tests and deleting them doesn't break any functionality.

✨ Result
Cleaner codebase without unused type definitions.

---
*PR created automatically by Jules for task [1062618660444031441](https://jules.google.com/task/1062618660444031441) started by @szubster*