### PR TITLE
Verify Documentation Macro Node Completion Epic

### DIFF
--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -55,3 +55,6 @@ When implementing shared state for multiple visual representations of the same u
 
 **Why this matters:**
 This prevents disjointed UI states, eliminates redundant parsing overhead, and simplifies synchronization. Future UI features that need DAG data (e.g., a Permanent Failure Dashboard) must subscribe to this central provider rather than establishing independent data fetching or parsing pipelines.
+
+### Epic Documentation Macro Node Completion Verification
+When verifying `epic-045-071-documentation-macro-node-completion`, it was noted that `story-071-110-verify-core-documentation` was completed without any corresponding child tasks. Late-binding nodes can be closed out if the work is verified or completed manually, but this highlights the need for the Auditor to always recursively confirm that all descendants are truly COMPLETED, and if a node has no children, that the intent of the node was actually fulfilled in the codebase.


### PR DESCRIPTION
Verifies the completion of the `epic-045-071-documentation-macro-node-completion` node. It was found that all descendant stories and their tasks are completed. It was also noted that `story-071-110-verify-core-documentation` had no child tasks, but its intent to verify core documentation was fulfilled. The auditor journal was updated to reflect this learning.

---
*PR created automatically by Jules for task [7185544490936476053](https://jules.google.com/task/7185544490936476053) started by @szubster*