### PR TITLE
feat: Create Gen 3 Trainer Data and RNG Calculator Integration PRDs

### DIFF
--- a/.foundry/ideas/idea-082-gen3-secret-id-shiny-rng.md
+++ b/.foundry/ideas/idea-082-gen3-secret-id-shiny-rng.md
@@ -37,5 +37,7 @@ Leverage DexHelper's programmatic save parsing to extract and display the player
 ## Value Proposition
 By surfacing this single hidden variable, DexHelper instantly becomes a mandatory foundational tool for a massive segment of the hardcore playerbase: Shiny Hunters and RNG Manipulators. It bridges the gap between raw save data and advanced community gameplay strategies, perfectly fitting the app's "premium utility" vision.
 
-## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD to define the implementation of Gen 3 Trainer Data extraction including the SID.
+## Acceptance Criteria
+- [x] Product Manager: Convert this idea into a PRD to define the implementation of Gen 3 Trainer Data extraction including the SID.
+- [ ] prd-082-099-gen3-trainer-data-extraction
+- [ ] prd-082-100-rng-calculator-integration

--- a/.foundry/prds/prd-082-099-gen3-trainer-data-extraction.md
+++ b/.foundry/prds/prd-082-099-gen3-trainer-data-extraction.md
@@ -1,0 +1,33 @@
+---
+id: prd-082-099-gen3-trainer-data-extraction
+type: PRD
+title: Gen 3 Trainer Data Extraction
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-082-gen3-secret-id-shiny-rng
+tags:
+  - feature
+  - gen3
+  - trainer
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Gen 3 Trainer Data Extraction
+
+## Objective
+Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file and display it in the application.
+
+## Requirements
+- Identify memory offsets for Trainer ID, and Secret ID in a save file.
+- Update the relevant interface to include Secret ID.
+- Implement extraction logic in `src/engine/saveParser/parsers/gen3.ts`.
+
+## Acceptance Criteria
+- [ ] Epic Planner: Convert this PRD into Epics.

--- a/.foundry/prds/prd-082-100-rng-calculator-integration.md
+++ b/.foundry/prds/prd-082-100-rng-calculator-integration.md
@@ -1,0 +1,32 @@
+---
+id: prd-082-100-rng-calculator-integration
+type: PRD
+title: RNG Calculator Integration
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-082-gen3-secret-id-shiny-rng
+tags:
+  - feature
+  - rng
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# RNG Calculator Integration
+
+## Objective
+Provide utilities and UI that displays TID and SID and formats this combo for RNG tools.
+
+## Requirements
+- Create a UI to display TID and SID together.
+- Offer copy-to-clipboard functionality for TID/SID.
+- Provide a brief explainer in the UI on how to use these values with RNG tools.
+
+## Acceptance Criteria
+- [ ] Epic Planner: Convert this PRD into Epics.


### PR DESCRIPTION
This PR creates two new PRDs derived from idea-082:
1. Gen 3 Trainer Data Extraction (`prd-082-099-gen3-trainer-data-extraction.md`) - focuses on parsing TID/SID from the save file.
2. RNG Calculator Integration (`prd-082-100-rng-calculator-integration.md`) - focuses on UI and formatting tools for shiny hunters.

It also updates the parent `idea-082-gen3-secret-id-shiny-rng.md` node to check off the conversion task and links the newly created PRDs.

---
*PR created automatically by Jules for task [17569399166325870915](https://jules.google.com/task/17569399166325870915) started by @szubster*