### PR TITLE
Foundry: properly cancel orphaned epic-044-073

### DIFF
--- a/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+++ b/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
@@ -37,5 +37,5 @@ Develop a dashboard view that presents the exact state of the roaming Pokémon, 
 - [ ] Ensure seamless integration with the Route Radar UI component.
 - [ ] Story Owner: Break down this Epic into executable Stories.
 
-### Cancellation Notice
+### Auditor Rejection
 **CANCELLED:** This epic is cancelled and replaced by `epic-044-096-gen3-roamer-dashboard-ui-v2.md` because its dependency on the Gen 3 Roamer Location Radar is impossible to satisfy.


### PR DESCRIPTION
This PR completes the cancellation of `epic-044-073-gen3-roamer-dashboard-ui.md` following the impossible map radar node failure by updating its markdown body with the `### Auditor Rejection` pattern, allowing the Orchestrator to bypass it and favor the v2 replacement node.

---
*PR created automatically by Jules for task [16060129029438039504](https://jules.google.com/task/16060129029438039504) started by @szubster*