### PR TITLE
feat(gen3): expose lower 16-bits of PV

### DIFF
--- a/.foundry/tasks/task-099-228-expose-lower-16bit-pv-impl.md
+++ b/.foundry/tasks/task-099-228-expose-lower-16bit-pv-impl.md
@@ -32,5 +32,5 @@ As part of the Mirage Island checking feature, after parsing the 32-bit PV, we n
 4. **Completion Contract**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement logic to expose lower 16-bits of PV.
-- [ ] Run `pnpm test` to ensure there are no regressions.
+- [x] Implement logic to expose lower 16-bits of PV.
+- [x] Run `pnpm test` to ensure there are no regressions.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -277,7 +277,7 @@ describe('parseGen3PersonalityValue', () => {
 
     const result = parseGen3PersonalityValue(view, 2);
 
-    expect(result).toBe(0x12345678);
+    expect(result).toEqual({ pv: 0x12345678, lower16: 0x5678 });
   });
 
   it('should explicitly catch RangeError on out-of-bounds reads and throw a corrupted file error', () => {

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -38,6 +38,7 @@ const SECRET_BASE_OFFSET_EMERALD = 0x1a9c;
 
 const SAVE_BLOCK_A = 0x0000;
 const SAVE_BLOCK_B = 0xe000;
+const LOWER_16_BIT_MASK = 0xffff;
 
 const GEN3_ROAMER_OFFSET_RS = 0x3144;
 const GEN3_ROAMER_OFFSET_EMERALD = 0x31dc;
@@ -739,12 +740,13 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
  *
  * @param view - The raw save file DataView.
  * @param offset - The offset within the buffer to read the PV from.
- * @returns The 32-bit unsigned integer representing the PV.
+ * @returns An object containing the 32-bit PV and its lower 16-bits pre-calculated.
  * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
  */
-export function parseGen3PersonalityValue(view: DataView, offset: number): number {
+export function parseGen3PersonalityValue(view: DataView, offset: number): { pv: number; lower16: number } {
   try {
-    return view.getUint32(offset, true);
+    const pv = view.getUint32(offset, true);
+    return { pv, lower16: pv & LOWER_16_BIT_MASK };
   } catch (error) {
     if (error instanceof RangeError) {
       throw new Error('The save file is corrupted or incomplete.');


### PR DESCRIPTION
Updates `parseGen3PersonalityValue` to pre-calculate and return the lower 16-bits of the personality value, which is necessary for the Mirage Island feature. Extracted `0xFFFF` bitmask into a constant `LOWER_16_BIT_MASK`. Fixes typings and test suite expectations.

---
*PR created automatically by Jules for task [11380305713727725481](https://jules.google.com/task/11380305713727725481) started by @szubster*