### PR TITLE
chore(foundry): complete QA task for orchestrator max rejection cancellation

### DIFF
--- a/.foundry/tasks/task-153-235-orchestrator-max-rejection-cancellation-qa.md
+++ b/.foundry/tasks/task-153-235-orchestrator-max-rejection-cancellation-qa.md
@@ -29,5 +29,5 @@ notes: ''
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Review foundry-orchestrator.ts to verify the cancellation logic for max rejection threshold is correctly implemented and works as expected.
-- [ ] If the artifact is already completely implemented, apply the Empty PR policy.
+- [x] Review foundry-orchestrator.ts to verify the cancellation logic for max rejection threshold is correctly implemented and works as expected.
+- [x] If the artifact is already completely implemented, apply the Empty PR policy.


### PR DESCRIPTION
Verified the implementation of the orchestrator's cancellation logic when the max rejection threshold is reached. Checked off acceptance criteria in the QA task node to execute the Empty PR policy.

---
*PR created automatically by Jules for task [5935484291540394699](https://jules.google.com/task/5935484291540394699) started by @szubster*