### PR TITLE
Foundry: Fix child node references in story-065-150-contest-warning-states-ui

### DIFF
--- a/.foundry/stories/story-065-150-contest-warning-states-ui.md
+++ b/.foundry/stories/story-065-150-contest-warning-states-ui.md
@@ -31,5 +31,5 @@ Implement visual warning states for edge cases identified by the Gen 3 Contest O
 ## Acceptance Criteria
 - [ ] Implement visual warnings for edge cases.
 - [ ] Alert users when a Pokémon has maxed out its Sheen but lacks stats for Master Rank contests.
-- [ ] .foundry/tasks/task-150-242-contest-warning-states-ui-impl.md
-- [ ] .foundry/tasks/task-150-243-contest-warning-states-ui-qa.md
+- [ ] task-150-242-contest-warning-states-ui-impl
+- [ ] task-150-243-contest-warning-states-ui-qa


### PR DESCRIPTION
Updates `.foundry/stories/story-065-150-contest-warning-states-ui.md` to properly reference its child task nodes by using their exact Node IDs instead of paths/extensions, as required by the Foundry architecture formatting rules. Also includes the child tasks in the patch without altering their logic or status.

---
*PR created automatically by Jules for task [11988758455390449295](https://jules.google.com/task/11988758455390449295) started by @szubster*