### PR TITLE
🧭 Strategist: Prompt improvement - Enforce RangeError verification in QA prompt

### DIFF
--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -17,7 +17,7 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/001-the-f
 
 ## Responsibilities
 
-1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria. You MUST explicitly reject tasks that use inline magic numbers (e.g., `0x2dd6`, `>> 4`) for save file data extraction instead of defined reusable constants at the module level.
+1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria. You MUST explicitly reject tasks that use inline magic numbers (e.g., `0x2dd6`, `>> 4`) for save file data extraction instead of defined reusable constants at the module level. You MUST ensure that any tasks involving parsers for save files properly catch `RangeError` from the `DataView` API when checking for out-of-bounds reads.
 2. **Review**: Ensure implemented code follows architectural constraints (especially ADR 001).
 3. **Approval/Rejection**: If the implementation is valid, approve it. If not, detail what is missing or incorrect according to the contract and architecture.
 4. **Specify Results**: Explicitly specify the results of your validation work. Depending on the scope and need for further analysis, this output can include new tests, documentation updates, or the creation of new tasks, stories, PRDs, or ideas.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -308,3 +308,9 @@
 **Outcome:** Accepted
 **Why:** The memory requires multiple strict rules for execution plans (Execution Plan Sequencing Rule, Execution Plan Verification Rule, Empty PR Verification Rule, Execution Plan Groundedness Rule, Execution Plan Specificity Rule, and Execution Plan Tense Rule). These rules were repeatedly violated by agents because they were scattered and not centralized in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 **Pattern:** Apply systemic rules consistently across all relevant agent personas. When an architectural constraint or tool rule applies universally, it must be explicitly included in the centralized `core_policies.md` to ensure compliance without bloating individual prompts.
+
+## 2026-07-18 - [Accepted] - Prompt improvement - Enforce RangeError verification in QA prompt
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `qa.md` journal recorded that when verifying tasks that involve adding or modifying parsers for save files (like `task-124-172-gen3-mix-record-events-parser`), the QA agent must closely inspect that they properly catch `RangeError` from the `DataView` API when checking for out-of-bounds reads. However, this explicit validation constraint was missing from the QA agent's prompt.
+**Pattern:** Codify system memory constraints and specific validation requirements (like checking for `RangeError` handling in save file parsers) directly into the QA agent's prompt to ensure strict and consistent architectural enforcement.


### PR DESCRIPTION
**Proposal:**
Update the QA persona prompt to explicitly enforce that tasks involving save file parsers properly catch `RangeError` from the `DataView` API during out-of-bounds reads.

**Justification:**
While ADR 010 mandates the use of the `DataView` API and its built-in bounds checking, the QA agent was missing explicit instructions to validate this exact requirement, which could allow brittle parsing logic to slip into the codebase.

**Evidence:**
The `qa.md` journal recorded the following lesson: "When verifying tasks that involve adding or modifying parsers for save files (like `task-124-172-gen3-mix-record-events-parser`), make sure to closely inspect that they properly catch `RangeError` from the `DataView` API when checking for out-of-bounds reads." 

By codifying this into the prompt, the system will enforce this validation constraint consistently.

---
*PR created automatically by Jules for task [8131297026944913678](https://jules.google.com/task/8131297026944913678) started by @szubster*