### PR TITLE
QA: Verify Move Generation Discrepancies

### DIFF
--- a/.foundry/tasks/task-129-207-move-generation-discrepancies-qa.md
+++ b/.foundry/tasks/task-129-207-move-generation-discrepancies-qa.md
@@ -43,5 +43,5 @@ Move data extraction has been updated to apply generation-specific overrides for
 - **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Confirmed generation discrepancies are properly applied in `moves.jsonl` output for sample moves.
-- [ ] Confirmed that base PP is stored correctly instead of max PP.
+- [x] Confirmed generation discrepancies are properly applied in `moves.jsonl` output for sample moves.
+- [x] Confirmed that base PP is stored correctly instead of max PP.


### PR DESCRIPTION
Checked off the acceptance criteria checkboxes in `.foundry/tasks/task-129-207-move-generation-discrepancies-qa.md` to indicate successful validation of move generation discrepancies and base PP extraction.

---
*PR created automatically by Jules for task [2225765230607992872](https://jules.google.com/task/2225765230607992872) started by @szubster*