### PR TITLE
chore: QA verification for Gen 2 box grouping

### DIFF
--- a/.foundry/tasks/task-245-250-gen2-box-grouping-qa.md
+++ b/.foundry/tasks/task-245-250-gen2-box-grouping-qa.md
@@ -42,7 +42,7 @@ A coder has implemented logic to group Gen 2 `PokemonInstance` data by `speciesI
 *   If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Grouping logic correctly aggregates by species ID.
-- [ ] Grouping logic successfully filters out Party and Daycare Pokémon.
-- [ ] Unit tests pass and provide sufficient coverage.
-- [ ] Verify that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
+- [x] Grouping logic correctly aggregates by species ID.
+- [x] Grouping logic successfully filters out Party and Daycare Pokémon.
+- [x] Unit tests pass and provide sufficient coverage.
+- [x] Verify that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.


### PR DESCRIPTION
Verified the task implementation against its acceptance criteria:
- Confirmed the box grouping functionality successfully excludes Party and Daycare Pokemon.
- Verified module-level constants are used as specified instead of magic numbers.
- Ensure all unit tests run and pass without regressions.
- Checked off all task Acceptance Criteria in the Markdown task body without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [11113518282972167790](https://jules.google.com/task/11113518282972167790) started by @szubster*