### PR TITLE
chore(foundry): break down daycare and egg hatch tracker prd into epics

### DIFF
--- a/.foundry/epics/epic-053-105-daycare-save-parsing.md
+++ b/.foundry/epics/epic-053-105-daycare-save-parsing.md
@@ -1,0 +1,37 @@
+---
+id: epic-053-105-daycare-save-parsing
+type: EPIC
+title: Daycare Core Data Extraction Engine
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-22'
+updated_at: '2026-06-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-083-053-daycare-egg-tracker
+tags:
+  - gen2
+  - gen3
+  - breeding
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Daycare Core Data Extraction Engine
+
+## Context
+As defined in `prd-083-053-daycare-egg-tracker.md`, players need a programmatic way to extract Daycare state without manually visiting the NPC in-game. This epic focuses purely on the engine/parsing layer.
+
+## Objective
+Implement offline save parsing to extract real-time Daycare data.
+
+## Scope
+- Extract the currently deposited Pokémon (species, nickname, level).
+- Calculate accumulated EXP/level gains while in the Daycare.
+- Surface the hidden "Egg is waiting" memory flag.
+
+## Acceptance Criteria
+- [ ] Break down into Stories.

--- a/.foundry/epics/epic-053-106-egg-hatch-parsing.md
+++ b/.foundry/epics/epic-053-106-egg-hatch-parsing.md
@@ -1,0 +1,37 @@
+---
+id: epic-053-106-egg-hatch-parsing
+type: EPIC
+title: Egg Hatch Tracker Data Extraction Engine
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-22'
+updated_at: '2026-06-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-083-053-daycare-egg-tracker
+tags:
+  - gen2
+  - gen3
+  - breeding
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Egg Hatch Tracker Data Extraction Engine
+
+## Context
+As defined in `prd-083-053-daycare-egg-tracker.md`, the vague in-game text prompts for Egg hatching are a massive pain point. This epic handles the raw data extraction to calculate exact numerical step counts.
+
+## Objective
+Implement offline save parsing to calculate exact steps remaining for Eggs.
+
+## Scope
+- Identify Eggs currently residing in the player's Party or PC.
+- Parse the remaining friendship/egg cycles byte for each Egg.
+- Multiply the parsed byte by the generation-specific cycle length to calculate exact numerical step count remaining.
+
+## Acceptance Criteria
+- [ ] Break down into Stories.

--- a/.foundry/epics/epic-053-107-daycare-egg-tracker-ui.md
+++ b/.foundry/epics/epic-053-107-daycare-egg-tracker-ui.md
@@ -1,0 +1,40 @@
+---
+id: epic-053-107-daycare-egg-tracker-ui
+type: EPIC
+title: Daycare & Egg Hatch Tracker UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-22'
+updated_at: '2026-06-22'
+depends_on:
+  - epic-053-105-daycare-save-parsing
+  - epic-053-106-egg-hatch-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-083-053-daycare-egg-tracker
+tags:
+  - gen2
+  - gen3
+  - breeding
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Daycare & Egg Hatch Tracker UI
+
+## Context
+As defined in `prd-083-053-daycare-egg-tracker.md`, the extracted Daycare and Egg Hatch data needs to be surfaced to the user in an actionable, real-time dashboard.
+
+## Objective
+Create the frontend UI dashboard for the Daycare and Egg mechanics.
+
+## Scope
+- Create a Daycare Status Dashboard component to display deposited Pokémon, EXP gains, and the "Egg is waiting" flag.
+- Create an Exact Egg Tracker component for Eggs in the Party/PC, displaying the exact numerical step count remaining.
+- Ensure components align with the tactical hardware aesthetic (ADR 008, 024).
+
+## Acceptance Criteria
+- [ ] Break down into Stories.

--- a/.foundry/prds/prd-083-053-daycare-egg-tracker.md
+++ b/.foundry/prds/prd-083-053-daycare-egg-tracker.md
@@ -35,4 +35,7 @@ Leverage DexHelper's offline-first programmatic save parsing to extract and disp
 By surfacing these highly opaque, heavily utilized mechanics, DexHelper immediately solves a massive pain point for competitive breeders and completionists. Transforming vague in-game hints into exact, actionable data points perfectly aligns with the app's mission to be the ultimate premium companion tool for retro Pokémon.
 
 ## Acceptance Criteria
-- [ ] Break down into Epics.
+- [x] Break down into Epics.
+- [ ] epic-053-105-daycare-save-parsing
+- [ ] epic-053-106-egg-hatch-parsing
+- [ ] epic-053-107-daycare-egg-tracker-ui


### PR DESCRIPTION
This PR logically breaks down `prd-083-053-daycare-egg-tracker` into actionable Epic nodes for the Daycare and Egg Tracker feature.

- Creates `epic-053-105-daycare-save-parsing` (Daycare backend parsing).
- Creates `epic-053-106-egg-hatch-parsing` (Egg hatch backend parsing).
- Creates `epic-053-107-daycare-egg-tracker-ui` (Frontend UI, dependent on the two backend epics).
- Updates the parent PRD markdown to link the newly generated child nodes as unchecked tasks, ensuring the orchestrator will not transition it to VERIFYING prematurely.
- Complies with ID schema rules and avoids circular dependency deadlocks.

---
*PR created automatically by Jules for task [82116722747390302](https://jules.google.com/task/82116722747390302) started by @szubster*