### PR TITLE
🖼️ Canvas: Tactical Graveyard Select Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -239,9 +239,3 @@
 **Outcome:** Accepted
 **Why:** Brings the mobile bottom navigation fully into the tactical specialized hardware motif. Floating app bars and subtle flicker animations break the illusion of using a rugged, purpose-built device.
 **Pattern:** Apply "bracketed" physical hardware layouts and explicit "membrane switch" button designs (using inset shadows, dashed borders, and strict monospaced labels) to navigation structures to maintain the device simulation across all viewports.
-
-## 2026-06-29 - [Accepted] - 🖼️ Canvas: Tactical Graveyard Select Redesign
-**What:** Redesigned the "Graveyard" control in the `SettingsControls` component to fully embrace the tactical "snooping" aesthetic. Replaced the generic HTML `<select>` dropdown (wrapped in `TacticalSelect`) with a dense, grid-based `TacticalSegmentedControl`.
-**Outcome:** Accepted
-**Why:** Brings the settings interface further in line with the heavily tactical, specialized hardware motif. Native browser dropdowns break the specialized device illusion, whereas a dense grid of physical-looking toggle buttons aligns perfectly with the tactical terminal visual identity.
-**Pattern:** Consistently eliminate generic web UI patterns (like native `<select>` dropdowns) for selecting options from lists. For sets with multiple options (like 14 storage boxes), use dense grid layouts within `TacticalSegmentedControl` to mimic hardware selection matrices.

--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -239,3 +239,9 @@
 **Outcome:** Accepted
 **Why:** Brings the mobile bottom navigation fully into the tactical specialized hardware motif. Floating app bars and subtle flicker animations break the illusion of using a rugged, purpose-built device.
 **Pattern:** Apply "bracketed" physical hardware layouts and explicit "membrane switch" button designs (using inset shadows, dashed borders, and strict monospaced labels) to navigation structures to maintain the device simulation across all viewports.
+
+## 2026-06-29 - [Accepted] - 🖼️ Canvas: Tactical Graveyard Select Redesign
+**What:** Redesigned the "Graveyard" control in the `SettingsControls` component to fully embrace the tactical "snooping" aesthetic. Replaced the generic HTML `<select>` dropdown (wrapped in `TacticalSelect`) with a dense, grid-based `TacticalSegmentedControl`.
+**Outcome:** Accepted
+**Why:** Brings the settings interface further in line with the heavily tactical, specialized hardware motif. Native browser dropdowns break the specialized device illusion, whereas a dense grid of physical-looking toggle buttons aligns perfectly with the tactical terminal visual identity.
+**Pattern:** Consistently eliminate generic web UI patterns (like native `<select>` dropdowns) for selecting options from lists. For sets with multiple options (like 14 storage boxes), use dense grid layouts within `TacticalSegmentedControl` to mimic hardware selection matrices.

--- a/src/components/settings/SettingsControls.tsx
+++ b/src/components/settings/SettingsControls.tsx
@@ -4,7 +4,6 @@ import type { GenerationConfig } from '../../utils/generationConfig';
 import { getGenerationConfig } from '../../utils/generationConfig';
 import { SettingsRow } from '../SettingsRow';
 import { TacticalSegmentedControl } from '../TacticalSegmentedControl';
-import { TacticalSelect } from '../TacticalSelect';
 
 interface SettingsControlsProps {
   effectiveVersion: GameVersion | 'unknown';
@@ -129,19 +128,22 @@ export function SettingsControls({
         iconColorClass="border-red-500/20 bg-red-500/10"
         label="Graveyard"
       >
-        <TacticalSelect
-          aria-label="Select Nuzlocke Graveyard Box"
-          value={nuzlockeGraveyardBox || ''}
-          onChange={(e) => setNuzlockeGraveyardBox(e.target.value === '' ? null : e.target.value)}
-          className="focus-visible:ring-red-500"
-        >
-          <option value="">[ NONE ]</option>
-          {storageLocations.map((loc) => (
-            <option key={loc} value={loc}>
-              [ {loc.toUpperCase()} ]
-            </option>
-          ))}
-        </TacticalSelect>
+        <TacticalSegmentedControl<string>
+          ariaLabel="Select Nuzlocke Graveyard Box"
+          containerClassName="[&>div]:grid [&>div]:grid-cols-3 [&>div]:sm:grid-cols-4 [&>div]:gap-2 [&>div]:border-none [&>button]:border"
+          buttonBaseClassName="!border-dashed !border focus-visible:ring-red-500 px-2 py-2 text-[8px]"
+          defaultActiveClassName="border-red-500 bg-red-500/20 text-red-400 shadow-[0_0_10px_rgba(239,68,68,0.3)]"
+          defaultInactiveClassName="border-zinc-800 bg-zinc-950 text-zinc-500 hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300"
+          selectedValue={nuzlockeGraveyardBox || ''}
+          onValueChange={(val) => setNuzlockeGraveyardBox(val === '' ? null : val)}
+          items={[
+            { id: '', label: '[ NONE ]' },
+            ...storageLocations.map((loc) => ({
+              id: loc,
+              label: `[ ${loc.toUpperCase()} ]`,
+            })),
+          ]}
+        />
       </SettingsRow>
     </div>
   );

--- a/src/components/settings/SettingsControls.tsx
+++ b/src/components/settings/SettingsControls.tsx
@@ -4,6 +4,7 @@ import type { GenerationConfig } from '../../utils/generationConfig';
 import { getGenerationConfig } from '../../utils/generationConfig';
 import { SettingsRow } from '../SettingsRow';
 import { TacticalSegmentedControl } from '../TacticalSegmentedControl';
+import { TacticalSelect } from '../TacticalSelect';
 
 interface SettingsControlsProps {
   effectiveVersion: GameVersion | 'unknown';
@@ -128,22 +129,19 @@ export function SettingsControls({
         iconColorClass="border-red-500/20 bg-red-500/10"
         label="Graveyard"
       >
-        <TacticalSegmentedControl<string>
-          ariaLabel="Select Nuzlocke Graveyard Box"
-          containerClassName="[&>div]:grid [&>div]:grid-cols-3 [&>div]:sm:grid-cols-4 [&>div]:gap-2 [&>div]:border-none [&>button]:border"
-          buttonBaseClassName="!border-dashed !border focus-visible:ring-red-500 px-2 py-2 text-[8px]"
-          defaultActiveClassName="border-red-500 bg-red-500/20 text-red-400 shadow-[0_0_10px_rgba(239,68,68,0.3)]"
-          defaultInactiveClassName="border-zinc-800 bg-zinc-950 text-zinc-500 hover:border-zinc-600 hover:bg-zinc-900 hover:text-zinc-300"
-          selectedValue={nuzlockeGraveyardBox || ''}
-          onValueChange={(val) => setNuzlockeGraveyardBox(val === '' ? null : val)}
-          items={[
-            { id: '', label: '[ NONE ]' },
-            ...storageLocations.map((loc) => ({
-              id: loc,
-              label: `[ ${loc.toUpperCase()} ]`,
-            })),
-          ]}
-        />
+        <TacticalSelect
+          aria-label="Select Nuzlocke Graveyard Box"
+          value={nuzlockeGraveyardBox || ''}
+          onChange={(e) => setNuzlockeGraveyardBox(e.target.value === '' ? null : e.target.value)}
+          className="focus-visible:ring-red-500"
+        >
+          <option value="">[ NONE ]</option>
+          {storageLocations.map((loc) => (
+            <option key={loc} value={loc}>
+              [ {loc.toUpperCase()} ]
+            </option>
+          ))}
+        </TacticalSelect>
       </SettingsRow>
     </div>
   );

--- a/src/components/settings/__tests__/SettingsControls.test.tsx
+++ b/src/components/settings/__tests__/SettingsControls.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { page, userEvent } from 'vitest/browser';
+import { page } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
 import type { GameVersion, PokeballType } from '../../../store';
 import { SettingsControls } from '../SettingsControls';

--- a/src/components/settings/__tests__/SettingsControls.test.tsx
+++ b/src/components/settings/__tests__/SettingsControls.test.tsx
@@ -53,12 +53,10 @@ describe('SettingsControls', () => {
       />,
     );
 
-    const select = page.getByRole('combobox');
-
-    await userEvent.selectOptions(select.element(), 'Box 1');
+    await page.getByText('[ BOX 1 ]').click();
     expect(setNuzlockeGraveyardBox).toHaveBeenCalledWith('Box 1');
 
-    await userEvent.selectOptions(select.element(), '');
+    await page.getByText('[ NONE ]').click();
     expect(setNuzlockeGraveyardBox).toHaveBeenCalledWith(null);
   });
 


### PR DESCRIPTION
# Canvas — Tactical Graveyard Redesign

**What:** Redesigned the "Graveyard" control in the `SettingsControls` component to fully embrace the tactical "snooping" aesthetic. Replaced the generic HTML `<select>` dropdown with a dense, grid-based `TacticalSegmentedControl`.

**Why:** Brings the settings interface further in line with the heavily tactical, specialized hardware motif. Native browser dropdowns break the specialized device illusion, whereas a dense grid of physical-looking toggle buttons aligns perfectly with the tactical terminal visual identity.

**Pattern applied:** Consistently eliminate generic web UI patterns (like native `<select>` dropdowns) for selecting options from lists. For sets with multiple options (like 14 storage boxes), use dense grid layouts within `TacticalSegmentedControl` to mimic hardware selection matrices.

This PR successfully passes `pnpm lint` and `pnpm test`, and includes frontend verification via Playwright demonstrating the correct rendering of the new UI control. An entry was also successfully appended to `.jules/canvas.md`.

---
*PR created automatically by Jules for task [10929826060147313832](https://jules.google.com/task/10929826060147313832) started by @szubster*