### PR TITLE
💡 Visionary: Gen 2/3 In-Game Trade Assistant Dashboard

### DIFF
--- a/.foundry/ideas/idea-095-in-game-trade-assistant.md
+++ b/.foundry/ideas/idea-095-in-game-trade-assistant.md
@@ -1,0 +1,31 @@
+---
+id: idea-095-in-game-trade-assistant
+type: IDEA
+title: "Gen 2/3 In-Game Trade Assistant Dashboard"
+status: PENDING
+owner_persona: "product_manager"
+created_at: "2026-06-29"
+updated_at: "2026-06-29"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen 2/3 In-Game Trade Assistant Dashboard
+
+## Problem
+In Generations 2 and 3, there are numerous in-game NPCs offering fixed Pokémon trades (e.g., trading a Bellsprout for an Onix, or an Abra for a Mr. Mime). These trades often provide Pokémon with beneficial DVs/IVs, rare held items, or bonus EXP rates. However, keeping track of which trades have already been completed, and remembering which specific Pokémon species are requested by which NPC, requires tedious memorization or repeatedly consulting external wikis.
+
+## Proposed Solution
+Build an "In-Game Trade Assistant Dashboard" that:
+1. Parses the save file's event flags to determine which one-time in-game NPC trades have already been completed.
+2. Displays a clear list of all available vs. completed trades for the loaded save.
+3. Automatically cross-references the requested Pokémon species for available trades against the player's current party and PC box contents, highlighting trades that can be executed immediately.
+
+This turns opaque, hidden game state into an actionable, highly useful strategy for casual players, completionists, and Nuzlockers alike, removing the need for external resources and tedious PC box checking.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -159,3 +159,7 @@
 ## 2026-06-28
 **Idea:** Gen 3 Move Tutor Availability Dashboard
 **Learning:** Targeting limited, one-time-use game resources (like Move Tutors) for data aggregation provides massive value to hardcore players. Automatically parsing which tutors have been used and instantly cross-referencing that against the player's current PC box contents for compatibility perfectly fits the offline-first companion app vision, eliminating tedious in-game traveling and wiki searches.
+
+## 2026-06-29
+**Idea:** Gen 2/3 In-Game Trade Assistant Dashboard
+**Learning:** Expanding on the success of the Move Tutor dashboard, targeting other one-time limited NPC interactions—like in-game trades—provides excellent utility. By automatically parsing the save file's event flags to determine trade availability, and cross-referencing requested species with the player's current PC box contents, we transform static event data into an actionable, dynamic "to-do" list. This strongly reinforces DexHelper's value as a premium companion app that eliminates tedious wiki searches and manual tracking.


### PR DESCRIPTION
This PR adds a new `IDEA` node for a Gen 2/3 In-Game Trade Assistant Dashboard.

The proposed feature parses the save file to determine which one-time in-game NPC trades have been completed. It then cross-references available trades with the player's current PC box and party contents, giving players an actionable "to-do" list for obtaining rare Pokémon, beneficial IVs, and held items without needing external wikis.

A new entry was also added to the visionary journal (`.jules/visionary.md`) detailing the rationale of leveraging programmatic access to one-time event flags to provide utility.

---
*PR created automatically by Jules for task [12492372491085046944](https://jules.google.com/task/12492372491085046944) started by @szubster*