### PR TITLE
QA Rejection: Breeding Pair Algorithm Implementation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -7,3 +7,5 @@ When you finish reviewing a node, do not modify the YAML frontmatter. Update onl
 
 ## Gen 2 Breeding Algorithm Constraints
 I rejected the implementation of the `calculateBreedingPairs` algorithm because it prioritized pairing two Shiny/Shiny Carrier Pokémon together (score = 2). In Gen 2, two Shiny Pokémon cannot breed with each other because Shininess is determined by DVs (Determinant Values). Pokémon with matching or highly similar Defense and Special DVs (which Shinies share) are considered "related" by the Daycare and will refuse to breed. The algorithm must explicitly exclude these pairs from valid breeding combinations.
+
+- Rejected task-084-210-breeding-pair-algorithm-impl because the algorithm does not handle the Gen 2 rule that prevents two Shiny (or Shiny Carrier) Pokémon from breeding with each other due to overlapping DVs. The rule states that shininess is determined by DVs, and Pokémon with identical or similar DVs are considered 'related' and incompatible for breeding.

--- a/.foundry/tasks/task-084-210-breeding-pair-algorithm-impl.md
+++ b/.foundry/tasks/task-084-210-breeding-pair-algorithm-impl.md
@@ -2,7 +2,7 @@
 id: task-084-210-breeding-pair-algorithm-impl
 type: TASK
 title: Implement Shiny Carrier Breeding Pair Algorithm
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-19'
 updated_at: '2026-06-29'
@@ -17,8 +17,8 @@ tags:
   - gen2
   - backend
 research_references: []
-rejection_count: 2
-rejection_reason: ''
+rejection_count: 3
+rejection_reason: 'Task implementation rejected because the algorithm does not handle the Gen 2 rule that prevents two Shiny (or Shiny Carrier) Pokémon from breeding with each other due to overlapping DVs.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-084-211-breeding-pair-algorithm-qa.md
+++ b/.foundry/tasks/task-084-211-breeding-pair-algorithm-qa.md
@@ -48,3 +48,4 @@ Verify the correctness of the Shiny Carrier breeding algorithm implementation, e
 
 ### QA Rejection
 Task implementation rejected because the algorithm does not handle the Gen 2 rule that prevents two Shiny (or Shiny Carrier) Pokémon from breeding with each other due to overlapping DVs.
+- Note: Failed the target task `task-084-210-breeding-pair-algorithm-impl` because the algorithm does not handle the Gen 2 rule that prevents two Shiny (or Shiny Carrier) Pokémon from breeding with each other due to overlapping DVs.


### PR DESCRIPTION
QA rejected the implementation of `task-084-210-breeding-pair-algorithm-impl` because it failed to account for Gen 2 Shiny breeding rules (where Shinies cannot breed with each other due to overlapping DVs).
Updated target task status to FAILED, incremented rejection count, documented the reason in the QA journal, and noted the failure in the QA task.

---
*PR created automatically by Jules for task [14717565454511215675](https://jules.google.com/task/14717565454511215675) started by @szubster*