### PR TITLE
Verify completed child nodes for idea-076-tpm-journal-bloat

### DIFF
--- a/.foundry/ideas/idea-076-tpm-journal-bloat.md
+++ b/.foundry/ideas/idea-076-tpm-journal-bloat.md
@@ -36,5 +36,5 @@ The objective is to determine if the continuous logging into the TPM journal ind
 - [x] Analyze the research findings.
 - [x] Create a TASK node (if applicable) to implement the removal of the logging statements from the orchestrator.
 
-- [ ] .foundry/research/research-076-189-investigate-tpm-journal-bloat.md
-- [ ] .foundry/tasks/task-076-194-remove-tpm-logging-orchestrator.md
+- [x] .foundry/research/research-076-189-investigate-tpm-journal-bloat.md
+- [x] .foundry/tasks/task-076-194-remove-tpm-logging-orchestrator.md


### PR DESCRIPTION
Checked off the completed RESEARCH and TASK child nodes in the IDEA's markdown body. Both descendant nodes have already transitioned to COMPLETED. This empty PR (updating the checkboxes) correctly signals the orchestrator to transition the IDEA node to VERIFYING.

---
*PR created automatically by Jules for task [1378761840219056221](https://jules.google.com/task/1378761840219056221) started by @szubster*