### PR TITLE
chore: complete task-242-249-gen3-roamer-dataview-parser-impl with empty PR

### DIFF
--- a/.foundry/tasks/task-242-249-gen3-roamer-dataview-parser-impl.md
+++ b/.foundry/tasks/task-242-249-gen3-roamer-dataview-parser-impl.md
@@ -53,7 +53,7 @@ The `Roamer` struct holds the state of the roaming legendary Pokémon in Generat
   - If you must abort or permanently fail the task (impossible or max rejections reached), update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 
 ## Acceptance Criteria
-- [ ] Create or update the Gen 3 parsing module to extract the `Roamer` struct using `DataView`.
-- [ ] Define all offsets (`0x31DC`, `0x3144`, `0x30D0`, `0x00`, `0x04`, `0x08`, `0x0A`, `0x0C`, `0x0D`, `0x13`) as module-level constants.
-- [ ] Extract the `active` boolean properly from offset `0x13`.
-- [ ] Catch `RangeError` from `DataView` operations and handle them gracefully.
+- [x] Create or update the Gen 3 parsing module to extract the `Roamer` struct using `DataView`.
+- [x] Define all offsets (`0x31DC`, `0x3144`, `0x30D0`, `0x00`, `0x04`, `0x08`, `0x0A`, `0x0C`, `0x0D`, `0x13`) as module-level constants.
+- [x] Extract the `active` boolean properly from offset `0x13`.
+- [x] Catch `RangeError` from `DataView` operations and handle them gracefully.


### PR DESCRIPTION
The `parseGen3Roamer` function and all required module-level constants for offset parsing (e.g., `ROAMER_ACTIVE_OFFSET`, `ROAMER_IVS_OFFSET`) already existed and fully satisfied the acceptance criteria in `src/engine/saveParser/parsers/gen3.ts`. I checked off the acceptance criteria checkboxes in `.foundry/tasks/task-242-249-gen3-roamer-dataview-parser-impl.md` and am submitting this as an empty PR to transition the node.

---
*PR created automatically by Jules for task [11075382855893639921](https://jules.google.com/task/11075382855893639921) started by @szubster*