### PR TITLE
feat(story): break down roamer radar epic into gen 2 specific stories

### DIFF
--- a/.foundry/epics/epic-043-069-roamer-radar-ui.md
+++ b/.foundry/epics/epic-043-069-roamer-radar-ui.md
@@ -35,4 +35,6 @@ Build a visible dashboard or map widget that lists all active roaming Pokémon i
 - [ ] The component shows the human-readable route location for each roamer.
 - [ ] Status tags ("Active", "Caught", "Defeated") are correctly displayed based on save data.
 - [ ] The roamer's current route is highlighted on the map.
-- [ ] Story Owner: Break down this Epic into executable Stories.
+- [x] Story Owner: Break down this Epic into executable Stories.
+- [ ] story-069-247-gen2-roamer-radar-widget
+- [ ] story-069-248-gen2-roamer-radar-map-integration

--- a/.foundry/stories/story-069-247-gen2-roamer-radar-widget.md
+++ b/.foundry/stories/story-069-247-gen2-roamer-radar-widget.md
@@ -1,0 +1,34 @@
+---
+id: story-069-247-gen2-roamer-radar-widget
+type: STORY
+title: Gen 2 Roamer Radar Widget
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-043-069-roamer-radar-ui
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Roamer Radar Widget
+
+## Objective
+Construct a UI component that displays a list of active Gen 2 roamers (Raikou, Entei, Suicune).
+
+## Description
+- Build a visible dashboard or map widget that lists all active roaming Pokémon in the Gen 2 save file.
+- The widget should show the human-readable route name where the roamer is currently located, obtained from the Translation Layer.
+- Add visual tags to indicate the roamer's status (e.g., "Active", "Caught", "Defeated").
+
+## Acceptance Criteria
+- [ ] A dedicated UI component displays the list of active Gen 2 roamers.
+- [ ] The component shows the human-readable route location for each roamer.
+- [ ] Status tags are correctly displayed based on save data.
+- [ ] Tech Lead: Break down into tasks.

--- a/.foundry/stories/story-069-248-gen2-roamer-radar-map-integration.md
+++ b/.foundry/stories/story-069-248-gen2-roamer-radar-map-integration.md
@@ -1,0 +1,32 @@
+---
+id: story-069-248-gen2-roamer-radar-map-integration
+type: STORY
+title: Gen 2 Roamer Radar Map Integration
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on:
+  - story-069-247-gen2-roamer-radar-widget
+jules_session_id: null
+pr_number: null
+parent: epic-043-069-roamer-radar-ui
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Roamer Radar Map Integration
+
+## Objective
+Highlight the active Gen 2 roamer's current route on the interactive map.
+
+## Description
+- Integrate the Gen 2 roamer radar widget with the broader DexHelper interactive map flow.
+- Ensure the roamer's current location is visually highlighted on the map.
+
+## Acceptance Criteria
+- [ ] The roamer's current route is highlighted on the map.
+- [ ] Tech Lead: Break down into tasks.


### PR DESCRIPTION
This PR fulfills the Story Owner's responsibility to break down `epic-043-069-roamer-radar-ui` into actionable `STORY` nodes.

**Context:**
- The dependency `epic-043-068-roamer-map-translation` failed because Gen 3 roamer locations cannot be extracted statically (`adr-108-027`).
- Therefore, the roamer radar features have been scoped exclusively to Gen 2.

**Changes:**
- Generated `.foundry/stories/story-069-247-gen2-roamer-radar-widget.md`.
- Generated `.foundry/stories/story-069-248-gen2-roamer-radar-map-integration.md`.
- Updated `epic-043-069-roamer-radar-ui.md` markdown body to check off acceptance criteria and append the new child nodes.
- Preserved the unmodified YAML frontmatter of the parent Epic as requested.

---
*PR created automatically by Jules for task [14345830178703057270](https://jules.google.com/task/14345830178703057270) started by @szubster*