### PR TITLE
Foundry: Add PRD for Automated Nuzlocke Tracker

### DIFF
--- a/.foundry/ideas/idea-057-automated-nuzlocke-tracker.md
+++ b/.foundry/ideas/idea-057-automated-nuzlocke-tracker.md
@@ -36,5 +36,6 @@ This significantly reduces the friction of playing Nuzlocke challenges on origin
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD.
 
-## Downstream Nodes
-- PRD: `.foundry/prds/prd-057-026-automated-nuzlocke-tracker.md`
+## Acceptance Criteria
+- [x] prd-057-026-automated-nuzlocke-tracker
+- [ ] prd-057-097-automated-nuzlocke-tracker

--- a/.foundry/prds/prd-057-097-automated-nuzlocke-tracker.md
+++ b/.foundry/prds/prd-057-097-automated-nuzlocke-tracker.md
@@ -1,0 +1,59 @@
+---
+id: prd-057-097-automated-nuzlocke-tracker
+type: PRD
+title: Automated Nuzlocke Verification and Run Tracker
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-057-automated-nuzlocke-tracker
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Automated Nuzlocke Verification and Run Tracker
+
+## Objective
+Provide a built-in "Nuzlocke Tracker" mode in DexHelper to automate the tracking of encounters and deaths for players doing Nuzlocke challenge runs, leveraging existing save file parsing capabilities to eliminate manual data entry.
+
+## Background
+The Nuzlocke challenge is a popular self-imposed rule set for playing Pokémon games. The two fundamental rules are:
+1. A player may only catch the *first* Pokémon encountered in each area/route.
+2. If a Pokémon faints (reaches 0 HP), it is considered "dead" and must be released or placed in a designated "Graveyard" PC box.
+Currently, players track this information manually using spreadsheets or third-party web apps. DexHelper, with its deep save file introspection, can automate this process.
+
+## Core Features
+
+1. **Automated Route Tracking:**
+   - DexHelper must iterate over all caught Pokémon in the save file (Party and PC) and aggregate them by their `met_location`.
+   - It should identify the first catch for every distinct location.
+   - It should flag a violation if multiple Pokémon share the same `met_location`, indicating the player caught more than one Pokémon in that area.
+
+2. **Automated Death Tracking:**
+   - Detect Pokémon currently at 0 HP (fainted in the party).
+   - Allow users to designate a specific PC Box as the "Graveyard". Any Pokémon placed in this box is permanently considered dead, regardless of its HP.
+   - Display these Pokémon visually distinct (e.g., greyscale or with a tombstone icon) in the UI.
+
+3. **Run Dashboard UI:**
+   - A dedicated dashboard view showing:
+     - The current "Alive" team.
+     - A checklist of visited routes and what was caught there.
+     - A list of unvisited available routes (based on story progress/game).
+     - The Graveyard (list of dead Pokémon).
+
+## Out of Scope
+- Enforcing the rules in-game (we cannot edit the game ROM or save to prevent actions).
+- "Species Clause" tracking (ignoring duplicate species across different routes) in the initial v1.
+- Randomizer tracking (assuming vanilla game routes).
+
+## Next Steps
+- [ ] Break down into Tasks
+- [ ] Break down into Epics


### PR DESCRIPTION
This PR creates `.foundry/prds/prd-057-097-automated-nuzlocke-tracker.md` to address the missing automated encounter tracking and status dashboard functionalities found by the Auditor. It also updates the parent IDEA node (`idea-057-automated-nuzlocke-tracker.md`) to include the new PRD as an unchecked task in its `## Acceptance Criteria` section, ensuring the IDEA node does not prematurely transition to VERIFYING.

---
*PR created automatically by Jules for task [14467244275825006133](https://jules.google.com/task/14467244275825006133) started by @szubster*