### PR TITLE
Verify Orchestrator Late-Binding Parent Node Cancellation Logic

### DIFF
--- a/.foundry/docs/knowledge_base/foundry/orchestrator/late-binding.md
+++ b/.foundry/docs/knowledge_base/foundry/orchestrator/late-binding.md
@@ -17,3 +17,5 @@ Directly adding a child story to a parent Epic's `depends_on` array creates a de
    - **Exception for Children**: A child node is normally blocked if its parent is `PENDING`. However, if the `PENDING` parent already has children, the orchestrator assumes it is in its "Wait for Children" cycle, and *does not* block the child.
 
 This ensures that the Epic waits in a PENDING state for its child stories to complete before spawning the next ones, creating a seamless, automated delivery pipeline.
+## Late-Binding Parent Node Cancellation Logic
+The orchestrator correctly handles `CANCELLED` children of late-binding parent nodes. When determining if all children are completed (in `.github/scripts/foundry-orchestrator.ts`), the system explicitly checks that a child is either `COMPLETED` or `CANCELLED`. This means a permanently `CANCELLED` child effectively behaves as "done" from the perspective of its parent. It does not cause a deadlock, and the parent will still correctly wake up once all its children have reached either `COMPLETED` or `CANCELLED` state.

--- a/.foundry/research/research-049-215-late-binding-cancellation.md
+++ b/.foundry/research/research-049-215-late-binding-cancellation.md
@@ -27,3 +27,8 @@ However, an unresolved question arose: How does the orchestrator behave when a c
 
 ## Goal
 Research and verify the orchestrator's behavior regarding late-binding parents when one or more of their children reach a CANCELLED status. Determine if the parent's `allChildrenCompleted` check correctly factors in CANCELLED states or if it deadlocks.
+
+## Research Report
+The orchestrator correctly handles `CANCELLED` children of a late-binding parent node. When determining if all children are completed (in `.github/scripts/foundry-orchestrator.ts`, specifically the `allChildrenCompleted` and `isHierarchicallyIncomplete` checks), the system explicitly checks that a child is either `COMPLETED` or `CANCELLED`.
+
+This means a permanently `CANCELLED` child effectively behaves as "done" from the perspective of its parent, satisfying the child completion constraint. It does not cause a deadlock; the late-binding parent will still correctly wake up (to `READY` or `COMPLETED`) once all of its children have reached either `COMPLETED` or `CANCELLED` state. We have verified this by auditing the `allChildrenCompleted` loop logic and verifying the related test coverage.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -505,6 +505,57 @@ vi.doMock('node:url', async (importOriginal) => {
     expect(storyContent).toContain('status: READY');
   });
 
+  test('Late-Binding: Parent wakes up when some children are CANCELLED and others COMPLETED', () => {
+    // Epic 1: PENDING (Waiting for children)
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    // Story 1: Child of Epic 1, COMPLETED
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+      parent: "epic-001"
+    });
+
+    // Story 2: Child of Epic 1, CANCELLED
+    createValidTestNode(tmpDir, '.foundry/stories/story-002.md', {
+      id: "story-002",
+      type: "STORY",
+      title: "Story 2",
+      status: "CANCELLED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+      parent: "epic-001",
+      rejection_reason: "Feature deprecated"
+    });
+
+    fs.appendFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), '\n\n## Acceptance Criteria\n- [ ] Create child nodes');
+
+    main();
+
+    const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
+    expect(epicContent).toContain('status: READY'); // Because it has an unchecked box
+  });
+
   test('Late-Binding: Parent wakes up when children are COMPLETED', () => {
     // Epic 1: PENDING (Waiting for children)
     createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {


### PR DESCRIPTION
This PR addresses the RESEARCH task `research-049-215-late-binding-cancellation`. It verifies that when a late-binding parent node has `CANCELLED` children, those children act as non-blocking states (akin to `COMPLETED`). A new test case has been added to `foundry-orchestrator.test.ts` to ensure this behavior is formally verified and will not regress. Documentation and the research node markdown have been updated accordingly.

---
*PR created automatically by Jules for task [11357373016189294279](https://jules.google.com/task/11357373016189294279) started by @szubster*