### PR TITLE
chore: mark qa gen 3 contest data error handling task as complete

### DIFF
--- a/.foundry/tasks/task-141-210-gen3-contest-error-handling-qa.md
+++ b/.foundry/tasks/task-141-210-gen3-contest-error-handling-qa.md
@@ -39,6 +39,6 @@ Validate the Gen 3 contest data error handling modifications to ensure that `Ran
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 4. Acceptance Criteria
-- [ ] Confirmed that `parseGen3ConditionStats` correctly handles `RangeError`.
-- [ ] Confirmed that `parseGen3Ribbons` correctly handles `RangeError`.
-- [ ] Confirmed that errors are handled upstream without application crashes.
+- [x] Confirmed that `parseGen3ConditionStats` correctly handles `RangeError`.
+- [x] Confirmed that `parseGen3Ribbons` correctly handles `RangeError`.
+- [x] Confirmed that errors are handled upstream without application crashes.


### PR DESCRIPTION
The implementation correctly uses DataView to parse Gen 3 condition stats and ribbons, throwing standard `RangeError` on out-of-bounds reads which are elegantly handled by the top-level parseGen3 try-catch block. The QA task acceptance criteria checkboxes have been checked to satisfy ADR 007 requirements. No regressions were introduced.

---
*PR created automatically by Jules for task [12801622351199077331](https://jules.google.com/task/12801622351199077331) started by @szubster*