### PR TITLE
chore: append missing story node for pokerus refactoring

### DIFF
--- a/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
+++ b/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
@@ -29,6 +29,7 @@ Read the specific byte flags for Pokerus for every Pokemon in the party and PC f
 - [ ] Extract pokerus data
 - [x] .foundry/stories/story-061-095-pokerus-byte-parsing.md
 - [x] .foundry/stories/story-061-096-pokerus-tests.md
+- [ ] .foundry/stories/story-061-155-refactor-pokerus-bitwise.md
 
 <!-- Tech Lead: Verified complete. Pokerus bitwise logic is thoroughly tested including cured state boundaries. -->
 

--- a/.foundry/stories/story-061-155-refactor-pokerus-bitwise.md
+++ b/.foundry/stories/story-061-155-refactor-pokerus-bitwise.md
@@ -1,0 +1,31 @@
+---
+id: story-061-155-refactor-pokerus-bitwise
+type: STORY
+title: Refactor Pokerus Bitwise Extraction
+status: READY
+owner_persona: tech_lead
+created_at: '2026-06-23'
+updated_at: '2026-06-23'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-038-061-pokerus-state-exfiltration
+tags:
+  - refactor
+  - save-engine
+  - pokerus
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Refactor Pokerus Bitwise Extraction
+
+## Description
+Refactor the inline bitwise logic for Pokerus state extraction from `src/engine/saveParser/parsers/gen2.ts` into a standardized shared helper function `parsePokerus(rawPokerus: number)` in `src/engine/saveParser/parsers/common.ts`, in accordance with ADR 026. Update the parsing logic to use this helper.
+
+## Acceptance Criteria
+- [ ] Create `parsePokerus` in `common.ts`
+- [ ] Refactor `gen2.ts` to use `parsePokerus`
+- [ ] Ensure tests cover boundary states


### PR DESCRIPTION
Added new story node to refactor pokerus bitwise extraction according to ADR 026, and appended to epic-038-061-pokerus-state-exfiltration.md.

---
*PR created automatically by Jules for task [15819677873681471713](https://jules.google.com/task/15819677873681471713) started by @szubster*