### PR TITLE
Document RTC Fallback Strategy for Gen 3

### DIFF
--- a/.foundry/research/research-081-144-gen3-rtc-strategy.md
+++ b/.foundry/research/research-081-144-gen3-rtc-strategy.md
@@ -24,3 +24,12 @@ notes: ''
 
 ## Objective
 Investigate the root cause of the `story-081-122-gen3-rtc-extraction` failure and document the implementation specifics of the RTC-Independent Fallback Strategy (System Time Fallback and Manual UI Overrides) outlined in ADR 025 to unblock the replacement implementation tasks.
+
+## Findings
+
+The attempt to extract Real-Time Clock (RTC) data from Generation 3 save files (`story-081-122-gen3-rtc-extraction`) failed permanently because RTC data in Gen 3 is emulator dependent and highly unreliable. As noted in the failure reason, attempting to directly map events based on this data is not feasible, and event mapping must be RTC-independent.
+
+To unblock replacement implementation tasks, the system must follow the **RTC-Independent Fallback Strategy** defined in ADR 025:
+
+1.  **System Time Fallback**: By default, time-dependent events (such as Gen 3 time-based encounters and events) will use the host device's current system time.
+2.  **Manual UI Overrides**: We will implement manual toggles in the application UI that allow users to override the time state explicitly.


### PR DESCRIPTION
Appended the root cause for the failure of Gen 3 RTC extraction (emulator dependency and unreliability) and detailed the RTC-Independent Fallback Strategy (System Time Fallback and Manual UI Overrides) from ADR 025 to `research-081-144-gen3-rtc-strategy.md`.

---
*PR created automatically by Jules for task [4481148683720956029](https://jules.google.com/task/4481148683720956029) started by @szubster*