### PR TITLE
fix: correctly demote late-binding parents without target artifacts

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -2,7 +2,7 @@
 id: epic-047-081-gen3-tv-swarm-data-extraction
 type: EPIC
 title: Gen 3 TV Broadcast and Swarm Tracker Data Extraction
-status: ACTIVE
+status: READY
 owner_persona: story_owner
 created_at: '2026-06-12'
 updated_at: '2026-06-25'

--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -2,7 +2,7 @@
 id: prd-071-040-tailwind-v4-utilities-migration
 type: PRD
 title: Tailwind v4 @utility Consolidation
-status: ACTIVE
+status: READY
 owner_persona: epic_planner
 created_at: '2026-06-09'
 updated_at: '2026-06-25'

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -2,7 +2,7 @@
 id: prd-071-044-gen3-roamer-tracker
 type: PRD
 title: Gen 3 Roaming Legendary Tracker and IV Glitch Inspector
-status: ACTIVE
+status: READY
 owner_persona: epic_planner
 created_at: '2026-06-09'
 updated_at: '2026-06-25'

--- a/.foundry/stories/story-044-084-breeding-pair-algorithm.md
+++ b/.foundry/stories/story-044-084-breeding-pair-algorithm.md
@@ -2,7 +2,7 @@
 id: story-044-084-breeding-pair-algorithm
 type: STORY
 title: Shiny Carrier Breeding Pair Algorithm
-status: ACTIVE
+status: READY
 owner_persona: tech_lead
 created_at: '2026-05-22'
 updated_at: '2026-06-25'

--- a/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
+++ b/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
@@ -2,7 +2,7 @@
 id: story-067-105-gen3-roamer-parser-implementation
 type: STORY
 title: Gen 3 Roamer Save Parsing
-status: ACTIVE
+status: READY
 owner_persona: tech_lead
 created_at: '2026-06-10'
 updated_at: '2026-06-25'

--- a/.foundry/stories/story-070-108-parse-secret-base-locations.md
+++ b/.foundry/stories/story-070-108-parse-secret-base-locations.md
@@ -2,7 +2,7 @@
 id: story-070-108-parse-secret-base-locations
 type: STORY
 title: Parse Gen 3 Secret Base Locations
-status: ACTIVE
+status: READY
 owner_persona: tech_lead
 created_at: '2026-06-10'
 updated_at: '2026-06-25'

--- a/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
+++ b/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
@@ -2,7 +2,7 @@
 id: story-081-121-gen3-tv-block-dataview-parser
 type: STORY
 title: Parse Gen 3 TV Block Data with DataView
-status: ACTIVE
+status: READY
 owner_persona: tech_lead
 created_at: '2026-06-12'
 updated_at: '2026-06-25'

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -842,14 +842,10 @@ function main(): void {
           info(`Preflight success: Valid target artifacts exist and are completed. Bypassing dispatch for ${node.repoPath}`);
           promoteNodeStatus(node, 'PENDING', 'COMPLETED');
         }
-      } else if (targetArtifacts.length === 0 && children.length > 0) {
-        if (hasUncheckedTasks) {
-          info(`Late-Binding Parent Waking Up: ${node.repoPath} has completed children, but still has unchecked tasks. Promoting to READY.`);
-          eligible.push(node);
-        } else {
-          info(`Late binding completion: ${node.repoPath} has no pending target artifacts and all spawned children are complete.`);
-          promoteNodeStatus(node, 'PENDING', 'COMPLETED');
-        }
+      } else if (children.length > 0) {
+        // If the node already has children, it is in a Late-Binding wait state.
+        // We MUST NOT push it to eligible here. Phase 4.1 will wake it up if all children are completed.
+        info(`Late-Binding Parent: ${node.repoPath} is waiting for children to complete.`);
       } else {
         eligible.push(node);
       }


### PR DESCRIPTION
Fixes the orchestrator logic bug that caused an infinite loop of empty PRs for late-binding parent nodes.

- Removed the incorrect check in Phase 4 that woke up parent nodes simply for having children.
- Ensured Phase 4.1 is the sole handler for waking up parent nodes once their children are fully `COMPLETED`.

---
*PR created automatically by Jules for task [15023093244508610431](https://jules.google.com/task/15023093244508610431) started by @szubster*