### PR TITLE
Auditor: Verify epic-038-061-pokerus-state-exfiltration

### DIFF
--- a/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
+++ b/.foundry/epics/epic-038-061-pokerus-state-exfiltration.md
@@ -35,6 +35,3 @@ Read the specific byte flags for Pokerus for every Pokemon in the party and PC f
 
 ## Follow-up Nodes
 - [x] .foundry/docs/adrs/adr-061-026-bitwise-state-extraction.md
-
-### Auditor Rejection
-Verification failed. The bitwise logic for Pokerus state extraction was implemented directly inline in `src/engine/saveParser/parsers/gen2.ts` instead of being standardized into shared helper functions in `src/engine/saveParser/parsers/common.ts`. This is a direct violation of ADR 026. Please refactor the extraction logic into a shared helper function in `common.ts` and update the parsing logic accordingly.


### PR DESCRIPTION
- Checked that all downstream nodes are fully COMPLETE.
- Removed the Auditor Rejection string from the `.foundry/epics/epic-038-061-pokerus-state-exfiltration.md` file since the previous Pokerus bitwise logic violation has been fully refactored, and all criteria is satisfied.
- Trigger transition to COMPLETED since the EPIC is complete.

---
*PR created automatically by Jules for task [11246232396798982707](https://jules.google.com/task/11246232396798982707) started by @szubster*