### PR TITLE
feat: implement Gen 3 Contest Sheen UI in Pokemon details

### DIFF
--- a/.foundry/tasks/task-138-209-individual-contest-sheen-ui-impl.md
+++ b/.foundry/tasks/task-138-209-individual-contest-sheen-ui-impl.md
@@ -46,6 +46,6 @@ This task integrates the `ContestSheenDisplay` component into the detailed Poké
 - **Empty PR Policy**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the YAML frontmatter on successful completion.
 
 ## 4. Acceptance Criteria
-- [ ] Integrate `ContestSheenDisplay` into `PokemonCaughtDetails.tsx` for Gen 3 Pokémon with condition stats.
-- [ ] Ensure the component renders beautifully and fits the tactical UI aesthetic.
-- [ ] Add tests to verify the integration.
+- [x] Integrate `ContestSheenDisplay` into `PokemonCaughtDetails.tsx` for Gen 3 Pokémon with condition stats.
+- [x] Ensure the component renders beautifully and fits the tactical UI aesthetic.
+- [x] Add tests to verify the integration.

--- a/src/components/pokemon/details/PokemonCaughtDetails.tsx
+++ b/src/components/pokemon/details/PokemonCaughtDetails.tsx
@@ -10,6 +10,7 @@ import { TacticalBadge } from '../../TacticalBadge';
 import { TacticalPanel } from '../../TacticalPanel';
 import { TelemetryDecoration } from '../../TelemetryDecoration';
 import { ContestRibbonsPanel } from './ContestRibbonsPanel';
+import { ContestSheenDisplay } from './ContestSheenDisplay';
 
 interface PokemonCaughtDetailsProps {
   yourPokemon: (PokemonInstance & { location: string })[];
@@ -123,6 +124,12 @@ export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps)
                 <span className="truncate font-black text-[10px] text-[var(--theme-primary)] uppercase tracking-tight">
                   {gen2Locations[p.caughtData.location] || 'UNKNOWN ZONE'}
                 </span>
+              </div>
+            )}
+
+            {generation === 3 && p.condition && (
+              <div className="relative z-10 border-white/5 border-t border-dashed bg-black/40 p-4">
+                <ContestSheenDisplay sheen={p.condition.sheen} />
               </div>
             )}
 

--- a/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
+++ b/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
@@ -102,4 +102,32 @@ describe('PokemonCaughtDetails', () => {
     await expect.element(page.getByText('Cool')).toBeInTheDocument();
     await expect.element(page.getByText('Master')).toBeInTheDocument();
   });
+
+  it('renders ContestSheenDisplay for Gen 3 pokemon with condition stats', async () => {
+    (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
+      (selector: unknown) =>
+        (selector as (state: unknown) => unknown)({
+          saveData: {
+            generation: 3,
+          },
+        }),
+    );
+
+    const gen3PokemonWithCondition = {
+      ...mockPokemon,
+      condition: {
+        cool: 10,
+        beauty: 20,
+        cute: 30,
+        smart: 40,
+        tough: 50,
+        sheen: 150,
+      },
+    };
+
+    await render(<PokemonCaughtDetails yourPokemon={[gen3PokemonWithCondition]} />);
+
+    await expect.element(page.getByText('Sheen')).toBeInTheDocument();
+    await expect.element(page.getByText('150 / 255')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Completes the implementation of the Contest Sheen UI for Gen 3 Pokémon by integrating the existing `ContestSheenDisplay` component into `PokemonCaughtDetails.tsx`. Includes unit test coverage for the sheen display logic.

---
*PR created automatically by Jules for task [4129025631926924830](https://jules.google.com/task/4129025631926924830) started by @szubster*