### PR TITLE
fix: enforce strict macro node completion for idea 066

### DIFF
--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -70,3 +70,10 @@ During the resurrection loop for `idea-066-save-file-health-scanner` (Attempt 5)
 
 **Action & Constraint:**
 When assigned to a macro node (like an IDEA) that has spawned children, DO NOT transition it to VERIFYING (by submitting an Empty PR with all boxes checked) until ALL descendant nodes have transitioned to COMPLETED. If the downstream nodes are still PENDING, you MUST keep the macro node in a PENDING state. To do this, uncheck the Acceptance Criteria checkbox corresponding to the uncompleted downstream dependency and submit the PR. This breaks the premature verification loop and allows the system to wait for downstream implementation.
+
+## 2026-07-03: IDEA Node Wait State
+**Observation:**
+During the attempt to process `idea-066-save-file-health-scanner`, it was noted that checking off its acceptance criteria violates the Strict Macro Node Completion rules since its generated children are still `PENDING`. As directed by the Auditor's notes, I must submit the PR with the checkboxes unchecked to explicitly wait for downstream nodes.
+
+**Action:**
+Reverted the checked acceptance criteria box for `idea-066-save-file-health-scanner` and will submit an empty PR with all boxes unchecked to ensure the DAG waits properly.


### PR DESCRIPTION
- Unchecked the Acceptance Criteria checkbox for the PRD generation in `idea-066-save-file-health-scanner.md` because the spawned PRD and Epics are still in `PENDING` status. This prevents the orchestrator from prematurely transitioning this node to `VERIFYING` and entering a permanent failure/resurrection loop.
- Added a journal entry in `.foundry/journals/product_manager.md` documenting this strict wait state logic as directed by the Auditor.

---
*PR created automatically by Jules for task [12665784843664540470](https://jules.google.com/task/12665784843664540470) started by @szubster*