### PR TITLE
tech lead: update breeding story blueprint and research nodes

### DIFF
--- a/.foundry/research/research-084-209-egg-groups-missing.md
+++ b/.foundry/research/research-084-209-egg-groups-missing.md
@@ -2,7 +2,7 @@
 id: research-084-209-egg-groups-missing
 type: RESEARCH
 title: Investigate Missing Egg Groups Data for Breeding Algorithm
-status: PENDING
+status: CANCELLED
 owner_persona: researcher
 created_at: '2026-06-19'
 updated_at: '2026-06-19'
@@ -16,7 +16,7 @@ tags:
   - breeding
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Researched already, creating implementation tasks directly'
 notes: ''
 ---
 

--- a/.foundry/stories/story-044-084-breeding-pair-algorithm.md
+++ b/.foundry/stories/story-044-084-breeding-pair-algorithm.md
@@ -38,8 +38,11 @@ Develop an algorithm to suggest optimal breeding pairs by cross-referencing Egg 
 
 ## Next Steps
 - [x] Tech Lead: Break down into backend Tasks.
+- [x] Tech Lead: Update schema and generate scripts to include Egg Group.
 - [x] .foundry/tasks/task-084-204-breeding-pair-algorithm-impl.md
 - [x] .foundry/tasks/task-084-205-breeding-pair-algorithm-qa.md
-- [ ] .foundry/research/research-084-209-egg-groups-missing.md
+- [x] .foundry/research/research-084-209-egg-groups-missing.md
 - [ ] .foundry/tasks/task-084-210-breeding-pair-algorithm-impl.md
 - [ ] .foundry/tasks/task-084-211-breeding-pair-algorithm-qa.md
+- [ ] .foundry/tasks/task-084-212-breeding-pair-algorithm-impl.md
+- [ ] .foundry/tasks/task-084-213-breeding-pair-algorithm-qa.md

--- a/.foundry/tasks/task-084-210-breeding-pair-algorithm-impl.md
+++ b/.foundry/tasks/task-084-210-breeding-pair-algorithm-impl.md
@@ -7,7 +7,7 @@ owner_persona: coder
 created_at: '2026-06-19'
 updated_at: '2026-06-19'
 depends_on:
-  - research-084-209-egg-groups-missing
+  - task-084-212-breeding-pair-algorithm-impl
 jules_session_id: null
 pr_number: null
 parent: story-044-084-breeding-pair-algorithm

--- a/.foundry/tasks/task-084-212-breeding-pair-algorithm-impl.md
+++ b/.foundry/tasks/task-084-212-breeding-pair-algorithm-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-084-212-breeding-pair-algorithm-impl
+type: TASK
+title: Update DB Schema and Generate Script for Egg Groups
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-25'
+updated_at: '2026-06-25'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-044-084-breeding-pair-algorithm
+tags:
+  - backend
+  - data
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update DB Schema and Generate Script for Egg Groups
+
+## Objective
+Update the `PokemonMetadata` interface in `src/db/schema.ts` to include `egg_groups` (as `eg: string[]` or `eg: number[]` for compactness) and modify `scripts/generate-pokedata.ts` to extract this information from the PokeAPI `pokemon-species` data.
+
+## Technical Contract
+- Extend `PokemonMetadata` in `src/db/schema.ts` with an `eg: string[]` field (or similar, representing the egg groups).
+- Update `scripts/generate-pokedata.ts` to parse `sData.egg_groups` and populate the new field.
+- Implement a utility function to calculate Gen 2 gender based on Attack DV and Gender Ratio (`gr`).
+- Write unit tests for the gender calculation logic.
+
+## Acceptance Criteria
+- [ ] `PokemonMetadata` includes an `eg` (egg groups) property.
+- [ ] `scripts/generate-pokedata.ts` correctly extracts egg groups.
+- [ ] Utility for Gen 2 gender calculation based on Attack DV and `gr` is implemented and tested.
+- [ ] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
+- [ ] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-084-213-breeding-pair-algorithm-qa.md
+++ b/.foundry/tasks/task-084-213-breeding-pair-algorithm-qa.md
@@ -1,0 +1,38 @@
+---
+id: task-084-213-breeding-pair-algorithm-qa
+type: TASK
+title: QA - Update DB Schema and Generate Script for Egg Groups
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-25'
+updated_at: '2026-06-25'
+depends_on:
+  - task-084-212-breeding-pair-algorithm-impl
+jules_session_id: null
+pr_number: null
+parent: story-044-084-breeding-pair-algorithm
+tags:
+  - backend
+  - data
+  - gen2
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Update DB Schema and Generate Script for Egg Groups
+
+## Objective
+Verify that `PokemonMetadata` properly includes egg groups and that the generator script populates it correctly. Verify the Gen 2 gender calculation utility.
+
+## Testing Contract
+- Run the code generation script and verify the resulting mock DB data or JSON outputs contain valid egg group lists for Pokemon.
+- Verify that unit tests for the Gen 2 gender calculation pass and handle edge cases (e.g. 100% female, 100% male, genderless).
+
+## Acceptance Criteria
+- [ ] DB generation correctly includes egg groups in the `PokemonMetadata`.
+- [ ] Gender calculation logic accurately reflects Gen 2 mechanics based on Attack DV and `gr`.
+- [ ] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
+- [ ] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This pull request breaks down the work into `task-084-212` and `task-084-213` directly updating the Database Schema instead of doing research first. We've cancelled `research-084-209-egg-groups-missing`. We've also updated dependencies to reflect that fact.

---
*PR created automatically by Jules for task [172563303749355085](https://jules.google.com/task/172563303749355085) started by @szubster*