### PR TITLE
Reject epic-045-070: Incomplete functional boundaries

### DIFF
--- a/.foundry/epics/epic-045-070-implement-dag-context.md
+++ b/.foundry/epics/epic-045-070-implement-dag-context.md
@@ -34,4 +34,7 @@ As per ADR 013 and ADR 017, the core DAG data state must be lifted into a shared
 ## Acceptance Criteria
 - [x] Break down into Stories
 - [x] .foundry/stories/story-070-108-create-dag-context-interfaces.md
-- [x] .foundry/stories/story-070-109-implement-dag-provider.md
+- [ ] .foundry/stories/story-070-109-implement-dag-provider.md
+
+### Auditor Rejection
+The generated artifacts do not meet the Acceptance Criteria of the Epic. While DagContext and DagProvider were created, DagProvider does not actually manage the core DAG data state (nodes, edges) by fetching it, nor does it wrap the DAG views. This work was improperly deferred to story-078-120. The Epic cannot be verified until the provider fully manages and provides the state as originally required.

--- a/.foundry/ideas/idea-096-macro-node-boundary-enforcement.md
+++ b/.foundry/ideas/idea-096-macro-node-boundary-enforcement.md
@@ -1,0 +1,27 @@
+---
+id: idea-096-macro-node-boundary-enforcement
+type: IDEA
+title: Enforce Macro Node Functional Boundaries
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - process
+  - orchestrator
+rejection_count: 0
+rejection_reason: ''
+notes: 'Spawned by Auditor after epic-045-070 rejection'
+---
+
+# Enforce Macro Node Functional Boundaries
+
+## Context
+Audits reveal that EPICs are being verified before their functional requirements are fully implemented, often because the spawned STORYs only scaffolded the architecture without integrating it.
+
+## Proposal
+Create a mechanism to ensure that an EPIC cannot be marked COMPLETED until its functional requirements are verifiably integrated into the application, not just scaffolded in isolated components.

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -55,3 +55,6 @@ When implementing shared state for multiple visual representations of the same u
 
 **Why this matters:**
 This prevents disjointed UI states, eliminates redundant parsing overhead, and simplifies synchronization. Future UI features that need DAG data (e.g., a Permanent Failure Dashboard) must subscribe to this central provider rather than establishing independent data fetching or parsing pipelines.
+
+### Lesson: Hierarchical Verification Failures
+When verifying macro nodes (EPICs/STORYs), verify that the implemented code actually fulfills the parent's requirements. In epic-045-070-implement-dag-context, the sub-tasks created the context and provider, but the provider didn't actually implement the data fetching or wrap the views, leading to premature verification. Macro node requirements must be fully realized in the codebase, not just partially scaffolded, before the parent is verified.


### PR DESCRIPTION
Rejects the verification of `epic-045-070-implement-dag-context` because the functional requirements were not fully met. The `DagProvider` was created but it does not actually manage the core DAG data state by fetching it, nor does it wrap the DAG views. This work was improperly deferred to another story. 

This PR unchecks the Acceptance Criteria for the `DagProvider` story, appends an `### Auditor Rejection` section to the Epic, and updates the auditor journal with this lesson. It also creates a new `IDEA` node (`idea-096-macro-node-boundary-enforcement`) to propose a mechanism to ensure EPICs cannot be marked COMPLETED until their functional requirements are verifiably integrated into the application.

---
*PR created automatically by Jules for task [16773937371536664266](https://jules.google.com/task/16773937371536664266) started by @szubster*