### PR TITLE
🧱 Mason: LocationRow extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -136,3 +136,4 @@
 - **Key Learnings**:
   - The extraction allows `CapacitySegmentedBar` to be easily dropped into other panels that require a tactical capacity readout (e.g. PC storage, memory limits, team size).
   - Passing `current` and `max` directly rather than the full `PokemonInstance[]` array decouples the component from domain-specific data models.
+## LocationRow Extraction\n- Identified a repeating JSX pattern in `PokemonLocations.tsx` for displaying location information (both evolution requirements and static encounters).\n- Extracted the pattern into a reusable `LocationRow` component.\n- **Key Learnings**:\n  - When extracting rows with specific, variable icon structures and tactical badges, leveraging React nodes (`icon`, `badge`) as props ensures maximum flexibility for the parent while containing the rigid wrapper styling logic.

--- a/src/components/pokemon/details/LocationRow.tsx
+++ b/src/components/pokemon/details/LocationRow.tsx
@@ -1,0 +1,29 @@
+import type React from 'react';
+import { cn } from '../../../utils/cn';
+
+interface LocationRowProps extends React.HTMLAttributes<HTMLDivElement> {
+  icon: React.ReactNode;
+  iconColorClass: string;
+  label: React.ReactNode;
+  badge: React.ReactNode;
+}
+
+export function LocationRow({ icon, iconColorClass, label, badge, className, ...props }: LocationRowProps) {
+  return (
+    <div
+      className={cn(
+        'group flex items-center justify-between rounded-none border border-white/5 border-dashed bg-zinc-900 p-4 transition-all hover:border-[var(--theme-primary)]/30',
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex items-center gap-3">
+        <div className={cn('rounded-none p-2', iconColorClass)}>{icon}</div>
+        <span className="font-bold text-xs uppercase tracking-wide transition-colors group-hover:text-white">
+          {label}
+        </span>
+      </div>
+      {badge}
+    </div>
+  );
+}

--- a/src/components/pokemon/details/PokemonLocations.tsx
+++ b/src/components/pokemon/details/PokemonLocations.tsx
@@ -5,6 +5,7 @@ import { isValidStaticGameVersion, staticEncounters } from '../../../engine/data
 import { SectionHeader } from '../../SectionHeader';
 import { TacticalBadge } from '../../TacticalBadge';
 import { TacticalPanel } from '../../TacticalPanel';
+import { LocationRow } from './LocationRow';
 
 interface EvoReq {
   fromId: number;
@@ -54,34 +55,22 @@ export function PokemonLocations({
           {hasEncounters ? (
             <>
               {evoReq && (
-                <div className="group flex items-center justify-between rounded-none border border-white/5 border-dashed bg-zinc-900 p-4 transition-all hover:border-[var(--theme-primary)]/30">
-                  <div className="flex items-center gap-3">
-                    <div className="rounded-none bg-amber-500/10 p-2 text-amber-500">
-                      <ArrowUpCircle size={14} />
-                    </div>
-                    <span className="font-bold text-xs uppercase tracking-wide transition-colors group-hover:text-white">
-                      Available via Evolving {evoReq.fromName.toUpperCase()}
-                    </span>
-                  </div>
-                  <TacticalBadge variant="amber">EVOLUTION</TacticalBadge>
-                </div>
+                <LocationRow
+                  icon={<ArrowUpCircle size={14} />}
+                  iconColorClass="bg-amber-500/10 text-amber-500"
+                  label={`Available via Evolving ${evoReq.fromName.toUpperCase()}`}
+                  badge={<TacticalBadge variant="amber">EVOLUTION</TacticalBadge>}
+                />
               )}
               {staticEnc?.map((loc, i) => (
-                <div
+                <LocationRow
                   // biome-ignore lint/suspicious/noArrayIndexKey: Array index is stable and required for duplicates
                   key={`static-${i}`}
-                  className="group flex items-center justify-between rounded-none border border-white/5 border-dashed bg-zinc-900 p-4 transition-all hover:border-[var(--theme-primary)]/30"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="rounded-none bg-red-500/10 p-2 text-red-500">
-                      <Target size={14} />
-                    </div>
-                    <span className="font-bold text-xs uppercase tracking-wide transition-colors group-hover:text-white">
-                      {loc}
-                    </span>
-                  </div>
-                  <TacticalBadge variant="red">STATIONARY</TacticalBadge>
-                </div>
+                  icon={<Target size={14} />}
+                  iconColorClass="bg-red-500/10 text-red-500"
+                  label={loc}
+                  badge={<TacticalBadge variant="red">STATIONARY</TacticalBadge>}
+                />
               ))}
               {versionEnc.map((e) => {
                 return (


### PR DESCRIPTION
🎯 What
Extracted a new `LocationRow` component in `src/components/pokemon/details/LocationRow.tsx` and updated `src/components/pokemon/details/PokemonLocations.tsx` to use it.

💡 Why
`PokemonLocations.tsx` had multiple repeating instances of a complex `div` structure (`div.group.flex.items-center.justify-between.rounded-none...`) for rendering individual location rows with icons, tactical badges, and varying content (e.g. evolution requirement vs. static encounters). Extracting it into a reusable component improves readability and maintainability.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to verify the application behavior did not change. All tests passed.

✨ Result
A cleaner `PokemonLocations` component with modular and reusable code for displaying single location items.

---
*PR created automatically by Jules for task [1354871840955012370](https://jules.google.com/task/1354871840955012370) started by @szubster*