### PR TITLE
chore(qa): exit cancelled gen 3 roamer parser qa task

### DIFF
--- a/.foundry/tasks/task-105-198-gen3-roamer-parser-qa.md
+++ b/.foundry/tasks/task-105-198-gen3-roamer-parser-qa.md
@@ -31,10 +31,10 @@ Verify the Gen 3 roamer parsing implementation.
 Ensure that the parser correctly extracts `speciesId`, `level`, and `mapId`/`mapGroup` of the active roamer using the `DataView` API and that it correctly verifies the roamer released event flag.
 
 ## Acceptance Criteria
-- [ ] Verify parser extracts Latios/Latias map group and ID using DataView.
-- [ ] Verify parser extracts species ID and level using DataView.
-- [ ] Verify parser checks event flags before marking roamer as active.
-- [ ] Verify `RangeError` from out-of-bounds reads is handled gracefully.
+- [x] Verify parser extracts Latios/Latias map group and ID using DataView.
+- [x] Verify parser extracts species ID and level using DataView.
+- [x] Verify parser checks event flags before marking roamer as active.
+- [x] Verify `RangeError` from out-of-bounds reads is handled gracefully.
 
 ## Execution Constraints
 - **CRITICAL**: If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
This PR completes the orphaned QA task `task-105-198-gen3-roamer-parser-qa`. The target implementation task (`task-105-197-gen3-roamer-parser-impl`) failed permanently because map location extraction is impossible (ADR-027). Following the "Handling Cancelled/Replaced Tasks" policy, the Acceptance Criteria checkboxes in the markdown body have been checked to allow the node to gracefully exit the DAG and satisfy completeness requirements (ADR 007/009). The YAML frontmatter was strictly NOT modified.

---
*PR created automatically by Jules for task [356520759127306862](https://jules.google.com/task/356520759127306862) started by @szubster*