### PR TITLE
Refactor Feebas magic numbers

### DIFF
--- a/.foundry/tasks/task-152-230-refactor-feebas-magic-numbers-impl.md
+++ b/.foundry/tasks/task-152-230-refactor-feebas-magic-numbers-impl.md
@@ -45,9 +45,9 @@ The algorithm in `calculateFeebasTiles` still contains inline magic numbers for 
 - **Magic Number Rules**: When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
 
 ## Acceptance Criteria
-- [ ] PRNG multiplier (`1103515245`) and addend (`12345`) are extracted into descriptive constants.
-- [ ] Bit shift (`16`) is extracted into a constant.
-- [ ] Lengths and boundaries (`447` total spots, `6` valid spots, `4` inaccessible boundary) are extracted into constants.
-- [ ] All new constants are exported at the module level.
-- [ ] The `calculateFeebasTiles` function is updated to use the new constants instead of inline magic numbers.
-- [ ] Tests pass (self-verified by coder).
+- [x] PRNG multiplier (`1103515245`) and addend (`12345`) are extracted into descriptive constants.
+- [x] Bit shift (`16`) is extracted into a constant.
+- [x] Lengths and boundaries (`447` total spots, `6` valid spots, `4` inaccessible boundary) are extracted into constants.
+- [x] All new constants are exported at the module level.
+- [x] The `calculateFeebasTiles` function is updated to use the new constants instead of inline magic numbers.
+- [x] Tests pass (self-verified by coder).

--- a/src/engine/gen3/feebas.ts
+++ b/src/engine/gen3/feebas.ts
@@ -3,6 +3,13 @@ import type { GameVersion } from '../saveParser/parsers/common';
 export const FEEBAS_SEED_OFFSET_RS = 0x2dd6;
 export const FEEBAS_SEED_OFFSET_EMERALD = 0x2e66;
 
+export const LCG_MULTIPLIER = 1103515245;
+export const LCG_ADDEND = 12345;
+export const FEEBAS_SPOT_BIT_SHIFT = 16;
+export const FEEBAS_TOTAL_SPOTS = 447;
+export const FEEBAS_VALID_SPOTS = 6;
+export const FEEBAS_BOUNDARY = 4;
+
 /**
  * Extracts the 16-bit Feebas seed from Gen 3 save files using the native DataView API.
  *
@@ -42,14 +49,14 @@ export function extractFeebasSeed(saveData: DataView, gameVersion: GameVersion):
 export function calculateFeebasTiles(seed: number): number[] {
   let rng = seed;
   const spots: number[] = [];
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < FEEBAS_VALID_SPOTS; i++) {
     let spot = 0;
     do {
-      rng = Math.imul(rng, 1103515245) + 12345;
+      rng = Math.imul(rng, LCG_MULTIPLIER) + LCG_ADDEND;
       rng = rng >>> 0;
-      spot = (rng >>> 16) % 447;
-      if (spot === 0) spot = 447;
-    } while (spot < 4);
+      spot = (rng >>> FEEBAS_SPOT_BIT_SHIFT) % FEEBAS_TOTAL_SPOTS;
+      if (spot === 0) spot = FEEBAS_TOTAL_SPOTS;
+    } while (spot < FEEBAS_BOUNDARY);
     spots.push(spot);
   }
   return spots;


### PR DESCRIPTION
Refactored the Gen 3 LCG Feebas tile calculation algorithm to use descriptive module-level constants instead of inline magic numbers. Verified all tests passed. Updated the corresponding task node in the Foundry DAG to mark the Acceptance Criteria as complete.

---
*PR created automatically by Jules for task [8378481881103752856](https://jules.google.com/task/8378481881103752856) started by @szubster*