### PR TITLE
docs: investigate missing integration in item list parsing

### DIFF
--- a/.foundry/research/research-128-210-item-list-parsing-failure.md
+++ b/.foundry/research/research-128-210-item-list-parsing-failure.md
@@ -30,9 +30,12 @@ Investigate and document the exact lines and areas in `vite-plugins/pokedata-plu
 
 ## Questions to Answer
 1. How does `vite-plugins/pokedata-plugin.ts` currently read `.jsonl` files from the source directory?
+   **Answer:** Existing `.jsonl` files are read using the custom `readJsonl(filePath: string)` function, which reads the file and parses each line as JSON. For example: `const pokemon = readJsonl(path.join(sourceDir, 'pokemon.jsonl'));` inside the `generateData()` function.
 2. How is the exported data structure (`exportData` object) currently built in `pokedata-plugin.ts` before being packed into the `msgpack` payload?
+   **Answer:** The `exportData` object is built by calling `readJsonl` for `pokemon.jsonl`, `encounters.jsonl`, and `locations.jsonl`, reading `metadata.json`, and then explicitly building an object literal: `{ poke: pokemon, enc: encounters, loc: locations, sourceSha: metadata.sourceSha }`. This object is then merged into `finalData` and packed into a `msgpack` payload using the `Packr` class.
 3. Where exactly does `items.jsonl` need to be loaded and attached to this payload?
+   **Answer:** To integrate `items.jsonl`, we need to call `const items = readJsonl(path.join(sourceDir, 'items.jsonl'));` directly after the other `readJsonl` calls inside the `generateData` function. Then, we must attach this `items` variable to the `exportData` object by adding `items: items,` (or simply `items,`) inside the object literal definition.
 
 ## Acceptance Criteria
-- [ ] Analyze `vite-plugins/pokedata-plugin.ts` and document how existing data files are read and bundled.
-- [ ] Provide the exact modifications required to include `items.jsonl` in the bundle payload.
+- [x] Analyze `vite-plugins/pokedata-plugin.ts` and document how existing data files are read and bundled.
+- [x] Provide the exact modifications required to include `items.jsonl` in the bundle payload.


### PR DESCRIPTION
This PR documents the exact modifications required to integrate `items.jsonl` into the `vite-plugins/pokedata-plugin.ts` build payload.

- Found that `readJsonl` is used to parse the `.jsonl` files.
- Documented that `exportData` is built by aggregating data files.
- Specified the exact lines and syntax needed to add `items.jsonl` to the `exportData` payload in the `generateData` function.
- Marked the Acceptance Criteria checkboxes as completed to allow the node to transition.

---
*PR created automatically by Jules for task [14090294499529964245](https://jules.google.com/task/14090294499529964245) started by @szubster*