### PR TITLE
chore(foundry): break down story-053-106 into tasks

### DIFF
--- a/.foundry/stories/story-053-106-dag-utils-unit-tests.md
+++ b/.foundry/stories/story-053-106-dag-utils-unit-tests.md
@@ -32,8 +32,8 @@ This story details the technical steps for creating unit tests for the extracted
 - Write unit tests for `getOrphanedNodes`.
 
 ## Generated Tasks
-- [ ] .foundry/tasks/task-106-159-dag-utils-unit-tests-impl.md
-- [ ] .foundry/tasks/task-106-160-dag-utils-unit-tests-qa.md
+- [ ] .foundry/tasks/task-106-226-dag-utils-unit-tests-impl.md
+- [ ] .foundry/tasks/task-106-227-dag-utils-unit-tests-qa.md
 
 ## Acceptance Criteria
 - [ ] Appropriate unit tests are added in `dag-utils.test.ts`.

--- a/.foundry/tasks/task-106-226-dag-utils-unit-tests-impl.md
+++ b/.foundry/tasks/task-106-226-dag-utils-unit-tests-impl.md
@@ -1,0 +1,38 @@
+---
+id: task-106-226-dag-utils-unit-tests-impl
+type: TASK
+title: Implement Unit Tests for Shared DAG Utilities
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-053-106-dag-utils-unit-tests
+tags:
+  - testing
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Unit Tests for Shared DAG Utilities
+
+## Context
+We have recently extracted shared DAG utility functions into \`.github/scripts/dag-utils.ts\`. This task is to write comprehensive unit tests for these utilities to ensure reliability.
+
+## Acceptance Criteria
+- [ ] Create \`.github/scripts/dag-utils.test.ts\`.
+- [ ] Write unit tests for \`buildReverseDependencyGraph\`.
+- [ ] Write unit tests for \`getOrphanedNodes\`.
+- [ ] Tests must cover standard cases, edge cases, and ensure proper typing.
+
+## Directives
+- Implement the unit tests using the existing testing framework used for other orchestrator scripts.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to \`status: FAILED\` with a \`rejection_reason\`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to \`status: CANCELLED\` with a \`rejection_reason\`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-106-227-dag-utils-unit-tests-qa.md
+++ b/.foundry/tasks/task-106-227-dag-utils-unit-tests-qa.md
@@ -1,0 +1,38 @@
+---
+id: task-106-227-dag-utils-unit-tests-qa
+type: TASK
+title: QA Unit Tests for Shared DAG Utilities
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on:
+  - task-106-226-dag-utils-unit-tests-impl
+jules_session_id: null
+pr_number: null
+parent: story-053-106-dag-utils-unit-tests
+tags:
+  - testing
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Unit Tests for Shared DAG Utilities
+
+## Context
+Unit tests have been implemented for \`.github/scripts/dag-utils.ts\`. Verify the tests are comprehensive and pass successfully.
+
+## Acceptance Criteria
+- [ ] Verify \`.github/scripts/dag-utils.test.ts\` exists.
+- [ ] Verify comprehensive tests exist for \`buildReverseDependencyGraph\`.
+- [ ] Verify comprehensive tests exist for \`getOrphanedNodes\`.
+- [ ] All tests pass successfully (\`pnpm test\` in the appropriate directory).
+
+## Directives
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to \`status: FAILED\` with a \`rejection_reason\`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to \`status: CANCELLED\` with a \`rejection_reason\`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Breaks down `story-053-106-dag-utils-unit-tests` into actionable implementation and QA tasks.

- Created `task-106-226-dag-utils-unit-tests-impl.md` for the coder.
- Created `task-106-227-dag-utils-unit-tests-qa.md` for QA.
- Updated `story-053-106-dag-utils-unit-tests.md` to reference the new task files.

---
*PR created automatically by Jules for task [12356602473462599333](https://jules.google.com/task/12356602473462599333) started by @szubster*