### PR TITLE
feat(saveParser): implement parsing for total accumulated Battle Points in Gen 3

### DIFF
--- a/.foundry/tasks/task-123-240-gen3-parse-battle-points-impl.md
+++ b/.foundry/tasks/task-123-240-gen3-parse-battle-points-impl.md
@@ -35,6 +35,6 @@ Implement logic to extract the total accumulated Battle Points (BP) from `SaveBl
 - If submitting an empty PR for a completed task, check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Parse total BP correctly from offset `0x0EB8`.
-- [ ] Module-level constants are used for offsets.
-- [ ] Error handling captures out-of-bounds reads (`RangeError`).
+- [x] Parse total BP correctly from offset `0x0EB8`.
+- [x] Module-level constants are used for offsets.
+- [x] Error handling captures out-of-bounds reads (`RangeError`).

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -220,6 +220,7 @@ export interface SaveData {
   /** Gen 3 specific: Battle Frontier symbols */
   gen3BattleFrontierSymbols?: Gen3BattleFrontierSymbols;
   /** Gen 3 specific: Battle Points (BP) balance */
+  gen3TotalBattlePoints?: number;
   gen3BattlePoints?: number;
 }
 

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -14,6 +14,7 @@ import {
   parseGen3Ribbons,
   parseGen3Roamer,
   parseGen3SecretBases,
+  parseGen3TotalBattlePoints,
 } from './gen3';
 
 describe('gen3 parser scaffolding', () => {
@@ -883,6 +884,28 @@ describe('parseGen3ActiveSwarm', () => {
 
     expect(() => parseGen3ActiveSwarm(view, offset)).toThrow(
       'The save file is corrupted or incomplete: Invalid TV block struct.',
+    );
+  });
+
+  it('parseGen3TotalBattlePoints should correctly extract the total BP balance', () => {
+    const buffer = new ArrayBuffer(8192);
+    const view = new DataView(buffer);
+    const saveBlock2Offset = 0;
+
+    // Set some total BP balance
+    view.setUint16(0x0eb8, 500, true);
+
+    const result = parseGen3TotalBattlePoints(view, saveBlock2Offset);
+    expect(result).toBe(500);
+  });
+
+  it('parseGen3TotalBattlePoints should throw custom error on RangeError', () => {
+    const buffer = new ArrayBuffer(10);
+    const view = new DataView(buffer);
+    const saveBlock2Offset = 0;
+
+    expect(() => parseGen3TotalBattlePoints(view, saveBlock2Offset)).toThrow(
+      'The save file is corrupted or incomplete.',
     );
   });
 });

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -90,6 +90,7 @@ const PIKE_RECORD_WIN_STREAKS_OFFSET = 0x0e08;
 const PYRAMID_WIN_STREAKS_OFFSET = 0x0e1a;
 const PYRAMID_RECORD_WIN_STREAKS_OFFSET = 0x0e1e;
 
+const TOTAL_BATTLE_POINTS_OFFSET = 0x0eb8;
 const BATTLE_POINTS_OFFSET = 0x1504;
 
 const TV_SHOWS_OFFSET = 0x27cc;
@@ -619,6 +620,26 @@ export function parseGen3BattleFrontierSymbols(view: DataView, saveBlock1Offset:
  * @returns The battle points balance.
  * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
  */
+
+/**
+ * Parses the total accumulated BP (Battle Points) from the save file.
+ *
+ * @param view - The raw save file DataView.
+ * @param saveBlock2Offset - The resolved memory offset to the active SaveBlock2.
+ * @returns The total battle points accumulated.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3TotalBattlePoints(view: DataView, saveBlock2Offset: number): number {
+  try {
+    return view.getUint16(saveBlock2Offset + TOTAL_BATTLE_POINTS_OFFSET, true);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
 export function parseGen3BattlePoints(view: DataView, saveBlock2Offset: number): number {
   try {
     return view.getUint16(saveBlock2Offset + BATTLE_POINTS_OFFSET, true);
@@ -751,6 +772,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
 
     let gen3BattleFrontierWinStreaks: Gen3BattleFrontierWinStreaks | undefined;
     let gen3BattleFrontierSymbols: Gen3BattleFrontierSymbols | undefined;
+    let gen3TotalBattlePoints: number | undefined;
     let gen3BattlePoints: number | undefined;
     if (_forcedVersion === 'emerald') {
       try {
@@ -760,6 +782,11 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       }
       try {
         gen3BattleFrontierSymbols = parseGen3BattleFrontierSymbols(view, section1Offset);
+      } catch {
+        // Ignored if missing or corrupted, allowing the rest of the save to load
+      }
+      try {
+        gen3TotalBattlePoints = parseGen3TotalBattlePoints(view, section2Offset);
       } catch {
         // Ignored if missing or corrupted, allowing the rest of the save to load
       }
@@ -801,6 +828,9 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     }
     if (gen3BattleFrontierSymbols) {
       result.gen3BattleFrontierSymbols = gen3BattleFrontierSymbols;
+    }
+    if (gen3TotalBattlePoints !== undefined) {
+      result.gen3TotalBattlePoints = gen3TotalBattlePoints;
     }
     if (gen3BattlePoints !== undefined) {
       result.gen3BattlePoints = gen3BattlePoints;


### PR DESCRIPTION
This PR implements parsing for the total accumulated Battle Points (BP) from Generation 3 save files. The total BP is extracted from offset `0x0EB8` in `SaveBlock2`. Proper error handling (`RangeError`) is implemented, and the new field `gen3TotalBattlePoints` is available in the `SaveData` object. Test coverage was included.

---
*PR created automatically by Jules for task [9107657610271688818](https://jules.google.com/task/9107657610271688818) started by @szubster*