### PR TITLE
Fix dynamic item list parsing epic state

### DIFF
--- a/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
+++ b/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
@@ -33,9 +33,9 @@ Currently, valid item lists are either manually maintained or fetched ad-hoc. Ma
 4. Replace manual/hardcoded tables for item data.
 
 ## Acceptance Criteria
-- [ ] Implement parsing logic in `scripts/generate-pokedata.ts` to extract item lists.
-- [ ] Handle any validation required for items (e.g. mapping across generations, PokeAPI IDs to internal ROM IDs).
-- [ ] Output the correct `items.jsonl` data payload.
+- [x] Implement parsing logic in `scripts/generate-pokedata.ts` to extract item lists.
+- [x] Handle any validation required for items (e.g. mapping across generations, PokeAPI IDs to internal ROM IDs).
+- [x] Output the correct `items.jsonl` data payload.
 
-- [x] .foundry/stories/story-087-128-dynamic-item-list-parsing.md
-- [ ] .foundry/stories/story-087-245-item-list-validation.md
+- [x] story-087-128-dynamic-item-list-parsing
+- [x] story-087-245-item-list-validation


### PR DESCRIPTION
Updates the epic node to properly reflect the completion state of the child stories, correctly checking off Acceptance Criteria and linking child nodes via their explicit IDs.

---
*PR created automatically by Jules for task [1159395289567358981](https://jules.google.com/task/1159395289567358981) started by @szubster*