### PR TITLE
Update epic-046-078-shared-dag-context-foundation to VERIFYING

### DIFF
--- a/.foundry/epics/epic-046-078-shared-dag-context-foundation.md
+++ b/.foundry/epics/epic-046-078-shared-dag-context-foundation.md
@@ -29,6 +29,6 @@ As required by PRD `prd-074-046-dag-context-architecture`, we need to extract th
 
 ## Acceptance Criteria
 - [x] Break down into Stories
-- [ ] story-078-118-refactor-parser-for-rejection-count
-- [ ] story-078-119-implement-dag-context-provider
-- [ ] story-078-120-integrate-dag-context-with-views
+- [x] story-078-118-refactor-parser-for-rejection-count
+- [x] story-078-119-implement-dag-context-provider
+- [x] story-078-120-integrate-dag-context-with-views


### PR DESCRIPTION
- Updated the Epic markdown body `.foundry/epics/epic-046-078-shared-dag-context-foundation.md` to check off the acceptance criteria for the generated stories (`story-078-118-refactor-parser-for-rejection-count`, `story-078-119-implement-dag-context-provider`, `story-078-120-integrate-dag-context-with-views`), as they are all COMPLETED.
- This transitions the epic to the VERIFYING state, as all child nodes have been completed.
- Verified that all unit tests and browser tests pass after making the changes.

---
*PR created automatically by Jules for task [15838667637105323785](https://jules.google.com/task/15838667637105323785) started by @szubster*