### PR TITLE
Break down battle frontier dashboard epic into stories

### DIFF
--- a/.foundry/epics/epic-046-079-gen3-battle-frontier-dashboard-ui.md
+++ b/.foundry/epics/epic-046-079-gen3-battle-frontier-dashboard-ui.md
@@ -26,8 +26,9 @@ notes: ''
 Create the `BattleFrontierDashboard` UI component. It must adhere to the "tactical hardware/snooping" aesthetic, displaying facility cards, BP wallet, and progress visuals.
 
 ## Acceptance Criteria
-- [ ] Create UI for the 7 facilities.
-- [ ] Create BP wallet display.
+- [x] Create UI for the 7 facilities.
+- [x] Create BP wallet display.
 - [ ] Create progress visuals towards the next Frontier Brain encounter.
-- [ ] Apply tactical styling (ADR 008, ADR 024).
-- [ ] story-079-116-battle-frontier-dashboard-ui
+- [x] Apply tactical styling (ADR 008, ADR 024).
+- [x] story-079-116-battle-frontier-dashboard-ui
+- [ ] story-079-252-battle-frontier-brain-progress-visuals

--- a/.foundry/stories/story-079-252-battle-frontier-brain-progress-visuals.md
+++ b/.foundry/stories/story-079-252-battle-frontier-brain-progress-visuals.md
@@ -1,0 +1,29 @@
+---
+id: story-079-252-battle-frontier-brain-progress-visuals
+type: STORY
+title: Battle Frontier Brain Progress Visuals
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-046-079-gen3-battle-frontier-dashboard-ui
+tags:
+  - feature
+  - gen3
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Battle Frontier Brain Progress Visuals
+
+## Description
+Create progress visuals towards the next Frontier Brain encounter using React Flow (ADR 008) to maintain architectural consistency. This addresses the remaining unimplemented aspect of the Battle Frontier Dashboard UI.
+
+## Acceptance Criteria
+- [ ] Translate into technical Tasks


### PR DESCRIPTION
- Appended new story `story-079-252-battle-frontier-brain-progress-visuals` to address the unimplemented progress visuals feature.
- Checked off completed acceptance criteria in `epic-046-079-gen3-battle-frontier-dashboard-ui.md`.

---
*PR created automatically by Jules for task [16558337458606037925](https://jules.google.com/task/16558337458606037925) started by @szubster*