### PR TITLE
chore: uncheck pending child nodes in prd-071-044

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -32,9 +32,9 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - Detect and display a warning if the "Roamer IV Glitch" affects the Pokémon.
 - Provide a Route Radar to map the roamer's current location index.
 
-- [x] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
-- [x] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
+- [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
+- [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
 - [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
 - [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
-- [x] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
-- [x] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md
+- [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
+- [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
Unchecked the acceptance criteria checkboxes for the pending child nodes (epic-044-070, epic-044-071, research-044-207, and epic-044-096) in `prd-071-044-gen3-roamer-tracker.md`. This ensures the PRD node does not prematurely transition to the VERIFYING state, keeping it in PENDING mode while it waits for these child nodes to complete. The checkboxes for the permanently cancelled/replaced child nodes (epic-044-072 and epic-044-073) were left checked, satisfying the ADR 007 completeness requirement.

---
*PR created automatically by Jules for task [7840946972891888564](https://jules.google.com/task/7840946972891888564) started by @szubster*