### PR TITLE
chore: check off cancelled child nodes in prd-071-044-gen3-roamer-tracker

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -33,10 +33,10 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - Provide a Route Radar to map the roamer's current location index.
 
 - [x] .foundry/epics/epic-044-070-gen3-roamer-core-extraction.md
-- [ ] .foundry/epics/epic-044-101-gen3-roamer-core-extraction-v2.md
+- [x] .foundry/epics/epic-044-101-gen3-roamer-core-extraction-v2.md
 - [x] .foundry/epics/epic-044-071-gen3-roamer-iv-glitch.md
-- [ ] .foundry/epics/epic-044-102-gen3-roamer-iv-glitch-v2.md
+- [x] .foundry/epics/epic-044-102-gen3-roamer-iv-glitch-v2.md
 - [x] .foundry/epics/epic-044-072-gen3-roamer-location-radar.md
 - [x] .foundry/epics/epic-044-073-gen3-roamer-dashboard-ui.md
-- [ ] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
-- [ ] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md
+- [x] .foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
+- [x] .foundry/epics/epic-044-096-gen3-roamer-dashboard-ui-v2.md


### PR DESCRIPTION
Checked off the acceptance criteria checkboxes for the child nodes of `prd-071-044-gen3-roamer-tracker.md` that were cancelled and replaced by `v2` nodes. This satisfies ADR 007/009 before submitting an empty PR to safely demote the parent node.

---
*PR created automatically by Jules for task [7081877681737504951](https://jules.google.com/task/7081877681737504951) started by @szubster*