### PR TITLE
epic_planner: Mark prd-071-044-gen3-roamer-tracker acceptance criteria as complete

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -32,9 +32,9 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - Detect and display a warning if the "Roamer IV Glitch" affects the Pokémon.
 - Provide a Route Radar to map the roamer's current location index.
 
-- [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
-- [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
+- [x] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
+- [x] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
 - [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
 - [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
-- [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
-- [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md
+- [x] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
+- [x] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
This empty PR progresses the Foundry DAG by checking off the accepted criteria for PRD `prd-071-044-gen3-roamer-tracker` indicating that all downstream child Epic and Research nodes have been completed successfully. No frontmatter or substantive code changes were made, adhering to the Empty PR policy for completed artifacts.

---
*PR created automatically by Jules for task [7405128340922905701](https://jules.google.com/task/7405128340922905701) started by @szubster*