### PR TITLE
chore: create task blueprints for remediation state transition logic

### DIFF
--- a/.foundry/stories/story-090-133-remediation-state-transition-logic.md
+++ b/.foundry/stories/story-090-133-remediation-state-transition-logic.md
@@ -30,7 +30,9 @@ Implement functionality to safely update the YAML frontmatter of identified zomb
 Following the detection of "zombie" nodes (nodes incorrectly stuck in the `ACTIVE` state) by the engine developed in `epic-050-089-zombie-node-detection-engine`, the system must remediate them by transitioning their state to `FAILED`. This allows the existing Resurrection Loop to pick them up and retry them.
 
 ## Acceptance Criteria
-- [ ] Create task breakdown.
+- [x] Create task breakdown.
 
 ### Next Steps
-- [ ] Break down into Tasks.
+- [x] Break down into Tasks.
+- [ ] .foundry/tasks/task-133-230-remediation-state-transition-logic-impl.md
+- [ ] .foundry/tasks/task-133-231-remediation-state-transition-logic-qa.md

--- a/.foundry/tasks/task-133-230-remediation-state-transition-logic-impl.md
+++ b/.foundry/tasks/task-133-230-remediation-state-transition-logic-impl.md
@@ -1,0 +1,37 @@
+---
+id: task-133-230-remediation-state-transition-logic-impl
+type: TASK
+title: Remediation State Transition Logic Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-090-133-remediation-state-transition-logic
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Remediation State Transition Logic Implementation
+
+## 1. Context
+Following the detection of "zombie" nodes (nodes incorrectly stuck in the `ACTIVE` state) by the engine developed in `epic-050-089-zombie-node-detection-engine`, the system must remediate them by transitioning their state to `FAILED`. This allows the existing Resurrection Loop to pick them up and retry them.
+
+## 2. Requirements
+- Write a utility function that safely updates the YAML frontmatter of a given node file.
+- The function should read the file, parse it using `gray-matter` (as per ADR 006), change `status: ACTIVE` to `status: FAILED`, and write it back.
+- Ensure the function preserves all other existing YAML frontmatter fields and the original markdown body.
+- Write unit tests to verify the update logic successfully transitions the state and handles file write errors.
+- **Reminder**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## 3. Acceptance Criteria
+- [ ] Implement utility function to update node frontmatter status to `FAILED`.
+- [ ] Create unit tests to verify state transition logic.

--- a/.foundry/tasks/task-133-231-remediation-state-transition-logic-qa.md
+++ b/.foundry/tasks/task-133-231-remediation-state-transition-logic-qa.md
@@ -1,0 +1,37 @@
+---
+id: task-133-231-remediation-state-transition-logic-qa
+type: TASK
+title: QA Remediation State Transition Logic Implementation
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on:
+  - task-133-230-remediation-state-transition-logic-impl
+jules_session_id: null
+pr_number: null
+parent: story-090-133-remediation-state-transition-logic
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Remediation State Transition Logic Implementation
+
+## 1. Context
+Following the implementation of the remediation state transition logic in `task-133-230-remediation-state-transition-logic-impl`, we must verify that the utility safely and correctly updates the YAML frontmatter of target nodes.
+
+## 2. Requirements
+- Verify that the implemented utility correctly transitions a node's status from `ACTIVE` to `FAILED`.
+- Ensure that `gray-matter` is used correctly and that no other YAML fields or the markdown body are altered or corrupted during the write.
+- Verify that the unit tests provide adequate coverage.
+- **Reminder**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## 3. Acceptance Criteria
+- [ ] Verify utility function updates status to `FAILED` without data loss.
+- [ ] Verify unit tests correctly cover the logic.


### PR DESCRIPTION
Created implementation and QA task blueprints for the remediation state transition logic required by story-090-133. These tasks will implement functionality to change zombie nodes' `status` from `ACTIVE` to `FAILED`.

---
*PR created automatically by Jules for task [6818854889538091671](https://jules.google.com/task/6818854889538091671) started by @szubster*