### PR TITLE
🧱 Mason: EmptyState extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -137,3 +137,9 @@
   - The extraction allows `CapacitySegmentedBar` to be easily dropped into other panels that require a tactical capacity readout (e.g. PC storage, memory limits, team size).
   - Passing `current` and `max` directly rather than the full `PokemonInstance[]` array decouples the component from domain-specific data models.
 ## LocationRow Extraction\n- Identified a repeating JSX pattern in `PokemonLocations.tsx` for displaying location information (both evolution requirements and static encounters).\n- Extracted the pattern into a reusable `LocationRow` component.\n- **Key Learnings**:\n  - When extracting rows with specific, variable icon structures and tactical badges, leveraging React nodes (`icon`, `badge`) as props ensures maximum flexibility for the parent while containing the rigid wrapper styling logic.
+
+## EmptyState Extraction
+- **What**: Extracted a repeated JSX pattern for empty states into a reusable `EmptyState` component.
+- **Why**: Reduced duplication of the verbose tactical utility classes `relative col-span-full flex flex-col items-center justify-center rounded-none border border-zinc-800/50 border-dashed bg-zinc-950/20 p-6 text-center` and standardizes the empty state presentation.
+- **Key Learnings**:
+  - Separating `className` and `labelClassName` gives flexibility for minor styling tweaks like making values bold or specific text sizes without breaking the core pattern.

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,25 @@
+import type React from 'react';
+import { cn } from '../utils/cn';
+import { CornerCrosshairs } from './CornerCrosshairs';
+
+interface EmptyStateProps {
+  label: string;
+  icon?: React.ReactNode;
+  className?: string;
+  labelClassName?: string;
+}
+
+export function EmptyState({ label, icon, className, labelClassName }: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'relative col-span-full flex flex-col items-center justify-center rounded-none border border-zinc-800/50 border-dashed bg-zinc-950/20 p-6 text-center',
+        className,
+      )}
+    >
+      <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700/50" />
+      {icon && <div className="mb-3 text-zinc-600">{icon}</div>}
+      <span className={cn('font-mono text-xs text-zinc-500 uppercase', labelClassName)}>{label}</span>
+    </div>
+  );
+}

--- a/src/components/run/GraveyardView.tsx
+++ b/src/components/run/GraveyardView.tsx
@@ -1,6 +1,7 @@
 import { Ghost } from 'lucide-react';
 import type { PokemonInstance } from '../../engine/saveParser/parsers/common';
 import { CornerCrosshairs } from '../CornerCrosshairs';
+import { EmptyState } from '../EmptyState';
 import { PokemonSprite } from '../pokemon/PokemonSprite';
 import { TacticalPanel } from '../TacticalPanel';
 import { TelemetryDecoration } from '../TelemetryDecoration';
@@ -43,11 +44,12 @@ export function GraveyardView({ graveyard, generation }: GraveyardViewProps) {
           </div>
         ))}
         {graveyard.length === 0 && (
-          <div className="relative col-span-full flex flex-col items-center justify-center border border-zinc-800/50 border-dashed bg-zinc-950/20 p-8 text-center">
-            <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700/50" />
-            <Ghost className="mb-3 h-8 w-8 text-zinc-600" />
-            <span className="tactical-text font-bold text-sm text-zinc-500">NO CASUALTIES RECORDED</span>
-          </div>
+          <EmptyState
+            label="NO CASUALTIES RECORDED"
+            icon={<Ghost className="h-8 w-8" />}
+            className="p-8"
+            labelClassName="tactical-text font-bold text-sm"
+          />
         )}
       </div>
     </TacticalPanel>

--- a/src/components/run/VisitedRoutesChecklist.tsx
+++ b/src/components/run/VisitedRoutesChecklist.tsx
@@ -1,6 +1,7 @@
 import { Check, CircleDot } from 'lucide-react';
 import type { PokemonInstance } from '../../engine/saveParser/parsers/common';
 import { CornerCrosshairs } from '../CornerCrosshairs';
+import { EmptyState } from '../EmptyState';
 import { TacticalPanel } from '../TacticalPanel';
 import { TelemetryDecoration } from '../TelemetryDecoration';
 
@@ -44,12 +45,7 @@ export function VisitedRoutesChecklist({ visited, unvisited }: VisitedRoutesChec
               </div>
             </div>
           ))}
-          {visited.length === 0 && (
-            <div className="relative col-span-full rounded-none border border-zinc-800/50 border-dashed bg-zinc-950/20 p-6 text-center font-mono text-xs text-zinc-500 uppercase">
-              <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700/50" />
-              NO ROUTES VISITED YET
-            </div>
-          )}
+          {visited.length === 0 && <EmptyState label="NO ROUTES VISITED YET" />}
         </div>
       </TacticalPanel>
 
@@ -68,12 +64,7 @@ export function VisitedRoutesChecklist({ visited, unvisited }: VisitedRoutesChec
               </span>
             </div>
           ))}
-          {unvisited.length === 0 && (
-            <div className="relative col-span-full rounded-none border border-zinc-800/50 border-dashed bg-zinc-950/20 p-6 text-center font-mono text-xs text-zinc-500 uppercase">
-              <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700/50" />
-              ALL ROUTES VISITED
-            </div>
-          )}
+          {unvisited.length === 0 && <EmptyState label="ALL ROUTES VISITED" />}
         </div>
       </TacticalPanel>
     </div>


### PR DESCRIPTION
🎯 What: Extracted a repeated JSX pattern for empty states into a reusable `EmptyState` component. Replaced the empty states in `GraveyardView.tsx` and `VisitedRoutesChecklist.tsx`.
💡 Why: Reduced duplication of the verbose tactical utility classes `relative col-span-full flex flex-col items-center justify-center rounded-none border border-zinc-800/50 border-dashed bg-zinc-950/20 p-6 text-center` and standardizes the empty state presentation.
✅ Verification: Ran `pnpm check:fix`, `pnpm format:biome`, `pnpm lint`, `pnpm test`, and `pnpm test:e2e`. All checks passed. Playwright tests confirmed the UI remains intact.
✨ Result: Cleaner, more modular code for empty states, allowing for easy updates and consistent styling across the application.

---
*PR created automatically by Jules for task [3802680352640446311](https://jules.google.com/task/3802680352640446311) started by @szubster*