### PR TITLE
Complete Research on Gen 2 Breeding DV Overlap Constraints

### DIFF
--- a/.foundry/docs/knowledge_base/development/gen2_breeding_dv_overlap.md
+++ b/.foundry/docs/knowledge_base/development/gen2_breeding_dv_overlap.md
@@ -1,0 +1,7 @@
+# Gen 2 Breeding: DV Overlap Constraint (Incest Prevention)
+
+In Generation 2, there is a structural quirk to prevent inbreeding. The game determines if two Pokémon are "related" based on their Individual Values (DVs). Two Pokémon are incompatible for breeding if:
+1. Their Defense DVs are exactly the same.
+2. AND their Special DVs are either identical OR they differ by exactly 8.
+
+Because shininess is tied to specific DV combinations in Gen 2 (Defense always 10, Special always 10), two shiny Pokémon (or shiny carriers) will almost certainly trigger this rule and be unable to breed. This logic must be enforced in any algorithm dealing with Gen 2 breeding pairs.

--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -66,3 +66,6 @@ When designing features for Generation 3 hardware, be aware of the stark differe
 
 ## Lesson: Save File Parsing Reusable Constants
 When documenting memory offsets or drafting parser requirements, it is a strict architectural constraint (enforced by QA Validation Rules) that all memory offsets, lengths, bit locations, and shifts must be defined as reusable, descriptive constants at the module level. Inline magic numbers are strictly forbidden and will result in permanent failure.
+
+## Proper Knowledge Storage
+**Lesson:** When I uncover universally applicable domain knowledge (e.g., Gen 2 breeding DV overlap rules), I MUST document it in `.foundry/docs/knowledge_base/` rather than adding it to my persona journal. My journal must be reserved for recording recurring pipeline failures, systemic constraints, and meta-lessons to prevent context window bloat.

--- a/.foundry/research/research-084-242-gen2-breeding-dvs.md
+++ b/.foundry/research/research-084-242-gen2-breeding-dvs.md
@@ -28,3 +28,44 @@ The QA task `task-084-211-breeding-pair-algorithm-qa` was rejected with the reas
 ## Objectives
 - Investigate and document the exact conditions where two Pokémon are considered "related" and therefore incompatible for breeding based on Gen 2 DVs.
 - Provide the exact logic and test cases required to enforce this constraint in the breeding algorithm.
+
+## Findings: Gen 2 DV Overlap Mechanics
+
+In Generation II, whether a Pokémon is Shiny is completely determined by its DVs (Individual Values).
+A Pokémon is considered Shiny if its Defense, Speed, and Special DVs are all exactly 10, and its Attack DV is 2, 3, 6, 7, 10, 11, 14, or 15.
+
+To prevent incest (inbreeding), the Gen 2 breeding algorithm enforces a strict constraint based on DVs:
+Two Pokémon are considered incompatible ("related") if:
+1. Their Defense DVs are strictly identical.
+2. AND their Special DVs are either identical OR differ by exactly 8.
+
+Because all Shiny Pokémon have a Defense DV of 10 and a Special DV of 10, any two Shiny Pokémon will trigger this rule (Defense DVs match, Special DVs match) and be unable to breed.
+This rule also heavily affects "Shiny Carriers" (Pokémon with DVs matching the Shiny criteria or 8 off in Special, often passed down from Shiny parents). A Shiny Carrier will frequently be unable to breed with a Shiny Pokémon or another Shiny Carrier if their Defense and Special DVs overlap in this manner.
+
+## Test Cases
+
+To properly implement this constraint, the breeding algorithm must evaluate the Defense and Special DVs of both parents (Parent A and Parent B).
+
+**Test Case 1: Two Shiny Pokémon**
+- Parent A: Defense DV = 10, Special DV = 10
+- Parent B: Defense DV = 10, Special DV = 10
+- Result: **Incompatible** (Defense match: `10 == 10`, Special match: `10 == 10`)
+
+**Test Case 2: Shiny and Shiny Carrier (Difference of 8)**
+- Parent A: Defense DV = 10, Special DV = 10 (Shiny)
+- Parent B: Defense DV = 10, Special DV = 2 (Carrier)
+- Result: **Incompatible** (Defense match: `10 == 10`, Special difference: `|10 - 2| == 8`)
+
+**Test Case 3: Shiny and Unrelated Non-Shiny**
+- Parent A: Defense DV = 10, Special DV = 10 (Shiny)
+- Parent B: Defense DV = 7, Special DV = 10 (Non-Shiny)
+- Result: **Compatible** (Defense mismatch: `10 != 7`)
+
+**Test Case 4: Identical Non-Shiny Defense, Different Special**
+- Parent A: Defense DV = 14, Special DV = 5
+- Parent B: Defense DV = 14, Special DV = 10
+- Result: **Compatible** (Defense match: `14 == 14`, but Special difference `|5 - 10| == 5` is not 0 or 8)
+
+## Acceptance Criteria
+- [x] Investigate and document the exact conditions where two Pokémon are considered "related" and therefore incompatible for breeding based on Gen 2 DVs.
+- [x] Provide the exact logic and test cases required to enforce this constraint in the breeding algorithm.


### PR DESCRIPTION
Completed the research objective for investigating and documenting the exact conditions where two Pokémon are considered "related" and therefore incompatible for breeding based on Gen 2 DVs. The findings confirm that two Pokémon cannot breed if their Defense DVs are strictly identical and their Special DVs are identical or differ by exactly 8. This rule heavily affects Shiny Pokémon and Shiny Carriers. Test cases have been documented and the overarching domain knowledge has been placed in the public knowledge base directory for downstream tasks to consume.

---
*PR created automatically by Jules for task [6040152355837937194](https://jules.google.com/task/6040152355837937194) started by @szubster*