### PR TITLE
Uncheck pending child epic in PRD

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -35,6 +35,6 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
 - [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
 - [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
-- [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
 - [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
 - [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
Unchecked the prematurely checked box for the pending child epic `epic-044-073-gen3-roamer-dashboard-ui.md` in the parent PRD `prd-071-044-gen3-roamer-tracker.md` to comply with the Premature Checkbox Correction Rule. This allows the orchestrator to correctly demote the PRD back to PENDING while it waits for its child nodes.

---
*PR created automatically by Jules for task [8140562729633462127](https://jules.google.com/task/8140562729633462127) started by @szubster*