### PR TITLE
feat: Break down PRD for schema VERIFYING state fix into Epic

### DIFF
--- a/.foundry/epics/epic-097-130-schema-verifying-state-update.md
+++ b/.foundry/epics/epic-097-130-schema-verifying-state-update.md
@@ -1,0 +1,28 @@
+---
+id: epic-097-130-schema-verifying-state-update
+type: EPIC
+title: Update schema.md regarding VERIFYING state
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-097-096-schema-verifying-state-fix
+tags:
+  - documentation
+  - schema
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Update schema.md regarding VERIFYING state
+
+## Description
+This epic implements the required changes from `prd-097-096-schema-verifying-state-fix`. We need to update Invariant 7 in `schema.md` to reflect that `VERIFYING` and `COMPLETED` nodes are read-only for implementing personas, as established by ADR 014.
+
+## Acceptance Criteria
+- [ ] Story created to update `schema.md` System Invariant 7.

--- a/.foundry/prds/prd-097-096-schema-verifying-state-fix.md
+++ b/.foundry/prds/prd-097-096-schema-verifying-state-fix.md
@@ -32,3 +32,4 @@ This issue updates the invariant to reflect the `VERIFYING` state accurately.
 
 ## Acceptance Criteria
 - [ ] Invariant 7 is updated to clarify that `VERIFYING` and `COMPLETED` nodes are read-only for implementing personas.
+- [ ] epic-097-130-schema-verifying-state-update


### PR DESCRIPTION
This PR breaks down PRD `prd-097-096-schema-verifying-state-fix` into an Epic node. The epic will manage updating Invariant 7 in `schema.md` to reflect the `VERIFYING` state changes. The PRD has been updated to track the epic's completion.

---
*PR created automatically by Jules for task [14002497237857172310](https://jules.google.com/task/14002497237857172310) started by @szubster*