### PR TITLE
docs: Reflect strict macro node completion rules in core documentation

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -11,6 +11,8 @@ Completely empty PRs should be fine and automerged by GitHub actions (there is a
 
 **CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.
 
+**MACRO NODE COMPLETION EXCEPTION:** Personas must NOT submit an Empty PR to transition a macro node (`IDEA`, `PRD`, `EPIC`, `STORY`) to VERIFYING (e.g. by checking off its acceptance criteria) until ALL of its generated descendant nodes have transitioned to COMPLETED. Premature verification violates hierarchical completion rules.
+
 ### Mason Prompt Adjustments
 When finding standard HTML elements or repeated JSX patterns, it is perfectly acceptable and encouraged to reuse existing reusable components (e.g. replacing `<button>` with `<TacticalButton>`) rather than strictly creating a new component, as long as it improves modularity and reduces code duplication.
 

--- a/.foundry/docs/knowledge_base/foundry/engine/strict-dag-completion.md
+++ b/.foundry/docs/knowledge_base/foundry/engine/strict-dag-completion.md
@@ -6,7 +6,7 @@ The Foundry engine now utilizes a **Strict DAG Completion** model. Traditional m
 ## Engine Behavior
 1.  **Heartbeat (`foundry-heartbeat.ts`)**: 
     - No longer scans for unchecked boxes.
-    - Automatically transitions a node to `COMPLETED` immediately upon its associated Pull Request being merged.
+    - Automatically transitions a node to `COMPLETED` immediately upon its associated Pull Request being merged (except for macro nodes which must wait for all children to complete).
 2.  **Orchestrator (`foundry-orchestrator.ts`)**:
     - Implements a **Self-Healing DAG** via Phase 3.5.
     - If a `COMPLETED` node is found to be **Hierarchically Incomplete** (i.e., it has children or dependencies that are not `COMPLETED`), it is demoted back to `PENDING`.

--- a/.foundry/docs/knowledge_base/foundry/orchestrator/hierarchical-completion.md
+++ b/.foundry/docs/knowledge_base/foundry/orchestrator/hierarchical-completion.md
@@ -10,8 +10,8 @@ A node `B` that depends on node `A` will ONLY be promoted to `READY` if:
 ## Implementation Details
 The `foundry-orchestrator.ts` script now builds a `parentToChildren` map during its resolution phase. It checks this map for every dependency listed in a node's `depends_on` field.
 
-- **Exceptions**: If a node `C` is a child of `A`, it is NOT blocked by this hierarchical rule (otherwise it could never start). Children only care about the explicit status of their dependencies and their parent's existence.
-- **Benefits**: This allows "Stories" to be marked `COMPLETED` by agents during the planning phase without erroneously unblocking the *next* Story before the current Story's tasks are actually implemented.
+- **Exceptions**: If a node `C` is a child of `A`, it is NOT blocked by this hierarchical rule (otherwise it could never start). Children only care about the explicit status of their dependencies and their parent's existence. Furthermore, while late-binding logic allows parents to spawn children, macro nodes (`IDEA`, `PRD`, `EPIC`, `STORY`) must NOT be marked `COMPLETED` via Empty PRs until all children are complete.
+- **Benefits**: This allows "Stories" to safely remain in `PENDING` (or transition back to it via Self-Healing) while waiting for children, without erroneously unblocking the *next* Story before the current Story's tasks are actually implemented.
 
 ## Verification
 This logic is covered by unit tests in `foundry-orchestrator.test.ts`.

--- a/.foundry/stories/story-071-110-verify-core-documentation.md
+++ b/.foundry/stories/story-071-110-verify-core-documentation.md
@@ -33,4 +33,4 @@ Verify that there are no conflicting statements across other core documentation 
 Verify that there are no conflicting statements across other core documentation.
 
 ## Acceptance Criteria
-- [ ] Verify that there are no conflicting statements across other core documentation.
+- [x] Verify that there are no conflicting statements across other core documentation.


### PR DESCRIPTION
Updates `core_policies.md`, `hierarchical-completion.md`, and `strict-dag-completion.md` to ensure macro nodes are not prematurely completed via Empty PRs until all descendant nodes are complete. Checks off the acceptance criteria in `story-071-110`.

---
*PR created automatically by Jules for task [4910287784692875262](https://jules.google.com/task/4910287784692875262) started by @szubster*