### PR TITLE
Fix Foundry link-checker for root-archived nodes

### DIFF
--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -32,6 +32,12 @@ function resolveNodeIdToPath(nodeId: string): string {
   if (fs.existsSync(archivePath)) {
     return archivePath;
   }
+
+  const rootArchivePath = `.foundry/archive/${nodeId}.md`;
+  if (fs.existsSync(rootArchivePath)) {
+    return rootArchivePath;
+  }
+
   return nodeId;
 }
 


### PR DESCRIPTION
The `link-checker` was failing during orchestration because it couldn't find nodes that had been moved directly to `.foundry/archive/` instead of their respective type-based subdirectories (e.g., `.foundry/archive/stories/`).

This change updates `resolveNodeIdToPath` in `scripts/check-links.ts` to check `.foundry/archive/${nodeId}.md` if other resolution attempts fail. This ensures that valid but archived nodes are correctly resolved, preventing false-positive broken link errors.

Verified the fix by running the link-checker against the failing story file and ensuring it exits successfully. Also ran the full test suite and linting to ensure no regressions.

Fixes #3642

---
*PR created automatically by Jules for task [366105208274906454](https://jules.google.com/task/366105208274906454) started by @szubster*