### PR TITLE
chore(docs): check off completed task 109-212

### DIFF
--- a/.foundry/tasks/task-109-212-update-adr001-macro-node-completion-impl.md
+++ b/.foundry/tasks/task-109-212-update-adr001-macro-node-completion-impl.md
@@ -37,4 +37,4 @@ Update `.foundry/docs/adrs/001-the-foundry-architecture.md` to detail the new ma
 6. Reminder: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior of macro nodes completion.
+- [x] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior of macro nodes completion.


### PR DESCRIPTION
Checking off Acceptance Criteria for `task-109-212-update-adr001-macro-node-completion-impl` since the ADR 001 document is already updated with the macro node completion rules.

---
*PR created automatically by Jules for task [13923293705295247057](https://jules.google.com/task/13923293705295247057) started by @szubster*