### PR TITLE
fix(orchestrator): prevent infinite loop when waking up parents

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -655,6 +655,9 @@ function main(): void {
         continue;
       }
       if (parentPath) {
+        if (isHierarchicallyIncomplete(parentPath, ignoredPaths)) {
+          continue;
+        }
         const parentNode = nodeMap.get(parentPath);
         if (
           parentNode &&


### PR DESCRIPTION
Fixes an issue where `ACTIVE` Foundry nodes are repeatedly scheduled by the orchestrator. The root cause is an infinite loop bug in Phase 3.6 where parents of `FAILED`/`CANCELLED` nodes are continually woken up, even if they have already spawned new replacement tasks (which correctly suspends them again). This change fixes the condition to ensure parents are only woken if they aren't otherwise blocked by incomplete dependencies.

---
*PR created automatically by Jules for task [17299237072660404163](https://jules.google.com/task/17299237072660404163) started by @szubster*