### PR TITLE
feat: archive CANCELLED nodes alongside COMPLETED in TPM sweep

### DIFF
--- a/.foundry/tasks/task-000-212-tpm-sweep-cancelled-nodes-impl.md
+++ b/.foundry/tasks/task-000-212-tpm-sweep-cancelled-nodes-impl.md
@@ -34,6 +34,6 @@ Update the `sweep-active-nodes.ts` script to also sweep and archive nodes that a
 3. Update any relevant unit tests (e.g., `sweep-active-nodes.test.ts`) to cover `CANCELLED` nodes.
 
 ## Acceptance Criteria
-- [ ] The `sweep-active-nodes.ts` script successfully identifies and archives `CANCELLED` nodes.
-- [ ] Existing functionality for sweeping `COMPLETED` nodes remains intact.
-- [ ] Unit tests are updated and all pass.
+- [x] The `sweep-active-nodes.ts` script successfully identifies and archives `CANCELLED` nodes.
+- [x] Existing functionality for sweeping `COMPLETED` nodes remains intact.
+- [x] Unit tests are updated and all pass.

--- a/.github/scripts/sweep-active-nodes.test.ts
+++ b/.github/scripts/sweep-active-nodes.test.ts
@@ -42,4 +42,40 @@ describe('sweepActiveNodes', () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toBe(path.join('.foundry', 'tasks', 'nested', 'active-task.md'));
   });
+
+  it('should archive COMPLETED and CANCELLED nodes', () => {
+    createValidTestNode(testEnvPath, '.foundry/ideas/completed-node.md', { status: 'COMPLETED', type: 'IDEA' });
+    createValidTestNode(testEnvPath, '.foundry/ideas/cancelled-node.md', { status: 'CANCELLED', type: 'IDEA' });
+    createValidTestNode(testEnvPath, '.foundry/ideas/active-node.md', { status: 'ACTIVE', type: 'IDEA' });
+    createValidTestNode(testEnvPath, '.foundry/ideas/pending-node.md', { status: 'PENDING', type: 'IDEA' });
+
+    // Invalid node
+    fs.writeFileSync(path.join(testEnvPath, '.foundry/ideas/invalid-node.md'), 'not a valid frontmatter', 'utf-8');
+
+    const result = sweepActiveNodes(testEnvPath);
+
+    // Result should only contain ACTIVE nodes
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(path.join('.foundry', 'ideas', 'active-node.md'));
+
+    // Check that files were moved
+    expect(fs.existsSync(path.join(testEnvPath, '.foundry/ideas/completed-node.md'))).toBe(false);
+    expect(fs.existsSync(path.join(testEnvPath, '.foundry/ideas/cancelled-node.md'))).toBe(false);
+    expect(fs.existsSync(path.join(testEnvPath, '.foundry/archive/ideas/completed-node.md'))).toBe(true);
+    expect(fs.existsSync(path.join(testEnvPath, '.foundry/archive/ideas/cancelled-node.md'))).toBe(true);
+
+    // Check that non-archived files were NOT moved
+    expect(fs.existsSync(path.join(testEnvPath, '.foundry/ideas/active-node.md'))).toBe(true);
+    expect(fs.existsSync(path.join(testEnvPath, '.foundry/ideas/pending-node.md'))).toBe(true);
+  });
+
+  it('should preserve nested directories when archiving', () => {
+    createValidTestNode(testEnvPath, '.foundry/tasks/nested/completed-task.md', { status: 'COMPLETED', type: 'TASK' });
+
+    const result = sweepActiveNodes(testEnvPath);
+    expect(result).toHaveLength(0); // Should return empty since it's COMPLETED
+
+    expect(fs.existsSync(path.join(testEnvPath, '.foundry/tasks/nested/completed-task.md'))).toBe(false);
+    expect(fs.existsSync(path.join(testEnvPath, '.foundry/archive/tasks/nested/completed-task.md'))).toBe(true);
+  });
 });

--- a/.github/scripts/sweep-active-nodes.ts
+++ b/.github/scripts/sweep-active-nodes.ts
@@ -23,6 +23,9 @@ export function sweepActiveNodes(repoRoot: string): string[] {
 
     for (const e of entries) {
       if (e.isDirectory()) {
+        if (e.name === 'archive' && current === foundryDir) {
+          continue;
+        }
         walk(path.join(current, e.name));
       } else if (e.isFile() && e.name.endsWith('.md')) {
         results.push(path.join(current, e.name));
@@ -38,9 +41,20 @@ export function sweepActiveNodes(repoRoot: string): string[] {
     try {
       const content = fs.readFileSync(fp, 'utf-8');
       const parsed = matter(content);
-      if (parsed.data && parsed.data['status'] === 'ACTIVE') {
+      const status = parsed.data?.['status'];
+
+      if (status === 'ACTIVE') {
         const relativePath = path.relative(repoRoot, fp);
         activeNodes.push(relativePath);
+      } else if (status === 'COMPLETED' || status === 'CANCELLED') {
+        // Move file to archive preserving structure
+        // e.g. .foundry/tasks/task.md -> .foundry/archive/tasks/task.md
+        const relativeToFoundry = path.relative(foundryDir, fp);
+        const archivePath = path.join(foundryDir, 'archive', relativeToFoundry);
+        const archiveDir = path.dirname(archivePath);
+
+        fs.mkdirSync(archiveDir, { recursive: true });
+        fs.renameSync(fp, archivePath);
       }
     } catch {
       // Ignore parse errors


### PR DESCRIPTION
- Modified `.github/scripts/sweep-active-nodes.ts` to identify and correctly move both `COMPLETED` and `CANCELLED` nodes into the `.foundry/archive/` directory while preserving nesting.
- Updated `sweepActiveNodes` to ensure the core functionality of extracting and returning a list of `ACTIVE` nodes remains intact.
- Rewrote the node tree walk to skip the `archive/` directory explicitly, avoiding processing already archived files.
- Added comprehensive unit tests in `.github/scripts/sweep-active-nodes.test.ts` to verify the handling of `COMPLETED`, `CANCELLED`, and `ACTIVE` nodes, confirming nesting correctness and ensuring active nodes are returned as expected.

---
*PR created automatically by Jules for task [6038359630449797454](https://jules.google.com/task/6038359630449797454) started by @szubster*