### PR TITLE
Fix: Integrate items.jsonl into pokedata bundle

### DIFF
--- a/.foundry/tasks/task-128-212-item-list-parsing-impl.md
+++ b/.foundry/tasks/task-128-212-item-list-parsing-impl.md
@@ -44,11 +44,11 @@ Ensure the generation logic leverages generation-specific datasets (e.g., `past_
 2. Ensure you read the conclusions from the research task `research-128-210-item-list-parsing-failure.md` to properly integrate `items.jsonl` into the bundle payload in `vite-plugins/pokedata-plugin.ts`.
 
 ## Acceptance Criteria
-- [ ] Implement parsing logic in `scripts/generate-pokedata.ts` to extract item data from the local PokeAPI dataset.
-- [ ] Apply compaction to remove nulls, default values, and zeros (like a cost of 0).
-- [ ] Ensure the generated structure matches the specification in ADR-049-025.
-- [ ] Output the processed data as `data/db/items.jsonl`.
-- [ ] Integrate `items.jsonl` into the payload within `vite-plugins/pokedata-plugin.ts`.
+- [x] Implement parsing logic in `scripts/generate-pokedata.ts` to extract item data from the local PokeAPI dataset.
+- [x] Apply compaction to remove nulls, default values, and zeros (like a cost of 0).
+- [x] Ensure the generated structure matches the specification in ADR-049-025.
+- [x] Output the processed data as `data/db/items.jsonl`.
+- [x] Integrate `items.jsonl` into the payload within `vite-plugins/pokedata-plugin.ts`.
 
 ## Critical Instructions for Coder
 - **Failure Policy**: If you must abort this task or it fails permanently, you MUST update the YAML frontmatter to `status: FAILED` and provide a `rejection_reason`. Do NOT check off any Acceptance Criteria in the event of failure.

--- a/vite-plugins/pokedata-plugin.ts
+++ b/vite-plugins/pokedata-plugin.ts
@@ -22,6 +22,7 @@ export function pokedataPlugin(options: PokeDataPluginOptions): Plugin {
     const pokemon = readJsonl(path.join(sourceDir, 'pokemon.jsonl'));
     const encounters = readJsonl(path.join(sourceDir, 'encounters.jsonl'));
     const locations = readJsonl(path.join(sourceDir, 'locations.jsonl'));
+    const items = readJsonl(path.join(sourceDir, 'items.jsonl'));
     const metadataPath = path.join(sourceDir, 'metadata.json');
     const metadata = fs.existsSync(metadataPath) ? JSON.parse(fs.readFileSync(metadataPath, 'utf-8')) : {};
 
@@ -29,6 +30,7 @@ export function pokedataPlugin(options: PokeDataPluginOptions): Plugin {
       poke: pokemon,
       enc: encounters,
       loc: locations,
+      items: items,
       sourceSha: metadata.sourceSha,
     };
 


### PR DESCRIPTION
Updates the Vite pokedata plugin to correctly read the dynamically generated `items.jsonl` file and include it in the final msgpack payload bundle, as specified in ADR-049-025. This fixes the issue preventing the item data from being available to the client.

---
*PR created automatically by Jules for task [16180831468023726085](https://jules.google.com/task/16180831468023726085) started by @szubster*