### PR TITLE
🛡️ Nurse: [type improvement]

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -95,3 +95,7 @@ To avoid unsafe `as` casts in callbacks for generic UI components like `Tactical
 **Learning:** When sorting or reducing over Object keys/entries that are inferred as `string`, using `[a as keyof typeof MY_OBJ]` bypasses TypeScript's strict mode checks.
 **Action:** Replace `as keyof typeof` casts by implementing a strict type guard function, e.g., `function isValidKey(k: string): k is KeyType { return k in MY_OBJ; }`. Using this type guard inside loops or `sort` functions safely narrows the string to the correct key type without needing `as`.
 - **Safe `unknown` handling with `typeof`**: Avoid unsafe casting like `(obj['key'] as string)` when extracting properties from `Record<string, unknown>`. Instead, use standard type guards like `typeof obj['key'] === 'string' ? obj['key'] : fallback` to safely narrow the type at runtime.
+
+## $(date +%Y-%m-%d) - Type-Safety: Avoid inline `as` casts for Object.entries
+**Learning:** When iterating over objects with string literal union keys, using `Object.entries(obj) as [Key, Value][]` is an unsafe cast that circumvents the type checker, which naturally widens keys to `string`.
+**Action:** Use the generic typed utilities `objectEntries` or `objectKeys` located in `src/utils/object.ts` instead. This elegantly narrows the keys without needing hardcoded casts or compromising runtime behavior.

--- a/src/components/pokemon/details/ContestRibbonsPanel.tsx
+++ b/src/components/pokemon/details/ContestRibbonsPanel.tsx
@@ -1,5 +1,6 @@
 import { Award } from 'lucide-react';
 import type { Gen3Ribbons } from '../../../engine/saveParser/parsers/common';
+import { objectEntries } from '../../../utils/object';
 import { type ContestConditionType, ContestRibbonBadge, type ContestRibbonRank } from './ContestRibbonBadge';
 
 interface ContestRibbonsPanelProps {
@@ -34,7 +35,7 @@ export function ContestRibbonsPanel({ ribbons }: ContestRibbonsPanelProps) {
         <Award size={8} /> Contest Ribbons
       </span>
       <div className="flex flex-wrap gap-2">
-        {(Object.entries(ribbons) as [keyof Gen3Ribbons, number][]).map(([key, rank]) => {
+        {objectEntries(ribbons).map(([key, rank]) => {
           if (rank === 0 || !rankMap[rank]) return null;
 
           return <ContestRibbonBadge key={key} type={conditionMap[key]} rank={rankMap[rank]} />;


### PR DESCRIPTION
**What was unsafe:**
The `Object.entries(ribbons)` function naturally widens its keys to `string`. To force it back to the specific `keyof Gen3Ribbons` type, the code used an unsafe type assertion `as [keyof Gen3Ribbons, number][]`. This bypasses the compiler and risks silent failures if the object shape changes.

**How it was fixed:**
I replaced the native `Object.entries` and its manual cast with the generic `objectEntries` wrapper imported from `src/utils/object.ts`.

**What the compiler now catches:**
The `objectEntries` utility natively preserves the correct literal string union keys based on the object's type, meaning the compiler accurately guarantees the `key` parameter maps correctly to `keyof Gen3Ribbons` without any manual type overriding.

---
*PR created automatically by Jules for task [3416556605682343777](https://jules.google.com/task/3416556605682343777) started by @szubster*