### PR TITLE
Fix prematurely checked acceptance criteria in Gen 3 Roamer Parse Story

### DIFF
--- a/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
+++ b/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
@@ -27,9 +27,9 @@ Implement binary parsing logic in `src/engine/saveParser/parsers/gen3.ts` to ext
 Identify the exact memory offsets for Latios/Latias in Ruby/Sapphire/Emerald save files. Update the parser to extract the `speciesId`, `level`, and `mapId`/`mapGroup` of the active roamer using the `DataView` API. Crucially, the parser must only consider a roamer as "active" if the corresponding event flag indicating it has been released is set in the save file.
 
 ## Acceptance Criteria
-- [x] Parser extracts Latios/Latias map group and ID.
-- [x] Parser extracts species ID and level.
-- [x] Parser verifies event flags before marking roamer as active.
+- [ ] Parser extracts Latios/Latias map group and ID.
+- [ ] Parser extracts species ID and level.
+- [ ] Parser verifies event flags before marking roamer as active.
 - [x] Break down this Story into executable Tasks.
 - [x] .foundry/research/research-105-196-gen3-roamer-event-flag.md
 - [x] .foundry/tasks/task-105-197-gen3-roamer-parser-impl.md


### PR DESCRIPTION
Fixes the `story-067-105-gen3-roamer-parser-implementation.md` node by unchecking the acceptance criteria for `task-105-197`, `task-105-198`, and `research-105-210`, resolving the dependency graph violation.

---
*PR created automatically by Jules for task [4208299653437016634](https://jules.google.com/task/4208299653437016634) started by @szubster*