### PR TITLE
feat: generate coder blueprint for updating DAG orchestration tests

### DIFF
--- a/.foundry/stories/story-053-107-update-dag-orchestration-tests.md
+++ b/.foundry/stories/story-053-107-update-dag-orchestration-tests.md
@@ -33,3 +33,4 @@ This story details the technical steps for updating the DAG orchestration tests 
 ## Acceptance Criteria
 - [ ] Existing orchestration tests are updated to use the new module.
 - [ ] All existing tests pass successfully.
+- [ ] task-107-253-update-dag-orchestration-tests

--- a/.foundry/tasks/task-107-253-update-dag-orchestration-tests.md
+++ b/.foundry/tasks/task-107-253-update-dag-orchestration-tests.md
@@ -1,0 +1,43 @@
+---
+id: task-107-253-update-dag-orchestration-tests
+type: TASK
+title: Update DAG Orchestration Tests
+status: READY
+owner_persona: coder
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-053-107-update-dag-orchestration-tests
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update DAG Orchestration Tests
+
+## Objective
+Update the DAG orchestration tests in `.github/scripts/foundry-orchestrator.test.ts` to use the new module `.github/scripts/dag-utils.ts`.
+
+## Context
+A recent refactor moved DAG utilities (like `todayISO`, `buildReverseDependencyGraph`, `getOrphanedNodes`) into a shared `dag-utils.ts` module. The orchestrator tests need to be updated to ensure they are compatible with this change. Note that the orchestrator itself (`.github/scripts/foundry-orchestrator.ts`) already uses these methods.
+
+## Technical Specifications
+- Review `.github/scripts/foundry-orchestrator.test.ts`.
+- Ensure that any functionality related to testing orchestrator logic still passes. It appears the tests already pass successfully when run, so if there is nothing to update, use the Empty PR Policy to mark this task as completed.
+- Ensure all tests in `.github/scripts` pass by running `cd .github/scripts && pnpm install && npx vitest run`.
+
+## Coder Contract Constraints
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Existing orchestration tests are verified to pass successfully.
+- [ ] Any necessary imports are updated, or if no changes are needed, an empty PR is submitted with this checkbox checked.


### PR DESCRIPTION
This PR transforms the product story `story-053-107-update-dag-orchestration-tests` into an actionable technical blueprint for the `coder` persona. It creates `task-107-253-update-dag-orchestration-tests.md` instructing the coder to verify or update the orchestrator tests regarding the recent `.github/scripts/dag-utils.ts` refactor. The parent story has been updated with the new task in its acceptance criteria checklist.

Testing/Linting:
- `pnpm install` successful.
- `npx playwright install chromium --with-deps` successful.
- `pnpm test` completed.
- `pnpm check` completed.

---
*PR created automatically by Jules for task [8299089616057572111](https://jules.google.com/task/8299089616057572111) started by @szubster*