### PR TITLE
Fix: Uncheck Premature Checkbox for Orchestrator Demotion

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -40,7 +40,7 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - Extract data indicating if events were inherited from another player's save file via the "Mix Record" feature.
 
 ## 3. Acceptance Criteria
-- [x] Story Owner: Break down into Stories.
+- [ ] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
 - [x] story-081-122-gen3-rtc-extraction


### PR DESCRIPTION
Unchecked prematurely checked criteria in the Epic to allow correct orchestrator demotion.

---
*PR created automatically by Jules for task [15130829655245507328](https://jules.google.com/task/15130829655245507328) started by @szubster*