### PR TITLE
Agile Coach: Prevent Blocking Bash Commands

### DIFF
--- a/.foundry/ideas/idea-095-prevent-blocking-bash-commands.md
+++ b/.foundry/ideas/idea-095-prevent-blocking-bash-commands.md
@@ -1,0 +1,37 @@
+---
+id: idea-095-prevent-blocking-bash-commands
+type: IDEA
+title: Automated Timeout Wrapper for Bash Sessions
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Automated Timeout Wrapper for Bash Sessions
+
+## Description
+Agent sessions (such as `coder`, `qa`, and `auditor`) frequently utilize the `run_in_bash_session` tool to explore the codebase or read logs. However, agents occasionally execute blocking bash commands, such as `tail -f`, which causes the session to hang indefinitely and eventually leads to an execution rejection or timeout by the orchestrator.
+
+## Proposal
+To prevent this friction and improve the resilience of the Foundry ecosystem, we should implement a wrapper or linter for `run_in_bash_session` that automatically enforces a timeout on executed commands. If a command runs beyond a specific threshold (e.g., 30 seconds), the wrapper should interrupt the process and return a helpful error message to the agent, suggesting non-blocking alternatives like `cat` or `tail -n`.
+
+## Impact
+- **Positive**: Reduces the number of failed Jules sessions due to infinite hangs.
+- **Positive**: Improves overall orchestration efficiency by freeing up blocked parallel execution slots.
+
+## Acceptance Criteria
+- [ ] Investigate the feasibility of wrapping bash execution with a timeout mechanism.
+- [ ] Implement the timeout logic if feasible, or implement static analysis to reject commands containing known blocking flags (like `-f` on `tail`).

--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -68,3 +68,11 @@ To resolve this, I have updated all relevant agents (`coder.md`, `qa.md`, `audit
 2. `CANCELLED` MUST be used for permanent failures (impossible tasks or max rejections reached) to formally drop them from the DAG and trigger parent recovery.
 
 Additionally, to prevent false positive Impossible Loops and incorrect failure tracking, the system must explicitly clear `rejection_reason` when transitioning nodes out of a `FAILED` state to ensure metadata accurately reflects the current node state.
+
+## 2026-06-29: Blocking Bash Session Executions
+
+While observing the system performance and logs, I noticed that several agent sessions were terminating abruptly or timing out. A recurring pattern is the use of blocking bash commands, particularly `tail -f`, via the `run_in_bash_session` tool. These commands hang the session indefinitely.
+
+To mitigate this operational friction, I have updated the `coder`, `qa`, `tech_lead`, and `auditor` persona prompts to explicitly forbid the use of blocking bash commands and recommend alternatives like `cat` or `tail -n`.
+
+Furthermore, I have generated `idea-095-prevent-blocking-bash-commands.md` to propose an automated, system-level timeout wrapper for `run_in_bash_session` to forcefully terminate hanging executions and return actionable feedback to the agent, providing a more resilient long-term solution.

--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -24,6 +24,8 @@ You are the Auditor persona in the Foundry system. Your role is to assess and ve
 **CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 
+**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
+
 
 **CRITICAL CONTEXT GATHERING INSTRUCTION:**
 When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -59,6 +59,8 @@ If you lack critical context or specifications (e.g., exact memory offsets) nece
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 When submitting an empty PR for a task that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 
+**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
+
 
 ## Architectural Compliance & QA Rejections
 When a QA agent rejects your task for missing architectural requirements (e.g., failing to implement a shared React Context mandated by an ADR), you MUST comprehensively implement the missing architectural layer. Do not simply fake a fix or ignore the architectural constraint. Repeatedly failing to adhere to ADRs will result in permanent failure and system penalties.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -63,6 +63,8 @@ If a cancelled or replaced task node is reawakened (e.g., because its previous i
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 When submitting an empty PR for a task that is completely validated and finished but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 
+**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
+
 
 ## Architectural Enforcement
 When validating tasks, you MUST strictly enforce architectural patterns mandated by ADRs (e.g., ADR 013 and ADR 017 requiring shared React Contexts). If a coder repeatedly ignores these requirements and fakes fixes, explicitly document this persistent failure in your journal and escalate by suggesting the creation of a specialized `RESEARCH` or `TASK` node to address the developer friction.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -74,6 +74,8 @@ This is your **only private memory**. When you see something worth rememberingâ€
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
 When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 
+**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
+
 ## Architectural Scaffolding
 If a Story involves complex shared state or architectural patterns (such as those mandated by ADR 013 and ADR 017), your blueprints MUST provide explicit scaffolding instructions. For example, explicitly instruct the coder to define the React Context layer first before implementing the UI components, to prevent tight coupling and permanent failures.
 


### PR DESCRIPTION
This PR proactively addresses an operational friction point where Jules agents occasionally execute blocking bash commands (such as `tail -f`), causing the orchestrator session to hang indefinitely and fail.

- Updates `.github/agents/{coder,qa,tech_lead,auditor}.md` to explicitly forbid blocking bash commands and recommend non-blocking alternatives (`cat`, `tail -n`).
- Creates `.foundry/ideas/idea-095-prevent-blocking-bash-commands.md` proposing a system-level timeout wrapper to automatically interrupt hanging commands.
- Logs the findings and actions taken in the Agile Coach's journal.

---
*PR created automatically by Jules for task [7084241264483207580](https://jules.google.com/task/7084241264483207580) started by @szubster*