### PR TITLE
chore(docs): reject epic-045-071 verification due to pending descendants

### DIFF
--- a/.foundry/epics/epic-045-071-documentation-macro-node-completion.md
+++ b/.foundry/epics/epic-045-071-documentation-macro-node-completion.md
@@ -34,9 +34,9 @@ Update the core system documentation to detail the new macro node completion rul
 3. **Other Knowledge Base Updates**: Update any other relevant documents if necessary (e.g. `core_policies.md`).
 
 ## Acceptance Criteria
-- [x] Update `schema.md` with hierarchical completion rules.
-- [x] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior.
-- [x] Verify that there are no conflicting statements across other core documentation.
+- [ ] Update `schema.md` with hierarchical completion rules.
+- [ ] Update `001-the-foundry-architecture.md` (ADR 001) to detail the behavior.
+- [ ] Verify that there are no conflicting statements across other core documentation.
 
 ### Stories
 - [x] .foundry/stories/story-071-108-update-schema-macro-node-completion.md
@@ -45,3 +45,6 @@ Update the core system documentation to detail the new macro node completion rul
 
 ### Follow-up Work
 - [x] .foundry/ideas/idea-097-schema-verifying-state-fix.md
+
+### Auditor Rejection
+Verification failed. The descendant macro node `idea-097-schema-verifying-state-fix` is in PENDING state, not COMPLETED. Macro nodes cannot be verified as completed until all of their spawned descendant nodes in the generated sub-tree have fully transitioned to the COMPLETED state.


### PR DESCRIPTION
The Auditor persona has verified `epic-045-071-documentation-macro-node-completion`. The verification has failed because one of the spawned descendant nodes (`idea-097-schema-verifying-state-fix`) is still in the `PENDING` state. According to strict macro node completion rules, all descendants in the generated sub-tree must be `COMPLETED` before the parent macro node can be verified.

The Acceptance Criteria checkboxes have been unchecked and an `### Auditor Rejection` block has been appended to the markdown body to trigger the Resurrection Loop and inform the owner persona of the failure. No YAML frontmatter modifications were made, preserving the required DAG state mechanics.

---
*PR created automatically by Jules for task [11904307626867972681](https://jules.google.com/task/11904307626867972681) started by @szubster*