### PR TITLE
Tech Lead: Handle Gen 3 Secret Base Parser failure and generate retries

### DIFF
--- a/.foundry/research/research-108-221-gen3-secret-base-rangeerror.md
+++ b/.foundry/research/research-108-221-gen3-secret-base-rangeerror.md
@@ -1,0 +1,35 @@
+---
+id: research-108-221-gen3-secret-base-rangeerror
+type: RESEARCH
+title: Investigate RangeError Handling in Gen 3 Secret Base Parser
+status: COMPLETED
+owner_persona: researcher
+created_at: '2026-06-24'
+updated_at: '2026-06-24'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-070-108-parse-secret-base-locations
+tags:
+  - research
+  - gen3
+  - secret-base
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# RESEARCH: Investigate RangeError Handling in Gen 3 Secret Base Parser
+
+## Context
+The previous implementation for Gen 3 Secret Base parsing (`task-108-163-gen3-secret-base-parser`) failed permanently because it violated ADR 010. While it used the `DataView` API, it failed to explicitly catch and handle `RangeError` from out-of-bounds reads.
+
+## Findings
+- **ADR 010 Requirement:** All new Gen3 save parsing logic MUST exclusively use the native `DataView` API. Crucially, the parser must rely on `DataView` to throw `RangeError` on out-of-bounds reads, which must be caught explicitly by the parser engine, and gracefully propagated up as specific validation errors (e.g., "Corrupted Save File"), rather than crashing the application or returning malformed data.
+- **Root Cause of Previous Failure:** The coder implemented `DataView` reading (e.g., `dataView.getUint8(offset)`) but did not wrap the parsing block in a `try...catch (e)` block that specifically checks for `e instanceof RangeError` and throws a controlled `CorruptedSaveFileError` or similar safe fallback.
+- **Architectural Constraint for Retries:** In addition to fixing the `RangeError` logic, a new constraint from the Tech Lead Journal must be enforced: "When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers."
+
+## Resolution
+New replacement tasks will be generated that explicitly mandate both the `try...catch` block for `RangeError` when using `DataView`, and the definition of all magic numbers as reusable module-level constants.

--- a/.foundry/stories/story-070-108-parse-secret-base-locations.md
+++ b/.foundry/stories/story-070-108-parse-secret-base-locations.md
@@ -33,5 +33,8 @@ As part of the Gen 3 Secret Base and Mixed Record Viewer, we need to extract the
 ## Acceptance Criteria
 - [x] Break down into Tasks.
 
-- [ ] task-108-163-gen3-secret-base-parser
-- [ ] task-108-164-gen3-secret-base-parser-qa
+- [x] task-108-163-gen3-secret-base-parser
+- [x] task-108-164-gen3-secret-base-parser-qa
+- [ ] research-108-221-gen3-secret-base-rangeerror
+- [ ] task-108-222-gen3-secret-base-parser-retry-impl
+- [ ] task-108-223-gen3-secret-base-parser-retry-qa

--- a/.foundry/tasks/task-108-164-gen3-secret-base-parser-qa.md
+++ b/.foundry/tasks/task-108-164-gen3-secret-base-parser-qa.md
@@ -47,3 +47,7 @@ Verify the implementation of the Gen 3 Secret Base Parser task. Because save fil
 ## Reminders for Personas
 - **Coder/QA:** If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.
 - **Coder/QA:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### Auditor Rejection
+**Status: CANCELLED**
+This QA task has been permanently cancelled because its dependency `task-108-163-gen3-secret-base-parser` reached the maximum rejection count. It is being replaced by new tasks that correctly address the `DataView` RangeError handling and memory offset reusable constant constraints.

--- a/.foundry/tasks/task-108-222-gen3-secret-base-parser-retry-impl.md
+++ b/.foundry/tasks/task-108-222-gen3-secret-base-parser-retry-impl.md
@@ -1,0 +1,52 @@
+---
+id: task-108-222-gen3-secret-base-parser-retry-impl
+type: TASK
+title: Implement Gen 3 Secret Base Parser (Retry)
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-24'
+updated_at: '2026-06-24'
+depends_on:
+  - research-108-221-gen3-secret-base-rangeerror
+jules_session_id: null
+pr_number: null
+parent: story-070-108-parse-secret-base-locations
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - save-parsing
+research_references:
+  - research-108-221-gen3-secret-base-rangeerror
+  - research-108-187-gen3-secret-base-offsets
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement Gen 3 Secret Base Parser (Retry)
+
+## Context
+As part of the Gen 3 Secret Base and Mixed Record Viewer, we need to extract the locations of all active Secret Bases from the save file. This task involves implementing the logic to parse the Secret Base locations using the `DataView` API.
+This is a retry of a previously failed task. The previous implementation failed because it violated ADR 010 by not explicitly catching `RangeError` on out-of-bounds reads.
+
+## Requirements
+- Identify the memory offsets for Gen 3 Secret Base data within the save file.
+- Implement a parser in the Gen 3 save engine (likely in `src/engine/save_parser/`) that extracts the map ID/location ID for active secret bases.
+- MUST use the `DataView` API exclusively for parsing per ADR 010. Do not use raw `Uint8Array` manipulations.
+- **CRITICAL:** Ensure bounded reads. You MUST wrap the `DataView` parsing block in a `try...catch (e)` block that explicitly checks if `e instanceof RangeError` and throws a gracefully handled error (e.g., "Corrupted Save File") rather than crashing the application.
+- **CRITICAL:** All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+- The extracted location IDs must be compatible with the mapping structures defined by `gen3MapGraph` logic.
+- Ensure the legacy Gen 1 and Gen 2 parsers remain unchanged (backwards compatibility).
+
+## Acceptance Criteria
+- [ ] Gen 3 Secret Base parser is implemented using `DataView`.
+- [ ] It correctly identifies and extracts map location IDs for active secret bases.
+- [ ] Rejections or errors handle corrupted/truncated data gracefully via explicit `RangeError` catching.
+- [ ] All memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level.
+- [ ] Appropriate unit tests are added for the parsing logic.
+
+## Reminders for Personas
+- **Coder/QA:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Coder/QA:** If you abort or permanently fail this task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Coder/QA:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-108-223-gen3-secret-base-parser-retry-qa.md
+++ b/.foundry/tasks/task-108-223-gen3-secret-base-parser-retry-qa.md
@@ -1,0 +1,50 @@
+---
+id: task-108-223-gen3-secret-base-parser-retry-qa
+type: TASK
+title: QA Gen 3 Secret Base Parser (Retry)
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-24'
+updated_at: '2026-06-24'
+depends_on:
+  - task-108-222-gen3-secret-base-parser-retry-impl
+jules_session_id: null
+pr_number: null
+parent: story-070-108-parse-secret-base-locations
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - save-parsing
+  - qa
+research_references:
+  - research-108-221-gen3-secret-base-rangeerror
+  - research-108-187-gen3-secret-base-offsets
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Gen 3 Secret Base Parser (Retry)
+
+## Context
+Verify the implementation of the Gen 3 Secret Base Parser (Retry) task. Because save file parsing involves complex risk and data corruption handling, it requires independent QA verification. The previous implementation was rejected for missing explicit `RangeError` bounds checking and magic number violations.
+
+## Requirements
+- Verify that `task-108-222-gen3-secret-base-parser-retry-impl` exclusively uses the `DataView` API for Gen 3 secret base parsing.
+- **CRITICAL:** Verify that the `DataView` parser block is wrapped in a `try...catch (e)` block that explicitly checks `e instanceof RangeError` and throws a handled error instead of crashing.
+- **CRITICAL:** Verify that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. Inline magic numbers are not allowed.
+- Confirm backwards compatibility: Gen 1 and Gen 2 parsing logic must not be broken or altered.
+- Review and run the unit tests provided by the coder. Add additional unit or integration tests if coverage is lacking.
+- Use `pnpm run test` and ensure all tests pass.
+
+## Acceptance Criteria
+- [ ] Confirmed `DataView` API usage with explicit `RangeError` catching.
+- [ ] Confirmed all magic numbers are defined as reusable module-level constants.
+- [ ] Existing Gen 1/2 tests pass.
+- [ ] Secret base extraction logic has adequate test coverage.
+
+## Reminders for Personas
+- **Coder/QA:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Coder/QA:** If you abort or permanently fail this task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Coder/QA:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
- Appended Auditor Rejection notice to `task-108-164-gen3-secret-base-parser-qa` because its implementation dependency failed permanently.
- Created `research-108-221-gen3-secret-base-rangeerror` to document the specific DataView RangeError out-of-bounds failure.
- Generated replacement tasks `task-108-222-gen3-secret-base-parser-retry-impl` and `task-108-223-gen3-secret-base-parser-retry-qa` that depend on the research.
- Added explicit requirements for DataView RangeError catching and module-level reusable constants (forbidding inline magic numbers).
- Checked off the cancelled tasks in the parent `story-070-108-parse-secret-base-locations` and appended the new replacement tasks.

---
*PR created automatically by Jules for task [13314305220492796661](https://jules.google.com/task/13314305220492796661) started by @szubster*