### PR TITLE
📝 Epic Planner: Breakdown Bash Timeout Wrapper PRD

### DIFF
--- a/.foundry/epics/epic-057-127-bash-timeout-wrapper.md
+++ b/.foundry/epics/epic-057-127-bash-timeout-wrapper.md
@@ -1,0 +1,30 @@
+---
+id: epic-057-127-bash-timeout-wrapper
+type: EPIC
+title: Timeout Wrapper for Bash Sessions
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-095-057-prevent-blocking-bash-commands
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Timeout Wrapper for Bash Sessions
+
+## Overview
+Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that run over a specific threshold (e.g., 30 seconds).
+
+## Acceptance Criteria
+- [ ] Implement timeout wrapper.
+- [ ] Implement feedback mechanism for interrupted commands.

--- a/.foundry/epics/epic-057-128-bash-static-analysis-linter.md
+++ b/.foundry/epics/epic-057-128-bash-static-analysis-linter.md
@@ -1,0 +1,30 @@
+---
+id: epic-057-128-bash-static-analysis-linter
+type: EPIC
+title: Static Analysis Linter for Bash Sessions
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on:
+  - epic-057-127-bash-timeout-wrapper
+jules_session_id: null
+pr_number: null
+parent: prd-095-057-prevent-blocking-bash-commands
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Static Analysis Linter for Bash Sessions
+
+## Overview
+Implement a static analysis linter to proactively block known infinite-blocking commands like `tail -f` before execution.
+
+## Acceptance Criteria
+- [ ] Implement static analysis linter.

--- a/.foundry/prds/prd-095-057-prevent-blocking-bash-commands.md
+++ b/.foundry/prds/prd-095-057-prevent-blocking-bash-commands.md
@@ -40,4 +40,6 @@ Agent sessions executing long-running or blocking bash commands (like `tail -f`)
 - **Feedback Mechanism**: If a command is interrupted, return a clear, user-facing error message describing why it was stopped and suggesting non-blocking alternatives.
 
 ## Acceptance Criteria
-- [ ] Break down this PRD into Epics mapping out the implementation strategy (e.g., exploring wrapper feasibility, updating bash tool infrastructure).
+- [x] Break down this PRD into Epics mapping out the implementation strategy (e.g., exploring wrapper feasibility, updating bash tool infrastructure).
+- [ ] epic-057-127-bash-timeout-wrapper
+- [ ] epic-057-128-bash-static-analysis-linter


### PR DESCRIPTION
This PR completes the Epic Planner breakdown for PRD `prd-095-057-prevent-blocking-bash-commands` ("Automated Timeout Wrapper for Bash Sessions").

It generates two explicit Epics to handle the core requirements:
1. `epic-057-127-bash-timeout-wrapper`: Responsible for wrapping `run_in_bash_session` to interrupt long-running commands.
2. `epic-057-128-bash-static-analysis-linter`: Responsible for proactively blocking known hanging commands before execution.

The PRD has been updated to reflect the new tasks in its Acceptance Criteria while respecting the Foundry rule to avoid altering YAML frontmatter for parent nodes. All generated nodes use exact ID mappings for `depends_on`.

---
*PR created automatically by Jules for task [7901105720251993128](https://jules.google.com/task/7901105720251993128) started by @szubster*