### PR TITLE
feat: Implement remediation state transition logic for zombie nodes

### DIFF
--- a/.foundry/tasks/task-133-230-remediation-state-transition-logic-impl.md
+++ b/.foundry/tasks/task-133-230-remediation-state-transition-logic-impl.md
@@ -33,5 +33,5 @@ Following the detection of "zombie" nodes (nodes incorrectly stuck in the `ACTIV
 - **Reminder**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 3. Acceptance Criteria
-- [ ] Implement utility function to update node frontmatter status to `FAILED`.
-- [ ] Create unit tests to verify state transition logic.
+- [x] Implement utility function to update node frontmatter status to `FAILED`.
+- [x] Create unit tests to verify state transition logic.

--- a/.github/scripts/remediate-zombie.test.ts
+++ b/.github/scripts/remediate-zombie.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { remediateZombieNode } from './remediate-zombie.ts';
+import { createValidTestNode } from './foundry-test-utils.ts';
+
+describe('remediateZombieNode', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remediate-test-'));
+    fs.mkdirSync(path.join(tmpDir, '.foundry', 'tasks'), { recursive: true });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('successfully updates an ACTIVE node to FAILED with rejection_reason', () => {
+    const nodePath = '.foundry/tasks/task-001.md';
+    createValidTestNode(tmpDir, nodePath, {
+      id: 'task-001',
+      type: 'TASK',
+      title: 'Task 1',
+      status: 'ACTIVE',
+      owner_persona: 'coder',
+      created_at: '2026-06-28',
+      updated_at: '2026-06-28',
+      depends_on: [],
+      jules_session_id: 'sess-123'
+    }, '# Body content\\n- [ ] Unchecked');
+
+    const result = remediateZombieNode(tmpDir, nodePath, 'Zombie detected by engine');
+    expect(result).toBe(true);
+
+    const fileContent = fs.readFileSync(path.join(tmpDir, nodePath), 'utf-8');
+    expect(fileContent).toContain('status: FAILED');
+    expect(fileContent).toContain('rejection_reason: Zombie detected by engine');
+    expect(fileContent).toContain('# Body content');
+    expect(fileContent).toContain('id: task-001'); // Preserves other frontmatter
+  });
+
+  it('fails if the file does not exist', () => {
+    const nodePath = '.foundry/tasks/non-existent.md';
+    const result = remediateZombieNode(tmpDir, nodePath);
+    expect(result).toBe(false);
+    expect(console.warn).toHaveBeenCalledWith(`File not found: ${path.join(tmpDir, nodePath)}`);
+  });
+
+  it('fails if the node has malformed YAML frontmatter', () => {
+    const nodePath = '.foundry/tasks/malformed.md';
+    const fullPath = path.join(tmpDir, nodePath);
+    fs.writeFileSync(fullPath, '---\\ninvalid yaml:\\n  - - -\\n---\\n# Content', 'utf-8');
+
+    const result = remediateZombieNode(tmpDir, nodePath);
+    expect(result).toBe(false);
+    expect(console.warn).toHaveBeenCalledWith(`Malformed YAML frontmatter in: ${fullPath}`);
+  });
+
+  it('fails if the node is not ACTIVE', () => {
+    const nodePath = '.foundry/tasks/task-002.md';
+    const fullPath = path.join(tmpDir, nodePath);
+    createValidTestNode(tmpDir, nodePath, {
+      id: 'task-002',
+      type: 'TASK',
+      title: 'Task 2',
+      status: 'PENDING',
+      owner_persona: 'coder',
+      created_at: '2026-06-28',
+      updated_at: '2026-06-28',
+      depends_on: [],
+      jules_session_id: null
+    });
+
+    const result = remediateZombieNode(tmpDir, nodePath);
+    expect(result).toBe(false);
+    expect(console.warn).toHaveBeenCalledWith(`Node is not ACTIVE: ${fullPath}`);
+  });
+
+  it('handles write errors gracefully', () => {
+    const nodePath = '.foundry/tasks/task-003.md';
+    const fullPath = path.join(tmpDir, nodePath);
+    createValidTestNode(tmpDir, nodePath, {
+      id: 'task-003',
+      type: 'TASK',
+      title: 'Task 3',
+      status: 'ACTIVE',
+      owner_persona: 'coder',
+      created_at: '2026-06-28',
+      updated_at: '2026-06-28',
+      depends_on: [],
+      jules_session_id: 'sess-123'
+    });
+
+    // Change file permissions to read-only so writeFileSync throws
+    fs.chmodSync(fullPath, 0o444);
+
+    try {
+      const result = remediateZombieNode(tmpDir, nodePath);
+      expect(result).toBe(false);
+      expect(console.error).toHaveBeenCalled();
+    } finally {
+      // Restore permissions so cleanup works
+      fs.chmodSync(fullPath, 0o666);
+    }
+  });
+});

--- a/.github/scripts/remediate-zombie.ts
+++ b/.github/scripts/remediate-zombie.ts
@@ -1,0 +1,56 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createRequire } from 'node:module';
+
+const _require = createRequire(import.meta.url);
+const matter = _require('gray-matter') as typeof import('gray-matter');
+
+/**
+ * Safely updates the YAML frontmatter of a given node file to remediate a zombie node.
+ * Changes `status: ACTIVE` to `status: FAILED` and sets `rejection_reason`.
+ * Preserves all other frontmatter fields and the original markdown body.
+ *
+ * @param repoRoot - The root directory of the repository.
+ * @param relativeFilePath - The relative path to the node file from the repo root.
+ * @param rejectionReason - The reason for transitioning to FAILED (defaults to 'Zombie node detected').
+ * @returns boolean - true if successful, false otherwise.
+ */
+export function remediateZombieNode(repoRoot: string, relativeFilePath: string, rejectionReason: string = 'Zombie node detected'): boolean {
+  const fullPath = path.join(repoRoot, relativeFilePath);
+
+  try {
+    if (!fs.existsSync(fullPath)) {
+      console.warn(`File not found: ${fullPath}`);
+      return false;
+    }
+
+    const content = fs.readFileSync(fullPath, 'utf-8');
+
+    let parsed: ReturnType<typeof matter>;
+    try {
+      parsed = matter(content);
+    } catch {
+      console.warn(`Malformed YAML frontmatter in: ${fullPath}`);
+      return false;
+    }
+
+    if (parsed.data?.status !== 'ACTIVE') {
+      console.warn(`Node is not ACTIVE: ${fullPath}`);
+      return false;
+    }
+
+    const newData = {
+      ...parsed.data,
+      status: 'FAILED',
+      rejection_reason: rejectionReason,
+    };
+
+    const newContent = matter.stringify(parsed.content, newData);
+    fs.writeFileSync(fullPath, newContent, 'utf-8');
+
+    return true;
+  } catch (error) {
+    console.error(`Failed to remediate zombie node at ${fullPath}:`, error);
+    return false;
+  }
+}


### PR DESCRIPTION
Implements the utility function `remediateZombieNode` as required by the task.

**Changes:**
- Added `.github/scripts/remediate-zombie.ts` which uses `gray-matter` to parse nodes, changes `status: ACTIVE` to `FAILED`, preserves all other frontmatter fields and the original markdown body, and sets a custom `rejection_reason`.
- Added `.github/scripts/remediate-zombie.test.ts` providing rigorous unit test coverage including edge cases like non-existent files, malformed YAML, incorrect status, and read-only filesystem errors using `vitest` mocks.
- Ensured `.foundry/tasks/task-133-230-remediation-state-transition-logic-impl.md` has its acceptance criteria checkboxes correctly checked, without touching its frontmatter.

Tested completely via project level `pnpm lint && pnpm test` and `.github/scripts` specific `vitest`.

---
*PR created automatically by Jules for task [15138185971453067695](https://jules.google.com/task/15138185971453067695) started by @szubster*