### PR TITLE
QA: Verify Remediation State Transition Logic

### DIFF
--- a/.foundry/tasks/task-133-231-remediation-state-transition-logic-qa.md
+++ b/.foundry/tasks/task-133-231-remediation-state-transition-logic-qa.md
@@ -33,5 +33,5 @@ Following the implementation of the remediation state transition logic in `task-
 - **Reminder**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 3. Acceptance Criteria
-- [ ] Verify utility function updates status to `FAILED` without data loss.
-- [ ] Verify unit tests correctly cover the logic.
+- [x] Verify utility function updates status to `FAILED` without data loss.
+- [x] Verify unit tests correctly cover the logic.


### PR DESCRIPTION
This pull request validates the implementation of the remediation state transition utility in `task-133-230-remediation-state-transition-logic-impl`. 

The implementation was checked and unit tests in `.github/scripts/remediate-zombie.test.ts` pass, correctly ensuring that `status: ACTIVE` is updated to `status: FAILED` with a rejection reason using `gray-matter`.

All Acceptance Criteria checkboxes have been verified and checked off.

---
*PR created automatically by Jules for task [2958845553093926294](https://jules.google.com/task/2958845553093926294) started by @szubster*