### PR TITLE
💡 Visionary: Gen 1-3 Static Encounter & Legendary Checklist

### DIFF
--- a/.foundry/ideas/idea-100-static-encounter-tracker.md
+++ b/.foundry/ideas/idea-100-static-encounter-tracker.md
@@ -1,0 +1,39 @@
+---
+id: idea-100-static-encounter-tracker
+type: IDEA
+title: Gen 1-3 Static Encounter & Legendary Checklist
+status: PENDING
+owner_persona: product_manager
+created_at: "2026-07-03"
+updated_at: "2026-07-03"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - feature
+  - gen1
+  - gen2
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Idea: Gen 1-3 Static Encounter & Legendary Checklist
+
+## Context
+Across Generations 1 through 3, players encounter specific Pokémon as one-time overworld interactions—often referred to as "static encounters" or "stationary encounters." These range from iconic Legendaries (Mewtwo, Ho-Oh, Rayquaza) to rare, non-respawning regular Pokémon (Snorlax blocking paths, Sudowoodo, Castform, Kecleon, or the Voltorb/Electrode disguised as items). Once a player faints or catches these Pokémon, the event flag is permanently set, and the encounter is gone forever on that save file. For players revisiting old save files or trying to catch everything available, figuring out which static encounters they have already completed requires physical in-game travel and guesswork.
+
+## Proposal
+Leverage DexHelper's capability to read event flags and hidden state from the save file to create a **Static Encounter & Legendary Checklist**.
+- **Unified Checklist:** Aggregate all available stationary encounters for the active game (e.g., all Snorlaxes in Gen 1, Sudowoodo in Gen 2, the Regi trio in Gen 3).
+- **Dynamic Completion Status:** By parsing specific event flags (e.g., the flag indicating Sudowoodo has been battled, or the flag for receiving the gift Castform), automatically check off which static encounters the player has completed.
+- **Actionable Hints:** For encounters that are still available, provide a quick reference on their exact location, level, and any prerequisites (e.g., needing the Poké Flute, SquirtBottle, or Silph Scope).
+
+## Value Proposition
+This directly tackles the anxiety of "Did I already catch the Snorlax on Route 12?" by surfacing hidden event flags. It perfectly complements existing collection trackers by transforming static game knowledge (wiki lists of legendaries/static spawns) into a highly personalized, dynamic "to-do list" based strictly on the player's unique save state. This deepens DexHelper's role as the ultimate completionist companion app.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD to detail the event flags to parse across Gens 1-3 for static encounters and define the UI presentation.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -171,3 +171,7 @@
 ## 2026-07-02
 **Idea:** Gen 3 Shoal Cave Tide Tracker
 **Learning:** The orchestrator architecture (specifically ADR 025) strictly forbids features that rely on extracting RTC data from save files because emulator handling is fragmented and physical dumps omit it. Future ideation must ensure proposed mechanics do not rely on exact internal RTC block parsing, and instead rely on the system-level fallback strategy.
+
+## 2026-07-03
+**Idea:** Gen 1-3 Static Encounter & Legendary Checklist
+**Learning:** Expanding DexHelper's collection capabilities beyond the full Pokédex to track limited, one-time static encounters provides immense unique value. While standard Pokédex trackers tell a player *what* they are missing, leveraging save-state event flags tells them exactly *where* to go in their specific playthrough to find non-respawning Pokémon (like Snorlax, Sudowoodo, or Legendaries). This directly reduces friction and aligns perfectly with the premium companion app philosophy.


### PR DESCRIPTION
Created `idea-100-static-encounter-tracker.md` to track Gen 1-3 static and legendary encounters. Updated visionary journal to reflect on the value of tracking limited, one-time static encounters.

---
*PR created automatically by Jules for task [828842455685059871](https://jules.google.com/task/828842455685059871) started by @szubster*