### PR TITLE
🧠 Trainer: Fix HM03 (Surf) detection in Assistant

### DIFF
--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -63,3 +63,7 @@
 >> 2024-05-24 - Assistant Breeding Suggestion Dynamic Support
 **Learning:** The Daycare breeding suggestion logic in `breedGenerator.ts` originally hardcoded `saveData.generation === 2`, which prevented breeding recommendations from functioning properly for subsequent generations (e.g., Gen 3). Breeding rules and availability are properly defined in the generation config files, not purely at the generation level.
 **Action:** Use `getGenerationConfig(saveData.generation)` to retrieve the active generation configuration, and perform the check using `if (genConfig.hasBreeding)` instead of hardcoding the generation number. This ensures smooth feature expansion as later games with breeding mechanics are added.
+
+## 2024-05-25 - Assistant HM03 Surf Requirements Fix
+**Learning:** In the suggestion engine's `extractPlayerTools` helper, the logic checking whether the player possessed the `hasSurf` capability incorrectly verified `id === 245` (Expert Belt) or `id === 341` (TM37 Sandstorm) instead of `id === 399` (HM03 Surf) due to a copy-paste error. This caused water-based catch encounter recommendations to be incorrectly surfaced or blocked.
+**Action:** When filtering assistant map recommendations by player capabilities, ensure that the `id === 399` correctly maps to the Surf HM for filtering water encounters via `extractPlayerTools`.

--- a/src/engine/assistant/__tests__/suggestionEngine.filter.test.ts
+++ b/src/engine/assistant/__tests__/suggestionEngine.filter.test.ts
@@ -358,7 +358,7 @@ describe('Catch Encounter Filtering', () => {
     const saveData = createMockSaveData({
       owned: new Set([16]),
       // biome-ignore lint/suspicious/noExplicitAny: Required for mock data overrides
-      inventory: [{ id: 245, quantity: 1 } as any],
+      inventory: [{ id: 399, quantity: 1 } as any],
     });
     const apiData = createMockApiData();
 

--- a/src/engine/assistant/utils/encounterTools.ts
+++ b/src/engine/assistant/utils/encounterTools.ts
@@ -42,8 +42,7 @@ export function extractPlayerTools(saveData: SaveData, allInstances: PokemonInst
       if (id === 192) hasHeadbutt = true;
       else if (id === 198) {
         hasRockSmash = true;
-        hasSurf = true;
-      } else if (id === 245 || id === 341) hasSurf = true;
+      } else if (id === 399) hasSurf = true;
       else if (id === 52 || id === 69 || id === 260) hasOldRod = true;
       else if (id === 53 || id === 70 || id === 261) hasGoodRod = true;
       else if (id === 54 || id === 71 || id === 262) hasSuperRod = true;
@@ -58,8 +57,7 @@ export function extractPlayerTools(saveData: SaveData, allInstances: PokemonInst
       if (id === 192) hasHeadbutt = true;
       else if (id === 198) {
         hasRockSmash = true;
-        hasSurf = true;
-      } else if (id === 245 || id === 341) hasSurf = true;
+      } else if (id === 399) hasSurf = true;
       else if (id === 52 || id === 69 || id === 260) hasOldRod = true;
       else if (id === 53 || id === 70 || id === 261) hasGoodRod = true;
       else if (id === 54 || id === 71 || id === 262) hasSuperRod = true;


### PR DESCRIPTION
The previous `extractPlayerTools` check for `hasSurf` in the player's inventory or PC items was incorrectly checking for item IDs 245 (Expert Belt) and 341 (TM37). This commit corrects it to check for item ID 399, which is the correct game ID for HM03 (Surf) across generations, enabling the Assistant to correctly recommend or deprioritize water encounters based on player tool possession.

---
*PR created automatically by Jules for task [17987861307157436289](https://jules.google.com/task/17987861307157436289) started by @szubster*