### PR TITLE
[Foundry] Break down epic-053-105 into daycare parsing stories

### DIFF
--- a/.foundry/epics/epic-053-105-daycare-save-parsing.md
+++ b/.foundry/epics/epic-053-105-daycare-save-parsing.md
@@ -34,4 +34,6 @@ Implement offline save parsing to extract real-time Daycare data.
 - Surface the hidden "Egg is waiting" memory flag.
 
 ## Acceptance Criteria
-- [ ] Break down into Stories.
+- [x] Break down into Stories.
+- [ ] .foundry/stories/story-105-240-daycare-gen2-parsing.md
+- [ ] .foundry/stories/story-105-241-daycare-gen3-parsing.md

--- a/.foundry/stories/story-105-240-daycare-gen2-parsing.md
+++ b/.foundry/stories/story-105-240-daycare-gen2-parsing.md
@@ -1,0 +1,28 @@
+---
+id: story-105-240-daycare-gen2-parsing
+type: STORY
+title: Parse Gen 2 Daycare Data
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-053-105-daycare-save-parsing
+tags:
+  - gen2
+  - breeding
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Parse Gen 2 Daycare Data
+
+## Context
+Extracting Gen 2 daycare info.
+
+## Acceptance Criteria
+- [ ] Create task to parse Gen 2 Daycare Pokémon.

--- a/.foundry/stories/story-105-241-daycare-gen3-parsing.md
+++ b/.foundry/stories/story-105-241-daycare-gen3-parsing.md
@@ -1,0 +1,29 @@
+---
+id: story-105-241-daycare-gen3-parsing
+type: STORY
+title: Parse Gen 3 Daycare Data
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on:
+  - story-105-240-daycare-gen2-parsing
+jules_session_id: null
+pr_number: null
+parent: epic-053-105-daycare-save-parsing
+tags:
+  - gen3
+  - breeding
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Parse Gen 3 Daycare Data
+
+## Context
+Extracting Gen 3 daycare info.
+
+## Acceptance Criteria
+- [ ] Create task to parse Gen 3 Daycare Pokémon.


### PR DESCRIPTION
This PR breaks down the `epic-053-105-daycare-save-parsing` into two smaller `STORY` nodes for Gen 2 and Gen 3 parsing, as per the late-binding logic.

- Created `story-105-240-daycare-gen2-parsing`
- Created `story-105-241-daycare-gen3-parsing` (depends on Gen 2 story)
- Updated the parent epic's markdown body to check off acceptance criteria and list the new stories.
- Kept the parent's YAML frontmatter untouched, respecting the hierarchical completion constraints.

---
*PR created automatically by Jules for task [3228881267899649676](https://jules.google.com/task/3228881267899649676) started by @szubster*