### PR TITLE
🧭 Strategist: Prompt improvement - Centralize Execution Plan Rules

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -36,3 +36,11 @@ The `palette` persona is the master of the Tailwind and styling ecosystem. This 
 1. Maintaining custom primitives in `src/index.css` using the `@utility` directive.
 2. Consolidating repeating utility combinations.
 3. Ensuring styling adherence to the tactical hardware aesthetic guidelines (e.g., `rounded-none`, `border-dashed`, monospaced fonts) as defined in ADR 024.
+
+## Execution Plan Rules
+**Execution Plan Sequencing Rule:** When formulating an execution plan, the required pre-commit verification step must be placed immediately before the final submission or PR creation step, with no intervening actions separating them.
+**Execution Plan Verification Rule:** Execution plans that involve creating new files or modifying existing ones must explicitly include verification steps (e.g., using `read_file`) immediately following the modifications to confirm the changes were written correctly.
+**Empty PR Verification Rule:** Even when submitting an Empty PR (zero file changes) to allow the orchestrator to demote a parent node, the execution plan must explicitly include a preliminary step to run core verification commands (`pnpm lint`, `pnpm test`, and `pnpm test:e2e`) to verify a clean system state before submission. Do not include unmentioned commands (e.g., `pnpm type-check`), as this violates the Groundedness Rule.
+**Execution Plan Groundedness Rule:** Execution plans must not propose actions that have already been successfully completed in the bash session. Your plan must reflect the current state of the workspace. Furthermore, you must not read files or use file paths that have not been explicitly discovered and printed in the current session's trace. Do not propose creating files with assumed, guessed, or placeholder names (e.g., `<NNN>`). Determine exact filenames before plan creation.
+**Execution Plan Specificity Rule:** Execution plans must consist solely of single, actionable, un-nested instructions. Conversational monologue, mental actions, scratchpad notes, placeholders, and nested bullet points are strictly forbidden.
+**Execution Plan Tense Rule:** Execution plans must consist solely of forward-looking, actionable steps required to complete the task. Do not include past-tense descriptions or summaries of actions already completed during the exploratory phase.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -302,3 +302,9 @@
 **Outcome:** Accepted
 **Why:** The journals for several planner personas (`story_owner`, `tech_lead`) noted that when handling a permanent child node failure, the parent node's markdown checkbox for the failed child node must be checked off (`- [x]`) so that the parent can eventually be marked COMPLETED and pass the ADR 007 validation. If left unchecked, the parent node will be permanently stuck in the PENDING state. This explicit instruction was missing from the "HANDLING PERMANENT CHILD FAILURES" section in the prompts for all generative personas (`product_manager`, `epic_planner`, `story_owner`, `tech_lead`).
 **Pattern:** Codify system constraints discovered by implementation agents (ADR 007 checklist compliance for failed/cancelled child nodes) explicitly into the prompts of the generative upstream agents to avoid task freezing or endless parent node PENDING loops.
+
+## 2026-07-17 - [Accepted] - Prompt improvement - Centralize Execution Plan Rules in Core Policies
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The memory requires multiple strict rules for execution plans (Execution Plan Sequencing Rule, Execution Plan Verification Rule, Empty PR Verification Rule, Execution Plan Groundedness Rule, Execution Plan Specificity Rule, and Execution Plan Tense Rule). These rules were repeatedly violated by agents because they were scattered and not centralized in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+**Pattern:** Apply systemic rules consistently across all relevant agent personas. When an architectural constraint or tool rule applies universally, it must be explicitly included in the centralized `core_policies.md` to ensure compliance without bloating individual prompts.


### PR DESCRIPTION
**Proposal**: Centralize the Execution Plan Rules (Sequencing, Verification, Empty PR, Groundedness, Specificity, Tense) into `.foundry/docs/knowledge_base/agents/core_policies.md` and log the update in the Strategist's journal (`.jules/strategist.md`).

**Justification**: These rules are currently scattered across individual agent prompts or injected passively as context by the orchestration layer. Agents consistently violate these rules, leading to plan review rejections, failed sessions, or impossible loops. By centralizing them in `core_policies.md`, all agents will explicitly read and adhere to them during their required context-gathering phase without blooming their individual prompt schedules.

**Evidence**: The Strategist journal and memory constraints continuously log agent failures related to "Execution Plan Groundedness", "Execution Plan Specificity", "Execution Plan Verification", "Empty PR Verification", and "Execution Plan Sequencing". The `strategist.md` schedule explicitly states to "read core_policies.md... to understand centralized policies". Putting these critical operational rules in `core_policies.md` satisfies the project requirement for universal agent knowledge dissemination.

---
*PR created automatically by Jules for task [55410920160172777](https://jules.google.com/task/55410920160172777) started by @szubster*