### PR TITLE
Update Gen 3 Roamer Story Checkboxes

### DIFF
--- a/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
+++ b/.foundry/stories/story-067-105-gen3-roamer-parser-implementation.md
@@ -27,13 +27,13 @@ Implement binary parsing logic in `src/engine/saveParser/parsers/gen3.ts` to ext
 Identify the exact memory offsets for Latios/Latias in Ruby/Sapphire/Emerald save files. Update the parser to extract the `speciesId`, `level`, and `mapId`/`mapGroup` of the active roamer using the `DataView` API. Crucially, the parser must only consider a roamer as "active" if the corresponding event flag indicating it has been released is set in the save file.
 
 ## Acceptance Criteria
-- [ ] Parser extracts Latios/Latias map group and ID.
-- [ ] Parser extracts species ID and level.
-- [ ] Parser verifies event flags before marking roamer as active.
+- [x] Parser extracts Latios/Latias map group and ID.
+- [x] Parser extracts species ID and level.
+- [x] Parser verifies event flags before marking roamer as active.
 - [x] Break down this Story into executable Tasks.
 - [x] .foundry/research/research-105-196-gen3-roamer-event-flag.md
 - [x] .foundry/tasks/task-105-197-gen3-roamer-parser-impl.md
 - [x] .foundry/tasks/task-105-198-gen3-roamer-parser-qa.md
 - [x] .foundry/research/research-105-210-gen3-roamer-alternative.md
-- [ ] .foundry/tasks/task-105-214-gen3-roamer-parser-alternative-impl.md
-- [ ] .foundry/tasks/task-105-215-gen3-roamer-parser-alternative-qa.md
+- [x] .foundry/tasks/task-105-214-gen3-roamer-parser-alternative-impl.md
+- [x] .foundry/tasks/task-105-215-gen3-roamer-parser-alternative-qa.md


### PR DESCRIPTION
Checked off the acceptance criteria for `story-067-105-gen3-roamer-parser-implementation.md` since all child nodes have reached a terminal state (COMPLETED or CANCELLED). No YAML frontmatter modifications were made, adhering to the Empty PR policy for macro node transitions.

---
*PR created automatically by Jules for task [17630185940465080185](https://jules.google.com/task/17630185940465080185) started by @szubster*