### PR TITLE
Refactor Pokerus Bitwise Extraction Implementation

### DIFF
--- a/.foundry/tasks/task-155-234-refactor-pokerus-bitwise-impl.md
+++ b/.foundry/tasks/task-155-234-refactor-pokerus-bitwise-impl.md
@@ -30,8 +30,8 @@ As per ADR 026:
 2. Cured State Enforcement: Any bitwise data structure representing a "condition" that degrades or changes over time (like Pokerus or Contest conditions) MUST explicitly define and test its boundary states.
 
 ## Acceptance Criteria
-- [ ] Create `parsePokerus` in `common.ts` using constants for shifts and masks
-- [ ] Refactor `gen2.ts` to use `parsePokerus`
+- [x] Create `parsePokerus` in `common.ts` using constants for shifts and masks
+- [x] Refactor `gen2.ts` to use `parsePokerus`
 
 ### Important Constraints
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/common.test.ts
+++ b/src/engine/saveParser/parsers/common.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
-import { checkShiny, checkShinyGene, decodeGen12String, parseDVs } from './common';
+import { checkShiny, checkShinyGene, decodeGen12String, parseDVs, parsePokerus } from './common';
 
 describe('common parsers', () => {
   describe('decodeGen12String', () => {
@@ -196,6 +196,36 @@ describe('common parsers', () => {
 
     test('returns false if Spc is neither 2 nor 10', () => {
       expect(checkShinyGene({ atk: 5, def: 10, spd: 5, spc: 3 })).toBe(false);
+    });
+  });
+
+  describe('parsePokerus', () => {
+    test('returns undefined for absolute zero state', () => {
+      expect(parsePokerus(0x00)).toBeUndefined();
+    });
+
+    test('parses boundary state correctly (cured/expired)', () => {
+      // 0x10 -> strain 1, days 0
+      expect(parsePokerus(0x10)).toEqual({
+        strain: 1,
+        daysRemaining: 0,
+      });
+    });
+
+    test('parses max boundary values correctly', () => {
+      // 0xFF -> strain 15, days 15
+      expect(parsePokerus(0xff)).toEqual({
+        strain: 15,
+        daysRemaining: 15,
+      });
+    });
+
+    test('parses mixed values correctly', () => {
+      // 0x5A -> strain 5, days 10
+      expect(parsePokerus(0x5a)).toEqual({
+        strain: 5,
+        daysRemaining: 10,
+      });
     });
   });
 });

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -392,3 +392,23 @@ export function checkShiny(dvs: { atk: number; def: number; spd: number; spc: nu
 export function checkShinyGene(dvs: { atk: number; def: number; spd: number; spc: number }) {
   return dvs.def === 10 && (dvs.spc === 2 || dvs.spc === 10);
 }
+
+const POKERUS_STRAIN_SHIFT = 4;
+const POKERUS_DAYS_MASK = 0x0f;
+
+/**
+ * Parses the Pokerus byte.
+ *
+ * @param rawPokerus - The raw byte value representing Pokerus.
+ * @returns An object with strain and daysRemaining if the Pokemon was infected, otherwise undefined.
+ */
+export function parsePokerus(rawPokerus: number) {
+  if (rawPokerus === 0) {
+    return undefined;
+  }
+
+  return {
+    strain: rawPokerus >> POKERUS_STRAIN_SHIFT,
+    daysRemaining: rawPokerus & POKERUS_DAYS_MASK,
+  };
+}

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -2,7 +2,7 @@ import gen2Landmarks from '../../data/gen2/landmarks.json';
 import gen2MapLocations from '../../data/gen2/mapLocations.json';
 import { GEN2_VERSION_EXCLUSIVES } from '../../exclusives/gen2Exclusives';
 import type { GameVersion, PokemonInstance, SaveData } from './common';
-import { checkShiny, checkShinyGene, decodeGen12String, parseDVs } from './common';
+import { checkShiny, checkShinyGene, decodeGen12String, parseDVs, parsePokerus } from './common';
 
 const POKEMON_OFFSET_SPECIES_ID = 0;
 const POKEMON_OFFSET_ITEM = 1;
@@ -15,9 +15,6 @@ const POKEMON_OFFSET_CAUGHT_BYTE_2 = 30;
 const POKEMON_OFFSET_LEVEL = 31;
 const POKEMON_OFFSET_OT_NAME = 32;
 const POKEMON_OFFSET_CURRENT_HP = 34;
-
-const POKERUS_STRAIN_SHIFT = 4;
-const POKERUS_DAYS_MASK = 0x0f;
 
 function isValidLandmark(id: string): id is keyof typeof gen2Landmarks {
   return id in gen2Landmarks;
@@ -103,13 +100,7 @@ function parseGen2PokemonInstance(
   const isShinyCarrier = checkShinyGene(dvs);
   const friendship = view.getUint8(offset + POKEMON_OFFSET_FRIENDSHIP);
   const rawPokerus = view.getUint8(offset + POKEMON_OFFSET_POKERUS);
-  const pokerus =
-    rawPokerus > 0
-      ? {
-          strain: rawPokerus >> POKERUS_STRAIN_SHIFT,
-          daysRemaining: rawPokerus & POKERUS_DAYS_MASK,
-        }
-      : undefined;
+  const pokerus = parsePokerus(rawPokerus);
   const level = view.getUint8(offset + POKEMON_OFFSET_LEVEL);
   const currentHp = storageLocation === 'Party' ? view.getUint16(offset + POKEMON_OFFSET_CURRENT_HP, false) : undefined;
   const caughtData = isCrystal ? parseCaughtData(view, offset) : undefined;


### PR DESCRIPTION
## Summary
Refactored the inline bitwise logic for Pokerus state extraction from `src/engine/saveParser/parsers/gen2.ts` into a standardized shared helper function `parsePokerus(rawPokerus: number)` in `src/engine/saveParser/parsers/common.ts`, in accordance with ADR 026.

## Changes
- Created `parsePokerus` in `common.ts` using module-level constants `POKERUS_STRAIN_SHIFT` and `POKERUS_DAYS_MASK`.
- Added comprehensive unit tests in `common.test.ts` for boundary states (absolute zero, cured/expired, max boundary values).
- Refactored `parseGen2PokemonInstance` in `gen2.ts` to use `parsePokerus`.
- Checked off acceptance criteria in `task-155-234-refactor-pokerus-bitwise-impl.md`.

---
*PR created automatically by Jules for task [17898480374231205194](https://jules.google.com/task/17898480374231205194) started by @szubster*