### PR TITLE
Fix shell quoting issues in GitHub Actions workflows

### DIFF
--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -177,13 +177,18 @@ jobs:
       - name: Invoke Jules Agent
         env:
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+          NODE_REPO_PATH: ${{ matrix.node.repo_path }}
+          NODE_OWNER_PERSONA: ${{ matrix.node.owner_persona }}
+          NODE_TITLE: ${{ matrix.node.title }}
+          GITHUB_REPO: ${{ github.repository }}
+          NODE_ID: ${{ matrix.node.id }}
         run: |
           set -o pipefail
           {
             # 1. Capture task content for the prompt
-            task_content=$(cat "${{ matrix.node.repo_path }}")
+            task_content=$(cat "$NODE_REPO_PATH")
             
-            owner_persona="${{ matrix.node.owner_persona }}"
+            owner_persona="$NODE_OWNER_PERSONA"
             agent_file=".github/agents/${owner_persona}.md"
 
             if [[ -n "$owner_persona" && -f "$agent_file" ]]; then
@@ -193,7 +198,7 @@ jobs:
             fi
 
             # 1.5 Extract research_references from parent chain safely
-            research_context_str=$(node --strip-types .github/scripts/extract-research.ts "${{ matrix.node.repo_path }}")
+            research_context_str=$(node --strip-types .github/scripts/extract-research.ts "$NODE_REPO_PATH")
 
             if [[ -n "$research_context_str" ]]; then
               agent_context="${agent_context}\n\n### RESEARCH REFERENCES\nThe following research context paths have been automatically injected from the node dependency chain. You may use the read_file tool to read their contents if necessary:\n${research_context_str}"
@@ -204,9 +209,9 @@ jobs:
             prompt_json=$(jq -n \
               --arg task "$task_content" \
               --arg agent_context "$agent_context" \
-              --arg title "${{ matrix.node.title }}" \
-              --arg repo "${{ github.repository }}" \
-              --arg schema_url "https://github.com/${{ github.repository }}/blob/main/.foundry/docs/schema.md" \
+              --arg title "$NODE_TITLE" \
+              --arg repo "$GITHUB_REPO" \
+              --arg schema_url "https://github.com/$GITHUB_REPO/blob/main/.foundry/docs/schema.md" \
               '{
                 "prompt": "\($agent_context)\n\n### CRITICAL RULE\nDO NOT modify the YAML frontmatter of the task node. Only update the markdown body (e.g., acceptance criteria checkboxes).\n\n### TASK NODE\n\($task)\n\n### SCHEMA\n\($schema_url)",
                 "sourceContext": {
@@ -220,7 +225,7 @@ jobs:
               }')
 
             # 3. Request session from Jules API
-            echo "Dispatching Jules session for: ${{ matrix.node.id }}"
+            echo "Dispatching Jules session for: $NODE_ID"
             response=$(curl -s -X POST "https://jules.googleapis.com/v1alpha/sessions" \
               -H "Content-Type: application/json" \
               -H "X-Goog-Api-Key: $JULES_API_KEY" \
@@ -247,16 +252,21 @@ jobs:
           } 2>&1 | tee invoke-agent.log
 
       - name: Transition node to ACTIVE
+        env:
+          NODE_REPO_PATH: ${{ matrix.node.repo_path }}
         run: |
           set -o pipefail
           # Transition the file to ACTIVE state and inject the real Jules ID
-          node --strip-types .github/scripts/foundry-active.ts "${{ matrix.node.repo_path }}" "$SESSION_ID" 2>&1 | tee active-transition.log
+          node --strip-types .github/scripts/foundry-active.ts "$NODE_REPO_PATH" "$SESSION_ID" 2>&1 | tee active-transition.log
 
       - name: Commit State Change
+        env:
+          NODE_REPO_PATH: ${{ matrix.node.repo_path }}
+          NODE_ID: ${{ matrix.node.id }}
         run: |
           set -o pipefail
-          git add "${{ matrix.node.repo_path }}"
-          git commit -m "Foundry: Transition ${{ matrix.node.id }} -> ACTIVE [$SESSION_ID]" 2>&1 | tee -a commit.log
+          git add "$NODE_REPO_PATH"
+          git commit -m "Foundry: Transition $NODE_ID -> ACTIVE [$SESSION_ID]" 2>&1 | tee -a commit.log
           git pull --rebase origin main 2>&1 | tee -a commit.log
           git push origin main 2>&1 | tee -a commit.log
 
@@ -264,12 +274,13 @@ jobs:
         if: failure() && env.SKIP_FAILURE_ISSUE != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.MY_ISSUES_PAT }}
+          NODE_ID: ${{ matrix.node.id }}
         run: |
-          ISSUE_TITLE="Foundry Engine: Execution Failure (${{ matrix.node.id }}) - ${{ github.run_id }}"
+          ISSUE_TITLE="Foundry Engine: Execution Failure ($NODE_ID) - ${{ github.run_id }}"
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           {
-            echo "The Foundry Engine failed during the execution phase for \`${{ matrix.node.id }}\`."
+            echo "The Foundry Engine failed during the execution phase for \`$NODE_ID\`."
             echo ""
             echo "**Jules Session ID:** \`${SESSION_ID:-Not generated or failed to capture}\`"
             echo "**Run Details:** [View Action Run]($RUN_URL)"

--- a/.github/workflows/foundry-scheduled-agent.yml
+++ b/.github/workflows/foundry-scheduled-agent.yml
@@ -35,8 +35,10 @@ jobs:
       - name: Invoke Jules Agent
         env:
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+          PERSONA: ${{ inputs.persona }}
+          GITHUB_REPO: ${{ github.repository }}
         run: |
-          persona="${{ inputs.persona }}"
+          persona="$PERSONA"
           agent_file=".github/agents/${persona}.md"
 
           if [[ ! -f "$agent_file" ]]; then
@@ -50,8 +52,8 @@ jobs:
           prompt_json=$(jq -n \
             --arg agent_context "$agent_context" \
             --arg empty_state "If you determine there is no actionable work to be done during this run, simply state that in your PR and complete your session. An empty PR diff is acceptable and will be closed automatically." \
-            --arg repo "${{ github.repository }}" \
-            --arg schema_url "https://github.com/${{ github.repository }}/blob/main/.foundry/docs/schema.md" \
+            --arg repo "$GITHUB_REPO" \
+            --arg schema_url "https://github.com/$GITHUB_REPO/blob/main/.foundry/docs/schema.md" \
             --arg title "Scheduled Agent: $persona" \
             '{
               "prompt": "\($agent_context)\n\n\($empty_state)\n\n### SCHEMA\n\($schema_url)",


### PR DESCRIPTION
This PR fixes a recurring issue where the Foundry Engine fails to invoke Jules agents because task titles containing spaces or special characters break the shell command's syntax (specifically within `jq` arguments).

Following GitHub Actions best practices, I've updated `.github/workflows/foundry-engine.yml` and `.github/workflows/foundry-scheduled-agent.yml` to:
1. Map `matrix.node` properties and other GHA expressions to environment variables in the `env` block.
2. Reference these environment variables using standard shell syntax (e.g., `"$NODE_TITLE"`) inside the `run` scripts.

This ensures that the shell correctly handles quoting and prevents data from being interpreted as part of the command structure. All tests and linting passed successfully.

Fixes #3634

---
*PR created automatically by Jules for task [9185066215149897133](https://jules.google.com/task/9185066215149897133) started by @szubster*