### PR TITLE
feat(engine): implement gen2 daycare data parsing

### DIFF
--- a/.foundry/tasks/task-240-245-gen2-daycare-parsing-impl.md
+++ b/.foundry/tasks/task-240-245-gen2-daycare-parsing-impl.md
@@ -42,7 +42,7 @@ The Egg species ID is `253` (`0xFD`).
 - If submitting an empty PR for a completed task, check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement a parser for Gen 2 Daycare slots that extracts the Pokémon in Slot 1 and Slot 2.
-- [ ] Implement parsing of the Egg Flag.
-- [ ] Ensure all offsets and sizes (e.g. 57, 32, 11, `0x2850`, `0x282c`, etc.) are defined as module-level constants.
-- [ ] Add unit tests verifying the parsing logic.
+- [x] Implement a parser for Gen 2 Daycare slots that extracts the Pokémon in Slot 1 and Slot 2.
+- [x] Implement parsing of the Egg Flag.
+- [x] Ensure all offsets and sizes (e.g. 57, 32, 11, `0x2850`, `0x282c`, etc.) are defined as module-level constants.
+- [x] Add unit tests verifying the parsing logic.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -55,6 +55,7 @@ export interface PokemonInstance {
       }
     | undefined;
   otName?: string | undefined;
+  nickname?: string | undefined;
   storageLocation: string;
   /** The 1-indexed position of the Pokémon within its storage container. */
   slot?: number | undefined;

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -13,8 +13,19 @@ const POKEMON_OFFSET_POKERUS = 28;
 const POKEMON_OFFSET_CAUGHT_BYTE_1 = 29;
 const POKEMON_OFFSET_CAUGHT_BYTE_2 = 30;
 const POKEMON_OFFSET_LEVEL = 31;
-const POKEMON_OFFSET_OT_NAME = 32;
+const POKEMON_DATA_BLOCK_SIZE = 32;
+const POKEMON_NAME_LENGTH = 11;
+const POKEMON_OFFSET_OT_NAME = POKEMON_DATA_BLOCK_SIZE;
+const POKEMON_OFFSET_NICKNAME = POKEMON_DATA_BLOCK_SIZE + POKEMON_NAME_LENGTH;
 const POKEMON_OFFSET_CURRENT_HP = 34;
+
+const DAYCARE_SLOT_1_OFFSET_GS = 0x2850;
+const DAYCARE_SLOT_2_OFFSET_GS = 0x2817;
+const DAYCARE_EGG_FLAG_OFFSET_GS = 0x284f;
+const DAYCARE_SLOT_1_OFFSET_CRYSTAL = 0x282c;
+const DAYCARE_SLOT_2_OFFSET_CRYSTAL = 0x27f3;
+const DAYCARE_EGG_FLAG_OFFSET_CRYSTAL = 0x282b;
+const DAYCARE_EGG_FLAG_MASK = 0x01;
 
 function isValidLandmark(id: string): id is keyof typeof gen2Landmarks {
   return id in gen2Landmarks;
@@ -106,7 +117,14 @@ function parseGen2PokemonInstance(
   const caughtData = isCrystal ? parseCaughtData(view, offset) : undefined;
 
   // OT names in daycare are immediately after the data block
-  const otName = storageLocation === 'Daycare' ? decodeGen12String(view, offset + POKEMON_OFFSET_OT_NAME) : undefined;
+  const otName =
+    storageLocation === 'Daycare'
+      ? decodeGen12String(view, offset + POKEMON_OFFSET_OT_NAME, POKEMON_NAME_LENGTH)
+      : undefined;
+  const nickname =
+    storageLocation === 'Daycare'
+      ? decodeGen12String(view, offset + POKEMON_OFFSET_NICKNAME, POKEMON_NAME_LENGTH)
+      : undefined;
 
   let unownForm: string | undefined;
   if (speciesId === 201) {
@@ -132,6 +150,7 @@ function parseGen2PokemonInstance(
     caughtData,
     dvs,
     otName,
+    nickname,
     storageLocation,
     slot,
     unownForm,
@@ -314,7 +333,7 @@ function parsePCBoxes(
   const pcDetails: PokemonInstance[] = [];
   const currentBoxDataOffset = offsets.currentBoxSpecies + 21; // After species list
   for (let i = 0; i < currentBoxCount; i++) {
-    const offset = currentBoxDataOffset + i * 32;
+    const offset = currentBoxDataOffset + i * POKEMON_DATA_BLOCK_SIZE;
     const p = parseGen2PokemonInstance(view, offset, isCrystal, `Box ${currentBoxNum + 1}`, i + 1);
     if (p) {
       pcDetails.push(p);
@@ -349,7 +368,7 @@ function parsePCBoxes(
 
     const boxDataOffset = offset + 22;
     for (let j = 0; j < count; j++) {
-      const pOff = boxDataOffset + j * 32;
+      const pOff = boxDataOffset + j * POKEMON_DATA_BLOCK_SIZE;
       const p = parseGen2PokemonInstance(view, pOff, isCrystal, `Box ${i + 1}`, j + 1);
       if (p) {
         pcDetails.push(p);
@@ -374,23 +393,26 @@ function parsePCBoxes(
  * @returns The Daycare Pokémon instances and a boolean indicating if an egg is ready.
  */
 function parseDaycare(view: DataView, isCrystal: boolean) {
-  const daycare1Offset = isCrystal ? 0x282c : 0x2850;
-  const daycare2Offset = daycare1Offset - 57;
-  const daycareEggOffset = daycare1Offset - 1;
+  const daycare1Offset = isCrystal ? DAYCARE_SLOT_1_OFFSET_CRYSTAL : DAYCARE_SLOT_1_OFFSET_GS;
+  const daycare2Offset = isCrystal ? DAYCARE_SLOT_2_OFFSET_CRYSTAL : DAYCARE_SLOT_2_OFFSET_GS;
+  const daycareEggOffset = isCrystal ? DAYCARE_EGG_FLAG_OFFSET_CRYSTAL : DAYCARE_EGG_FLAG_OFFSET_GS;
 
   const daycare: PokemonInstance[] = [];
 
-  for (const offset of [daycare1Offset, daycare2Offset]) {
+  const offsets = [daycare1Offset, daycare2Offset];
+  for (let i = 0; i < offsets.length; i++) {
+    const offset = offsets[i];
+    if (offset === undefined) continue;
     const speciesId = view.getUint8(offset);
     if (speciesId !== 0 && speciesId !== 0xff) {
-      const p = parseGen2PokemonInstance(view, offset, isCrystal, 'Daycare');
+      const p = parseGen2PokemonInstance(view, offset, isCrystal, 'Daycare', i + 1);
       if (p) {
         daycare.push(p);
       }
     }
   }
 
-  const daycareHasEgg = (view.getUint8(daycareEggOffset) & 0x01) !== 0;
+  const daycareHasEgg = (view.getUint8(daycareEggOffset) & DAYCARE_EGG_FLAG_MASK) !== 0;
 
   return { daycare, daycareHasEgg };
 }

--- a/src/engine/saveParser/parsers/gen2_daycare.test.ts
+++ b/src/engine/saveParser/parsers/gen2_daycare.test.ts
@@ -12,6 +12,12 @@ describe('gen2 daycare parsing', () => {
     view.setUint8(daycare1Offset, 1); // Species
     view.setUint8(daycare1Offset + 31, 5); // Level
 
+    const nameOffsets = daycare1Offset + 32;
+    view.setUint8(nameOffsets, 0x80); // 'A' (OT Name)
+    view.setUint8(nameOffsets + 1, 0x50); // end of string
+    view.setUint8(daycare1Offset + 43, 0x81); // 'B' (Nickname)
+    view.setUint8(daycare1Offset + 43 + 1, 0x50);
+
     // Egg flag
     view.setUint8(eggFlagOffset, 0);
 
@@ -21,6 +27,9 @@ describe('gen2 daycare parsing', () => {
       speciesId: 1,
       level: 5,
       storageLocation: 'Daycare',
+      otName: 'A',
+      nickname: 'B',
+      slot: 1,
     });
     expect(data.daycareHasEgg).toBe(false);
   });


### PR DESCRIPTION
Implemented Gen 2 Daycare data parsing, ensuring module-level constants are used for offsets. Validated extraction of Pokémon slots, OT Name, Nickname, and Egg Flag.

---
*PR created automatically by Jules for task [14562293871297410461](https://jules.google.com/task/14562293871297410461) started by @szubster*