### PR TITLE
feat(foundry): generate PRDs for gen3 ribbon master tracker

### DIFF
--- a/.foundry/ideas/idea-093-gen3-ribbon-master-tracker.md
+++ b/.foundry/ideas/idea-093-gen3-ribbon-master-tracker.md
@@ -31,3 +31,8 @@ Features should include:
 - Warnings for "point of no return" actions, such as preventing a player from assuming a Pokémon is ready to transfer out of Gen 3 if it is still missing available Ribbons.
 
 This aligns perfectly with DexHelper's vision as a premium companion app by taking an obtuse, multi-faceted endgame goal and turning it into an actionable, tracked dashboard that prevents high-friction failures.
+
+## Acceptance Criteria
+- [ ] prd-093-101-gen3-ribbon-data-extraction
+- [ ] prd-093-102-gen3-ribbon-dashboard
+- [x] Break down into PRDs

--- a/.foundry/prds/prd-093-101-gen3-ribbon-data-extraction.md
+++ b/.foundry/prds/prd-093-101-gen3-ribbon-data-extraction.md
@@ -1,0 +1,60 @@
+---
+id: prd-093-101-gen3-ribbon-data-extraction
+type: PRD
+title: "Gen 3 Ribbon Master Challenge Tracker - Data Extraction"
+status: PENDING
+owner_persona: epic_planner
+created_at: "2026-07-02"
+updated_at: "2026-07-02"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - gen3
+  - save-engine
+  - data-extraction
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen 3 Ribbon Master Challenge Tracker - Data Extraction
+
+## Background
+The "Ribbon Master" challenge is a hardcore Pokémon community activity where a player attempts to collect every single obtainable Ribbon on a single Pokémon. In Generation 3, there are 27 different Ribbons to collect, spanning the Pokémon League, Pokémon Contests, the Battle Tower, and GameCube games (e.g., Mt. Battle). Manually tracking this progress via the in-game UI is tedious and error-prone, risking permanent failure if a Ribbon is missed before migrating the Pokémon to a newer generation.
+
+## Objective
+This PRD outlines the requirements for extending our programmatic save parsing engine to extract Ribbon and Contest Condition data from Generation 3 (Ruby, Sapphire, Emerald, FireRed, LeafGreen) save files. This data will feed a downstream UI dashboard to track Ribbon Master challenge progress.
+
+## Requirements
+
+### 1. Ribbon Data Extraction
+*   **Target Data:** Extract the 32-bit Ribbon and Obedience bitfield for each Pokémon.
+*   **Location:** This data is located in the **Miscellaneous (M)** substructure at **offset 8** of the 48-byte encrypted Data block within the 100-byte Pokémon structure.
+*   **Decryption:** The engine must handle the XOR cipher decryption using the Pokémon's Personality Value (PV) and Original Trainer ID (OT ID), and resolve the `PV % 24` permutation to locate the 'M' substructure.
+*   **Parsing Logic:** Implement bitwise operations to parse the specific 32-bit field:
+    *   Bits 0-14: Contest Ribbons (Cool, Beauty, Cute, Smart, Tough) — 3 bits each, representing ranks 1-4.
+    *   Bits 15-26: Miscellaneous Ribbons (Champion, Winning, Victory, Artist, Effort, Battle Champion, Regional Champion, National Champion, Country, National, Earth, World).
+    *   Bit 31: Obedience flag (ignore for this feature, but document its presence).
+
+### 2. Contest Condition Data Extraction
+*   **Target Data:** Extract the Pokémon's Contest stats (Coolness, Beauty, Cuteness, Smartness, Toughness, Feel).
+*   **Location:** This data is located in the **EVs & Condition (E)** substructure of the 48-byte encrypted Data block.
+*   **Purpose:** These stats are required to determine if a Pokémon is "Challenge Ready" for specific Contest Ribbons.
+
+### 3. Save File Parser Integration
+*   Ensure the extracted Ribbon and Condition data is seamlessly integrated into the application's overall `PokeData` representation.
+*   Use MsgPack serialization optimizations where applicable (e.g., omitting `0` or `false` values) to minimize payload size.
+*   Maintain backwards compatibility with existing Gen 1 and Gen 2 parsing logic.
+
+## Technical Context
+*   Reference `.foundry/docs/knowledge_base/gen3_pokemon_data_structure.md` for specific offsets and the decryption algorithm.
+*   Ensure all new memory offsets and bit locations are defined as reusable constants at the module level, avoiding inline magic numbers.
+
+## Acceptance Criteria
+- [ ] Define reusable constants for all Ribbon bitmask offsets and lengths.
+- [ ] Implement extraction logic for the 32-bit Ribbon bitfield from the 'M' substructure.
+- [ ] Implement extraction logic for Contest stats from the 'E' substructure.
+- [ ] Write unit tests to verify Ribbon and Condition data extraction using known Gen 3 save file fixtures (`test.extend` pattern).

--- a/.foundry/prds/prd-093-102-gen3-ribbon-dashboard.md
+++ b/.foundry/prds/prd-093-102-gen3-ribbon-dashboard.md
@@ -1,0 +1,64 @@
+---
+id: prd-093-102-gen3-ribbon-dashboard
+type: PRD
+title: "Gen 3 Ribbon Master Challenge Tracker - UI Dashboard"
+status: PENDING
+owner_persona: epic_planner
+created_at: "2026-07-02"
+updated_at: "2026-07-02"
+depends_on:
+  - prd-093-101-gen3-ribbon-data-extraction
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - gen3
+  - ui
+  - endgame
+  - completionist
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen 3 Ribbon Master Challenge Tracker - UI Dashboard
+
+## Background
+Following the extraction of Gen 3 Ribbon and Contest Condition data from save files (see `prd-093-101-gen3-ribbon-data-extraction`), this data must be presented to the user in an actionable, visual format. The Ribbon Master challenge is highly demanding and easy to permanently fail. A dedicated dashboard will significantly improve the user experience by reducing friction and preventing mistakes.
+
+## Objective
+This PRD outlines the requirements for building a dedicated "Ribbon Master Dashboard" UI component in DexHelper. This dashboard will consume the Ribbon data extracted by the engine and provide users with a clear overview of their progress for any Pokémon in their party or PC.
+
+## Requirements
+
+### 1. Ribbon Checklist Visualization
+*   **Visual Layout:** Create a clear, visually appealing checklist or grid showing all 27 obtainable Gen 3 Ribbons.
+*   **Status Indicators:** Clearly distinguish between obtained Ribbons and missing Ribbons (e.g., using opacity, color coding, or distinct icons).
+*   **Contest Ribbon Grouping:** Group the 5 categories of Contest Ribbons (Cool, Beauty, Cute, Smart, Tough) logically, and visually indicate the current rank achieved (Normal, Super, Hyper, Master).
+
+### 2. "Challenge Ready" Indicators
+*   **Prerequisite Checking:** Cross-reference the Pokémon's current stats (Level, Contest Condition) against the prerequisites for missing Ribbons.
+*   **Visual Cues:** Highlight missing Ribbons where the Pokémon is currently "ready" to attempt obtaining them.
+    *   *Example 1:* If missing a Master Rank Cool Ribbon, check if the Coolness stat is sufficiently high.
+    *   *Example 2:* If missing the Level 50 Battle Tower Ribbon, ensure the Pokémon is Level 50 or below.
+
+### 3. Point-of-No-Return Warnings
+*   **Migration Warning:** Display a prominent warning or visual indicator if a user views a Pokémon that is missing available Gen 3 Ribbons, cautioning against transferring it to Gen 4 before completing the challenge.
+*   **Irreversible Action Warning:** Alert users if they are about to exceed a level cap (e.g., leveling past 50 before obtaining the Level 50 Battle Tower Ribbon).
+
+### 4. Integration and Styling
+*   **Placement:** Integrate the Ribbon Master Dashboard into the existing Pokémon summary/detail view.
+*   **Aesthetic Adherence:** Strictly adhere to the project's "tactical hardware/snooping" aesthetic (ADR 008, ADR 024):
+    *   Use sharp edges (`rounded-none`).
+    *   Use dashed borders (`border-dashed`).
+    *   Use monospaced telemetry fonts (`font-mono`).
+    *   Utilize Tailwind v4's native `@utility` directives.
+
+## Acceptance Criteria
+- [ ] Create UI components to display the 27 Gen 3 Ribbons in a clear checklist format.
+- [ ] Implement logic to visually distinguish obtained vs. missing Ribbons based on `PokeData`.
+- [ ] Implement "Challenge Ready" prerequisite checking logic and visual indicators.
+- [ ] Implement prominent warnings for point-of-no-return actions (e.g., missing Ribbons before migration, level caps).
+- [ ] Ensure all new UI components strictly follow the tactical hardware aesthetic guidelines.
+- [ ] Write integration tests for the dashboard components, ensuring they render correctly with mocked save data.


### PR DESCRIPTION
Generated two granular PRDs for the Gen 3 Ribbon Master Challenge Tracker: one for data extraction and one for the UI dashboard. Updated the parent IDEA node with checked acceptance criteria.

---
*PR created automatically by Jules for task [7312756770259255608](https://jules.google.com/task/7312756770259255608) started by @szubster*