### PR TITLE
Update Epic 038-061 Pokerus State Exfiltration

### DIFF
--- a/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
+++ b/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
@@ -26,10 +26,10 @@ notes: ''
 Read the specific byte flags for Pokerus for every Pokemon in the party and PC from the Gen 2 sav files.
 
 ## Acceptance Criteria
-- [ ] Extract pokerus data
+- [x] Extract pokerus data
 - [x] .foundry/stories/story-061-095-pokerus-byte-parsing.md
 - [x] .foundry/archive/story-061-096-pokerus-tests.md
-- [ ] .foundry/stories/story-061-155-refactor-pokerus-bitwise.md
+- [x] .foundry/stories/story-061-155-refactor-pokerus-bitwise.md
 
 <!-- Tech Lead: Verified complete. Pokerus bitwise logic is thoroughly tested including cured state boundaries. -->
 


### PR DESCRIPTION
Check off the remaining acceptance criteria for `epic-038-061-pokerus-state-exfiltration.md` after the `tech_lead`, `coder`, and `qa` personas successfully completed the `parsePokerus` bitwise extraction refactoring into `common.ts` as requested by the Auditor Rejection.

---
*PR created automatically by Jules for task [1012433337001562931](https://jules.google.com/task/1012433337001562931) started by @szubster*