### PR TITLE
chore: verify epic-046-078-gen3-battle-frontier-data-extraction completion

### DIFF
--- a/.foundry/epics/epic-046-078-gen3-battle-frontier-data-extraction.md
+++ b/.foundry/epics/epic-046-078-gen3-battle-frontier-data-extraction.md
@@ -28,9 +28,9 @@ notes: ''
 Extend the Gen 3 save parser to extract Battle Frontier data using the offsets discovered in the research phase. It must strictly use the `DataView` API as per ADR 010.
 
 ## Acceptance Criteria
-- [ ] Parse win streaks, max records, and symbol status for all 7 facilities.
-- [ ] Parse total BP.
-- [ ] Handle out-of-bounds reads gracefully via `DataView`.
-- [ ] story-078-121-gen3-parse-battle-frontier-win-streaks
-- [ ] story-078-122-gen3-parse-battle-frontier-symbols
-- [ ] story-078-123-gen3-parse-battle-points
+- [x] Parse win streaks, max records, and symbol status for all 7 facilities.
+- [x] Parse total BP.
+- [x] Handle out-of-bounds reads gracefully via `DataView`.
+- [x] story-078-121-gen3-parse-battle-frontier-win-streaks
+- [x] story-078-122-gen3-parse-battle-frontier-symbols
+- [x] story-078-123-gen3-parse-battle-points


### PR DESCRIPTION
Checks off all acceptance criteria for epic-046-078-gen3-battle-frontier-data-extraction. All descendant stories (`story-078-121-gen3-parse-battle-frontier-win-streaks`, `story-078-122-gen3-parse-battle-frontier-symbols`, `story-078-123-gen3-parse-battle-points`) have successfully transitioned to `COMPLETED` state. Submitting PR to transition this macro epic to `VERIFYING` state.

---
*PR created automatically by Jules for task [14680739535331603907](https://jules.google.com/task/14680739535331603907) started by @szubster*