### PR TITLE
chore(foundry): apply empty PR policy for max rejection cancellation task

### DIFF
--- a/.foundry/tasks/task-153-234-orchestrator-max-rejection-cancellation-impl.md
+++ b/.foundry/tasks/task-153-234-orchestrator-max-rejection-cancellation-impl.md
@@ -28,5 +28,5 @@ notes: ''
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Ensure foundry-orchestrator.ts has logic in Phase 3.0 to change a node's status to CANCELLED if its status is FAILED and its rejection_count >= MAX_REJECTION_THRESHOLD.
-- [ ] If the artifact already correctly implements this feature, apply the Empty PR policy.
+- [x] Ensure foundry-orchestrator.ts has logic in Phase 3.0 to change a node's status to CANCELLED if its status is FAILED and its rejection_count >= MAX_REJECTION_THRESHOLD.
+- [x] If the artifact already correctly implements this feature, apply the Empty PR policy.


### PR DESCRIPTION
The objective was to implement the max rejection cancellation feature in the Foundry Orchestrator. 

Upon inspection of `.github/scripts/foundry-orchestrator.ts`, the logic for Phase 3.0 already correctly implements this:
```typescript
  // ── Phase 3.0: MAX REJECTION THRESHOLD CHECK ───────────────────────────────
  info('Phase 3.0: Checking for max rejection threshold...');
  for (const node of nodes) {
    if (node.frontmatter.status === 'FAILED' && (node.frontmatter.rejection_count || 0) >= MAX_REJECTION_THRESHOLD) {
      promoteNodeToCancelledWithReason(node, 'Max rejection count reached');
    }
  }
```

Since the code is already compliant, this PR executes the "Empty PR Policy" by simply checking off the Acceptance Criteria checkboxes in the task's markdown file to allow the DAG to advance.

---
*PR created automatically by Jules for task [14433295448611379486](https://jules.google.com/task/14433295448611379486) started by @szubster*