### PR TITLE
Foundry: Blueprint Story 109 into implementation and QA tasks

### DIFF
--- a/.foundry/stories/story-070-109-extract-mixed-record-trainer-data.md
+++ b/.foundry/stories/story-070-109-extract-mixed-record-trainer-data.md
@@ -33,4 +33,6 @@ When players mix records in Gen 3, they exchange Secret Bases and trainer data. 
 - Calculate or extract the EV yields associated with defeating these trainers.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks.
+- [x] Break down into Tasks.
+- [ ] task-109-247-parse-secret-base-trainer-party
+- [ ] task-109-248-parse-secret-base-trainer-party-qa

--- a/.foundry/tasks/task-109-247-parse-secret-base-trainer-party.md
+++ b/.foundry/tasks/task-109-247-parse-secret-base-trainer-party.md
@@ -1,0 +1,43 @@
+---
+id: task-109-247-parse-secret-base-trainer-party
+type: TASK
+title: Implement Gen 3 Secret Base Trainer and Party Parsing
+status: PENDING
+owner_persona: coder
+created_at: "2026-06-30"
+updated_at: "2026-06-30"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-070-109-extract-mixed-record-trainer-data
+tags:
+  - gen3
+  - save-parsing
+  - secret-base
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement Gen 3 Secret Base Trainer and Party Parsing
+
+## Context
+When players mix records in Gen 3, they exchange Secret Bases. We need to parse the `SecretBase` (or `SecretBaseRecord`) structures to extract the trainer details (name, ID) and their party composition.
+
+## Objectives
+Implement the logic to extract:
+1. `trainerName` (7 chars in RS, 8 chars in Emerald, starts at offset 2).
+2. `trainerId` (4 bytes, starts at offset 9 in RS, 10 in Emerald).
+3. The `party` struct (108 bytes, starts at offset 52 in both).
+
+## Technical Constraints & Directives
+- **DataView API:** You MUST exclusively use the native `DataView` API for all read operations, and gracefully handle `RangeError` for out-of-bounds reads (ADR 010).
+- **No Inline Magic Numbers:** All memory offsets, lengths, bit locations, and shifts MUST be defined as reusable constants at the module level.
+- **Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort permanently (impossible or max rejections), you MUST update to `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement parsing for `trainerName` and `trainerId` within the Secret Base struct.
+- [ ] Implement parsing for the `SecretBaseParty` structure (6 Pokémon: personality, moves, species, heldItems, levels, EVs).
+- [ ] Ensure all offsets and sizes are module-level constants.
+- [ ] Exclusively use `DataView` API.

--- a/.foundry/tasks/task-109-248-parse-secret-base-trainer-party-qa.md
+++ b/.foundry/tasks/task-109-248-parse-secret-base-trainer-party-qa.md
@@ -1,0 +1,43 @@
+---
+id: task-109-248-parse-secret-base-trainer-party-qa
+type: TASK
+title: QA - Gen 3 Secret Base Trainer and Party Parsing
+status: PENDING
+owner_persona: qa
+created_at: "2026-06-30"
+updated_at: "2026-06-30"
+depends_on:
+  - task-109-247-parse-secret-base-trainer-party
+jules_session_id: null
+pr_number: null
+parent: story-070-109-extract-mixed-record-trainer-data
+tags:
+  - qa
+  - gen3
+  - save-parsing
+  - secret-base
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA - Gen 3 Secret Base Trainer and Party Parsing
+
+## Context
+The coder has implemented the parsing logic for Gen 3 Secret Base trainer information and their party Pokémon. Your job is to verify this implementation.
+
+## Verification Protocol
+1. Verify that the coder used exclusively the `DataView` API (no raw `Uint8Array` access).
+2. Verify that all memory offsets (e.g. `0x34` for party), lengths, and bit locations are defined as reusable constants at the module level (no inline magic numbers).
+3. Ensure tests adequately cover bounds-checking / graceful failure.
+
+## Directives
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort permanently (impossible or max rejections), you MUST update to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify `DataView` API is used exclusively.
+- [ ] Verify module-level constants are used instead of magic numbers for offsets.
+- [ ] Verify comprehensive unit tests are present.


### PR DESCRIPTION
This PR completes `story-070-109-extract-mixed-record-trainer-data` by breaking down its requirements into actionable technical TASK nodes.

### Changes Made:
1.  **Drafted Implementation Blueprint:** Created `.foundry/tasks/task-109-247-parse-secret-base-trainer-party.md` for the `coder` persona. The blueprint explicitly mandates adherence to ADR 010 (exclusive use of the `DataView` API) and strictly forbids inline magic numbers for memory offsets and shifts, requiring module-level constants instead. It outlines the specific byte offsets required for extracting the `trainerName`, `trainerId`, and `party` structs.
2.  **Drafted Verification Protocol:** Created `.foundry/tasks/task-109-248-parse-secret-base-trainer-party-qa.md` for the `qa` persona to independently verify the coder's implementation against the architectural constraints (specifically `DataView` usage and constant definitions).
3.  **Updated Story Tracker:** Modified `.foundry/stories/story-070-109-extract-mixed-record-trainer-data.md` to include references to the newly generated child tasks as unchecked markdown lists and checked off its own acceptance criteria, ensuring compliance with ADR 007.

The DAG is now ready to route these tasks to the engineering personas.

---
*PR created automatically by Jules for task [324226336566927318](https://jules.google.com/task/324226336566927318) started by @szubster*