### PR TITLE
chore(foundry): replace impossible gen3 roamer location parsing with alternative tasks

### DIFF
--- a/.foundry/research/research-105-210-gen3-roamer-alternative.md
+++ b/.foundry/research/research-105-210-gen3-roamer-alternative.md
@@ -1,0 +1,37 @@
+---
+id: research-105-210-gen3-roamer-alternative
+type: RESEARCH
+title: Gen 3 Roamer Parsing Alternative Approach
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-22'
+updated_at: '2026-06-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-067-105-gen3-roamer-parser-implementation
+tags:
+  - gen3
+  - roamer
+  - save-offsets
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Parsing Alternative Approach
+
+## Objective
+Investigate an alternative parsing approach for tracking the Gen 3 roaming Pokémon (Latios/Latias in RS/E or Legendary Beast in FRLG), given that extracting dynamic map locations from the save file is impossible as established in `adr-108-027-gen3-roamer-location-impossible`.
+
+## Description
+Determine what data can realistically be extracted from the save file to track the roamer's state. Based on prior research (`gen3_roamer_offsets.md`), we know the `Roamer` struct contains:
+- IVs
+- Personality
+- Species ID
+- HP and Level
+- Status and Contest Stats
+- Active boolean flag
+
+Formulate a new parsing data schema that provides value to the user (e.g., indicating the roamer has been released and is active on the map, its stats if caught/encountered, etc.) without relying on map location mapping.

--- a/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
+++ b/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
@@ -34,3 +34,6 @@ Identify the exact memory offsets for Latios/Latias in Ruby/Sapphire/Emerald sav
 - [ ] .foundry/research/research-105-196-gen3-roamer-event-flag.md
 - [ ] .foundry/tasks/task-105-197-gen3-roamer-parser-impl.md
 - [ ] .foundry/tasks/task-105-198-gen3-roamer-parser-qa.md
+- [ ] .foundry/research/research-105-210-gen3-roamer-alternative.md
+- [ ] .foundry/tasks/task-105-214-gen3-roamer-parser-alternative-impl.md
+- [ ] .foundry/tasks/task-105-215-gen3-roamer-parser-alternative-qa.md

--- a/.foundry/tasks/task-105-214-gen3-roamer-parser-alternative-impl.md
+++ b/.foundry/tasks/task-105-214-gen3-roamer-parser-alternative-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-105-214-gen3-roamer-parser-alternative-impl
+type: TASK
+title: Implement Gen 3 Roamer Alternative Parse Logic
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-22'
+updated_at: '2026-06-22'
+depends_on:
+  - research-105-210-gen3-roamer-alternative
+jules_session_id: null
+pr_number: null
+parent: story-067-105-gen3-roamer-parser-implementation
+tags:
+  - gen3
+  - roamer
+  - parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Roamer Alternative Parse Logic
+
+## Objective
+Implement binary parsing logic in `src/engine/saveParser/parsers/gen3.ts` to extract the available Gen 3 roaming data using the `DataView` API.
+
+## Description
+Based on the alternative approach research, update the Gen 3 parser to extract valid data for the roaming Pokémon (such as `speciesId`, `level`, and the `active` status boolean, or IVs) using the `DataView` API. Do NOT attempt to extract map location data. Ensure that the parser accurately reflects the roamer's active status. Ensure all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. Inline magic numbers are forbidden.
+
+## Acceptance Criteria
+- [ ] Parser extracts species ID and level using DataView.
+- [ ] Parser extracts active status flag using DataView.
+- [ ] Parser extracts available valid metadata (like IVs) using DataView.
+- [ ] Gracefully handles `RangeError` from out-of-bounds reads.
+- [ ] No inline magic numbers are used for parsing; all constants are defined at the module level.
+
+## Execution Constraints
+- **CRITICAL**: If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **CRITICAL**: If you must abort or permanently fail a task (impossible or max rejections reached), update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **CRITICAL**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-105-215-gen3-roamer-parser-alternative-qa.md
+++ b/.foundry/tasks/task-105-215-gen3-roamer-parser-alternative-qa.md
@@ -1,13 +1,13 @@
 ---
-id: task-105-198-gen3-roamer-parser-qa
+id: task-105-215-gen3-roamer-parser-alternative-qa
 type: TASK
-title: QA Gen 3 Roamer Parse Logic
+title: QA Gen 3 Roamer Alternative Parse Logic
 status: PENDING
 owner_persona: qa
-created_at: '2026-06-17'
-updated_at: '2026-06-17'
+created_at: '2026-06-22'
+updated_at: '2026-06-22'
 depends_on:
-  - task-105-197-gen3-roamer-parser-impl
+  - task-105-214-gen3-roamer-parser-alternative-impl
 jules_session_id: null
 pr_number: null
 parent: story-067-105-gen3-roamer-parser-implementation
@@ -22,24 +22,22 @@ rejection_reason: ''
 notes: ''
 ---
 
-# QA Gen 3 Roamer Parse Logic
+# QA Gen 3 Roamer Alternative Parse Logic
 
 ## Objective
-Verify the Gen 3 roamer parsing implementation.
+Verify the Gen 3 alternative roamer parsing implementation.
 
 ## Description
-Ensure that the parser correctly extracts `speciesId`, `level`, and `mapId`/`mapGroup` of the active roamer using the `DataView` API and that it correctly verifies the roamer released event flag.
+Ensure that the parser correctly extracts `speciesId`, `level`, `active` status boolean, and IV metadata of the roamer using the `DataView` API. Verify that no map location parsing is attempted and that all parsing relies on module-level constants instead of inline magic numbers.
 
 ## Acceptance Criteria
-- [ ] Verify parser extracts Latios/Latias map group and ID using DataView.
 - [ ] Verify parser extracts species ID and level using DataView.
-- [ ] Verify parser checks event flags before marking roamer as active.
+- [ ] Verify parser extracts active status flag using DataView.
+- [ ] Verify parser extracts IV metadata using DataView.
 - [ ] Verify `RangeError` from out-of-bounds reads is handled gracefully.
+- [ ] Verify no inline magic numbers are used in the parsing logic.
 
 ## Execution Constraints
 - **CRITICAL**: If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
 - **CRITICAL**: If you must abort or permanently fail a task (impossible or max rejections reached), update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - **CRITICAL**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
-
-### Auditor Rejection
-CANCELLED: The implementation task failed permanently because extraction of Gen 3 roamer mapId and mapGroup is impossible (per adr-108-027-gen3-roamer-location-impossible). Replaced by new tasks focusing on IVs and active flag.


### PR DESCRIPTION
Handles the permanent failure of `task-105-197` (impossible to parse Gen 3 roamer map locations from save files). Spawns a new research node to investigate alternatives (`research-105-210`), and creates replacement implementation and QA tasks (`task-105-214` and `task-105-215`). Appends the new tasks to the parent story `story-067-105` and correctly records the auditor rejection in the orphaned QA task `task-105-198`.

---
*PR created automatically by Jules for task [15640015420932584574](https://jules.google.com/task/15640015420932584574) started by @szubster*