### PR TITLE
Break down PRD 092 into Epics

### DIFF
--- a/.foundry/epics/epic-092-116-gen3-ev-data-extraction.md
+++ b/.foundry/epics/epic-092-116-gen3-ev-data-extraction.md
@@ -1,0 +1,40 @@
+---
+id: epic-092-116-gen3-ev-data-extraction
+type: EPIC
+title: Epic - Gen 3 EV Data Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-092-056-gen3-ev-training-dashboard
+tags:
+  - gen3
+  - save-engine
+  - endgame
+  - competitive
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic - Gen 3 EV Data Extraction
+
+## 1. Objective
+Develop the parsing logic in the save engine to accurately extract the 6 Effort Value (EV) stats (HP, Attack, Defense, Sp. Atk, Sp. Def, Speed) for all Pokémon in the current party and PC boxes across all Generation 3 games.
+
+## 2. Background
+This epic covers the backend/data layer requirements of the Gen 3 EV Training Dashboard PRD (`prd-092-056-gen3-ev-training-dashboard.md`). Data extraction must be accurate, efficient, and support Ruby, Sapphire, Emerald, FireRed, and LeafGreen.
+
+## 3. Scope
+- Implement the parsing logic in `src/engine/gen3/` or appropriate module to read EV offsets for Party and PC Pokémon.
+- Ensure the extraction uses the native `DataView` API exclusively (ADR 010).
+- Catch `RangeError` from the `DataView` API gracefully for corrupted or truncated files.
+- Return the extracted EV data in a structured format suitable for the frontend dashboard.
+
+## 4. Acceptance Criteria
+- [ ] Save engine successfully extracts EV data for party and PC Pokémon in Gen 3.
+- [ ] Extraction logic handles all Generation 3 games (Ruby, Sapphire, Emerald, FireRed, LeafGreen).
+- [ ] The parsing implementation strictly uses the `DataView` API.

--- a/.foundry/epics/epic-092-117-gen3-ev-dashboard-ui.md
+++ b/.foundry/epics/epic-092-117-gen3-ev-dashboard-ui.md
@@ -1,0 +1,42 @@
+---
+id: epic-092-117-gen3-ev-dashboard-ui
+type: EPIC
+title: Epic - Gen 3 EV Dashboard UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on:
+  - epic-092-116-gen3-ev-data-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-092-056-gen3-ev-training-dashboard
+tags:
+  - gen3
+  - ui
+  - endgame
+  - competitive
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic - Gen 3 EV Dashboard UI
+
+## 1. Objective
+Develop the EV visualization dashboard UI to show EV distribution and remaining values for selected Pokémon in Generation 3.
+
+## 2. Background
+This epic covers the frontend UI requirements of the Gen 3 EV Training Dashboard PRD (`prd-092-056-gen3-ev-training-dashboard.md`). It relies on the data extraction logic implemented in `epic-092-116-gen3-ev-data-extraction`.
+
+## 3. Scope
+- Create a dashboard component to display the EV distribution for selected Pokémon.
+- Use a radar chart and/or a detailed bar graph for visualization.
+- Show exact numerical values for each stat's EV out of the individual stat cap (255) and the total accumulated EVs out of the absolute maximum (510).
+- Display an "EVs Remaining" counter clearly indicating how many points are left to train.
+- Ensure the UI components strictly follow the tactical hardware aesthetic guidelines (ADR 008, ADR 024) with monospaced fonts, sharp edges, and dashed borders.
+- Efficiently render the dashboard without delaying initial load.
+
+## 4. Acceptance Criteria
+- [ ] The dashboard accurately visualizes the EV distribution and total remaining EVs.
+- [ ] UI components strictly follow the tactical aesthetic guidelines.

--- a/.foundry/epics/epic-092-118-gen3-ev-training-recommendations.md
+++ b/.foundry/epics/epic-092-118-gen3-ev-training-recommendations.md
@@ -1,0 +1,38 @@
+---
+id: epic-092-118-gen3-ev-training-recommendations
+type: EPIC
+title: Epic - Gen 3 EV Training Recommendations
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on:
+  - epic-092-117-gen3-ev-dashboard-ui
+jules_session_id: null
+pr_number: null
+parent: prd-092-056-gen3-ev-training-dashboard
+tags:
+  - gen3
+  - recommendations
+  - endgame
+  - competitive
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic - Gen 3 EV Training Recommendations
+
+## 1. Objective
+Develop the logic and UI to provide actionable route and trainer recommendations for optimal EV farming based on the Pokémon's current EVs and goals.
+
+## 2. Background
+This epic covers the training recommendations aspect of the Gen 3 EV Training Dashboard PRD (`prd-092-056-gen3-ev-training-dashboard.md`). It integrates with the dashboard UI created in `epic-092-117-gen3-ev-dashboard-ui`.
+
+## 3. Scope
+- Integrate recommendation logic that evaluates a Pokémon's current EV distribution and suggests routes or specific trainers that yield the missing required EVs.
+- The logic can assume common competitive builds or allow basic goal setting.
+- Display these recommendations within the EV visualization dashboard.
+
+## 4. Acceptance Criteria
+- [ ] Training recommendations provide actionable route/trainer data for EV farming.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -14,3 +14,4 @@ When a child node (e.g., an Epic or Story) is proven mathematically or technical
 
 ## Pattern: Parent-Linked ID Schema Enforcement
 When generating downstream nodes using the parent-linked ID schema (`<type>-<parent_NNN>-<NNN>-<slug>`), ensure that the `<parent_NNN>` segment strictly corresponds to the direct parent's sequence number (e.g., `054` from `prd-088-054-trick-house-tracker`), not the grandparent or project grouping ID (`088`). Similarly, `depends_on` arrays must reference exact Node IDs without file paths or extensions.
+When updating a parent node (like a PRD), do NOT check off its functional acceptance criteria. Only append newly generated child node references as unchecked tasks (`- [ ]`). The parent node's functional criteria must remain unchecked until all child nodes are completely finished.

--- a/.foundry/prds/prd-092-056-gen3-ev-training-dashboard.md
+++ b/.foundry/prds/prd-092-056-gen3-ev-training-dashboard.md
@@ -50,3 +50,6 @@ In Pokémon Generation 3, EVs are completely invisible to the player, making com
 - [ ] The dashboard accurately visualizes the EV distribution and total remaining EVs.
 - [ ] Training recommendations provide actionable route/trainer data for EV farming.
 - [ ] UI components strictly follow the tactical aesthetic guidelines.
+- [ ] .foundry/epics/epic-092-116-gen3-ev-data-extraction.md
+- [ ] .foundry/epics/epic-092-117-gen3-ev-dashboard-ui.md
+- [ ] .foundry/epics/epic-092-118-gen3-ev-training-recommendations.md


### PR DESCRIPTION
Breaks down the "Gen 3 EV Training Dashboard" PRD into granular EPIC nodes. Maps dependencies among the Epics properly and links them to the parent PRD without prematurely completing its functional criteria.

---
*PR created automatically by Jules for task [1984652679342753907](https://jules.google.com/task/1984652679342753907) started by @szubster*