### PR TITLE
Fix Gen 3 TV Block DataView Parser Implementation

### DIFF
--- a/.foundry/tasks/task-121-219-gen3-tv-block-parser-retry-impl.md
+++ b/.foundry/tasks/task-121-219-gen3-tv-block-parser-retry-impl.md
@@ -34,10 +34,10 @@ Any out-of-bounds reads or structurally corrupt states within the TV block MUST 
 **CRITICAL CONSTRAINT:** All memory offsets, lengths, bit locations, and shifts MUST be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
 
 ## Acceptance Criteria
-- [ ] The TV block extraction logic is built entirely using `DataView` as per the research findings.
-- [ ] All memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level.
-- [ ] Explicit error handling is in place to catch `RangeError` exceptions natively thrown by `DataView` on malformed saves.
-- [ ] New parsing functions conform to the existing Gen 1 and Gen 2 backward-compatible parsing interfaces without breaking them.
+- [x] The TV block extraction logic is built entirely using `DataView` as per the research findings.
+- [x] All memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level.
+- [x] Explicit error handling is in place to catch `RangeError` exceptions natively thrown by `DataView` on malformed saves.
+- [x] New parsing functions conform to the existing Gen 1 and Gen 2 backward-compatible parsing interfaces without breaking them.
 
 ## Important Protocols (For Coder)
 - **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -441,7 +441,9 @@ describe('parseGen3MixRecords', () => {
     const buffer = new ArrayBuffer(800); // Not enough space for 25 items (900 bytes)
     const view = new DataView(buffer);
 
-    expect(() => parseGen3MixRecords(view, 0)).toThrowError('The save file is corrupted or incomplete.');
+    expect(() => parseGen3MixRecords(view, 0)).toThrowError(
+      'The save file is corrupted or incomplete: Invalid TV block struct.',
+    );
   });
 });
 
@@ -471,7 +473,9 @@ describe('parseGen3PokeNews', () => {
     const buffer = new ArrayBuffer(60); // Not enough space for 16 items (64 bytes)
     const view = new DataView(buffer);
 
-    expect(() => parseGen3PokeNews(view, 0)).toThrowError('The save file is corrupted or incomplete.');
+    expect(() => parseGen3PokeNews(view, 0)).toThrowError(
+      'The save file is corrupted or incomplete: Invalid PokeNews struct.',
+    );
   });
 });
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -88,6 +88,19 @@ const PIKE_RECORD_WIN_STREAKS_OFFSET = 0x0e08;
 const PYRAMID_WIN_STREAKS_OFFSET = 0x0e1a;
 const PYRAMID_RECORD_WIN_STREAKS_OFFSET = 0x0e1e;
 
+const TV_SHOWS_OFFSET = 0x27cc;
+const TV_SHOWS_COUNT = 25;
+const TV_SHOW_SIZE = 36;
+const TV_SHOW_KIND_OFFSET = 0;
+const TV_SHOW_ACTIVE_OFFSET = 1;
+
+const POKE_NEWS_OFFSET = 0x2b50;
+const POKE_NEWS_COUNT = 16;
+const POKE_NEWS_SIZE = 4;
+const POKE_NEWS_KIND_OFFSET = 0;
+const POKE_NEWS_STATE_OFFSET = 1;
+const POKE_NEWS_COUNTDOWN_OFFSET = 2;
+
 const TOWER_SILVER_OFFSET = 0x1388;
 const TOWER_SILVER_BIT = 4;
 const TOWER_GOLD_OFFSET = 0x1388;
@@ -373,10 +386,10 @@ export function parseGen3Roamer(view: DataView, saveBlock1Offset: number, gameVe
 export function parseGen3MixRecords(view: DataView, offset: number) {
   try {
     const mixRecords = [];
-    for (let i = 0; i < 25; i++) {
-      const itemOffset = offset + i * 36;
-      const kind = view.getUint8(itemOffset);
-      const active = view.getUint8(itemOffset + 1) !== 0;
+    for (let i = 0; i < TV_SHOWS_COUNT; i++) {
+      const itemOffset = offset + i * TV_SHOW_SIZE;
+      const kind = view.getUint8(itemOffset + TV_SHOW_KIND_OFFSET);
+      const active = view.getUint8(itemOffset + TV_SHOW_ACTIVE_OFFSET) !== 0;
 
       // Check if the show is a Mix Record event (21 to 40)
       if (active && kind >= 21 && kind <= 40) {
@@ -386,7 +399,7 @@ export function parseGen3MixRecords(view: DataView, offset: number) {
     return mixRecords;
   } catch (error) {
     if (error instanceof RangeError) {
-      throw new Error('The save file is corrupted or incomplete.');
+      throw new Error('The save file is corrupted or incomplete: Invalid TV block struct.');
     }
     throw error;
   }
@@ -615,8 +628,8 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     const gen3BerryPatches = extractBerryPatches(view, section1Offset);
     const gen3SecretBases = parseGen3SecretBases(view, section1Offset, _forcedVersion || 'ruby');
 
-    const gen3PokeNews = parseGen3PokeNews(view, section1Offset + 0x2b50);
-    const gen3MixRecords = parseGen3MixRecords(view, section1Offset + 0x27cc);
+    const gen3PokeNews = parseGen3PokeNews(view, section1Offset + POKE_NEWS_OFFSET);
+    const gen3MixRecords = parseGen3MixRecords(view, section1Offset + TV_SHOWS_OFFSET);
 
     const roamingLegendaries = [];
     try {
@@ -779,17 +792,17 @@ export function parseGen3Ribbons(view: DataView, offset: number): Gen3Ribbons {
 export function parseGen3PokeNews(view: DataView, offset: number) {
   try {
     const news = [];
-    for (let i = 0; i < 16; i++) {
-      const itemOffset = offset + i * 4;
-      const kind = view.getUint8(itemOffset);
-      const state = view.getUint8(itemOffset + 1);
-      const dayCountdown = view.getUint16(itemOffset + 2, true);
+    for (let i = 0; i < POKE_NEWS_COUNT; i++) {
+      const itemOffset = offset + i * POKE_NEWS_SIZE;
+      const kind = view.getUint8(itemOffset + POKE_NEWS_KIND_OFFSET);
+      const state = view.getUint8(itemOffset + POKE_NEWS_STATE_OFFSET);
+      const dayCountdown = view.getUint16(itemOffset + POKE_NEWS_COUNTDOWN_OFFSET, true);
       news.push({ kind, state, dayCountdown });
     }
     return news;
   } catch (error) {
     if (error instanceof RangeError) {
-      throw new Error('The save file is corrupted or incomplete.');
+      throw new Error('The save file is corrupted or incomplete: Invalid PokeNews struct.');
     }
     throw error;
   }


### PR DESCRIPTION
Implemented Gen 3 TV Block DataView Parser by defining memory offsets, lengths, bit locations, and shifts as reusable constants at the module level in `gen3.ts`, replacing magic numbers in `parseGen3MixRecords`, `parseGen3PokeNews`, and `parseGen3`. Added explicit descriptive error handling (`RangeError` mapping) for malformed saves. Checked off acceptance criteria in `task-121-219-gen3-tv-block-parser-retry-impl.md`.

---
*PR created automatically by Jules for task [5085442707176409667](https://jules.google.com/task/5085442707176409667) started by @szubster*