### PR TITLE
Check off child tasks in story-105-240-daycare-gen2-parsing

### DIFF
--- a/.foundry/stories/story-105-240-daycare-gen2-parsing.md
+++ b/.foundry/stories/story-105-240-daycare-gen2-parsing.md
@@ -26,5 +26,5 @@ Extracting Gen 2 daycare info.
 
 ## Acceptance Criteria
 - [x] Create task to parse Gen 2 Daycare Pokémon.
-- [ ] .foundry/tasks/task-240-245-gen2-daycare-parsing-impl.md
-- [ ] .foundry/tasks/task-240-246-gen2-daycare-parsing-qa.md
+- [x] task-240-245-gen2-daycare-parsing-impl
+- [x] task-240-246-gen2-daycare-parsing-qa


### PR DESCRIPTION
This empty PR checks off the acceptance criteria for the child tasks (`task-240-245-gen2-daycare-parsing-impl` and `task-240-246-gen2-daycare-parsing-qa`) which have transitioned to `COMPLETED`. This is required to unblock the parent node and transition it to `VERIFYING` according to ADR 007.

---
*PR created automatically by Jules for task [552562679008046799](https://jules.google.com/task/552562679008046799) started by @szubster*