### PR TITLE
Fix Foundry link checker archive resolution

### DIFF
--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -32,6 +32,10 @@ function resolveNodeIdToPath(nodeId: string): string {
   if (fs.existsSync(archivePath)) {
     return archivePath;
   }
+  const flatArchivePath = `.foundry/archive/${nodeId}.md`;
+  if (fs.existsSync(flatArchivePath)) {
+    return flatArchivePath;
+  }
   return nodeId;
 }
 


### PR DESCRIPTION
The `link-checker` was failing because it couldn't resolve node IDs for files located directly in `.foundry/archive/`. This PR adds a check for `.foundry/archive/${nodeId}.md` to the `resolveNodeIdToPath` function in `scripts/check-links.ts`, ensuring that archived stories and tasks are correctly identified even when they aren't in type-specific subdirectories within the archive.

Verified by running:
`node --experimental-strip-types scripts/check-links.ts .foundry/stories/story-053-107-update-dag-orchestration-tests.md`
which now passes successfully.

Fixes #3644

---
*PR created automatically by Jules for task [18347208384497673354](https://jules.google.com/task/18347208384497673354) started by @szubster*