### PR TITLE
Fix Link-Checker Archive Path Resolution

### DIFF
--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -32,6 +32,12 @@ function resolveNodeIdToPath(nodeId: string): string {
   if (fs.existsSync(archivePath)) {
     return archivePath;
   }
+
+  const flatArchivePath = `.foundry/archive/${nodeId}.md`;
+  if (fs.existsSync(flatArchivePath)) {
+    return flatArchivePath;
+  }
+
   return nodeId;
 }
 


### PR DESCRIPTION
The `link-checker` was failing during orchestration because it couldn't resolve references to nodes that had been moved to the `.foundry/archive/` directory without their corresponding subfolders (e.g., `stories/`, `tasks/`).

This PR updates `scripts/check-links.ts` to include a fallback check for `.foundry/archive/${nodeId}.md`.

Changes:
- Added `flatArchivePath` check in `resolveNodeIdToPath` function within `scripts/check-links.ts`.
- Verified that `story-053-107-update-dag-orchestration-tests.md` now passes validation.
- Confirmed that this resolves multiple broken links in the archive that were previously failing.

Fixes #3646

---
*PR created automatically by Jules for task [9332866647074021634](https://jules.google.com/task/9332866647074021634) started by @szubster*