### PR TITLE
docs: check off acceptance criteria for palette styling ownership

### DIFF
--- a/.foundry/tasks/task-114-214-document-palette-styling-ownership-impl.md
+++ b/.foundry/tasks/task-114-214-document-palette-styling-ownership-impl.md
@@ -38,5 +38,5 @@ You are tasked with fulfilling the documentation update as requested by `story-0
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` is updated.
-- [ ] Documentation accurately reflects `palette` ownership of styling per ADR 024.
+- [x] `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` is updated.
+- [x] Documentation accurately reflects `palette` ownership of styling per ADR 024.


### PR DESCRIPTION
The `palette` persona's responsibility over `src/index.css` and custom tactical `@utility` primitives in the relevant Foundry system definitions and policies is already documented, aligning with ADR 024.

`schema.md` already has `palette` in the "Owner Persona Enum" table.
`core_policies.md` already has a `Styling Ownership (Palette Persona)` section.

Therefore, this is an empty PR that only checks off the acceptance criteria checkboxes in `.foundry/tasks/task-114-214-document-palette-styling-ownership-impl.md`.

---
*PR created automatically by Jules for task [9872758464569349025](https://jules.google.com/task/9872758464569349025) started by @szubster*