### PR TITLE
chore: check off cancelled tasks in story-087-128

### DIFF
--- a/.foundry/stories/story-087-128-dynamic-item-list-parsing.md
+++ b/.foundry/stories/story-087-128-dynamic-item-list-parsing.md
@@ -35,8 +35,8 @@ To eliminate manually maintained static item lists in the repository, we need to
 - [ ] Perform compaction to omit nulls and default values.
 - [ ] Output the final structure to `data/db/items.jsonl`.
 - [x] Break down this STORY into concrete TASK nodes for implementation.
-- [ ] task-128-181-implement-item-list-parsing (CANCELLED)
-- [ ] task-128-182-qa-item-list-parsing (CANCELLED)
+- [x] task-128-181-implement-item-list-parsing (CANCELLED)
+- [x] task-128-182-qa-item-list-parsing (CANCELLED)
 - [ ] research-128-210-item-list-parsing-failure
 - [ ] task-128-212-item-list-parsing-impl
 - [ ] task-128-213-item-list-parsing-qa


### PR DESCRIPTION
Check off cancelled tasks `task-128-181-implement-item-list-parsing` and `task-128-182-qa-item-list-parsing` in `story-087-128-dynamic-item-list-parsing.md` per the Cancelled Child Node Parent Update Rule.

---
*PR created automatically by Jules for task [4736518020874249547](https://jules.google.com/task/4736518020874249547) started by @szubster*