### PR TITLE
chore(foundry): handle max rejection of task-121-219-gen3-tv-block-parser-retry-impl

### DIFF
--- a/.foundry/research/research-121-246-gen3-tv-block-parser-retry-failure.md
+++ b/.foundry/research/research-121-246-gen3-tv-block-parser-retry-failure.md
@@ -1,0 +1,31 @@
+---
+id: research-121-246-gen3-tv-block-parser-retry-failure
+type: RESEARCH
+title: Investigate Gen 3 TV Block Parser Retry Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-081-121-gen3-tv-block-dataview-parser
+tags:
+  - research
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Investigate Gen 3 TV Block Parser Retry Failure
+
+## Objective
+Investigate the root cause of the `task-121-219-gen3-tv-block-parser-retry-impl` failure (which reached its max rejection count). Determine why the coder failed to adhere to the strict constraint regarding module-level reusable constants, and define explicit instructions and memory offsets/constants that MUST be used in the next iteration to prevent a recurring QA rejection.
+
+## Instructions
+1. Analyze the failure feedback from QA in `task-121-220-gen3-tv-block-parser-retry-qa` (specifically the use of inline magic numbers `21` and `40` in `parseGen3MixRecords`).
+2. Identify the correct module-level constant names and values that should replace these magic numbers based on the `gen3_tv_shows_and_events.md` or related knowledge base documents.
+3. Document these explicit constants so the next implementer blueprint can mandate their exact usage.

--- a/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
+++ b/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
@@ -35,5 +35,8 @@ Implement the foundational logic to locate and read the TV broadcast data block 
 - [ ] research-121-216-gen3-tv-block-parser-failure
 - [x] task-121-217-gen3-tv-block-parser-retry-impl
 - [x] task-121-218-gen3-tv-block-parser-retry-qa
-- [ ] task-121-219-gen3-tv-block-parser-retry-impl
-- [ ] task-121-220-gen3-tv-block-parser-retry-qa
+- [x] task-121-219-gen3-tv-block-parser-retry-impl
+- [x] task-121-220-gen3-tv-block-parser-retry-qa
+- [ ] research-121-246-gen3-tv-block-parser-retry-failure
+- [ ] task-121-256-gen3-tv-block-parser-retry2-impl
+- [ ] task-121-257-gen3-tv-block-parser-retry2-qa

--- a/.foundry/tasks/task-121-220-gen3-tv-block-parser-retry-qa.md
+++ b/.foundry/tasks/task-121-220-gen3-tv-block-parser-retry-qa.md
@@ -38,3 +38,6 @@ Verify the implementation of the Gen 3 TV block `DataView` parser to ensure it c
 - **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
 - **Permanent Failure:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - **Empty PR Protocol:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### Auditor Rejection
+**CANCELLED:** The associated implementation task `task-121-219-gen3-tv-block-parser-retry-impl` reached its max rejection count. This QA task is therefore orphaned and cancelled. It is replaced by `research-121-246-gen3-tv-block-parser-retry-failure`, `task-121-256-gen3-tv-block-parser-retry2-impl`, and `task-121-257-gen3-tv-block-parser-retry2-qa`.

--- a/.foundry/tasks/task-121-256-gen3-tv-block-parser-retry2-impl.md
+++ b/.foundry/tasks/task-121-256-gen3-tv-block-parser-retry2-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-121-256-gen3-tv-block-parser-retry2-impl
+type: TASK
+title: Implement Gen 3 TV Block DataView Parser (Retry 2)
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on:
+  - research-121-246-gen3-tv-block-parser-retry-failure
+jules_session_id: null
+pr_number: null
+parent: story-081-121-gen3-tv-block-dataview-parser
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Gen 3 TV Block DataView Parser (Retry 2)
+
+## Description
+This task requires you to implement the foundational logic to locate and read the TV broadcast data block from the Gen 3 save file structure, addressing the feedback from `research-121-246-gen3-tv-block-parser-retry-failure`.
+
+As mandated by **ADR 010**, you MUST strictly utilize the `DataView` API for all new Gen 3 data parsing logic to ensure robustness and safety.
+You must avoid legacy `Uint8Array` manual read methods and instead use `DataView` methods such as `getUint8`, `getUint16`, etc., to enforce native bounds checking.
+
+Any out-of-bounds reads or structurally corrupt states within the TV block MUST trigger a gracefully caught `RangeError` which the parser translates into a descriptive structural error, rather than crashing the application.
+
+**CRITICAL CONSTRAINT:** All memory offsets, lengths, bit locations, and shifts MUST be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden. You must explicitly define reusable constants for values such as the ID for Mix Record events (`21` or similar, depending on research findings) and the record length (`40` or similar), instead of hardcoding them into the parsing logic.
+
+## Acceptance Criteria
+- [ ] The TV block extraction logic is built entirely using `DataView`.
+- [ ] All memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level.
+- [ ] Explicit error handling is in place to catch `RangeError` exceptions natively thrown by `DataView` on malformed saves.
+- [ ] New parsing functions conform to the existing Gen 1 and Gen 2 backward-compatible parsing interfaces without breaking them.
+
+## Important Protocols (For Coder)
+- **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failure:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Protocol:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-121-257-gen3-tv-block-parser-retry2-qa.md
+++ b/.foundry/tasks/task-121-257-gen3-tv-block-parser-retry2-qa.md
@@ -1,0 +1,38 @@
+---
+id: task-121-257-gen3-tv-block-parser-retry2-qa
+type: TASK
+title: QA Gen 3 TV Block DataView Parser (Retry 2)
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on:
+  - task-121-256-gen3-tv-block-parser-retry2-impl
+jules_session_id: null
+pr_number: null
+parent: story-081-121-gen3-tv-block-dataview-parser
+tags:
+  - qa
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Gen 3 TV Block DataView Parser (Retry 2)
+
+## Description
+Verify the implementation of the Gen 3 TV block `DataView` parser to ensure it correctly and safely parses the data according to the architecture guidelines and the findings from `research-121-246-gen3-tv-block-parser-retry-failure`.
+
+## Acceptance Criteria
+- [ ] Verify the TV block extraction logic uses `DataView` exclusively, with no legacy `Uint8Array` manual read methods.
+- [ ] Verify all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. No inline magic numbers. Specifically check for `21` and `40` to ensure they are handled properly based on the research.
+- [ ] Verify `RangeError` exceptions are gracefully caught and translated into descriptive structural errors.
+- [ ] Ensure existing Gen 1 and Gen 2 parsers remain unbroken by running the full test suite.
+
+## Important Protocols (For QA)
+- **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failure:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Protocol:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR addresses the permanent failure (reached max rejection count) of `task-121-219-gen3-tv-block-parser-retry-impl`. It follows the exact protocol for handling permanent child node failures:
- Appends an `### Auditor Rejection` section to the orphaned `qa` task to mark it as CANCELLED (without touching the YAML frontmatter).
- Checks off the failed tasks in the parent `STORY` node.
- Creates a new `RESEARCH` node to investigate the root cause of the failure and explicitly define the module-level reusable constants that the coder must use.
- Creates new `impl` and `qa` retry tasks that depend on the `RESEARCH` node.
- Appends the new child tasks to the parent `STORY` node.

---
*PR created automatically by Jules for task [11481930854118183864](https://jules.google.com/task/11481930854118183864) started by @szubster*