### PR TITLE
🖼️ Canvas: Tactical Contest Stats Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -221,3 +221,9 @@
 **Outcome:** Accepted
 **Why:** The search and filter controls are primary interaction points, but they looked like standard web form inputs. By styling them as a specialized hardware console with distinct labeled panes, radar visualizer, and physical-looking switch states, the user's primary interface for manipulating the data grid now fully aligns with the tactical device simulation.
 **Pattern:** When designing dense control clusters (like search bars and filter sets), wrap them in labeled hardware panels (`[ UPLINK ]`, `[ MATRIX ]`). Integrate faux-hardware visualizers (like radar sweeps) near inputs, and treat selectable options as physical membrane switches with LED dots, moving away from generic segmented controls.
+
+## 2026-07-25 - [Accepted] - 🖼️ Canvas: Tactical Contest Stats Redesign
+**What:** Redesigned the `ContestConditionStats` component to fully embrace the tactical "snooping" aesthetic. Replaced the generic continuous progress bars with segmented tactical displays, utilizing an array of individual block elements for stats, matching `AliveTeamView` and `StorageGrid`. Also updated the label layout to strictly use bracketed monospaced telemetry fonts (e.g., `[ COOL ]`) and wrapped the stats inside a `<TacticalPanel>` and `<TelemetryDecoration>` (`SYS.CONTEST_STATS`).
+**Outcome:** Accepted
+**Why:** Brings the contest attribute component in line with the established specialized hardware motif. Continuous smooth progress bars break the "specialized hardware" illusion, whereas segmented terminal bars effectively mimic a rugged, low-resolution CRT display.
+**Pattern:** Avoid continuous progress bars for visualizing data distributions. Consistently use segmented bars built from distinct block elements for all health, capacity, or attribute statistics across the application to reinforce the hardware simulation.

--- a/src/components/ContestConditionStats.tsx
+++ b/src/components/ContestConditionStats.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { cn } from '../utils/cn';
 import { TacticalPanel } from './TacticalPanel';
+import { TelemetryDecoration } from './TelemetryDecoration';
 
 export interface ContestConditionStatsProps extends React.HTMLAttributes<HTMLDivElement> {
   cool?: number;
@@ -15,56 +16,89 @@ const StatBar = ({
   value,
   max = 255,
   colorClass,
-  bgClass,
+  emptyColorClass,
 }: {
   label: string;
   value: number;
   max?: number;
   colorClass: string;
-  bgClass: string;
+  emptyColorClass: string;
 }) => {
-  const percentage = Math.min(100, Math.max(0, (value / max) * 100));
+  const segmentCount = 15;
 
   return (
-    <div className="flex flex-col gap-1 font-mono text-sm">
-      <div className="flex justify-between text-white/70">
-        <span className="uppercase tracking-wider">{label}</span>
-        <span>{value}</span>
+    <div className="flex flex-col gap-1.5 border-zinc-800 border-l border-dashed pl-3 transition-colors hover:border-zinc-500">
+      <div className="tactical-text flex justify-between text-[9px] text-zinc-400">
+        <span className="font-black uppercase tracking-widest">[ {label} ]</span>
+        <span className="font-mono text-zinc-500">{value}</span>
       </div>
-      <div className={cn('h-3 w-full rounded-none border border-dashed p-[1px]', borderClassMap[colorClass])}>
-        <div
-          className={cn('h-full rounded-none', bgClass)}
-          style={{ width: `${percentage}%` }}
-          data-role="progressbar"
-          data-valuenow={value}
-        />
+      {/* oxlint-disable jsx-a11y/prefer-tag-over-role */}
+      <div
+        className="flex h-2 w-full gap-px bg-black p-px"
+        role="progressbar"
+        aria-valuenow={value}
+        aria-valuemax={max}
+      >
+        {Array.from({ length: segmentCount }).map((_, i) => {
+          const ratio = value / max;
+          const threshold = (i + 1) / segmentCount;
+          const isActive = ratio >= threshold;
+
+          return (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: Array index is stable and safe here
+              key={`stat-segment-${i}`}
+              className={cn('h-full flex-1', isActive ? colorClass : emptyColorClass)}
+            />
+          );
+        })}
       </div>
     </div>
   );
 };
 
-const borderClassMap: Record<string, string> = {
-  'bg-red-500': 'border-red-500/50',
-  'bg-blue-500': 'border-blue-500/50',
-  'bg-pink-500': 'border-pink-500/50',
-  'bg-emerald-500': 'border-emerald-500/50',
-  'bg-amber-500': 'border-amber-500/50',
-};
-
 export const ContestConditionStats = React.forwardRef<HTMLDivElement, ContestConditionStatsProps>(
   ({ cool = 0, beauty = 0, cute = 0, smart = 0, tough = 0, className, ...props }, ref) => {
     return (
-      <TacticalPanel ref={ref} variant="default" className={cn('flex flex-col gap-4 p-4', className)} {...props}>
-        <div className="flex items-center gap-2 border-white/20 border-b border-dashed pb-2">
-          <span className="tactical-text font-bold text-sm text-white">Contest Conditions</span>
-        </div>
+      <TacticalPanel
+        ref={ref}
+        variant="default"
+        className={cn('relative flex flex-col gap-6 p-6 pt-8', className)}
+        {...props}
+      >
+        <TelemetryDecoration label="SYS.CONTEST_STATS" className="-top-1 left-4" />
 
-        <div className="flex flex-col gap-3">
-          <StatBar label="Cool" value={cool} colorClass="bg-red-500" bgClass="bg-red-500/60" />
-          <StatBar label="Beauty" value={beauty} colorClass="bg-blue-500" bgClass="bg-blue-500/60" />
-          <StatBar label="Cute" value={cute} colorClass="bg-pink-500" bgClass="bg-pink-500/60" />
-          <StatBar label="Smart" value={smart} colorClass="bg-emerald-500" bgClass="bg-emerald-500/60" />
-          <StatBar label="Tough" value={tough} colorClass="bg-amber-500" bgClass="bg-amber-500/60" />
+        <div className="flex flex-col gap-4">
+          <StatBar
+            label="Cool"
+            value={cool}
+            colorClass="bg-red-500 shadow-[0_0_5px_rgba(239,68,68,0.8)]"
+            emptyColorClass="bg-red-950/30"
+          />
+          <StatBar
+            label="Beauty"
+            value={beauty}
+            colorClass="bg-blue-500 shadow-[0_0_5px_rgba(59,130,246,0.8)]"
+            emptyColorClass="bg-blue-950/30"
+          />
+          <StatBar
+            label="Cute"
+            value={cute}
+            colorClass="bg-pink-500 shadow-[0_0_5px_rgba(236,72,153,0.8)]"
+            emptyColorClass="bg-pink-950/30"
+          />
+          <StatBar
+            label="Smart"
+            value={smart}
+            colorClass="bg-emerald-500 shadow-[0_0_5px_rgba(16,185,129,0.8)]"
+            emptyColorClass="bg-emerald-950/30"
+          />
+          <StatBar
+            label="Tough"
+            value={tough}
+            colorClass="bg-amber-500 shadow-[0_0_5px_rgba(245,158,11,0.8)]"
+            emptyColorClass="bg-amber-950/30"
+          />
         </div>
       </TacticalPanel>
     );

--- a/src/components/__tests__/ContestConditionStats.test.tsx
+++ b/src/components/__tests__/ContestConditionStats.test.tsx
@@ -5,18 +5,18 @@ import { ContestConditionStats } from '../ContestConditionStats';
 
 test('renders ContestConditionStats with default values', async () => {
   const { container } = await render(<ContestConditionStats />);
-  await expect.element(page.getByText('Contest Conditions')).toBeInTheDocument();
-  await expect.element(page.getByText('COOL')).toBeInTheDocument();
-  await expect.element(page.getByText('BEAUTY')).toBeInTheDocument();
-  await expect.element(page.getByText('CUTE')).toBeInTheDocument();
-  await expect.element(page.getByText('SMART')).toBeInTheDocument();
-  await expect.element(page.getByText('TOUGH')).toBeInTheDocument();
+  await expect.element(page.getByText('SYS.CONTEST_STATS')).toBeInTheDocument();
+  await expect.element(page.getByText('[ Cool ]')).toBeInTheDocument();
+  await expect.element(page.getByText('[ Beauty ]')).toBeInTheDocument();
+  await expect.element(page.getByText('[ Cute ]')).toBeInTheDocument();
+  await expect.element(page.getByText('[ Smart ]')).toBeInTheDocument();
+  await expect.element(page.getByText('[ Tough ]')).toBeInTheDocument();
 
   // All values should default to 0
-  const progressBars = container.querySelectorAll('[data-role="progressbar"]');
+  const progressBars = container.querySelectorAll('[role="progressbar"]');
   expect(progressBars.length).toBe(5);
   for (const bar of progressBars) {
-    expect(bar.getAttribute('data-valuenow')).toBe('0');
+    expect(bar.getAttribute('aria-valuenow')).toBe('0');
   }
 });
 
@@ -25,22 +25,22 @@ test('renders ContestConditionStats with provided values', async () => {
     <ContestConditionStats cool={50} beauty={100} cute={150} smart={200} tough={255} />,
   );
 
-  const progressBars = container.querySelectorAll('[data-role="progressbar"]');
+  const progressBars = container.querySelectorAll('[role="progressbar"]');
   expect(progressBars.length).toBe(5);
 
-  expect(progressBars[0]?.getAttribute('data-valuenow')).toBe('50');
-  expect(progressBars[1]?.getAttribute('data-valuenow')).toBe('100');
-  expect(progressBars[2]?.getAttribute('data-valuenow')).toBe('150');
-  expect(progressBars[3]?.getAttribute('data-valuenow')).toBe('200');
-  expect(progressBars[4]?.getAttribute('data-valuenow')).toBe('255');
+  expect(progressBars[0]?.getAttribute('aria-valuenow')).toBe('50');
+  expect(progressBars[1]?.getAttribute('aria-valuenow')).toBe('100');
+  expect(progressBars[2]?.getAttribute('aria-valuenow')).toBe('150');
+  expect(progressBars[3]?.getAttribute('aria-valuenow')).toBe('200');
+  expect(progressBars[4]?.getAttribute('aria-valuenow')).toBe('255');
 });
 
 test('handles missing values gracefully', async () => {
   const { container } = await render(<ContestConditionStats cool={10} />);
 
-  const progressBars = container.querySelectorAll('[data-role="progressbar"]');
+  const progressBars = container.querySelectorAll('[role="progressbar"]');
   expect(progressBars.length).toBe(5);
 
-  expect(progressBars[0]?.getAttribute('data-valuenow')).toBe('10');
-  expect(progressBars[1]?.getAttribute('data-valuenow')).toBe('0');
+  expect(progressBars[0]?.getAttribute('aria-valuenow')).toBe('10');
+  expect(progressBars[1]?.getAttribute('aria-valuenow')).toBe('0');
 });


### PR DESCRIPTION
Redesigned the `ContestConditionStats` component to fully embrace the tactical "snooping" aesthetic of the application. The continuous progress bars have been replaced with segmented tactical displays built from individual block elements. The labels have been updated to use bracketed monospaced telemetry fonts (e.g., `[ COOL ]`), and the entire component is now wrapped inside a `<TacticalPanel>` with a `<TelemetryDecoration>` header (`SYS.CONTEST_STATS`). Also updated `.jules/canvas.md` to reflect this change.

---
*PR created automatically by Jules for task [1941039707816267560](https://jules.google.com/task/1941039707816267560) started by @szubster*