### PR TITLE
feat: generate PRD for Gen 2/3 In-Game Trade Assistant Dashboard

### DIFF
--- a/.foundry/ideas/idea-095-in-game-trade-assistant.md
+++ b/.foundry/ideas/idea-095-in-game-trade-assistant.md
@@ -29,3 +29,6 @@ Build an "In-Game Trade Assistant Dashboard" that:
 3. Automatically cross-references the requested Pokémon species for available trades against the player's current party and PC box contents, highlighting trades that can be executed immediately.
 
 This turns opaque, hidden game state into an actionable, highly useful strategy for casual players, completionists, and Nuzlockers alike, removing the need for external resources and tedious PC box checking.
+
+## Acceptance Criteria
+- [ ] .foundry/prds/prd-095-056-in-game-trade-assistant.md

--- a/.foundry/prds/prd-095-056-in-game-trade-assistant.md
+++ b/.foundry/prds/prd-095-056-in-game-trade-assistant.md
@@ -1,0 +1,30 @@
+---
+id: prd-095-056-in-game-trade-assistant
+type: PRD
+title: Gen 2/3 In-Game Trade Assistant Dashboard
+status: PENDING
+owner_persona: epic_planner
+created_at: "2026-06-30"
+updated_at: "2026-06-30"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-095-in-game-trade-assistant
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+# Gen 2/3 In-Game Trade Assistant Dashboard PRD
+
+## Context
+In-game NPC trades provide Pokémon with good IVs and rare items, but tracking them is tedious. We need a dashboard to show available trades and cross-reference them with the player's party and PC.
+
+## Requirements
+- Parse save file event flags to track completed in-game trades for Gen 2 and Gen 3.
+- Display a list of available and completed trades.
+- Automatically cross-reference requested Pokémon against the player's party and PC box to highlight actionable trades.
+
+## Acceptance Criteria
+- [ ] Break down into Epics (Parse Data, Build UI).


### PR DESCRIPTION
This PR creates the `prd-095-056-in-game-trade-assistant` node derived from the `idea-095-in-game-trade-assistant` idea. It updates the IDEA node with an acceptance criteria checklist containing the reference to the newly generated PRD. All DAG schemas and orchestrator guidelines were followed.

---
*PR created automatically by Jules for task [17002018617277256621](https://jules.google.com/task/17002018617277256621) started by @szubster*