### PR TITLE
feat: implement gen3 battle frontier win streaks extraction

### DIFF
--- a/.foundry/tasks/task-121-171-gen3-parse-battle-frontier-win-streaks-impl.md
+++ b/.foundry/tasks/task-121-171-gen3-parse-battle-frontier-win-streaks-impl.md
@@ -49,6 +49,6 @@ Offsets (relative to start of `SaveBlock2`, `0x0000`):
 - `0x0E1E` - `pyramidRecordStreaks`
 
 ## Acceptance Criteria
-- [ ] Extract current win streaks for Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid.
-- [ ] Extract max win records for all 7 facilities.
-- [ ] Implement error handling for out-of-bounds reads.
+- [x] Extract current win streaks for Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid.
+- [x] Extract max win records for all 7 facilities.
+- [x] Implement error handling for out-of-bounds reads.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -96,6 +96,16 @@ export interface Gen3BerryPatch {
   watered4: boolean;
 }
 
+export interface Gen3BattleFrontierWinStreaks {
+  tower: { current: number; record: number };
+  dome: { current: number; record: number };
+  palace: { current: number; record: number };
+  arena: { current: number; record: number };
+  factory: { current: number; record: number };
+  pike: { current: number; record: number };
+  pyramid: { current: number; record: number };
+}
+
 export interface SaveData {
   /** The generation of the parsed save file (1 or 2). */
   generation: Generation;
@@ -177,6 +187,8 @@ export interface SaveData {
   }[];
   /** Gen 3 specific: The 16-bit daily Mirage Island random value. */
   mirageIslandValue?: number;
+  /** Gen 3 specific: Battle Frontier win streaks */
+  gen3BattleFrontierWinStreaks?: Gen3BattleFrontierWinStreaks;
 }
 
 // Removed byte helper as DataView provides getUint8 natively.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   isGen3Save,
   parseGen3,
+  parseGen3BattleFrontierWinStreaks,
   parseGen3ConditionStats,
   parseGen3MirageIslandValue,
   parseGen3MixRecords,
@@ -470,6 +471,58 @@ describe('parseGen3PokeNews', () => {
     const view = new DataView(buffer);
 
     expect(() => parseGen3PokeNews(view, 0)).toThrowError('The save file is corrupted or incomplete.');
+  });
+});
+
+describe('parseGen3BattleFrontierWinStreaks', () => {
+  const saveBlock2Offset = 0x1000;
+
+  it('extracts win streaks and records for all 7 facilities', () => {
+    const buffer = new ArrayBuffer(8192);
+    const view = new DataView(buffer);
+    const base = saveBlock2Offset;
+
+    // Set some dummy data using the defined offsets
+    view.setUint16(base + 0x0ce0, 10, true); // tower current
+    view.setUint16(base + 0x0cf0, 20, true); // tower record
+
+    view.setUint16(base + 0x0d0c, 5, true); // dome current
+    view.setUint16(base + 0x0d14, 15, true); // dome record
+
+    view.setUint16(base + 0x0dc8, 12, true); // palace current
+    view.setUint16(base + 0x0dd0, 22, true); // palace record
+
+    view.setUint16(base + 0x0dda, 7, true); // arena current
+    view.setUint16(base + 0x0dde, 17, true); // arena record
+
+    view.setUint16(base + 0x0de2, 8, true); // factory current
+    view.setUint16(base + 0x0dea, 18, true); // factory record
+
+    view.setUint16(base + 0x0e04, 3, true); // pike current
+    view.setUint16(base + 0x0e08, 13, true); // pike record
+
+    view.setUint16(base + 0x0e1a, 2, true); // pyramid current
+    view.setUint16(base + 0x0e1e, 12, true); // pyramid record
+
+    const result = parseGen3BattleFrontierWinStreaks(view, saveBlock2Offset);
+
+    expect(result.tower).toEqual({ current: 10, record: 20 });
+    expect(result.dome).toEqual({ current: 5, record: 15 });
+    expect(result.palace).toEqual({ current: 12, record: 22 });
+    expect(result.arena).toEqual({ current: 7, record: 17 });
+    expect(result.factory).toEqual({ current: 8, record: 18 });
+    expect(result.pike).toEqual({ current: 3, record: 13 });
+    expect(result.pyramid).toEqual({ current: 2, record: 12 });
+  });
+
+  it('throws "The save file is corrupted or incomplete." on out-of-bounds reads', () => {
+    // Buffer too small to hold all offsets
+    const buffer = new ArrayBuffer(0x0e00);
+    const view = new DataView(buffer);
+
+    expect(() => {
+      parseGen3BattleFrontierWinStreaks(view, 0);
+    }).toThrow('The save file is corrupted or incomplete.');
   });
 });
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -18,7 +18,14 @@
  * is determined by `PV % 24`.
  */
 
-import type { GameVersion, Gen3BerryPatch, Gen3Ribbons, Gen3SecretBase, SaveData } from './common';
+import type {
+  GameVersion,
+  Gen3BattleFrontierWinStreaks,
+  Gen3BerryPatch,
+  Gen3Ribbons,
+  Gen3SecretBase,
+  SaveData,
+} from './common';
 
 const SIGNATURE = 0x08012025;
 const SECTION_SIZE = 4096;
@@ -50,6 +57,21 @@ const IV_SHIFT_DEF = 10;
 const IV_SHIFT_SPD = 15;
 const IV_SHIFT_SPATK = 20;
 const IV_SHIFT_SPDEF = 25;
+
+const TOWER_WIN_STREAKS_OFFSET = 0x0ce0;
+const TOWER_RECORD_WIN_STREAKS_OFFSET = 0x0cf0;
+const DOME_WIN_STREAKS_OFFSET = 0x0d0c;
+const DOME_RECORD_WIN_STREAKS_OFFSET = 0x0d14;
+const PALACE_WIN_STREAKS_OFFSET = 0x0dc8;
+const PALACE_RECORD_WIN_STREAKS_OFFSET = 0x0dd0;
+const ARENA_WIN_STREAKS_OFFSET = 0x0dda;
+const ARENA_RECORD_WIN_STREAKS_OFFSET = 0x0dde;
+const FACTORY_WIN_STREAKS_OFFSET = 0x0de2;
+const FACTORY_RECORD_WIN_STREAKS_OFFSET = 0x0dea;
+const PIKE_WIN_STREAKS_OFFSET = 0x0e04;
+const PIKE_RECORD_WIN_STREAKS_OFFSET = 0x0e08;
+const PYRAMID_WIN_STREAKS_OFFSET = 0x0e1a;
+const PYRAMID_RECORD_WIN_STREAKS_OFFSET = 0x0e1e;
 
 /**
  * Locates the most recent memory offset for a specific save section in Gen 3 flash memory.
@@ -429,6 +451,59 @@ export function parseGen3SecretBases(view: DataView, saveBlock1Offset: number, g
   }
 }
 
+/**
+ * Parses the Gen 3 Battle Frontier win streaks from the save file.
+ *
+ * @param view - The raw save file DataView.
+ * @param saveBlock2Offset - The resolved memory offset to the active SaveBlock2.
+ * @returns An object containing the extracted win streaks and records for all 7 facilities.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3BattleFrontierWinStreaks(
+  view: DataView,
+  saveBlock2Offset: number,
+): Gen3BattleFrontierWinStreaks {
+  try {
+    const baseOffset = saveBlock2Offset; // Using relative offsets to SaveBlock2 start directly, rather than baseOffset + BATTLE_FRONTIER_OFFSET, because the task requirements list offsets relative to the start of SaveBlock2.
+
+    return {
+      tower: {
+        current: view.getUint16(baseOffset + TOWER_WIN_STREAKS_OFFSET, true),
+        record: view.getUint16(baseOffset + TOWER_RECORD_WIN_STREAKS_OFFSET, true),
+      },
+      dome: {
+        current: view.getUint16(baseOffset + DOME_WIN_STREAKS_OFFSET, true),
+        record: view.getUint16(baseOffset + DOME_RECORD_WIN_STREAKS_OFFSET, true),
+      },
+      palace: {
+        current: view.getUint16(baseOffset + PALACE_WIN_STREAKS_OFFSET, true),
+        record: view.getUint16(baseOffset + PALACE_RECORD_WIN_STREAKS_OFFSET, true),
+      },
+      arena: {
+        current: view.getUint16(baseOffset + ARENA_WIN_STREAKS_OFFSET, true),
+        record: view.getUint16(baseOffset + ARENA_RECORD_WIN_STREAKS_OFFSET, true),
+      },
+      factory: {
+        current: view.getUint16(baseOffset + FACTORY_WIN_STREAKS_OFFSET, true),
+        record: view.getUint16(baseOffset + FACTORY_RECORD_WIN_STREAKS_OFFSET, true),
+      },
+      pike: {
+        current: view.getUint16(baseOffset + PIKE_WIN_STREAKS_OFFSET, true),
+        record: view.getUint16(baseOffset + PIKE_RECORD_WIN_STREAKS_OFFSET, true),
+      },
+      pyramid: {
+        current: view.getUint16(baseOffset + PYRAMID_WIN_STREAKS_OFFSET, true),
+        record: view.getUint16(baseOffset + PYRAMID_RECORD_WIN_STREAKS_OFFSET, true),
+      },
+    };
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
 export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveData {
   try {
     let section2Offset: number;
@@ -481,8 +556,17 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     const mirageIslandOffset = _forcedVersion === 'emerald' ? 0x0464 : 0x0408;
     const mirageIslandValue = parseGen3MirageIslandValue(view, section2Offset + mirageIslandOffset);
 
+    let gen3BattleFrontierWinStreaks: Gen3BattleFrontierWinStreaks | undefined;
+    if (_forcedVersion === 'emerald') {
+      try {
+        gen3BattleFrontierWinStreaks = parseGen3BattleFrontierWinStreaks(view, section2Offset);
+      } catch {
+        // Ignored if missing or corrupted, allowing the rest of the save to load
+      }
+    }
+
     // Dummy scaffold values for now until fully implemented
-    return {
+    const result: SaveData = {
       generation: 3,
       owned: new Set(),
       seen: new Set(),
@@ -506,6 +590,10 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       gen3MixRecords,
       roamingLegendaries,
     };
+    if (gen3BattleFrontierWinStreaks) {
+      result.gen3BattleFrontierWinStreaks = gen3BattleFrontierWinStreaks;
+    }
+    return result;
   } catch (error) {
     if (error instanceof RangeError) {
       throw new Error('The save file is corrupted or incomplete.');


### PR DESCRIPTION
This PR implements the Gen 3 Battle Frontier win streaks extraction functionality requested in `task-121-171-gen3-parse-battle-frontier-win-streaks-impl`.

### Changes Made:
1. **Added `Gen3BattleFrontierWinStreaks` Interface**: Defined the type structure for all 7 facilities (`tower`, `dome`, `palace`, `arena`, `factory`, `pike`, `pyramid`) tracking `current` and `record` values in `src/engine/saveParser/parsers/common.ts`.
2. **Updated `SaveData` Interface**: Included `gen3BattleFrontierWinStreaks?: Gen3BattleFrontierWinStreaks` into the global `SaveData` payload.
3. **Implemented Extraction Logic**: Created `parseGen3BattleFrontierWinStreaks` inside `src/engine/saveParser/parsers/gen3.ts`, reading from `SaveBlock2` with strict offset constants.
4. **DataView Protection**: Used `DataView` with try/catch to wrap RangeErrors into "The save file is corrupted or incomplete." strings as per ADR 010.
5. **Unit Testing**: Wrote robust unit tests ensuring extraction correctly handles the multi-facility offsets and correctly catches out-of-bound buffers in `gen3.test.ts`.

All Acceptance Criteria checkboxes have been successfully checked. Tests and static analyses passed.

---
*PR created automatically by Jules for task [16310462981945225309](https://jules.google.com/task/16310462981945225309) started by @szubster*