### PR TITLE
chore: Update epic-045-071 with completed stories

### DIFF
--- a/.foundry/epics/epic-045-071-documentation-macro-node-completion.md
+++ b/.foundry/epics/epic-045-071-documentation-macro-node-completion.md
@@ -34,11 +34,11 @@ Update the core system documentation to detail the new macro node completion rul
 3. **Other Knowledge Base Updates**: Update any other relevant documents if necessary (e.g. `core_policies.md`).
 
 ## Acceptance Criteria
-- [ ] Update `schema.md` with hierarchical completion rules.
-- [ ] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior.
-- [ ] Verify that there are no conflicting statements across other core documentation.
+- [x] Update `schema.md` with hierarchical completion rules.
+- [x] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior.
+- [x] Verify that there are no conflicting statements across other core documentation.
 
 ### Stories
-- [ ] .foundry/stories/story-071-108-update-schema-macro-node-completion.md
-- [ ] .foundry/stories/story-071-109-update-adr001-macro-node-completion.md
-- [ ] .foundry/stories/story-071-110-verify-core-documentation.md
+- [x] .foundry/stories/story-071-108-update-schema-macro-node-completion.md
+- [x] .foundry/stories/story-071-109-update-adr001-macro-node-completion.md
+- [x] .foundry/stories/story-071-110-verify-core-documentation.md


### PR DESCRIPTION
Checked off the acceptance criteria and the listed stories in `epic-045-071-documentation-macro-node-completion.md` since all child stories are COMPLETED, allowing the orchestrator to transition the node.

---
*PR created automatically by Jules for task [1887899313875888184](https://jules.google.com/task/1887899313875888184) started by @szubster*