### PR TITLE
Draft tasks for Gen 3 friendship data extraction

### DIFF
--- a/.foundry/stories/story-094-152-gen3-friendship-extraction.md
+++ b/.foundry/stories/story-094-152-gen3-friendship-extraction.md
@@ -29,3 +29,5 @@ Implement the logic to extract the Friendship (Happiness) value for Gen 3 Pokém
 - [ ] Implement Gen 3 PC parsing to extract Friendship.
 - [ ] Ensure `DataView` API is used for rigorous bounds checking (ADR 010).
 - [ ] Update Gen 3 unit tests to verify the extracted Friendship value.
+- [ ] task-152-258-gen3-friendship-impl
+- [ ] task-152-259-gen3-friendship-qa

--- a/.foundry/tasks/task-152-258-gen3-friendship-impl.md
+++ b/.foundry/tasks/task-152-258-gen3-friendship-impl.md
@@ -1,0 +1,47 @@
+---
+id: task-152-258-gen3-friendship-impl
+type: TASK
+title: Implement Gen 3 Friendship Data Extraction
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-094-152-gen3-friendship-extraction
+tags:
+  - gen3
+  - save-parsing
+  - friendship
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement Gen 3 Friendship Data Extraction
+
+## Context
+As part of the Gen 3 data extraction effort (story-094-152-gen3-friendship-extraction), we need to extract the Friendship (Happiness) value for Pokémon. In Gen 3, a Pokémon's data structure is 100 bytes long, and the core details are in a 48-byte encrypted Data block. This block has four 12-byte substructures (G, A, E, M).
+Friendship is located at offset 4 of the **Growth (G)** substructure. The order of the substructures depends on `PV % 24`.
+
+## Requirements
+1.  **Party and PC Parsing**: Implement logic to extract Friendship for Gen 3 Pokémon in both the active Party and PC Boxes (even if currently stubbed in `src/engine/saveParser/parsers/gen3.ts`, build the foundational utility functions or integrate if appropriate).
+2.  **PV % 24 Permutations**: The implementation must correctly determine the permutation order using `PV % 24` to locate the Growth (G) substructure.
+3.  **DataView API**: You MUST exclusively use the native `DataView` API (e.g., `getUint8`, `getUint16`, `getUint32`) for rigorous bounds checking (as per ADR 010). Do not use raw `Uint8Array` manipulations.
+4.  **No Inline Magic Numbers**: All memory offsets, lengths, bit locations, and shifts MUST be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+5.  **Bounds Checking**: Rely on `DataView` to throw `RangeError` on out-of-bounds reads. Catch these explicitly and gracefully propagate them as specific validation errors.
+6.  **Unit Tests**: Update/create Gen 3 unit tests to verify the extracted Friendship value is correct.
+
+## Reminders
+*   If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+*   If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+*   If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Create constants for all memory offsets (e.g., Growth substructure offset, Friendship offset within Growth, etc.).
+- [ ] Implement utility/logic to determine the `PV % 24` permutation.
+- [ ] Implement logic to extract the Friendship byte from the Data block using the `DataView` API.
+- [ ] Integrate or prepare the logic for Party and PC Box parsing.
+- [ ] Write unit tests verifying Friendship extraction works for various `PV % 24` permutations.

--- a/.foundry/tasks/task-152-259-gen3-friendship-qa.md
+++ b/.foundry/tasks/task-152-259-gen3-friendship-qa.md
@@ -1,0 +1,45 @@
+---
+id: task-152-259-gen3-friendship-qa
+type: TASK
+title: QA Gen 3 Friendship Data Extraction
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - task-152-258-gen3-friendship-impl
+jules_session_id: null
+pr_number: null
+parent: story-094-152-gen3-friendship-extraction
+tags:
+  - gen3
+  - save-parsing
+  - friendship
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA Gen 3 Friendship Data Extraction
+
+## Context
+The Coder (task-152-258-gen3-friendship-impl) has implemented logic to extract the Friendship (Happiness) value for Gen 3 Pokémon from the 48-byte encrypted Data block. This requires correctly applying the `PV % 24` permutation logic to find the Growth (G) substructure.
+
+## Requirements
+1.  **Validate `PV % 24` Logic**: Verify the logic correctly handles all permutations to locate the Growth (G) substructure and extracts the byte at offset 4.
+2.  **Validate `DataView` Usage**: Ensure the Coder exclusively used the `DataView` API (e.g., `getUint8`) and relied on it for bounds checking (catching `RangeError`), strictly avoiding `Uint8Array` as per ADR 010.
+3.  **Validate No Magic Numbers**: Verify that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. Reject any inline magic numbers.
+4.  **Validate Tests**: Run the tests and ensure adequate coverage for different `PV % 24` permutations.
+
+## Reminders
+*   If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+*   If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+*   If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify `DataView` is used exclusively for memory reads and correctly catches `RangeError`s.
+- [ ] Verify there are absolutely no inline magic numbers for offsets or lengths.
+- [ ] Verify the `PV % 24` permutation logic is correct and well-tested.
+- [ ] Verify unit tests pass and cover different Friendship scenarios.


### PR DESCRIPTION
This PR transforms story-094-152-gen3-friendship-extraction into two actionable technical TASK nodes:
1. `task-152-258-gen3-friendship-impl` for the Coder to implement the extraction logic handling `PV % 24` permutations, strictly using the `DataView` API and avoiding inline magic numbers.
2. `task-152-259-gen3-friendship-qa` for the QA persona to verify the coder's implementation against these architectural constraints.

The parent story's markdown has been updated to track these new children as unchecked Acceptance Criteria.

---
*PR created automatically by Jules for task [3423574153491535022](https://jules.google.com/task/3423574153491535022) started by @szubster*