### PR TITLE
chore: breakdown tailwind v4 utility migration epic into granular stories

### DIFF
--- a/.foundry/epics/epic-071-097-define-tailwind-v4-utilities-retry.md
+++ b/.foundry/epics/epic-071-097-define-tailwind-v4-utilities-retry.md
@@ -40,3 +40,8 @@ Extract and consolidate common, repetitive Tailwind class patterns used througho
 ## Acceptance Criteria
 - [ ] Appropriate `@utility` primitives are defined in `src/index.css`.
 - [ ] Tailwind v4 formatting and structure is respected.
+
+## Child Nodes
+- [ ] .foundry/stories/story-097-242-tailwind-v4-tactical-containers.md
+- [ ] .foundry/stories/story-097-243-tailwind-v4-tactical-interactive.md
+- [ ] .foundry/stories/story-097-244-tailwind-v4-tactical-typography.md

--- a/.foundry/stories/story-097-242-tailwind-v4-tactical-containers.md
+++ b/.foundry/stories/story-097-242-tailwind-v4-tactical-containers.md
@@ -1,0 +1,30 @@
+---
+id: story-097-242-tailwind-v4-tactical-containers
+type: STORY
+title: Extract Tactical Container Utilities
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-06-29"
+updated_at: "2026-06-29"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-071-097-define-tailwind-v4-utilities-retry
+tags:
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Extract Tactical Container Utilities
+
+## Objective
+Define the `tactical-panel` and `tactical-card` custom utilities in `src/index.css` using Tailwind v4's native `@utility` directive.
+
+## Acceptance Criteria
+- [ ] `tactical-panel` utility is defined in `src/index.css`.
+- [ ] `tactical-card` utility is defined in `src/index.css`.
+- [ ] The definitions follow the guidelines in ADR 024.

--- a/.foundry/stories/story-097-243-tailwind-v4-tactical-interactive.md
+++ b/.foundry/stories/story-097-243-tailwind-v4-tactical-interactive.md
@@ -1,0 +1,31 @@
+---
+id: story-097-243-tailwind-v4-tactical-interactive
+type: STORY
+title: Extract Tactical Interactive Utilities
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-06-29"
+updated_at: "2026-06-29"
+depends_on:
+  - story-097-242-tailwind-v4-tactical-containers
+jules_session_id: null
+pr_number: null
+parent: epic-071-097-define-tailwind-v4-utilities-retry
+tags:
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Extract Tactical Interactive Utilities
+
+## Objective
+Define the `tactical-button` and `tactical-input` custom utilities in `src/index.css` using Tailwind v4's native `@utility` directive.
+
+## Acceptance Criteria
+- [ ] `tactical-button` utility is defined in `src/index.css`.
+- [ ] `tactical-input` utility is defined in `src/index.css`.
+- [ ] The definitions follow the guidelines in ADR 024.

--- a/.foundry/stories/story-097-244-tailwind-v4-tactical-typography.md
+++ b/.foundry/stories/story-097-244-tailwind-v4-tactical-typography.md
@@ -1,0 +1,31 @@
+---
+id: story-097-244-tailwind-v4-tactical-typography
+type: STORY
+title: Extract Tactical Typography and State Utilities
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-06-29"
+updated_at: "2026-06-29"
+depends_on:
+  - story-097-243-tailwind-v4-tactical-interactive
+jules_session_id: null
+pr_number: null
+parent: epic-071-097-define-tailwind-v4-utilities-retry
+tags:
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Extract Tactical Typography and State Utilities
+
+## Objective
+Define the `tactical-text` and `tactical-focus` custom utilities in `src/index.css` using Tailwind v4's native `@utility` directive.
+
+## Acceptance Criteria
+- [ ] `tactical-text` utility is defined in `src/index.css`.
+- [ ] `tactical-focus` utility is defined in `src/index.css`.
+- [ ] The definitions follow the guidelines in ADR 024.


### PR DESCRIPTION
This PR breaks down `epic-071-097-define-tailwind-v4-utilities-retry` into three sequential STORY nodes to handle the migration of existing utility classes to Tailwind v4 native `@utility` directives.

This PR adheres to the Foundry hierarchical completion rules by:
1. Creating independent story nodes for extracting containers, interactives, and typography.
2. Linking stories chronologically in the dependency DAG to enforce smooth integration.
3. Appending child references to the parent epic while ensuring the parent acceptance criteria remain explicitly unchecked, retaining the epic in its current state until downstream nodes finish.

---
*PR created automatically by Jules for task [4043626321245444506](https://jules.google.com/task/4043626321245444506) started by @szubster*