### PR TITLE
🗃️ Archivist: Remove execution logs from agent journals

### DIFF
--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -4,20 +4,13 @@
 
 While reviewing the system for potential improvements and friction points, I discovered that `.github/scripts/foundry-heartbeat.ts` still uses custom regex to mutate YAML frontmatter (e.g., changing status to FAILED, READY, or COMPLETED). This directly violates ADR-006, which mandates the use of `gray-matter` for all programmatic read and write operations.
 
-Autonomously generated `idea-018-migrate-heartbeat-to-gray-matter.md` to propose migrating the heartbeat script to use `gray-matter`, ensuring compliance with the architectural decision and preventing brittle regex-related bugs.
-
 ## 2026-05-22: Empty PR Acceptance Criteria Loophole Fix
 
 While analyzing recent runs, I observed that `task-062-100-gen3-locations-script-impl.md` failed permanently (Max rejection count reached). Reviewing the Empty PR submissions by the Auditor persona revealed a critical loophole: the Auditor instructions did not explicitly mandate checking off Acceptance Criteria checkboxes (`- [ ]` -> `- [x]`) before submitting an Empty PR for a completed task. This led to orchestrator rejections under ADR 007 and ADR 009.
 
-Autonomously updated `.github/agents/auditor.md` to include a strict directive to ensure all checkboxes are marked before submitting Empty PRs.
-
 ## 2026-05-23: Refined Empty PR Checklists and Failure Status Directives
 
-
-While the instructions were documented, they were not strictly enforced across all relevant persona prompts. I have proactively updated the `coder.md`, `qa.md`, and `tech_lead.md` prompts to explicitly include these directives.
-
-Additionally, to prevent future regressions related to ADR 006 (gray-matter usage), I generated `idea-064-enforce-gray-matter-linter.md` to propose a programmatic linter rule targeting the `.github/scripts/` directory to automatically catch and forbid regex frontmatter manipulation.
+While the instructions were documented, they were not strictly enforced across all relevant persona prompts.
 
 ## 2026-05-28: Enforce Hierarchical Verification Timing for Macro Nodes
 
@@ -28,26 +21,19 @@ To resolve this, I updated the orchestrator (`foundry-orchestrator.ts`) to enfor
 
 While reviewing rejected nodes, I discovered that `task-072-128-implement-dag-cancellation.md` was repeatedly rejected. The rejection reason indicated a critical bug in the orchestrator: the "Wait and Wake" phase erroneously modifies immutable `COMPLETED` nodes to `PENDING`, causing them to be incorrectly swept up by the cascade cancellation logic.
 
-Autonomously generated `idea-066-fix-wait-and-wake-cancellation-bug.md` to propose a fix for this bug and prevent the orchestrator from mutating immutable `COMPLETED` nodes.
 ## 2026-05-25: Refactoring DAG operations to shared utility module
 
 While analyzing the codebase for systemic improvements, I noticed significant duplication of core DAG operations (such as traversing reverse dependencies and updating node statuses via gray-matter) between `foundry-orchestrator.ts` and `foundry-heartbeat.ts`. This duplication creates a surface area for bugs where one script might diverge from the other (e.g. failing to properly append `rejection_reason` or mutating YAML fields via regex).
 
-To proactively mitigate this technical debt and improve the maintainability of the Foundry engine, I autonomously generated `idea-067-extract-dag-utils.md` to propose extracting these common functions into a shared `dag-utils.ts` module. I also generated `idea-066-enforce-gray-matter-linter.md` to codify the ADR 006 requirements into a CI-enforced linter rule.
-
 ## 2026-06-10: Strict Architectural Enforcement for Coders
 I analyzed the repeated failure of `task-085-142-impl-extract-rejection-count`. The Coder persona failed to implement the required React Context layer (violating ADR 013 and ADR 017) leaving state tightly coupled, and falsely claimed it was implemented after a QA rejection.
 
-To resolve this persistent friction point, I have updated the `coder`, `qa`, and `tech_lead` persona prompts to strictly enforce architectural compliance and improve blueprint scaffolding. Additionally, I autonomously generated `idea-073-refactor-dag-dashboard-context.md` to initiate a dedicated effort to implement the missing `DagContext` layer properly, unblocking future dashboard features.
-
 ## 2026-06-15: Introduced Permanent Failures Dashboard View
 
-To improve visibility into system deadlocks (ADR 017), I have implemented a 'Permanent Failures' toggle on the DAG Dashboard. This filters and highlights nodes with a `rejection_count >= 3`, allowing the team to quickly spot orphaned tasks and 'Impossible Loops' without needing to manually inspect the repository structure.
-
-This required updating the `DagFilterPanel`, `DagDashboard`, and `DagNode` components to consume the already-parsed `rejection_count` property. Going forward, PMs and Tech Leads should check this view regularly.
+To improve visibility into system deadlocks (ADR 017), I have implemented a 'Permanent Failures' toggle on the DAG Dashboard. This filters and highlights nodes with a `rejection_count >= 3`, allowing the team to quickly spot orphaned tasks and 'Impossible Loops' without needing to manually inspect the repository structure. Going forward, PMs and Tech Leads should check this view regularly.
 
 ## 2026-06-22: Archive CANCELLED nodes
-I noticed CANCELLED nodes were accumulating in the workspace. I updated the TPM persona and schema to explicitly archive CANCELLED nodes alongside COMPLETED ones, and spawned task-000-212 to update the sweep script accordingly.
+I noticed CANCELLED nodes were accumulating in the workspace. CANCELLED nodes should be explicitly archived alongside COMPLETED ones.
 ## 2026-06-17: Late-Binding Hierarchy Orchestrator Exception
 
 Added formal notes regarding the Late-Binding process to clarify orchestrator deadlock prevention. A `PENDING` parent node will not block its children from starting *if* the parent node already has children. This exception to the normal hierarchical completion rule avoids circular dependency deadlocks where a parent waits for children that are inherently waiting for their parent to become active.
@@ -57,9 +43,7 @@ Added formal notes regarding the Late-Binding process to clarify orchestrator de
 
 ## 2026-06-14: Consolidated Permanent Failure & Impossible Loop Protocol
 
-
-
-To resolve this, I have updated all relevant agents (`coder.md`, `qa.md`, `auditor.md`, `tech_lead.md`, `product_manager.md`, `epic_planner.md`) to explicitly clarify the difference:
+To resolve this, all relevant agents MUST explicitly clarify the difference:
 1. `FAILED` is strictly for transient errors triggering a resurrection retry.
 2. `CANCELLED` MUST be used for permanent failures (impossible tasks or max rejections reached) to formally drop them from the DAG and trigger parent recovery.
 
@@ -69,6 +53,4 @@ Additionally, to prevent false positive Impossible Loops and incorrect failure t
 
 While observing the system performance and logs, I noticed that several agent sessions were terminating abruptly or timing out. A recurring pattern is the use of blocking bash commands, particularly `tail -f`, via the `run_in_bash_session` tool. These commands hang the session indefinitely.
 
-To mitigate this operational friction, I have updated the `coder`, `qa`, `tech_lead`, and `auditor` persona prompts to explicitly forbid the use of blocking bash commands and recommend alternatives like `cat` or `tail -n`.
-
-Furthermore, I have generated `idea-095-prevent-blocking-bash-commands.md` to propose an automated, system-level timeout wrapper for `run_in_bash_session` to forcefully terminate hanging executions and return actionable feedback to the agent, providing a more resilient long-term solution.
+To mitigate this operational friction, agents must explicitly forbid the use of blocking bash commands and use alternatives like `cat` or `tail -n`.

--- a/.foundry/journals/architect.md
+++ b/.foundry/journals/architect.md
@@ -7,7 +7,7 @@ The Foundry Orchestrator was flagging TASK nodes owned by the 'architect' person
 Architects frequently perform evaluation tasks (e.g., assessing graph libraries, prototyping integration approaches) that result in ADRs or technical specifications. These activities are best represented as TASK nodes within the Foundry DAG.
 
 ## 2026-05-17
-* **MsgPack Transition for Gen 3:** As part of the Gen 3 data implementation, I created ADR 010 to mandate a shift from JSON to MsgPack (`msgpackr`) for data storage and hydration. As previously researched in `data_format_strategy.md`, expanding from ~177 KB of Gen 1-2 data up to the full Gen 3 size risks ballooning the bundle and slowing down client-side parsing. By making this transition now, we optimize application efficiency.
+* **MsgPack Transition for Gen 3:** As part of the Gen 3 data implementation, ADR 010 mandates a shift from JSON to MsgPack (`msgpackr`) for data storage and hydration. Expanding from ~177 KB of Gen 1-2 data up to the full Gen 3 size risks ballooning the bundle and slowing down client-side parsing. By making this transition now, we optimize application efficiency.
 - When referencing other nodes in YAML frontmatter fields like `parent` or `depends_on`, strictly use the exact node ID (e.g., `prd-053-022-gen3-data-parsing`) rather than the relative file path to avoid Groundedness Rule violations.
 
 ## 2026-05-19: Late Binding Correction
@@ -18,7 +18,7 @@ Learning: My role is strictly architectural blueprinting (creating ADRs, schemas
 When utilizing advanced serializers with object structure deduplication (like `msgpackr` with `useRecords`), stripping property names down to minified keys (e.g., `n` instead of `name`) for size reduction becomes an anti-pattern. The serialization library already extracts these keys into extensions, making the short names redundant. Moving forward, we should prioritize readable, verbose property names to preserve Developer Experience (DX) rather than prematurely optimizing property lengths, as the size gains are negligible (e.g., ~52 bytes per 1,000 objects). Enum-to-integer optimizations remain valid as strings cannot be perfectly deduplicated.
 
 ## 2026-05-22
-Anomaly detected: Assigned to node `prd-063-034-permanent-failure-dashboard` despite Architects being forbidden from owning PRDs (`rejection_reason: Invalid owner_persona mapping`). I fulfilled the task constraints (creating the requested ADR and updating schema.md) and checked off the task in the PRD, but I am unable to change the invalid `owner_persona` mapping in the frontmatter due to core rules. This node will likely need to be re-assigned or recreated by the PM.
+Anomaly detected: Assigned to node `prd-063-034-permanent-failure-dashboard` despite Architects being forbidden from owning PRDs (`rejection_reason: Invalid owner_persona mapping`). I am unable to change the invalid `owner_persona` mapping in the frontmatter due to core rules. This node will likely need to be re-assigned or recreated by the PM.
 
 ## 2026-06-07: Feebas Route 119 Visualization Architecture (ADR 020)
 **Context:** Implemented an ADR for rendering the Feebas tile locations in Gen 3 (Ruby, Sapphire, Emerald).

--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -90,10 +90,6 @@
 - **Key Learnings**:
   - `React.HTMLAttributes<HTMLHeadingElement>` includes a built-in `title` prop typed as `string | undefined`, which conflicts if you want `title` to accept a `React.ReactNode` for rendering JSX elements inline. To fix this type clash when using TypeScript, use `Omit<React.HTMLAttributes<HTMLHeadingElement>, 'title'>` when extending the interface.
 
-## Fix CI: Test has no assertions
-- **What**: CI failed because three tests in `src/components/assistant/__tests__/AssistantSuggestionCard.test.tsx` had no assertions. I added `await expect.element(page.getByText(...)).toBeVisible()` to satisfy the `oxlint` `vitest(expect-expect)` rule.
-- **Why**: The rule enforces that every test has at least one assertion.
-
 ## TacticalBadge Refactoring
 - Identified repeated inline JSX patterns for standard badge styles (`rounded-none border border-... border-dashed bg-... px-... py-... font-black text-... uppercase tracking-widest`) scattered across multiple components (`PokemonLocations.tsx`, `PokemonCatchProbability.tsx`, `PokemonEvolutions.tsx`, `PokemonCaughtDetails.tsx`).
 - Replaced these repetitive raw `div` and `span` blocks with the existing `TacticalBadge` reusable component, significantly cleaning up the markup.


### PR DESCRIPTION
Removes routine execution log patterns ("I did X", "I updated Y", etc.) from `.jules/mason.md`, `.foundry/journals/agile_coach.md`, and `.foundry/journals/architect.md`.

This fixes an issue where multiple agents were using their journals to log task verification records and routine status updates, which bloats context windows and provides no long-term value to future runs, violating the centralized Empty PR Policy and Core Agent Policies.

Testing:
- Verified changes with `pnpm lint` and `pnpm test`.
- All tests pass, ensuring no agent workflows are broken.

---
*PR created automatically by Jules for task [13764755894916208531](https://jules.google.com/task/13764755894916208531) started by @szubster*