### PR TITLE
feat(foundry): break down epic-031-036-progression-tracking into stories

### DIFF
--- a/.foundry/epics/epic-031-036-progression-tracking.md
+++ b/.foundry/epics/epic-031-036-progression-tracking.md
@@ -31,4 +31,7 @@ As part of Phase 2 of the Cloudflare Sync backend, we need to support storing an
 - Maintain offline-first mandate.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Break this Epic down into Stories.
+- [x] Story Owner: Break this Epic down into Stories.
+- [ ] story-036-255-progression-save-model
+- [ ] story-036-256-progression-sync-logic
+- [ ] story-036-257-concurrent-game-management

--- a/.foundry/stories/story-036-255-progression-save-model.md
+++ b/.foundry/stories/story-036-255-progression-save-model.md
@@ -1,0 +1,33 @@
+---
+id: story-036-255-progression-save-model
+type: STORY
+title: Database Schema for Multiple Saves
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-031-036-progression-tracking
+tags:
+  - backend
+  - progression
+  - database
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Database Schema for Multiple Saves
+
+## Context
+To support progression tracking and multiple save files per playthrough, we need to update our offline-first database schema (using IndexedDB/Dexie or equivalent) to model the relationships between a Trainer/Playthrough and their multiple save states over time.
+
+## Requirements
+- Define the data model for storing multiple save files per playthrough.
+- Design relationships between Trainer profiles and their respective save history.
+- Ensure the schema supports syncing with the Cloudflare backend.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break this Story down into Tasks to define the specific database tables and indexes needed for managing multiple save files.

--- a/.foundry/stories/story-036-256-progression-sync-logic.md
+++ b/.foundry/stories/story-036-256-progression-sync-logic.md
@@ -1,0 +1,34 @@
+---
+id: story-036-256-progression-sync-logic
+type: STORY
+title: Progression Sync Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - story-036-255-progression-save-model
+jules_session_id: null
+pr_number: null
+parent: epic-031-036-progression-tracking
+tags:
+  - backend
+  - progression
+  - sync
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Progression Sync Logic
+
+## Context
+With the database schema in place for storing multiple saves, we need to implement the backend synchronization logic. This sync logic must maintain an offline-first mandate, ensuring that progression tracking over time is captured locally and synced to Cloudflare seamlessly.
+
+## Requirements
+- Implement logic to handle adding new progression points (save states) to a playthrough.
+- Ensure synchronization works with the Cloudflare native authentication and sync backend.
+- Resolve conflicts intelligently, prioritizing the most recent local offline progression.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break this Story down into Tasks to implement the progression recording and sync conflict resolution algorithms.

--- a/.foundry/stories/story-036-257-concurrent-game-management.md
+++ b/.foundry/stories/story-036-257-concurrent-game-management.md
@@ -1,0 +1,34 @@
+---
+id: story-036-257-concurrent-game-management
+type: STORY
+title: Concurrent Game Management UI/UX
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - story-036-256-progression-sync-logic
+jules_session_id: null
+pr_number: null
+parent: epic-031-036-progression-tracking
+tags:
+  - frontend
+  - progression
+  - ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Concurrent Game Management UI/UX
+
+## Context
+Users may play multiple games simultaneously (e.g., swapping between Pokémon Red and Emerald). We need frontend state management and UI components to allow users to switch between their active, concurrent playthroughs easily and view their progression timelines.
+
+## Requirements
+- Develop a UI for users to select and manage multiple active playthroughs across different game versions.
+- Implement state management to quickly swap the context of the current active game.
+- Build a timeline or visualization showing the progression of a specific playthrough over its saved history.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break this Story down into Tasks to implement the concurrent game switcher UI, state management, and progression visualization.


### PR DESCRIPTION
This PR breaks down `epic-031-036-progression-tracking` into three granular `STORY` nodes for technical planning:
1. `story-036-255-progression-save-model`: Database Schema for Multiple Saves
2. `story-036-256-progression-sync-logic`: Progression Sync Logic
3. `story-036-257-concurrent-game-management`: Concurrent Game Management UI/UX

The parent epic's markdown body has been updated correctly without modifying its YAML frontmatter. Dependencies between the newly created stories have been set using exact Node IDs.

---
*PR created automatically by Jules for task [7336513781442121775](https://jules.google.com/task/7336513781442121775) started by @szubster*