### PR TITLE
Foundry: Max Rejection Cancellation Story Breakdown

### DIFF
--- a/.foundry/stories/story-096-153-max-rejection-cancellation.md
+++ b/.foundry/stories/story-096-153-max-rejection-cancellation.md
@@ -23,5 +23,7 @@ notes: ''
 # Story: Max Rejection Cancellation
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks.
+- [x] Break down into Tasks.
 - [ ] Update `foundry-orchestrator.ts` so that when a node is evaluated and `status === 'FAILED'`, if `rejection_count >= MAX_REJECTION_THRESHOLD`, its status changes to `CANCELLED`.
+- [ ] task-153-234-orchestrator-max-rejection-cancellation-impl
+- [ ] task-153-235-orchestrator-max-rejection-cancellation-qa

--- a/.foundry/tasks/task-153-234-orchestrator-max-rejection-cancellation-impl.md
+++ b/.foundry/tasks/task-153-234-orchestrator-max-rejection-cancellation-impl.md
@@ -1,0 +1,32 @@
+---
+id: task-153-234-orchestrator-max-rejection-cancellation-impl
+type: TASK
+title: Implement Max Rejection Cancellation
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-096-153-max-rejection-cancellation
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement Max Rejection Cancellation
+
+## Reminders for Coder
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Ensure foundry-orchestrator.ts has logic in Phase 3.0 to change a node's status to CANCELLED if its status is FAILED and its rejection_count >= MAX_REJECTION_THRESHOLD.
+- [ ] If the artifact already correctly implements this feature, apply the Empty PR policy.

--- a/.foundry/tasks/task-153-235-orchestrator-max-rejection-cancellation-qa.md
+++ b/.foundry/tasks/task-153-235-orchestrator-max-rejection-cancellation-qa.md
@@ -1,0 +1,33 @@
+---
+id: task-153-235-orchestrator-max-rejection-cancellation-qa
+type: TASK
+title: QA Max Rejection Cancellation
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on:
+  - task-153-234-orchestrator-max-rejection-cancellation-impl
+jules_session_id: null
+pr_number: null
+parent: story-096-153-max-rejection-cancellation
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA Max Rejection Cancellation
+
+## Reminders for QA
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Review foundry-orchestrator.ts to verify the cancellation logic for max rejection threshold is correctly implemented and works as expected.
+- [ ] If the artifact is already completely implemented, apply the Empty PR policy.


### PR DESCRIPTION
- Broke down `story-096-153-max-rejection-cancellation` into tasks.
- Created `task-153-234-orchestrator-max-rejection-cancellation-impl` for implementation.
- Created `task-153-235-orchestrator-max-rejection-cancellation-qa` for QA.
- Added boilerplate warnings for Coder/QA about failure procedures.

---
*PR created automatically by Jules for task [11435785696863952223](https://jules.google.com/task/11435785696863952223) started by @szubster*