### PR TITLE
Break down Pokegear Phone Tracker PRD into Epics and Research node

### DIFF
--- a/.foundry/epics/epic-055-116-pokegear-active-callers.md
+++ b/.foundry/epics/epic-055-116-pokegear-active-callers.md
@@ -1,0 +1,37 @@
+---
+id: epic-055-116-pokegear-active-callers
+type: EPIC
+title: Pokegear Active Callers Dashboard
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on:
+  - research-055-244-pokegear-mechanics
+jules_session_id: null
+pr_number: null
+parent: prd-090-055-pokegear-phone-tracker
+tags:
+  - feature
+  - gen2
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Pokegear Active Callers Dashboard
+
+## Objective
+Create a dashboard view displaying all registered Pokegear NPCs and their current status in Generation 2 (Gold, Silver, Crystal).
+
+## Requirements
+- Parse the registered numbers list from the save file based on the research findings.
+- Render the current status of each registered NPC on a centralized dashboard (e.g., "Ready for Rematch", "Has Item", "Idle").
+- Provide a clean and responsive UI for tracking active callers.
+
+## Acceptance Criteria
+- [ ] Create UI for Active Callers Dashboard
+- [ ] Implement save file parsing for registered numbers
+- [ ] Integrate parsed data with dashboard UI

--- a/.foundry/epics/epic-055-117-pokegear-predictor.md
+++ b/.foundry/epics/epic-055-117-pokegear-predictor.md
@@ -1,0 +1,36 @@
+---
+id: epic-055-117-pokegear-predictor
+type: EPIC
+title: Pokegear Call Probability & Predictor Engine
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on:
+  - research-055-244-pokegear-mechanics
+jules_session_id: null
+pr_number: null
+parent: prd-090-055-pokegear-phone-tracker
+tags:
+  - feature
+  - gen2
+  - mechanics
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Pokegear Call Probability & Predictor Engine
+
+## Objective
+Implement the logic to predict Pokegear call probability based on Gen 2 save file data and RNG mechanics.
+
+## Requirements
+- Utilize the RNG mechanics and timer data documented in the research node.
+- Implement a predictor engine that calculates the probability of each active NPC calling the player.
+- Display these probability values or indicators on the Active Callers Dashboard.
+
+## Acceptance Criteria
+- [ ] Implement predictor logic based on RNG mechanics
+- [ ] Display call probabilities on the UI

--- a/.foundry/epics/epic-055-118-pokegear-alerts.md
+++ b/.foundry/epics/epic-055-118-pokegear-alerts.md
@@ -1,0 +1,36 @@
+---
+id: epic-055-118-pokegear-alerts
+type: EPIC
+title: Pokegear Swarm & Item Alerts
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on:
+  - research-055-244-pokegear-mechanics
+jules_session_id: null
+pr_number: null
+parent: prd-090-055-pokegear-phone-tracker
+tags:
+  - feature
+  - gen2
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Pokegear Swarm & Item Alerts
+
+## Objective
+Implement specific UI alerts and filtering for high-value Pokegear calls (swarms and rare items) in Generation 2.
+
+## Requirements
+- Identify and filter NPCs that offer rare items (e.g., Fisher Tully's Water Stone) or notify about swarms, based on the research node's findings.
+- Create distinct UI highlights or separate sections for these high-value calls on the dashboard.
+- Differentiate these special calls from standard rematch calls to allow players to focus their efforts.
+
+## Acceptance Criteria
+- [ ] Implement filtering for swarm and item-giving calls
+- [ ] Create distinct UI alerts for high-value calls

--- a/.foundry/prds/prd-090-055-pokegear-phone-tracker.md
+++ b/.foundry/prds/prd-090-055-pokegear-phone-tracker.md
@@ -32,4 +32,8 @@ In Generation 2 (Gold, Silver, Crystal), the Pokégear Phone is a central featur
 - **Swarm/Item Alerts:** Specifically highlight NPCs that offer rare items (like Water Stone from Fisher Tully) or notify about swarms, separating them from standard rematch calls.
 
 ## Acceptance Criteria
-- [ ] Break down into Epics
+- [x] Break down into Epics
+- [ ] .foundry/research/research-055-244-pokegear-mechanics.md
+- [ ] .foundry/epics/epic-055-116-pokegear-active-callers.md
+- [ ] .foundry/epics/epic-055-117-pokegear-predictor.md
+- [ ] .foundry/epics/epic-055-118-pokegear-alerts.md

--- a/.foundry/research/research-055-244-pokegear-mechanics.md
+++ b/.foundry/research/research-055-244-pokegear-mechanics.md
@@ -1,0 +1,36 @@
+---
+id: research-055-244-pokegear-mechanics
+type: RESEARCH
+title: Gen 2 Pokegear Call Mechanics Research
+status: PENDING
+owner_persona: researcher
+created_at: '2026-06-30'
+updated_at: '2026-06-30'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-090-055-pokegear-phone-tracker
+tags:
+  - feature
+  - gen2
+  - mechanics
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Gen 2 Pokegear Call Mechanics
+
+## Objective
+Investigate and document the exact save file offsets, RNG mechanics, and state flags governing Pokegear phone calls in Generation 2 (Gold, Silver, Crystal).
+
+## Requirements
+- Identify the memory blocks where registered Pokegear numbers are stored.
+- Determine the RNG logic and timers that trigger an incoming phone call.
+- Document how swarm notifications and item-giving states (like evolutionary stones from specific NPCs) are stored and manipulated.
+
+## Acceptance Criteria
+- [ ] Document registered number memory offsets
+- [ ] Document RNG call trigger logic
+- [ ] Document swarm and item-giving state flags


### PR DESCRIPTION
Generated one Research node to document save file/RNG mechanics and three Epic nodes (Dashboard, Predictor, Alerts) to fulfill PRD-090-055 requirements. Updated parent PRD checkboxes with newly generated child nodes, strictly adhering to DAG ID constraints without modifying parent YAML.

---
*PR created automatically by Jules for task [2400102194657318913](https://jules.google.com/task/2400102194657318913) started by @szubster*