### PR TITLE
feat: Add PRDs for save state history and metadata inference

### DIFF
--- a/.foundry/ideas/idea-066-save-state-history.md
+++ b/.foundry/ideas/idea-066-save-state-history.md
@@ -38,4 +38,8 @@ By utilizing IndexedDB to store a local history of sequential save file uploads 
 This unlocks "modern" features for retro games entirely locally. It allows players to build a true history and narrative of their playthrough, making the app much stickier and encouraging frequent save uploads (especially if paired with Emulator Auto-Sync).
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD detailing the diffing logic and storage requirements for save file versioning.
+- [x] Product Manager: Convert this idea into a PRD detailing the diffing logic and storage requirements for save file versioning.
+
+## Acceptance Criteria
+- [ ] prd-066-099-save-state-history-storage
+- [ ] prd-066-100-save-state-history-diffing

--- a/.foundry/prds/prd-066-099-save-state-history-storage.md
+++ b/.foundry/prds/prd-066-099-save-state-history-storage.md
@@ -1,0 +1,38 @@
+---
+id: prd-066-099-save-state-history-storage
+type: PRD
+title: IndexedDB Storage Engine for Save State History
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-066-save-state-history
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: IndexedDB Storage Engine for Save State History
+
+## Overview
+To support save state version history, we need a robust local storage solution. We will use IndexedDB to store sequential `.sav` file uploads for a given playthrough. This PRD focuses purely on the storage mechanics.
+
+## Requirements
+- The storage engine must be capable of storing multiple, sequential `.sav` files for a single playthrough.
+- Each stored state must be timestamped and retain its original file data.
+- Must handle storage limits gracefully (e.g., maximum number of states per playthrough, LRU eviction if necessary).
+- Must provide an API for retrieving the *previous* state relative to any given state for diffing purposes.
+- Should integrate with or extend existing DexHelper storage mechanisms if applicable, otherwise establish a new IndexedDB schema.
+
+## Acceptance Criteria
+- [ ] Define storage schema (DB name, object stores, indexes).
+- [ ] Implement write API to store a new save state.
+- [ ] Implement read API to retrieve states (by playthrough, ordered by time).

--- a/.foundry/prds/prd-066-100-save-state-history-diffing.md
+++ b/.foundry/prds/prd-066-100-save-state-history-diffing.md
@@ -1,0 +1,39 @@
+---
+id: prd-066-100-save-state-history-diffing
+type: PRD
+title: Save State Diffing and Metadata Inference Engine
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on:
+  - prd-066-099-save-state-history-storage
+jules_session_id: null
+pr_number: null
+parent: idea-066-save-state-history
+tags:
+  - diffing
+  - metadata
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Save State Diffing and Metadata Inference Engine
+
+## Overview
+Once save states are stored sequentially, we need an engine to compare two states (State A and State B) and infer metadata that is missing from the raw save files (especially for Gen 1/2), such as "date caught" or inferred location.
+
+## Requirements
+- Must implement a diffing algorithm that compares the Pokémon collections between two sequential states.
+- When a new Pokémon appears in State B that wasn't in State A, infer its "date caught" as the timestamp of State B's upload (or an interpolated time).
+- Attempt to infer "location met" by analyzing the player's map coordinates and party changes between State A and State B.
+- The diffing process should be performant and run locally in the browser.
+- Inferred metadata must be structured and associated with the specific Pokémon instance in the app's view state.
+
+## Acceptance Criteria
+- [ ] Define the diffing algorithm logic.
+- [ ] Implement Pokémon identification across states (how do we know it's the *same* Pokémon if it leveled up?).
+- [ ] Implement metadata inference rules (date caught, location).


### PR DESCRIPTION
Added the requested PRD nodes for the save state version history and metadata inference features, correctly splitting them into storage and diffing engine components. The parent IDEA node was successfully updated with proper references to the newly generated child nodes without prematurely transitioning it to completion.

---
*PR created automatically by Jules for task [2835810479515254543](https://jules.google.com/task/2835810479515254543) started by @szubster*