### PR TITLE
Suspend offline auth task pending Cloudflare Access URL research

### DIFF
--- a/.foundry/research/research-199-222-cloudflare-access-paths.md
+++ b/.foundry/research/research-199-222-cloudflare-access-paths.md
@@ -1,0 +1,24 @@
+---
+id: research-199-222-cloudflare-access-paths
+type: RESEARCH
+title: Investigate Cloudflare Access Auth Paths
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-27'
+updated_at: '2026-06-27'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-076-199-offline-auth-state-impl
+tags:
+  - auth
+  - cloudflare
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Investigate Cloudflare Access Auth Paths
+
+Determine the exact Cloudflare access URLs required for login and logout functionality for offline authentication state management, as this information is missing from the codebase.

--- a/.foundry/tasks/task-076-199-offline-auth-state-impl.md
+++ b/.foundry/tasks/task-076-199-offline-auth-state-impl.md
@@ -2,11 +2,12 @@
 id: task-076-199-offline-auth-state-impl
 type: TASK
 title: Implement Client-side Offline Auth State Management
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-17'
 updated_at: '2026-06-27'
-depends_on: []
+depends_on:
+  - research-199-222-cloudflare-access-paths
 jules_session_id: '2479577009823059105'
 pr_number: null
 parent: story-038-076-offline-auth-state
@@ -18,7 +19,7 @@ tags:
   - offline
 research_references: []
 rejection_count: 1
-rejection_reason: ''
+rejection_reason: 'Suspended pending research on Cloudflare access paths'
 notes: ''
 ---
 


### PR DESCRIPTION
The exact Cloudflare Access URLs required to implement the offline authentication state management (login/logout functionality) are missing from the task context and the codebase. Following the Late Binding for Missing Context pattern, this PR creates a new RESEARCH node to investigate the required URLs and suspends the implementation task (`status: FAILED`) by adding the research node to its dependencies.

---
*PR created automatically by Jules for task [2479577009823059105](https://jules.google.com/task/2479577009823059105) started by @szubster*