### PR TITLE
fix: do not require session id for VERIFYING nodes

### DIFF
--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -46,3 +46,7 @@ In Gen 2, gender is intrinsically linked to the Attack DV. The `gender_rate` fro
 
 ## PokeAPI Egg Groups
 Egg groups are retrieved from the `pokemon-species` endpoint. They must be mapped to integer constants to fit within DexHelper's memory-optimized schemas.
+
+## VERIFYING Node State
+- **Finding:** The `VERIFYING` state, introduced in ADR 014, functions as a queue state for the `auditor` persona, similar to the `READY` state.
+- **Constraint:** When a node transitions to `VERIFYING`, its `jules_session_id` is explicitly stripped (set to `null`). Therefore, pipeline validation logic must not expect or enforce the presence of a `jules_session_id` on `VERIFYING` nodes. Doing so causes false positive system failures.

--- a/.foundry/research/research-071-217-investigate-session-id-failure.md
+++ b/.foundry/research/research-071-217-investigate-session-id-failure.md
@@ -31,3 +31,16 @@ Investigate the root cause of the permanent failure of `epic-071-074-define-tail
 ## Deliverables
 - A summary of findings appended to this document.
 - Proposed solution.
+
+## Findings
+
+1. According to ADR 014 (Auditor Persona and VERIFYING State Machine Modifications), the `VERIFYING` state was introduced as a queue state for the `auditor` persona. When a task completes and its PR merges, it transitions from `ACTIVE` to `VERIFYING`.
+2. When a node transitions to `VERIFYING`, its `jules_session_id` is explicitly stripped (set to `null`), just as it is when a node returns to `READY` (see `.github/scripts/foundry-heartbeat.ts` lines 118-119).
+3. The bug lies in the `foundry-heartbeat.ts` script. On lines 321 and 332, it aggregates `ACTIVE` and `VERIFYING` nodes together and enforces that they must have a valid `jules_session_id`. If they don't, it forces a failure: `warn("Node ${node.repoPath} is ${node.frontmatter.status} but missing session ID. Failing.")`.
+
+Because `VERIFYING` nodes are effectively queue states waiting for the `auditor` persona to pick them up, they do not inherently have an active session ID.
+
+## Proposed Solution
+
+1. Modify `.github/scripts/foundry-heartbeat.ts` so that the `jules_session_id` validation only applies to `ACTIVE` nodes, not `VERIFYING` nodes.
+2. Ensure that the heartbeat script accurately differentiates between queue states (`READY`, `VERIFYING`) which don't require session IDs, and execution states (`ACTIVE`) which do.

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -157,7 +157,7 @@ ok: true,
   });
 
 
-  it('should transition a node to FAILED if VERIFYING and jules_session_id is missing', async () => {
+  it('should NOT transition a node to FAILED if VERIFYING and jules_session_id is missing', async () => {
     const mockNode = {
       filePath: '/mock/repo/.foundry/tasks/task-1.md',
       repoPath: '.foundry/tasks/task-1.md',
@@ -180,7 +180,7 @@ ok: true,
 
     await main();
 
-    expect(fs.writeFileSync).toHaveBeenCalled();
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
   });
 
   it('should transition a node to FAILED if jules_session_id is missing', async () => {

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -318,7 +318,7 @@ export async function main() {
   for (const fp of filePaths) {
     const node = parseNodeFile(fp, repoRoot);
     if (!node) continue;
-    if (node.frontmatter.status === 'ACTIVE' || node.frontmatter.status === 'VERIFYING') activeNodes.push(node);
+    if (node.frontmatter.status === 'ACTIVE' ) activeNodes.push(node);
     if (node.frontmatter.status === 'FAILED') failedNodes.push(node);
   }
 
@@ -329,7 +329,7 @@ export async function main() {
     const sessionId = getSessionId(node);
     const isHuman = node.frontmatter.owner_persona === 'human';
 
-    if (!isHuman && !sessionId && (node.frontmatter.status === 'ACTIVE' || node.frontmatter.status === 'VERIFYING')) {
+    if (!isHuman && !sessionId && (node.frontmatter.status === 'ACTIVE' )) {
       warn(`Node ${node.repoPath} is ${node.frontmatter.status} but missing session ID. Failing.`);
       await transitionNodeToFailed(node, repoRoot, `${node.frontmatter.status} node missing or malformed session ID`);
       continue;


### PR DESCRIPTION
- Research indicated that `VERIFYING` nodes are queue-states (similar to `READY`) and do not have an active `jules_session_id`.
- The `foundry-heartbeat.ts` script incorrectly enforced that `VERIFYING` nodes must have a session ID, causing false positive system failures.
- Removed `VERIFYING` from the list of states that must have a session ID in `.github/scripts/foundry-heartbeat.ts`.
- Updated test assertions in `.github/scripts/foundry-heartbeat.test.ts`.
- Appended findings and proposed solution to the research task document `.foundry/research/research-071-217-investigate-session-id-failure.md`.
- Appended a note about `VERIFYING` nodes to the researcher journal.

---
*PR created automatically by Jules for task [10988734401999645831](https://jules.google.com/task/10988734401999645831) started by @szubster*