### PR TITLE
chore: break down epic-095-119-in-game-trade-data-extraction into executable stories

### DIFF
--- a/.foundry/epics/epic-095-119-in-game-trade-data-extraction.md
+++ b/.foundry/epics/epic-095-119-in-game-trade-data-extraction.md
@@ -36,4 +36,8 @@ Implement and standardize the extraction of in-game NPC trade completion flags f
 - [ ] Gen 3 NPC trade flags are identified and extracted for all core versions (RSE/FRLG).
 - [ ] The `npcTradeFlags` field in `SaveData` is consistently populated across both generations.
 - [ ] All parsing logic strictly adheres to the `DataView` API and handles `RangeError` for corrupted saves.
-- [ ] Story Owner: Break down this Epic into executable Stories.
+- [x] Story Owner: Break down this Epic into executable Stories.
+- [ ] story-119-258-gen2-npc-trade-parsing
+- [ ] story-119-259-gen3-npc-trade-parsing
+- [ ] story-119-260-npc-trade-data-mapping
+- [ ] story-119-261-npc-trade-state-integration

--- a/.foundry/stories/story-119-258-gen2-npc-trade-parsing.md
+++ b/.foundry/stories/story-119-258-gen2-npc-trade-parsing.md
@@ -1,0 +1,29 @@
+---
+id: story-119-258-gen2-npc-trade-parsing
+type: STORY
+title: "Gen 2 NPC Trade Extraction"
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-095-119-in-game-trade-data-extraction
+tags:
+  - backend
+  - save-parsing
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 2 NPC Trade Extraction
+
+## Objective
+Implement extraction of NPC trade completion flags from Gen 2 (Gold, Silver, Crystal) save files.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break down into tasks for identifying and extracting Gen 2 trade flags.

--- a/.foundry/stories/story-119-259-gen3-npc-trade-parsing.md
+++ b/.foundry/stories/story-119-259-gen3-npc-trade-parsing.md
@@ -1,0 +1,29 @@
+---
+id: story-119-259-gen3-npc-trade-parsing
+type: STORY
+title: "Gen 3 NPC Trade Extraction"
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-095-119-in-game-trade-data-extraction
+tags:
+  - backend
+  - save-parsing
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 NPC Trade Extraction
+
+## Objective
+Identify and extract NPC trade flags for all core Gen 3 versions (RSE/FRLG) using `DataView`.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break down into tasks for Gen 3 extraction and offset discovery.

--- a/.foundry/stories/story-119-260-npc-trade-data-mapping.md
+++ b/.foundry/stories/story-119-260-npc-trade-data-mapping.md
@@ -1,0 +1,30 @@
+---
+id: story-119-260-npc-trade-data-mapping
+type: STORY
+title: "NPC Trade Data Mapping"
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - story-119-258-gen2-npc-trade-parsing
+  - story-119-259-gen3-npc-trade-parsing
+jules_session_id: null
+pr_number: null
+parent: epic-095-119-in-game-trade-data-extraction
+tags:
+  - backend
+  - mapping
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: NPC Trade Data Mapping
+
+## Objective
+Create a standard mapping connecting raw bitflags to specific NPC trade encounters (e.g., MUSCLE the Machop).
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break down into tasks for creating data maps across generations.

--- a/.foundry/stories/story-119-261-npc-trade-state-integration.md
+++ b/.foundry/stories/story-119-261-npc-trade-state-integration.md
@@ -1,0 +1,29 @@
+---
+id: story-119-261-npc-trade-state-integration
+type: STORY
+title: "NPC Trade State Integration"
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - story-119-260-npc-trade-data-mapping
+jules_session_id: null
+pr_number: null
+parent: epic-095-119-in-game-trade-data-extraction
+tags:
+  - backend
+  - state-integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: NPC Trade State Integration
+
+## Objective
+Integrate the extracted flags into the unified `SaveData` object, ensuring consistency and proper `RangeError` handling.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break down into tasks for `SaveData` update and test coverage.


### PR DESCRIPTION
Break down `epic-095-119-in-game-trade-data-extraction` into four discrete executable Story nodes:
- `story-119-258-gen2-npc-trade-parsing`
- `story-119-259-gen3-npc-trade-parsing`
- `story-119-260-npc-trade-data-mapping`
- `story-119-261-npc-trade-state-integration`

Appended these nodes to the Epic's acceptance criteria per standard hierarchical DAG completion rules, while correctly keeping the parent node in `PENDING` by explicitly not checking off the newly appended child references.

---
*PR created automatically by Jules for task [15623487794657129697](https://jules.google.com/task/15623487794657129697) started by @szubster*