### PR TITLE
Update PRD to reflect cancelled epics

### DIFF
--- a/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+++ b/.foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
@@ -38,4 +38,4 @@ Develop a dashboard view that presents the exact state of the roaming Pokémon, 
 - [ ] Story Owner: Break down this Epic into executable Stories.
 
 ### Auditor Rejection
-**CANCELLED:** This epic is cancelled and replaced by `epic-044-096-gen3-roamer-dashboard-ui-v2.md` because its dependency on the Gen 3 Roamer Location Radar is impossible to satisfy.
+**CANCELLED:** This epic is cancelled and replaced by `epic-044-096-gen3-roamer-dashboard-ui-v2.md` and `research-044-207-gen3-roamer-ui-alternatives.md` because its dependency on the Gen 3 Roamer Location Radar is impossible to satisfy.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -30,3 +30,6 @@ I learned that the cancelled child node (`epic-044-072-gen3-roamer-location-rada
 
 ## 2026-06-24: Handling permanently failed child nodes
 When handling permanent child failures, I must cancel the failed node and any orphaned pending nodes by updating their markdown bodies, NOT their YAML frontmatter (for pending ones). I must also check off the cancelled tasks in the parent PRD and append the new replacement tasks including a RESEARCH node to investigate the root cause.
+
+## 2026-06-26: Handling permanently failed child nodes (Update)
+When handling permanent child failures (like an impossible dependency), I must update the YAML frontmatter of the target failed node to `status: CANCELLED` and provide a `rejection_reason`. I must also check off the cancelled tasks in the parent's markdown body (`- [x]`) to prevent the parent from being permanently blocked, as per ADR 007. I must never update the YAML frontmatter of orphaned pending nodes, only their markdown bodies if necessary.

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -35,6 +35,6 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - [ ] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
 - [ ] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
 - [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
-- [ ] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
+- [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
 - [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
 - [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
Updates the PRD by checking off a cancelled epic and updates the cancelled epic to clarify the replacement nodes.

---
*PR created automatically by Jules for task [3697880695880242751](https://jules.google.com/task/3697880695880242751) started by @szubster*