### PR TITLE
chore(foundry): replace cancelled tailwind epics with v2 nodes

### DIFF
--- a/.foundry/epics/epic-071-123-define-tailwind-v4-utilities-v2.md
+++ b/.foundry/epics/epic-071-123-define-tailwind-v4-utilities-v2.md
@@ -1,0 +1,42 @@
+---
+id: epic-071-123-define-tailwind-v4-utilities-v2
+type: EPIC
+title: Define Tailwind v4 Tactical Utilities V2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - task-071-150-tailwind-v4-adr
+  - research-071-217-investigate-session-id-failure
+jules_session_id: null
+pr_number: null
+parent: prd-071-040-tailwind-v4-utilities-migration
+tags:
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Define Tailwind v4 Tactical Utilities V2
+
+## Objective
+Extract and consolidate common, repetitive Tailwind class patterns used throughout `src/components/` into semantic custom utilities. Define these new primitives using Tailwind v4's native `@utility` directive in `src/index.css`.
+
+## Scope
+1. **Analyze existing codebase**: Identify repetitive tactical styling patterns such as panels with dashed borders, sharp corners (`rounded-none`), monospaced retro text, and specific focus states.
+2. **Define Utilities**: Create corresponding `@utility` definitions in `src/index.css`. Expected primitives include:
+    - `tactical-panel`
+    - `tactical-button`
+    - `tactical-focus`
+    - `tactical-card`
+    - `tactical-input`
+    - `tactical-text` (or equivalent variations)
+3. **Verify Compliance**: Ensure all custom utilities correctly use `@apply` or raw CSS to define the desired baseline "tactical hardware" aesthetic as dictated by ADR 024. Confirm that hover and focus states can be correctly inherited natively through v4's directive structure.
+
+## Acceptance Criteria
+- [ ] Appropriate `@utility` primitives are defined in `src/index.css`.
+- [ ] Tailwind v4 formatting and structure is respected.

--- a/.foundry/epics/epic-071-124-migrate-core-tactical-components-v2.md
+++ b/.foundry/epics/epic-071-124-migrate-core-tactical-components-v2.md
@@ -1,0 +1,45 @@
+---
+id: epic-071-124-migrate-core-tactical-components-v2
+type: EPIC
+title: Migrate Core Tactical Components V2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - epic-071-123-define-tailwind-v4-utilities-v2
+jules_session_id: null
+pr_number: null
+parent: prd-071-040-tailwind-v4-utilities-migration
+tags:
+  - styling
+  - refactor
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Migrate Core Tactical Components V2
+
+## Objective
+Refactor the fundamental tactical UI components within the `src/components/` directory to utilize the new `@utility` classes defined in `src/index.css`.
+
+## Scope
+1. **Target Components**: Focus on foundational, reusable UI building blocks. Examples include, but are not limited to:
+   - `TacticalPanel.tsx`
+   - `TacticalButton.tsx`
+   - `TacticalCard.tsx`
+   - `TacticalInput.tsx`
+   - `TacticalSelect.tsx`
+   - `TacticalBadge.tsx`
+   - `TacticalSegmentedControl.tsx`
+   - `TacticalMultiSelectControl.tsx`
+2. **Refactoring Process**: Replace long strings of repetitive inline Tailwind classes (like `border-dashed`, `rounded-none`, etc.) with their equivalent semantic `tactical-*` classes (e.g., `tactical-panel`, `tactical-button`).
+3. **No Visual Regressions**: Ensure that the migration accurately preserves the pre-existing visual appearance.
+4. **Clean up Specificity and Overrides**: Ensure that any component-specific overrides (like changing padding or colors via props) still function correctly alongside the new base utility classes.
+
+## Acceptance Criteria
+- [ ] Core tactical components are updated to use the new `tactical-*` utilities.
+- [ ] Component aesthetics remain strictly consistent with the tactical hardware style (no visual regressions).
+- [ ] Components pass `pnpm run lint` and `pnpm test`.

--- a/.foundry/epics/epic-071-125-migrate-complex-app-components-v2.md
+++ b/.foundry/epics/epic-071-125-migrate-complex-app-components-v2.md
@@ -1,0 +1,40 @@
+---
+id: epic-071-125-migrate-complex-app-components-v2
+type: EPIC
+title: Migrate Complex App Components V2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - epic-071-124-migrate-core-tactical-components-v2
+jules_session_id: null
+pr_number: null
+parent: prd-071-040-tailwind-v4-utilities-migration
+tags:
+  - styling
+  - refactor
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Migrate Complex App Components V2
+
+## Objective
+Refactor higher-level, complex application components and views to leverage the new `@utility` classes, extending the cleanup effort beyond the foundational core components.
+
+## Scope
+1. **Target Areas**: Focus on complex composites and full page layouts, such as:
+   - Dashboard layouts (`src/components/dashboard/`)
+   - Data visualization containers (e.g., Radar displays, heatmaps)
+   - Specialized trackers (e.g., Berry tracker UI, Pokérus tracker UI)
+2. **Refactoring Process**:
+   - Replace redundant inline tactical classes with their corresponding semantic `@utility` class (e.g., `tactical-panel`, `tactical-text`).
+   - Where a specific combination of utilities is used *only* once for a highly specialized layout, it may remain as inline classes.
+3. **No Visual Regressions**: Ensure the application maintains its precise tactical hardware aesthetic. Pay special attention to z-indexing, layout stacking, and responsive behaviours.
+
+## Acceptance Criteria
+- [ ] High-level components and views are updated to use semantic `@utility` classes where appropriate.
+- [ ] The tactical hardware aesthetic is maintained without visual regressions.

--- a/.foundry/epics/epic-071-126-tailwind-designer-persona-v2.md
+++ b/.foundry/epics/epic-071-126-tailwind-designer-persona-v2.md
@@ -1,0 +1,34 @@
+---
+id: epic-071-126-tailwind-designer-persona-v2
+type: EPIC
+title: Implement Tailwind Designer Persona Ownership V2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - epic-071-125-migrate-complex-app-components-v2
+jules_session_id: null
+pr_number: null
+parent: prd-071-040-tailwind-v4-utilities-migration
+tags:
+  - styling
+  - agents
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Implement Tailwind Designer Persona Ownership V2
+
+## Objective
+Enhance the existing scheduled `palette` persona to maintain `src/index.css`, enforce the tactical hardware aesthetic, and manage custom `@utility` primitives, fulfilling the intent of ADR 024.
+
+## Scope
+1. **Persona Prompt/Role Definition**: Update the relevant agent prompts or system configurations to explicitly define the `palette` persona's responsibility for maintaining `src/index.css`, enforcing the tactical hardware aesthetic, and managing custom `@utility` primitives.
+2. **Documentation**: Update `.foundry/docs/schema.md` or `.foundry/docs/knowledge_base/agents/core_policies.md` to formally document this new domain ownership within the multi-agent pipeline.
+
+## Acceptance Criteria
+- [ ] Agent prompts/configurations are updated to assign styling ownership to the `palette` persona.
+- [ ] Relevant documentation is updated to reflect this new responsibility.

--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -49,14 +49,15 @@ DexHelper is transitioning from repetitive inline Tailwind classes to semantic c
 - [x] epic-071-074-define-tailwind-v4-utilities
 - [x] epic-071-075-migrate-core-tactical-components
 - [x] epic-071-076-migrate-complex-app-components
-
 - [x] epic-071-077-tailwind-designer-persona
-
-### Auditor Rejection
-The epic-071-074 permanently failed. All its children are cancelled. Replaced by research-071-217 and retried epics.
 
 - [x] research-071-217-investigate-session-id-failure
 - [x] epic-071-097-define-tailwind-v4-utilities-retry
 - [x] epic-071-098-migrate-core-tactical-components-retry
 - [x] epic-071-099-migrate-complex-app-components-retry
 - [x] epic-071-100-tailwind-designer-persona-retry
+
+- [ ] epic-071-123-define-tailwind-v4-utilities-v2
+- [ ] epic-071-124-migrate-core-tactical-components-v2
+- [ ] epic-071-125-migrate-complex-app-components-v2
+- [ ] epic-071-126-tailwind-designer-persona-v2


### PR DESCRIPTION
- Created epic-071-123 through epic-071-126 as v2 replacements for the permanently cancelled tailwind v4 utility migration epics.
- Maintained DAG constraints by checking off failed/orphaned checkboxes in the parent PRD (prd-071-040) while removing the auditor rejection block.
- Appended the new replacement epics to the parent PRD markdown body as unchecked tasks to properly block the DAG.
- Fixed dependency resolution paths for the newly generated epics to use exact node IDs.

---
*PR created automatically by Jules for task [17329071446619111222](https://jules.google.com/task/17329071446619111222) started by @szubster*