### PR TITLE
doc(research): document Gen 3 TV Block parser failure constraints

### DIFF
--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -63,3 +63,6 @@ When designing features for Generation 3 hardware, be aware of the stark differe
 **Architectural Constraint:** It is impossible to statically extract a roamer's exact map location from a `.sav` file.
 
 **UI Pivot Strategy:** When faced with impossible geographic extraction, pivot UI designs from "map-based tracking" (e.g., Route Radars) to "stat-based interception dossiers." We can still provide value by exposing the hidden internal state that *is* saved, such as the `Roamer` struct (IVs, HP, Nature) and its overarching `active` boolean flag, presenting it under a tactical "data snooping" aesthetic.
+
+## Lesson: Save File Parsing Reusable Constants
+When documenting memory offsets or drafting parser requirements, it is a strict architectural constraint (enforced by QA Validation Rules) that all memory offsets, lengths, bit locations, and shifts must be defined as reusable, descriptive constants at the module level. Inline magic numbers are strictly forbidden and will result in permanent failure.

--- a/.foundry/research/research-121-216-gen3-tv-block-parser-failure.md
+++ b/.foundry/research/research-121-216-gen3-tv-block-parser-failure.md
@@ -24,3 +24,8 @@ notes: ''
 
 ## Objective
 Investigate the root cause of the `task-121-171-gen3-tv-block-parser-impl` failure (which reached its max rejection count). Determine why the `DataView` API approach failed or what architectural constraints prevented its successful implementation, and document the findings to unblock the replacement implementation tasks.
+
+## Findings
+The `task-121-171-gen3-tv-block-parser-impl` failed permanently because the implementation violated a strict QA architectural constraint. Specifically, it failed to define memory offsets, lengths, bit locations, and shifts as reusable constants at the module level, and instead used inline magic numbers.
+
+To unblock replacement implementation tasks (such as `task-121-219` and `task-121-220`), their blueprints must explicitly specify this constraint, mandating the use of reusable constants over magic numbers to prevent QA rejection.


### PR DESCRIPTION
This PR completes `research-121-216-gen3-tv-block-parser-failure`.

- Investigated the root cause of the `task-121-171` failure by reviewing the tech lead and QA journals.
- Confirmed that the implementation failed QA validation because it violated the architectural constraint mandating that memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level rather than inline magic numbers.
- Appended findings directly to the research document to unblock replacement tasks.
- Recorded a new long-term memory in the `researcher.md` journal regarding this save file parsing requirement.

---
*PR created automatically by Jules for task [674929458040234483](https://jules.google.com/task/674929458040234483) started by @szubster*