### PR TITLE
fix: Handle permanent child failure for gen3 roamer dashboard UI epic in PRD

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -35,6 +35,6 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
 - [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
 - [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
-- [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
 - [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
 - [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
This PR handles the permanent child failure of the Gen 3 Roamer Dashboard UI epic (`epic-044-073-gen3-roamer-dashboard-ui`). 
Since it was cancelled due to impossible location extraction (ADR 108-027) and replaced by an alternative research/epic (`epic-044-096-gen3-roamer-dashboard-ui-v2`), its markdown checkbox in the parent PRD (`prd-071-044-gen3-roamer-tracker`) needs to be checked off (`- [x]`) to satisfy ADR 007 and allow the PRD to eventually transition to COMPLETED.

---
*PR created automatically by Jules for task [15757180595337360777](https://jules.google.com/task/15757180595337360777) started by @szubster*