### PR TITLE
Foundry: Break down epic-047-081-gen3-tv-swarm-data-extraction into stories

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -40,7 +40,7 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - Extract data indicating if events were inherited from another player's save file via the "Mix Record" feature.
 
 ## 3. Acceptance Criteria
-- [ ] Story Owner: Break down into Stories.
+- [x] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
 - [x] story-081-122-gen3-rtc-extraction
@@ -48,3 +48,4 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [ ] story-081-124-gen3-event-forecast-schedule
 - [ ] research-081-144-gen3-rtc-strategy
 - [ ] story-081-144-gen3-rtc-fallback-strategy
+- [ ] story-081-156-gen3-mix-record-features

--- a/.foundry/stories/story-081-156-gen3-mix-record-features.md
+++ b/.foundry/stories/story-081-156-gen3-mix-record-features.md
@@ -1,0 +1,30 @@
+---
+id: story-081-156-gen3-mix-record-features
+type: STORY
+title: Parse Gen 3 Mix Record Data
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-27'
+updated_at: '2026-06-27'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Parse Gen 3 Mix Record Data
+
+## Description
+Extract data indicating if events were inherited from another player's save file via the "Mix Record" feature. This is necessary to properly evaluate whether time-gated events and swarm data have been synchronized from another save.
+
+## Acceptance Criteria
+- [ ] Implement parser logic to extract Mix Record flags.
+- [ ] Parse data structures related to inherited swarms and TV events from other trainers.


### PR DESCRIPTION
This PR breaks down `epic-047-081-gen3-tv-swarm-data-extraction` into individual tasks by creating the missing child story node `story-081-156-gen3-mix-record-features` and linking it. This fulfills the `[x] Story Owner: Break down into Stories.` acceptance criteria.

---
*PR created automatically by Jules for task [4843791110371999745](https://jules.google.com/task/4843791110371999745) started by @szubster*