### PR TITLE
Implement tests for UnownDexPanel

### DIFF
--- a/.foundry/tasks/task-132-206-unown-dex-data-integration-impl.md
+++ b/.foundry/tasks/task-132-206-unown-dex-data-integration-impl.md
@@ -40,6 +40,6 @@ Determine which of the 26 Unown forms (A-Z) the player possesses in their active
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Data integration logic mapping the `unownForm` property to the Unown Dex Panel UI component is implemented.
-- [ ] The UI component correctly displays the owned/missing states for the 26 Unown forms.
-- [ ] Appropriate tests are added to verify the integration.
+- [x] Data integration logic mapping the `unownForm` property to the Unown Dex Panel UI component is implemented.
+- [x] The UI component correctly displays the owned/missing states for the 26 Unown forms.
+- [x] Appropriate tests are added to verify the integration.

--- a/src/components/pokemon/unown/__tests__/UnownDexPanel.test.tsx
+++ b/src/components/pokemon/unown/__tests__/UnownDexPanel.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { cleanup, render } from 'vitest-browser-react';
+import type { PokemonInstance } from '../../../../engine/saveParser';
+import { UnownDexPanel } from '../UnownDexPanel';
+
+describe('UnownDexPanel', () => {
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  const basePokemon: PokemonInstance & { location: string } = {
+    speciesId: 201,
+    level: 5,
+    isShiny: false,
+    moves: [],
+    location: 'Party',
+    storageLocation: 'Party',
+  };
+
+  test('renders 0 / 26 discovered when no Unown forms are owned', async () => {
+    await render(<UnownDexPanel yourPokemon={[]} />);
+    await expect.element(page.getByText('0')).toBeInTheDocument();
+    await expect.element(page.getByText(/26 Forms Discovered/)).toBeInTheDocument();
+  });
+
+  test('renders correctly when multiple Unown forms are owned', async () => {
+    const mockYourPokemon = [
+      { ...basePokemon, unownForm: 'A' },
+      { ...basePokemon, unownForm: 'Z' },
+    ];
+    await render(<UnownDexPanel yourPokemon={mockYourPokemon} />);
+    await expect.element(page.getByText('2', { exact: true })).toBeInTheDocument();
+  });
+
+  test('ignores non-Unown Pokémon when calculating owned forms', async () => {
+    const mockYourPokemon = [
+      { ...basePokemon, speciesId: 1, unownForm: 'A' }, // Not Unown
+      { ...basePokemon, unownForm: 'B' }, // Unown
+    ];
+    await render(<UnownDexPanel yourPokemon={mockYourPokemon} />);
+    await expect.element(page.getByText('1', { exact: true })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR adds tests to ensure the newly implemented Unown Dex Panel mapping logic parses the player's saved unown properly. It also updates the Markdown body with correctly formatted acceptance criteria checkboxes to satisfy the empty PR policy correctly.

---
*PR created automatically by Jules for task [793392214438386512](https://jules.google.com/task/793392214438386512) started by @szubster*