### PR TITLE
Reject: Breeding Pair Algorithm Implementation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -4,3 +4,6 @@
 When verifying tasks that involve adding or modifying parsers for save files (like `task-124-172-gen3-mix-record-events-parser`), make sure to closely inspect that they properly catch `RangeError` from the `DataView` API when checking for out-of-bounds reads.
 Always ensure you run `pnpm lint && pnpm test` to verify no regressions were introduced.
 When you finish reviewing a node, do not modify the YAML frontmatter. Update only the markdown body by checking off the Acceptance Criteria.
+
+## Gen 2 Breeding Algorithm Constraints
+I rejected the implementation of the `calculateBreedingPairs` algorithm because it prioritized pairing two Shiny/Shiny Carrier Pokémon together (score = 2). In Gen 2, two Shiny Pokémon cannot breed with each other because Shininess is determined by DVs (Determinant Values). Pokémon with matching or highly similar Defense and Special DVs (which Shinies share) are considered "related" by the Daycare and will refuse to breed. The algorithm must explicitly exclude these pairs from valid breeding combinations.

--- a/.foundry/tasks/task-084-210-breeding-pair-algorithm-impl.md
+++ b/.foundry/tasks/task-084-210-breeding-pair-algorithm-impl.md
@@ -2,7 +2,7 @@
 id: task-084-210-breeding-pair-algorithm-impl
 type: TASK
 title: Implement Shiny Carrier Breeding Pair Algorithm
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-19'
 updated_at: '2026-06-29'
@@ -17,8 +17,8 @@ tags:
   - gen2
   - backend
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Algorithm does not account for the Gen 2 rule that prevents two Shiny (or Shiny Carrier) Pokémon from breeding together due to identical DVs.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-084-211-breeding-pair-algorithm-qa.md
+++ b/.foundry/tasks/task-084-211-breeding-pair-algorithm-qa.md
@@ -45,3 +45,6 @@ Verify the correctness of the Shiny Carrier breeding algorithm implementation, e
 - [ ] All associated unit tests pass.
 - [ ] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
 - [ ] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### QA Rejection
+Task implementation rejected because the algorithm does not handle the Gen 2 rule that prevents two Shiny (or Shiny Carrier) Pokémon from breeding with each other due to overlapping DVs.


### PR DESCRIPTION
Rejects the implementation of the breeding pair algorithm. The algorithm incorrectly prioritizes pairing two Shiny/Shiny Carrier Pokémon. In Gen 2, two Shiny Pokémon cannot breed because Shininess is determined by DVs, and Pokémon with matching or highly similar DVs (Defense and Special) are considered "related" and will refuse to breed. The algorithm must be updated to exclude these pairs.

---
*PR created automatically by Jules for task [2764339193627664124](https://jules.google.com/task/2764339193627664124) started by @szubster*