### PR TITLE
chore(foundry): break down story-077-114 into implementation and QA tasks

### DIFF
--- a/.foundry/stories/story-077-114-document-palette-styling-ownership.md
+++ b/.foundry/stories/story-077-114-document-palette-styling-ownership.md
@@ -35,4 +35,6 @@ Update `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_po
 - [ ] Documentation accurately reflects `palette` ownership of styling per ADR 024.
 
 ## Child Tasks
-- [ ] task-114-201-document-palette-styling-ownership-impl
+- [x] task-114-201-document-palette-styling-ownership-impl
+- [ ] task-114-214-document-palette-styling-ownership-impl
+- [ ] task-114-215-document-palette-styling-ownership-qa

--- a/.foundry/tasks/task-114-214-document-palette-styling-ownership-impl.md
+++ b/.foundry/tasks/task-114-214-document-palette-styling-ownership-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-114-214-document-palette-styling-ownership-impl
+type: TASK
+title: Implement palette persona documentation updates
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-22'
+updated_at: '2026-06-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-077-114-document-palette-styling-ownership
+tags:
+  - styling
+  - agents
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement palette persona documentation updates
+
+## Objective
+Update `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` to formally document this expanded styling ownership within the multi-agent pipeline.
+
+## Blueprint / Contract
+You are tasked with fulfilling the documentation update as requested by `story-077-114-document-palette-styling-ownership`.
+
+1. Ensure the `palette` persona's responsibility over `src/index.css` and custom tactical `@utility` primitives in the relevant Foundry system definitions and policies is documented, aligning with ADR 024.
+2. In `schema.md`, you can add `palette` to the "Owner Persona Enum" table.
+3. In `core_policies.md`, you can create a new section for Palette guidelines if necessary, or styling ownership.
+
+**Important Reminders for Coder:**
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` is updated.
+- [ ] Documentation accurately reflects `palette` ownership of styling per ADR 024.

--- a/.foundry/tasks/task-114-215-document-palette-styling-ownership-qa.md
+++ b/.foundry/tasks/task-114-215-document-palette-styling-ownership-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-114-215-document-palette-styling-ownership-qa
+type: TASK
+title: Verify palette persona documentation updates
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-22'
+updated_at: '2026-06-22'
+depends_on:
+  - task-114-214-document-palette-styling-ownership-impl
+jules_session_id: null
+pr_number: null
+parent: story-077-114-document-palette-styling-ownership
+tags:
+  - styling
+  - agents
+  - documentation
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Verify palette persona documentation updates
+
+## Objective
+Verify that the `coder` has successfully updated `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` to reflect `palette` persona's styling ownership.
+
+## Blueprint / Contract
+You are tasked with verifying the completion of `task-114-214-document-palette-styling-ownership-impl`.
+
+1. Review the changes made to `.foundry/docs/schema.md` and/or `.foundry/docs/knowledge_base/agents/core_policies.md`.
+2. Ensure the `palette` persona's responsibility over `src/index.css` and custom tactical `@utility` primitives in the relevant Foundry system definitions and policies is documented, and aligns with ADR 024.
+
+**Important Reminders for QA:**
+- If the coder's implementation is incomplete, incorrect, or violates architectural guidelines, you MUST reject the work by updating your YAML frontmatter to `status: FAILED` with a `rejection_reason`, which will invoke the Resurrection Loop.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` is correctly updated.
+- [ ] Documentation accurately reflects `palette` ownership of styling per ADR 024.


### PR DESCRIPTION
Drafted `task-114-214` and `task-114-215` for the `coder` and `qa` personas to implement and verify the palette persona documentation updates per ADR 024. Appended child references to the parent story `story-077-114-document-palette-styling-ownership`.

---
*PR created automatically by Jules for task [133483591519394539](https://jules.google.com/task/133483591519394539) started by @szubster*