### PR TITLE
feat: Implement Gen 2 gender utility and Egg Groups schema update

### DIFF
--- a/scripts/generate-pokedata.ts
+++ b/scripts/generate-pokedata.ts
@@ -210,6 +210,7 @@ async function main() {
       n: sData.names.find((n: PokeApiName) => n.language.name === 'en')?.name || sData.name,
       cr: sData.capture_rate,
       gr: sData.gender_rate,
+      eg: sData.egg_groups?.map((g: any) => g.name) || [],
       baby: sData.is_baby,
       // Temporaries to be filled in second pass
       eto: [],

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -133,6 +133,7 @@ export interface PokemonMetadata {
   n: string; // name
   cr: number; // capture rate
   gr?: number | undefined; // gender rate
+  eg?: string[] | undefined; // egg groups
   baby: boolean; // is baby
   // Embedded evolution data
   eto: CompactChainLink[];

--- a/src/utils/gender.test.ts
+++ b/src/utils/gender.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { calculateGen2Gender } from './gender.ts';
+
+describe('calculateGen2Gender', () => {
+  it('should return genderless for gender rate -1', () => {
+    expect(calculateGen2Gender(15, -1)).toBe('genderless');
+    expect(calculateGen2Gender(0, -1)).toBe('genderless');
+  });
+
+  it('should return male for gender rate 0 (male only)', () => {
+    expect(calculateGen2Gender(0, 0)).toBe('male');
+    expect(calculateGen2Gender(15, 0)).toBe('male');
+  });
+
+  it('should return female for gender rate 8 (female only)', () => {
+    expect(calculateGen2Gender(0, 8)).toBe('female');
+    expect(calculateGen2Gender(15, 8)).toBe('female');
+  });
+
+  it('should correctly calculate gender for 7:1 ratio (gender rate 1)', () => {
+    expect(calculateGen2Gender(0, 1)).toBe('female');
+    expect(calculateGen2Gender(1, 1)).toBe('female');
+    expect(calculateGen2Gender(2, 1)).toBe('male');
+    expect(calculateGen2Gender(15, 1)).toBe('male');
+  });
+
+  it('should correctly calculate gender for 3:1 ratio (gender rate 2)', () => {
+    expect(calculateGen2Gender(0, 2)).toBe('female');
+    expect(calculateGen2Gender(3, 2)).toBe('female');
+    expect(calculateGen2Gender(4, 2)).toBe('male');
+    expect(calculateGen2Gender(15, 2)).toBe('male');
+  });
+
+  it('should correctly calculate gender for 1:1 ratio (gender rate 4)', () => {
+    expect(calculateGen2Gender(0, 4)).toBe('female');
+    expect(calculateGen2Gender(7, 4)).toBe('female');
+    expect(calculateGen2Gender(8, 4)).toBe('male');
+    expect(calculateGen2Gender(15, 4)).toBe('male');
+  });
+
+  it('should correctly calculate gender for 1:3 ratio (gender rate 6)', () => {
+    expect(calculateGen2Gender(0, 6)).toBe('female');
+    expect(calculateGen2Gender(11, 6)).toBe('female');
+    expect(calculateGen2Gender(12, 6)).toBe('male');
+    expect(calculateGen2Gender(15, 6)).toBe('male');
+  });
+});

--- a/src/utils/gender.ts
+++ b/src/utils/gender.ts
@@ -1,0 +1,42 @@
+/**
+ * Calculates the gender of a Generation 2 Pokémon based on its Attack DV and gender ratio.
+ *
+ * @param attackDv The physical Attack DV of the Pokémon (0-15).
+ * @param genderRate The gender rate of the species (PokeAPI format, representing eighths of female chance. -1 for genderless).
+ * @returns 'male', 'female', or 'genderless'
+ */
+export function calculateGen2Gender(attackDv: number, genderRate: number): 'male' | 'female' | 'genderless' {
+  if (genderRate === -1) {
+    return 'genderless';
+  }
+  if (genderRate === 0) {
+    return 'male';
+  }
+  if (genderRate === 8) {
+    return 'female';
+  }
+
+  // Determine the threshold for female based on the gender rate
+  let femaleThreshold = -1;
+  switch (genderRate) {
+    case 1: // 1/8 female (7:1 male:female)
+      femaleThreshold = 1;
+      break;
+    case 2: // 1/4 female (3:1 male:female)
+      femaleThreshold = 3;
+      break;
+    case 4: // 1/2 female (1:1 male:female)
+      femaleThreshold = 7;
+      break;
+    case 6: // 3/4 female (1:3 male:female)
+      femaleThreshold = 11;
+      break;
+    default:
+      // Fallback for unexpected rates, though PokeAPI only uses the above values
+      // Approximation: threshold = (genderRate / 8) * 16 - 1 = genderRate * 2 - 1
+      femaleThreshold = genderRate * 2 - 1;
+      break;
+  }
+
+  return attackDv <= femaleThreshold ? 'female' : 'male';
+}


### PR DESCRIPTION
This PR implements task `task-084-212-breeding-pair-algorithm-impl` by fulfilling its specific technical contract:

1. **DB Schema Update**: Extended `PokemonMetadata` with an `eg?: string[] | undefined;` field in `src/db/schema.ts`.
2. **Generation Script Update**: Modified `scripts/generate-pokedata.ts` to correctly parse `sData.egg_groups` mapping to the new `eg` property. We also verified that empty array compaction correctly handles any missing groups.
3. **Gender Utility**: Created `calculateGen2Gender(attackDv, genderRate)` in `src/utils/gender.ts` to compute Gen 2 gender rules (based on attack DV thresholds dynamically inferred from the generic PokeAPI representation). Fully covered with unit tests in `src/utils/gender.test.ts`.

All Acceptance Criteria check boxes were confirmed done and verified. Tests and linters are all green.

---
*PR created automatically by Jules for task [16038735002414938897](https://jules.google.com/task/16038735002414938897) started by @szubster*