### PR TITLE
Fix Dependabot package-ecosystem for pnpm support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
Fixes a validation error in `.github/dependabot.yml` where 'pnpm' was used as an invalid `package-ecosystem`. Updated the value to 'npm' as per GitHub Dependabot documentation. Verified that the change is correct and that the repository's tests and linting pass.

Fixes #3687

---
*PR created automatically by Jules for task [11000385418645144081](https://jules.google.com/task/11000385418645144081) started by @szubster*