### PR TITLE
🧪 Sentinel: add tests for PokemonLocations component

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -156,3 +156,8 @@ When writing E2E tests, do not import helper methods like `argosScreenshot` dire
 **What:** Added visual regression tests (`argosScreenshot`) to `tests/e2e/pokemon-details.spec.ts`.
 **Why:** Fulfills the boundary to cover untested visual flows.
 **Learning:** When writing E2E tests for visual components, ensure `argosScreenshot` is imported directly from `@argos-ci/playwright` as per instructions, avoiding local wrappers unless specifically told otherwise.
+The Sentinel persona's private memory is strictly `.jules/sentinel.md` and must be used solely to log long-term lessons, architectural constraints, and recurring failures, never as an execution logbook or a ledger to record completed tasks.
+In Playwright E2E tests, always call `await waitForSync(page)` after navigation to ensure IndexedDB sync completes.
+Always provide explicit type parameters to `vi.fn()` (e.g., `vi.fn<() => void>()`) to satisfy strict Biome type-checking and avoid `any` usage.
+When writing E2E tests for visual components, use `argosScreenshot(page, 'name')` from `@argos-ci/playwright` to ensure visual fidelity.
+When writing test cases, ensure correct typing is applied to mocked objects to avoid 'any' usage, using assertions such as 'as unknown as string' when strictly required to bypass type errors during mock data injection without disabling the linting check altogether.

--- a/src/components/pokemon/details/__tests__/PokemonLocations.test.tsx
+++ b/src/components/pokemon/details/__tests__/PokemonLocations.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import type { CompactEncounter } from '../../../../db/schema';
+import { PokemonLocations } from '../PokemonLocations';
+
+describe('PokemonLocations', () => {
+  const mockAreaNames = {
+    1: 'Pallet Town',
+    2: 'Route 1',
+  };
+
+  const defaultProps = {
+    pokemonId: 1, // Bulbasaur
+    gameVersion: 'red',
+    encounters: [] as CompactEncounter[],
+    areaNames: mockAreaNames,
+    evoReq: null,
+    loading: false,
+  };
+
+  it('renders loading state correctly', async () => {
+    await render(<PokemonLocations {...defaultProps} loading={true} />);
+    const locationList = page.getByTestId('location-list');
+    await expect.element(locationList).not.toBeInTheDocument();
+  });
+
+  it('renders correctly when there are no encounters (fallback)', async () => {
+    const fallbackEncounters: CompactEncounter[] = [
+      { aid: 2, v: 2, d: [] }, // Version 2 (blue), area 2
+    ];
+
+    // Using pokemonId 2 (Ivysaur) to avoid picking up Bulbasaur's static encounter in 'red'
+    await render(<PokemonLocations {...defaultProps} pokemonId={2} encounters={fallbackEncounters} />);
+
+    await expect.element(page.getByText(/Species unavailable in RED/i)).toBeInTheDocument();
+    await expect.element(page.getByText('ROUTE 1')).toBeInTheDocument();
+    await expect.element(page.getByText('V-ID: 2')).toBeInTheDocument();
+  });
+
+  it('renders encounters correctly for the current version', async () => {
+    const versionEncounters: CompactEncounter[] = [
+      {
+        aid: 1,
+        v: 1, // 'red' has POKE_VERSION_MAP id 1
+        d: [
+          { min: 5, max: 5, m: 1, c: 100 }, // 'walk' maps to 1 in ENCOUNTER_METHOD_MAP
+        ],
+      },
+    ];
+
+    await render(<PokemonLocations {...defaultProps} pokemonId={2} encounters={versionEncounters} />);
+
+    await expect.element(page.getByText('PALLET TOWN')).toBeInTheDocument();
+    await expect.element(page.getByText('LV.5-5')).toBeInTheDocument();
+    await expect.element(page.getByText(/WALK.*100%/i)).toBeInTheDocument();
+  });
+
+  it('renders evolution requirements correctly', async () => {
+    const evoReq = {
+      fromId: 1,
+      fromName: 'Bulbasaur',
+      method: 'Level 16',
+    };
+
+    await render(<PokemonLocations {...defaultProps} evoReq={evoReq} />);
+
+    await expect.element(page.getByText(/Available via Evolving BULBASAUR/i)).toBeInTheDocument();
+    await expect.element(page.getByText('EVOLUTION')).toBeInTheDocument();
+  });
+
+  it('renders static encounters correctly', async () => {
+    // pokemonId 1 (Bulbasaur) in 'red' should have a static encounter in Pallet Town
+    await render(<PokemonLocations {...defaultProps} pokemonId={1} gameVersion="red" />);
+
+    await expect.element(page.getByText('PALLET TOWN')).toBeInTheDocument();
+    await expect.element(page.getByText('STATIONARY')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
🎯 What: Added tests to the `PokemonLocations` component to cover untested logic.
📊 Coverage: Added a Vitest browser test file testing the loading state, the `FallbackLocations` component (used when species are unavailable in the current version), encounters mapped from `encounters` data, evolution requirements handling via `evoReq`, and `staticEncounters`.
✨ Result: The new test cases pass and the overall coverage of `PokemonLocations` is improved without altering the source logic.

---
*PR created automatically by Jules for task [5814885063720700535](https://jules.google.com/task/5814885063720700535) started by @szubster*