### PR TITLE
Implement Pokerus State Exfiltration for Gen 2

### DIFF
--- a/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
+++ b/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
@@ -2,7 +2,7 @@
 id: epic-038-061-pokerus-state-exfiltration
 type: EPIC
 title: Pokerus State Exfiltration Epic
-status: VERIFYING
+status: COMPLETED
 owner_persona: story_owner
 created_at: '2026-06-07'
 updated_at: '2026-06-22'

--- a/src/engine/saveParser/parsers/common.test.ts
+++ b/src/engine/saveParser/parsers/common.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
-import { checkShiny, checkShinyGene, decodeGen12String, parseDVs } from './common';
+import { checkShiny, checkShinyGene, decodeGen12String, parseDVs, parsePokerusByte } from './common';
 
 describe('common parsers', () => {
   describe('decodeGen12String', () => {
@@ -196,6 +196,24 @@ describe('common parsers', () => {
 
     test('returns false if Spc is neither 2 nor 10', () => {
       expect(checkShinyGene({ atk: 5, def: 10, spd: 5, spc: 3 })).toBe(false);
+    });
+  });
+
+  describe('parsePokerusByte', () => {
+    test('returns undefined for 0x00', () => {
+      expect(parsePokerusByte(0x00)).toBeUndefined();
+    });
+
+    test('parses strain and daysRemaining correctly', () => {
+      expect(parsePokerusByte(0x1a)).toEqual({ strain: 1, daysRemaining: 10 });
+    });
+
+    test('parses cured state (non-zero strain, 0 days remaining)', () => {
+      expect(parsePokerusByte(0x50)).toEqual({ strain: 5, daysRemaining: 0 });
+    });
+
+    test('parses max boundary (strain 15, days 15)', () => {
+      expect(parsePokerusByte(0xff)).toEqual({ strain: 15, daysRemaining: 15 });
     });
   });
 });

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -348,3 +348,28 @@ export function checkShiny(dvs: { atk: number; def: number; spd: number; spc: nu
 export function checkShinyGene(dvs: { atk: number; def: number; spd: number; spc: number }) {
   return dvs.def === 10 && (dvs.spc === 2 || dvs.spc === 10);
 }
+
+/**
+ * Extracts the Pokerus status (strain and days remaining) from a raw status byte.
+ *
+ * @param rawByte - The 8-bit Pokerus status byte.
+ * @returns An object containing the 4-bit strain and 4-bit daysRemaining, or undefined if no infection is present.
+ *
+ * @remarks
+ * In Generation 2, Pokerus is stored as a single byte where the upper 4 bits
+ * represent the strain (identity) and the lower 4 bits represent the number
+ * of days remaining before the Pokémon is cured.
+ *
+ * Standard bitwise rules (ADR 026):
+ * - If the entire byte is 0, the Pokémon has never had Pokerus.
+ * - If strain > 0 but daysRemaining is 0, the Pokémon is "Cured" (can no longer spread it).
+ * - If strain > 0 and daysRemaining > 0, the Pokémon is currently "Infected".
+ */
+export function parsePokerusByte(rawByte: number) {
+  if (rawByte === 0) return undefined;
+
+  return {
+    strain: rawByte >> 4,
+    daysRemaining: rawByte & 0x0f,
+  };
+}

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -210,6 +210,24 @@ describe('gen2 parsers', () => {
       expect(data.pcDetails.length).toBe(2);
     });
 
+    it('should parse pokerus for PC pokemon', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x288a, 1);
+      view.setUint8(0x288b, 1);
+      view.setUint8(0x288b + 7, 1);
+
+      view.setUint8(0x2724, 0);
+      view.setUint8(0x2d10, 1);
+      view.setUint8(0x2d11, 2); // ID Ivysaur
+      const pcOff = 0x2d11 + 21;
+      view.setUint8(pcOff, 2); // speciesId
+      view.setUint8(pcOff + 28, 0x42); // Pokerus: strain 4, days 2
+
+      const data = parseGen2(view, false);
+      expect(data.pcDetails[0]?.pokerus).toEqual({ strain: 4, daysRemaining: 2 });
+    });
+
     it('should correctly count badges and map location', () => {
       const buffer = new ArrayBuffer(32768);
       const view = new DataView(buffer);

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -2,7 +2,18 @@ import gen2Landmarks from '../../data/gen2/landmarks.json';
 import gen2MapLocations from '../../data/gen2/mapLocations.json';
 import { GEN2_VERSION_EXCLUSIVES } from '../../exclusives/gen2Exclusives';
 import type { GameVersion, PokemonInstance, SaveData } from './common';
-import { checkShiny, checkShinyGene, decodeGen12String, parseDVs } from './common';
+import { checkShiny, checkShinyGene, decodeGen12String, parseDVs, parsePokerusByte } from './common';
+
+const GEN2_POKEMON_STRUCT_SIZE_PARTY = 48;
+const GEN2_POKEMON_STRUCT_SIZE_PC = 32;
+
+const GEN2_OFF_OT_FRIENDSHIP = 27;
+const GEN2_OFF_POKERUS = 28;
+const GEN2_OFF_CAUGHT_DATA_1 = 29;
+const GEN2_OFF_CAUGHT_DATA_2 = 30;
+const GEN2_OFF_LEVEL = 31;
+const GEN2_OFF_DAYCARE_OT = 32;
+const GEN2_OFF_PARTY_HP = 34;
 
 function isValidLandmark(id: string): id is keyof typeof gen2Landmarks {
   return id in gen2Landmarks;
@@ -26,8 +37,8 @@ function isValidMapId<T extends Record<string, string>>(id: string, dict: T): id
  * @returns An object containing the time, level, location ID, and location name, or undefined if missing.
  */
 function parseCaughtData(view: DataView, offset: number) {
-  const caughtByte1 = view.getUint8(offset + 29);
-  const caughtByte2 = view.getUint8(offset + 30);
+  const caughtByte1 = view.getUint8(offset + GEN2_OFF_CAUGHT_DATA_1);
+  const caughtByte2 = view.getUint8(offset + GEN2_OFF_CAUGHT_DATA_2);
 
   if (caughtByte1 === 0 && caughtByte2 === 0) return undefined;
 
@@ -86,21 +97,15 @@ function parseGen2PokemonInstance(
   const dvs = parseDVs(view.getUint16(offset + 21, false));
   const isShiny = checkShiny(dvs);
   const isShinyCarrier = checkShinyGene(dvs);
-  const friendship = view.getUint8(offset + 27);
-  const rawPokerus = view.getUint8(offset + 28);
-  const pokerus =
-    rawPokerus > 0
-      ? {
-          strain: rawPokerus >> 4,
-          daysRemaining: rawPokerus & 0x0f,
-        }
-      : undefined;
-  const level = view.getUint8(offset + 31);
-  const currentHp = storageLocation === 'Party' ? view.getUint16(offset + 34, false) : undefined;
+  const friendship = view.getUint8(offset + GEN2_OFF_OT_FRIENDSHIP);
+  const rawPokerus = view.getUint8(offset + GEN2_OFF_POKERUS);
+  const pokerus = parsePokerusByte(rawPokerus);
+  const level = view.getUint8(offset + GEN2_OFF_LEVEL);
+  const currentHp = storageLocation === 'Party' ? view.getUint16(offset + GEN2_OFF_PARTY_HP, false) : undefined;
   const caughtData = isCrystal ? parseCaughtData(view, offset) : undefined;
 
   // OT names in daycare are immediately after the data block
-  const otName = storageLocation === 'Daycare' ? decodeGen12String(view, offset + 32) : undefined;
+  const otName = storageLocation === 'Daycare' ? decodeGen12String(view, offset + GEN2_OFF_DAYCARE_OT) : undefined;
 
   let unownForm: string | undefined;
   if (speciesId === 201) {
@@ -266,7 +271,7 @@ function parseParty(view: DataView, offsets: { partyCount: number; partySpecies:
   const partyDetails: PokemonInstance[] = [];
   const partyDataOffset = offsets.partySpecies + 7; // After species list
   for (let i = 0; i < partyCount; i++) {
-    const offset = partyDataOffset + i * 48;
+    const offset = partyDataOffset + i * GEN2_POKEMON_STRUCT_SIZE_PARTY;
     const p = parseGen2PokemonInstance(view, offset, isCrystal, 'Party', i + 1);
     if (p) {
       partyDetails.push(p);
@@ -308,7 +313,7 @@ function parsePCBoxes(
   const pcDetails: PokemonInstance[] = [];
   const currentBoxDataOffset = offsets.currentBoxSpecies + 21; // After species list
   for (let i = 0; i < currentBoxCount; i++) {
-    const offset = currentBoxDataOffset + i * 32;
+    const offset = currentBoxDataOffset + i * GEN2_POKEMON_STRUCT_SIZE_PC;
     const p = parseGen2PokemonInstance(view, offset, isCrystal, `Box ${currentBoxNum + 1}`, i + 1);
     if (p) {
       pcDetails.push(p);
@@ -343,7 +348,7 @@ function parsePCBoxes(
 
     const boxDataOffset = offset + 22;
     for (let j = 0; j < count; j++) {
-      const pOff = boxDataOffset + j * 32;
+      const pOff = boxDataOffset + j * GEN2_POKEMON_STRUCT_SIZE_PC;
       const p = parseGen2PokemonInstance(view, pOff, isCrystal, `Box ${i + 1}`, j + 1);
       if (p) {
         pcDetails.push(p);


### PR DESCRIPTION
This PR implements the extraction and parsing of Pokerus state (strain and days remaining) from Generation 2 save files. It centralizes the parsing logic as per ADR 026 and ensures full coverage for Party, PC, and Daycare Pokémon.

Fixes #3056

---
*PR created automatically by Jules for task [4893553711513718100](https://jules.google.com/task/4893553711513718100) started by @szubster*