### PR TITLE
🧭 Strategist: Prompt improvement - Remove Auditor Rejection blocks on resubmission

### DIFF
--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -42,7 +42,7 @@ This is your **only private memory**. When you see something worth rememberingâ€
 
 
 ### Handling Rejections & Aborts
-**CRITICAL - RESUMING FAILED TASKS:** If you are assigned to a TASK node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the QA persona's journal (`.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting the same code.
+**CRITICAL - RESUMING FAILED TASKS:** If you are assigned to a TASK node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the QA persona's journal (`.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback and remove the `### Auditor Rejection` block (and its contents) from the markdown body rather than blindly resubmitting the same code.
 
 If you encounter a permanent failure, reach max rejection count, or must abort a task because it is impossible:
 1. You MUST update the target task's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -42,7 +42,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 5. **CRITICAL:** You MUST check off the markdown checkboxes (`- [x]`) of the permanently failed and orphaned child nodes in your own markdown body. If they remain unchecked, ADR 007 will prevent this parent node from ever transitioning to COMPLETED.
 
 ### Handling Rejections & Aborts
-**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
+**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback and remove the `### Auditor Rejection` block (and its contents) from the markdown body rather than blindly resubmitting.
 
 If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:
 1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -36,7 +36,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 5. **CRITICAL:** You MUST check off the markdown checkboxes (`- [x]`) of the permanently failed and orphaned child nodes in your own markdown body. If they remain unchecked, ADR 007 will prevent this parent node from ever transitioning to COMPLETED.
 
 ### Handling Rejections & Aborts
-**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
+**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback and remove the `### Auditor Rejection` block (and its contents) from the markdown body rather than blindly resubmitting.
 
 If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:
 1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -38,7 +38,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 
 
 ### Handling Rejections & Aborts
-**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
+**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback and remove the `### Auditor Rejection` block (and its contents) from the markdown body rather than blindly resubmitting.
 
 If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:
 1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -56,7 +56,7 @@ If you lack critical context or specifications (e.g., exact memory offsets) nece
 2. Append the new `RESEARCH` node's ID to the current STORY's `depends_on` array in its YAML frontmatter.
 3. Update the current STORY's `status` to `FAILED` and provide a clear `rejection_reason` indicating that it is suspended pending research.
 
-**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback rather than blindly resubmitting.
+**CRITICAL - RESUMING FAILED NODES:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor.md` or `.foundry/journals/qa.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback and remove the `### Auditor Rejection` block (and its contents) from the markdown body rather than blindly resubmitting.
 
 If you encounter a permanent failure, reach max rejection count, or must abort a node because it is impossible:
 1. You MUST update the target node's YAML frontmatter to `status: CANCELLED` (do NOT use `FAILED` for permanent aborts, as that triggers infinite resurrection loops).

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -320,3 +320,9 @@
 **Outcome:** Merged
 **Why:** The memory requires that when appending child nodes as unchecked tasks (`- [ ] <node_id>`) to a parent node, the parent must have an `## Acceptance Criteria` section, and the `<node_id>` must be strictly the exact Node ID without file extensions or directory paths. Several agent prompts lacked these instructions, which could lead to malformed parent nodes or DAG validation errors.
 **Pattern:** Apply systemic rules consistently across all relevant agent personas. When an architectural constraint or tool rule applies to formatting or ID usage, it must be explicitly included in all generative agent prompts to ensure compliance.
+
+## 2026-07-20 - [Accepted] - Prompt improvement - Remove Auditor Rejection blocks on resubmission
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** Agents were repeatedly leaving the `### Auditor Rejection` blocks in the markdown bodies of their nodes after resolving the issues and resubmitting. This left dead/stale comments cluttering the files.
+**Pattern:** Explicitly instruct implementation agents (Coder, Tech Lead, Story Owner, Epic Planner, and Product Manager) to not only address the feedback but also explicitly remove the `### Auditor Rejection` block (and its contents) from the markdown body when resubmitting, keeping node bodies clean.


### PR DESCRIPTION
### Proposal
Add an explicit instruction to the prompts of implementation agents (Coder, Tech Lead, Story Owner, Epic Planner, and Product Manager) to remove the `### Auditor Rejection` block (and its contents) from the markdown body when resolving an auditor rejection and resubmitting a node.

### Justification
Currently, agents address the feedback but fail to remove the `### Auditor Rejection` markdown blocks. This causes stale failure notices to clutter the markdown body of nodes even after they've been resubmitted and successfully implemented, misleading future processes and other agents reviewing the file history.

### Evidence
Running `grep -r "### Auditor Rejection" .foundry/` revealed many nodes with left-over `### Auditor Rejection` blocks, including nodes that had the block duplicated multiple times under headers like "Attempt 3", "Attempt 4", etc. The implementation agents were missing explicit instructions to clean up the marker when resuming a failed node.

---
*PR created automatically by Jules for task [14772318861110412321](https://jules.google.com/task/14772318861110412321) started by @szubster*