### PR TITLE
Cancel Idea 066: Enforce Gray-Matter Linter

### DIFF
--- a/.foundry/ideas/idea-066-enforce-gray-matter-linter.md
+++ b/.foundry/ideas/idea-066-enforce-gray-matter-linter.md
@@ -2,7 +2,7 @@
 id: idea-066-enforce-gray-matter-linter
 type: IDEA
 title: Enforce Gray-Matter Linter for Scripts
-status: ACTIVE
+status: CANCELLED
 owner_persona: product_manager
 created_at: '2026-05-25'
 updated_at: '2026-07-01'
@@ -15,7 +15,7 @@ tags:
   - foundry
 research_references: []
 rejection_count: 1
-rejection_reason: ''
+rejection_reason: 'Low Return on Investment (ROI) to implement a custom Biome/ESLint rule for this edge case. The maintenance overhead outweighs the benefits compared to standard PR reviews.'
 notes: >-
   Resurrected: Auditor found that frontmatter regressions are still common and a
   linter would be valuable.

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -57,3 +57,9 @@ When transforming an `IDEA` to a `PRD`, and there are existing acceptance criter
 ## Anomaly: Target Artifact Already Exists (2026-06-29)
 **Observation:**
 During the session for node `idea-090-pokegear-phone-tracker`, it was discovered that the target artifact `prd-090-055-pokegear-phone-tracker.md` did not exist but was requested by the user, yet earlier documentation anomalies note situations where artifacts existed prematurely. I am documenting that I successfully created the node and no anomalous pre-existence occurred, confirming expected system behavior. However, to fulfill the pre-commit reflection requirement, I'm noting this smooth execution as the baseline expected state.
+
+## Idea 066 Cancellation: Questionable ROI (2026-07-01)
+**Observation:**
+Idea 066 proposed a custom Biome/ESLint rule to enforce `gray-matter` for parsing frontmatter in `.github/scripts/`. Upon evaluation, it was determined that the technical cost and maintenance burden of implementing and supporting this highly specific rule for a minor edge case outweighs the benefits.
+**Action:**
+Cancelled `idea-066-enforce-gray-matter-linter` directly as the return on investment (ROI) is too low compared to relying on standard PR reviews. This aligns with the constraint to decline low-ROI ideas early in the pipeline to avoid wasting engineering cycles.


### PR DESCRIPTION
Cancelled `idea-066-enforce-gray-matter-linter` because creating a custom Biome/ESLint rule for a minor edge case has low ROI compared to relying on PR reviews. Updated the node status to CANCELLED and added a rejection reason to the frontmatter. Also logged the decision in the PM journal.

---
*PR created automatically by Jules for task [3707606369679750578](https://jules.google.com/task/3707606369679750578) started by @szubster*