### PR TITLE
feat: Implement Individual Contest Stats UI

### DIFF
--- a/.foundry/tasks/task-137-209-individual-contest-stats-ui-impl.md
+++ b/.foundry/tasks/task-137-209-individual-contest-stats-ui-impl.md
@@ -29,9 +29,9 @@ This task implements the UI required to show individual contest stats for a spec
 4. Update `src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx` to include testing for these new visual components.
 
 ## 3. Acceptance Criteria
-- [ ] `ContestConditionStats` renders correctly within `PokemonCaughtDetails` if `condition` data is passed.
-- [ ] `ContestSheenDisplay` renders correctly within `PokemonCaughtDetails` if `condition` data contains `sheen`.
-- [ ] Tests in `PokemonCaughtDetails.test.tsx` cover the rendering of these new condition stat displays.
-- [ ] If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- [ ] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- [x] `ContestConditionStats` renders correctly within `PokemonCaughtDetails` if `condition` data is passed.
+- [x] `ContestSheenDisplay` renders correctly within `PokemonCaughtDetails` if `condition` data contains `sheen`.
+- [x] Tests in `PokemonCaughtDetails.test.tsx` cover the rendering of these new condition stat displays.
+- [x] If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- [x] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- [x] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/src/components/pokemon/details/PokemonCaughtDetails.tsx
+++ b/src/components/pokemon/details/PokemonCaughtDetails.tsx
@@ -3,6 +3,7 @@ import { gen2Items, gen2Locations } from '../../../engine/data/gen2/legacyNameMa
 import type { PokemonInstance } from '../../../engine/saveParser/index';
 import { useStore } from '../../../store';
 import { getTimeCapsuleValidation } from '../../../utils/timeCapsule';
+import { ContestConditionStats } from '../../ContestConditionStats';
 import { HoverScanner } from '../../HoverScanner';
 import { LcdGrid } from '../../LcdGrid';
 import { SectionHeader } from '../../SectionHeader';
@@ -10,6 +11,7 @@ import { TacticalBadge } from '../../TacticalBadge';
 import { TacticalPanel } from '../../TacticalPanel';
 import { TelemetryDecoration } from '../../TelemetryDecoration';
 import { ContestRibbonsPanel } from './ContestRibbonsPanel';
+import { ContestSheenDisplay } from './ContestSheenDisplay';
 
 interface PokemonCaughtDetailsProps {
   yourPokemon: (PokemonInstance & { location: string })[];
@@ -129,6 +131,19 @@ export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps)
             {p.ribbons && generation === 3 && (
               <div className="relative z-10 border-white/5 border-t border-dashed bg-black/40 p-4">
                 <ContestRibbonsPanel ribbons={p.ribbons} />
+              </div>
+            )}
+
+            {p.condition && (
+              <div className="relative z-10 flex flex-col gap-4 border-white/5 border-t border-dashed bg-black/40 p-4">
+                <ContestConditionStats
+                  cool={p.condition.cool}
+                  beauty={p.condition.beauty}
+                  cute={p.condition.cute}
+                  smart={p.condition.smart}
+                  tough={p.condition.tough}
+                />
+                {p.condition.sheen !== undefined && <ContestSheenDisplay sheen={p.condition.sheen} />}
               </div>
             )}
           </TacticalPanel>

--- a/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
+++ b/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
@@ -99,7 +99,36 @@ describe('PokemonCaughtDetails', () => {
     await render(<PokemonCaughtDetails yourPokemon={[gen3PokemonWithRibbons]} />);
 
     await expect.element(page.getByText('Contest Ribbons')).toBeInTheDocument();
-    await expect.element(page.getByText('Cool')).toBeInTheDocument();
+    await expect.element(page.getByText('Cool', { exact: true })).toBeInTheDocument();
     await expect.element(page.getByText('Master')).toBeInTheDocument();
+  });
+
+  it('renders ContestConditionStats and ContestSheenDisplay for pokemon with condition', async () => {
+    (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
+      (selector: unknown) =>
+        (selector as (state: unknown) => unknown)({
+          saveData: {
+            generation: 3,
+          },
+        }),
+    );
+
+    const pokemonWithCondition = {
+      ...mockPokemon,
+      condition: {
+        cool: 50,
+        beauty: 60,
+        cute: 70,
+        smart: 80,
+        tough: 90,
+        sheen: 200,
+      },
+    };
+
+    await render(<PokemonCaughtDetails yourPokemon={[pokemonWithCondition]} />);
+
+    await expect.element(page.getByText('SYS.CONTEST_STATS')).toBeInTheDocument();
+    await expect.element(page.getByText('Sheen')).toBeInTheDocument();
+    await expect.element(page.getByText('200 / 255')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR implements the Individual Contest Stats UI for caught Pokemon. It adds the `ContestConditionStats` and `ContestSheenDisplay` components to `PokemonCaughtDetails.tsx` when a generation 3 pokemon with a condition is being displayed. It also updates the tests in `PokemonCaughtDetails.test.tsx` to ensure these new components are rendered correctly. Finally, it checks off the corresponding acceptance criteria in the task markdown file.

---
*PR created automatically by Jules for task [874095919134660341](https://jules.google.com/task/874095919134660341) started by @szubster*