### PR TITLE
chore: check off acceptance criteria for cancelled qa task

### DIFF
--- a/.foundry/tasks/task-084-193-breeding-pair-algorithm-qa.md
+++ b/.foundry/tasks/task-084-193-breeding-pair-algorithm-qa.md
@@ -38,8 +38,8 @@ Verify the implementation of the Shiny Carrier Breeding Pair Algorithm.
 - Validate that the algorithm correctly respects Gen 2 breeding rules (e.g., Egg Group compatibility, gender requirements).
 
 ## Acceptance Criteria
-- [ ] Implementation passes all tests and correctly identifies valid breeding pairs.
-- [ ] Optimal pairs involving Shiny Carriers are correctly highlighted.
+- [x] Implementation passes all tests and correctly identifies valid breeding pairs.
+- [x] Optimal pairs involving Shiny Carriers are correctly highlighted.
 
 ### Auditor Rejection
 **CANCELLED:** This task was cancelled and replaced by `task-084-205-breeding-pair-algorithm-qa` due to the cancellation of its implementation dependency.


### PR DESCRIPTION
Check off the acceptance criteria for `task-084-193-breeding-pair-algorithm-qa` as it has been marked CANCELLED in its body. This fulfills ADR 007 and ADR 009, enabling an empty PR merge to let the node gracefully exit the DAG.

---
*PR created automatically by Jules for task [7672807359936631661](https://jules.google.com/task/7672807359936631661) started by @szubster*