### PR TITLE
Break down PRD into Epics for macro node boundary enforcement

### DIFF
--- a/.foundry/epics/epic-057-127-orchestrator-safeguard-investigation.md
+++ b/.foundry/epics/epic-057-127-orchestrator-safeguard-investigation.md
@@ -1,0 +1,31 @@
+---
+id: epic-057-127-orchestrator-safeguard-investigation
+type: EPIC
+title: Orchestrator Safeguard Investigation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-096-057-macro-node-boundary-enforcement
+tags:
+  - process
+  - orchestrator
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Orchestrator Safeguard Investigation
+
+## Context
+As part of enforcing macro node functional boundaries, we need to ensure that an EPIC cannot be marked `COMPLETED` until its functional requirements are verifiably integrated and tested.
+
+## Goal
+Investigate `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts` to see if there are programmatic ways to enforce that an EPIC cannot bypass the verification stage without a dedicated Integration/E2E story.
+
+## Acceptance Criteria
+- [ ] Analyze orchestrator scripts for programmatic safeguards.
+- [ ] Create necessary STORY nodes for investigation and implementation if viable.

--- a/.foundry/epics/epic-057-128-epic-planner-process-update.md
+++ b/.foundry/epics/epic-057-128-epic-planner-process-update.md
@@ -1,0 +1,31 @@
+---
+id: epic-057-128-epic-planner-process-update
+type: EPIC
+title: Epic Planner Process Update
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - .foundry/epics/epic-057-127-orchestrator-safeguard-investigation.md
+jules_session_id: null
+pr_number: null
+parent: prd-096-057-macro-node-boundary-enforcement
+tags:
+  - process
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Epic Planner Process Update
+
+## Context
+As part of enforcing macro node functional boundaries, we need to enforce a process where every EPIC MUST generate a final STORY dedicated to Integration and E2E Verification.
+
+## Goal
+Define the process changes for Epic Planners to require an Integration/Verification story for every EPIC breakdown.
+
+## Acceptance Criteria
+- [ ] Define the specific process changes required for Epic Planners.
+- [ ] Ensure that the final story of an EPIC contains specific acceptance criteria requiring E2E test execution.

--- a/.foundry/epics/epic-057-129-schema-documentation-updates.md
+++ b/.foundry/epics/epic-057-129-schema-documentation-updates.md
@@ -1,0 +1,32 @@
+---
+id: epic-057-129-schema-documentation-updates
+type: EPIC
+title: Schema and Documentation Updates
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - .foundry/epics/epic-057-128-epic-planner-process-update.md
+jules_session_id: null
+pr_number: null
+parent: prd-096-057-macro-node-boundary-enforcement
+tags:
+  - process
+  - documentation
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Schema and Documentation Updates
+
+## Context
+As part of enforcing macro node functional boundaries, we need to update templates and documentation to reflect the new process changes for Epic Planners.
+
+## Goal
+Update `.foundry/docs/schema.md` or other relevant documentation/templates to explicitly require an Integration/E2E Story for all new Epics.
+
+## Acceptance Criteria
+- [ ] Update `.foundry/docs/schema.md` with the new process requirements.
+- [ ] Update any other necessary documentation and schemas.

--- a/.foundry/prds/prd-096-057-macro-node-boundary-enforcement.md
+++ b/.foundry/prds/prd-096-057-macro-node-boundary-enforcement.md
@@ -40,3 +40,6 @@ Ensure that an EPIC cannot be marked `COMPLETED` until its functional requiremen
 - [ ] Investigate Orchestrator changes for boundary enforcement.
 - [ ] Define the process changes for Epic Planners.
 - [ ] Update necessary documentation and schemas.
+- [ ] epic-057-127-orchestrator-safeguard-investigation
+- [ ] epic-057-128-epic-planner-process-update
+- [ ] epic-057-129-schema-documentation-updates


### PR DESCRIPTION
This PR breaks down PRD `prd-096-057-macro-node-boundary-enforcement` into 3 new EPICs:
- `epic-057-127-orchestrator-safeguard-investigation`: Investigate orchestrator scripts for programmatic safeguards.
- `epic-057-128-epic-planner-process-update`: Define the process changes for Epic Planners.
- `epic-057-129-schema-documentation-updates`: Update necessary documentation and schemas.

It appends these 3 Epics as unchecked boxes to the PRD file.

---
*PR created automatically by Jules for task [1134262754955394232](https://jules.google.com/task/1134262754955394232) started by @szubster*