### PR TITLE
🧭 Strategist: Prompt improvement - Enforce checkbox checking for failed child nodes

### DIFF
--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -39,6 +39,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 2. Create a new set of replacement nodes (e.g., stories) that explicitly depend on the `RESEARCH` node being completed.
 3. Append these new nodes to your own markdown body.
 4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending nodes associated with the failed implementation. Instead, update the orphaned node's Markdown body indicating that it is CANCELLED and replaced by the new nodes.
+5. **CRITICAL:** You MUST check off the markdown checkboxes (`- [x]`) of the permanently failed and orphaned child nodes in your own markdown body. If they remain unchecked, ADR 007 will prevent this parent node from ever transitioning to COMPLETED.
 
 ### Handling Rejections & Aborts
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -33,6 +33,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 2. Create a new set of replacement nodes that explicitly depend on the `RESEARCH` node being completed.
 3. Append these new nodes to your own markdown body.
 4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending nodes associated with the failed implementation. Instead, update the orphaned node's Markdown body indicating that it is CANCELLED and replaced by the new nodes.
+5. **CRITICAL:** You MUST check off the markdown checkboxes (`- [x]`) of the permanently failed and orphaned child nodes in your own markdown body. If they remain unchecked, ADR 007 will prevent this parent node from ever transitioning to COMPLETED.
 
 ### Handling Rejections & Aborts
 **CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -34,6 +34,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 2. Create a new set of replacement nodes (e.g., tasks) that explicitly depend on the `RESEARCH` node being completed.
 3. Append these new nodes to your own markdown body.
 4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending nodes (like `QA` task nodes) associated with the failed implementation. Instead, update the orphaned node's Markdown body indicating that it is CANCELLED and replaced by the new tasks.
+5. **CRITICAL:** You MUST check off the markdown checkboxes (`- [x]`) of the permanently failed and orphaned child nodes in your own markdown body. If they remain unchecked, ADR 007 will prevent this parent node from ever transitioning to COMPLETED.
 
 
 ### Handling Rejections & Aborts

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -46,6 +46,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 2. Create a new set of replacement implementation and/or QA tasks that explicitly depend on the `RESEARCH` node being completed.
 3. Append these new nodes to your own markdown body.
 4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending `QA` task nodes associated with the failed implementation. Instead, update the orphaned QA task's Markdown body indicating that it is CANCELLED and replaced by the new tasks, and append an `### Auditor Rejection` section.
+5. **CRITICAL:** You MUST check off the markdown checkboxes (`- [x]`) of the permanently failed and orphaned child nodes in your own markdown body. If they remain unchecked, ADR 007 will prevent this parent node from ever transitioning to COMPLETED.
 
 ### Handling Rejections & Aborts
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -296,3 +296,9 @@
 **Outcome:** Rejected → journaled
 **Why:** Modifying the `coder.md` prompt to submit an Empty PR for late-binding dependencies created a severe logical contradiction. If the agent modifies the node file's YAML to add the new dependency, committing those changes means the PR is *not* empty. Conversely, if it strictly submits an empty PR, the dependency changes are discarded, breaking the late binding pattern entirely. Additionally, it instructed the agent *not* to change the status to `FAILED`, which violated the "Core Policies" restricting YAML modifications *only* to `FAILED` or `CANCELLED` statuses. The proposed workflow for the Coder agent was impossible.
 **Pattern:** Do not propose prompt changes that create logical paradoxes or impossible workflows, such as requiring an "Empty PR" for a step that inherently requires file modifications (like updating a `depends_on` array).
+
+## 2026-07-16 - [Accepted] - Prompt improvement - Enforce checkbox checking for failed child nodes
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The journals for several planner personas (`story_owner`, `tech_lead`) noted that when handling a permanent child node failure, the parent node's markdown checkbox for the failed child node must be checked off (`- [x]`) so that the parent can eventually be marked COMPLETED and pass the ADR 007 validation. If left unchecked, the parent node will be permanently stuck in the PENDING state. This explicit instruction was missing from the "HANDLING PERMANENT CHILD FAILURES" section in the prompts for all generative personas (`product_manager`, `epic_planner`, `story_owner`, `tech_lead`).
+**Pattern:** Codify system constraints discovered by implementation agents (ADR 007 checklist compliance for failed/cancelled child nodes) explicitly into the prompts of the generative upstream agents to avoid task freezing or endless parent node PENDING loops.


### PR DESCRIPTION
**Proposal**: Add an explicit instruction to the prompts of all planner personas (Product Manager, Epic Planner, Story Owner, Tech Lead) requiring them to check off the markdown checkboxes (`- [x]`) for permanently failed and orphaned child nodes when handling the "Impossible Loop".

**Justification**: The journals for several planner personas (`story_owner`, `tech_lead`) repeatedly noted a constraint under ADR 007: if the markdown checkbox corresponding to a cancelled/permanently failed child node is left unchecked (`- [ ]`) in the parent node's markdown, the parent node can never successfully transition to `COMPLETED`. The parent becomes permanently stuck in the `PENDING` state and creates a DAG deadlock. This crucial constraint was missing from the "HANDLING PERMANENT CHILD FAILURES" section in all generative agent prompts.

**Evidence**: 
* `tech_lead.md` journal (2026-06-19): "Do NOT check off failed tasks: In the parent node... do NOT check off the acceptance criteria checkboxes for permanently failed nodes" (This was a prior, incorrect learning that created deadlocks, later corrected).
* `story_owner.md` journal (2026-05-22 & later): "When a child node is permanently cancelled, its corresponding checkbox in the parent node's markdown body MUST be checked off (`[x]`) to satisfy ADR 007 and allow parent completion."

---
*PR created automatically by Jules for task [4829324802113681567](https://jules.google.com/task/4829324802113681567) started by @szubster*