### PR TITLE
feat: break down gen 3 roamer core extraction epic into stories

### DIFF
--- a/.foundry/epics/epic-044-101-gen3-roamer-core-extraction-v2.md
+++ b/.foundry/epics/epic-044-101-gen3-roamer-core-extraction-v2.md
@@ -33,4 +33,6 @@ Parse the `Roamer` struct from the save file (SaveBlock1) to extract the IVs, Pe
 - [ ] Implement robust `DataView` parsing for the Gen 3 `Roamer` struct across all Gen 3 game versions.
 - [ ] Extract and expose the `active` boolean to determine if the roamer is currently available in the game world.
 - [ ] Write unit tests verifying extraction against known good save fixtures for each game version.
-- [ ] Story Owner: Break down this Epic into executable Stories.
+- [x] Story Owner: Break down this Epic into executable Stories.
+- [ ] story-101-242-gen3-roamer-parser
+- [ ] story-101-243-gen3-roamer-state-schema

--- a/.foundry/stories/story-101-242-gen3-roamer-parser.md
+++ b/.foundry/stories/story-101-242-gen3-roamer-parser.md
@@ -1,0 +1,40 @@
+---
+id: story-101-242-gen3-roamer-parser
+type: STORY
+title: Gen 3 Roamer DataView Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-044-101-gen3-roamer-core-extraction-v2
+tags:
+  - gen3
+  - roamer
+  - dataview
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer DataView Parsing
+
+## Objective
+Implement robust `DataView` parsing for the Gen 3 `Roamer` struct across all Gen 3 game versions (Emerald, Ruby/Sapphire, FireRed/LeafGreen) to fulfill the first and third acceptance criteria of Epic 101.
+
+## Description
+The `Roamer` struct holds the state of the roaming legendary. We need to parse this struct from SaveBlock1.
+- **Emerald:** `0x31DC`
+- **Ruby/Sapphire:** `0x3144`
+- **FireRed/LeafGreen:** `0x30D0`
+
+We must extract IVs (`0x00`), Personality (`0x04`), Species (`0x08`), HP (`0x0A`), Level (`0x0C`), Status (`0x0D`), and Active boolean (`0x13`).
+
+## Acceptance Criteria
+- [ ] Implement a parser using `DataView` API that extracts the `Roamer` struct based on the version-specific offsets.
+- [ ] Extract and expose the `active` boolean properly.
+- [ ] Add unit tests using Vitest verifying the extraction logic against mock save data blocks for Emerald, RS, and FRLG.
+- [ ] Tech Lead: Break down this Story into executable Tasks.

--- a/.foundry/stories/story-101-243-gen3-roamer-state-schema.md
+++ b/.foundry/stories/story-101-243-gen3-roamer-state-schema.md
@@ -1,0 +1,35 @@
+---
+id: story-101-243-gen3-roamer-state-schema
+type: STORY
+title: Gen 3 Roamer State Schema
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on:
+  - story-101-242-gen3-roamer-parser
+jules_session_id: null
+pr_number: null
+parent: epic-044-101-gen3-roamer-core-extraction-v2
+tags:
+  - gen3
+  - roamer
+  - schema
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer State Schema
+
+## Objective
+Define the application schema `Gen3RoamerState` and integrate it with the parsed data to support the UI requirements (Dossier format).
+
+## Description
+Based on the parsed `Roamer` struct, define the exact Typescript interface `Gen3RoamerState` as specified in `.foundry/docs/knowledge_base/gen3_roamer_offsets.md`. Ensure that the parser populates this interface, specifically making the `isActive` property prominent.
+
+## Acceptance Criteria
+- [ ] Define the `Gen3RoamerState` Typescript interface.
+- [ ] Map the parsed raw data from the `Roamer` struct to the `Gen3RoamerState` object.
+- [ ] Tech Lead: Break down this Story into executable Tasks.


### PR DESCRIPTION
This PR fulfills the Story Owner's responsibility for Epic `epic-044-101-gen3-roamer-core-extraction-v2` by breaking it down into executable stories:

- `story-101-242-gen3-roamer-parser`: Implements the `DataView` parsing of the `Roamer` struct from SaveBlock1 across Emerald, RS, and FRLG offsets.
- `story-101-243-gen3-roamer-state-schema`: Defines the `Gen3RoamerState` TypeScript interface and integrates the parsed struct data.

The Epic's acceptance criteria for the breakdown has been checked off and the child stories appended to the body.

---
*PR created automatically by Jules for task [13225066515218828724](https://jules.google.com/task/13225066515218828724) started by @szubster*