### PR TITLE
fix(foundry): fix infinite loop in idea-066 by maintaining PENDING state

### DIFF
--- a/.foundry/ideas/idea-066-save-file-health-scanner.md
+++ b/.foundry/ideas/idea-066-save-file-health-scanner.md
@@ -38,7 +38,7 @@ Introduce a "Save File Health Scanner" feature. When a user uploads a `.sav` fil
 This feature pivots DexHelper from just a tracking tool into a critical utility for retro game preservation. It solves a massive pain point for retro gamers who live in fear of losing hundreds of hours of progress to battery failure or bad cartridge dumps, providing peace of mind and actionable recovery diagnostics.
 
 ## Acceptance Criteria
-- [x] Product Manager: Convert this idea into a PRD.
+- [ ] Product Manager: Convert this idea into a PRD.
 - [ ] prd-066-036-save-file-health-scanner
 
 ### Auditor Rejection

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -63,3 +63,10 @@ During the session for node `idea-090-pokegear-phone-tracker`, it was discovered
 Idea 066 proposed a custom Biome/ESLint rule to enforce `gray-matter` for parsing frontmatter in `.github/scripts/`. Upon evaluation, it was determined that the technical cost and maintenance burden of implementing and supporting this highly specific rule for a minor edge case outweighs the benefits.
 **Action:**
 Cancelled `idea-066-enforce-gray-matter-linter` directly as the return on investment (ROI) is too low compared to relying on standard PR reviews. This aligns with the constraint to decline low-ROI ideas early in the pipeline to avoid wasting engineering cycles.
+
+## 2026-07-02: Strict Macro Node Completion Enforcement and Wait States
+**Observation:**
+During the resurrection loop for `idea-066-save-file-health-scanner` (Attempt 5), the IDEA node repeatedly failed verification because it was submitted via Empty PR while its generated downstream PRD and Epic nodes were still `PENDING`. This violates the Strict Macro Node Completion rules (IDEA-072).
+
+**Action & Constraint:**
+When assigned to a macro node (like an IDEA) that has spawned children, DO NOT transition it to VERIFYING (by submitting an Empty PR with all boxes checked) until ALL descendant nodes have transitioned to COMPLETED. If the downstream nodes are still PENDING, you MUST keep the macro node in a PENDING state. To do this, uncheck the Acceptance Criteria checkbox corresponding to the uncompleted downstream dependency and submit the PR. This breaks the premature verification loop and allows the system to wait for downstream implementation.


### PR DESCRIPTION
Unchecked the acceptance criteria for idea-066-save-file-health-scanner to prevent premature verification and submitted an Empty PR to wait for downstream nodes. Added documentation in product_manager journal for this explicit wait state.

---
*PR created automatically by Jules for task [4256572097386929209](https://jules.google.com/task/4256572097386929209) started by @szubster*