### PR TITLE
Reject orchestrator strict completion epic

### DIFF
--- a/.foundry/epics/epic-045-070-orchestrator-strict-completion.md
+++ b/.foundry/epics/epic-045-070-orchestrator-strict-completion.md
@@ -35,9 +35,12 @@ Update the DAG Orchestrator to ensure strict hierarchical completion. A node mus
 3. **Tests**: Add unit tests in `.github/scripts/foundry-orchestrator.test.ts` to ensure these new validations work correctly and don't break existing functionality.
 
 ## Acceptance Criteria
-- [x] Implement hierarchical completion logic in `foundry-orchestrator.ts`.
-- [x] Add unit tests verifying the behavior blocks transition when children are not completed.
-- [x] Ensure tests cover both `parent` field links and markdown body references.
+- [ ] Implement hierarchical completion logic in `foundry-orchestrator.ts`.
+- [ ] Add unit tests verifying the behavior blocks transition when children are not completed.
+- [ ] Ensure tests cover both `parent` field links and markdown body references.
 
-- [x] story-070-108-orchestrator-hierarchical-completion-logic
-- [x] story-070-109-orchestrator-hierarchical-completion-tests
+- [ ] story-070-108-orchestrator-hierarchical-completion-logic
+- [ ] story-070-109-orchestrator-hierarchical-completion-tests
+
+### Auditor Rejection
+The hierarchical completion logic in `.github/scripts/foundry-orchestrator.ts` fails to treat `VERIFYING` children as incomplete. Because of this, parent macro nodes are prematurely transitioning to `VERIFYING` or `COMPLETED` when their descendant nodes have only reached `VERIFYING`, instead of waiting for them to fully reach `COMPLETED` or `CANCELLED`.


### PR DESCRIPTION
Appended an Auditor Rejection block to `epic-045-070-orchestrator-strict-completion.md` as the implementation for Orchestrator Hierarchical Completion Checks is missing or incomplete.

---
*PR created automatically by Jules for task [1003074017915180091](https://jules.google.com/task/1003074017915180091) started by @szubster*