### PR TITLE
Fix ContestSheenDisplay generation check

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -4,3 +4,4 @@
 When verifying tasks that involve adding or modifying parsers for save files (like `task-124-172-gen3-mix-record-events-parser`), make sure to closely inspect that they properly catch `RangeError` from the `DataView` API when checking for out-of-bounds reads.
 Always ensure you run `pnpm lint && pnpm test` to verify no regressions were introduced.
 When you finish reviewing a node, do not modify the YAML frontmatter. Update only the markdown body by checking off the Acceptance Criteria.
+Code fix added missing generation check for ContestSheenDisplay during validation.

--- a/.foundry/tasks/task-138-210-individual-contest-sheen-ui-qa.md
+++ b/.foundry/tasks/task-138-210-individual-contest-sheen-ui-qa.md
@@ -40,6 +40,6 @@ This QA task verifies the integration of the `ContestSheenDisplay` component int
 - **Empty PR Policy**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the YAML frontmatter on successful completion.
 
 ## 4. Acceptance Criteria
-- [ ] Verify `ContestSheenDisplay` is correctly integrated for Gen 3 Pokémon in `PokemonCaughtDetails.tsx`.
-- [ ] Verify unit tests cover the new component rendering.
-- [ ] Verify aesthetic fit.
+- [x] Verify `ContestSheenDisplay` is correctly integrated for Gen 3 Pokémon in `PokemonCaughtDetails.tsx`.
+- [x] Verify unit tests cover the new component rendering.
+- [x] Verify aesthetic fit.

--- a/src/components/pokemon/details/PokemonCaughtDetails.tsx
+++ b/src/components/pokemon/details/PokemonCaughtDetails.tsx
@@ -134,7 +134,7 @@ export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps)
               </div>
             )}
 
-            {p.condition && (
+            {p.condition && generation === 3 && (
               <div className="relative z-10 flex flex-col gap-4 border-white/5 border-t border-dashed bg-black/40 p-4">
                 <ContestConditionStats
                   cool={p.condition.cool}


### PR DESCRIPTION
Added `generation === 3` condition check to `PokemonCaughtDetails.tsx` when rendering `ContestConditionStats` and `ContestSheenDisplay`. Verified with tests. Marked QA task as complete.

---
*PR created automatically by Jules for task [4867053823246774364](https://jules.google.com/task/4867053823246774364) started by @szubster*