### PR TITLE
💡 Visionary: Gen 3 Pokémon Lottery Predictor

### DIFF
--- a/.foundry/ideas/idea-098-gen3-pokemon-lottery-predictor.md
+++ b/.foundry/ideas/idea-098-gen3-pokemon-lottery-predictor.md
@@ -1,0 +1,34 @@
+---
+id: idea-098-gen3-pokemon-lottery-predictor
+type: IDEA
+title: Gen 3 Pokémon Lottery Predictor
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - feature
+  - gen3
+notes: ''
+rejection_reason: ''
+---
+
+# Idea: Gen 3 Pokémon Lottery Predictor
+
+## Context
+In Gen 3 games (Ruby/Sapphire/Emerald), Lilycove Department Store hosts a Pokémon Lottery Corner. The winning lottery number changes daily based on a PRNG seed in the save file. Checking the lottery requires flying to Lilycove City and matching the daily number against the Original Trainer (OT) IDs of Pokémon in the party or PC boxes.
+
+## Proposal
+Leverage DexHelper's programmatic save parsing to read the current Lottery PRNG seed/number.
+- Extract the winning lottery number from the save file.
+- Scan the player's PC boxes and party to find the best match (based on matching trailing digits of the Original Trainer ID).
+- Display a quick indicator showing if the player has a winning ticket (e.g., "Match 3 digits! Reward: Exp. Share") and exactly which Pokémon they should bring to claim the prize, saving them the trip and manual box searching.
+
+## Value Proposition
+This transforms a tedious, manual daily chore (flying to Lilycove, checking the lotto, potentially missing a match because of a buried PC box Pokémon) into an instant, actionable insight. It aligns with DexHelper's vision of turning opaque game data into a premium utility feature for hardcore players and shiny hunters (who often have many traded Pokémon with different IDs).
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -163,3 +163,7 @@
 ## 2026-06-29
 **Idea:** Gen 2/3 In-Game Trade Assistant Dashboard
 **Learning:** Expanding on the success of the Move Tutor dashboard, targeting other one-time limited NPC interactions—like in-game trades—provides excellent utility. By automatically parsing the save file's event flags to determine trade availability, and cross-referencing requested species with the player's current PC box contents, we transform static event data into an actionable, dynamic "to-do" list. This strongly reinforces DexHelper's value as a premium companion app that eliminates tedious wiki searches and manual tracking.
+
+## 2026-07-01
+**Idea:** Gen 3 Pokémon Lottery Predictor
+**Learning:** Expanding the app to parse the hidden daily PRNG seed for the Pokémon Lottery Corner and cross-referencing it with the player's PC box Original Trainer IDs turns a highly tedious, manual daily chore into an instant actionable insight. This strongly fits the project's vision of providing premium utility features for hardcore players and shiny hunters.


### PR DESCRIPTION
Proposing a new feature to extract the Gen 3 daily Pokémon Lottery Corner winning number from the save file and cross-reference it with the Original Trainer IDs of all Pokémon in the PC boxes to instantly find winning matches. This transforms a tedious manual check into a highly actionable insight.

---
*PR created automatically by Jules for task [6073654945542351485](https://jules.google.com/task/6073654945542351485) started by @szubster*