### PR TITLE
QA - Expose lower 16-bits of PV

### DIFF
--- a/.foundry/tasks/task-099-229-expose-lower-16bit-pv-qa.md
+++ b/.foundry/tasks/task-099-229-expose-lower-16bit-pv-qa.md
@@ -33,6 +33,6 @@ The Coder has implemented the logic to pre-calculate and expose the lower 16 bit
 4. **Completion Contract**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Validate logic correctly exposes lower 16-bits of PV.
-- [ ] Write/update tests to verify functionality.
-- [ ] Run `pnpm test` to ensure tests pass.
+- [x] Validate logic correctly exposes lower 16-bits of PV.
+- [x] Write/update tests to verify functionality.
+- [x] Run `pnpm test` to ensure tests pass.


### PR DESCRIPTION
Submitting empty PR for QA task to expose lower 16-bits of PV.

The implementation correctly added `lower16: pv & LOWER_16_BIT_MASK`, and explicit checks for `RangeError` within `parseGen3PersonalityValue`. Tests were correctly updated, running and passing `pnpm test`. Acceptance criteria have been checked off for the empty PR.

---
*PR created automatically by Jules for task [13983523466967499658](https://jules.google.com/task/13983523466967499658) started by @szubster*