### PR TITLE
Create Story to implement DagProvider state management and wrapping logic

### DIFF
--- a/.foundry/epics/epic-045-070-implement-dag-context.md
+++ b/.foundry/epics/epic-045-070-implement-dag-context.md
@@ -35,6 +35,7 @@ As per ADR 013 and ADR 017, the core DAG data state must be lifted into a shared
 - [x] Break down into Stories
 - [x] .foundry/stories/story-070-108-create-dag-context-interfaces.md
 - [ ] .foundry/stories/story-070-109-implement-dag-provider.md
+- [ ] .foundry/stories/story-070-245-implement-dag-provider-state-management.md
 
 ### Auditor Rejection
 The generated artifacts do not meet the Acceptance Criteria of the Epic. While DagContext and DagProvider were created, DagProvider does not actually manage the core DAG data state (nodes, edges) by fetching it, nor does it wrap the DAG views. This work was improperly deferred to story-078-120. The Epic cannot be verified until the provider fully manages and provides the state as originally required.

--- a/.foundry/stories/story-070-245-implement-dag-provider-state-management.md
+++ b/.foundry/stories/story-070-245-implement-dag-provider-state-management.md
@@ -1,0 +1,29 @@
+---
+id: story-070-245-implement-dag-provider-state-management
+type: STORY
+title: Implement DagProvider State Management and Wrapper
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on:
+  - story-070-108-create-dag-context-interfaces
+jules_session_id: null
+pr_number: null
+parent: epic-045-070-implement-dag-context
+tags:
+  - architecture
+  - ui
+  - context
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement DagProvider State Management and Wrapper
+
+## Overview
+The Auditor rejected `epic-045-070-implement-dag-context` because `DagProvider` does not fetch or manage the core DAG data state, nor does it wrap the DAG views. This story ensures that the state management, data fetching, and view wrapping logic are correctly implemented in `DagProvider`.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
The Auditor rejected `epic-045-070-implement-dag-context` because `DagProvider` was created but does not fetch or manage the core DAG data state, nor does it wrap the DAG views.

This PR creates a new Story node (`story-070-245-implement-dag-provider-state-management`) and appends it to the Epic's Acceptance Criteria to ensure the `tech_lead` plans the tasks to properly implement the state management and wrapper logic for `DagProvider`.

---
*PR created automatically by Jules for task [10055485629191340062](https://jules.google.com/task/10055485629191340062) started by @szubster*