### PR TITLE
🖼️ Canvas: Tactical BottomNav Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -233,3 +233,9 @@
 **Outcome:** Accepted
 **Why:** The previous sync modal felt too much like a standard web loading state, breaking the "specialized hardware" immersion during a critical application action. Evolving it into a multi-pane data terminal with explicit radar and block-matrix visualizations reinforces the fantasy of intercepting and processing raw hardware data.
 **Pattern:** For loading states or long-running processes, avoid standard spinners or simple progress bars. Transform them into active "Terminal Operations" featuring multi-pane layouts, explicit data stream visualizations (like block matrices or hex grids), and faux hardware scanners to maintain the specialized device aesthetic.
+
+## 2026-07-15 - [Accepted] - 🖼️ Canvas: Tactical BottomNav Redesign
+**What:** Redesigned `BottomNav` and `NavButton` to resemble a rigid, physical instrument panel with chunky membrane switches instead of a generic floating app bar. Added layered borders, inset shadows for depressed states, and mechanical-looking sliding brackets for the active indicator.
+**Outcome:** Accepted
+**Why:** Brings the mobile bottom navigation fully into the tactical specialized hardware motif. Floating app bars and subtle flicker animations break the illusion of using a rugged, purpose-built device.
+**Pattern:** Apply "bracketed" physical hardware layouts and explicit "membrane switch" button designs (using inset shadows, dashed borders, and strict monospaced labels) to navigation structures to maintain the device simulation across all viewports.

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -30,20 +30,18 @@ export function BottomNav() {
         className="-top-[21px] left-4 rounded-none border-t border-b-0 bg-zinc-950 text-[10px]"
       />
 
-      <div className="relative mx-auto flex h-16 max-w-md items-center gap-2 rounded-none border border-zinc-800 border-dashed bg-black/60 p-1">
+      <div className="relative mx-auto flex h-16 max-w-md items-center gap-1 rounded-none border-[4px] border-zinc-800 border-t-zinc-700 border-l-zinc-700 bg-zinc-900 p-1 shadow-[4px_4px_0px_rgba(0,0,0,0.8)]">
         {/* Active Indicator Hardware Frame */}
         {activeIndex !== -1 && (
           <div
-            className="pointer-events-none absolute z-0 h-[calc(100%-8px)] w-[calc(20%-8px)] transition-transform duration-300 ease-[cubic-bezier(0.2,1,0.2,1)]"
-            style={{ transform: `translateX(calc(${activeIndex * 100}% + ${activeIndex * 8}px))` }}
+            className="pointer-events-none absolute z-20 h-[calc(100%-8px)] w-[calc(20%-5.6px)] transition-transform duration-300 ease-[cubic-bezier(0.2,1,0.2,1)]"
+            style={{ transform: `translateX(calc(${activeIndex * 100}% + ${activeIndex * 4}px))` }}
           >
-            <div className="absolute inset-0 border-[3px] border-[var(--theme-primary)] opacity-80 shadow-[0_0_10px_var(--theme-primary)]" />
-
             {/* Sliding Bracket Corners */}
-            <div className="absolute -top-1 -left-1 h-3 w-3 border-[var(--theme-primary)] border-t-[4px] border-l-[4px]" />
-            <div className="absolute -top-1 -right-1 h-3 w-3 border-[var(--theme-primary)] border-t-[4px] border-r-[4px]" />
-            <div className="absolute -bottom-1 -left-1 h-3 w-3 border-[var(--theme-primary)] border-b-[4px] border-l-[4px]" />
-            <div className="absolute -right-1 -bottom-1 h-3 w-3 border-[var(--theme-primary)] border-r-[4px] border-b-[4px]" />
+            <div className="absolute -top-1 -left-1 h-3 w-3 border-[var(--theme-primary)] border-t-[4px] border-l-[4px] drop-shadow-[0_0_5px_var(--theme-primary)]" />
+            <div className="absolute -top-1 -right-1 h-3 w-3 border-[var(--theme-primary)] border-t-[4px] border-r-[4px] drop-shadow-[0_0_5px_var(--theme-primary)]" />
+            <div className="absolute -bottom-1 -left-1 h-3 w-3 border-[var(--theme-primary)] border-b-[4px] border-l-[4px] drop-shadow-[0_0_5px_var(--theme-primary)]" />
+            <div className="absolute -right-1 -bottom-1 h-3 w-3 border-[var(--theme-primary)] border-r-[4px] border-b-[4px] drop-shadow-[0_0_5px_var(--theme-primary)]" />
           </div>
         )}
 

--- a/src/components/NavButton.tsx
+++ b/src/components/NavButton.tsx
@@ -27,17 +27,17 @@ export function NavButton({ to, isActive, onClick, icon: Icon, label, activeLabe
           className={cn(isActive && 'drop-shadow-[0_0_8px_rgba(var(--theme-primary-rgb),0.8)]')}
         />
         <span className="font-black font-mono text-[9px] uppercase tracking-[0.2em]">
-          {isActive ? activeLabel : label}
+          [ {isActive ? activeLabel : label} ]
         </span>
       </div>
     </>
   );
 
   const className = cn(
-    'group focus-visible:tactical-focus relative z-10 flex h-full flex-col items-center justify-center rounded-none border border-dashed transition-all duration-300',
+    'group focus-visible:tactical-focus relative z-10 flex h-full flex-col items-center justify-center rounded-none transition-all duration-300',
     isActive
-      ? 'border-[var(--theme-primary)]/50 bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_15px_rgba(var(--theme-primary-rgb),0.3)]'
-      : 'border-zinc-800 bg-zinc-950/80 text-zinc-600 shadow-[inset_0_2px_4px_rgba(255,255,255,0.05)] hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-400',
+      ? 'border-2 border-zinc-900 bg-zinc-950 text-[var(--theme-primary)] shadow-[inset_0_4px_10px_rgba(0,0,0,0.8)]'
+      : 'border-2 border-t-zinc-700 border-r-zinc-900 border-b-zinc-900 border-l-zinc-700 bg-zinc-800 text-zinc-500 shadow-[2px_2px_0px_rgba(0,0,0,0.5)] hover:bg-zinc-700 hover:text-zinc-300',
   );
 
   if (to) {


### PR DESCRIPTION
Redesigned `BottomNav` and `NavButton` to resemble a rigid, physical instrument panel with chunky membrane switches.
Added layered borders, inset shadows for depressed states, and mechanical-looking sliding brackets for the active indicator.
This brings the mobile bottom navigation fully into the tactical specialized hardware motif.

---
*PR created automatically by Jules for task [3815506888739902510](https://jules.google.com/task/3815506888739902510) started by @szubster*