### PR TITLE
Check off acceptance criteria for dag-utils unit tests

### DIFF
--- a/.foundry/tasks/task-106-226-dag-utils-unit-tests-impl.md
+++ b/.foundry/tasks/task-106-226-dag-utils-unit-tests-impl.md
@@ -26,10 +26,10 @@ notes: ''
 We have recently extracted shared DAG utility functions into \`.github/scripts/dag-utils.ts\`. This task is to write comprehensive unit tests for these utilities to ensure reliability.
 
 ## Acceptance Criteria
-- [ ] Create \`.github/scripts/dag-utils.test.ts\`.
-- [ ] Write unit tests for \`buildReverseDependencyGraph\`.
-- [ ] Write unit tests for \`getOrphanedNodes\`.
-- [ ] Tests must cover standard cases, edge cases, and ensure proper typing.
+- [x] Create \`.github/scripts/dag-utils.test.ts\`.
+- [x] Write unit tests for \`buildReverseDependencyGraph\`.
+- [x] Write unit tests for \`getOrphanedNodes\`.
+- [x] Tests must cover standard cases, edge cases, and ensure proper typing.
 
 ## Directives
 - Implement the unit tests using the existing testing framework used for other orchestrator scripts.


### PR DESCRIPTION
The target `.github/scripts/dag-utils.test.ts` was already completed in a previous branch commit (`9be1c68b`). This Empty PR simply checks off the Acceptance Criteria checkboxes in `.foundry/tasks/task-106-226-dag-utils-unit-tests-impl.md` to formally transition this leaf node and satisfy the completeness requirements defined in ADR 007. Tests pass via `pnpm test`.

---
*PR created automatically by Jules for task [2350041201530531065](https://jules.google.com/task/2350041201530531065) started by @szubster*