### PR TITLE
Create STORY node for item list validation

### DIFF
--- a/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
+++ b/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
@@ -38,3 +38,4 @@ Currently, valid item lists are either manually maintained or fetched ad-hoc. Ma
 - [ ] Output the correct `items.jsonl` data payload.
 
 - [x] .foundry/stories/story-087-128-dynamic-item-list-parsing.md
+- [ ] .foundry/stories/story-087-245-item-list-validation.md

--- a/.foundry/stories/story-087-245-item-list-validation.md
+++ b/.foundry/stories/story-087-245-item-list-validation.md
@@ -1,0 +1,36 @@
+---
+id: story-087-245-item-list-validation
+type: STORY
+title: Item List Generation Validation and Mapping
+status: READY
+owner_persona: tech_lead
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on:
+  - story-087-128-dynamic-item-list-parsing
+jules_session_id: null
+pr_number: null
+parent: epic-049-087-dynamic-item-list-parsing
+tags:
+  - refactor
+  - build
+  - db
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Item List Generation Validation and Mapping
+
+## Background
+The extraction of item data into `items.jsonl` has been implemented. However, we need to ensure that proper validation is handled, such as mapping across generations and aligning PokeAPI IDs to internal ROM IDs for consistency.
+
+## Goals
+1. Handle validation required for items, including cross-generation discrepancies.
+2. Establish robust mapping between PokeAPI IDs and internal ROM IDs where required.
+
+## Acceptance Criteria
+- [ ] Implement cross-generation mapping logic for items.
+- [ ] Ensure PokeAPI IDs are mapped to internal ROM IDs accurately.
+- [ ] Break down this STORY into concrete TASK nodes for implementation.


### PR DESCRIPTION
This PR creates the `.foundry/stories/story-087-245-item-list-validation.md` STORY node as per the acceptance criteria in `epic-049-087-dynamic-item-list-parsing.md`. It assigns the story to the `tech_lead` persona and sets the proper parent/depends_on frontmatter fields. The Epic's checklist is also updated.

---
*PR created automatically by Jules for task [6351029732875519498](https://jules.google.com/task/6351029732875519498) started by @szubster*