### PR TITLE
Create Task Blueprints for Gen 3 Roamer DataView Parsing

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -114,3 +114,7 @@ When drafting QA tasks, explicitly use exact Node IDs without file extensions or
 
 ## [Anomaly] Target artifacts existed prior to session
 When assigned to STORY `story-058-152-refactor-feebas-magic-numbers`, I found that the child task `task-152-230-refactor-feebas-magic-numbers-impl.md` already existed and was in the `COMPLETED` state, and the code changes in `feebas.ts` were already made. Proceeding to submit empty PR to complete the story.
+
+When setting node references in YAML fields (`depends_on`, `parent`) or appending child node references to a parent's markdown checklist (`- [ ]`), strictly use the exact Node ID without file extensions or directory paths (e.g., use `task-123-slug`, NOT `.foundry/tasks/task-123-slug.md`). Violating this causes orchestrator DAG validation errors.
+
+When determining the next available sequence number for nodes using the `<type>-<parent_NNN>-<NNN>-<slug>` schema, extract the third token (the actual `NNN`) from existing files using tools like `awk -F'-' '{print $3}'` rather than relying on standard directory sorting, to prevent sequence ID collisions and sorting misalignments.

--- a/.foundry/stories/story-101-242-gen3-roamer-parser.md
+++ b/.foundry/stories/story-101-242-gen3-roamer-parser.md
@@ -37,4 +37,6 @@ We must extract IVs (`0x00`), Personality (`0x04`), Species (`0x08`), HP (`0x0A`
 - [ ] Implement a parser using `DataView` API that extracts the `Roamer` struct based on the version-specific offsets.
 - [ ] Extract and expose the `active` boolean properly.
 - [ ] Add unit tests using Vitest verifying the extraction logic against mock save data blocks for Emerald, RS, and FRLG.
-- [ ] Tech Lead: Break down this Story into executable Tasks.
+- [x] Tech Lead: Break down this Story into executable Tasks.
+- [ ] task-242-249-gen3-roamer-dataview-parser-impl
+- [ ] task-242-250-gen3-roamer-dataview-parser-qa

--- a/.foundry/tasks/task-242-249-gen3-roamer-dataview-parser-impl.md
+++ b/.foundry/tasks/task-242-249-gen3-roamer-dataview-parser-impl.md
@@ -1,0 +1,59 @@
+---
+id: task-242-249-gen3-roamer-dataview-parser-impl
+type: TASK
+title: Gen 3 Roamer DataView Parsing Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-101-242-gen3-roamer-parser
+tags:
+  - gen3
+  - roamer
+  - dataview
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer DataView Parsing Implementation
+
+## Objective
+Implement a robust parser for the Gen 3 `Roamer` struct using the `DataView` API.
+
+## Description
+The `Roamer` struct holds the state of the roaming legendary Pokémon in Generation 3 games. This task requires extracting this struct from `SaveBlock1` using version-specific offsets.
+
+**Base Offsets in SaveBlock1:**
+- Emerald: `0x31DC`
+- Ruby/Sapphire: `0x3144`
+- FireRed/LeafGreen: `0x30D0`
+
+**Fields to Extract (relative to the base offset):**
+- IVs: `0x00` (32-bit integer)
+- Personality: `0x04` (32-bit integer)
+- Species: `0x08` (16-bit integer)
+- HP: `0x0A` (16-bit integer)
+- Level: `0x0C` (8-bit integer)
+- Status: `0x0D` (8-bit integer)
+- Active: `0x13` (Boolean, 8-bit integer where non-zero is true)
+
+## Architectural Constraints & Rules (CRITICAL)
+- **DataView API Only:** All parsing logic MUST exclusively use the native `DataView` API. Do not use raw `Uint8Array` manipulations.
+- **No Magic Numbers:** All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+- **Bounds Checking:** The parser must rely on `DataView` to throw `RangeError` on out-of-bounds reads. These `RangeError`s must be caught explicitly by the parser and gracefully propagated up as specific validation errors (e.g., "Corrupted Save File").
+- **Bitwise Operations:** When unpacking bitwise data (e.g., IVs if they need unpacking), use explicit bitwise shifting (`>>`) and masking (`&`) to isolate discrete properties.
+- **Empty PRs:** If you determine the artifact already exists and meets all criteria, you must still submit an empty PR. **CRITICAL:** Before submitting an empty PR, you MUST check off all Acceptance Criteria checkboxes. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009.
+- **Failures:**
+  - If you experience a transient failure requiring a retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+  - If you must abort or permanently fail the task (impossible or max rejections reached), update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+
+## Acceptance Criteria
+- [ ] Create or update the Gen 3 parsing module to extract the `Roamer` struct using `DataView`.
+- [ ] Define all offsets (`0x31DC`, `0x3144`, `0x30D0`, `0x00`, `0x04`, `0x08`, `0x0A`, `0x0C`, `0x0D`, `0x13`) as module-level constants.
+- [ ] Extract the `active` boolean properly from offset `0x13`.
+- [ ] Catch `RangeError` from `DataView` operations and handle them gracefully.

--- a/.foundry/tasks/task-242-250-gen3-roamer-dataview-parser-qa.md
+++ b/.foundry/tasks/task-242-250-gen3-roamer-dataview-parser-qa.md
@@ -1,0 +1,49 @@
+---
+id: task-242-250-gen3-roamer-dataview-parser-qa
+type: TASK
+title: Gen 3 Roamer DataView Parsing QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on:
+  - task-242-249-gen3-roamer-dataview-parser-impl
+jules_session_id: null
+pr_number: null
+parent: story-101-242-gen3-roamer-parser
+tags:
+  - gen3
+  - roamer
+  - dataview
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer DataView Parsing QA
+
+## Objective
+Verify the robust parser for the Gen 3 `Roamer` struct that uses the `DataView` API.
+
+## Description
+The implementation task `task-242-249-gen3-roamer-dataview-parser-impl` added logic to extract the `Roamer` struct from `SaveBlock1` using version-specific offsets for Emerald, Ruby/Sapphire, and FireRed/LeafGreen. This QA task is responsible for verifying that the extraction logic is correct and robust by adding comprehensive unit tests.
+
+## Architectural Constraints & Rules (CRITICAL)
+- **DataView API Verification:** Ensure the implementation exclusively uses the `DataView` API.
+- **No Magic Numbers:** Verify that no magic numbers are used in the implementation and all memory offsets, lengths, bit locations, and shifts are defined as reusable constants.
+- **Bounds Checking:** Verify the parser correctly catches `RangeError` from `DataView` out-of-bounds reads and propagates them as validation errors.
+- **Test Framework:** Unit tests must be written using Vitest.
+- **Mock Data:** Tests must run against mock save data blocks representing Emerald, Ruby/Sapphire, and FireRed/LeafGreen `SaveBlock1` data.
+- **Empty PRs:** If you determine the artifact already exists and meets all criteria, you must still submit an empty PR. **CRITICAL:** Before submitting an empty PR, you MUST check off all Acceptance Criteria checkboxes. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009.
+- **Failures:**
+  - If you experience a transient failure requiring a retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+  - If you must abort or permanently fail the task (impossible or max rejections reached), update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+
+## Acceptance Criteria
+- [ ] Add unit tests using Vitest verifying the extraction logic against mock save data blocks for Emerald.
+- [ ] Add unit tests using Vitest verifying the extraction logic against mock save data blocks for Ruby/Sapphire.
+- [ ] Add unit tests using Vitest verifying the extraction logic against mock save data blocks for FireRed/LeafGreen.
+- [ ] Add unit tests verifying that out-of-bounds `DataView` reads throw `RangeError` and are caught/handled appropriately.
+- [ ] Verify the `active` boolean is extracted correctly from offset `0x13` in all version mock tests.


### PR DESCRIPTION
Breaks down the story for Gen 3 roamer DataView parsing into actionable implementation and QA tasks. It strictly enforces the use of the `DataView` API and the definition of module-level constants for all memory offsets without relying on inline magic numbers. Both tasks are safely integrated into the DAG schema.

---
*PR created automatically by Jules for task [18420166074103566797](https://jules.google.com/task/18420166074103566797) started by @szubster*