### PR TITLE
feat: implement gen2 egg hatch parsing

### DIFF
--- a/.foundry/tasks/task-158-249-gen2-egg-hatch-parsing-impl.md
+++ b/.foundry/tasks/task-158-249-gen2-egg-hatch-parsing-impl.md
@@ -50,6 +50,6 @@ In `src/engine/saveParser/saveParser.test.ts` (or the appropriate test file like
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] `PokemonInstance` is updated with `eggSteps?: number`.
-- [ ] `parseGen2PokemonInstance` calculates `eggSteps` correctly for eggs (species ID 253).
-- [ ] Unit tests are written to verify the calculation.
+- [x] `PokemonInstance` is updated with `eggSteps?: number`.
+- [x] `parseGen2PokemonInstance` calculates `eggSteps` correctly for eggs (species ID 253).
+- [x] Unit tests are written to verify the calculation.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -41,6 +41,7 @@ export interface PokemonInstance {
   isShinyCarrier?: boolean;
   item?: number | undefined;
   moves: number[];
+  eggSteps?: number | undefined;
   friendship?: number | undefined;
   pokerus?: { strain: number; daysRemaining: number } | undefined;
   currentHp?: number | undefined;

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -352,6 +352,43 @@ describe('gen2 parsers', () => {
     });
   });
 
+  describe('Gen 2 Egg Parsing', () => {
+    it('should correctly calculate eggSteps for an Egg (speciesId 253)', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+
+      view.setUint8(0x288a, 1);
+      view.setUint8(0x288b, 253); // Party species list: Egg
+
+      // Party Pokémon data offset for GS is 0x288A + 8 = 0x2892
+      const dataOffset = 0x2892;
+      view.setUint8(dataOffset, 253); // speciesId
+      view.setUint8(dataOffset + 27, 10); // friendship byte (cycle count)
+
+      const data = parseGen2(view, false);
+      expect(data.partyDetails[0]?.speciesId).toBe(253);
+      expect(data.partyDetails[0]?.eggSteps).toBe(10 * 256);
+      expect(data.partyDetails[0]?.friendship).toBe(10);
+    });
+
+    it('should not define eggSteps for non-Egg Pokemon', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+
+      view.setUint8(0x288a, 1);
+      view.setUint8(0x288b, 1); // Party species list: Bulbasaur
+
+      // Party Pokémon data offset for GS is 0x288A + 8 = 0x2892
+      const dataOffset = 0x2892;
+      view.setUint8(dataOffset, 1); // speciesId
+      view.setUint8(dataOffset + 27, 70); // friendship byte
+
+      const data = parseGen2(view, false);
+      expect(data.partyDetails[0]?.speciesId).toBe(1);
+      expect(data.partyDetails[0]?.eggSteps).toBeUndefined();
+    });
+  });
+
   describe('parseGen2 - Unown Forms', () => {
     it('should correctly parse Unown Form A', () => {
       const buffer = new ArrayBuffer(32768);

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -15,6 +15,8 @@ const POKEMON_OFFSET_CAUGHT_BYTE_2 = 30;
 const POKEMON_OFFSET_LEVEL = 31;
 const POKEMON_OFFSET_OT_NAME = 32;
 const POKEMON_OFFSET_CURRENT_HP = 34;
+const GEN2_EGG_SPECIES_ID = 253;
+const GEN2_EGG_CYCLE_STEPS = 256;
 
 function isValidLandmark(id: string): id is keyof typeof gen2Landmarks {
   return id in gen2Landmarks;
@@ -102,6 +104,8 @@ function parseGen2PokemonInstance(
   const rawPokerus = view.getUint8(offset + POKEMON_OFFSET_POKERUS);
   const pokerus = parsePokerus(rawPokerus);
   const level = view.getUint8(offset + POKEMON_OFFSET_LEVEL);
+
+  const eggSteps = speciesId === GEN2_EGG_SPECIES_ID ? friendship * GEN2_EGG_CYCLE_STEPS : undefined;
   const currentHp = storageLocation === 'Party' ? view.getUint16(offset + POKEMON_OFFSET_CURRENT_HP, false) : undefined;
   const caughtData = isCrystal ? parseCaughtData(view, offset) : undefined;
 
@@ -127,6 +131,7 @@ function parseGen2PokemonInstance(
     isShinyCarrier,
     item,
     moves,
+    eggSteps,
     friendship,
     pokerus,
     caughtData,


### PR DESCRIPTION
Implement logic to extract the remaining egg cycles for Gen 2 Eggs and calculate exact remaining steps for the egg to hatch.

- Adds `eggSteps` to `PokemonInstance` interface
- Updates Gen 2 parsing logic to check for species ID 253 and assign `eggSteps` dynamically without inline magic numbers.
- Adds test cases to `gen2.test.ts` checking both the egg case and non-egg case logic.

---
*PR created automatically by Jules for task [14734252185691957192](https://jules.google.com/task/14734252185691957192) started by @szubster*