### PR TITLE
Fix: define IV_SHIFT_HP constant for Gen 3 roamer parsing

### DIFF
--- a/.foundry/tasks/task-108-212-gen3-roamer-dataview-extraction-impl.md
+++ b/.foundry/tasks/task-108-212-gen3-roamer-dataview-extraction-impl.md
@@ -42,11 +42,11 @@ The struct layout is:
 **Constraint:** All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. Inline magic numbers are forbidden.
 
 ## Acceptance Criteria
-- [ ] Define all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level (no inline magic numbers).
-- [ ] Implement `DataView` logic to read the 20-byte Gen 3 roamer structure from the correct save offset based on version.
-- [ ] Parse the 32-bit IV field into 6 distinct integer stats (HP, Atk, Def, Spe, SpA, SpD).
-- [ ] Parse the Level and Current HP fields correctly.
-- [ ] Include unit tests validating data extraction against known good boundary cases (e.g., all 0 IVs, all 31 IVs).
-- [ ] **Coder Mandate:** If experiencing a transient failure requiring a retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- [ ] **Coder Mandate:** If the task must be permanently aborted, update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- [ ] **Coder Mandate:** If submitting an empty PR for a completed task, check off all Acceptance Criteria checkboxes before submitting.
+- [x] Define all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level (no inline magic numbers).
+- [x] Implement `DataView` logic to read the 20-byte Gen 3 roamer structure from the correct save offset based on version.
+- [x] Parse the 32-bit IV field into 6 distinct integer stats (HP, Atk, Def, Spe, SpA, SpD).
+- [x] Parse the Level and Current HP fields correctly.
+- [x] Include unit tests validating data extraction against known good boundary cases (e.g., all 0 IVs, all 31 IVs).
+- [x] **Coder Mandate:** If experiencing a transient failure requiring a retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- [x] **Coder Mandate:** If the task must be permanently aborted, update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- [x] **Coder Mandate:** If submitting an empty PR for a completed task, check off all Acceptance Criteria checkboxes before submitting.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -513,6 +513,59 @@ describe('parseGen3Roamer', () => {
     });
   });
 
+  it('should parse Gen 3 roamer data with all 0 IVs', () => {
+    const buffer = new ArrayBuffer(0x3144 + 20);
+    const view = new DataView(buffer);
+    const offset = 0x3144;
+
+    view.setUint32(offset, 0, true);
+    view.setUint32(offset + 4, 0x12345678, true);
+    view.setUint16(offset + 8, 380, true);
+    view.setUint16(offset + 10, 150, true);
+    view.setUint8(offset + 12, 40);
+    view.setUint8(offset + 13, 1);
+    view.setUint8(offset + 19, 1);
+
+    const result = parseGen3Roamer(view, 0, 'ruby');
+
+    expect(result).toEqual({
+      ivs: { hp: 0, atk: 0, def: 0, spd: 0, spAtk: 0, spDef: 0 },
+      personalityValue: 0x12345678,
+      speciesId: 380,
+      hp: 150,
+      level: 40,
+      statusCondition: 1,
+      active: true,
+    });
+  });
+
+  it('should parse Gen 3 roamer data with all 31 IVs', () => {
+    const buffer = new ArrayBuffer(0x3144 + 20);
+    const view = new DataView(buffer);
+    const offset = 0x3144;
+
+    // 31 | (31 << 5) | (31 << 10) | (31 << 15) | (31 << 20) | (31 << 25) = 1073741823 (0x3FFFFFFF)
+    view.setUint32(offset, 0x3fffffff, true);
+    view.setUint32(offset + 4, 0x12345678, true);
+    view.setUint16(offset + 8, 380, true);
+    view.setUint16(offset + 10, 150, true);
+    view.setUint8(offset + 12, 40);
+    view.setUint8(offset + 13, 1);
+    view.setUint8(offset + 19, 1);
+
+    const result = parseGen3Roamer(view, 0, 'ruby');
+
+    expect(result).toEqual({
+      ivs: { hp: 31, atk: 31, def: 31, spd: 31, spAtk: 31, spDef: 31 },
+      personalityValue: 0x12345678,
+      speciesId: 380,
+      hp: 150,
+      level: 40,
+      statusCondition: 1,
+      active: true,
+    });
+  });
+
   it('should explicitly catch RangeError and throw corrupted file error on out-of-bounds reads', () => {
     // A buffer that is not large enough to hold the 20-byte roamer struct at the correct offset
     const buffer = new ArrayBuffer(0x3144 + 10);

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -39,6 +39,7 @@ const ROAMER_STATUS_OFFSET = 13;
 const ROAMER_ACTIVE_OFFSET = 19;
 
 const IV_MASK = 0x1f;
+const IV_SHIFT_HP = 0;
 const IV_SHIFT_ATK = 5;
 const IV_SHIFT_DEF = 10;
 const IV_SHIFT_SPD = 15;
@@ -260,7 +261,7 @@ export function parseGen3Roamer(view: DataView, saveBlock1Offset: number, gameVe
     const statusCondition = view.getUint8(offset + ROAMER_STATUS_OFFSET);
     const active = view.getUint8(offset + ROAMER_ACTIVE_OFFSET) !== 0;
 
-    const ivHp = ivs & IV_MASK;
+    const ivHp = (ivs >> IV_SHIFT_HP) & IV_MASK;
     const atk = (ivs >> IV_SHIFT_ATK) & IV_MASK;
     const def = (ivs >> IV_SHIFT_DEF) & IV_MASK;
     const spd = (ivs >> IV_SHIFT_SPD) & IV_MASK;


### PR DESCRIPTION
- Extracted the implicit 0 shift for HP IV extraction into `IV_SHIFT_HP` constant in `src/engine/saveParser/parsers/gen3.ts`.
- Added tests in `src/engine/saveParser/parsers/gen3.test.ts` for all 0 and all 31 IV edge cases.
- Checked off acceptance criteria in `.foundry/tasks/task-108-212-gen3-roamer-dataview-extraction-impl.md`.

---
*PR created automatically by Jules for task [17190305728862028996](https://jules.google.com/task/17190305728862028996) started by @szubster*