### PR TITLE
🧭 Strategist: Prompt improvement - Relax QA task pairing enforcement for Auditor

### DIFF
--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -31,3 +31,6 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Journal
 
 When you discover recurring patterns, long-term lessons, architectural constraints, or recurring failures during audits, you MUST generate a memory by updating your persona journal (`.foundry/journals/auditor.md`). Explain *why* the lesson matters. Do not use your journal as a logbook for completed tasks or PRs merged.
+
+## QA Task Verification Pairing Flexibility
+While generally QA tasks verify implementations, the coder is always responsible for writing tests. For simple tasks, it is acceptable for the Tech Lead to decide that the coder's tests and implementation are sufficient without a dedicated, explicit QA task pair. Do not strictly enforce QA task pairing for every single implementation task if the Tech Lead has deemed the complexity low enough to bypass it.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -273,3 +273,9 @@
 **Outcome:** Accepted
 **Why:** The memory requires that context gathering is done using the `read_file` tool rather than bash scripts/`cat` to avoid truncation. Several agent prompts (qa, auditor, researcher, strategist) lacked this explicit `CRITICAL CONTEXT GATHERING INSTRUCTION`. Additionally, the Strategist prompt lacked the `Scratchpad Cleanup` section to prevent repository pollution.
 **Pattern:** Apply systemic rules consistently across all relevant agent personas. When an architectural constraint or tool rule applies to exploration or repository hygiene, it must be explicitly included in all agent prompts to ensure compliance.
+
+## 2026-07-14 - [Accepted] - Prompt improvement - Relax QA task pairing enforcement for Auditor
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The Auditor journal noted that the coder is always responsible for writing tests, and for simple tasks, the Tech Lead can bypass creating a dedicated QA task. The Auditor agent must not falsely reject macro nodes due to missing QA tasks if the Tech Lead deemed them unnecessary.
+**Pattern:** Codify system memory constraints into agent prompts to avoid false-positive rejections. Do not strictly enforce QA task pairing for every single implementation task if the Tech Lead has deemed the complexity low enough.


### PR DESCRIPTION
**Proposal**: Relax the strict requirement for the Auditor persona to expect a paired QA task for every single implementation task.
**Justification**: The Tech Lead persona's Intelligent Verification Protocol allows for bypassing explicit QA tasks for low-complexity or low-risk implementations (since the Coder is responsible for tests). However, the Auditor was sometimes falsely rejecting the verification of parent macro nodes (like stories) if they lacked these QA tasks.
**Evidence**: The Auditor journal explicitly noted this under `### QA Task Verification Pairing Flexibility`, stating: "For simple tasks, it is acceptable for the Tech Lead to decide that the coder's tests and implementation are sufficient without a dedicated, explicit QA task pair."

---
*PR created automatically by Jules for task [1949398642109166619](https://jules.google.com/task/1949398642109166619) started by @szubster*