### PR TITLE
feat(foundry): generate palette prompt update task

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -114,3 +114,6 @@ When drafting QA tasks, explicitly use exact Node IDs without file extensions or
 
 ## [Anomaly] Target artifacts existed prior to session
 When assigned to STORY `story-058-152-refactor-feebas-magic-numbers`, I found that the child task `task-152-230-refactor-feebas-magic-numbers-impl.md` already existed and was in the `COMPLETED` state, and the code changes in `feebas.ts` were already made. Proceeding to submit empty PR to complete the story.
+
+## [Anomaly] Target artifacts existed prior to session
+When assigned to STORY story-100-245-update-palette-persona-retry, I found that the target changes in .github/agents/palette.md were already made. Proceeding with the Empty PR Policy Handoff pattern by creating a TASK for the Coder to verify and submit the Empty PR.

--- a/.foundry/stories/story-100-245-update-palette-persona-retry.md
+++ b/.foundry/stories/story-100-245-update-palette-persona-retry.md
@@ -31,3 +31,4 @@ Update the relevant agent prompts or system configurations to explicitly define 
 ## Acceptance Criteria
 - [ ] Agent prompt explicitly states `palette` persona owns `src/index.css`.
 - [ ] Palette persona is tasked with enforcing the tactical hardware aesthetic and managing custom `@utility` primitives.
+- [ ] .foundry/tasks/task-245-249-update-palette-persona-impl.md

--- a/.foundry/tasks/task-245-249-update-palette-persona-impl.md
+++ b/.foundry/tasks/task-245-249-update-palette-persona-impl.md
@@ -1,0 +1,37 @@
+---
+id: task-245-249-update-palette-persona-impl
+type: TASK
+title: Implement palette agent prompt update
+status: PENDING
+owner_persona: coder
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-100-245-update-palette-persona-retry
+tags:
+  - styling
+  - agents
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement palette agent prompt update
+
+## Objective
+Update `.github/agents/palette.md` to explicitly define the `palette` persona's responsibility for maintaining `src/index.css`, enforcing the tactical hardware aesthetic, and managing custom `@utility` primitives per ADR 024.
+
+## Technical Contract
+- Ensure `.github/agents/palette.md` clearly states the ownership of `src/index.css`.
+- Ensure `.github/agents/palette.md` states the responsibility for tactical utility definitions via `@utility`.
+- **Note to Coder:** It is highly likely this target artifact already matches the required state. If so, you MUST submit an Empty PR in accordance with the Empty PR Policy. You MUST check off all Acceptance Criteria checkboxes before submitting an empty PR.
+- **System Rule Reminders:**
+  - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+  - If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+
+## Acceptance Criteria
+- [ ] Agent prompt explicitly states `palette` persona owns `src/index.css`.
+- [ ] Palette persona is tasked with enforcing the tactical hardware aesthetic and managing custom `@utility` primitives.


### PR DESCRIPTION
This PR fulfills the Tech Lead requirement for `story-100-245-update-palette-persona-retry`.

The target modifications in `.github/agents/palette.md` to define the persona's ownership of `src/index.css` and `@utility` primitives were found to already exist in the codebase. As per the Empty PR Policy Handoff rule, a TASK blueprint (`task-245-249`) has been generated and assigned to the Coder persona to formally execute the Empty PR submission and verify the completion state. 

The generated task has been appended to the parent STORY node without modifying its YAML frontmatter to prevent premature transition to VERIFYING. The anomaly was also logged in the tech lead journal.

---
*PR created automatically by Jules for task [5353644333763626509](https://jules.google.com/task/5353644333763626509) started by @szubster*