### PR TITLE
Break down Gen 3 Roamer Status Condition Parsing story into tasks

### DIFF
--- a/.foundry/stories/story-070-109-gen3-roamer-status-parsing.md
+++ b/.foundry/stories/story-070-109-gen3-roamer-status-parsing.md
@@ -31,4 +31,7 @@ Building upon the base structure extracted in the previous story, implement the 
 
 ## Acceptance Criteria
 - [ ] Implement parsing logic for the Status Condition from the 20-byte roamer structure.
-- [ ] Tech Lead: Break down this Story into executable Tasks.
+- [x] Tech Lead: Break down this Story into executable Tasks.
+
+- [ ] .foundry/tasks/task-109-224-gen3-roamer-status-parsing-impl.md
+- [ ] .foundry/tasks/task-109-225-gen3-roamer-status-parsing-qa.md

--- a/.foundry/tasks/task-109-224-gen3-roamer-status-parsing-impl.md
+++ b/.foundry/tasks/task-109-224-gen3-roamer-status-parsing-impl.md
@@ -1,0 +1,36 @@
+---
+id: task-109-224-gen3-roamer-status-parsing-impl
+type: TASK
+title: Implement Gen 3 Roamer Status Condition Parsing
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-27'
+updated_at: '2026-06-27'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-070-109-gen3-roamer-status-parsing
+tags:
+  - gen3
+  - roamer
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement Gen 3 Roamer Status Condition Parsing
+
+## Objective
+Extract and parse the Status Condition from the 20-byte Gen 3 roamer data structure.
+
+## Description
+Building upon the base structure extracted in the previous story, implement the parsing logic necessary to identify and extract the Status Condition field from the Gen 3 roamer data. The Status Condition is an 8-bit unsigned integer at offset `0x0D` of the Roamer structure. Use the `DataView` API to extract this value. Ensure that the offset is defined as a reusable constant at the module level to avoid magic numbers. Note: This functionality might already be implemented, in which case you should verify it and submit an Empty PR.
+
+## Acceptance Criteria
+- [ ] Implement parsing logic for the Status Condition from the 20-byte roamer structure using the `DataView` API.
+- [ ] Ensure all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level (no inline magic numbers).
+- [ ] If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- [ ] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-109-225-gen3-roamer-status-parsing-qa.md
+++ b/.foundry/tasks/task-109-225-gen3-roamer-status-parsing-qa.md
@@ -1,0 +1,40 @@
+---
+id: task-109-225-gen3-roamer-status-parsing-qa
+type: TASK
+title: QA Gen 3 Roamer Status Condition Parsing
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-27'
+updated_at: '2026-06-27'
+depends_on:
+  - task-109-224-gen3-roamer-status-parsing-impl
+jules_session_id: null
+pr_number: null
+parent: story-070-109-gen3-roamer-status-parsing
+tags:
+  - gen3
+  - roamer
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA Gen 3 Roamer Status Condition Parsing
+
+## Objective
+Verify the implementation logic for parsing the Status Condition from the Gen 3 roamer data structure.
+
+## Description
+The `coder` persona was tasked with implementing the extraction of the Gen 3 roamer status condition using the `DataView` API, avoiding magic numbers by defining constants. Your task is to verify that this implementation works correctly.
+
+**CRITICAL INSTRUCTIONS:**
+- If the implementation is missing, flawed, or fails tests, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`. Do NOT set it to `COMPLETED` manually.
+- You must verify the existence of the implementation files before attempting validation.
+- If you submit an empty PR because the verification passes without requiring code changes, you MUST check all Acceptance Criteria checkboxes before doing so.
+
+## Acceptance Criteria
+- [ ] Verify that the status condition is correctly extracted from the 20-byte roamer structure.
+- [ ] Verify that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level (no inline magic numbers).
+- [ ] Verify that the provided tests adequately cover the logic and correctly handle edge cases.


### PR DESCRIPTION
As the Tech Lead, I have transformed the `story-070-109-gen3-roamer-status-parsing` story into actionable blueprints. 

I generated:
1. `task-109-224-gen3-roamer-status-parsing-impl` for the Coder to implement the DataView extraction of the Status Condition, strictly defining constants.
2. `task-109-225-gen3-roamer-status-parsing-qa` for the QA persona to verify the functionality.

I also updated the parent story's markdown to include these new nodes as unchecked criteria, ensuring it will not prematurely complete until the child tasks are finished. DAG ID strictness was adhered to for the dependency graph.

---
*PR created automatically by Jules for task [7983098903312013267](https://jules.google.com/task/7983098903312013267) started by @szubster*