### PR TITLE
🧭 Strategist: Prompt improvement - Add Empty PR Verification Rule to Sweeper

### DIFF
--- a/.github/agents/sweeper.md
+++ b/.github/agents/sweeper.md
@@ -46,3 +46,4 @@ This is your **only private memory**. When you see something worth rememberingâ€
 ## Core Policies
 **CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's Environment Troubleshooting and Empty PR Policies.
+When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -314,3 +314,9 @@
 **Outcome:** Merged
 **Why:** The `qa.md` journal recorded that when verifying tasks that involve adding or modifying parsers for save files (like `task-124-172-gen3-mix-record-events-parser`), the QA agent must closely inspect that they properly catch `RangeError` from the `DataView` API when checking for out-of-bounds reads. However, this explicit validation constraint was missing from the QA agent's prompt.
 **Pattern:** Codify system memory constraints and specific validation requirements (like checking for `RangeError` handling in save file parsers) directly into the QA agent's prompt to ensure strict and consistent architectural enforcement.
+
+## 2026-07-20 - [Accepted] - Prompt improvement - Add Empty PR Verification Rule to Sweeper
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The memory requires that when submitting empty PRs for nodes that are completely implemented, any unchecked Acceptance Criteria checkboxes MUST be checked (`- [x]`) before submitting to satisfy ADR 007 and ADR 009. This constraint is explicitly detailed in other agent prompts but was missing in the Sweeper prompt.
+**Pattern:** Codify system memory constraints into agent prompts to avoid regressions and ensure consistency across personas.


### PR DESCRIPTION
**Proposal**: Added the Empty PR Verification Rule text to the `## Core Policies` section of the Sweeper agent prompt.

**Justification**: The `core_policies.md` explicitly references the "Empty PR Verification Rule" enforcing that unchecked Acceptance Criteria checkboxes must be checked when an empty PR is submitted. Other agent prompts (`qa`, `architect`, `coder`, `tech_lead`) include this detail to satisfy ADR 007 and ADR 009. The Sweeper prompt was missing this specific guidance, leaving it vulnerable to empty PR rejections.

**Evidence**: The Strategist journal indicates that codifying system memory constraints (like ADR 007 and ADR 009 checklist compliance) into agent prompts ensures consistency and prevents regressions across personas. The absence of this rule in the Sweeper prompt could lead to false-positive completions or rejections.

---
*PR created automatically by Jules for task [16288505264975202892](https://jules.google.com/task/16288505264975202892) started by @szubster*