### PR TITLE
feat(foundry): convert living dex tracker idea to prd

### DIFF
--- a/.foundry/ideas/idea-056-living-dex-tracker.md
+++ b/.foundry/ideas/idea-056-living-dex-tracker.md
@@ -38,7 +38,7 @@ Create a dedicated "Living Dex Tracker" view in the DexHelper UI.
 This directly addresses a hardcore collector playstyle, heavily leaning into our "premium storage viewer" capabilities by solving a specific, highly manual pain point in older Pokémon generations.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD.
+- [x] Product Manager: Convert this idea into a PRD.
 
 ### Auditor Rejection
 The specialized "Living Dex Tracker" UI has not been implemented. While there is a global "Living Dex" toggle in the settings that modifies the standard Pokédex view, the specific requirements of this IDEA (a dedicated view with numerical grid, PC Box/Slot overlay, and highlighting for ghosts/duplicates) are completely missing from the codebase. Furthermore, no downstream PRD node exists for this idea. The Product Manager must create a formal PRD that details the implementation of this dedicated UI view, and it must be fully implemented and merged by downstream child tasks before this IDEA can be verified as complete.
@@ -48,3 +48,6 @@ The node has been rejected again. The Product Manager must create the correspond
 
 ### Auditor Rejection
 The PRD has still not been created. The `product_manager` MUST create the actual PRD file in `.foundry/prds/` (e.g., `prd-056-101-living-dex-tracker.md`) and append a reference to it in this node's Acceptance Criteria. Do not submit this node for verification until the PRD and its downstream implementations are fully complete.
+
+## Acceptance Criteria
+- [ ] prd-056-103-living-dex-tracker

--- a/.foundry/prds/prd-056-103-living-dex-tracker.md
+++ b/.foundry/prds/prd-056-103-living-dex-tracker.md
@@ -1,0 +1,41 @@
+---
+id: prd-056-103-living-dex-tracker
+type: PRD
+title: Specialized "Living Dex" Organization Tracker UI
+status: PENDING
+owner_persona: epic_planner
+created_at: "2026-07-03"
+updated_at: "2026-07-03"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-056-living-dex-tracker
+tags:
+  - feature
+  - ui
+  - living-dex
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# PRD: Specialized "Living Dex" Organization Tracker UI
+
+## 1. Context & Motivation
+Players of early Pokémon games (Gen 1 and Gen 2, and soon Gen 3) frequently aim to assemble a "Living Dex" — exactly one of every Pokémon stored in numerical order in their PC boxes. Organizing PC boxes manually in these games is extremely tedious without automated sorting. DexHelper currently acts as a premium storage viewer but lacks a dedicated Living Dex organization tool.
+
+## 2. Product Requirements
+We need a dedicated "Living Dex Tracker" view in the DexHelper UI.
+
+- **Numerical Grid View**: Display a unified grid of all Pokémon in the regional or national Pokédex in numerical order.
+- **PC Box and Slot Overlay**: Visually overlay the player's current PC box and Party state onto this grid. Crucially, show exactly which PC Box and Slot the currently owned Pokémon resides in.
+- **Ghost Highlighting**: Highlight "ghosts" (missing Pokémon slots).
+- **Evolution Path Highlighting**: Highlight "duplicates" or "evolution paths" indicating raw material available to fill missing slots (e.g., if you have 3 Bulbasaurs but no Ivysaur, it highlights that a Bulbasaur can be evolved).
+
+## 3. Scope & Constraints
+- Must align with the tactical hardware/snooping aesthetic (ADR 008, `rounded-none`, `border-dashed`, monospaced fonts).
+- Toggleable or accessible from the main DexHelper storage view.
+
+## 4. Acceptance Criteria
+- [ ] Epic Planner: Break down this PRD into manageable Epics.


### PR DESCRIPTION
Creates the downstream PRD node `prd-056-103-living-dex-tracker.md` for the Living Dex Tracker IDEA, setting the owner persona to epic_planner. Correctly updates the parent IDEA node with checked tasks and the appended Acceptance Criteria reference without modifying its YAML frontmatter, adhering to strict macro node completion constraints and ADR 007.

---
*PR created automatically by Jules for task [12765842356091810959](https://jules.google.com/task/12765842356091810959) started by @szubster*