### PR TITLE
📜 Scribe: [parseGen3 JSDoc documentation]

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -2,3 +2,6 @@ The Scribe persona's private memory is strictly `.jules/scribe.md` and must be u
 
 ### JSDoc within Scripts
 When documenting ETL scripts like `generate-pokedata.ts`, it is crucial to explain the context of why certain architectural decisions were made. In complex data pipelines where data structures are heavily processed, explaining the "why" (e.g. why compaction is necessary due to IndexedDB constraints and payload size, or why a function processes sequentially rather than concurrently to prevent memory pressure) provides much higher value than simply explaining "what" the script does.
+
+### Documenting Scaffolding and Complex Entrypoints
+When a file contains a complex architecture overview but leaves its primary exported entry point (e.g. `parseGen3`) undocumented, it creates a disconnect for consumers importing that function. Always ensure that the main entry point summarizes the module's execution flow (like A/B bank scanning and section resolution in Gen 3) even if the internal implementation is partially scaffolded, so consumers understand the expected input/output contract.

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -596,6 +596,19 @@ export function parseGen3BattleFrontierWinStreaks(
   }
 }
 
+/**
+ * Main entry point for parsing a Generation 3 (R/S/E/FR/LG) save file.
+ *
+ * ## Execution Flow
+ * 1. **Section Resolution:** Scans the A/B flash memory banks to locate the most recent, valid memory offsets for SaveBlock2 (Section 2) and SaveBlock1 (Section 1).
+ * 2. **State Extraction:** Extracts world state data including Berry Patches, Secret Bases, PokeNews, Mix Records, Roaming Legendaries, and Mirage Island values.
+ * 3. **Data Compilation:** Compiles the parsed values into a unified `SaveData` object. Note: Party and PC box parsing are currently stubbed in this scaffold.
+ *
+ * @param view - The raw save file DataView.
+ * @param _forcedVersion - An optional game version override (e.g. 'ruby', 'emerald') to dictate memory offsets.
+ * @returns The fully constructed SaveData object.
+ * @throws {Error} If the save file is corrupted, incomplete, or out-of-bounds reads occur.
+ */
 export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveData {
   try {
     let section2Offset: number;


### PR DESCRIPTION
Added JSDoc to the exported `parseGen3` function inside `src/engine/saveParser/parsers/gen3.ts` to explain its execution flow (section resolution, state extraction, and compilation) and parameters. This addresses the documentation gap where a complex domain module's main entry point was left undocumented. Also recorded a lesson to the Scribe journal about documenting partially scaffolded complex entry points.

---
*PR created automatically by Jules for task [11471155368011802428](https://jules.google.com/task/11471155368011802428) started by @szubster*