### PR TITLE
feat(engine): implement gen 2 box parsing grouping utility

### DIFF
--- a/.foundry/tasks/task-245-249-gen2-box-grouping-impl.md
+++ b/.foundry/tasks/task-245-249-gen2-box-grouping-impl.md
@@ -41,7 +41,7 @@ The goal is to prepare Gen 2 PC box data for the frontend Comparison Matrix UI. 
 *   If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Grouping logic is implemented to group `PokemonInstance` objects by `speciesId`.
-- [ ] Party and Daycare Pokémon are actively excluded from the grouping output.
-- [ ] Unit tests are written to verify grouping and filtering behavior.
-- [ ] Ensure that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
+- [x] Grouping logic is implemented to group `PokemonInstance` objects by `speciesId`.
+- [x] Party and Daycare Pokémon are actively excluded from the grouping output.
+- [x] Unit tests are written to verify grouping and filtering behavior.
+- [x] Ensure that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.

--- a/src/engine/saveParser/utils/boxGrouping.test.ts
+++ b/src/engine/saveParser/utils/boxGrouping.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { PokemonInstance } from '../parsers/common';
+import { groupBoxPokemonBySpecies } from './boxGrouping';
+
+describe('boxGrouping', () => {
+  it('groups Pokemon by speciesId and filters non-box Pokemon', () => {
+    const mockPokemon: PokemonInstance[] = [
+      {
+        speciesId: 1,
+        level: 5,
+        isShiny: false,
+        moves: [],
+        storageLocation: 'Box 1',
+        dvs: { hp: 15, atk: 15, def: 15, spd: 15, spc: 15 },
+      },
+      {
+        speciesId: 1,
+        level: 10,
+        isShiny: true,
+        moves: [],
+        storageLocation: 'Box 2',
+        dvs: { hp: 10, atk: 10, def: 10, spd: 10, spc: 10 },
+      },
+      {
+        speciesId: 2,
+        level: 20,
+        isShiny: false,
+        moves: [],
+        storageLocation: 'Box 3',
+        dvs: { hp: 0, atk: 0, def: 0, spd: 0, spc: 0 },
+      },
+      {
+        speciesId: 1,
+        level: 100,
+        isShiny: false,
+        moves: [],
+        storageLocation: 'Party',
+        dvs: { hp: 15, atk: 15, def: 15, spd: 15, spc: 15 },
+      },
+      {
+        speciesId: 3,
+        level: 50,
+        isShiny: false,
+        moves: [],
+        storageLocation: 'Daycare',
+        dvs: { hp: 8, atk: 8, def: 8, spd: 8, spc: 8 },
+      },
+    ];
+
+    const result = groupBoxPokemonBySpecies(mockPokemon);
+
+    expect(Object.keys(result)).toEqual(['1', '2']);
+    expect(result[1]?.length).toBe(2);
+    expect(result[2]?.length).toBe(1);
+    expect(result[3]).toBeUndefined();
+
+    // Verify properties like DVs and shininess are retained
+    expect(result[1]?.[0]?.storageLocation).toBe('Box 1');
+    expect(result[1]?.[0]?.dvs?.hp).toBe(15);
+    expect(result[1]?.[1]?.isShiny).toBe(true);
+    expect(result[2]?.[0]?.storageLocation).toBe('Box 3');
+  });
+
+  it('handles empty arrays', () => {
+    const result = groupBoxPokemonBySpecies([]);
+    expect(Object.keys(result).length).toBe(0);
+  });
+});

--- a/src/engine/saveParser/utils/boxGrouping.ts
+++ b/src/engine/saveParser/utils/boxGrouping.ts
@@ -1,0 +1,28 @@
+import type { PokemonInstance } from '../parsers/common';
+
+const BOX_LOCATION_PREFIX = 'Box';
+
+/**
+ * Groups an array of PokemonInstance by speciesId, filtering out any Pokemon
+ * that are not stored in a PC Box.
+ *
+ * @param pokemonList Array of PokemonInstance to filter and group
+ * @returns Record grouping speciesId to an array of PokemonInstance
+ */
+export function groupBoxPokemonBySpecies(pokemonList: PokemonInstance[]): Record<number, PokemonInstance[]> {
+  const grouped: Record<number, PokemonInstance[]> = {};
+
+  for (const pokemon of pokemonList) {
+    if (pokemon.storageLocation?.startsWith(BOX_LOCATION_PREFIX)) {
+      if (!grouped[pokemon.speciesId]) {
+        grouped[pokemon.speciesId] = [];
+      }
+      const group = grouped[pokemon.speciesId];
+      if (group) {
+        group.push(pokemon);
+      }
+    }
+  }
+
+  return grouped;
+}


### PR DESCRIPTION
Adds `groupBoxPokemonBySpecies` utility to `src/engine/saveParser/utils/boxGrouping.ts`.
- Groups `PokemonInstance` array by `speciesId`.
- Filters out non-PC Box instances (e.g. Party, Daycare).
- Tested against empty arrays, non-box locations, and validates DV/Shiny retention.
- Replaces magic string `'Box'` with `BOX_LOCATION_PREFIX` module constant.

---
*PR created automatically by Jules for task [2324158207491763169](https://jules.google.com/task/2324158207491763169) started by @szubster*