### PR TITLE
Document Gen 3 Secret Base RangeError Handling Strategy

### DIFF
--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -46,3 +46,8 @@ In Gen 2, gender is intrinsically linked to the Attack DV. The `gender_rate` fro
 
 ## PokeAPI Egg Groups
 Egg groups are retrieved from the `pokemon-species` endpoint. They must be mapped to integer constants to fit within DexHelper's memory-optimized schemas.
+
+## Gen 3 DataView RangeError Handling
+**Lesson:** When parsing dynamically structured Gen 3 save data like Secret Bases, which iterate across large flat arrays (`3200` bytes inside `SaveBlock1`), we cannot trust the internal offset pointers implicitly. A truncated save file or malformed index will cause standard `DataView.getUint8` calls to throw out-of-bounds errors.
+- **Constraint (ADR 010):** We must not crash the application on these bounds errors. Parsers like `parseGen3SecretBases` must explicitly wrap iterating logic in a `try/catch`, filter for `error instanceof RangeError`, and gracefully re-throw the standard normalized error (`Error('The save file is corrupted or incomplete.')`).
+- **Why it matters:** Higher-order validation engines rely on matching this exact string to detect bad saves rather than generic JS errors. Failing to handle `RangeError` properly results in unhandled promise rejections that bring down the orchestration pipeline and result in immediate rejection by the QA/Auditor persona.

--- a/.foundry/research/research-108-221-gen3-secret-base-rangeerror.md
+++ b/.foundry/research/research-108-221-gen3-secret-base-rangeerror.md
@@ -32,10 +32,50 @@ The previous implementation task for parsing Gen 3 Secret Base locations (`task-
 - Document any specific boundaries or truncated save file states that commonly trigger these errors in the context of the `3200` byte Secret Base array in SaveBlock1.
 
 ## Acceptance Criteria
-- [ ] Determine the correct try/catch pattern for `DataView` `RangeError` within the save parser.
-- [ ] Document how the error should be gracefully propagated or logged without crashing the parent parsing process.
-- [ ] Ensure the findings align strictly with ADR 010.
+- [x] Determine the correct try/catch pattern for `DataView` `RangeError` within the save parser.
+- [x] Document how the error should be gracefully propagated or logged without crashing the parent parsing process.
+- [x] Ensure the findings align strictly with ADR 010.
 
 ## Reminders for Personas
 - **Researcher:** If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - **Researcher:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Findings
+
+### RangeError Handling Pattern
+To comply with `ADR 010: Gen3 Data Parsing Strategy`, parsing Gen 3 Secret Base arrays (which span `3200` bytes in `SaveBlock1`) must use a `try/catch` block encapsulating the `DataView` array traversal. If the active save block pointer is malformed or the file is truncated, iterating through the 20 `SecretBase` records (`160` bytes each) can trigger out-of-bounds reads.
+
+When a `DataView` read (e.g., `view.getUint8(offset)`) exceeds the underlying ArrayBuffer boundaries, JavaScript natively throws a `RangeError`. This exception must be caught explicitly by the `parseGen3SecretBases` function and wrapped in a generalized error that the higher-level parser understands, propagating it without abruptly crashing the application.
+
+### Recommended Implementation Strategy
+```typescript
+export function parseGen3SecretBases(view: DataView, saveBlock1Offset: number, gameVersion: string): Gen3SecretBase[] {
+  let baseOffset = saveBlock1Offset;
+  if (gameVersion === 'emerald') {
+    baseOffset += SECRET_BASE_OFFSET_EMERALD;
+  } else {
+    baseOffset += SECRET_BASE_OFFSET_RS;
+  }
+
+  try {
+    const secretBases: Gen3SecretBase[] = [];
+    for (let i = 0; i < SECRET_BASES_COUNT; i++) {
+      const offset = baseOffset + i * SECRET_BASE_SIZE;
+      const secretBaseId = view.getUint8(offset); // Triggers RangeError if file is truncated
+
+      if (secretBaseId > 0) {
+        secretBases.push({ secretBaseId });
+      }
+    }
+    return secretBases;
+  } catch (error) {
+    if (error instanceof RangeError) {
+      // Gracefully map the native RangeError to a specific corrupt file error per ADR 010
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+```
+
+The error mapping from `RangeError` to `Error('The save file is corrupted or incomplete.')` allows the global `saveParser` engine to catch the normalized string and present user-friendly fallback mechanisms instead of an unhandled promise rejection or crashing the UI. Tests confirm this exact behavior is now present in `src/engine/saveParser/parsers/gen3.ts`.


### PR DESCRIPTION
This PR completes the RESEARCH node for investigating how to correctly handle out-of-bounds `RangeError` exceptions during Gen 3 Secret Base DataView parsing.

The findings have been documented in the markdown file and the researcher journal, outlining the requirement to explicitly catch `RangeError` and propagate `'The save file is corrupted or incomplete.'` up to the higher-order parsers.

---
*PR created automatically by Jules for task [18409133827750611623](https://jules.google.com/task/18409133827750611623) started by @szubster*