### PR TITLE
chore(qa): Verify Gen 3 TV Block DataView Parser

### DIFF
--- a/.foundry/tasks/task-121-220-gen3-tv-block-parser-retry-qa.md
+++ b/.foundry/tasks/task-121-220-gen3-tv-block-parser-retry-qa.md
@@ -29,10 +29,10 @@ Verify the implementation of the Gen 3 TV block `DataView` parser to ensure it c
 **Validation Note (2026-06-30):** Rejected `task-121-219-gen3-tv-block-parser-retry-impl`. The implementer correctly used `DataView` but violated the strict constraint against inline magic numbers by using `21` and `40` directly in the `parseGen3MixRecords` conditional check instead of defining them as module-level reusable constants. The task has been failed and sent back for retry.
 
 ## Acceptance Criteria
-- [ ] Verify the TV block extraction logic uses `DataView` exclusively, with no legacy `Uint8Array` manual read methods.
-- [ ] Verify all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. No inline magic numbers.
-- [ ] Verify `RangeError` exceptions are gracefully caught and translated into descriptive structural errors.
-- [ ] Ensure existing Gen 1 and Gen 2 parsers remain unbroken by running the full test suite.
+- [x] Verify the TV block extraction logic uses `DataView` exclusively, with no legacy `Uint8Array` manual read methods.
+- [x] Verify all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. No inline magic numbers.
+- [x] Verify `RangeError` exceptions are gracefully caught and translated into descriptive structural errors.
+- [x] Ensure existing Gen 1 and Gen 2 parsers remain unbroken by running the full test suite.
 
 ## Important Protocols (For QA)
 - **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Check all acceptance criteria boxes for `task-121-220-gen3-tv-block-parser-retry-qa`. The implementation correctly uses DataView, avoids magic numbers by defining reusable constants, catches RangeError appropriately, and maintains passing test suites.

---
*PR created automatically by Jules for task [11083851004217137628](https://jules.google.com/task/11083851004217137628) started by @szubster*