### PR TITLE
Generate stories for Gen 3 EV data extraction

### DIFF
--- a/.foundry/epics/epic-092-116-gen3-ev-data-extraction.md
+++ b/.foundry/epics/epic-092-116-gen3-ev-data-extraction.md
@@ -38,3 +38,6 @@ This epic covers the backend/data layer requirements of the Gen 3 EV Training Da
 - [ ] Save engine successfully extracts EV data for party and PC Pokémon in Gen 3.
 - [ ] Extraction logic handles all Generation 3 games (Ruby, Sapphire, Emerald, FireRed, LeafGreen).
 - [ ] The parsing implementation strictly uses the `DataView` API.
+- [ ] story-116-249-gen3-ev-interface-definition
+- [ ] story-116-250-gen3-ev-parsing-logic
+- [ ] story-116-251-gen3-ev-integration

--- a/.foundry/stories/story-116-249-gen3-ev-interface-definition.md
+++ b/.foundry/stories/story-116-249-gen3-ev-interface-definition.md
@@ -1,0 +1,34 @@
+---
+id: story-116-249-gen3-ev-interface-definition
+type: STORY
+title: Story - Gen 3 EV Interface Definition
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-092-116-gen3-ev-data-extraction
+tags:
+  - gen3
+  - save-engine
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story - Gen 3 EV Interface Definition
+
+## 1. Objective
+Update the shared `PokemonInstance` interface to support structured Effort Values (EVs) for Gen 3 Pokémon.
+
+## 2. Background
+To properly represent EV data extracted from Gen 3 save files, the `PokemonInstance` interface needs a dedicated property to store the 6 EV stats (HP, Attack, Defense, Sp. Atk, Sp. Def, Speed).
+
+## 3. Scope
+- Update `src/engine/saveParser/parsers/common.ts` to include an `evs` property in the `PokemonInstance` interface.
+- Ensure the property is optional to maintain compatibility with other generations that do not yet extract EVs.
+- The `evs` property should be an object containing `hp`, `atk`, `def`, `spa`, `spd`, and `spe` properties.
+
+## 4. Acceptance Criteria

--- a/.foundry/stories/story-116-250-gen3-ev-parsing-logic.md
+++ b/.foundry/stories/story-116-250-gen3-ev-parsing-logic.md
@@ -1,0 +1,35 @@
+---
+id: story-116-250-gen3-ev-parsing-logic
+type: STORY
+title: Story - Gen 3 EV Parsing Logic
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on:
+  - story-116-249-gen3-ev-interface-definition
+jules_session_id: null
+pr_number: null
+parent: epic-092-116-gen3-ev-data-extraction
+tags:
+  - gen3
+  - save-engine
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story - Gen 3 EV Parsing Logic
+
+## 1. Objective
+Implement the logic to extract Effort Values (EVs) from the decrypted Gen 3 Pokémon data structure using the `DataView` API.
+
+## 2. Background
+In Gen 3, EV data is stored in the EVs & Condition (E) substructure of the 48-byte encrypted Data block. The order of the substructures depends on `PV % 24`. We need to locate this substructure and read the 6 EV bytes correctly.
+
+## 3. Scope
+- Add parsing logic to extract EVs (HP, Attack, Defense, Speed, Sp. Atk, Sp. Def) from the `DataView`.
+- Follow ADR 010 by exclusively using `DataView` methods.
+- Make sure to correctly map the decrypted bytes to their corresponding stats.
+
+## 4. Acceptance Criteria

--- a/.foundry/stories/story-116-251-gen3-ev-integration.md
+++ b/.foundry/stories/story-116-251-gen3-ev-integration.md
@@ -1,0 +1,35 @@
+---
+id: story-116-251-gen3-ev-integration
+type: STORY
+title: Story - Gen 3 EV Integration
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on:
+  - story-116-250-gen3-ev-parsing-logic
+jules_session_id: null
+pr_number: null
+parent: epic-092-116-gen3-ev-data-extraction
+tags:
+  - gen3
+  - save-engine
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story - Gen 3 EV Integration
+
+## 1. Objective
+Integrate the Gen 3 EV parsing logic to populate the `evs` property for Party and PC Box Pokémon instances during save extraction.
+
+## 2. Background
+Now that the EV parsing logic and the `PokemonInstance` interface updates are defined, the parser needs to actually apply them.
+
+## 3. Scope
+- Update `parseGen3Pokemon` or the relevant extraction functions in `src/engine/saveParser/parsers/gen3.ts` to call the EV extraction logic.
+- Ensure the result is correctly populated into the `PokemonInstance` objects returned for both party and PC box Pokémon.
+- Ensure `RangeError` from the `DataView` is caught and handled gracefully (e.g., throwing a formatted Error).
+
+## 4. Acceptance Criteria


### PR DESCRIPTION
This PR generates the child `STORY` nodes required to fulfill the objectives of `epic-092-116-gen3-ev-data-extraction`.

The epic has been broken down into three granular stories:
1.  **Interface Definition:** Updating `PokemonInstance` to support structured EVs.
2.  **Parsing Logic:** Extracting EV data using the `DataView` API.
3.  **Integration:** Applying the extraction logic to populate the `evs` property during save parsing.

The newly created stories have been appropriately referenced as unchecked tasks in the parent epic's markdown body, leaving the epic's YAML frontmatter unmodified as per system rules.

---
*PR created automatically by Jules for task [6898239128233894775](https://jules.google.com/task/6898239128233894775) started by @szubster*