### PR TITLE
feat: add PRD for Smart Egg Move Breeding Path Finder

### DIFF
--- a/.foundry/ideas/idea-091-smart-egg-move-path-finder.md
+++ b/.foundry/ideas/idea-091-smart-egg-move-path-finder.md
@@ -35,4 +35,5 @@ Leverage DexHelper's static database (Egg Groups, Egg Moves, learnsets) and comb
 This feature eliminates the need for complex, manual cross-referencing between wikis and the game UI. By joining complex static pathfinding data with the player's dynamic inventory, DexHelper provides a highly personalized, actionable strategy that is impossible to achieve with standard guides. This heavily reinforces DexHelper as the ultimate, indispensable companion app for hardcore players.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD to investigate the graph algorithms needed to calculate breeding chains across Egg Groups.
+- [x] Product Manager: Convert this idea into a PRD to investigate the graph algorithms needed to calculate breeding chains across Egg Groups.
+- [ ] .foundry/prds/prd-091-055-smart-egg-move-path-finder.md

--- a/.foundry/prds/prd-091-055-smart-egg-move-path-finder.md
+++ b/.foundry/prds/prd-091-055-smart-egg-move-path-finder.md
@@ -1,0 +1,36 @@
+---
+id: prd-091-055-smart-egg-move-path-finder
+type: PRD
+title: Smart Egg Move Breeding Path Finder
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-28'
+updated_at: '2026-06-28'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-091-smart-egg-move-path-finder
+tags:
+  - feature
+  - tool
+  - mechanics
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Smart Egg Move Breeding Path Finder
+
+## Overview
+Breeding for "Egg Moves" is a core mechanic for competitive battling and challenge runs in Gen 2 and Gen 3. The Smart Egg Move Breeding Path Finder will automate the process of calculating the shortest breeding chain across Egg Groups. It will leverage DexHelper's static database (Egg Groups, Egg Moves, learnsets) and combine it with the player's dynamic save state (PC boxes and party) to identify required intermediate parents that the player already owns.
+
+## Goals
+- Allow the user to select a target Pokémon and a desired Egg Move.
+- Calculate the shortest valid breeding chain(s) to pass the Egg Move down.
+- Cross-reference the calculated chain with the player's dynamic inventory.
+- Highlight required "parents" that the player already owns (checking species and male gender).
+- Identify the missing links the player needs to catch.
+
+## Next Steps
+- [ ] Epic Planner: Break this PRD down into actionable EPICs.


### PR DESCRIPTION
Adds PRD node `.foundry/prds/prd-091-055-smart-egg-move-path-finder.md` for the Smart Egg Move Breeding Path Finder and checks off the IDEA node acceptance criteria.

---
*PR created automatically by Jules for task [10496626212696601499](https://jules.google.com/task/10496626212696601499) started by @szubster*