### PR TITLE
chore(foundry): mark epic-038-061-gen2-event-flag-parsing as completed

### DIFF
--- a/.foundry/epics/epic-038-061-gen2-event-flag-parsing.md
+++ b/.foundry/epics/epic-038-061-gen2-event-flag-parsing.md
@@ -25,10 +25,10 @@ notes: ''
 Develop the core save file parsing engine to extract specific time-gated event flags from Generation 2 save files. This is the foundational data layer required to power the dynamic event checklist. Note: We must NOT depend on RTC data from the save file itself, as it is emulator-dependent and incompatible with raw cartridge dumps.
 
 ## Acceptance Criteria
-- [ ] Parse event flags indicating completion of daily/weekly events.
-- [ ] Expose this data cleanly to the frontend UI components.
+- [x] Parse event flags indicating completion of daily/weekly events.
+- [x] Expose this data cleanly to the frontend UI components.
 
 
 ### Implementation Tasks
-- [ ] .foundry/stories/story-061-095-gen2-event-flag-extraction.md
-- [ ] .foundry/stories/story-061-096-gen2-event-data-layer.md
+- [x] .foundry/stories/story-061-095-gen2-event-flag-extraction.md
+- [x] .foundry/stories/story-061-096-gen2-event-data-layer.md


### PR DESCRIPTION
The Gen 2 event flag parsing implementation (`story-061-095`) and data layer integration (`story-061-096`) are fully complete. This empty-ish PR merely checks off the acceptance criteria checkboxes within `epic-038-061-gen2-event-flag-parsing.md` to unblock downstream dependencies without violating ADR 007 and ADR 009.

---
*PR created automatically by Jules for task [7332891714139288944](https://jules.google.com/task/7332891714139288944) started by @szubster*