### PR TITLE
Break down relative offsets PRD into Epics

### DIFF
--- a/.foundry/epics/epic-053-103-relative-offsets-adr.md
+++ b/.foundry/epics/epic-053-103-relative-offsets-adr.md
@@ -1,0 +1,33 @@
+---
+id: epic-053-103-relative-offsets-adr
+type: EPIC
+title: Relative Offsets ADR
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-27'
+updated_at: '2026-06-27'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-084-053-standardize-relative-offsets
+tags:
+  - architecture
+  - save-parsing
+  - offset-mapping
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Relative Offsets ADR
+
+## Objective
+Investigate if a linter rule can be built to flag hardcoded offsets during save parsing. If a linter is not feasible, establish a strict architectural ADR mandating relative offset mapping for dynamic save block extraction.
+
+## Context
+Currently, save file extraction uses absolute hardcoded offsets for dynamic blocks, which can lead to unpredictable behavior and regressions.
+
+## Acceptance Criteria
+- [ ] Investigate linter feasibility.
+- [ ] Create ADR or implement linter rule.

--- a/.foundry/epics/epic-053-104-relative-offsets-guidance.md
+++ b/.foundry/epics/epic-053-104-relative-offsets-guidance.md
@@ -1,0 +1,33 @@
+---
+id: epic-053-104-relative-offsets-guidance
+type: EPIC
+title: Relative Offsets Guidance Rollout
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-27'
+updated_at: '2026-06-27'
+depends_on:
+  - epic-053-103-relative-offsets-adr
+jules_session_id: null
+pr_number: null
+parent: prd-084-053-standardize-relative-offsets
+tags:
+  - architecture
+  - save-parsing
+  - offset-mapping
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Relative Offsets Guidance Rollout
+
+## Objective
+Roll out guidance to Coder and QA personas regarding the new relative offset mapping rules.
+
+## Context
+Following the establishment of the new ADR/Linter for relative offsets, the team needs to be informed and updated on the new standard.
+
+## Acceptance Criteria
+- [ ] Roll out guidance to Coder and QA personas.

--- a/.foundry/prds/prd-084-053-standardize-relative-offsets.md
+++ b/.foundry/prds/prd-084-053-standardize-relative-offsets.md
@@ -36,3 +36,5 @@ We need an architectural rule (e.g., an ADR) or a linter check to enforce that, 
 ## Acceptance Criteria
 - [ ] If a linter is not feasible, establish a strict architectural ADR mandating relative offset mapping for dynamic save block extraction.
 - [ ] Roll out guidance to Coder and QA personas.
+- [ ] .foundry/epics/epic-053-103-relative-offsets-adr.md
+- [ ] .foundry/epics/epic-053-104-relative-offsets-guidance.md


### PR DESCRIPTION
This PR breaks down `prd-084-053-standardize-relative-offsets.md` into two actionable Epic nodes, properly routing the investigation and the subsequent team guidance rollout while respecting the DAG dependencies.

---
*PR created automatically by Jules for task [3423314044753651255](https://jules.google.com/task/3423314044753651255) started by @szubster*