### PR TITLE
Epic Planner: Breakdown Gen 3 Ash Gathering Tracker PRD

### DIFF
--- a/.foundry/epics/epic-054-113-gen3-ash-save-parsing.md
+++ b/.foundry/epics/epic-054-113-gen3-ash-save-parsing.md
@@ -1,0 +1,27 @@
+---
+id: epic-054-113-gen3-ash-save-parsing
+type: EPIC
+title: Gen 3 Ash Gathering Save Parsing
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on:
+  - research-054-243-gen3-ash-gathering-offsets
+jules_session_id: null
+pr_number: null
+parent: prd-089-054-gen3-ash-gathering-tracker
+tags:
+  - gen3
+  - ash
+  - parsing
+research_references:
+  - .foundry/research/research-054-243-gen3-ash-gathering-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Ash Gathering Save Parsing
+
+- [ ] Create Story for extracting Volcanic Ash count using DataView API based on research findings.

--- a/.foundry/epics/epic-054-114-gen3-ash-dashboard.md
+++ b/.foundry/epics/epic-054-114-gen3-ash-dashboard.md
@@ -1,0 +1,26 @@
+---
+id: epic-054-114-gen3-ash-dashboard
+type: EPIC
+title: Gen 3 Ash Gathering Dashboard UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on:
+  - epic-054-113-gen3-ash-save-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-089-054-gen3-ash-gathering-tracker
+tags:
+  - gen3
+  - ash
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Ash Gathering Dashboard UI
+
+- [ ] Create Story for implementing Ash Tracker Dashboard UI adhering to tactical hardware aesthetic (ADR 024).

--- a/.foundry/epics/epic-054-115-gen3-ash-goal-planner.md
+++ b/.foundry/epics/epic-054-115-gen3-ash-goal-planner.md
@@ -1,0 +1,26 @@
+---
+id: epic-054-115-gen3-ash-goal-planner
+type: EPIC
+title: Gen 3 Ash Goal Planner
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on:
+  - epic-054-114-gen3-ash-dashboard
+jules_session_id: null
+pr_number: null
+parent: prd-089-054-gen3-ash-gathering-tracker
+tags:
+  - gen3
+  - ash
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Ash Goal Planner
+
+- [ ] Create Story for implementing goal planner logic with static mapping of items and progress bar.

--- a/.foundry/prds/prd-089-054-gen3-ash-gathering-tracker.md
+++ b/.foundry/prds/prd-089-054-gen3-ash-gathering-tracker.md
@@ -64,4 +64,8 @@ By extracting the Volcanic Ash count from the Gen 3 save file, DexHelper can pro
 - **No PokeAPI Dependency:** This feature relies entirely on internal logic and local save data, adhering to the offline-first modernization strategy.
 
 ## 5. Acceptance Criteria
-- [ ] Epic Planner: Break down this PRD into corresponding EPICs (e.g., Save Parsing, UI Dashboard, Goal Planner Logic).
+- [x] Epic Planner: Break down this PRD into corresponding EPICs (e.g., Save Parsing, UI Dashboard, Goal Planner Logic).
+- [ ] .foundry/research/research-054-243-gen3-ash-gathering-offsets.md
+- [ ] .foundry/epics/epic-054-113-gen3-ash-save-parsing.md
+- [ ] .foundry/epics/epic-054-114-gen3-ash-dashboard.md
+- [ ] .foundry/epics/epic-054-115-gen3-ash-goal-planner.md

--- a/.foundry/research/research-054-243-gen3-ash-gathering-offsets.md
+++ b/.foundry/research/research-054-243-gen3-ash-gathering-offsets.md
@@ -1,0 +1,25 @@
+---
+id: research-054-243-gen3-ash-gathering-offsets
+type: RESEARCH
+title: Gen 3 Volcanic Ash Offsets
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-089-054-gen3-ash-gathering-tracker
+tags:
+  - gen3
+  - research
+  - ash
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Volcanic Ash Offsets
+
+- [ ] Research Volcanic Ash counter offsets in Gen 3 saves (Ruby, Sapphire, Emerald).


### PR DESCRIPTION
I have successfully completed the breakdown of the PRD `prd-089-054-gen3-ash-gathering-tracker` into its corresponding Epics and a required Research node as requested.

The following nodes were generated and properly linked via their `depends_on` and `parent` fields:
- `research-054-243-gen3-ash-gathering-offsets`
- `epic-054-113-gen3-ash-save-parsing`
- `epic-054-114-gen3-ash-dashboard`
- `epic-054-115-gen3-ash-goal-planner`

The parent PRD has been updated to reflect these new children as unchecked tasks, and its acceptance criteria checkbox has been ticked, all without modifying the YAML frontmatter. Validation steps were successful.

---
*PR created automatically by Jules for task [18091754646668839210](https://jules.google.com/task/18091754646668839210) started by @szubster*