### PR TITLE
🗃️ Archivist: Resolve design standards contradiction

### DIFF
--- a/.foundry/docs/knowledge_base/onboarding/style_and_conventions.md
+++ b/.foundry/docs/knowledge_base/onboarding/style_and_conventions.md
@@ -23,10 +23,10 @@ Following the project's `.agents/rules/testing_rules.md`:
 
 ## Visual Excellence & Design Standards
 
-- **Premium UI**: Use curated color palettes, glassmorphism, and smooth gradients. Avoid generic styles.
-- **Modern Retro**: Blend classic Pokédex aesthetics with high-fidelity modern UI patterns.
+- **Tactical Hardware Aesthetic**: Adhere strictly to the "tactical hardware/snooping" aesthetic as defined in ADR 024. Use sharp edges (`rounded-none`), dashed borders (`border-dashed`), and monospaced telemetry fonts (`font-mono`). Avoid rounded glassmorphism or overly slick holographic elements.
+- **Modern Retro**: Blend classic Pokédex utility with specialized hardware UI patterns to evoke the feeling of a real device.
 - **No Placeholders**: Never use placeholder images. Use `generate_image` or real assets.
-- **Animations**: Implement subtle micro-animations and interactive transitions (hover effects, smooth state changes) to make the UI feel "alive".
+- **Animations**: Prefer immediate, utilitarian state changes or blocky segmented loading effects over smooth web-standard transitions.
 
 ## Code Analysis and Formatting
 

--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -65,3 +65,8 @@
 **Learning:** Foundry journals (`coder.md`, `tech_lead.md`, `auditor.md`, `story_owner.md`) frequently accumulate pure execution logs ("I did X", task verification records) and heavily duplicated pattern insights (e.g., Epic cancellation procedures).
 **Action:** Scrubbed pure execution logs to preserve context windows and consolidated duplicated pattern insights into canonical architectural constraints.
 - The directory `.serena/memories/` is a symbolic link mapping to `../.foundry/docs/knowledge_base/`. Agents must be careful not to mistake it for a duplicate directory or attempt recursive operations that result in duplicate changes.
+
+## 2026-07-15 - Archivist Run Learnings
+
+**Learning:** High-level onboarding documents (like `style_and_conventions.md`) are highly susceptible to knowledge rot when overarching application aesthetics or paradigms change. For example, the project's design standard shifted from "glassmorphism" to a "tactical hardware/snooping" aesthetic (ADR 024, logged heavily in Canvas journals), but the onboarding document still instructed agents to use generic premium UI and smooth gradients, causing contradictory behaviors.
+**Action:** Resolved the contradiction in `onboarding/style_and_conventions.md` by explicitly pointing to the "tactical hardware" guidelines in ADR 024. Going forward, when sweeping architectural or aesthetic decisions are made, maintainers and planning agents MUST ensure that introductory/onboarding documentation is explicitly updated to reflect the new paradigms to prevent confusing future agents.


### PR DESCRIPTION
This PR updates `.foundry/docs/knowledge_base/onboarding/style_and_conventions.md` to resolve a contradiction regarding design standards. The previous generic "glassmorphism and smooth gradients" guidelines have been replaced with the "tactical hardware/snooping" aesthetic, accurately reflecting ADR 024 and recent project-wide UI changes. It also logs this critical learning about onboarding document knowledge rot in `.jules/archivist.md`.

---
*PR created automatically by Jules for task [18208190598981814367](https://jules.google.com/task/18208190598981814367) started by @szubster*