### PR TITLE
⚡ Bolt: [SearchAndFilters] Memoize filtersSet to reduce allocation overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -148,3 +148,7 @@ Memoized TacticalCard in StorageGrid.tsx and extracted StorageCard to avoid N+1 
 **Measured Improvement:** Micro-benchmarks demonstrate a ~20-30% drop in execution time for aggregate operations (`aggregateEncountersByLocation`) and significant reduction for `getGraveyardPokemon` (332ms -> 179ms for 10k iterations).
 Performance Learnings:
 - In React lists or frequently rendering components, identify deeply nested child components like DataPoint that do not need to re-render when a parent context updates. Wrapping them in React.memo reduces main thread blocking time during state updates.
+## Execution Learnings
+- **React.useMemo & Set Allocation**: In UI panels with heavy text input (like `SearchAndFilters.tsx`), creating a `new Set` from an array on every keystroke render causes O(N) memory allocation and garbage collection overhead. Wrapping it in `React.useMemo` prevents unnecessary instantiation.
+- **Hook Placement Constraint**: When adding `useMemo`, it must be placed *before* any early returns (`if (!data) return null;`) to strictly adhere to React's Rules of Hooks, otherwise Biome's `lint/correctness/useHookAtTopLevel` check will fail.
+- **Environment Dependency**: Running `pnpm test` requires Playwright browsers to be downloaded (`pnpm exec playwright install chromium`) because `@vitest/browser` depends on them.

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -1,5 +1,5 @@
 import { Search } from 'lucide-react';
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { FILTER_TYPES, type FilterType, useStore } from '../store';
 import { ClearFiltersBadge } from './ClearFiltersBadge';
 import { FilterBadge } from './FilterBadge';
@@ -19,9 +19,10 @@ export function SearchAndFilters() {
   const toggleFilter = useStore((s) => s.toggleFilter);
   const setFilters = useStore((s) => s.setFilters);
 
-  if (!saveData) return null;
+  // ⚡ Bolt: Memoized filter set creation to avoid redundant object allocation on every keystroke
+  const filtersSet = useMemo(() => new Set(filters), [filters]);
 
-  const filtersSet = new Set(filters);
+  if (!saveData) return null;
 
   const handleClearSearch = () => {
     setSearchTerm('');


### PR DESCRIPTION
💡 What: Wrapped `new Set(filters)` in a `useMemo` hook in `SearchAndFilters.tsx` and moved the early return below it.
🎯 Why: `SearchAndFilters` re-renders frequently on every keystroke because it subscribes to `searchTerm` via Zustand. Previously, it recreated the `filtersSet` on every render, causing O(N) allocation and garbage collection churn.
📊 Measured Improvement: Eliminates O(N) object allocation on every keystroke in the main search bar component, slightly decreasing main thread blocking time.
How to Verify: Run `pnpm test` and `pnpm test:e2e`. The app should behave exactly identically, but use slightly less CPU/memory when typing rapidly in the search bar.

---
*PR created automatically by Jules for task [12509063804802826884](https://jules.google.com/task/12509063804802826884) started by @szubster*