### PR TITLE
feat: Implement Global Ribbon Checklist Dashboard Scaffold

### DIFF
--- a/.foundry/tasks/task-137-209-global-ribbon-dashboard-scaffold-impl.md
+++ b/.foundry/tasks/task-137-209-global-ribbon-dashboard-scaffold-impl.md
@@ -43,7 +43,7 @@ We need to scaffold the `GlobalRibbonChecklistDashboard` component to provide a 
 - **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Scaffold `GlobalRibbonChecklistDashboard` component in the frontend.
-- [ ] Connect the component to read from Living Dex / PC Box data context.
-- [ ] Render a list or grid displaying basic ribbon availability for each Pokémon.
-- [ ] Add explicit integration tests or usage to verify rendering and prevent orphaned components.
+- [x] Scaffold `GlobalRibbonChecklistDashboard` component in the frontend.
+- [x] Connect the component to read from Living Dex / PC Box data context.
+- [x] Render a list or grid displaying basic ribbon availability for each Pokémon.
+- [x] Add explicit integration tests or usage to verify rendering and prevent orphaned components.

--- a/src/components/dashboard/ribbons/GlobalRibbonChecklistDashboard.tsx
+++ b/src/components/dashboard/ribbons/GlobalRibbonChecklistDashboard.tsx
@@ -15,7 +15,7 @@ export const GlobalRibbonChecklistDashboard: React.FC = () => {
   const isLivingDex = useStore((s) => s.isLivingDex);
 
   const pokemonList = useMemo(() => {
-    if (!saveData || saveData.generation !== 3) {
+    if (saveData?.generation !== 3) {
       return [];
     }
     const allPokemon = [...saveData.partyDetails, ...saveData.pcDetails];

--- a/src/components/dashboard/ribbons/GlobalRibbonChecklistDashboard.tsx
+++ b/src/components/dashboard/ribbons/GlobalRibbonChecklistDashboard.tsx
@@ -1,0 +1,86 @@
+import type React from 'react';
+import { useMemo } from 'react';
+import { useStore } from '../../../store';
+import { objectEntries } from '../../../utils/object';
+import {
+  type ContestConditionType,
+  ContestRibbonBadge,
+  type ContestRibbonRank,
+} from '../../pokemon/details/ContestRibbonBadge';
+import { TacticalPanel } from '../../TacticalPanel';
+import { TelemetryDecoration } from '../../TelemetryDecoration';
+
+export const GlobalRibbonChecklistDashboard: React.FC = () => {
+  const saveData = useStore((s) => s.saveData);
+  const isLivingDex = useStore((s) => s.isLivingDex);
+
+  const pokemonList = useMemo(() => {
+    if (!saveData || saveData.generation !== 3) {
+      return [];
+    }
+    const allPokemon = [...saveData.partyDetails, ...saveData.pcDetails];
+    // Deduplicate or filter if needed, for now just show all with ribbons
+    return allPokemon.filter((p) => p.ribbons && Object.values(p.ribbons).some((r) => r > 0));
+  }, [saveData]);
+
+  if (saveData?.generation !== 3) {
+    return null;
+  }
+
+  if (pokemonList.length === 0) {
+    return (
+      <TacticalPanel className="mt-6 p-4 text-center">
+        <span className="tactical-text text-zinc-500">NO POKEMON WITH RIBBONS FOUND</span>
+      </TacticalPanel>
+    );
+  }
+
+  const rankMap: Record<number, ContestRibbonRank> = {
+    1: 'Normal',
+    2: 'Super',
+    3: 'Hyper',
+    4: 'Master',
+  };
+
+  const conditionMap: Record<keyof Exclude<(typeof pokemonList)[0]['ribbons'], undefined>, ContestConditionType> = {
+    cool: 'Cool',
+    beauty: 'Beauty',
+    cute: 'Cute',
+    smart: 'Smart',
+    tough: 'Tough',
+  };
+
+  return (
+    <div className="mt-6 flex flex-col gap-6">
+      <TacticalPanel className="relative flex flex-col gap-4 border-[var(--theme-primary)]/50 border-t-2 p-4 pt-6">
+        <TelemetryDecoration label="SYS.GLOBAL_RIBBONS" className="-top-[17px] left-[-1px]" />
+        <div className="flex items-center justify-between">
+          <span className="tactical-text z-10 font-black text-lg text-white">GLOBAL RIBBON CHECKLIST</span>
+          <span className="tactical-text z-10 text-xs text-zinc-400">
+            MODE: {isLivingDex ? 'LIVING DEX' : 'STANDARD'}
+          </span>
+        </div>
+
+        <div className="flex max-h-[500px] flex-col gap-2 overflow-y-auto">
+          {pokemonList.map((pokemon, i) => (
+            <div
+              key={`${pokemon.speciesId}-${pokemon.slot || i}`}
+              className="flex items-center justify-between border-zinc-800 border-b border-dashed p-2"
+            >
+              <span className="font-mono text-sm text-white">
+                {pokemon.nickname || `Species ${pokemon.speciesId}`} (Lv {pokemon.level})
+              </span>
+              <div className="flex flex-wrap justify-end gap-2">
+                {pokemon.ribbons &&
+                  objectEntries(pokemon.ribbons).map(([key, rank]) => {
+                    if (rank === 0 || !rankMap[rank]) return null;
+                    return <ContestRibbonBadge key={key} type={conditionMap[key]} rank={rankMap[rank]} />;
+                  })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </TacticalPanel>
+    </div>
+  );
+};

--- a/src/components/dashboard/ribbons/__tests__/GlobalRibbonChecklistDashboard.test.tsx
+++ b/src/components/dashboard/ribbons/__tests__/GlobalRibbonChecklistDashboard.test.tsx
@@ -6,14 +6,14 @@ import { useStore } from '../../../../store';
 import { GlobalRibbonChecklistDashboard } from '../GlobalRibbonChecklistDashboard';
 
 vi.mock('../../../../store', () => ({
-  useStore: vi.fn(),
+  useStore: vi.fn<() => unknown>(),
 }));
 
 describe('GlobalRibbonChecklistDashboard', () => {
   it('renders nothing if not generation 3', async () => {
-    vi.mocked(useStore).mockImplementation((selector: any) => {
-      const state = { saveData: { generation: 2 } };
-      return selector(state);
+    vi.mocked(useStore).mockImplementation((selector) => {
+      const state = { saveData: { generation: 2 } as SaveData, isLivingDex: false };
+      return selector(state as unknown as Parameters<Parameters<typeof useStore>[0]>[0]);
     });
 
     await render(<GlobalRibbonChecklistDashboard />);
@@ -21,7 +21,7 @@ describe('GlobalRibbonChecklistDashboard', () => {
   });
 
   it('renders NO POKEMON WITH RIBBONS FOUND if no pokemon have ribbons', async () => {
-    vi.mocked(useStore).mockImplementation((selector: any) => {
+    vi.mocked(useStore).mockImplementation((selector) => {
       const state = {
         saveData: {
           generation: 3,
@@ -30,7 +30,7 @@ describe('GlobalRibbonChecklistDashboard', () => {
         } as unknown as SaveData,
         isLivingDex: false,
       };
-      return selector(state);
+      return selector(state as unknown as Parameters<Parameters<typeof useStore>[0]>[0]);
     });
 
     await render(<GlobalRibbonChecklistDashboard />);
@@ -38,7 +38,7 @@ describe('GlobalRibbonChecklistDashboard', () => {
   });
 
   it('renders list of pokemon with ribbons', async () => {
-    vi.mocked(useStore).mockImplementation((selector: any) => {
+    vi.mocked(useStore).mockImplementation((selector) => {
       const state = {
         saveData: {
           generation: 3,
@@ -54,7 +54,7 @@ describe('GlobalRibbonChecklistDashboard', () => {
         } as unknown as SaveData,
         isLivingDex: true,
       };
-      return selector(state);
+      return selector(state as unknown as Parameters<Parameters<typeof useStore>[0]>[0]);
     });
 
     await render(<GlobalRibbonChecklistDashboard />);

--- a/src/components/dashboard/ribbons/__tests__/GlobalRibbonChecklistDashboard.test.tsx
+++ b/src/components/dashboard/ribbons/__tests__/GlobalRibbonChecklistDashboard.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import type { SaveData } from '../../../../engine/saveParser/parsers/common';
+import { useStore } from '../../../../store';
+import { GlobalRibbonChecklistDashboard } from '../GlobalRibbonChecklistDashboard';
+
+vi.mock('../../../../store', () => ({
+  useStore: vi.fn(),
+}));
+
+describe('GlobalRibbonChecklistDashboard', () => {
+  it('renders nothing if not generation 3', async () => {
+    vi.mocked(useStore).mockImplementation((selector: any) => {
+      const state = { saveData: { generation: 2 } };
+      return selector(state);
+    });
+
+    await render(<GlobalRibbonChecklistDashboard />);
+    await expect.element(page.getByText('GLOBAL RIBBON CHECKLIST')).not.toBeInTheDocument();
+  });
+
+  it('renders NO POKEMON WITH RIBBONS FOUND if no pokemon have ribbons', async () => {
+    vi.mocked(useStore).mockImplementation((selector: any) => {
+      const state = {
+        saveData: {
+          generation: 3,
+          partyDetails: [],
+          pcDetails: [],
+        } as unknown as SaveData,
+        isLivingDex: false,
+      };
+      return selector(state);
+    });
+
+    await render(<GlobalRibbonChecklistDashboard />);
+    await expect.element(page.getByText('NO POKEMON WITH RIBBONS FOUND')).toBeInTheDocument();
+  });
+
+  it('renders list of pokemon with ribbons', async () => {
+    vi.mocked(useStore).mockImplementation((selector: any) => {
+      const state = {
+        saveData: {
+          generation: 3,
+          partyDetails: [
+            {
+              speciesId: 25,
+              level: 10,
+              nickname: 'PIKACHU',
+              ribbons: { cool: 1, beauty: 0, cute: 2, smart: 0, tough: 0 },
+            },
+          ],
+          pcDetails: [],
+        } as unknown as SaveData,
+        isLivingDex: true,
+      };
+      return selector(state);
+    });
+
+    await render(<GlobalRibbonChecklistDashboard />);
+    await expect.element(page.getByText('GLOBAL RIBBON CHECKLIST')).toBeInTheDocument();
+    await expect.element(page.getByText('PIKACHU (Lv 10)')).toBeInTheDocument();
+    await expect.element(page.getByText('Cool')).toBeInTheDocument();
+    await expect.element(page.getByText('Cute')).toBeInTheDocument();
+  });
+});

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { ShieldAlert } from 'lucide-react';
 import { BattleFrontierDashboard } from '../components/dashboard/battle-frontier/BattleFrontierDashboard';
+import { GlobalRibbonChecklistDashboard } from '../components/dashboard/ribbons/GlobalRibbonChecklistDashboard';
 import { EmptyState } from '../components/EmptyState';
 import { useStore } from '../store';
 
@@ -16,8 +17,9 @@ function DashboardPage() {
   }
 
   return (
-    <div className="flex h-full flex-col pt-4">
+    <div className="mb-20 flex h-full flex-col gap-6 pt-4 pb-[env(safe-area-inset-bottom,16px)] md:mb-0">
       <BattleFrontierDashboard saveData={saveData} />
+      <GlobalRibbonChecklistDashboard />
     </div>
   );
 }


### PR DESCRIPTION
This PR implements the `GlobalRibbonChecklistDashboard` component as per TASK-137-209.

Changes included:
1. Scaffolded `GlobalRibbonChecklistDashboard` to aggregate and display Pokémon with ribbons from both the party and PC boxes.
2. Connected the component to read from the application's shared state via `useStore`.
3. Integrated the component into the `DashboardPage` (`src/routes/dashboard.tsx`).
4. Authored comprehensive tests using Vitest and `vitest-browser-react` to verify rendering and data filtering.
5. Ensured adherence to the ADR 008 "tactical hardware" UI guidelines (e.g., dashed borders, sharp edges, monospaced fonts).

---
*PR created automatically by Jules for task [13405589159786056128](https://jules.google.com/task/13405589159786056128) started by @szubster*