### PR TITLE
chore(foundry): update schema verifying state and agent policies

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -188,7 +188,7 @@ These are the hard rules the orchestrator, heartbeat, and resurrection loop rely
 4. **A node in `ACTIVE` status must have a non-null `jules_session_id`.** If it doesn't, the heartbeat will flip it to `FAILED`.
 5. **Only the orchestrator writes `READY`.** Personas must never set this status manually.
 6. **Implementers (Coder/QA) must NOT modify node frontmatter**, EXCEPT for the `status` field if they need to mark the task as `FAILED`, and the `rejection_reason` field. They are strictly forbidden from setting the status to `COMPLETED` or `DONE`. They should primarily update the Markdown body.
-7. **`COMPLETED` nodes are read-only.** Once a PR is merged, the node must not be edited. The TPM archives it.
+7. **`COMPLETED` nodes are read-only.** Once a PR is merged, the node transitions to `VERIFYING`. Once verified, it becomes `COMPLETED` and must not be edited. The TPM archives it.
 8. **`depends_on` paths must be resolvable.** The orchestrator will treat an unresolvable path as a permanent block (equivalent to `BLOCKED`). Always verify paths exist before committing.
 9. **Every `.foundry/**/*.md` file that is not a journal or doc must have valid YAML frontmatter.** The orchestrator will skip malformed files and log a warning — they will never be dispatched.
 10. **The `id` field must be globally unique across all `.foundry/` directories.** Duplicate IDs are undefined behaviour in the orchestrator.

--- a/.foundry/tasks/task-255-255-cleanup-duplicate-ideas.md
+++ b/.foundry/tasks/task-255-255-cleanup-duplicate-ideas.md
@@ -1,0 +1,32 @@
+---
+id: task-255-255-cleanup-duplicate-ideas
+type: TASK
+title: Clean up duplicate idea nodes
+status: PENDING
+owner_persona: tpm
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - tpm
+  - cleanup
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Clean up duplicate idea nodes
+
+## Context
+Duplicate IDEA nodes `idea-073-refactor-dag-dashboard-context.md` and `idea-074-refactor-dag-dashboard-context.md` were created, leading to duplicate PRDs and Epics.
+
+## Requirements
+- Identify and archive the duplicate nodes.
+- Ensure any dangling dependencies are handled properly.
+
+## Acceptance Criteria
+- [ ] Duplicate IDEA, PRD, and EPIC nodes for `refactor-dag-dashboard-context` are removed or archived.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -20,6 +20,8 @@ When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/d
 ## Save File Parsing & Magic Numbers
 When implementing save file parsing or data definitions, you MUST explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Strictly avoid using inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions. This ensures robustness against version-specific shifts and prevents brittle code.
 
+When parsing bitwise blocks (like event flag arrays) using the `DataView` API, you must explicitly map the specific bit offsets corresponding to target events. Just extracting the array is insufficient; explicitly identifying the individual bit offsets is required for downstream consumption.
+
 ## UI Aesthetic Constraints (ADR 008)
 When implementing UI components, you MUST adhere strictly to the "tactical hardware/snooping" aesthetic outlined in ADR 008.
 - Explicitly use sharp edges (`rounded-none`).


### PR DESCRIPTION
- Updated `.foundry/docs/schema.md` Invariant 7 to clarify that nodes transition to `VERIFYING` after a PR is merged, before becoming `COMPLETED`.
- Updated `.github/agents/coder.md` to instruct Coders to explicitly map bit offsets when extracting bitwise blocks using `DataView`.
- Created `task-255-255-cleanup-duplicate-ideas.md` for the TPM to remove duplicate nodes `idea-073` and `idea-074`.

---
*PR created automatically by Jules for task [15677471945453861368](https://jules.google.com/task/15677471945453861368) started by @szubster*