### PR TITLE
docs(research): define gen 3 roamer ui alternatives

### DIFF
--- a/.foundry/docs/knowledge_base/ui/gen3_roamer_dashboard_spec.md
+++ b/.foundry/docs/knowledge_base/ui/gen3_roamer_dashboard_spec.md
@@ -1,0 +1,67 @@
+# Gen 3 Roamer Dashboard UI Specification
+
+## Overview
+
+Due to the architectural constraints outlined in ADR 108-027 (impossibility of statically extracting Gen 3 roamer map locations from save files), the Gen 3 Roamer Dashboard shifts its focus from a geographical "Route Radar" to a strictly data-driven "Roamer Dossier".
+
+The UI must present the roamer's internal state as extracted directly from the save file's `Roamer` struct and related event flags, leaning heavily into a tactical, snooping aesthetic as defined in ADR 008.
+
+## Core Components
+
+The dashboard will be composed of the following primary sections:
+
+### 1. Active Status Indicator
+A highly visible telemetry indicator showing whether the roamer is currently active on the map.
+- **Data Source:** The `active` boolean field at offset `0x13` of the `Roamer` struct, and the corresponding game event flag (e.g., `FLAG_LATIOS_OR_LATIAS_ROAMING`).
+- **Visuals:** Use a blinking or high-contrast status dot. When inactive (caught or defeated), the UI should clearly indicate the roamer is no longer at large.
+
+### 2. Roamer Dossier (Stat Breakdown)
+A detailed breakdown of the roamer's internal stats, presented as raw intercepted data.
+- **Data Displayed:**
+  - Species ID (resolved to name, e.g., Latias or Latios)
+  - Level (extracted from `0x0C`)
+  - HP (extracted from `0x0A`)
+  - Status Condition (extracted from `0x0D`)
+  - Internal IVs (extracted from `0x00`)
+  - Personality Value (extracted from `0x04` for nature calculation)
+
+### 3. Roamer IV Glitch Warning Module
+A dedicated alert box that detects and warns the user if their roamer is a victim of the Gen 3 Roamer IV Glitch (where Attack, Defense, Speed, Sp. Atk, and Sp. Def IVs are severely truncated or set to 0 due to a programming error in Ruby/Sapphire and FireRed/LeafGreen).
+- **Condition:** If the game version is known to be affected and the IVs match the glitch signature (extremely low non-HP IVs).
+- **Visuals:** Use a warning color scheme (e.g., amber or red text), `border-dashed`, and an alert icon to signify data corruption or hardware anomaly.
+
+## Aesthetic Constraints (ADR 008 Compliance)
+
+All components must strictly adhere to the tactical hardware/snooping aesthetic:
+- **Borders:** Use dashed borders (`border-dashed`) to simulate terminal or raw data output boxes.
+- **Corners:** Sharp edges only. Strictly avoid rounded corners (`rounded-none`).
+- **Typography:** Use monospaced telemetry fonts (`font-mono`) for all data values, labels, and headers to emphasize the "raw data extraction" feel.
+- **Layout:** Dense, data-heavy layouts are preferred over spacious consumer-facing designs. Use CSS Grid or Flexbox to create a rigid, tabular structure for the dossier.
+
+## Example Component Structure (Conceptual Tailwind)
+
+```html
+<div class="border-2 border-dashed border-gray-600 p-4 rounded-none font-mono text-green-500 bg-black">
+  <div class="flex justify-between border-b border-dashed border-gray-600 pb-2 mb-4">
+    <h2 class="text-xl uppercase">Roamer Dossier</h2>
+    <span class="text-red-500 blink">[ ACTIVE ]</span>
+  </div>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div>
+      <p class="text-gray-400">SPECIES:</p>
+      <p>LATIOS</p>
+    </div>
+    <div>
+      <p class="text-gray-400">LEVEL:</p>
+      <p>40</p>
+    </div>
+    <!-- ... IVs and other stats ... -->
+  </div>
+
+  <!-- IV Glitch Warning (Conditional) -->
+  <div class="mt-4 border border-dashed border-amber-500 p-2 text-amber-500">
+    <p>WARNING: SEVERE IV TRUNCATION DETECTED (ROAMER GLITCH)</p>
+  </div>
+</div>
+```

--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -46,3 +46,13 @@ In Gen 2, gender is intrinsically linked to the Attack DV. The `gender_rate` fro
 
 ## PokeAPI Egg Groups
 Egg groups are retrieved from the `pokemon-species` endpoint. They must be mapped to integer constants to fit within DexHelper's memory-optimized schemas.
+
+## Gen 3 Roamer Location Constraints (ADR 108-027)
+
+When designing features for Generation 3 hardware, be aware of the stark difference between persistent save data and dynamic EWRAM data.
+
+**The Lesson:** Data that feels "persistent" to the player (like the exact current location of a roaming legendary) may actually be highly ephemeral and recalculated on the fly. In Gen 3, `sRoamerLocation` and `sLocationHistory` exist exclusively in dynamically allocated EWRAM during gameplay. When the game saves, these precise coordinates are **not** serialized.
+
+**Architectural Constraint:** It is impossible to statically extract a roamer's exact map location from a `.sav` file.
+
+**UI Pivot Strategy:** When faced with impossible geographic extraction, pivot UI designs from "map-based tracking" (e.g., Route Radars) to "stat-based interception dossiers." We can still provide value by exposing the hidden internal state that *is* saved, such as the `Roamer` struct (IVs, HP, Nature) and its overarching `active` boolean flag, presenting it under a tactical "data snooping" aesthetic.

--- a/.foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
+++ b/.foundry/research/research-044-207-gen3-roamer-ui-alternatives.md
@@ -30,5 +30,18 @@ Investigate and define UI alternatives for the Gen 3 Roamer Dashboard now that p
 The original UI design required a Route Radar map component. Since we cannot extract the exact map location from EWRAM, we need to design alternative visualizations that still provide value. Possible options include highlighting general region availability or focusing entirely on the detailed IV and Status breakdown.
 
 ## Acceptance Criteria
-- [ ] Determine the most valuable way to display roamer state without a Route Radar.
-- [ ] Update the UI specification for the new Dashboard component.
+- [x] Determine the most valuable way to display roamer state without a Route Radar.
+- [x] Update the UI specification for the new Dashboard component.
+
+## Research Findings
+
+Based on ADR 108-027, the Gen 3 roamer's exact map location is kept in dynamically allocated EWRAM during gameplay and is not serialized into the save file. This makes static extraction of the map coordinates impossible.
+
+As an alternative, the UI should pivot to a data-heavy "Roamer Dossier" format, focusing on the following information extracted from the `Roamer` struct and event flags:
+- **Active Status Indicator:** Leveraging the `active` boolean in the `Roamer` struct (offset `0x13`).
+- **Internal Stats Breakdown:** Extracting Level, HP, Status, and IVs.
+- **Roamer IV Glitch Warning:** Explicitly displaying a warning if the Pokémon is affected by the Gen 3 Roamer IV Glitch.
+
+All UI components must adhere strictly to the tactical hardware aesthetic constraints outlined in ADR 008 (`border-dashed`, `rounded-none`, `font-mono`).
+
+The detailed UI specification can be found here: `.foundry/docs/knowledge_base/ui/gen3_roamer_dashboard_spec.md`.


### PR DESCRIPTION
This PR fulfills the `research-044-207-gen3-roamer-ui-alternatives` task by outlining a UI specification for the Gen 3 Roamer Dashboard. Since static map location extraction is impossible, the design pivots to a tactical, data-heavy "Roamer Dossier" focusing on internal stats, active status, and IV Glitch warnings, matching the aesthetic constraints of ADR 008.

---
*PR created automatically by Jules for task [7296602212498859565](https://jules.google.com/task/7296602212498859565) started by @szubster*