### PR TITLE
🎨 Palette: [TacticalButton tooltip fallback]

### DIFF
--- a/src/components/TacticalButton.tsx
+++ b/src/components/TacticalButton.tsx
@@ -10,9 +10,11 @@ interface TacticalButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEleme
 
 export const TacticalButton = React.forwardRef<HTMLButtonElement, TacticalButtonProps>(
   ({ className, variant = 'default', size = 'default', hasCrosshairs = false, children, ...props }, ref) => {
+    const title = props.title || props['aria-label'];
     return (
       <button
         ref={ref}
+        title={title}
         className={cn(
           'group tactical-text focus-visible:tactical-focus relative inline-flex shrink-0 items-center justify-center gap-3 overflow-hidden rounded-none border border-dashed font-black transition-all disabled:cursor-not-allowed disabled:opacity-50',
           {


### PR DESCRIPTION
Added an automatic `title` fallback using `aria-label` for `TacticalButton` component to ensure accessibility for sighted users. This mimics the existing behavior of `TacticalIconButton`.
- Modifies `src/components/TacticalButton.tsx` to display `aria-label` content via the `title` attribute.
- Resolves missing tooltips on icon-only variations of `TacticalButton`.

---
*PR created automatically by Jules for task [2262648183145493181](https://jules.google.com/task/2262648183145493181) started by @szubster*