### PR TITLE
fix(data): apply Gen 1-3 specific move stat overrides

### DIFF
--- a/.foundry/tasks/task-129-206-move-generation-discrepancies-impl.md
+++ b/.foundry/tasks/task-129-206-move-generation-discrepancies-impl.md
@@ -40,6 +40,6 @@ Moves can have different stats (like PP, Power, Accuracy) across different gener
 - **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Identify generation discrepancies for moves relevant to Gen 1-3 within the generation script logic.
-- [ ] Apply necessary overrides to the extracted move data before saving to `moves.jsonl`.
-- [ ] Ensure that only base PP is stored for each move.
+- [x] Identify generation discrepancies for moves relevant to Gen 1-3 within the generation script logic.
+- [x] Apply necessary overrides to the extracted move data before saving to `moves.jsonl`.
+- [x] Ensure that only base PP is stored for each move.

--- a/data/db/metadata.json
+++ b/data/db/metadata.json
@@ -1,4 +1,4 @@
 {
   "sourceSha": "",
-  "generatedAt": "2026-06-25T02:58:58.636Z"
+  "generatedAt": "2026-06-27T23:35:32.701Z"
 }

--- a/data/db/moves.jsonl
+++ b/data/db/moves.jsonl
@@ -11,35 +11,35 @@
 {"id":11,"name":"Vise Grip","type":1,"p":55,"pp":30,"dmg_class":1}
 {"id":12,"name":"Guillotine","type":1,"acc":30,"pp":5,"dmg_class":1}
 {"id":13,"name":"Razor Wind","type":1,"p":80,"pp":10,"dmg_class":2}
-{"id":14,"name":"Swords Dance","type":1,"pp":20,"dmg_class":3}
+{"id":14,"name":"Swords Dance","type":1,"pp":30,"dmg_class":3}
 {"id":15,"name":"Cut","type":1,"p":50,"acc":95,"pp":30,"dmg_class":1}
 {"id":16,"name":"Gust","type":3,"p":40,"pp":35,"dmg_class":2}
 {"id":17,"name":"Wing Attack","type":3,"p":60,"pp":35,"dmg_class":1}
 {"id":18,"name":"Whirlwind","type":1,"pp":20,"dmg_class":3}
-{"id":19,"name":"Fly","type":3,"p":90,"acc":95,"pp":15,"dmg_class":1}
-{"id":20,"name":"Bind","type":1,"p":15,"acc":85,"pp":20,"dmg_class":1,"effect":100}
+{"id":19,"name":"Fly","type":3,"p":70,"acc":95,"pp":15,"dmg_class":1}
+{"id":20,"name":"Bind","type":1,"p":15,"acc":75,"pp":20,"dmg_class":1,"effect":100}
 {"id":21,"name":"Slam","type":1,"p":80,"acc":75,"pp":20,"dmg_class":1}
-{"id":22,"name":"Vine Whip","type":12,"p":45,"pp":25,"dmg_class":1}
+{"id":22,"name":"Vine Whip","type":12,"p":45,"pp":10,"dmg_class":1}
 {"id":23,"name":"Stomp","type":1,"p":65,"pp":20,"dmg_class":1,"effect":30}
 {"id":24,"name":"Double Kick","type":2,"p":30,"pp":30,"dmg_class":1}
 {"id":25,"name":"Mega Kick","type":1,"p":120,"acc":75,"pp":5,"dmg_class":1}
-{"id":26,"name":"Jump Kick","type":2,"p":100,"acc":95,"pp":10,"dmg_class":1}
+{"id":26,"name":"Jump Kick","type":2,"p":70,"acc":95,"pp":10,"dmg_class":1}
 {"id":27,"name":"Rolling Kick","type":2,"p":60,"acc":85,"pp":15,"dmg_class":1,"effect":30}
 {"id":28,"name":"Sand Attack","type":5,"pp":15,"dmg_class":3}
 {"id":29,"name":"Headbutt","type":1,"p":70,"pp":15,"dmg_class":1,"effect":30}
 {"id":30,"name":"Horn Attack","type":1,"p":65,"pp":25,"dmg_class":1}
 {"id":31,"name":"Fury Attack","type":1,"p":15,"acc":85,"pp":20,"dmg_class":1}
 {"id":32,"name":"Horn Drill","type":1,"acc":30,"pp":5,"dmg_class":1}
-{"id":33,"name":"Tackle","type":1,"p":40,"pp":35,"dmg_class":1}
+{"id":33,"name":"Tackle","type":1,"p":35,"acc":95,"pp":35,"dmg_class":1}
 {"id":34,"name":"Body Slam","type":1,"p":85,"pp":15,"dmg_class":1,"effect":30}
-{"id":35,"name":"Wrap","type":1,"p":15,"acc":90,"pp":20,"dmg_class":1,"effect":100}
+{"id":35,"name":"Wrap","type":1,"p":15,"acc":85,"pp":20,"dmg_class":1,"effect":100}
 {"id":36,"name":"Take Down","type":1,"p":90,"acc":85,"pp":20,"dmg_class":1}
-{"id":37,"name":"Thrash","type":1,"p":120,"pp":10,"dmg_class":1}
+{"id":37,"name":"Thrash","type":1,"p":90,"pp":20,"dmg_class":1}
 {"id":38,"name":"Double-Edge","type":1,"p":120,"pp":15,"dmg_class":1}
 {"id":39,"name":"Tail Whip","type":1,"pp":30,"dmg_class":3}
 {"id":40,"name":"Poison Sting","type":4,"p":15,"pp":35,"dmg_class":1,"effect":30}
 {"id":41,"name":"Twineedle","type":7,"p":25,"pp":20,"dmg_class":1,"effect":20}
-{"id":42,"name":"Pin Missile","type":7,"p":25,"acc":95,"pp":20,"dmg_class":1}
+{"id":42,"name":"Pin Missile","type":7,"p":14,"acc":85,"pp":20,"dmg_class":1}
 {"id":43,"name":"Leer","type":1,"pp":30,"dmg_class":3,"effect":100}
 {"id":44,"name":"Bite","type":17,"p":60,"pp":25,"dmg_class":1,"effect":30}
 {"id":45,"name":"Growl","type":1,"pp":40,"dmg_class":3}
@@ -47,29 +47,29 @@
 {"id":47,"name":"Sing","type":1,"acc":55,"pp":15,"dmg_class":3,"effect":2}
 {"id":48,"name":"Supersonic","type":1,"acc":55,"pp":20,"dmg_class":3,"effect":6}
 {"id":49,"name":"Sonic Boom","type":1,"acc":90,"pp":20,"dmg_class":2}
-{"id":50,"name":"Disable","type":1,"pp":20,"dmg_class":3,"effect":13}
+{"id":50,"name":"Disable","type":1,"acc":55,"pp":20,"dmg_class":3,"effect":13}
 {"id":51,"name":"Acid","type":4,"p":40,"pp":30,"dmg_class":2,"effect":10}
 {"id":52,"name":"Ember","type":10,"p":40,"pp":25,"dmg_class":2,"effect":10}
-{"id":53,"name":"Flamethrower","type":10,"p":90,"pp":15,"dmg_class":2,"effect":10}
+{"id":53,"name":"Flamethrower","type":10,"p":95,"pp":15,"dmg_class":2,"effect":10}
 {"id":54,"name":"Mist","type":15,"pp":30,"dmg_class":3}
 {"id":55,"name":"Water Gun","type":11,"p":40,"pp":25,"dmg_class":2}
-{"id":56,"name":"Hydro Pump","type":11,"p":110,"acc":80,"pp":5,"dmg_class":2}
-{"id":57,"name":"Surf","type":11,"p":90,"pp":15,"dmg_class":2}
-{"id":58,"name":"Ice Beam","type":15,"p":90,"pp":10,"dmg_class":2,"effect":10}
-{"id":59,"name":"Blizzard","type":15,"p":110,"acc":70,"pp":5,"dmg_class":2,"effect":10}
+{"id":56,"name":"Hydro Pump","type":11,"p":120,"acc":80,"pp":5,"dmg_class":2}
+{"id":57,"name":"Surf","type":11,"p":95,"pp":15,"dmg_class":2}
+{"id":58,"name":"Ice Beam","type":15,"p":95,"pp":10,"dmg_class":2,"effect":10}
+{"id":59,"name":"Blizzard","type":15,"p":120,"acc":70,"pp":5,"dmg_class":2,"effect":10}
 {"id":60,"name":"Psybeam","type":14,"p":65,"pp":20,"dmg_class":2,"effect":10}
 {"id":61,"name":"Bubble Beam","type":11,"p":65,"pp":20,"dmg_class":2,"effect":10}
 {"id":62,"name":"Aurora Beam","type":15,"p":65,"pp":20,"dmg_class":2,"effect":10}
 {"id":63,"name":"Hyper Beam","type":1,"p":150,"acc":90,"pp":5,"dmg_class":2}
 {"id":64,"name":"Peck","type":3,"p":35,"pp":35,"dmg_class":1}
 {"id":65,"name":"Drill Peck","type":3,"p":80,"pp":20,"dmg_class":1}
-{"id":66,"name":"Submission","type":2,"p":80,"acc":80,"pp":20,"dmg_class":1}
+{"id":66,"name":"Submission","type":2,"p":80,"acc":80,"pp":25,"dmg_class":1}
 {"id":67,"name":"Low Kick","type":2,"pp":20,"dmg_class":1}
 {"id":68,"name":"Counter","type":2,"pp":20,"dmg_class":1}
 {"id":69,"name":"Seismic Toss","type":2,"pp":20,"dmg_class":1}
 {"id":70,"name":"Strength","type":1,"p":80,"pp":15,"dmg_class":1}
-{"id":71,"name":"Absorb","type":12,"p":20,"pp":25,"dmg_class":2}
-{"id":72,"name":"Mega Drain","type":12,"p":40,"pp":15,"dmg_class":2}
+{"id":71,"name":"Absorb","type":12,"p":20,"pp":20,"dmg_class":2}
+{"id":72,"name":"Mega Drain","type":12,"p":40,"pp":10,"dmg_class":2}
 {"id":73,"name":"Leech Seed","type":12,"acc":90,"pp":10,"dmg_class":3,"effect":18}
 {"id":74,"name":"Growth","type":1,"pp":20,"dmg_class":3}
 {"id":75,"name":"Razor Leaf","type":12,"p":55,"acc":95,"pp":25,"dmg_class":1}
@@ -77,19 +77,19 @@
 {"id":77,"name":"Poison Powder","type":4,"acc":75,"pp":35,"dmg_class":3,"effect":5}
 {"id":78,"name":"Stun Spore","type":12,"acc":75,"pp":30,"dmg_class":3,"effect":1}
 {"id":79,"name":"Sleep Powder","type":12,"acc":75,"pp":15,"dmg_class":3,"effect":2}
-{"id":80,"name":"Petal Dance","type":12,"p":120,"pp":10,"dmg_class":2}
+{"id":80,"name":"Petal Dance","type":12,"p":70,"pp":10,"dmg_class":2}
 {"id":81,"name":"String Shot","type":7,"acc":95,"pp":40,"dmg_class":3}
 {"id":82,"name":"Dragon Rage","type":16,"pp":10,"dmg_class":2}
-{"id":83,"name":"Fire Spin","type":10,"p":35,"acc":85,"pp":15,"dmg_class":2,"effect":100}
+{"id":83,"name":"Fire Spin","type":10,"p":15,"acc":70,"pp":15,"dmg_class":2,"effect":100}
 {"id":84,"name":"Thunder Shock","type":13,"p":40,"pp":30,"dmg_class":2,"effect":10}
-{"id":85,"name":"Thunderbolt","type":13,"p":90,"pp":15,"dmg_class":2,"effect":10}
-{"id":86,"name":"Thunder Wave","type":13,"acc":90,"pp":20,"dmg_class":3,"effect":1}
-{"id":87,"name":"Thunder","type":13,"p":110,"acc":70,"pp":10,"dmg_class":2,"effect":30}
+{"id":85,"name":"Thunderbolt","type":13,"p":95,"pp":15,"dmg_class":2,"effect":10}
+{"id":86,"name":"Thunder Wave","type":13,"pp":20,"dmg_class":3,"effect":1}
+{"id":87,"name":"Thunder","type":13,"p":120,"acc":70,"pp":10,"dmg_class":2,"effect":30}
 {"id":88,"name":"Rock Throw","type":6,"p":50,"acc":90,"pp":15,"dmg_class":1}
 {"id":89,"name":"Earthquake","type":5,"p":100,"pp":10,"dmg_class":1}
 {"id":90,"name":"Fissure","type":5,"acc":30,"pp":5,"dmg_class":1}
-{"id":91,"name":"Dig","type":5,"p":80,"pp":10,"dmg_class":1}
-{"id":92,"name":"Toxic","type":4,"acc":90,"pp":10,"dmg_class":3,"effect":5}
+{"id":91,"name":"Dig","type":5,"p":60,"pp":10,"dmg_class":1}
+{"id":92,"name":"Toxic","type":4,"acc":85,"pp":10,"dmg_class":3,"effect":5}
 {"id":93,"name":"Confusion","type":14,"p":50,"pp":25,"dmg_class":2,"effect":10}
 {"id":94,"name":"Psychic","type":14,"p":90,"pp":10,"dmg_class":2,"effect":10}
 {"id":95,"name":"Hypnosis","type":14,"acc":60,"pp":20,"dmg_class":3,"effect":2}
@@ -102,14 +102,14 @@
 {"id":102,"name":"Mimic","type":1,"pp":10,"dmg_class":3}
 {"id":103,"name":"Screech","type":1,"acc":85,"pp":40,"dmg_class":3}
 {"id":104,"name":"Double Team","type":1,"pp":15,"dmg_class":3}
-{"id":105,"name":"Recover","type":1,"pp":5,"dmg_class":3}
+{"id":105,"name":"Recover","type":1,"pp":20,"dmg_class":3}
 {"id":106,"name":"Harden","type":1,"pp":30,"dmg_class":3}
-{"id":107,"name":"Minimize","type":1,"pp":10,"dmg_class":3}
+{"id":107,"name":"Minimize","type":1,"pp":20,"dmg_class":3}
 {"id":108,"name":"Smokescreen","type":1,"pp":20,"dmg_class":3}
 {"id":109,"name":"Confuse Ray","type":8,"pp":10,"dmg_class":3,"effect":6}
 {"id":110,"name":"Withdraw","type":11,"pp":40,"dmg_class":3}
 {"id":111,"name":"Defense Curl","type":1,"pp":40,"dmg_class":3}
-{"id":112,"name":"Barrier","type":14,"pp":20,"dmg_class":3}
+{"id":112,"name":"Barrier","type":14,"pp":30,"dmg_class":3}
 {"id":113,"name":"Light Screen","type":14,"pp":30,"dmg_class":3}
 {"id":114,"name":"Haze","type":15,"pp":30,"dmg_class":3}
 {"id":115,"name":"Reflect","type":14,"pp":20,"dmg_class":3}
@@ -119,37 +119,37 @@
 {"id":119,"name":"Mirror Move","type":3,"pp":20,"dmg_class":3}
 {"id":120,"name":"Self-Destruct","type":1,"p":200,"pp":5,"dmg_class":1}
 {"id":121,"name":"Egg Bomb","type":1,"p":100,"acc":75,"pp":10,"dmg_class":1}
-{"id":122,"name":"Lick","type":8,"p":30,"pp":30,"dmg_class":1,"effect":30}
-{"id":123,"name":"Smog","type":4,"p":30,"acc":70,"pp":20,"dmg_class":2,"effect":40}
+{"id":122,"name":"Lick","type":8,"p":20,"pp":30,"dmg_class":1,"effect":30}
+{"id":123,"name":"Smog","type":4,"p":20,"acc":70,"pp":20,"dmg_class":2,"effect":40}
 {"id":124,"name":"Sludge","type":4,"p":65,"pp":20,"dmg_class":2,"effect":30}
 {"id":125,"name":"Bone Club","type":5,"p":65,"acc":85,"pp":20,"dmg_class":1,"effect":10}
-{"id":126,"name":"Fire Blast","type":10,"p":110,"acc":85,"pp":5,"dmg_class":2,"effect":10}
+{"id":126,"name":"Fire Blast","type":10,"p":120,"acc":85,"pp":5,"dmg_class":2,"effect":10}
 {"id":127,"name":"Waterfall","type":11,"p":80,"pp":15,"dmg_class":1,"effect":20}
-{"id":128,"name":"Clamp","type":11,"p":35,"acc":85,"pp":15,"dmg_class":1,"effect":100}
+{"id":128,"name":"Clamp","type":11,"p":35,"acc":75,"pp":10,"dmg_class":1,"effect":100}
 {"id":129,"name":"Swift","type":1,"p":60,"pp":20,"dmg_class":2}
-{"id":130,"name":"Skull Bash","type":1,"p":130,"pp":10,"dmg_class":1,"effect":100}
+{"id":130,"name":"Skull Bash","type":1,"p":100,"pp":15,"dmg_class":1,"effect":100}
 {"id":131,"name":"Spike Cannon","type":1,"p":20,"pp":15,"dmg_class":1}
 {"id":132,"name":"Constrict","type":1,"p":10,"pp":35,"dmg_class":1,"effect":10}
 {"id":133,"name":"Amnesia","type":14,"pp":20,"dmg_class":3}
 {"id":134,"name":"Kinesis","type":14,"acc":80,"pp":15,"dmg_class":3}
 {"id":135,"name":"Soft-Boiled","type":1,"pp":5,"dmg_class":3}
-{"id":136,"name":"High Jump Kick","type":2,"p":130,"acc":90,"pp":10,"dmg_class":1}
-{"id":137,"name":"Glare","type":1,"pp":30,"dmg_class":3,"effect":1}
+{"id":136,"name":"High Jump Kick","type":2,"p":85,"acc":90,"pp":10,"dmg_class":1}
+{"id":137,"name":"Glare","type":1,"acc":75,"pp":30,"dmg_class":3,"effect":1}
 {"id":138,"name":"Dream Eater","type":14,"p":100,"pp":15,"dmg_class":2}
-{"id":139,"name":"Poison Gas","type":4,"acc":90,"pp":40,"dmg_class":3,"effect":5}
+{"id":139,"name":"Poison Gas","type":4,"acc":55,"pp":40,"dmg_class":3,"effect":5}
 {"id":140,"name":"Barrage","type":1,"p":15,"acc":85,"pp":20,"dmg_class":1}
-{"id":141,"name":"Leech Life","type":7,"p":80,"pp":10,"dmg_class":1}
+{"id":141,"name":"Leech Life","type":7,"p":20,"pp":15,"dmg_class":1}
 {"id":142,"name":"Lovely Kiss","type":1,"acc":75,"pp":10,"dmg_class":3,"effect":2}
 {"id":143,"name":"Sky Attack","type":3,"p":140,"acc":90,"pp":5,"dmg_class":1,"effect":30}
 {"id":144,"name":"Transform","type":1,"pp":10,"dmg_class":3}
-{"id":145,"name":"Bubble","type":11,"p":40,"pp":30,"dmg_class":2,"effect":10}
+{"id":145,"name":"Bubble","type":11,"p":20,"pp":30,"dmg_class":2,"effect":10}
 {"id":146,"name":"Dizzy Punch","type":1,"p":70,"pp":10,"dmg_class":1,"effect":20}
 {"id":147,"name":"Spore","type":12,"pp":15,"dmg_class":3,"effect":2}
-{"id":148,"name":"Flash","type":1,"pp":20,"dmg_class":3}
-{"id":149,"name":"Psywave","type":14,"pp":15,"dmg_class":2}
+{"id":148,"name":"Flash","type":1,"acc":70,"pp":20,"dmg_class":3}
+{"id":149,"name":"Psywave","type":14,"acc":80,"pp":15,"dmg_class":2}
 {"id":150,"name":"Splash","type":1,"pp":40,"dmg_class":3}
-{"id":151,"name":"Acid Armor","type":4,"pp":20,"dmg_class":3}
-{"id":152,"name":"Crabhammer","type":11,"p":100,"acc":90,"pp":10,"dmg_class":1}
+{"id":151,"name":"Acid Armor","type":4,"pp":40,"dmg_class":3}
+{"id":152,"name":"Crabhammer","type":11,"p":100,"acc":85,"pp":10,"dmg_class":1}
 {"id":153,"name":"Explosion","type":1,"p":250,"pp":5,"dmg_class":1}
 {"id":154,"name":"Fury Swipes","type":1,"p":18,"acc":80,"pp":15,"dmg_class":1}
 {"id":155,"name":"Bonemerang","type":5,"p":50,"acc":90,"pp":10,"dmg_class":1}
@@ -165,49 +165,49 @@
 {"id":165,"name":"Struggle","type":1,"p":50,"pp":1,"dmg_class":1}
 {"id":166,"name":"Sketch","type":1,"pp":1,"dmg_class":3}
 {"id":167,"name":"Triple Kick","type":2,"p":10,"acc":90,"pp":10,"dmg_class":1}
-{"id":168,"name":"Thief","type":17,"p":60,"pp":25,"dmg_class":1}
+{"id":168,"name":"Thief","type":17,"p":40,"pp":10,"dmg_class":1}
 {"id":169,"name":"Spider Web","type":7,"pp":10,"dmg_class":3}
-{"id":170,"name":"Mind Reader","type":1,"pp":5,"dmg_class":3}
+{"id":170,"name":"Mind Reader","type":1,"pp":40,"dmg_class":3}
 {"id":171,"name":"Nightmare","type":8,"pp":15,"dmg_class":3,"effect":9}
 {"id":172,"name":"Flame Wheel","type":10,"p":60,"pp":25,"dmg_class":1,"effect":10}
-{"id":173,"name":"Snore","type":1,"p":50,"pp":15,"dmg_class":2,"effect":30}
-{"id":174,"name":"Curse","type":8,"pp":10,"dmg_class":3}
+{"id":173,"name":"Snore","type":1,"p":40,"pp":15,"dmg_class":2,"effect":30}
+{"id":174,"name":"Curse","type":10001,"pp":10,"dmg_class":3}
 {"id":175,"name":"Flail","type":1,"pp":15,"dmg_class":1}
 {"id":176,"name":"Conversion 2","type":1,"pp":30,"dmg_class":3}
 {"id":177,"name":"Aeroblast","type":3,"p":100,"acc":95,"pp":5,"dmg_class":2}
-{"id":178,"name":"Cotton Spore","type":12,"pp":40,"dmg_class":3}
+{"id":178,"name":"Cotton Spore","type":12,"acc":85,"pp":40,"dmg_class":3}
 {"id":179,"name":"Reversal","type":2,"pp":15,"dmg_class":1}
 {"id":180,"name":"Spite","type":8,"pp":10,"dmg_class":3}
 {"id":181,"name":"Powder Snow","type":15,"p":40,"pp":25,"dmg_class":2,"effect":10}
 {"id":182,"name":"Protect","type":1,"pp":10,"dmg_class":3}
 {"id":183,"name":"Mach Punch","type":2,"p":40,"pp":30,"dmg_class":1}
-{"id":184,"name":"Scary Face","type":1,"pp":10,"dmg_class":3}
+{"id":184,"name":"Scary Face","type":1,"acc":90,"pp":10,"dmg_class":3}
 {"id":185,"name":"Feint Attack","type":17,"p":60,"pp":20,"dmg_class":1}
-{"id":186,"name":"Sweet Kiss","type":18,"acc":75,"pp":10,"dmg_class":3,"effect":6}
+{"id":186,"name":"Sweet Kiss","type":1,"acc":75,"pp":10,"dmg_class":3,"effect":6}
 {"id":187,"name":"Belly Drum","type":1,"pp":10,"dmg_class":3}
 {"id":188,"name":"Sludge Bomb","type":4,"p":90,"pp":10,"dmg_class":2,"effect":30}
 {"id":189,"name":"Mud-Slap","type":5,"p":20,"pp":10,"dmg_class":2,"effect":100}
 {"id":190,"name":"Octazooka","type":11,"p":65,"acc":85,"pp":10,"dmg_class":2,"effect":50}
 {"id":191,"name":"Spikes","type":5,"pp":20,"dmg_class":3}
-{"id":192,"name":"Zap Cannon","type":13,"p":120,"acc":50,"pp":5,"dmg_class":2,"effect":100}
+{"id":192,"name":"Zap Cannon","type":13,"p":100,"acc":50,"pp":5,"dmg_class":2,"effect":100}
 {"id":193,"name":"Foresight","type":1,"pp":40,"dmg_class":3,"effect":17}
 {"id":194,"name":"Destiny Bond","type":8,"pp":5,"dmg_class":3}
 {"id":195,"name":"Perish Song","type":1,"pp":5,"dmg_class":3,"effect":20}
 {"id":196,"name":"Icy Wind","type":15,"p":55,"acc":95,"pp":15,"dmg_class":2,"effect":100}
 {"id":197,"name":"Detect","type":2,"pp":5,"dmg_class":3}
-{"id":198,"name":"Bone Rush","type":5,"p":25,"acc":90,"pp":10,"dmg_class":1}
+{"id":198,"name":"Bone Rush","type":5,"p":25,"acc":80,"pp":10,"dmg_class":1}
 {"id":199,"name":"Lock-On","type":1,"pp":5,"dmg_class":3}
-{"id":200,"name":"Outrage","type":16,"p":120,"pp":10,"dmg_class":1}
+{"id":200,"name":"Outrage","type":16,"p":90,"pp":10,"dmg_class":1}
 {"id":201,"name":"Sandstorm","type":6,"pp":10,"dmg_class":3}
-{"id":202,"name":"Giga Drain","type":12,"p":75,"pp":10,"dmg_class":2}
+{"id":202,"name":"Giga Drain","type":12,"p":75,"pp":5,"dmg_class":2}
 {"id":203,"name":"Endure","type":1,"pp":10,"dmg_class":3}
-{"id":204,"name":"Charm","type":18,"pp":20,"dmg_class":3}
+{"id":204,"name":"Charm","type":1,"pp":20,"dmg_class":3}
 {"id":205,"name":"Rollout","type":6,"p":30,"acc":90,"pp":20,"dmg_class":1}
 {"id":206,"name":"False Swipe","type":1,"p":40,"pp":40,"dmg_class":1}
-{"id":207,"name":"Swagger","type":1,"acc":85,"pp":15,"dmg_class":3,"effect":6}
+{"id":207,"name":"Swagger","type":1,"acc":90,"pp":15,"dmg_class":3,"effect":6}
 {"id":208,"name":"Milk Drink","type":1,"pp":5,"dmg_class":3}
 {"id":209,"name":"Spark","type":13,"p":65,"pp":20,"dmg_class":1,"effect":30}
-{"id":210,"name":"Fury Cutter","type":7,"p":40,"acc":95,"pp":20,"dmg_class":1}
+{"id":210,"name":"Fury Cutter","type":7,"p":10,"acc":95,"pp":20,"dmg_class":1}
 {"id":211,"name":"Steel Wing","type":9,"p":70,"acc":90,"pp":25,"dmg_class":1,"effect":10}
 {"id":212,"name":"Mean Look","type":1,"pp":5,"dmg_class":3}
 {"id":213,"name":"Attract","type":1,"pp":15,"dmg_class":3,"effect":7}
@@ -226,15 +226,15 @@
 {"id":226,"name":"Baton Pass","type":1,"pp":40,"dmg_class":3}
 {"id":227,"name":"Encore","type":1,"pp":5,"dmg_class":3}
 {"id":228,"name":"Pursuit","type":17,"p":40,"pp":20,"dmg_class":1}
-{"id":229,"name":"Rapid Spin","type":1,"p":50,"pp":40,"dmg_class":1,"effect":100}
+{"id":229,"name":"Rapid Spin","type":1,"p":20,"pp":40,"dmg_class":1,"effect":100}
 {"id":230,"name":"Sweet Scent","type":1,"pp":20,"dmg_class":3}
 {"id":231,"name":"Iron Tail","type":9,"p":100,"acc":75,"pp":15,"dmg_class":1,"effect":30}
 {"id":232,"name":"Metal Claw","type":9,"p":50,"acc":95,"pp":35,"dmg_class":1,"effect":10}
 {"id":233,"name":"Vital Throw","type":2,"p":70,"pp":10,"dmg_class":1}
 {"id":234,"name":"Morning Sun","type":1,"pp":5,"dmg_class":3}
 {"id":235,"name":"Synthesis","type":12,"pp":5,"dmg_class":3}
-{"id":236,"name":"Moonlight","type":18,"pp":5,"dmg_class":3}
-{"id":237,"name":"Hidden Power","type":1,"p":60,"pp":15,"dmg_class":2}
+{"id":236,"name":"Moonlight","type":1,"pp":5,"dmg_class":3}
+{"id":237,"name":"Hidden Power","type":1,"p":1,"pp":15,"dmg_class":2}
 {"id":238,"name":"Cross Chop","type":2,"p":100,"acc":80,"pp":5,"dmg_class":1}
 {"id":239,"name":"Twister","type":16,"p":40,"pp":20,"dmg_class":2,"effect":20}
 {"id":240,"name":"Rain Dance","type":11,"pp":5,"dmg_class":3}
@@ -245,24 +245,24 @@
 {"id":245,"name":"Extreme Speed","type":1,"p":80,"pp":5,"dmg_class":1}
 {"id":246,"name":"Ancient Power","type":6,"p":60,"pp":5,"dmg_class":2,"effect":10}
 {"id":247,"name":"Shadow Ball","type":8,"p":80,"pp":15,"dmg_class":2,"effect":20}
-{"id":248,"name":"Future Sight","type":14,"p":120,"pp":10,"dmg_class":2}
-{"id":249,"name":"Rock Smash","type":2,"p":40,"pp":15,"dmg_class":1,"effect":50}
-{"id":250,"name":"Whirlpool","type":11,"p":35,"acc":85,"pp":15,"dmg_class":2,"effect":100}
-{"id":251,"name":"Beat Up","type":17,"pp":10,"dmg_class":1}
+{"id":248,"name":"Future Sight","type":14,"p":80,"acc":90,"pp":15,"dmg_class":2}
+{"id":249,"name":"Rock Smash","type":2,"p":20,"pp":15,"dmg_class":1,"effect":50}
+{"id":250,"name":"Whirlpool","type":11,"p":15,"acc":70,"pp":15,"dmg_class":2,"effect":100}
+{"id":251,"name":"Beat Up","type":17,"p":10,"pp":10,"dmg_class":1}
 {"id":252,"name":"Fake Out","type":1,"p":40,"pp":10,"dmg_class":1,"effect":100}
-{"id":253,"name":"Uproar","type":1,"p":90,"pp":10,"dmg_class":2}
-{"id":254,"name":"Stockpile","type":1,"pp":20,"dmg_class":3}
+{"id":253,"name":"Uproar","type":1,"p":50,"pp":10,"dmg_class":2}
+{"id":254,"name":"Stockpile","type":1,"pp":10,"dmg_class":3}
 {"id":255,"name":"Spit Up","type":1,"pp":10,"dmg_class":2}
 {"id":256,"name":"Swallow","type":1,"pp":10,"dmg_class":3}
-{"id":257,"name":"Heat Wave","type":10,"p":95,"acc":90,"pp":10,"dmg_class":2,"effect":10}
+{"id":257,"name":"Heat Wave","type":10,"p":100,"acc":90,"pp":10,"dmg_class":2,"effect":10}
 {"id":258,"name":"Hail","type":15,"pp":10,"dmg_class":3}
 {"id":259,"name":"Torment","type":17,"pp":15,"dmg_class":3,"effect":12}
 {"id":260,"name":"Flatter","type":17,"pp":15,"dmg_class":3,"effect":6}
-{"id":261,"name":"Will-O-Wisp","type":10,"acc":85,"pp":15,"dmg_class":3,"effect":4}
+{"id":261,"name":"Will-O-Wisp","type":10,"acc":75,"pp":15,"dmg_class":3,"effect":4}
 {"id":262,"name":"Memento","type":17,"pp":10,"dmg_class":3}
 {"id":263,"name":"Facade","type":1,"p":70,"pp":20,"dmg_class":1}
 {"id":264,"name":"Focus Punch","type":2,"p":150,"pp":20,"dmg_class":1}
-{"id":265,"name":"Smelling Salts","type":1,"p":70,"pp":10,"dmg_class":1}
+{"id":265,"name":"Smelling Salts","type":1,"p":60,"pp":10,"dmg_class":1}
 {"id":266,"name":"Follow Me","type":1,"pp":20,"dmg_class":3}
 {"id":267,"name":"Nature Power","type":1,"pp":20,"dmg_class":3}
 {"id":268,"name":"Charge","type":13,"pp":20,"dmg_class":3}
@@ -279,7 +279,7 @@
 {"id":279,"name":"Revenge","type":2,"p":60,"pp":10,"dmg_class":1}
 {"id":280,"name":"Brick Break","type":2,"p":75,"pp":15,"dmg_class":1}
 {"id":281,"name":"Yawn","type":1,"pp":10,"dmg_class":3,"effect":14}
-{"id":282,"name":"Knock Off","type":17,"p":65,"pp":20,"dmg_class":1}
+{"id":282,"name":"Knock Off","type":17,"p":20,"pp":20,"dmg_class":1}
 {"id":283,"name":"Endeavor","type":1,"pp":5,"dmg_class":1}
 {"id":284,"name":"Eruption","type":10,"p":150,"pp":5,"dmg_class":2}
 {"id":285,"name":"Skill Swap","type":14,"pp":10,"dmg_class":3}
@@ -288,12 +288,12 @@
 {"id":288,"name":"Grudge","type":8,"pp":5,"dmg_class":3}
 {"id":289,"name":"Snatch","type":17,"pp":10,"dmg_class":3}
 {"id":290,"name":"Secret Power","type":1,"p":70,"pp":20,"dmg_class":1,"effect":30}
-{"id":291,"name":"Dive","type":11,"p":80,"pp":10,"dmg_class":1}
+{"id":291,"name":"Dive","type":11,"p":60,"pp":10,"dmg_class":1}
 {"id":292,"name":"Arm Thrust","type":2,"p":15,"pp":20,"dmg_class":1}
 {"id":293,"name":"Camouflage","type":1,"pp":20,"dmg_class":3}
 {"id":294,"name":"Tail Glow","type":7,"pp":20,"dmg_class":3}
 {"id":295,"name":"Luster Purge","type":14,"p":95,"pp":5,"dmg_class":2,"effect":50}
-{"id":296,"name":"Mist Ball","type":14,"p":95,"pp":5,"dmg_class":2,"effect":50}
+{"id":296,"name":"Mist Ball","type":14,"p":70,"pp":5,"dmg_class":2,"effect":50}
 {"id":297,"name":"Feather Dance","type":3,"pp":15,"dmg_class":3}
 {"id":298,"name":"Teeter Dance","type":1,"pp":20,"dmg_class":3,"effect":6}
 {"id":299,"name":"Blaze Kick","type":10,"p":85,"acc":90,"pp":10,"dmg_class":1,"effect":10}
@@ -306,15 +306,15 @@
 {"id":306,"name":"Crush Claw","type":1,"p":75,"acc":95,"pp":10,"dmg_class":1,"effect":50}
 {"id":307,"name":"Blast Burn","type":10,"p":150,"acc":90,"pp":5,"dmg_class":2}
 {"id":308,"name":"Hydro Cannon","type":11,"p":150,"acc":90,"pp":5,"dmg_class":2}
-{"id":309,"name":"Meteor Mash","type":9,"p":90,"acc":90,"pp":10,"dmg_class":1,"effect":20}
+{"id":309,"name":"Meteor Mash","type":9,"p":100,"acc":85,"pp":10,"dmg_class":1,"effect":20}
 {"id":310,"name":"Astonish","type":8,"p":30,"pp":15,"dmg_class":1,"effect":30}
 {"id":311,"name":"Weather Ball","type":1,"p":50,"pp":10,"dmg_class":2}
 {"id":312,"name":"Aromatherapy","type":12,"pp":5,"dmg_class":3}
 {"id":313,"name":"Fake Tears","type":17,"pp":20,"dmg_class":3}
-{"id":314,"name":"Air Cutter","type":3,"p":60,"acc":95,"pp":25,"dmg_class":2}
-{"id":315,"name":"Overheat","type":10,"p":130,"acc":90,"pp":5,"dmg_class":2,"effect":100}
+{"id":314,"name":"Air Cutter","type":3,"p":55,"acc":95,"pp":25,"dmg_class":2}
+{"id":315,"name":"Overheat","type":10,"p":140,"acc":90,"pp":5,"dmg_class":2,"effect":100}
 {"id":316,"name":"Odor Sleuth","type":1,"pp":40,"dmg_class":3,"effect":17}
-{"id":317,"name":"Rock Tomb","type":6,"p":60,"acc":95,"pp":15,"dmg_class":1,"effect":100}
+{"id":317,"name":"Rock Tomb","type":6,"p":50,"acc":80,"pp":10,"dmg_class":1,"effect":100}
 {"id":318,"name":"Silver Wind","type":7,"p":60,"pp":5,"dmg_class":2,"effect":10}
 {"id":319,"name":"Metal Sound","type":9,"acc":85,"pp":40,"dmg_class":3}
 {"id":320,"name":"Grass Whistle","type":12,"acc":55,"pp":15,"dmg_class":3,"effect":2}
@@ -323,14 +323,14 @@
 {"id":323,"name":"Water Spout","type":11,"p":150,"pp":5,"dmg_class":2}
 {"id":324,"name":"Signal Beam","type":7,"p":75,"pp":15,"dmg_class":2,"effect":10}
 {"id":325,"name":"Shadow Punch","type":8,"p":60,"pp":20,"dmg_class":1}
-{"id":326,"name":"Extrasensory","type":14,"p":80,"pp":20,"dmg_class":2,"effect":10}
+{"id":326,"name":"Extrasensory","type":14,"p":80,"pp":30,"dmg_class":2,"effect":10}
 {"id":327,"name":"Sky Uppercut","type":2,"p":85,"acc":90,"pp":15,"dmg_class":1}
-{"id":328,"name":"Sand Tomb","type":5,"p":35,"acc":85,"pp":15,"dmg_class":1,"effect":100}
+{"id":328,"name":"Sand Tomb","type":5,"p":15,"acc":70,"pp":15,"dmg_class":1,"effect":100}
 {"id":329,"name":"Sheer Cold","type":15,"acc":30,"pp":5,"dmg_class":2}
-{"id":330,"name":"Muddy Water","type":11,"p":90,"acc":85,"pp":10,"dmg_class":2,"effect":30}
-{"id":331,"name":"Bullet Seed","type":12,"p":25,"pp":30,"dmg_class":1}
+{"id":330,"name":"Muddy Water","type":11,"p":95,"acc":85,"pp":10,"dmg_class":2,"effect":30}
+{"id":331,"name":"Bullet Seed","type":12,"p":10,"pp":30,"dmg_class":1}
 {"id":332,"name":"Aerial Ace","type":3,"p":60,"pp":20,"dmg_class":1}
-{"id":333,"name":"Icicle Spear","type":15,"p":25,"pp":30,"dmg_class":1}
+{"id":333,"name":"Icicle Spear","type":15,"p":10,"pp":30,"dmg_class":1}
 {"id":334,"name":"Iron Defense","type":9,"pp":15,"dmg_class":3}
 {"id":335,"name":"Block","type":1,"pp":5,"dmg_class":3}
 {"id":336,"name":"Howl","type":1,"pp":40,"dmg_class":3}
@@ -340,15 +340,15 @@
 {"id":340,"name":"Bounce","type":3,"p":85,"acc":85,"pp":5,"dmg_class":1,"effect":30}
 {"id":341,"name":"Mud Shot","type":5,"p":55,"acc":95,"pp":15,"dmg_class":2,"effect":100}
 {"id":342,"name":"Poison Tail","type":4,"p":50,"pp":25,"dmg_class":1,"effect":10}
-{"id":343,"name":"Covet","type":1,"p":60,"pp":25,"dmg_class":1}
+{"id":343,"name":"Covet","type":1,"p":40,"pp":25,"dmg_class":1}
 {"id":344,"name":"Volt Tackle","type":13,"p":120,"pp":15,"dmg_class":1,"effect":10}
 {"id":345,"name":"Magical Leaf","type":12,"p":60,"pp":20,"dmg_class":2}
 {"id":346,"name":"Water Sport","type":11,"pp":15,"dmg_class":3}
 {"id":347,"name":"Calm Mind","type":14,"pp":20,"dmg_class":3}
-{"id":348,"name":"Leaf Blade","type":12,"p":90,"pp":15,"dmg_class":1}
+{"id":348,"name":"Leaf Blade","type":12,"p":70,"pp":15,"dmg_class":1}
 {"id":349,"name":"Dragon Dance","type":16,"pp":20,"dmg_class":3}
-{"id":350,"name":"Rock Blast","type":6,"p":25,"acc":90,"pp":10,"dmg_class":1}
+{"id":350,"name":"Rock Blast","type":6,"p":25,"acc":80,"pp":10,"dmg_class":1}
 {"id":351,"name":"Shock Wave","type":13,"p":60,"pp":20,"dmg_class":2}
 {"id":352,"name":"Water Pulse","type":11,"p":60,"pp":20,"dmg_class":2,"effect":20}
-{"id":353,"name":"Doom Desire","type":9,"p":140,"pp":5,"dmg_class":2}
+{"id":353,"name":"Doom Desire","type":9,"p":120,"acc":85,"pp":5,"dmg_class":2}
 {"id":354,"name":"Psycho Boost","type":14,"p":140,"acc":90,"pp":5,"dmg_class":2,"effect":100}

--- a/scripts/generate-pokedata.ts
+++ b/scripts/generate-pokedata.ts
@@ -608,6 +608,18 @@ console.log('\nProcessing Moves...');
 const moves: any[] = [];
 // We primarily care about moves present up to Gen 3
 const MAX_MOVE_ID = 354;
+
+const genMap: Record<number, number> = {
+  1: 1, 2: 1,
+  3: 2, 4: 2,
+  5: 3, 6: 3, 7: 3, 12: 3, 13: 3,
+  8: 4, 9: 4, 10: 4,
+  11: 5, 14: 5,
+  15: 6, 16: 6,
+  17: 7, 18: 7, 19: 7,
+  20: 8
+};
+
 for (let i = 1; i <= MAX_MOVE_ID; i++) {
   const mDataPath = path.join(dataPath, `move/${i}/index.json`);
   const mData = readJson(mDataPath);
@@ -644,6 +656,30 @@ for (let i = 1; i <= MAX_MOVE_ID; i++) {
     pp: mData.pp,
     dmg_class: dmgClass,
   };
+
+  if (mData.past_values && mData.past_values.length > 0) {
+    const targetGen = 3;
+    const sortedPastValues = [...mData.past_values].sort((a, b) => {
+      const vgA = parseInt(a.version_group.url.split('/').filter(Boolean).pop() || '0', 10);
+      const vgB = parseInt(b.version_group.url.split('/').filter(Boolean).pop() || '0', 10);
+      return (genMap[vgA] || 99) - (genMap[vgB] || 99);
+    });
+
+    for (const pv of sortedPastValues) {
+      const vgId = parseInt(pv.version_group.url.split('/').filter(Boolean).pop() || '0', 10);
+      const vgGen = genMap[vgId] || 99;
+
+      if (vgGen > targetGen) {
+        if (pv.accuracy !== null) move.acc = pv.accuracy;
+        if (pv.power !== null) move.p = pv.power;
+        if (pv.pp !== null) move.pp = pv.pp;
+        if (pv.type !== null) {
+          move.type = parseInt(pv.type.url.split('/').filter(Boolean).pop() || '0', 10);
+        }
+        break;
+      }
+    }
+  }
 
   if (effect !== undefined) {
     move.effect = effect;


### PR DESCRIPTION
Fixes the move generation scripts to apply discrepancies for past generation moves (Gen 1-3) based on `past_values`. 
- `scripts/generate-pokedata.ts`: Added sorting logic for `past_values` to prioritize the oldest changes first, and override the default latest PokeAPI stats with the correct base stats that were in effect during Gen 1-3.
- `data/db/moves.jsonl` / `data/db/metadata.json`: Auto-generated updates based on the script.
- `.foundry/tasks/task-129-206-move-generation-discrepancies-impl.md`: Marked acceptance criteria checkboxes.

---
*PR created automatically by Jules for task [13525768377188504297](https://jules.google.com/task/13525768377188504297) started by @szubster*