### PR TITLE
🧭 Strategist: Prompt improvement - Add Late Binding protocol to Tech Lead

### DIFF
--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -48,6 +48,13 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending `QA` task nodes associated with the failed implementation. Instead, update the orphaned QA task's Markdown body indicating that it is CANCELLED and replaced by the new tasks, and append an `### Auditor Rejection` section.
 
 ### Handling Rejections & Aborts
+
+### Late Binding for Missing Context
+If you lack critical context or specifications (e.g., exact memory offsets) necessary to generate actionable implementation TASK blueprints, DO NOT guess or draft generic fallbacks. Instead, you MUST utilize the late binding pattern to suspend your STORY:
+1. Spawn a new `RESEARCH` node to investigate the missing information.
+2. Append the new `RESEARCH` node's ID to the current STORY's `depends_on` array in its YAML frontmatter.
+3. Update the current STORY's `status` to `FAILED` and provide a clear `rejection_reason` indicating that it is suspended pending research.
+
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
 
 If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -239,6 +239,12 @@
 **Outcome:** Merged
 **Why:** The Auditor journal observed that failed macro nodes (e.g., IDEA, PRD) in the Resurrection Loop were being blindly resubmitted by the planners without addressing the rejection reasons. This led to infinite loops. Planners previously lacked the explicit instructions that implementation agents (like Coder) had for resuming FAILED nodes.
 **Pattern:** Ensure all upstream generating personas (Product Manager, Epic Planner, Story Owner, Tech Lead) have explicit instructions to read the `rejection_reason` and the reviewing persona's journal (Auditor or QA) when assigned a resurrected FAILED node, to fix the actual issue instead of blindly resubmitting.
+## 2026-07-15 - [Accepted] - Prompt improvement - Add Late Binding protocol to Tech Lead
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `coder` persona already utilizes the Late Binding pattern to gracefully suspend tasks when missing critical context (like memory offsets) by spawning a RESEARCH node and adding it to `depends_on`. The `tech_lead` persona often faces the exact same issue when attempting to translate a vague STORY into actionable technical TASK blueprints. Without explicit Late Binding instructions, the Tech Lead might hallucinate data or write impossible tasks instead of suspending the parent story pending proper research.
+**Pattern:** Apply successful operational patterns (like Late Binding) universally across all relevant personas in the pipeline (from planning to implementation) to ensure consistent error handling and context discovery without hallucination.
+
 ## 2026-06-11 - [Accepted] - Prompt improvement - Add Scratchpad Cleanup rule
 **Type:** Prompt improvement
 **Outcome:** Accepted


### PR DESCRIPTION
**Proposal**: Add the "Late Binding for Missing Context" protocol to the Tech Lead persona's prompt.
**Justification**: The `coder` persona already utilizes the Late Binding pattern to gracefully suspend tasks when missing critical context (like memory offsets) by spawning a RESEARCH node and adding it to `depends_on`. The `tech_lead` persona often faces the exact same issue when attempting to translate a vague STORY into actionable technical TASK blueprints. Without explicit Late Binding instructions, the Tech Lead might hallucinate data or write impossible tasks instead of suspending the parent story pending proper research.
**Evidence**: Examples from the Coder journal demonstrate the successful application of the Late Binding pattern when context is missing. Bringing this pattern upstream to the Tech Lead prevents the generation of un-implementable tasks.

---
*PR created automatically by Jules for task [9101294910716945384](https://jules.google.com/task/9101294910716945384) started by @szubster*