### PR TITLE
Reject IDEA 056 due to missing PRD and implementation

### DIFF
--- a/.foundry/ideas/idea-056-living-dex-tracker.md
+++ b/.foundry/ideas/idea-056-living-dex-tracker.md
@@ -42,3 +42,6 @@ This directly addresses a hardcore collector playstyle, heavily leaning into our
 
 ### Auditor Rejection
 The specialized "Living Dex Tracker" UI has not been implemented. While there is a global "Living Dex" toggle in the settings that modifies the standard Pokédex view, the specific requirements of this IDEA (a dedicated view with numerical grid, PC Box/Slot overlay, and highlighting for ghosts/duplicates) are completely missing from the codebase. Furthermore, no downstream PRD node exists for this idea. The Product Manager must create a formal PRD that details the implementation of this dedicated UI view, and it must be fully implemented and merged by downstream child tasks before this IDEA can be verified as complete.
+
+### Auditor Rejection
+The node has been rejected again. The Product Manager must create the corresponding PRD (`.foundry/prds/prd-056-<NNN>-living-dex-tracker.md`) and append it as a checkbox in this IDEA node. The IDEA node cannot be verified and transitioned to COMPLETED until the PRD and its downstream implementation tasks are fully completed and merged.

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -78,3 +78,6 @@ During the verification of `epic-045-071-documentation-macro-node-completion`, i
 
 ### Lesson: Macro Node Spawn Verification
 When evaluating macro nodes like IDEA, PRD, EPIC, or STORY, the Auditor must verify that the downstream child nodes were actually spawned and fully completed before transitioning the macro node to COMPLETED. If an IDEA node's acceptance criteria are marked as completed (e.g., "- [x] Product Manager: Convert this idea into a PRD"), but no corresponding PRD file actually exists in the codebase, the verification MUST fail. A macro node is only verified if its intent is actually realized in the implementation through its generated descendants.
+
+### Lesson: Macro Node Recurring Verification Failures
+When evaluating macro nodes (like IDEA, PRD), a recurring pattern of failure is agents submitting the macro node (with an Empty PR) without actually spawning the required child nodes (e.g., the Product Manager marking the IDEA as complete without creating the PRD). This violates the core invariant that macro nodes cannot complete until all of their descendant nodes in the DAG have reached the COMPLETED or CANCELLED status. If the child nodes do not exist, the macro node's intent is unrealized, and verification MUST fail, rejecting the submission back to the responsible agent to generate the downstream nodes.


### PR DESCRIPTION
The `idea-056-living-dex-tracker` node was marked as verified by the PM, but no corresponding PRD was created and the feature was not implemented. This commit rejects the node, adding an Auditor Rejection section, and records a lesson in the Auditor journal regarding macro-node verification failures.

---
*PR created automatically by Jules for task [12542415236611805023](https://jules.google.com/task/12542415236611805023) started by @szubster*