### PR TITLE
Verify Contest Warning States UI

### DIFF
--- a/.foundry/tasks/task-150-243-contest-warning-states-ui-qa.md
+++ b/.foundry/tasks/task-150-243-contest-warning-states-ui-qa.md
@@ -44,10 +44,10 @@ This task is for the `qa` persona to verify the Contest Warning States UI implem
    - Verify that tests exist and are passing, specifically ensuring the warning state renders correctly under the "dead-end" conditions.
 
 ## Acceptance Criteria
-- [ ] Verify `ContestRecommendationPanel` accepts the `sheen` prop.
-- [ ] Verify the visual warning for the edge case (maxed sheen, low stats) is implemented.
-- [ ] Verify the tactical hardware aesthetic (ADR 008) is applied.
-- [ ] Verify tests are written and passing for the warning state.
+- [x] Verify `ContestRecommendationPanel` accepts the `sheen` prop.
+- [x] Verify the visual warning for the edge case (maxed sheen, low stats) is implemented.
+- [x] Verify the tactical hardware aesthetic (ADR 008) is applied.
+- [x] Verify tests are written and passing for the warning state.
 
 ## Important Reminder for QA
 - **Transient Failure**: If you experience a transient failure requiring retry or the implementation is incomplete, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Submits empty PR (only checking off markdown acceptance criteria) to verify the Contest Warning States UI, advancing task `task-150-243-contest-warning-states-ui-qa` to VERIFYING. Tests passed, functionality verified.

---
*PR created automatically by Jules for task [16511068275781913397](https://jules.google.com/task/16511068275781913397) started by @szubster*