### PR TITLE
📜 Auditor: Fix orchestrator hierarchical completion checking for raw IDs

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -2108,6 +2108,73 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     expect(storyContent).toContain('status: READY');
   });
 
+  test('Late-Binding with Markdown ID references: suspends ACTIVE parent to PENDING if child referenced by ID is incomplete', () => {
+    // Epic 1: ACTIVE (started work, but child isn't done)
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "ACTIVE",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: "sess-123",
+    }, `## Acceptance Criteria\n- [ ] story-001\n`);
+
+    // Story 1: Child of Epic 1, PENDING
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
+    expect(epicContent).toContain('status: PENDING');
+
+    const storyContent = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-001.md'), 'utf-8');
+    expect(storyContent).toContain('status: READY');
+  });
+
+  test('Late-Binding with Markdown ID references: Parent wakes up to READY if it has unchecked tasks and completed children referenced by ID', () => {
+    createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
+      id: "idea-001",
+      type: "IDEA",
+      title: "Idea 1",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    }, `# Title\n## Acceptance Criteria\n\n- [ ] Unchecked task\n- [x] prd-001\n`);
+
+    createValidTestNode(tmpDir, '.foundry/prds/prd-001.md', {
+      id: "prd-001",
+      type: "PRD",
+      title: "PRD 1",
+      status: "COMPLETED",
+      owner_persona: "epic_planner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const ideaContent = fs.readFileSync(path.join(tmpDir, '.foundry/ideas/idea-001.md'), 'utf-8');
+    expect(ideaContent).toContain('status: READY');
+  });
+
   test('Late-Binding with Markdown Link: Parent wakes up to READY if it has unchecked tasks and completed children', () => {
     createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
       id: "idea-001",

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -415,10 +415,18 @@ function main(): void {
       childToParents.get(node.repoPath)!.add(parentPath);
     }
 
-    // Parse body for regex to find markdown links to children
+    // Parse body for regex to find markdown links to children and raw node IDs
     const linkRegex = /\]\((?:\.\/)?(\.foundry\/(?:ideas|prds|epics|stories|tasks|research)\/[^)]+\.md)\)/g;
+    const idRegex = /(?:idea|prd|epic|story|task|research|adr)-[a-zA-Z0-9_-]+/g;
     const body = node.body;
-    const matches = [...new Set([...body.matchAll(linkRegex)].map(m => m[1]))];
+
+    const linkMatches = [...body.matchAll(linkRegex)].map(m => m[1]);
+    const idMatches = [...body.matchAll(idRegex)]
+      .map(m => m[0])
+      .map(id => idToPathMap.get(id))
+      .filter((path): path is string => !!path);
+
+    const matches = [...new Set([...linkMatches, ...idMatches])];
 
     for (const match of matches) {
       // node.repoPath is the parent, match is the child


### PR DESCRIPTION
Fixes an issue where macro nodes would bypass hierarchical wait states when their spawned children were referenced via raw node IDs in the markdown body instead of links. 

* Extract raw node IDs during Phase 3 node mapping and link them to `idToPathMap`.
* Expand `foundry-orchestrator.test.ts` to cover raw node ID tracking.

---
*PR created automatically by Jules for task [2247757745395510242](https://jules.google.com/task/2247757745395510242) started by @szubster*