### PR TITLE
chore(foundry): update acceptance criteria for prd-071-044-gen3-roamer-tracker

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -33,10 +33,10 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - Provide a Route Radar to map the roamer's current location index.
 
 - [x] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
-- [ ] .foundry/epics/epic-044-101-gen3-roamer-core-extraction-v2.md
+- [x] .foundry/epics/epic-044-101-gen3-roamer-core-extraction-v2.md
 - [x] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
-- [ ] .foundry/epics/epic-044-102-gen3-roamer-iv-glitch-v2.md
+- [x] .foundry/epics/epic-044-102-gen3-roamer-iv-glitch-v2.md
 - [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
 - [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
-- [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
-- [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md
+- [x] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
+- [x] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
Checked off all the generated epics and research nodes in the acceptance criteria since they have all been created. Submitted as an Empty PR to let the DAG transition.

---
*PR created automatically by Jules for task [16421203811856467459](https://jules.google.com/task/16421203811856467459) started by @szubster*