### PR TITLE
🧹 Refactor duplicated mapGraph logic into common shared module

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -2,3 +2,4 @@
 
 * When using static analysis tools like `knip` to find unused exports, you must explicitly verify candidates using a global repository search (e.g., `grep`) before removal to ensure they are not implicitly required by tests, mocks, or CI scripts.
 * Scheduled or foundry agents can dynamically spawn new IDEA, TASK, RESEARCH, or ADR nodes in the `.foundry/` directory to handle larger architectural changes or missing context, ensuring the `owner_persona` is set to the appropriate role (e.g., 'researcher' for RESEARCH).
+* Sweeper PRs must use the title format `🧹 [description]` and include `🎯 What`, `💡 Why`, `✅ Verification`, and `✨ Result` in the body.

--- a/src/engine/mapGraph/common.ts
+++ b/src/engine/mapGraph/common.ts
@@ -1,0 +1,109 @@
+import type { UnifiedLocation } from '../../db/schema';
+
+// ⚡ Bolt: Cache locations map to prevent O(N) Array.find calls on every lookup
+const locationCache = new Map<number, UnifiedLocation>();
+let lastLocationsRef: UnifiedLocation[] | null = null;
+
+/**
+ * Retrieves a location by ID using a cached Map to ensure O(1) lookup performance.
+ * The cache is automatically invalidated and rebuilt if the `allLocations` array reference changes.
+ * This optimization is necessary because the suggestion engine frequently looks up locations
+ * by ID during graph traversal, and O(N) `Array.find` calls would degrade performance.
+ *
+ * @param allLocations - The unified list of all map locations.
+ * @param id - The ID of the location to retrieve.
+ * @returns The UnifiedLocation object, or undefined if not found.
+ */
+export function getLocation(allLocations: UnifiedLocation[], id: number): UnifiedLocation | undefined {
+  if (lastLocationsRef !== allLocations) {
+    locationCache.clear();
+    for (const loc of allLocations) {
+      locationCache.set(loc.id, loc);
+    }
+    lastLocationsRef = allLocations;
+  }
+  return locationCache.get(id);
+}
+
+/**
+ * Resolves an indoor map to its connected outdoor parent map.
+ * Handles multi-level indoor maps by recursively traversing the `prnt` property.
+ *
+ * @param allLocations - The unified list of all map locations.
+ * @param mapId - The Map ID to resolve.
+ * @returns The parent outdoor Map ID, or the original ID if it is already an outdoor map.
+ *
+ * @remarks
+ * **Why this is needed:**
+ * The map graph distance matrix (`dist`) is only computed between major outdoor hubs and routes.
+ * Indoor maps (houses, caves, buildings) are structurally represented as children of these hubs via
+ * the `prnt` property. To calculate the distance to a target from inside a building, we must first
+ * "step outside" by resolving the current location to its parent map.
+ */
+export function resolveOutdoorMapId(allLocations: UnifiedLocation[], mapId: number): number {
+  let currentMapId = mapId;
+  let loc = getLocation(allLocations, currentMapId);
+  const visited = new Set<number>();
+
+  while (loc?.prnt !== undefined && !visited.has(currentMapId)) {
+    visited.add(currentMapId);
+    currentMapId = loc.prnt;
+    loc = getLocation(allLocations, currentMapId);
+  }
+
+  return currentMapId;
+}
+
+/**
+ * Calculates the shortest path distance (in graph edges/hops) between the player's
+ * current location and a target area.
+ *
+ * @param allLocations - The unified list of all map locations, pre-populated with Floyd-Warshall distances (`dist`).
+ * @param startMapId - The internal Map ID where the player is currently standing.
+ * @param targetAid - The location Area ID (aid) where the target Pokémon can be found.
+ * @param fallbackStartMapId - The fallback start Map ID if the player is in an unknown location.
+ * @returns An object containing the `distance` (number of hops) and the `name` of the target area, or `null` if unreachable.
+ *
+ * @remarks
+ * **Architecture Note:**
+ * This function does NOT perform real-time pathfinding (e.g., BFS or Dijkstra).
+ * Instead, it relies on the `dist` property of the `UnifiedLocation` objects, which contains
+ * a precomputed lookup table generated at build-time using the Floyd-Warshall algorithm.
+ * This ensures O(1) distance lookups during runtime, which is critical since the suggestion
+ * engine evaluates hundreds of potential encounters simultaneously.
+ */
+export function getDistanceToMapBase(
+  allLocations: UnifiedLocation[],
+  startMapId: number,
+  targetAid: number,
+  fallbackStartMapId: number,
+): { distance: number; name: string } | null {
+  // 1. Resolve target location (where the Pokémon is found)
+  const targetLoc = getLocation(allLocations, targetAid);
+  if (!targetLoc) return null;
+
+  const targetDisplayName = targetLoc.n;
+
+  // 2. Resolve start location (where the player is)
+  const outdoorStartMapId = resolveOutdoorMapId(allLocations, startMapId);
+  let startLoc = getLocation(allLocations, outdoorStartMapId);
+
+  // Fallback if unknown
+  if (!startLoc) {
+    startLoc = getLocation(allLocations, fallbackStartMapId);
+  }
+
+  if (!startLoc) return null;
+
+  // 3. Precomputed lookup
+  if (startLoc.id === targetLoc.id) {
+    return { distance: 0, name: targetDisplayName };
+  }
+
+  const distance = startLoc.dist?.[targetLoc.id];
+  if (distance !== undefined) {
+    return { distance, name: targetDisplayName };
+  }
+
+  return null;
+}

--- a/src/engine/mapGraph/gen1Graph.ts
+++ b/src/engine/mapGraph/gen1Graph.ts
@@ -1,108 +1,13 @@
 import type { UnifiedLocation } from '../../db/schema';
+import { resolveOutdoorMapId as commonResolveOutdoorMapId, getDistanceToMapBase } from './common';
 
-/**
- * Calculates the shortest path distance (in graph edges/hops) between the player's
- * current location and a target area.
- *
- * @param allLocations - The unified list of all map locations, pre-populated with Floyd-Warshall distances (`dist`).
- * @param startMapId - The internal Map ID where the player is currently standing.
- * @param targetAid - The location Area ID (aid) where the target Pokémon can be found.
- * @returns An object containing the `distance` (number of hops) and the `name` of the target area, or `null` if unreachable.
- *
- * @remarks
- * **Architecture Note:**
- * This function does NOT perform real-time pathfinding (e.g., BFS or Dijkstra).
- * Instead, it relies on the `dist` property of the `UnifiedLocation` objects, which contains
- * a precomputed lookup table generated at build-time using the Floyd-Warshall algorithm.
- * This ensures O(1) distance lookups during runtime, which is critical since the suggestion
- * engine evaluates hundreds of potential encounters simultaneously.
- */
-// ⚡ Bolt: Cache locations map to prevent O(N) Array.find calls on every lookup
-const locationCache = new Map<number, UnifiedLocation>();
-let lastLocationsRef: UnifiedLocation[] | null = null;
-
-/**
- * Retrieves a location by ID using a cached Map to ensure O(1) lookup performance.
- * The cache is automatically invalidated and rebuilt if the `allLocations` array reference changes.
- * This optimization is necessary because the suggestion engine frequently looks up locations
- * by ID during graph traversal, and O(N) `Array.find` calls would degrade performance.
- *
- * @param allLocations - The unified list of all map locations.
- * @param id - The ID of the location to retrieve.
- * @returns The UnifiedLocation object, or undefined if not found.
- */
-function getLocation(allLocations: UnifiedLocation[], id: number): UnifiedLocation | undefined {
-  if (lastLocationsRef !== allLocations) {
-    locationCache.clear();
-    for (const loc of allLocations) {
-      locationCache.set(loc.id, loc);
-    }
-    lastLocationsRef = allLocations;
-  }
-  return locationCache.get(id);
-}
+export const resolveOutdoorMapId = commonResolveOutdoorMapId;
 
 export function getDistanceToMap(
   allLocations: UnifiedLocation[],
   startMapId: number,
   targetAid: number,
 ): { distance: number; name: string } | null {
-  // 1. Resolve target location (where the Pokémon is found)
-  const targetLoc = getLocation(allLocations, targetAid);
-  if (!targetLoc) return null;
-
-  const targetDisplayName = targetLoc.n;
-
-  // 2. Resolve start location (where the player is)
-  const outdoorStartMapId = resolveOutdoorMapId(allLocations, startMapId);
-  let startLoc = getLocation(allLocations, outdoorStartMapId);
-
-  // Fallback if unknown
-  if (!startLoc) {
-    // Saffron City (Map ID 10 in Kanto)
-    startLoc = getLocation(allLocations, 10);
-  }
-
-  if (!startLoc) return null;
-
-  // 3. Precomputed lookup
-  if (startLoc.id === targetLoc.id) {
-    return { distance: 0, name: targetDisplayName };
-  }
-
-  const distance = startLoc.dist?.[targetLoc.id];
-  if (distance !== undefined) {
-    return { distance, name: targetDisplayName };
-  }
-
-  return null;
-}
-
-/**
- * Resolves an indoor map to its connected outdoor parent map.
- * Handles multi-level indoor maps by recursively traversing the `prnt` property.
- *
- * @param allLocations - The unified list of all map locations.
- * @param mapId - The Map ID to resolve.
- * @returns The parent outdoor Map ID, or the original ID if it is already an outdoor map.
- *
- * @remarks
- * **Why this is needed:**
- * The map graph distance matrix (`dist`) is only computed between major outdoor hubs and routes.
- * Indoor maps (houses, caves, buildings) are structurally represented as children of these hubs via
- * the `prnt` property. To calculate the distance to a target from inside a building, we must first
- * "step outside" by resolving the current location to its parent map.
- */
-export function resolveOutdoorMapId(allLocations: UnifiedLocation[], mapId: number): number {
-  let currentMapId = mapId;
-  let loc = getLocation(allLocations, currentMapId);
-  const visited = new Set<number>();
-
-  while (loc?.prnt !== undefined && !visited.has(currentMapId)) {
-    visited.add(currentMapId);
-    currentMapId = loc.prnt;
-    loc = getLocation(allLocations, currentMapId);
-  }
-
-  return currentMapId;
+  // Saffron City (Map ID 10 in Kanto)
+  return getDistanceToMapBase(allLocations, startMapId, targetAid, 10);
 }

--- a/src/engine/mapGraph/gen2Graph.ts
+++ b/src/engine/mapGraph/gen2Graph.ts
@@ -1,108 +1,13 @@
 import type { UnifiedLocation } from '../../db/schema';
+import { resolveOutdoorMapId as commonResolveOutdoorMapId, getDistanceToMapBase } from './common';
 
-/**
- * Calculates the shortest path distance (in graph edges/hops) between the player's
- * current location and a target area.
- *
- * @param allLocations - The unified list of all map locations, pre-populated with Floyd-Warshall distances (`dist`).
- * @param startMapId - The internal Map ID where the player is currently standing.
- * @param targetAid - The location Area ID (aid) where the target Pokémon can be found.
- * @returns An object containing the `distance` (number of hops) and the `name` of the target area, or `null` if unreachable.
- *
- * @remarks
- * **Architecture Note:**
- * This function does NOT perform real-time pathfinding (e.g., BFS or Dijkstra).
- * Instead, it relies on the `dist` property of the `UnifiedLocation` objects, which contains
- * a precomputed lookup table generated at build-time using the Floyd-Warshall algorithm.
- * This ensures O(1) distance lookups during runtime, which is critical since the suggestion
- * engine evaluates hundreds of potential encounters simultaneously.
- */
-// ⚡ Bolt: Cache locations map to prevent O(N) Array.find calls on every lookup
-const locationCache = new Map<number, UnifiedLocation>();
-let lastLocationsRef: UnifiedLocation[] | null = null;
-
-/**
- * Retrieves a location by ID using a cached Map to ensure O(1) lookup performance.
- * The cache is automatically invalidated and rebuilt if the `allLocations` array reference changes.
- * This optimization is necessary because the suggestion engine frequently looks up locations
- * by ID during graph traversal, and O(N) `Array.find` calls would degrade performance.
- *
- * @param allLocations - The unified list of all map locations.
- * @param id - The ID of the location to retrieve.
- * @returns The UnifiedLocation object, or undefined if not found.
- */
-function getLocation(allLocations: UnifiedLocation[], id: number): UnifiedLocation | undefined {
-  if (lastLocationsRef !== allLocations) {
-    locationCache.clear();
-    for (const loc of allLocations) {
-      locationCache.set(loc.id, loc);
-    }
-    lastLocationsRef = allLocations;
-  }
-  return locationCache.get(id);
-}
+export const resolveOutdoorMapId = commonResolveOutdoorMapId;
 
 export function getDistanceToMap(
   allLocations: UnifiedLocation[],
   startMapId: number,
   targetAid: number,
 ): { distance: number; name: string } | null {
-  // 1. Resolve target location (where the Pokémon is found)
-  const targetLoc = getLocation(allLocations, targetAid);
-  if (!targetLoc) return null;
-
-  const targetDisplayName = targetLoc.n;
-
-  // 2. Resolve start location (where the player is)
-  const outdoorStartMapId = resolveOutdoorMapId(allLocations, startMapId);
-  let startLoc = getLocation(allLocations, outdoorStartMapId);
-
-  // Fallback if unknown
-  if (!startLoc) {
-    // Goldenrod City (Map Group 3, Map ID 6 -> 0x0306)
-    startLoc = getLocation(allLocations, 0x0306);
-  }
-
-  if (!startLoc) return null;
-
-  // 3. Precomputed lookup
-  if (startLoc.id === targetLoc.id) {
-    return { distance: 0, name: targetDisplayName };
-  }
-
-  const distance = startLoc.dist?.[targetLoc.id];
-  if (distance !== undefined) {
-    return { distance, name: targetDisplayName };
-  }
-
-  return null;
-}
-
-/**
- * Resolves an indoor map to its connected outdoor parent map.
- * Handles multi-level indoor maps by recursively traversing the `prnt` property.
- *
- * @param allLocations - The unified list of all map locations.
- * @param mapId - The Map ID to resolve.
- * @returns The parent outdoor Map ID, or the original ID if it is already an outdoor map.
- *
- * @remarks
- * **Why this is needed:**
- * The map graph distance matrix (`dist`) is only computed between major outdoor hubs and routes.
- * Indoor maps (houses, caves, buildings) are structurally represented as children of these hubs via
- * the `prnt` property. To calculate the distance to a target from inside a building, we must first
- * "step outside" by resolving the current location to its parent map.
- */
-export function resolveOutdoorMapId(allLocations: UnifiedLocation[], mapId: number): number {
-  let currentMapId = mapId;
-  let loc = getLocation(allLocations, currentMapId);
-  const visited = new Set<number>();
-
-  while (loc?.prnt !== undefined && !visited.has(currentMapId)) {
-    visited.add(currentMapId);
-    currentMapId = loc.prnt;
-    loc = getLocation(allLocations, currentMapId);
-  }
-
-  return currentMapId;
+  // Goldenrod City (Map Group 3, Map ID 6 -> 0x0306)
+  return getDistanceToMapBase(allLocations, startMapId, targetAid, 0x0306);
 }

--- a/src/engine/mapGraph/gen3Graph.ts
+++ b/src/engine/mapGraph/gen3Graph.ts
@@ -1,114 +1,13 @@
 import type { UnifiedLocation } from '../../db/schema';
+import { resolveOutdoorMapId as commonResolveOutdoorMapId, getDistanceToMapBase } from './common';
 
-/**
- * Gen 3 Map Graph module for determining precomputed distances between locations.
- * This function relies on the `dist` property of the `UnifiedLocation` objects, which contains
- * a pre-calculated distance mapping to other accessible locations.
- */
+export const resolveOutdoorMapId = commonResolveOutdoorMapId;
 
-// A simple cache to avoid repeatedly finding the same location object by ID
-const locationCache = new Map<number, UnifiedLocation>();
-let lastLocationsRef: UnifiedLocation[] | null = null;
-
-/**
- * Retrieves a location by ID using a cached Map to ensure O(1) lookup performance.
- * The cache is automatically invalidated and rebuilt if the `allLocations` array reference changes.
- * This optimization is necessary because the suggestion engine frequently looks up locations
- * by ID during graph traversal, and O(N) `Array.find` calls would degrade performance and lock the UI thread.
- *
- * @param allLocations - The unified list of all map locations.
- * @param id - The ID of the location to retrieve.
- * @returns The UnifiedLocation object, or undefined if not found.
- */
-function getLocation(allLocations: UnifiedLocation[], id: number): UnifiedLocation | undefined {
-  if (lastLocationsRef !== allLocations) {
-    locationCache.clear();
-    lastLocationsRef = allLocations;
-    for (const loc of allLocations) {
-      locationCache.set(loc.id, loc);
-    }
-  }
-  return locationCache.get(id);
-}
-
-/**
- * Recursively resolves a map ID to its top-level (outdoor) parent map ID.
- * The Floyd-Warshall distance matrix is only computed between major outdoor hubs (e.g., Littleroot Town, Route 101)
- * to save build time and payload size. If a player saves inside a building, we must recursively traverse
- * the `prnt` property until we step outside to an outdoor map before we can use the O(1) distance lookup.
- *
- * @param allLocations - The unified list of all map locations.
- * @param mapId - The ID to resolve.
- * @returns The resolved top-level outdoor map ID.
- */
-export function resolveOutdoorMapId(allLocations: UnifiedLocation[], mapId: number): number {
-  let currentId = mapId;
-  const visited = new Set<number>();
-
-  while (true) {
-    const loc = getLocation(allLocations, currentId);
-    if (!loc) break;
-    if (loc.prnt === undefined) break;
-
-    // Cycle detection
-    if (visited.has(currentId)) break;
-    visited.add(currentId);
-
-    currentId = loc.prnt;
-  }
-  return currentId;
-}
-
-/**
- * Calculates the shortest path distance (in graph edges/hops) between the player's
- * current location and a target area.
- *
- * @param allLocations - The unified list of all map locations, pre-populated with Floyd-Warshall distances (`dist`).
- * @param startMapId - The internal Map ID where the player is currently standing.
- * @param targetAid - The location Area ID (aid) where the target Pokémon can be found.
- * @returns An object containing the `distance` (number of hops) and the `name` of the target area, or `null` if unreachable.
- *
- * @remarks
- * **Architecture Note:**
- * This function does NOT perform real-time pathfinding (e.g., BFS or Dijkstra).
- * Instead, it relies on the `dist` property of the `UnifiedLocation` objects, which contains
- * a precomputed lookup table generated at build-time using the Floyd-Warshall algorithm.
- * This ensures O(1) distance lookups during runtime, which is critical since the suggestion
- * engine evaluates hundreds of potential encounters simultaneously without locking the UI thread.
- */
 export function getDistanceToMap(
   allLocations: UnifiedLocation[],
   startMapId: number,
   targetAid: number,
 ): { distance: number; name: string } | null {
-  const targetLocation = getLocation(allLocations, targetAid);
-
-  if (!targetLocation) {
-    return null;
-  }
-
-  // Resolve start map to an outdoor map if it's indoor
-  let startOutdoorId = resolveOutdoorMapId(allLocations, startMapId);
-  let startLocation = getLocation(allLocations, startOutdoorId);
-
-  // If the starting location isn't valid, try to default to Littleroot Town (0)
-  if (!startLocation) {
-    startOutdoorId = 0;
-    startLocation = getLocation(allLocations, startOutdoorId);
-    if (!startLocation) {
-      return null;
-    }
-  }
-
-  // Use the precomputed distance lookup table
-  if (startOutdoorId === targetAid) {
-    return { distance: 0, name: targetLocation.n };
-  }
-
-  const dist = startLocation.dist?.[targetAid];
-  if (dist === undefined) {
-    return null;
-  }
-
-  return { distance: dist, name: targetLocation.n };
+  // Littleroot Town (Map ID 0)
+  return getDistanceToMapBase(allLocations, startMapId, targetAid, 0);
 }


### PR DESCRIPTION
🎯 What: Extracted duplicated map graph distance calculation logic from `gen1Graph.ts`, `gen2Graph.ts`, and `gen3Graph.ts` into a unified `common.ts` module.
💡 Why: The exact same graph resolution logic (`resolveOutdoorMapId` and `getDistanceToMap`) was copy-pasted across all 3 generations with only one variable change (the fallback start map ID).
✅ Verification: Ran `pnpm lint` and the complete test suite via `pnpm test`. Code formatting was applied by Biome.
✨ Result: Reduced code duplication and technical debt, making the `mapGraph` layer easier to maintain.

---
*PR created automatically by Jules for task [3982407569320511392](https://jules.google.com/task/3982407569320511392) started by @szubster*