### PR TITLE
chore(foundry): mark strict macro node completion epic as complete

### DIFF
--- a/.foundry/epics/epic-045-070-orchestrator-strict-completion.md
+++ b/.foundry/epics/epic-045-070-orchestrator-strict-completion.md
@@ -35,9 +35,9 @@ Update the DAG Orchestrator to ensure strict hierarchical completion. A node mus
 3. **Tests**: Add unit tests in `.github/scripts/foundry-orchestrator.test.ts` to ensure these new validations work correctly and don't break existing functionality.
 
 ## Acceptance Criteria
-- [ ] Implement hierarchical completion logic in `foundry-orchestrator.ts`.
-- [ ] Add unit tests verifying the behavior blocks transition when children are not completed.
-- [ ] Ensure tests cover both `parent` field links and markdown body references.
+- [x] Implement hierarchical completion logic in `foundry-orchestrator.ts`.
+- [x] Add unit tests verifying the behavior blocks transition when children are not completed.
+- [x] Ensure tests cover both `parent` field links and markdown body references.
 
-- [ ] story-070-108-orchestrator-hierarchical-completion-logic
-- [ ] story-070-109-orchestrator-hierarchical-completion-tests
+- [x] story-070-108-orchestrator-hierarchical-completion-logic
+- [x] story-070-109-orchestrator-hierarchical-completion-tests


### PR DESCRIPTION
Checked off the acceptance criteria for `epic-045-070-orchestrator-strict-completion.md` since all child nodes have been completed. This is submitted as an empty PR as no new code changes are needed.

---
*PR created automatically by Jules for task [9059450868363838237](https://jules.google.com/task/9059450868363838237) started by @szubster*