### PR TITLE
Verify epic-035-049-late-binding-accommodation

### DIFF
--- a/.foundry/epics/epic-035-049-late-binding-accommodation.md
+++ b/.foundry/epics/epic-035-049-late-binding-accommodation.md
@@ -35,3 +35,7 @@ Ensure late-binding nodes work smoothly with the new implicit dependencies. Upda
 
 - [x] .foundry/stories/story-049-116-verify-late-binding-logic.md
 - [x] .foundry/stories/story-049-117-update-tpm-agile-coach-journal.md
+
+### Auditor Output
+Spawned follow-up research node to investigate edge cases:
+- .foundry/research/research-049-215-late-binding-cancellation.md

--- a/.foundry/research/research-049-215-late-binding-cancellation.md
+++ b/.foundry/research/research-049-215-late-binding-cancellation.md
@@ -1,0 +1,29 @@
+---
+id: research-049-215-late-binding-cancellation
+type: RESEARCH
+title: Orchestrator Late-Binding Parent Node Cancellation Logic
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-25'
+updated_at: '2026-06-25'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - orchestrator
+  - research
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Orchestrator Late-Binding Parent Node Cancellation Logic
+
+## Context
+During the audit of epic-035-049-late-binding-accommodation, we verified that the orchestrator properly handles late-binding parent nodes (allowing a PENDING parent with generated children to not block those children from starting).
+However, an unresolved question arose: How does the orchestrator behave when a child of a late-binding parent is permanently CANCELLED? Does it properly wake up the parent, or does the parent remain permanently PENDING waiting for a completion signal that will never arrive?
+
+## Goal
+Research and verify the orchestrator's behavior regarding late-binding parents when one or more of their children reach a CANCELLED status. Determine if the parent's `allChildrenCompleted` check correctly factors in CANCELLED states or if it deadlocks.


### PR DESCRIPTION
Verified the EPIC node and its late-binding orchestrator exception. Extracted an unresolved question regarding late-binding parent node cancellation logic and spawned a new RESEARCH node to investigate it. Appended the output to the epic markdown without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [16805397858725839215](https://jules.google.com/task/16805397858725839215) started by @szubster*