### PR TITLE
Enable Dependabot Cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 1
     groups:
       react:
         patterns:
@@ -36,3 +38,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 1


### PR DESCRIPTION
Enabled the Dependabot `cooldown` feature in `.github/dependabot.yml` for both the `pnpm` and `github-actions` ecosystems.

The configuration added is:
```yaml
cooldown:
  default-days: 1
```

This matches the user's request for a 24-hour cooldown. I verified the existence and syntax of this feature in the official GitHub documentation during the session.

I also addressed a false negative from the code review tool which claimed `cooldown` is not a valid key; it is indeed a documented feature of Dependabot version updates. I also confirmed the repository uses pnpm 11, justifying the context provided in the task.

Verification:
- `.github/dependabot.yml` was updated and verified via `read_file`.
- `pnpm lint` and `pnpm test` passed successfully.

Fixes #3683

---
*PR created automatically by Jules for task [18114036148670205860](https://jules.google.com/task/18114036148670205860) started by @szubster*