### PR TITLE
chore(foundry): mark story-078-122-gen3-parse-battle-frontier-symbols as completed

### DIFF
--- a/.foundry/stories/story-078-122-gen3-parse-battle-frontier-symbols.md
+++ b/.foundry/stories/story-078-122-gen3-parse-battle-frontier-symbols.md
@@ -28,10 +28,10 @@ notes: ''
 Extract the Gold and Silver symbol status flags for the 7 Battle Frontier facilities from the SaveBlock1 flags array, using `DataView` for bit manipulation, as discovered in `research-046-140-gen3-battle-frontier`.
 
 ## Acceptance Criteria
-- [ ] Parse Silver and Gold symbol flags for all 7 facilities.
-- [ ] Read correctly using byte offsets and bit indices within the flags array.
-- [ ] Fail gracefully if out of bounds.
+- [x] Parse Silver and Gold symbol flags for all 7 facilities.
+- [x] Read correctly using byte offsets and bit indices within the flags array.
+- [x] Fail gracefully if out of bounds.
 
 ### Tasks
-- [ ] task-122-234-parse-battle-frontier-symbols-impl
-- [ ] task-122-235-parse-battle-frontier-symbols-qa
+- [x] task-122-234-parse-battle-frontier-symbols-impl
+- [x] task-122-235-parse-battle-frontier-symbols-qa


### PR DESCRIPTION
Checks off the acceptance criteria checkboxes in `story-078-122-gen3-parse-battle-frontier-symbols.md` because the child implementation and QA tasks (`task-122-234-parse-battle-frontier-symbols-impl` and `task-122-235-parse-battle-frontier-symbols-qa`) are already marked `COMPLETED`.

This complies with ADR 007 and ADR 009 to allow the orchestrator to transition the story node out of `ACTIVE`.

---
*PR created automatically by Jules for task [1341492726355807837](https://jules.google.com/task/1341492726355807837) started by @szubster*