### PR TITLE
feat(dag-views): Breakdown Story 078-120 (Integrate DagContext with Dashboard Views)

### DIFF
--- a/.foundry/stories/story-078-120-integrate-dag-context-with-views.md
+++ b/.foundry/stories/story-078-120-integrate-dag-context-with-views.md
@@ -29,4 +29,6 @@ Update the existing DAG views (e.g., the React Flow DAG visualizer) to consume t
 Following the creation of `DagProvider` (ADR 013), existing visualization components must be refactored to consume the unified DAG data (nodes, edges, and `rejection_count`). This ensures consistent state across the UI.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks
+- [x] Break down into Tasks
+- [ ] task-120-236-refactor-dagdashboard-context-impl
+- [ ] task-120-237-refactor-dagdashboard-context-qa

--- a/.foundry/tasks/task-120-236-refactor-dagdashboard-context-impl.md
+++ b/.foundry/tasks/task-120-236-refactor-dagdashboard-context-impl.md
@@ -1,0 +1,44 @@
+---
+id: task-120-236-refactor-dagdashboard-context-impl
+type: TASK
+title: Refactor DagDashboard and DagProvider to use DagContext
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-078-120-integrate-dag-context-with-views
+tags:
+  - refactor
+  - dashboard
+  - state-management
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Refactor DagDashboard and DagProvider to use DagContext
+
+## Objective
+Refactor `DagDashboard` to consume the unified DAG data (nodes, edges, and loading state) from `DagContext` instead of managing it locally. Update `DagProvider` to handle data fetching and layout logic.
+
+## Context
+Following ADR 013, we need to unify the DAG data state management into `DagContext`. Currently, `DagDashboard` fetches data and manages `nodes`, `edges`, and `isLoading` locally. The new Kanban board view will also need access to this data. To support both views efficiently, the data fetching and layout derivation must be lifted up to `DagProvider`, and `DagDashboard` must consume it via `useDagContext()`.
+
+## Requirements
+- Move the `loadData` function, fetch logic, and `getLayoutedElements` from `DagDashboard.tsx` into `DagProvider` in `DagContext.tsx`.
+- Update `DagProvider` to manage the fetching side-effects (`useEffect`) and layout generation, setting its internal state (`nodes`, `edges`, `isLoading`).
+- Update `DagDashboard.tsx` to use `useDagContext()` and consume `nodes`, `edges`, and `isLoading`. Remove its local `useState` and `useEffect` for data loading.
+- Ensure integration tests in `DagDashboard.test.tsx` pass with these changes. Ensure rendering components are properly integrated into the application's view hierarchy.
+
+## Developer Notes
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Move fetching and layout logic from `DagDashboard` to `DagProvider`.
+- [ ] `DagDashboard` consumes state from `useDagContext()`.
+- [ ] Existing functionality works as before and tests pass.

--- a/.foundry/tasks/task-120-237-refactor-dagdashboard-context-qa.md
+++ b/.foundry/tasks/task-120-237-refactor-dagdashboard-context-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-120-237-refactor-dagdashboard-context-qa
+type: TASK
+title: QA Verification for DagContext Refactor in DagDashboard
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on:
+  - task-120-236-refactor-dagdashboard-context-impl
+jules_session_id: null
+pr_number: null
+parent: story-078-120-integrate-dag-context-with-views
+tags:
+  - qa
+  - dashboard
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Verification for DagContext Refactor in DagDashboard
+
+## Objective
+Verify that `DagDashboard` successfully consumes `DagContext` data and that existing functionality and interactions remain unbroken.
+
+## Context
+The Coder has refactored the DAG visualization to share state management via `DagProvider` instead of fetching data locally inside `DagDashboard`. We need to ensure that the component renders correctly and interactivity (toggles, clicking, hovering) functions properly.
+
+## Requirements
+- Verify that the layout remains the same in the Dashboard view.
+- Verify that dependencies hover and click functionalities are intact.
+- Check that tests correctly mock or wrap the component in `DagProvider`.
+- Review the implemented code for adherence to best practices.
+
+## Developer Notes
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] DagDashboard is verified to render properly using DagContext.
+- [ ] Interactivity behaves as expected with the new context provider.
+- [ ] All tests run and pass without regressions.


### PR DESCRIPTION
This PR breaks down `story-078-120-integrate-dag-context-with-views` into actionable technical blueprints:

1. **task-120-236-refactor-dagdashboard-context-impl**: Coder task to refactor `DagDashboard` and `DagProvider`.
2. **task-120-237-refactor-dagdashboard-context-qa**: QA task to verify the refactor.

The parent story's markdown body has been updated to include these child tasks as unchecked checkboxes, and its acceptance criteria for breakdown has been checked off. The YAML frontmatter of the parent story was left untouched.

All tests passed successfully locally.

---
*PR created automatically by Jules for task [8617718184112593029](https://jules.google.com/task/8617718184112593029) started by @szubster*