### PR TITLE
Update story-067-105-gen3-roamer-parser-implementation

### DIFF
--- a/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
+++ b/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
@@ -35,5 +35,5 @@ Identify the exact memory offsets for Latios/Latias in Ruby/Sapphire/Emerald sav
 - [x] .foundry/tasks/task-105-197-gen3-roamer-parser-impl.md
 - [x] .foundry/tasks/task-105-198-gen3-roamer-parser-qa.md
 - [x] .foundry/research/research-105-210-gen3-roamer-alternative.md
-- [x] .foundry/tasks/task-105-214-gen3-roamer-parser-alternative-impl.md
-- [x] .foundry/tasks/task-105-215-gen3-roamer-parser-alternative-qa.md
+- [ ] .foundry/tasks/task-105-214-gen3-roamer-parser-alternative-impl.md
+- [ ] .foundry/tasks/task-105-215-gen3-roamer-parser-alternative-qa.md

--- a/.foundry/tasks/task-105-198-gen3-roamer-parser-qa.md
+++ b/.foundry/tasks/task-105-198-gen3-roamer-parser-qa.md
@@ -43,3 +43,4 @@ Ensure that the parser correctly extracts `speciesId`, `level`, and `mapId`/`map
 
 ### Auditor Rejection
 CANCELLED: The implementation task failed permanently because extraction of Gen 3 roamer mapId and mapGroup is impossible (per adr-108-027-gen3-roamer-location-impossible). Replaced by new tasks focusing on IVs and active flag.
+CANCELLED: The original Gen 3 roamer parser implementation task (`task-105-197-gen3-roamer-parser-impl`) failed permanently because map location extraction is impossible. This QA task is therefore orphaned and cancelled. It has been replaced by the alternative tasks `task-105-214-gen3-roamer-parser-alternative-impl` and `task-105-215-gen3-roamer-parser-alternative-qa`.


### PR DESCRIPTION
Updated story-067-105 and task-105-198 to handle the permanent failure of the original Gen 3 roamer parsing implementation. Checked off cancelled tasks in the parent and appended an Auditor Rejection to the orphaned QA task. The parent story will correctly revert to PENDING to wait for the new alternative child tasks.

---
*PR created automatically by Jules for task [3556150972772074074](https://jules.google.com/task/3556150972772074074) started by @szubster*