### PR TITLE
Break down Epic 030-039 (Cloudflare R2 Offline-First Save Syncing) into stories

### DIFF
--- a/.foundry/epics/epic-030-039-cloudflare-r2-save-sync.md
+++ b/.foundry/epics/epic-030-039-cloudflare-r2-save-sync.md
@@ -38,4 +38,9 @@ Following the establishment of a secure authentication layer, the application ne
 - Ensure graceful degradation so save files continue to use local browser storage without errors when Cloudflare is unavailable (e.g., hosted on GitHub pages).
 
 ## Acceptance Criteria
-- [ ] Story Owner: Break this Epic down into Stories.
+- [x] Story Owner: Break this Epic down into Stories.
+- [ ] story-039-262-r2-client-infrastructure
+- [ ] story-039-263-r2-pull-sync-logic
+- [ ] story-039-264-r2-push-sync-logic
+- [ ] story-039-265-r2-offline-conflict-resolution
+- [ ] story-039-266-r2-graceful-degradation

--- a/.foundry/stories/story-039-262-r2-client-infrastructure.md
+++ b/.foundry/stories/story-039-262-r2-client-infrastructure.md
@@ -1,0 +1,33 @@
+---
+id: story-039-262-r2-client-infrastructure
+type: STORY
+title: Cloudflare R2 Client Infrastructure
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-030-039-cloudflare-r2-save-sync
+tags:
+  - backend
+  - sync
+  - r2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Cloudflare R2 Client Infrastructure
+
+## Context
+We need to establish the basic API bindings and infrastructure to connect to Cloudflare R2 from our application to store and retrieve save files.
+
+## Requirements
+- Set up the necessary R2 bindings.
+- Implement fundamental read/write/list operations for the save files.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks.

--- a/.foundry/stories/story-039-263-r2-pull-sync-logic.md
+++ b/.foundry/stories/story-039-263-r2-pull-sync-logic.md
@@ -1,0 +1,34 @@
+---
+id: story-039-263-r2-pull-sync-logic
+type: STORY
+title: Cloudflare R2 Pull Sync Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on:
+  - story-039-262-r2-client-infrastructure
+jules_session_id: null
+pr_number: null
+parent: epic-030-039-cloudflare-r2-save-sync
+tags:
+  - backend
+  - sync
+  - r2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Cloudflare R2 Pull Sync Logic
+
+## Context
+When a user logs in on a new device, the application must pull their latest save data from Cloudflare R2.
+
+## Requirements
+- Implement logic to fetch save data from R2 upon successful login.
+- Ensure the downloaded data hydrates the local application state.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks.

--- a/.foundry/stories/story-039-264-r2-push-sync-logic.md
+++ b/.foundry/stories/story-039-264-r2-push-sync-logic.md
@@ -1,0 +1,34 @@
+---
+id: story-039-264-r2-push-sync-logic
+type: STORY
+title: Cloudflare R2 Push Sync Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on:
+  - story-039-263-r2-pull-sync-logic
+jules_session_id: null
+pr_number: null
+parent: epic-030-039-cloudflare-r2-save-sync
+tags:
+  - backend
+  - sync
+  - r2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Cloudflare R2 Push Sync Logic
+
+## Context
+As the user makes progress or uploads new saves locally, these changes must be synchronized back to Cloudflare R2.
+
+## Requirements
+- Implement logic to push local save data to R2.
+- Define when pushes occur (e.g., periodically, on explicit save).
+
+## Acceptance Criteria
+- [ ] Break down into Tasks.

--- a/.foundry/stories/story-039-265-r2-offline-conflict-resolution.md
+++ b/.foundry/stories/story-039-265-r2-offline-conflict-resolution.md
@@ -1,0 +1,34 @@
+---
+id: story-039-265-r2-offline-conflict-resolution
+type: STORY
+title: Cloudflare R2 Offline Conflict Resolution
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on:
+  - story-039-264-r2-push-sync-logic
+jules_session_id: null
+pr_number: null
+parent: epic-030-039-cloudflare-r2-save-sync
+tags:
+  - backend
+  - sync
+  - r2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Cloudflare R2 Offline Conflict Resolution
+
+## Context
+Because the app is offline-first, a user might make local changes while disconnected, while the remote R2 state has changed from another device. We need conflict resolution.
+
+## Requirements
+- Implement logic to detect conflicts between the local and remote R2 state.
+- Implement a resolution strategy (e.g., timestamp-based last-write-wins, or prompting the user).
+
+## Acceptance Criteria
+- [ ] Break down into Tasks.

--- a/.foundry/stories/story-039-266-r2-graceful-degradation.md
+++ b/.foundry/stories/story-039-266-r2-graceful-degradation.md
@@ -1,0 +1,33 @@
+---
+id: story-039-266-r2-graceful-degradation
+type: STORY
+title: Cloudflare R2 Graceful Degradation
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on:
+  - story-039-265-r2-offline-conflict-resolution
+jules_session_id: null
+pr_number: null
+parent: epic-030-039-cloudflare-r2-save-sync
+tags:
+  - backend
+  - sync
+  - r2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Cloudflare R2 Graceful Degradation
+
+## Context
+The application must continue to function even if Cloudflare services are unavailable or unreachable (e.g., when hosted independently on GitHub Pages).
+
+## Requirements
+- Ensure save files gracefully fall back to using local browser IndexedDB storage without throwing fatal errors if R2 sync fails or is unavailable.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks.


### PR DESCRIPTION
This PR breaks down the Epic `epic-030-039-cloudflare-r2-save-sync` into granular Story nodes to implement Cloudflare R2 save syncing. It introduces five new stories covering infrastructure, pull sync, push sync, conflict resolution, and graceful degradation, and links them via dependencies while updating the parent Epic's acceptance criteria.

---
*PR created automatically by Jules for task [15829302644220984255](https://jules.google.com/task/15829302644220984255) started by @szubster*