### PR TITLE
Break down Tailwind Designer Persona Ownership Retry Epic into Stories

### DIFF
--- a/.foundry/epics/epic-071-100-tailwind-designer-persona-retry.md
+++ b/.foundry/epics/epic-071-100-tailwind-designer-persona-retry.md
@@ -33,3 +33,7 @@ Enhance the existing scheduled `palette` persona to maintain `src/index.css`, en
 ## Acceptance Criteria
 - [ ] Agent prompts/configurations are updated to assign styling ownership to the `palette` persona.
 - [ ] Relevant documentation is updated to reflect this new responsibility.
+
+### Child Stories
+- [ ] .foundry/stories/story-100-245-update-palette-persona-retry.md
+- [ ] .foundry/stories/story-100-246-document-palette-styling-ownership-retry.md

--- a/.foundry/stories/story-100-245-update-palette-persona-retry.md
+++ b/.foundry/stories/story-100-245-update-palette-persona-retry.md
@@ -1,0 +1,33 @@
+---
+id: story-100-245-update-palette-persona-retry
+type: STORY
+title: Update palette agent prompt to define ownership of Tailwind styling
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-071-100-tailwind-designer-persona-retry
+tags:
+  - styling
+  - agents
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update palette agent prompt to define ownership of Tailwind styling
+
+## Objective
+Update the relevant agent prompts or system configurations to explicitly define the scheduled `palette` persona's responsibility for maintaining `src/index.css`, enforcing the tactical hardware aesthetic, and managing custom `@utility` primitives.
+
+## Scope
+1. Update `.github/agents/palette.md` to clarify its ownership over `src/index.css`.
+2. Explicitly define responsibility for tactical utility definitions via `@utility` per ADR 024.
+
+## Acceptance Criteria
+- [ ] Agent prompt explicitly states `palette` persona owns `src/index.css`.
+- [ ] Palette persona is tasked with enforcing the tactical hardware aesthetic and managing custom `@utility` primitives.

--- a/.foundry/stories/story-100-246-document-palette-styling-ownership-retry.md
+++ b/.foundry/stories/story-100-246-document-palette-styling-ownership-retry.md
@@ -1,0 +1,35 @@
+---
+id: story-100-246-document-palette-styling-ownership-retry
+type: STORY
+title: Update documentation to reflect palette persona styling ownership
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on:
+  - story-100-245-update-palette-persona-retry
+jules_session_id: null
+pr_number: null
+parent: epic-071-100-tailwind-designer-persona-retry
+tags:
+  - styling
+  - agents
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update documentation to reflect palette persona styling ownership
+
+## Objective
+Update `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` to formally document this expanded styling ownership within the multi-agent pipeline.
+
+## Scope
+1. Document the `palette` persona's responsibility over `src/index.css` and custom tactical `@utility` primitives in the relevant Foundry system definitions and policies.
+2. Ensure it aligns with ADR 024.
+
+## Acceptance Criteria
+- [ ] `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` is updated.
+- [ ] Documentation accurately reflects `palette` ownership of styling per ADR 024.


### PR DESCRIPTION
This PR breaks down `epic-071-100-tailwind-designer-persona-retry` into two child stories (`story-100-245-update-palette-persona-retry.md` and `story-100-246-document-palette-styling-ownership-retry.md`), assigns them to the `tech_lead` persona, and appends them to the epic's markdown body. The epic's acceptance criteria remain unchecked as the work is now delegated.

---
*PR created automatically by Jules for task [15427290488937628359](https://jules.google.com/task/15427290488937628359) started by @szubster*