### PR TITLE
feat(save): implement Gen 3 Battle Frontier symbols extraction

### DIFF
--- a/.foundry/tasks/task-122-234-parse-battle-frontier-symbols-impl.md
+++ b/.foundry/tasks/task-122-234-parse-battle-frontier-symbols-impl.md
@@ -55,10 +55,10 @@ This task follows ADR 010 (Mandate `DataView` API) and ADR 026 (Bitwise State Ex
 4. **Testing**: Write unit tests to verify the bitwise extraction logic, boundary tests for the `DataView`, and ensure absolute zero state parsing handles properly (as per ADR 026).
 
 ## Acceptance Criteria
-- [ ] Implement symbol flags parsing using `DataView` with exact offsets and bit masks.
-- [ ] Define module-level constants for all offsets and bits.
-- [ ] Catch `RangeError` from `DataView` and handle it gracefully.
-- [ ] Write unit tests to cover the implementation.
+- [x] Implement symbol flags parsing using `DataView` with exact offsets and bit masks.
+- [x] Define module-level constants for all offsets and bits.
+- [x] Catch `RangeError` from `DataView` and handle it gracefully.
+- [x] Write unit tests to cover the implementation.
 
 ## Reminders
 - If you encounter a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -106,6 +106,16 @@ export interface Gen3BattleFrontierWinStreaks {
   pyramid: { current: number; record: number };
 }
 
+export interface Gen3BattleFrontierSymbols {
+  tower: { silver: boolean; gold: boolean };
+  dome: { silver: boolean; gold: boolean };
+  palace: { silver: boolean; gold: boolean };
+  arena: { silver: boolean; gold: boolean };
+  factory: { silver: boolean; gold: boolean };
+  pike: { silver: boolean; gold: boolean };
+  pyramid: { silver: boolean; gold: boolean };
+}
+
 export interface SaveData {
   /** The generation of the parsed save file (1 or 2). */
   generation: Generation;
@@ -198,6 +208,8 @@ export interface SaveData {
   mirageIslandValue?: number;
   /** Gen 3 specific: Battle Frontier win streaks */
   gen3BattleFrontierWinStreaks?: Gen3BattleFrontierWinStreaks;
+  /** Gen 3 specific: Battle Frontier symbols */
+  gen3BattleFrontierSymbols?: Gen3BattleFrontierSymbols;
 }
 
 // Removed byte helper as DataView provides getUint8 natively.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   isGen3Save,
   parseGen3,
+  parseGen3BattleFrontierSymbols,
   parseGen3BattleFrontierWinStreaks,
   parseGen3ConditionStats,
   parseGen3MirageIslandValue,
@@ -471,6 +472,91 @@ describe('parseGen3PokeNews', () => {
     const view = new DataView(buffer);
 
     expect(() => parseGen3PokeNews(view, 0)).toThrowError('The save file is corrupted or incomplete.');
+  });
+});
+
+describe('parseGen3BattleFrontierSymbols', () => {
+  const saveBlock1Offset = 0;
+
+  it('correctly extracts silver and gold flags using bitwise logic', () => {
+    const buffer = new ArrayBuffer(0x1390); // Large enough to include 0x138A + 1
+    const view = new DataView(buffer);
+
+    // Tower: Silver (bit 4), Gold (bit 5) at 0x1388
+    // 0011 0000 -> 0x30
+    view.setUint8(0x1388, 0x30);
+
+    // Dome: Silver (bit 6), Gold (bit 7) at 0x1388
+    // 1111 0000 -> 0xF0 (Includes Tower)
+    view.setUint8(0x1388, 0xf0);
+
+    // Palace: Silver (bit 0), Gold (bit 1) at 0x1389
+    // 0000 0011 -> 0x03
+    // Arena: Silver (bit 2), Gold (bit 3) at 0x1389
+    // Factory: Silver (bit 4), Gold (bit 5) at 0x1389
+    // Pike: Silver (bit 6), Gold (bit 7) at 0x1389
+    // Let's set Palace Silver, Arena Gold, Factory Silver, Pike Gold
+    // Palace Silver: 1 << 0 = 1
+    // Arena Gold: 1 << 3 = 8
+    // Factory Silver: 1 << 4 = 16
+    // Pike Gold: 1 << 7 = 128
+    // 1 + 8 + 16 + 128 = 153 -> 0x99
+    view.setUint8(0x1389, 0x99);
+
+    // Pyramid: Silver (bit 0), Gold (bit 1) at 0x138A
+    // Let's set both: 0000 0011 -> 0x03
+    view.setUint8(0x138a, 0x03);
+
+    const result = parseGen3BattleFrontierSymbols(view, saveBlock1Offset);
+
+    expect(result.tower.silver).toBe(true);
+    expect(result.tower.gold).toBe(true);
+    expect(result.dome.silver).toBe(true);
+    expect(result.dome.gold).toBe(true);
+
+    expect(result.palace.silver).toBe(true);
+    expect(result.palace.gold).toBe(false);
+    expect(result.arena.silver).toBe(false);
+    expect(result.arena.gold).toBe(true);
+    expect(result.factory.silver).toBe(true);
+    expect(result.factory.gold).toBe(false);
+    expect(result.pike.silver).toBe(false);
+    expect(result.pike.gold).toBe(true);
+
+    expect(result.pyramid.silver).toBe(true);
+    expect(result.pyramid.gold).toBe(true);
+  });
+
+  it('handles absolute zero state parsing properly', () => {
+    const buffer = new ArrayBuffer(0x1390);
+    const view = new DataView(buffer);
+    // ArrayBuffer is initialized with zeros
+
+    const result = parseGen3BattleFrontierSymbols(view, saveBlock1Offset);
+
+    expect(result.tower.silver).toBe(false);
+    expect(result.tower.gold).toBe(false);
+    expect(result.dome.silver).toBe(false);
+    expect(result.dome.gold).toBe(false);
+    expect(result.palace.silver).toBe(false);
+    expect(result.palace.gold).toBe(false);
+    expect(result.arena.silver).toBe(false);
+    expect(result.arena.gold).toBe(false);
+    expect(result.factory.silver).toBe(false);
+    expect(result.factory.gold).toBe(false);
+    expect(result.pike.silver).toBe(false);
+    expect(result.pike.gold).toBe(false);
+    expect(result.pyramid.silver).toBe(false);
+    expect(result.pyramid.gold).toBe(false);
+  });
+
+  it('explicitly catches RangeError on out-of-bounds reads and throws corrupted file error', () => {
+    const buffer = new ArrayBuffer(0x1300); // Too small
+    const view = new DataView(buffer);
+
+    expect(() => parseGen3BattleFrontierSymbols(view, saveBlock1Offset)).toThrowError(
+      'The save file is corrupted or incomplete.',
+    );
   });
 });
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -20,6 +20,7 @@
 
 import type {
   GameVersion,
+  Gen3BattleFrontierSymbols,
   Gen3BattleFrontierWinStreaks,
   Gen3BerryPatch,
   Gen3Ribbons,
@@ -86,6 +87,35 @@ const PIKE_WIN_STREAKS_OFFSET = 0x0e04;
 const PIKE_RECORD_WIN_STREAKS_OFFSET = 0x0e08;
 const PYRAMID_WIN_STREAKS_OFFSET = 0x0e1a;
 const PYRAMID_RECORD_WIN_STREAKS_OFFSET = 0x0e1e;
+
+const TOWER_SILVER_OFFSET = 0x1388;
+const TOWER_SILVER_BIT = 4;
+const TOWER_GOLD_OFFSET = 0x1388;
+const TOWER_GOLD_BIT = 5;
+const DOME_SILVER_OFFSET = 0x1388;
+const DOME_SILVER_BIT = 6;
+const DOME_GOLD_OFFSET = 0x1388;
+const DOME_GOLD_BIT = 7;
+const PALACE_SILVER_OFFSET = 0x1389;
+const PALACE_SILVER_BIT = 0;
+const PALACE_GOLD_OFFSET = 0x1389;
+const PALACE_GOLD_BIT = 1;
+const ARENA_SILVER_OFFSET = 0x1389;
+const ARENA_SILVER_BIT = 2;
+const ARENA_GOLD_OFFSET = 0x1389;
+const ARENA_GOLD_BIT = 3;
+const FACTORY_SILVER_OFFSET = 0x1389;
+const FACTORY_SILVER_BIT = 4;
+const FACTORY_GOLD_OFFSET = 0x1389;
+const FACTORY_GOLD_BIT = 5;
+const PIKE_SILVER_OFFSET = 0x1389;
+const PIKE_SILVER_BIT = 6;
+const PIKE_GOLD_OFFSET = 0x1389;
+const PIKE_GOLD_BIT = 7;
+const PYRAMID_SILVER_OFFSET = 0x138a;
+const PYRAMID_SILVER_BIT = 0;
+const PYRAMID_GOLD_OFFSET = 0x138a;
+const PYRAMID_GOLD_BIT = 1;
 
 /**
  * Locates the most recent memory offset for a specific save section in Gen 3 flash memory.
@@ -466,6 +496,54 @@ export function parseGen3SecretBases(view: DataView, saveBlock1Offset: number, g
 }
 
 /**
+ * Parses the Gen 3 Battle Frontier symbols from the save file.
+ *
+ * @param view - The raw save file DataView.
+ * @param saveBlock1Offset - The resolved memory offset to the active SaveBlock1.
+ * @returns An object containing the extracted symbols for all 7 facilities.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3BattleFrontierSymbols(view: DataView, saveBlock1Offset: number): Gen3BattleFrontierSymbols {
+  try {
+    return {
+      tower: {
+        silver: !!((view.getUint8(saveBlock1Offset + TOWER_SILVER_OFFSET) >> TOWER_SILVER_BIT) & 1),
+        gold: !!((view.getUint8(saveBlock1Offset + TOWER_GOLD_OFFSET) >> TOWER_GOLD_BIT) & 1),
+      },
+      dome: {
+        silver: !!((view.getUint8(saveBlock1Offset + DOME_SILVER_OFFSET) >> DOME_SILVER_BIT) & 1),
+        gold: !!((view.getUint8(saveBlock1Offset + DOME_GOLD_OFFSET) >> DOME_GOLD_BIT) & 1),
+      },
+      palace: {
+        silver: !!((view.getUint8(saveBlock1Offset + PALACE_SILVER_OFFSET) >> PALACE_SILVER_BIT) & 1),
+        gold: !!((view.getUint8(saveBlock1Offset + PALACE_GOLD_OFFSET) >> PALACE_GOLD_BIT) & 1),
+      },
+      arena: {
+        silver: !!((view.getUint8(saveBlock1Offset + ARENA_SILVER_OFFSET) >> ARENA_SILVER_BIT) & 1),
+        gold: !!((view.getUint8(saveBlock1Offset + ARENA_GOLD_OFFSET) >> ARENA_GOLD_BIT) & 1),
+      },
+      factory: {
+        silver: !!((view.getUint8(saveBlock1Offset + FACTORY_SILVER_OFFSET) >> FACTORY_SILVER_BIT) & 1),
+        gold: !!((view.getUint8(saveBlock1Offset + FACTORY_GOLD_OFFSET) >> FACTORY_GOLD_BIT) & 1),
+      },
+      pike: {
+        silver: !!((view.getUint8(saveBlock1Offset + PIKE_SILVER_OFFSET) >> PIKE_SILVER_BIT) & 1),
+        gold: !!((view.getUint8(saveBlock1Offset + PIKE_GOLD_OFFSET) >> PIKE_GOLD_BIT) & 1),
+      },
+      pyramid: {
+        silver: !!((view.getUint8(saveBlock1Offset + PYRAMID_SILVER_OFFSET) >> PYRAMID_SILVER_BIT) & 1),
+        gold: !!((view.getUint8(saveBlock1Offset + PYRAMID_GOLD_OFFSET) >> PYRAMID_GOLD_BIT) & 1),
+      },
+    };
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+/**
  * Parses the Gen 3 Battle Frontier win streaks from the save file.
  *
  * @param view - The raw save file DataView.
@@ -571,9 +649,15 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     const mirageIslandValue = parseGen3MirageIslandValue(view, section2Offset + mirageIslandOffset);
 
     let gen3BattleFrontierWinStreaks: Gen3BattleFrontierWinStreaks | undefined;
+    let gen3BattleFrontierSymbols: Gen3BattleFrontierSymbols | undefined;
     if (_forcedVersion === 'emerald') {
       try {
         gen3BattleFrontierWinStreaks = parseGen3BattleFrontierWinStreaks(view, section2Offset);
+      } catch {
+        // Ignored if missing or corrupted, allowing the rest of the save to load
+      }
+      try {
+        gen3BattleFrontierSymbols = parseGen3BattleFrontierSymbols(view, section1Offset);
       } catch {
         // Ignored if missing or corrupted, allowing the rest of the save to load
       }
@@ -606,6 +690,9 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     };
     if (gen3BattleFrontierWinStreaks) {
       result.gen3BattleFrontierWinStreaks = gen3BattleFrontierWinStreaks;
+    }
+    if (gen3BattleFrontierSymbols) {
+      result.gen3BattleFrontierSymbols = gen3BattleFrontierSymbols;
     }
     return result;
   } catch (error) {


### PR DESCRIPTION
Implements extraction of Gen 3 Battle Frontier Silver and Gold symbols from SaveBlock1. Updates SaveData interface and parseGen3 logic. Complies with requirements in task-122-234-parse-battle-frontier-symbols-impl.

---
*PR created automatically by Jules for task [16380654223830525386](https://jules.google.com/task/16380654223830525386) started by @szubster*