### PR TITLE
feat(ui): implement contest warning states for dead-end optimization

### DIFF
--- a/.foundry/tasks/task-150-242-contest-warning-states-ui-impl.md
+++ b/.foundry/tasks/task-150-242-contest-warning-states-ui-impl.md
@@ -45,11 +45,11 @@ This task implements visual warning states for edge cases identified by the Gen 
    - Update `src/components/__tests__/ContestRecommendationPanel.test.tsx` to include a test case that verifies the warning state renders correctly when `sheen` is 255 and scores are below 200.
 
 ## Acceptance Criteria
-- [ ] Update `ContestRecommendationPanel` to accept a `sheen` prop.
-- [ ] Implement the "dead-end" detection logic (`sheen >= 255` and top score `< 200`).
-- [ ] Display a distinct visual warning when the dead-end state is reached.
-- [ ] Adhere strictly to the tactical hardware aesthetic (ADR 008).
-- [ ] Write tests to verify the warning state renders properly.
+- [x] Update `ContestRecommendationPanel` to accept a `sheen` prop.
+- [x] Implement the "dead-end" detection logic (`sheen >= 255` and top score `< 200`).
+- [x] Display a distinct visual warning when the dead-end state is reached.
+- [x] Adhere strictly to the tactical hardware aesthetic (ADR 008).
+- [x] Write tests to verify the warning state renders properly.
 
 ## Important Reminder for the Coder
 - **Transient Failure**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/components/ContestRecommendationPanel.tsx
+++ b/src/components/ContestRecommendationPanel.tsx
@@ -8,6 +8,7 @@ import { TelemetryDecoration } from './TelemetryDecoration';
 
 export interface ContestRecommendationPanelProps extends React.HTMLAttributes<HTMLDivElement> {
   recommendations: ContestRecommendation[];
+  sheen?: number;
 }
 
 function getReasoningCopy(score: number): string {
@@ -21,7 +22,10 @@ function getReasoningCopy(score: number): string {
 }
 
 export const ContestRecommendationPanel = React.forwardRef<HTMLDivElement, ContestRecommendationPanelProps>(
-  ({ recommendations, className, ...props }, ref) => {
+  ({ recommendations, sheen, className, ...props }, ref) => {
+    const topScore = recommendations?.length > 0 && recommendations[0] ? recommendations[0].score : 0;
+    const isDeadEnd = sheen !== undefined && sheen >= 255 && topScore < 200;
+
     return (
       <TacticalPanel
         ref={ref}
@@ -30,6 +34,22 @@ export const ContestRecommendationPanel = React.forwardRef<HTMLDivElement, Conte
         {...props}
       >
         <TelemetryDecoration label="SYS.STRATEGY_MATRIX" className="-top-1 left-4" />
+
+        {isDeadEnd && (
+          <div className="relative mb-2 flex flex-col gap-2 rounded-none border border-amber-500/50 border-dashed bg-amber-500/10 p-4">
+            <LcdGrid />
+            <HoverScanner />
+            <div className="relative z-10 flex items-center gap-2 border-amber-500/30 border-b border-dashed pb-2">
+              <span className="font-bold font-mono text-amber-500 text-sm uppercase tracking-widest drop-shadow-[0_0_4px_rgba(245,158,11,0.5)]">
+                [ WARNING: OPTIMIZATION_DEAD_END ]
+              </span>
+            </div>
+            <div className="relative z-10 font-mono text-[10px] text-amber-400/90 uppercase leading-relaxed">
+              MAXIMUM SHEEN (255) DETECTED. INSUFFICIENT METRICS FOR MASTER RANK. FURTHER ENHANCEMENT VIA POKÉBLOCKS IS
+              IMPOSSIBLE.
+            </div>
+          </div>
+        )}
 
         {recommendations.length === 0 ? (
           <div className="relative flex h-16 items-center justify-center overflow-hidden rounded-none border border-zinc-800 border-dashed bg-black/40">

--- a/src/components/__tests__/ContestRecommendationPanel.test.tsx
+++ b/src/components/__tests__/ContestRecommendationPanel.test.tsx
@@ -48,6 +48,28 @@ test('renders only the top 2 recommendations if more are provided', async () => 
   await expect.element(page.getByText('cool')).not.toBeInTheDocument();
 });
 
+test('renders warning state when sheen is 255 and score is below 200', async () => {
+  const recommendations: ContestRecommendation[] = [{ category: 'cool', score: 190 }];
+  await render(<ContestRecommendationPanel recommendations={recommendations} sheen={255} />);
+
+  await expect.element(page.getByText(/WARNING: OPTIMIZATION_DEAD_END/)).toBeInTheDocument();
+  await expect.element(page.getByText(/MAXIMUM SHEEN \(255\) DETECTED/)).toBeInTheDocument();
+});
+
+test('does not render warning state when sheen is below 255', async () => {
+  const recommendations: ContestRecommendation[] = [{ category: 'cool', score: 190 }];
+  await render(<ContestRecommendationPanel recommendations={recommendations} sheen={254} />);
+
+  await expect.element(page.getByText(/WARNING: OPTIMIZATION_DEAD_END/)).not.toBeInTheDocument();
+});
+
+test('does not render warning state when sheen is 255 but score is 200 or above', async () => {
+  const recommendations: ContestRecommendation[] = [{ category: 'cool', score: 200 }];
+  await render(<ContestRecommendationPanel recommendations={recommendations} sheen={255} />);
+
+  await expect.element(page.getByText(/WARNING: OPTIMIZATION_DEAD_END/)).not.toBeInTheDocument();
+});
+
 test('applies ADR 008 aesthetic classes (rounded-none, border-dashed, font-mono)', async () => {
   const recommendations: ContestRecommendation[] = [{ category: 'smart', score: 500 }];
   const { container } = await render(<ContestRecommendationPanel recommendations={recommendations} />);


### PR DESCRIPTION
Implemented visual warning states for edge cases identified by the Gen 3 Contest Optimization Advisor algorithm. Specifically, this PR alerts users when a Pokémon has maxed out its Sheen (>= 255) but lacks the requisite stats for Master Rank contests (top score < 200). The UI adheres to the tactical hardware aesthetic constraints specified in ADR 008. Tests were also updated to ensure correct rendering.

---
*PR created automatically by Jules for task [2245414162262557999](https://jules.google.com/task/2245414162262557999) started by @szubster*