### PR TITLE
Epic: Break down Gen 3 Mix Record Events into its own story

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -40,7 +40,7 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - Extract data indicating if events were inherited from another player's save file via the "Mix Record" feature.
 
 ## 3. Acceptance Criteria
-- [ ] Story Owner: Break down into Stories.
+- [x] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
 - [x] story-081-122-gen3-rtc-extraction
@@ -48,3 +48,4 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [ ] story-081-124-gen3-event-forecast-schedule
 - [ ] research-081-144-gen3-rtc-strategy
 - [ ] story-081-144-gen3-rtc-fallback-strategy
+- [ ] story-081-156-gen3-mix-record-parsing

--- a/.foundry/stories/story-081-124-gen3-event-forecast-schedule.md
+++ b/.foundry/stories/story-081-124-gen3-event-forecast-schedule.md
@@ -23,12 +23,9 @@ notes: ''
 # Story: Parse Gen 3 Event Forecasting and Mix Records
 
 ## Description
-Extract the forecasting schedule for upcoming events (e.g., Energy Guru sales) and parse data indicating if events were inherited from "Mix Record" feature.
+Extract the forecasting schedule for upcoming events (e.g., Energy Guru sales).
 
 ## Acceptance Criteria
 - [ ] Extract upcoming event schedule data from the save file.
-- [ ] Extract Mix Record flags/data to identify inherited events.
 - [ ] task-124-171-gen3-event-schedule-parser
-- [ ] task-124-172-gen3-mix-record-events-parser
 - [ ] task-124-173-qa-gen3-event-schedule-parser
-- [ ] task-124-174-qa-gen3-mix-record-events-parser

--- a/.foundry/stories/story-081-156-gen3-mix-record-parsing.md
+++ b/.foundry/stories/story-081-156-gen3-mix-record-parsing.md
@@ -1,0 +1,29 @@
+---
+id: story-081-156-gen3-mix-record-parsing
+type: STORY
+title: Parse Gen 3 Mix Record Events
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-27'
+updated_at: '2026-06-27'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Parse Gen 3 Mix Record Events
+
+## Description
+Extract data indicating if events were inherited from another player's save file via the "Mix Record" feature.
+
+## Acceptance Criteria
+- [ ] Extract Mix Record flags/data to identify inherited events.


### PR DESCRIPTION
This commit addresses the Auditor's feedback by creating a new STORY node specifically for parsing Gen 3 Mix Record Events (`story-081-156-gen3-mix-record-parsing.md`), appending it to `epic-047-081-gen3-tv-swarm-data-extraction.md`, and removing the Mix Record parsing requirement from `story-081-124-gen3-event-forecast-schedule.md` to adhere to the granularity rule. It also correctly checks off the `Story Owner: Break down into Stories.` Acceptance Criteria on the epic.

---
*PR created automatically by Jules for task [10785262080699548588](https://jules.google.com/task/10785262080699548588) started by @szubster*