### PR TITLE
Verify completion of Epic 049-086

### DIFF
--- a/.foundry/epics/epic-049-086-dynamic-move-pp-parsing.md
+++ b/.foundry/epics/epic-049-086-dynamic-move-pp-parsing.md
@@ -33,10 +33,10 @@ Currently, data such as move PPs are either manually maintained or fetched ad-ho
 4. Replace manual/hardcoded tables for move data.
 
 ## Acceptance Criteria
-- [ ] Implement parsing logic in `scripts/generate-pokedata.ts` to extract moves data (including PPs).
-- [ ] Handle any discrepancies between generations for moves.
-- [ ] Output the correct `moves.jsonl` data payload.
+- [x] Implement parsing logic in `scripts/generate-pokedata.ts` to extract moves data (including PPs).
+- [x] Handle any discrepancies between generations for moves.
+- [x] Output the correct `moves.jsonl` data payload.
 
-- [ ] story-086-128-move-data-extraction
-- [ ] story-086-129-move-generation-discrepancies
-- [ ] story-086-130-move-jsonl-compaction
+- [x] story-086-128-move-data-extraction
+- [x] story-086-129-move-generation-discrepancies
+- [x] story-086-130-move-jsonl-compaction


### PR DESCRIPTION
Checks off all acceptance criteria for EPIC: Dynamic Generation of Moves PP PokeData, since all of its child STORY nodes (128, 129, 130) are successfully COMPLETED. This empty PR is intended to unblock the Foundry DAG and allow the node to transition to the VERIFYING state.

---
*PR created automatically by Jules for task [17229713725675796890](https://jules.google.com/task/17229713725675796890) started by @szubster*