### PR TITLE
QA: Verify Pokerus bitwise extraction refactor

### DIFF
--- a/.foundry/tasks/task-155-235-refactor-pokerus-bitwise-qa.md
+++ b/.foundry/tasks/task-155-235-refactor-pokerus-bitwise-qa.md
@@ -36,10 +36,10 @@ As per ADR 026:
    - Max boundary values (e.g., max strain and max days remaining).
 
 ## Acceptance Criteria
-- [ ] Verify tests in `common.test.ts` for `parsePokerus` cover absolute zero state
-- [ ] Verify tests in `common.test.ts` for `parsePokerus` cover cured boundary state
-- [ ] Verify tests in `common.test.ts` for `parsePokerus` cover max boundary values
-- [ ] Ensure all parsing logic involving bitwise extraction defines constants at module level (no magic numbers)
+- [x] Verify tests in `common.test.ts` for `parsePokerus` cover absolute zero state
+- [x] Verify tests in `common.test.ts` for `parsePokerus` cover cured boundary state
+- [x] Verify tests in `common.test.ts` for `parsePokerus` cover max boundary values
+- [x] Ensure all parsing logic involving bitwise extraction defines constants at module level (no magic numbers)
 
 ### Important Constraints
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Checked off the acceptance criteria for the Pokerus bitwise extraction refactor QA task after verifying that the `parsePokerus` implementation uses module-level constants and that `common.test.ts` includes comprehensive boundary testing for the absolute zero state, cured boundary state, and max boundary values, successfully adhering to ADR 026.

---
*PR created automatically by Jules for task [10419312625828062514](https://jules.google.com/task/10419312625828062514) started by @szubster*