### PR TITLE
chore: Generate Gen 3 Contest Data Mapping Tasks

### DIFF
--- a/.foundry/stories/story-065-142-gen3-contest-data-mapping.md
+++ b/.foundry/stories/story-065-142-gen3-contest-data-mapping.md
@@ -35,3 +35,7 @@ Derived from `epic-040-065-gen3-contest-data-integration`, this story focuses on
 ## 3. Acceptance Criteria
 - [ ] Map the extracted Condition, Sheen, and Ribbon data to the appropriate `condition` and `ribbons` fields in the internal Pokémon data structure (`PokemonInstance`).
 - [ ] Confirm all existing Gen 1 and Gen 2 save parsing tests pass without modification.
+
+## 4. Tasks
+- [ ] task-142-249-gen3-contest-data-mapping-impl
+- [ ] task-142-250-gen3-contest-data-mapping-qa

--- a/.foundry/tasks/task-142-249-gen3-contest-data-mapping-impl.md
+++ b/.foundry/tasks/task-142-249-gen3-contest-data-mapping-impl.md
@@ -1,0 +1,36 @@
+---
+id: task-142-249-gen3-contest-data-mapping-impl
+type: TASK
+title: Implement Gen 3 Contest Data Mapping
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-065-142-gen3-contest-data-mapping
+tags: [feature, gen3, contests, mapping]
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement Gen 3 Contest Data Mapping
+
+## 1. Context
+This task implements the logic for mapping extracted Gen 3 contest data (`Gen3ConditionStats` and `Gen3Ribbons`) to the `PokemonInstance` structure for Gen 3 saves.
+
+## 2. Requirements
+- Update the `PokemonInstance` interface in `src/engine/saveParser/parsers/common.ts` to include optional fields: `condition?: Gen3ConditionStats` and `ribbons?: Gen3Ribbons`.
+- When generating the `PokemonInstance` list for `partyDetails` and `pcDetails` in `parseGen3` (inside `src/engine/saveParser/parsers/gen3.ts`), ensure the extraction functions `parseGen3ConditionStats` and `parseGen3Ribbons` are invoked and the results are mapped to the respective Pokémon instances.
+- **CRITICAL CONTRACT**: All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+- Ensure backwards compatibility: Gen 1 and Gen 2 parsing interfaces must remain unmodified.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## 3. Acceptance Criteria
+- [ ] Update `PokemonInstance` interface to include `condition` and `ribbons` fields.
+- [ ] Implement mapping in `parseGen3` to correctly assign contest stats and ribbons to `PokemonInstance` objects.

--- a/.foundry/tasks/task-142-250-gen3-contest-data-mapping-qa.md
+++ b/.foundry/tasks/task-142-250-gen3-contest-data-mapping-qa.md
@@ -1,0 +1,35 @@
+---
+id: task-142-250-gen3-contest-data-mapping-qa
+type: TASK
+title: QA Gen 3 Contest Data Mapping
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on:
+  - task-142-249-gen3-contest-data-mapping-impl
+jules_session_id: null
+pr_number: null
+parent: story-065-142-gen3-contest-data-mapping
+tags: [qa, gen3, contests, mapping]
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Gen 3 Contest Data Mapping
+
+## 1. Context
+This task verifies that the mapping of Gen 3 contest data to the `PokemonInstance` structure was implemented correctly and maintains backward compatibility.
+
+## 2. Requirements
+- Verify that Gen 3 `partyDetails` and `pcDetails` in the parsed output contain the correct `condition` and `ribbons` properties.
+- Confirm all existing Gen 1 and Gen 2 save parsing tests pass without modification.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## 3. Acceptance Criteria
+- [ ] Verify Gen 3 contest data is successfully parsed and attached to `PokemonInstance` structures in unit and/or integration tests.
+- [ ] Verify that Gen 1 and Gen 2 test suites continue to pass without issues.


### PR DESCRIPTION
Broke down `story-065-142-gen3-contest-data-mapping` into implementation and QA TASK nodes according to Foundry architectural directives.

---
*PR created automatically by Jules for task [4825660412000648075](https://jules.google.com/task/4825660412000648075) started by @szubster*