### PR TITLE
Reject Pokerus State Exfiltration Epic

### DIFF
--- a/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
+++ b/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
@@ -26,7 +26,7 @@ notes: ''
 Read the specific byte flags for Pokerus for every Pokemon in the party and PC from the Gen 2 sav files.
 
 ## Acceptance Criteria
-- [x] Extract pokerus data
+- [ ] Extract pokerus data
 - [x] .foundry/stories/story-061-095-pokerus-byte-parsing.md
 - [x] .foundry/stories/story-061-096-pokerus-tests.md
 
@@ -34,3 +34,6 @@ Read the specific byte flags for Pokerus for every Pokemon in the party and PC f
 
 ## Follow-up Nodes
 - [x] .foundry/docs/adrs/adr-061-026-bitwise-state-extraction.md
+
+### Auditor Rejection
+Verification failed. The bitwise logic for Pokerus state extraction was implemented directly inline in `src/engine/saveParser/parsers/gen2.ts` instead of being standardized into shared helper functions in `src/engine/saveParser/parsers/common.ts`. This is a direct violation of ADR 026. Please refactor the extraction logic into a shared helper function in `common.ts` and update the parsing logic accordingly.


### PR DESCRIPTION
Rejected epic-038-061-pokerus-state-exfiltration. The bitwise logic for Pokerus state extraction was implemented inline instead of being standardized into shared helper functions, violating ADR 026. The Resurrection Loop will be triggered.

---
*PR created automatically by Jules for task [11014340797089229145](https://jules.google.com/task/11014340797089229145) started by @szubster*