### PR TITLE
chore(qa): Complete QA for Gen 3 Battle Points parsing

### DIFF
--- a/.foundry/tasks/task-123-241-gen3-parse-battle-points-qa.md
+++ b/.foundry/tasks/task-123-241-gen3-parse-battle-points-qa.md
@@ -36,6 +36,6 @@ Verify the implementation of the total Battle Points (BP) extraction logic for G
 - If submitting an empty PR for a completed task, check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] BP parsing logic correctly handles offset `0x0EB8`.
-- [ ] Module-level constants are used.
-- [ ] Error handling catches `RangeError`.
+- [x] BP parsing logic correctly handles offset `0x0EB8`.
+- [x] Module-level constants are used.
+- [x] Error handling catches `RangeError`.


### PR DESCRIPTION
The implementation of the Battle Points (BP) parsing logic for Gen 3 correctly used the memory offset `0x0EB8` stored in a module level constant `TOTAL_BATTLE_POINTS_OFFSET`, and handles `RangeError` properly.

This PR checks the acceptance criteria for the QA task since validation passed and no further code changes were needed.

---
*PR created automatically by Jules for task [12048224866937447208](https://jules.google.com/task/12048224866937447208) started by @szubster*