### PR TITLE
Add stories for Hidden Items Finder UI

### DIFF
--- a/.foundry/epics/epic-037-060-hidden-items-ui.md
+++ b/.foundry/epics/epic-037-060-hidden-items-ui.md
@@ -36,3 +36,7 @@ This Epic corresponds to the third requirement in the Missing Hidden Items Finde
 - [ ] UI component is built displaying the checklist, filtered and grouped logically.
 - [ ] UI updates dynamically to check off acquired items upon save file hydration.
 - [ ] E2E tests verify the new view correctly renders based on an initialized save state.
+
+## 4. Generated Stories
+- [ ] .foundry/stories/story-060-156-hidden-items-checklist-component.md
+- [ ] .foundry/stories/story-060-157-hidden-items-e2e-tests.md

--- a/.foundry/stories/story-060-156-hidden-items-checklist-component.md
+++ b/.foundry/stories/story-060-156-hidden-items-checklist-component.md
@@ -1,0 +1,36 @@
+---
+id: story-060-156-hidden-items-checklist-component
+type: STORY
+title: Build Hidden Items Checklist Component
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-060-hidden-items-ui
+tags:
+  - feature
+  - tool
+  - quality-of-life
+  - ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Build Hidden Items Checklist Component
+
+## 1. Context & Background
+As part of the Missing Hidden Items Finder feature, we need to create a dedicated view within DexHelper to display a checklist of valuable hidden items. The view should visually reflect items the player has acquired.
+
+## 2. Product Requirements
+- Build a UI component displaying a categorized checklist of valuable hidden items (grouped by route, town, or region).
+- The component must adhere to the 'tactical hardware/snooping' aesthetic (ADR 008) using sharp edges, dashed borders, and monospaced telemetry fonts.
+- Integrate the component to dynamically check off items based on the hydrated save data.
+
+## 3. Acceptance Criteria
+- [ ] Checklist UI is built and styled correctly.
+- [ ] Checklist is logically grouped and filterable.
+- [ ] Component is connected to save file state for dynamic checking of acquired items.

--- a/.foundry/stories/story-060-157-hidden-items-e2e-tests.md
+++ b/.foundry/stories/story-060-157-hidden-items-e2e-tests.md
@@ -1,0 +1,35 @@
+---
+id: story-060-157-hidden-items-e2e-tests
+type: STORY
+title: E2E Tests for Hidden Items UI
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on:
+  - story-060-156-hidden-items-checklist-component
+jules_session_id: null
+pr_number: null
+parent: epic-037-060-hidden-items-ui
+tags:
+  - testing
+  - e2e
+  - ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: E2E Tests for Hidden Items UI
+
+## 1. Context & Background
+To ensure the Hidden Items Finder UI functions as expected and integrates properly with save file hydration, we must write E2E tests validating the component's behavior.
+
+## 2. Product Requirements
+- Write an E2E test using Playwright.
+- Verify that the Hidden Items view renders correctly after save hydration.
+- Verify that acquired items are visually checked off.
+
+## 3. Acceptance Criteria
+- [ ] E2E tests are implemented and pass consistently.
+- [ ] Tests correctly evaluate component rendering and dynamic updates.


### PR DESCRIPTION
- Created story node `story-060-156-hidden-items-checklist-component.md` to build the checklist component.
- Created story node `story-060-157-hidden-items-e2e-tests.md` to implement E2E tests for the new UI.
- Appended the new child nodes as unchecked tasks in the markdown body of the parent epic `epic-037-060-hidden-items-ui.md` to maintain the DAG state.

---
*PR created automatically by Jules for task [9539578262221732459](https://jules.google.com/task/9539578262221732459) started by @szubster*