### PR TITLE
feat(orchestrator): add tasks for max rejection cancellation

### DIFF
--- a/.foundry/stories/story-096-153-max-rejection-cancellation.md
+++ b/.foundry/stories/story-096-153-max-rejection-cancellation.md
@@ -25,5 +25,5 @@ notes: ''
 ## Acceptance Criteria
 - [x] Break down into Tasks.
 - [ ] Update `foundry-orchestrator.ts` so that when a node is evaluated and `status === 'FAILED'`, if `rejection_count >= MAX_REJECTION_THRESHOLD`, its status changes to `CANCELLED`.
-- [ ] task-153-234-orchestrator-max-rejection-cancellation-impl
-- [ ] task-153-235-orchestrator-max-rejection-cancellation-qa
+- [ ] task-153-254-orchestrator-max-rejection-cancellation-impl
+- [ ] task-153-255-orchestrator-max-rejection-cancellation-qa

--- a/.foundry/tasks/task-153-254-orchestrator-max-rejection-cancellation-impl.md
+++ b/.foundry/tasks/task-153-254-orchestrator-max-rejection-cancellation-impl.md
@@ -1,0 +1,31 @@
+---
+id: task-153-254-orchestrator-max-rejection-cancellation-impl
+type: TASK
+title: Implement Max Rejection Cancellation
+status: READY
+owner_persona: coder
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-096-153-max-rejection-cancellation
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Max Rejection Cancellation
+
+## Reminders for Coder
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Ensure `foundry-orchestrator.ts` has logic to change a node's status to `CANCELLED` if its status is `FAILED` and its `rejection_count >= MAX_REJECTION_THRESHOLD`.

--- a/.foundry/tasks/task-153-255-orchestrator-max-rejection-cancellation-qa.md
+++ b/.foundry/tasks/task-153-255-orchestrator-max-rejection-cancellation-qa.md
@@ -1,0 +1,32 @@
+---
+id: task-153-255-orchestrator-max-rejection-cancellation-qa
+type: TASK
+title: QA Max Rejection Cancellation
+status: READY
+owner_persona: qa
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on:
+  - task-153-254-orchestrator-max-rejection-cancellation-impl
+jules_session_id: null
+pr_number: null
+parent: story-096-153-max-rejection-cancellation
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Max Rejection Cancellation
+
+## Reminders for QA
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Review `foundry-orchestrator.ts` to verify the cancellation logic for max rejection threshold is correctly implemented and works as expected.


### PR DESCRIPTION
Creates the task nodes for the `max rejection cancellation` feature and updates the parent `story` node to properly track these tasks.

- Added `task-153-254-orchestrator-max-rejection-cancellation-impl`
- Added `task-153-255-orchestrator-max-rejection-cancellation-qa`
- Updated `story-096-153-max-rejection-cancellation` markdown.

---
*PR created automatically by Jules for task [551008995648742183](https://jules.google.com/task/551008995648742183) started by @szubster*