### PR TITLE
fix(breeding): prevent two shiny/carrier parents from breeding in Gen 2

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -105,3 +105,6 @@ When assigned a task to extract Gen 3 roamer map coordinates (`mapId` and `mapGr
 
 ## 2026-06-27: Rejecting Task due to Missing Dependencies
 Permanently failed `task-084-192-breeding-pair-algorithm-impl`. The task lacked sufficient clarity and missing dependencies related to Egg Groups. It was cancelled and replaced by `task-084-204-breeding-pair-algorithm-impl`. Its status has been updated to CANCELLED in the frontmatter, with a descriptive `rejection_reason`. Its acceptance criteria checkboxes were left unchecked, ensuring it correctly exits the DAG without masquerading as successfully completed.
+
+## 2026-06-29: Gen 2 Breeding Constraints
+In Generation 2, two Shiny or Shiny Carrier Pokémon cannot breed with each other. Shininess is determined by DVs, and Pokémon with identical or similar DVs are considered 'related' and incompatible for breeding. The breeding algorithm must explicitly exclude these pairs.

--- a/src/engine/breeding/pair_algorithm.test.ts
+++ b/src/engine/breeding/pair_algorithm.test.ts
@@ -44,10 +44,36 @@ describe('calculateBreedingPairs', () => {
     };
 
     const pairs = calculateBreedingPairs([p1, p2, p3]);
-    expect(pairs).toHaveLength(2);
-    expect(pairs[0]?.score).toBe(2);
-    expect(pairs[0]?.parentA.id).toBe('1');
-    expect(pairs[0]?.parentB.id).toBe('3');
+    // Since p1 and p3 are both shiny carriers, they cannot breed.
+    // p2 and p3 are both Female, so they cannot breed.
+    // So the only valid pair is p1 + p2.
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0]?.score).toBe(1);
+
+    // Check that p1 and p3 are not paired together
+    const pairIds = pairs.map((p) => `${p.parentA.id}-${p.parentB.id}`);
+    expect(pairIds).not.toContain('1-3');
+    expect(pairIds).not.toContain('3-1');
+  });
+
+  test('two shiny/shiny carrier parents cannot breed', () => {
+    const p1: PokemonWithMetadata = {
+      id: '1',
+      speciesId: 1,
+      gender: 'Male',
+      eggGroups: ['Monster'],
+      isShinyCarrier: true,
+    };
+    const p2: PokemonWithMetadata = {
+      id: '2',
+      speciesId: 2,
+      gender: 'Female',
+      eggGroups: ['Monster'],
+      isShiny: true,
+    };
+
+    const pairs = calculateBreedingPairs([p1, p2]);
+    expect(pairs).toHaveLength(0);
   });
 
   test('handles Ditto mechanics correctly', () => {

--- a/src/engine/breeding/pair_algorithm.ts
+++ b/src/engine/breeding/pair_algorithm.ts
@@ -83,5 +83,9 @@ function isValidPair(p1: PokemonWithMetadata, p2: PokemonWithMetadata): boolean 
   if (p1.gender === 'Genderless' || p2.gender === 'Genderless') return false;
   if (p1.gender === p2.gender) return false;
 
+  const p1IsShiny = p1.isShiny || p1.isShinyCarrier;
+  const p2IsShiny = p2.isShiny || p2.isShinyCarrier;
+  if (p1IsShiny && p2IsShiny) return false;
+
   return p1.eggGroups.some((group) => p2.eggGroups.includes(group));
 }


### PR DESCRIPTION
In Gen 2, two Shiny Pokémon cannot breed with each other because Shininess is determined by DVs (Determinant Values). Pokémon with matching or highly similar Defense and Special DVs (which Shinies share) are considered "related" by the Daycare and will refuse to breed. The algorithm must explicitly exclude these pairs from valid breeding combinations.

Updates:
- `src/engine/breeding/pair_algorithm.ts`: Modified `isValidPair` function to explicitly return `false` if both `p1` and `p2` are shiny or shiny carriers.
- `src/engine/breeding/pair_algorithm.test.ts`: Updated tests to adjust the existing expectations for shiny carriers and added a new test case validating that two Shiny/Shiny Carrier parents cannot breed.
- `.foundry/journals/coder.md`: Logged this Gen 2 breeding constraint.

---
*PR created automatically by Jules for task [16957739463122208839](https://jules.google.com/task/16957739463122208839) started by @szubster*