### PR TITLE
Implement Shiny Carrier Breeding Pair Algorithm

### DIFF
--- a/.foundry/tasks/task-084-243-breeding-pair-algorithm-impl.md
+++ b/.foundry/tasks/task-084-243-breeding-pair-algorithm-impl.md
@@ -35,9 +35,9 @@ Implement a core backend algorithm (`src/engine/breeding/pair_algorithm.ts` or s
 - **Constraint**: Do not implement UI in this task. Focus strictly on the data structure and pure function logic.
 
 ## Acceptance Criteria
-- [ ] Algorithm correctly matches valid Gen 2 breeding pairs based on Egg Groups and Gender.
-- [ ] Algorithm correctly prevents "related" Pokémon (e.g. two Shinies) from breeding based on DVs.
-- [ ] Output explicitly highlights/prioritizes pairs involving Shiny Carriers.
-- [ ] Include unit tests (`test.ts`) validating these specific matching rules with mocked Gen 2 Pokémon data.
-- [ ] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
-- [ ] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- [x] Algorithm correctly matches valid Gen 2 breeding pairs based on Egg Groups and Gender.
+- [x] Algorithm correctly prevents "related" Pokémon (e.g. two Shinies) from breeding based on DVs.
+- [x] Output explicitly highlights/prioritizes pairs involving Shiny Carriers.
+- [x] Include unit tests (`test.ts`) validating these specific matching rules with mocked Gen 2 Pokémon data.
+- [x] If transient failures occur, update YAML to `status: FAILED` with a `rejection_reason`. If aborting, update to `status: CANCELLED` with `rejection_reason`.
+- [x] If submitting an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/src/engine/breeding/pair_algorithm.test.ts
+++ b/src/engine/breeding/pair_algorithm.test.ts
@@ -28,12 +28,14 @@ describe('calculateBreedingPairs', () => {
       gender: 'Male',
       eggGroups: ['Monster'],
       isShinyCarrier: true,
+      dvs: { attack: 15, defense: 10, speed: 10, special: 2 },
     };
     const p2: PokemonWithMetadata = {
       id: '2',
       speciesId: 2,
       gender: 'Female',
       eggGroups: ['Monster'],
+      dvs: { attack: 1, defense: 1, speed: 1, special: 1 },
     };
     const p3: PokemonWithMetadata = {
       id: '3',
@@ -41,10 +43,11 @@ describe('calculateBreedingPairs', () => {
       gender: 'Female',
       eggGroups: ['Monster'],
       isShinyCarrier: true,
+      dvs: { attack: 15, defense: 10, speed: 10, special: 10 },
     };
 
     const pairs = calculateBreedingPairs([p1, p2, p3]);
-    // Since p1 and p3 are both shiny carriers, they cannot breed.
+    // Since p1 and p3 are both shiny carriers, but they share defense 10 and special difference is 8 (10-2). Thus they cannot breed.
     // p2 and p3 are both Female, so they cannot breed.
     // So the only valid pair is p1 + p2.
     expect(pairs).toHaveLength(1);
@@ -56,13 +59,14 @@ describe('calculateBreedingPairs', () => {
     expect(pairIds).not.toContain('3-1');
   });
 
-  test('two shiny/shiny carrier parents cannot breed', () => {
+  test('Test Case 1: Two Shiny Pokémon', () => {
     const p1: PokemonWithMetadata = {
       id: '1',
       speciesId: 1,
       gender: 'Male',
       eggGroups: ['Monster'],
-      isShinyCarrier: true,
+      isShiny: true,
+      dvs: { attack: 10, defense: 10, speed: 10, special: 10 },
     };
     const p2: PokemonWithMetadata = {
       id: '2',
@@ -70,10 +74,74 @@ describe('calculateBreedingPairs', () => {
       gender: 'Female',
       eggGroups: ['Monster'],
       isShiny: true,
+      dvs: { attack: 10, defense: 10, speed: 10, special: 10 },
     };
 
     const pairs = calculateBreedingPairs([p1, p2]);
-    expect(pairs).toHaveLength(0);
+    expect(pairs).toHaveLength(0); // Defense 10 == 10, Special 10 == 10
+  });
+
+  test('Test Case 2: Shiny and Shiny Carrier (Difference of 8)', () => {
+    const p1: PokemonWithMetadata = {
+      id: '1',
+      speciesId: 1,
+      gender: 'Male',
+      eggGroups: ['Monster'],
+      isShiny: true,
+      dvs: { attack: 10, defense: 10, speed: 10, special: 10 },
+    };
+    const p2: PokemonWithMetadata = {
+      id: '2',
+      speciesId: 2,
+      gender: 'Female',
+      eggGroups: ['Monster'],
+      isShinyCarrier: true,
+      dvs: { attack: 15, defense: 10, speed: 15, special: 2 },
+    };
+
+    const pairs = calculateBreedingPairs([p1, p2]);
+    expect(pairs).toHaveLength(0); // Defense 10 == 10, Special |10-2| == 8
+  });
+
+  test('Test Case 3: Shiny and Unrelated Non-Shiny', () => {
+    const p1: PokemonWithMetadata = {
+      id: '1',
+      speciesId: 1,
+      gender: 'Male',
+      eggGroups: ['Monster'],
+      isShiny: true,
+      dvs: { attack: 10, defense: 10, speed: 10, special: 10 },
+    };
+    const p2: PokemonWithMetadata = {
+      id: '2',
+      speciesId: 2,
+      gender: 'Female',
+      eggGroups: ['Monster'],
+      dvs: { attack: 15, defense: 7, speed: 15, special: 10 },
+    };
+
+    const pairs = calculateBreedingPairs([p1, p2]);
+    expect(pairs).toHaveLength(1); // Defense 10 != 7
+  });
+
+  test('Test Case 4: Identical Non-Shiny Defense, Different Special', () => {
+    const p1: PokemonWithMetadata = {
+      id: '1',
+      speciesId: 1,
+      gender: 'Male',
+      eggGroups: ['Monster'],
+      dvs: { attack: 15, defense: 14, speed: 15, special: 5 },
+    };
+    const p2: PokemonWithMetadata = {
+      id: '2',
+      speciesId: 2,
+      gender: 'Female',
+      eggGroups: ['Monster'],
+      dvs: { attack: 15, defense: 14, speed: 15, special: 10 },
+    };
+
+    const pairs = calculateBreedingPairs([p1, p2]);
+    expect(pairs).toHaveLength(1); // Defense 14 == 14, Special |5-10| = 5 != 8 or 0
   });
 
   test('handles Ditto mechanics correctly', () => {
@@ -82,18 +150,21 @@ describe('calculateBreedingPairs', () => {
       speciesId: 132,
       gender: 'Genderless',
       eggGroups: ['Ditto'],
+      dvs: { attack: 1, defense: 1, speed: 1, special: 1 },
     };
     const maleBulba: PokemonWithMetadata = {
       id: '2',
       speciesId: 1,
       gender: 'Male',
       eggGroups: ['Monster'],
+      dvs: { attack: 2, defense: 2, speed: 2, special: 2 },
     };
     const genderlessMagnemite: PokemonWithMetadata = {
       id: '3',
       speciesId: 81,
       gender: 'Genderless',
       eggGroups: ['Mineral'],
+      dvs: { attack: 3, defense: 3, speed: 3, special: 3 },
     };
     const noEggsMewtwo: PokemonWithMetadata = {
       id: '4',

--- a/src/engine/breeding/pair_algorithm.ts
+++ b/src/engine/breeding/pair_algorithm.ts
@@ -1,3 +1,10 @@
+export interface PokemonDVs {
+  attack: number;
+  defense: number;
+  speed: number;
+  special: number;
+}
+
 export interface PokemonWithMetadata {
   id: string; // Unique identifier for the specific pokemon instance
   speciesId: number;
@@ -5,6 +12,7 @@ export interface PokemonWithMetadata {
   eggGroups: string[];
   isShinyCarrier?: boolean;
   isShiny?: boolean;
+  dvs?: PokemonDVs;
 }
 
 export interface BreedingPair {
@@ -60,6 +68,7 @@ export function calculateBreedingPairs(pokemonList: PokemonWithMetadata[]): Bree
  * - Genderless Pokémon can only breed with Ditto.
  * - Genders must be opposite.
  * - At least one egg group must intersect.
+ * - In Gen 2, two Pokémon are incompatible if their Defense DVs are identical and their Special DVs are identical or differ by exactly 8.
  *
  * @param p1 - First parent candidate.
  * @param p2 - Second parent candidate.
@@ -74,18 +83,28 @@ function isValidPair(p1: PokemonWithMetadata, p2: PokemonWithMetadata): boolean 
   const p1IsDitto = p1.eggGroups.includes('Ditto');
   const p2IsDitto = p2.eggGroups.includes('Ditto');
 
-  // Two dittos can't breed with each other, right? Let's check Pokemon breeding rules.
-  // Wait, in Gen 2 two Dittos CAN breed, yielding a Ditto. But usually "Two Dittos cannot breed". Let's assume standard rules: Two Dittos CANNOT breed.
   if (p1IsDitto && p2IsDitto) return false;
-
-  if (p1IsDitto || p2IsDitto) return true;
+  if (p1IsDitto || p2IsDitto) {
+    if (checkDvsIncompatible(p1, p2)) return false;
+    return true;
+  }
 
   if (p1.gender === 'Genderless' || p2.gender === 'Genderless') return false;
   if (p1.gender === p2.gender) return false;
 
-  const p1IsShiny = p1.isShiny || p1.isShinyCarrier;
-  const p2IsShiny = p2.isShiny || p2.isShinyCarrier;
-  if (p1IsShiny && p2IsShiny) return false;
+  if (checkDvsIncompatible(p1, p2)) return false;
 
   return p1.eggGroups.some((group) => p2.eggGroups.includes(group));
+}
+
+function checkDvsIncompatible(p1: PokemonWithMetadata, p2: PokemonWithMetadata): boolean {
+  if (p1.dvs && p2.dvs) {
+    if (p1.dvs.defense === p2.dvs.defense) {
+      const specialDiff = Math.abs(p1.dvs.special - p2.dvs.special);
+      if (specialDiff === 0 || specialDiff === 8) {
+        return true; // Related and incompatible
+      }
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
Implemented strict Gen 2 DV overlap constraints for breeding pairs (Shiny and Shiny Carriers) to prevent incest breeding loops, properly scoring valid pairs.

---
*PR created automatically by Jules for task [17791331143296889944](https://jules.google.com/task/17791331143296889944) started by @szubster*