### PR TITLE
chore(foundry): break down box duplicate analyzer PRD into Epics

### DIFF
--- a/.foundry/epics/epic-054-108-box-analyzer-save-parsing.md
+++ b/.foundry/epics/epic-054-108-box-analyzer-save-parsing.md
@@ -1,0 +1,42 @@
+---
+id: epic-054-108-box-analyzer-save-parsing
+type: EPIC
+title: Box Analyzer Save Parsing
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-086-054-box-duplicate-analyzer
+tags:
+  - feature
+  - backend
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Box Analyzer Save Parsing
+
+## Objective
+Implement the backend data grouping and aggregation logic to parse PC box data from Generation 2 and Generation 3 save files, extract all stored Pokémon, and group them by species ID for duplicate analysis.
+
+## Scope
+- Extract PC Box Pokémon from Gen 2 and Gen 3 save files.
+- Exclude Party Pokémon to prevent accidental releases.
+- Group the extracted Pokémon by their species ID.
+- Ensure calculation of Individual Values (DVs/IVs), Natures (Gen 3), Hidden Power (Type and Base Power), and Shininess for each Pokémon.
+- Format the aggregated data into a structure suitable for the frontend Comparison Matrix UI.
+
+## Dependencies
+- Existing save file parsing infrastructure for Gen 2 and Gen 3.
+
+## Acceptance Criteria
+- [ ] Implement Gen 2 PC box parsing and species grouping.
+- [ ] Implement Gen 3 PC box parsing and species grouping.
+- [ ] Verify that Party Pokémon are successfully excluded from the extracted data.
+- [ ] Ensure all required stats (DVs/IVs, Natures, Hidden Power, Shininess) are calculated correctly for each Pokémon.

--- a/.foundry/epics/epic-054-109-box-analyzer-matrix-ui.md
+++ b/.foundry/epics/epic-054-109-box-analyzer-matrix-ui.md
@@ -1,0 +1,42 @@
+---
+id: epic-054-109-box-analyzer-matrix-ui
+type: EPIC
+title: Box Analyzer Comparison Matrix UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on:
+  - epic-054-108-box-analyzer-save-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-086-054-box-duplicate-analyzer
+tags:
+  - feature
+  - ui
+  - ux
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Box Analyzer Comparison Matrix UI
+
+## Objective
+Develop the frontend "Duplicate Analyzer" view within DexHelper, featuring a tabular comparison matrix to display grouped Pokémon species and highlight critical competitive stats.
+
+## Scope
+- Create a dedicated view for the Duplicate Analyzer.
+- Implement a dense, tabular matrix layout using monospaced fonts (adhering to ADR 024 tactical hardware aesthetic).
+- Display required stat columns: Level, Gender, DVs/IVs, Calculated IV Total/Average, Nature, Hidden Power, and Shininess.
+- Implement visual highlighting for the "best" stats within a species group (e.g., perfect 31 IVs in green).
+
+## Dependencies
+- `epic-054-108-box-analyzer-save-parsing` for the grouped backend data.
+
+## Acceptance Criteria
+- [ ] Build the Comparison Matrix UI component.
+- [ ] Render all specified stat columns accurately.
+- [ ] Implement visual highlighting for optimal stats.
+- [ ] Ensure the UI adheres to the established design guidelines (ADR 024).

--- a/.foundry/epics/epic-054-110-box-analyzer-release-workflow.md
+++ b/.foundry/epics/epic-054-110-box-analyzer-release-workflow.md
@@ -1,0 +1,41 @@
+---
+id: epic-054-110-box-analyzer-release-workflow
+type: EPIC
+title: Box Analyzer Release Checklist Workflow
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on:
+  - epic-054-109-box-analyzer-matrix-ui
+jules_session_id: null
+pr_number: null
+parent: prd-086-054-box-duplicate-analyzer
+tags:
+  - feature
+  - ui
+  - state-management
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Box Analyzer Release Checklist Workflow
+
+## Objective
+Implement the interactive tagging system and summary sidebar that allows users to mark specific duplicate Pokémon for release and persist this state locally during their session.
+
+## Scope
+- Add a toggleable "To Release" state for each Pokémon row in the Comparison Matrix.
+- Build a persistent sidebar or summary view displaying all tagged Pokémon.
+- The checklist must clearly indicate the Box Number and Slot/Position for easy in-game reference.
+- Implement local session persistence for tagged items (e.g., using IndexedDB or component state) without modifying the original `.sav` file.
+
+## Dependencies
+- `epic-054-109-box-analyzer-matrix-ui` for the matrix UI where tagging will occur.
+
+## Acceptance Criteria
+- [ ] Implement the "To Release" toggle functionality in the matrix.
+- [ ] Build the Checklist summary view showing Box Number and Slot/Position.
+- [ ] Implement local state persistence for the tags during the active session.

--- a/.foundry/prds/prd-086-054-box-duplicate-analyzer.md
+++ b/.foundry/prds/prd-086-054-box-duplicate-analyzer.md
@@ -60,4 +60,7 @@ Build a "Duplicate Analyzer" view inside DexHelper's PC Box tracking system. Thi
 - **Speed:** Grouping and calculating IVs/Hidden Power for hundreds of Pokémon must be near-instantaneous upon loading the `.sav` file.
 
 ## 5. Next Steps
-- [ ] Break down this PRD into Epics for backend parsing extensions and frontend UI implementation.
+- [x] Break down this PRD into Epics for backend parsing extensions and frontend UI implementation.
+- [ ] .foundry/epics/epic-054-108-box-analyzer-save-parsing.md
+- [ ] .foundry/epics/epic-054-109-box-analyzer-matrix-ui.md
+- [ ] .foundry/epics/epic-054-110-box-analyzer-release-workflow.md


### PR DESCRIPTION
Break down the `prd-086-054-box-duplicate-analyzer` node into three Epic nodes and update the parent PRD markdown body with references to the new children.

---
*PR created automatically by Jules for task [14497817569503950135](https://jules.google.com/task/14497817569503950135) started by @szubster*