### PR TITLE
QA: Gen 3 Parse Battle Frontier Win Streaks

### DIFF
--- a/.foundry/tasks/task-121-172-gen3-parse-battle-frontier-win-streaks-qa.md
+++ b/.foundry/tasks/task-121-172-gen3-parse-battle-frontier-win-streaks-qa.md
@@ -33,6 +33,6 @@ Validate the implementation of the Battle Frontier win streak parsing functional
 Verify that current win streaks and max win records for all 7 facilities (Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid) are correctly extracted and that error handling for out-of-bounds reads functions properly. Add corresponding unit tests.
 
 ## Acceptance Criteria
-- [ ] Verify unit tests correctly parse current win streaks.
-- [ ] Verify unit tests correctly parse max win records.
-- [ ] Verify unit tests handle out-of-bounds read errors.
+- [x] Verify unit tests correctly parse current win streaks.
+- [x] Verify unit tests correctly parse max win records.
+- [x] Verify unit tests handle out-of-bounds read errors.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -524,6 +524,38 @@ describe('parseGen3BattleFrontierWinStreaks', () => {
       parseGen3BattleFrontierWinStreaks(view, 0);
     }).toThrow('The save file is corrupted or incomplete.');
   });
+
+  it('correctly handles a save file with all zero win streaks and records', () => {
+    const buffer = new ArrayBuffer(8192);
+    const view = new DataView(buffer);
+    const base = saveBlock2Offset;
+
+    // By default, ArrayBuffer initializes with zeros, but let's be explicit for safety
+    view.setUint16(base + 0x0ce0, 0, true);
+    view.setUint16(base + 0x0cf0, 0, true);
+    view.setUint16(base + 0x0d0c, 0, true);
+    view.setUint16(base + 0x0d14, 0, true);
+    view.setUint16(base + 0x0dc8, 0, true);
+    view.setUint16(base + 0x0dd0, 0, true);
+    view.setUint16(base + 0x0dda, 0, true);
+    view.setUint16(base + 0x0dde, 0, true);
+    view.setUint16(base + 0x0de2, 0, true);
+    view.setUint16(base + 0x0dea, 0, true);
+    view.setUint16(base + 0x0e04, 0, true);
+    view.setUint16(base + 0x0e08, 0, true);
+    view.setUint16(base + 0x0e1a, 0, true);
+    view.setUint16(base + 0x0e1e, 0, true);
+
+    const result = parseGen3BattleFrontierWinStreaks(view, saveBlock2Offset);
+
+    expect(result.tower).toEqual({ current: 0, record: 0 });
+    expect(result.dome).toEqual({ current: 0, record: 0 });
+    expect(result.palace).toEqual({ current: 0, record: 0 });
+    expect(result.arena).toEqual({ current: 0, record: 0 });
+    expect(result.factory).toEqual({ current: 0, record: 0 });
+    expect(result.pike).toEqual({ current: 0, record: 0 });
+    expect(result.pyramid).toEqual({ current: 0, record: 0 });
+  });
 });
 
 describe('parseGen3Roamer', () => {


### PR DESCRIPTION
This PR completes the QA task `task-121-172-gen3-parse-battle-frontier-win-streaks-qa`.

The previous implementation of `parseGen3BattleFrontierWinStreaks` accurately extracts the data and properly uses `DataView` with bound checking (`RangeError`). This PR verifies the Acceptance Criteria and introduces a new unit test that explicitly checks extraction against a buffer initialized to all zeros.

- Checked off acceptance criteria in `task-121-172-gen3-parse-battle-frontier-win-streaks-qa.md`
- Added explicit test case in `src/engine/saveParser/parsers/gen3.test.ts`
- Verified tests passing with `pnpm test` and `pnpm test:e2e`

---
*PR created automatically by Jules for task [13322314103033658418](https://jules.google.com/task/13322314103033658418) started by @szubster*