### PR TITLE
docs(auditor): verify epic-038-061 and spawn research for daily offsets

### DIFF
--- a/.foundry/epics/epic-038-061-gen2-event-flag-parsing.md
+++ b/.foundry/epics/epic-038-061-gen2-event-flag-parsing.md
@@ -26,9 +26,13 @@ Develop the core save file parsing engine to extract specific time-gated event f
 
 ## Acceptance Criteria
 - [x] Parse event flags indicating completion of daily/weekly events.
-- [x] Expose this data cleanly to the frontend UI components.
+- [ ] Expose this data cleanly to the frontend UI components.
 
 
 ### Implementation Tasks
-- [x] .foundry/stories/story-061-095-gen2-event-flag-extraction.md
-- [x] .foundry/stories/story-061-096-gen2-event-data-layer.md
+- [x] story-061-095-gen2-event-flag-extraction
+- [x] story-061-096-gen2-event-data-layer
+- [ ] research-061-245-gen2-daily-event-offsets
+
+### Auditor Rejection
+The node was implemented to parse the raw event flags byte array, and basic static gifts were added. However, the core requirement of the parent PRD is a "Gen 2 Daily and Weekly Event Tracker", and none of the specific time-gated event flags (Lapras, Haircut Brothers, Bug Catching Contest) were mapped or exposed to the UI layer. Spawning a research node to find these offsets.

--- a/.foundry/research/research-061-245-gen2-daily-event-offsets.md
+++ b/.foundry/research/research-061-245-gen2-daily-event-offsets.md
@@ -1,0 +1,34 @@
+---
+id: research-061-245-gen2-daily-event-offsets
+type: RESEARCH
+title: Investigate Gen 2 Daily and Weekly Event Offsets
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-038-061-gen2-event-flag-parsing
+tags:
+  - gen2
+  - backend
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Gen 2 Daily and Weekly Event Offsets
+
+## Context
+During the audit of `epic-038-061-gen2-event-flag-parsing`, it was discovered that while the general event flags block (`eventFlags`) is extracted, the specific daily and weekly time-gated events (such as Friday Lapras, Bug Catching Contest, Haircut Brothers, Daily Mystery Gift) have not been properly mapped or exposed to the frontend data layer.
+
+## Goal
+Find and document the exact event flag offsets (or bit indices) that track whether these daily and weekly events have been completed.
+
+## Tasks
+- [ ] 1. Find the specific event flag for the Friday Lapras encounter.
+- [ ] 2. Find the event flags related to the Bug-Catching Contest (e.g. has participated today).
+- [ ] 3. Find the event flags for the Haircut Brothers in Goldenrod Underground.
+- [ ] 4. Investigate other daily/weekly events like the Weekly Siblings (Arthur, etc.) and Buena's Password.


### PR DESCRIPTION
Auditor verification of `epic-038-061-gen2-event-flag-parsing`.

The core raw event flags extraction (DataView migration) and the basic static gifts mapping were completed successfully by the engineering tasks. However, the epic failed verification because the parent PRD's core requirement ("Gen 2 Daily and Weekly Event Tracker") was missed. Specifically, none of the time-gated event flags (such as Lapras on Friday, Haircut Brothers, or Bug Catching Contest) were mapped or exposed to the UI layer. 

I've spawned `research-061-245-gen2-daily-event-offsets.md` to investigate the exact bit offsets for these mechanics and appended it to the epic's task list. The epic has been rejected so it can re-enter the Resurrection Loop to fulfill these missing requirements.

---
*PR created automatically by Jules for task [18159458014007047786](https://jules.google.com/task/18159458014007047786) started by @szubster*