### PR TITLE
Implement Gen 1 Hall of Fame records parsing

### DIFF
--- a/.foundry/tasks/task-149-212-gen1-hof-records-impl.md
+++ b/.foundry/tasks/task-149-212-gen1-hof-records-impl.md
@@ -52,9 +52,9 @@ The Hall of Fame data structure described by Bulbapedia does *not* include the p
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement `parseGen1HallOfFameRecords` function in `src/engine/saveParser/parsers/gen1.ts` (or similar appropriate location).
-- [ ] Define reusable constants at the module level for all Hall of Fame offsets and lengths.
-- [ ] Extract the Pokémon species, level, and nickname for each record.
-- [ ] Use the global `trainerName` for the player name associated with the records.
-- [ ] Update the `SaveData` interface in `src/engine/saveParser/parsers/common.ts` to include the new `hallOfFameRecords` property (array of records).
-- [ ] Integrate the extraction logic into `parseGen1` and populate the new property.
+- [x] Implement `parseGen1HallOfFameRecords` function in `src/engine/saveParser/parsers/gen1.ts` (or similar appropriate location).
+- [x] Define reusable constants at the module level for all Hall of Fame offsets and lengths.
+- [x] Extract the Pokémon species, level, and nickname for each record.
+- [x] Use the global `trainerName` for the player name associated with the records.
+- [x] Update the `SaveData` interface in `src/engine/saveParser/parsers/common.ts` to include the new `hallOfFameRecords` property (array of records).
+- [x] Integrate the extraction logic into `parseGen1` and populate the new property.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -147,6 +147,15 @@ export interface SaveData {
   currentBoxCount: number;
   /** The number of times the player has entered the Hall of Fame. Used to verify Mewtwo accessibility in Gen 1. */
   hallOfFameCount: number;
+  /** The extracted records of the player's Hall of Fame teams. */
+  hallOfFameRecords?: {
+    playerName: string;
+    pokemon: {
+      speciesId: number;
+      level: number;
+      nickname: string;
+    }[];
+  }[];
   /** Raw byte array containing all in-game event flags (e.g., claimed static gifts, story progression). */
   eventFlags?: Uint8Array;
   /** Raw byte array containing hidden item event flags. */

--- a/src/engine/saveParser/parsers/gen1.test.ts
+++ b/src/engine/saveParser/parsers/gen1.test.ts
@@ -241,6 +241,49 @@ describe('parseGen1 - additional branches', () => {
     const data = parseGen1(view);
     expect(data.hallOfFameCount).toBe(0);
   });
+
+  it('should extract Hall of Fame records correctly', () => {
+    const buffer = new ArrayBuffer(32768);
+    const view = new DataView(buffer);
+
+    // Trainer name 'AB'
+    view.setUint8(0x2598, 0x80);
+    view.setUint8(0x2599, 0x81);
+    view.setUint8(0x259a, 0x50);
+
+    // Party count 0
+    view.setUint8(0x2f2c, 0);
+
+    // hallOfFameCount = 1
+    view.setUint8(0x25b3, 1);
+
+    // HoF record 0
+    const hofBase = 0x0598;
+    // Pokemon 0 in record 0
+    view.setUint8(hofBase + 0, 0x01); // internal ID 0x01 -> dex 112 (Rhydon)
+    view.setUint8(hofBase + 1, 16); // level 16
+    // Nickname 'B'
+    view.setUint8(hofBase + 2, 0x81);
+    view.setUint8(hofBase + 3, 0x50);
+
+    // Empty Pokemon 1 in record 0 (to test skip)
+    view.setUint8(hofBase + 0x10, 0xff);
+
+    const data = parseGen1(view);
+
+    expect(data.hallOfFameCount).toBe(1);
+    expect(data.hallOfFameRecords).toBeDefined();
+    expect(data.hallOfFameRecords?.length).toBe(1);
+
+    const record = data.hallOfFameRecords?.[0];
+    expect(record?.playerName).toBe('AB');
+    expect(record?.pokemon.length).toBe(1);
+
+    const pkmn = record?.pokemon[0];
+    expect(pkmn?.speciesId).toBe(112);
+    expect(pkmn?.level).toBe(16);
+    expect(pkmn?.nickname).toBe('B');
+  });
 });
 
 describe('parseGen1 - yellow version fallbacks', () => {

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -6,6 +6,12 @@ function isValidMapId(id: string): id is keyof typeof gen1MapLocations {
   return id in gen1MapLocations;
 }
 
+const HOF_BASE_OFFSET = 0x0598;
+const HOF_RECORD_LENGTH = 0x60;
+const HOF_MAX_RECORDS = 50;
+const HOF_POKEMON_COUNT = 6;
+const HOF_POKEMON_LENGTH = 0x10;
+
 const INTERNAL_ID_TO_DEX: Record<number, number> = {
   1: 112,
   2: 115,
@@ -307,6 +313,53 @@ export function isGen1Save(view: DataView): boolean {
 }
 
 /**
+ * Parses the Hall of Fame records from a Gen 1 save.
+ *
+ * @param view - The raw save file DataView.
+ * @param hallOfFameCount - The total number of times the player has entered the Hall of Fame.
+ * @param trainerName - The player's Original Trainer name.
+ * @returns An array of parsed Hall of Fame records.
+ */
+function parseGen1HallOfFameRecords(view: DataView, hallOfFameCount: number, trainerName: string) {
+  const records: {
+    playerName: string;
+    pokemon: { speciesId: number; level: number; nickname: string }[];
+  }[] = [];
+
+  const maxRecords = Math.min(hallOfFameCount, HOF_MAX_RECORDS);
+
+  for (let recordIndex = 0; recordIndex < maxRecords; recordIndex++) {
+    const pokemon: { speciesId: number; level: number; nickname: string }[] = [];
+
+    for (let pokemonIndex = 0; pokemonIndex < HOF_POKEMON_COUNT; pokemonIndex++) {
+      const offset = HOF_BASE_OFFSET + recordIndex * HOF_RECORD_LENGTH + pokemonIndex * HOF_POKEMON_LENGTH;
+
+      const internalId = view.getUint8(offset);
+      if (internalId === 0x00 || internalId === 0xff) {
+        continue;
+      }
+
+      const speciesId = INTERNAL_ID_TO_DEX[internalId];
+      if (!speciesId) {
+        continue;
+      }
+
+      const level = view.getUint8(offset + 1);
+      const nickname = decodeGen12String(view, offset + 2, 11);
+
+      pokemon.push({ speciesId, level, nickname });
+    }
+
+    records.push({
+      playerName: trainerName,
+      pokemon,
+    });
+  }
+
+  return records;
+}
+
+/**
  * Extracts all relevant game data (party, PC boxes, inventory, Pokédex, etc.) from a Gen 1 save.
  *
  * Gen 1 save file structures differ slightly based on version and region. Notably, Yellow version
@@ -603,6 +656,9 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
   }
 
   const hallOfFameRaw = view.getUint8(0x25b3 + offsetShift);
+  const hallOfFameCount = hallOfFameRaw === 0xff ? 0 : hallOfFameRaw;
+  const hallOfFameRecords = parseGen1HallOfFameRecords(view, hallOfFameCount, trainerName);
+
   const eventFlagsOffset = 0x29e6 + offsetShift;
   const eventFlags = new Uint8Array(view.buffer, eventFlagsOffset, 0x118);
   const hiddenItemFlagsOffset = 0x299c + offsetShift;
@@ -628,7 +684,8 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
     inventory,
     pcItems,
     currentBoxCount,
-    hallOfFameCount: hallOfFameRaw === 0xff ? 0 : hallOfFameRaw,
+    hallOfFameCount,
+    hallOfFameRecords,
     eventFlags,
     hiddenItemFlags,
     hiddenCoinFlags,


### PR DESCRIPTION
This PR implements Gen 1 Hall of Fame records extraction.

It adds the necessary parsing logic to `parseGen1` to retrieve the historical teams from Bank 0 at offset `0x0598`. The new `hallOfFameRecords` property on the `SaveData` interface accurately stores these teams along with the player name, correctly bounded by `hallOfFameCount` and bounded structurally to max 50 records.

All tests passed successfully, and linting errors were fixed.

---
*PR created automatically by Jules for task [1213026116768773068](https://jules.google.com/task/1213026116768773068) started by @szubster*