### PR TITLE
QA Verification: Gen 2 Event Data Layer

### DIFF
--- a/.foundry/tasks/task-096-203-gen2-event-data-layer-qa.md
+++ b/.foundry/tasks/task-096-203-gen2-event-data-layer-qa.md
@@ -32,5 +32,5 @@ Verify the implementation of `task-096-202-gen2-event-data-layer-impl`.
   - If you submit an empty PR for a completed task, check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Run test suite to verify Gen 2 event data layer integration.
-- [ ] Confirm no regressions in the strategy engine test coverage.
+- [x] Run test suite to verify Gen 2 event data layer integration.
+- [x] Confirm no regressions in the strategy engine test coverage.


### PR DESCRIPTION
- Checked off Acceptance Criteria checkboxes in `task-096-203-gen2-event-data-layer-qa.md`.
- Verified Gen 2 suggestion generation correctly hides claimed gifts when event flags are set.
- Ensured no regressions in Gen 1 logic by running `pnpm test src/engine/assistant/`.

---
*PR created automatically by Jules for task [14170799967717542751](https://jules.google.com/task/14170799967717542751) started by @szubster*