### PR TITLE
Canvas: Redesign Battle Frontier dashboard to tactical simulation matrix

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -245,3 +245,9 @@
 **Outcome:** Accepted
 **Why:** Brings the AI recommendation panel fully into the tactical specialization motif. Standard shaded boxes look like a regular web UI; the new data-pipe nodes feel like an active intelligence analysis readout.
 **Pattern:** Always elevate AI or recommendation readouts into active "Strategy Matrices" by utilizing data pipe visuals, CRT/Scanline backgrounds, mono brackets, and strictly capitalized terminal-style copy to reinforce the specialized intelligence fantasy.
+
+## 2025-10-25 - [Accepted] - 🖼️ Canvas: Tactical Battle Frontier Matrix Redesign
+**What:** Redesigned the `BattleFrontierDashboard` component into a 'Tactical Combat Simulation Matrix'. Replaced the generic flex-col layout and basic `tactical-panel` div classes with active `TacticalPanel` components featuring `LcdGrid`, `HoverScanner`, and `CornerCrosshairs`. Replaced the basic wallet balance display with a dedicated `DataPoint`. The facility panels dynamically adapt their `TacticalPanel` variants (`amber` for gold, `white` for silver) and use rigid segmented telemetry structures for streaks instead of standard flex layouts.
+**Outcome:** Accepted
+**Why:** Brings the Battle Frontier dashboard fully in line with the established specialized hardware motif. Standard shaded boxes looked like a regular web UI; treating the facilities as active simulation nodes with scanning grids and physical crosshairs fits the tactical intelligence readouts seen elsewhere.
+**Pattern:** Consistently elevate generic dashboard lists into active 'Simulation Matrices' or 'Telemetry Nodes' by wrapping them in `TacticalPanel`, applying `LcdGrid`/`HoverScanner` for CRT effects, and utilizing `DataPoint` components for core stats to reinforce the specialized hardware fantasy.

--- a/src/components/dashboard/battle-frontier/BattleFrontierDashboard.tsx
+++ b/src/components/dashboard/battle-frontier/BattleFrontierDashboard.tsx
@@ -1,5 +1,9 @@
 import type React from 'react';
 import type { Gen3BattleFrontierWinStreaks, SaveData } from '../../../engine/saveParser/parsers/common';
+import { DataPoint } from '../../DataPoint';
+import { TacticalPanel } from '../../TacticalPanel';
+import { TelemetryDecoration } from '../../TelemetryDecoration';
+
 export interface BattleFrontierDashboardProps {
   saveData: SaveData;
 }
@@ -23,70 +27,80 @@ export const BattleFrontierDashboard: React.FC<BattleFrontierDashboardProps> = (
 
   if (gen3BattlePoints === undefined || !gen3BattleFrontierWinStreaks || !gen3BattleFrontierSymbols) {
     return (
-      <div className="tactical-panel p-4 text-center">
+      <TacticalPanel className="p-4 text-center">
         <span className="tactical-text text-zinc-500">NO BATTLE FRONTIER DATA FOUND</span>
-      </div>
+      </TacticalPanel>
     );
   }
 
   const facilities = (Object.keys(FACILITY_NAMES) as Array<keyof Gen3BattleFrontierWinStreaks>).map((key) => {
+    const symbols = gen3BattleFrontierSymbols[key] || { silver: false, gold: false };
     return {
       key,
       name: FACILITY_NAMES[key],
       streaks: gen3BattleFrontierWinStreaks[key] || { current: 0, record: 0 },
-      symbols: gen3BattleFrontierSymbols[key] || { silver: false, gold: false },
+      symbols,
+      variant: symbols.gold ? 'amber' : symbols.silver ? 'white' : 'default',
     };
   });
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="tactical-panel flex items-center justify-between p-4">
-        <span className="tactical-text font-black text-lg text-white">BATTLE FRONTIER STATUS</span>
-        <div className="flex flex-col items-end">
-          <span className="tactical-text font-black text-[10px] text-zinc-500">WALLET BALANCE</span>
-          <span className="tactical-text font-black text-2xl text-[var(--theme-primary)]">{gen3BattlePoints} BP</span>
+      <TacticalPanel className="mt-4 flex items-center justify-between border-[var(--theme-primary)]/50 border-t-2 p-4 pt-6">
+        <TelemetryDecoration label="SYS.BATTLE_FRONTIER" className="-top-[17px] left-[-1px]" />
+        <span className="tactical-text z-10 font-black text-lg text-white">COMBAT SIMULATION MATRIX</span>
+        <div className="z-10 flex flex-col items-end">
+          <DataPoint
+            label="WALLET_BALANCE"
+            value={`${gen3BattlePoints} BP`}
+            valueClassName="text-2xl text-[var(--theme-primary)]"
+          />
         </div>
-      </div>
+      </TacticalPanel>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
         {facilities.map((facility) => (
-          <div key={facility.key} className="tactical-panel flex flex-col gap-3 p-4">
-            <div className="flex items-center justify-between border-zinc-800 border-b border-dashed pb-2">
-              <span className="tactical-text font-black text-white">{facility.name}</span>
+          <TacticalPanel
+            key={facility.key}
+            variant={facility.variant as 'amber' | 'white' | 'default'}
+            className="flex flex-col gap-0 border-l-2 p-0"
+          >
+            <div className="flex items-center justify-between border-zinc-800 border-b border-dashed bg-black/40 p-3 pb-2">
+              <span className="tactical-text z-10 font-black text-white">[ {facility.name} ]</span>
             </div>
 
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center justify-between">
-                <span className="tactical-text font-black text-[10px] text-zinc-500">CURRENT STREAK</span>
-                <span className="tactical-text font-black text-[12px] text-white">{facility.streaks.current}</span>
+            <div className="z-10 flex flex-col gap-0 divide-y divide-dashed divide-zinc-800 bg-black/20 p-2">
+              <div className="flex items-center justify-between px-2 py-1.5 hover:bg-white/5">
+                <span className="tactical-text font-black text-[10px] text-zinc-500">CURRENT_STREAK</span>
+                <span className="font-bold font-mono text-[12px] text-white">{facility.streaks.current}</span>
               </div>
-              <div className="flex items-center justify-between">
-                <span className="tactical-text font-black text-[10px] text-zinc-500">RECORD STREAK</span>
-                <span className="tactical-text font-black text-[12px] text-zinc-400">{facility.streaks.record}</span>
+              <div className="flex items-center justify-between px-2 py-1.5 hover:bg-white/5">
+                <span className="tactical-text font-black text-[10px] text-zinc-500">RECORD_STREAK</span>
+                <span className="font-bold font-mono text-[12px] text-zinc-400">{facility.streaks.record}</span>
               </div>
 
               {(facility.symbols.silver || facility.symbols.gold) && (
-                <div className="mt-1 flex flex-col gap-1 border-zinc-800 border-t border-dashed pt-2">
+                <div className="flex flex-col gap-1 px-2 py-2">
                   {facility.symbols.silver && !facility.symbols.gold && (
                     <div className="flex items-center gap-2">
-                      <div className="h-2 w-2 rounded-none bg-zinc-300" />
-                      <span className="tactical-text font-black text-[9px] text-zinc-300 tracking-widest">
-                        SILVER SYMBOL ACQUIRED
+                      <div className="h-1.5 w-1.5 animate-pulse rounded-none bg-zinc-300" />
+                      <span className="font-black font-mono text-[9px] text-zinc-300 uppercase tracking-widest">
+                        SILVER_SYMBOL_ACQUIRED
                       </span>
                     </div>
                   )}
                   {facility.symbols.gold && (
                     <div className="flex items-center gap-2">
-                      <div className="h-2 w-2 rounded-none bg-yellow-500" />
-                      <span className="tactical-text font-black text-[9px] text-yellow-500 tracking-widest">
-                        GOLD SYMBOL ACQUIRED
+                      <div className="h-1.5 w-1.5 animate-[pulse_2s_ease-in-out_infinite] rounded-none bg-amber-500" />
+                      <span className="font-black font-mono text-[9px] text-amber-500 uppercase tracking-widest">
+                        GOLD_SYMBOL_ACQUIRED
                       </span>
                     </div>
                   )}
                 </div>
               )}
             </div>
-          </div>
+          </TacticalPanel>
         ))}
       </div>
     </div>

--- a/src/components/dashboard/battle-frontier/__tests__/BattleFrontierDashboard.test.tsx
+++ b/src/components/dashboard/battle-frontier/__tests__/BattleFrontierDashboard.test.tsx
@@ -43,7 +43,7 @@ test('renders dashboard with correct data', async () => {
   const data = mockSaveData as SaveData;
   await render(<BattleFrontierDashboard saveData={data} />);
 
-  await expect.element(page.getByText('BATTLE FRONTIER STATUS')).toBeInTheDocument();
+  await expect.element(page.getByText('COMBAT SIMULATION MATRIX')).toBeInTheDocument();
   await expect.element(page.getByText('1234 BP')).toBeInTheDocument();
 
   await expect.element(page.getByText('BATTLE TOWER')).toBeInTheDocument();
@@ -52,8 +52,8 @@ test('renders dashboard with correct data', async () => {
   await expect.element(page.getByText('35')).toBeInTheDocument();
   await expect.element(page.getByText('70')).toBeInTheDocument();
 
-  await expect.element(page.getByText('SILVER SYMBOL ACQUIRED')).toBeInTheDocument();
-  await expect.element(page.getByText('GOLD SYMBOL ACQUIRED')).toBeInTheDocument();
+  await expect.element(page.getByText('SILVER_SYMBOL_ACQUIRED')).toBeInTheDocument();
+  await expect.element(page.getByText('GOLD_SYMBOL_ACQUIRED')).toBeInTheDocument();
 });
 
 test('does not throw an error if no symbols or win streaks exist', async () => {
@@ -80,5 +80,5 @@ test('renders with no facilities safely', async () => {
     gen3BattleFrontierSymbols: {},
   } as unknown as SaveData;
   await render(<BattleFrontierDashboard saveData={data} />);
-  await expect.element(page.getByText('BATTLE FRONTIER STATUS')).toBeInTheDocument();
+  await expect.element(page.getByText('COMBAT SIMULATION MATRIX')).toBeInTheDocument();
 });


### PR DESCRIPTION
- Wrapped main content in `TacticalPanel` and redesigned the layout for a terminal readout aesthetic
- Extracted wallet balance into a `DataPoint` component
- Converted individual facilities into `TacticalPanel` components utilizing dynamically calculated `amber` (gold) and `white` (silver) variants based on acquired symbols
- Refactored internal data layouts for facilities to use segmented telemetry rows
- Appended Canvas journal entry detailing pattern and outcome of redesign

---
*PR created automatically by Jules for task [5089271005758640709](https://jules.google.com/task/5089271005758640709) started by @szubster*