### PR TITLE
feat: convert schema.md verifying state idea to PRD

### DIFF
--- a/.foundry/ideas/idea-097-schema-verifying-state-fix.md
+++ b/.foundry/ideas/idea-097-schema-verifying-state-fix.md
@@ -23,3 +23,6 @@ notes: ''
 
 ## Concept
 `schema.md` contains a contradiction in its System Invariants. Invariant 7 states: "COMPLETED nodes are read-only. Once a PR is merged, the node must not be edited." However, ADR 014 changed the lifecycle so that when a PR is merged, nodes transition to `VERIFYING`, not `COMPLETED`. The invariant needs to be updated to reflect the `VERIFYING` state accurately.
+
+## Derived Nodes
+- [ ] .foundry/prds/prd-097-096-schema-verifying-state-fix.md

--- a/.foundry/prds/prd-097-096-schema-verifying-state-fix.md
+++ b/.foundry/prds/prd-097-096-schema-verifying-state-fix.md
@@ -1,0 +1,34 @@
+---
+id: prd-097-096-schema-verifying-state-fix
+type: PRD
+title: Fix contradiction in schema.md regarding VERIFYING state
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-097-schema-verifying-state-fix
+tags:
+  - documentation
+  - schema
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Fix contradiction in schema.md regarding VERIFYING state
+
+## Background
+`schema.md` contains a contradiction in its System Invariants regarding the node lifecycle. Invariant 7 stated: "COMPLETED nodes are read-only. Once a PR is merged, the node must not be edited."
+However, ADR 014 changed the lifecycle so that when a PR is merged, nodes transition to `VERIFYING`, not `COMPLETED`.
+This issue updates the invariant to reflect the `VERIFYING` state accurately.
+
+## Requirements
+- `schema.md` must accurately reflect the node lifecycle changes introduced by ADR 014.
+- Invariant 7 must be updated.
+
+## Acceptance Criteria
+- [ ] Invariant 7 is updated to clarify that `VERIFYING` and `COMPLETED` nodes are read-only for implementing personas.


### PR DESCRIPTION
This PR transforms the `idea-097-schema-verifying-state-fix` node into a formal Product Requirements Document (`prd-097-096-schema-verifying-state-fix.md`) as part of the normal PM workflow.

It ensures that the actual code fix (updating `schema.md`) is properly handed off to the downstream execution pipeline by creating the requirements node and tracking it within the parent's markdown body.

---
*PR created automatically by Jules for task [18201326834989065594](https://jules.google.com/task/18201326834989065594) started by @szubster*