### PR TITLE
Fix broken link in prd-065-035-epic-verification-timing.md

### DIFF
--- a/.foundry/prds/prd-065-035-epic-verification-timing.md
+++ b/.foundry/prds/prd-065-035-epic-verification-timing.md
@@ -53,5 +53,5 @@ This ensures that "Epic implementation is done" is semantically accurate.
 
 
 ## Generated Epics
-- [.foundry/archive/epics/epic-035-048-implicit-dependency-enforcement.md](./../epics/epic-035-048-implicit-dependency-enforcement.md)
+- [.foundry/archive/epics/epic-035-048-implicit-dependency-enforcement.md](./../archive/epics/epic-035-048-implicit-dependency-enforcement.md)
 - [.foundry/epics/epic-035-049-late-binding-accommodation.md](./../epics/epic-035-049-late-binding-accommodation.md)


### PR DESCRIPTION
This PR fixes a broken relative link in `.foundry/prds/prd-065-035-epic-verification-timing.md`. The target file `epic-035-048-implicit-dependency-enforcement.md` had been moved to the `archive/epics` directory, but the PRD was still pointing to the `epics` directory.

Verification:
- Ran `node --experimental-strip-types scripts/check-links.ts .foundry/prds/prd-065-035-epic-verification-timing.md` and it passed.
- Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no regressions.

Fixes #3453

---
*PR created automatically by Jules for task [13812020199061855928](https://jules.google.com/task/13812020199061855928) started by @szubster*