### PR TITLE
🧹 [chore] clean up unused exports and files

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -13,6 +13,7 @@
     "src/test-setup.ts",
     "scripts/validate-foundry-schema.ts",
     ".github/scripts/extract-research.ts",
+    ".github/scripts/verify-dag-refs.ts",
     "scripts/gen3-fetch-locations.ts",
     "functions/_middleware.ts",
     "scripts/data/gen3/match_call/etl.ts"

--- a/src/engine/gen3/matchCall/offsets.ts
+++ b/src/engine/gen3/matchCall/offsets.ts
@@ -13,5 +13,3 @@ export const MATCH_CALL_UNLOCK_FLAG_BIT = 7;
 
 // Rematch readiness and tier states
 export const MATCH_CALL_REMATCH_NOT_READY = 0;
-// Where 0 is not ready, >0 means ready and represents the internal tier index
-export type MatchCallRematchEntry = number;


### PR DESCRIPTION
- Removes unused `MatchCallRematchEntry` from `src/engine/gen3/matchCall/offsets.ts`
- Adds `.github/scripts/verify-dag-refs.ts` to `knip.json` ignore list to fix false positive

---
*PR created automatically by Jules for task [6406892954752857437](https://jules.google.com/task/6406892954752857437) started by @szubster*