### PR TITLE
feat(foundry): generate tasks for gen 2 egg hatch parsing

### DIFF
--- a/.foundry/stories/story-106-158-gen2-egg-hatch-parsing.md
+++ b/.foundry/stories/story-106-158-gen2-egg-hatch-parsing.md
@@ -30,3 +30,5 @@ In Gen 2, if a Pokémon is an Egg (species ID 253), its Friendship byte is repur
 - [ ] Parse the Friendship byte for Gen 2 Eggs (Party and PC).
 - [ ] Multiply the parsed cycle count by 256 to calculate exact steps.
 - [ ] Write unit tests verifying the calculation.
+- [ ] task-158-249-gen2-egg-hatch-parsing-impl
+- [ ] task-158-250-gen2-egg-hatch-parsing-qa

--- a/.foundry/tasks/task-158-249-gen2-egg-hatch-parsing-impl.md
+++ b/.foundry/tasks/task-158-249-gen2-egg-hatch-parsing-impl.md
@@ -1,0 +1,55 @@
+---
+id: task-158-249-gen2-egg-hatch-parsing-impl
+type: TASK
+title: Implement Gen 2 Egg Hatch Data Extraction
+status: READY
+owner_persona: coder
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-106-158-gen2-egg-hatch-parsing
+tags:
+  - gen2
+  - save-parsing
+  - breeding
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 2 Egg Hatch Data Extraction
+
+## Objective
+Implement the logic to extract the remaining egg cycles for Gen 2 Eggs and calculate the exact remaining steps for the egg to hatch.
+
+## Technical Blueprint
+
+### 1. Update `PokemonInstance` Interface
+In `src/engine/saveParser/parsers/common.ts`:
+- Add an optional `eggSteps?: number | undefined;` property to the `PokemonInstance` interface.
+
+### 2. Update Gen 2 Parsing Logic
+In `src/engine/saveParser/parsers/gen2.ts`, inside the `parseGen2PokemonInstance` function:
+- Check if the Pokémon is an Egg by checking if `speciesId === 253`.
+- If the Pokémon is an Egg, its `friendship` byte represents the remaining "Egg Cycles".
+- Calculate `eggSteps` by multiplying the parsed friendship byte (cycle count) by `256` (the Gen 2 cycle length).
+- Add the `eggSteps` property to the returned object.
+
+### 3. Add Unit Tests
+In `src/engine/saveParser/saveParser.test.ts` (or the appropriate test file like `gen2.test.ts` depending on where the `parseGen2PokemonInstance` tests reside):
+- Add test cases to verify the calculation.
+- Mock a `DataView` where the species ID is 253 and the friendship byte is set to a known value. Verify that the returned instance has the correctly calculated `eggSteps`.
+- Verify that non-Egg Pokémon (species ID !== 253) do not have `eggSteps` defined.
+
+## Constraints & Contract
+- Ensure all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. Do not use inline magic numbers.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] `PokemonInstance` is updated with `eggSteps?: number`.
+- [ ] `parseGen2PokemonInstance` calculates `eggSteps` correctly for eggs (species ID 253).
+- [ ] Unit tests are written to verify the calculation.

--- a/.foundry/tasks/task-158-250-gen2-egg-hatch-parsing-qa.md
+++ b/.foundry/tasks/task-158-250-gen2-egg-hatch-parsing-qa.md
@@ -1,0 +1,42 @@
+---
+id: task-158-250-gen2-egg-hatch-parsing-qa
+type: TASK
+title: QA - Verify Gen 2 Egg Hatch Data Extraction
+status: PENDING
+owner_persona: qa
+created_at: '2026-06-29'
+updated_at: '2026-06-29'
+depends_on:
+  - task-158-249-gen2-egg-hatch-parsing-impl
+jules_session_id: null
+pr_number: null
+parent: story-106-158-gen2-egg-hatch-parsing
+tags:
+  - qa
+  - gen2
+  - save-parsing
+  - breeding
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Verify Gen 2 Egg Hatch Data Extraction
+
+## Objective
+Verify that the coder successfully implemented the Gen 2 egg hatch data extraction logic and that the calculation is accurate.
+
+## Verification Steps
+1. Verify that `eggSteps?: number | undefined;` is present in the `PokemonInstance` interface (`src/engine/saveParser/parsers/common.ts`).
+2. Verify that in `src/engine/saveParser/parsers/gen2.ts` (`parseGen2PokemonInstance`), `eggSteps` is calculated as `friendship * 256` if the `speciesId` is `253`.
+3. Verify that unit tests were written and they pass by running `pnpm test`. The tests should cover both Egg and non-Egg parsing.
+
+## Constraints & Contract
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] `PokemonInstance` is confirmed to have the `eggSteps` property.
+- [ ] `parseGen2PokemonInstance` is confirmed to correctly calculate `eggSteps` for eggs.
+- [ ] Unit tests for `eggSteps` pass and cover edge cases.


### PR DESCRIPTION
As the Tech Lead, I have transformed the `story-106-158-gen2-egg-hatch-parsing` into two actionable technical blueprints (TASK nodes).

1.  **Implementation Task**: `task-158-249-gen2-egg-hatch-parsing-impl` assigned to the `coder` persona. It details the exact logic required to update the `PokemonInstance` interface and parse the `friendship` byte for eggs (species ID 253) in Gen 2 save files, multiplying by 256 to calculate `eggSteps`. It includes strict instructions regarding module-level constants and testing.
2.  **QA Task**: `task-158-250-gen2-egg-hatch-parsing-qa` assigned to the `qa` persona to verify the coder's implementation against the acceptance criteria.

I have updated the parent STORY node's markdown body to include these new child nodes as unchecked tasks under the Acceptance Criteria and have successfully verified that no regressions were introduced to the project via `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [9409126495042513641](https://jules.google.com/task/9409126495042513641) started by @szubster*