### PR TITLE
chore(tasks): mark task-109-224-gen3-roamer-status-parsing-impl as completed

### DIFF
--- a/.foundry/tasks/task-109-224-gen3-roamer-status-parsing-impl.md
+++ b/.foundry/tasks/task-109-224-gen3-roamer-status-parsing-impl.md
@@ -29,8 +29,8 @@ Extract and parse the Status Condition from the 20-byte Gen 3 roamer data struct
 Building upon the base structure extracted in the previous story, implement the parsing logic necessary to identify and extract the Status Condition field from the Gen 3 roamer data. The Status Condition is an 8-bit unsigned integer at offset `0x0D` of the Roamer structure. Use the `DataView` API to extract this value. Ensure that the offset is defined as a reusable constant at the module level to avoid magic numbers. Note: This functionality might already be implemented, in which case you should verify it and submit an Empty PR.
 
 ## Acceptance Criteria
-- [ ] Implement parsing logic for the Status Condition from the 20-byte roamer structure using the `DataView` API.
-- [ ] Ensure all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level (no inline magic numbers).
-- [ ] If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- [ ] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- [x] Implement parsing logic for the Status Condition from the 20-byte roamer structure using the `DataView` API.
+- [x] Ensure all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level (no inline magic numbers).
+- [x] If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- [x] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- [x] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR checks off all acceptance criteria checkboxes in `.foundry/tasks/task-109-224-gen3-roamer-status-parsing-impl.md` to indicate task completion. The required functionality (parsing Gen 3 roamer status condition using DataView and module-level constants) is already fully implemented in the current codebase (`src/engine/saveParser/parsers/gen3.ts`).

---
*PR created automatically by Jules for task [2158167670346913792](https://jules.google.com/task/2158167670346913792) started by @szubster*