### PR TITLE
feat(epic-planner): Break down nuzlocke tracker PRD into Epics

### DIFF
--- a/.foundry/epics/epic-097-130-nuzlocke-route-tracking.md
+++ b/.foundry/epics/epic-097-130-nuzlocke-route-tracking.md
@@ -1,0 +1,34 @@
+---
+id: epic-097-130-nuzlocke-route-tracking
+type: EPIC
+title: Automated Route Tracking
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-057-097-automated-nuzlocke-tracker
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Automated Route Tracking
+
+## Objective
+Implement the logic to track which Pokémon were caught on which routes based on save file data.
+
+## Scope
+- Parse save files for all caught Pokémon (Party and PC).
+- Aggregate Pokémon by their `met_location`.
+- Identify the first catch for each distinct location.
+- Flag violations when multiple Pokémon share the same `met_location`.
+
+## Acceptance Criteria
+- [ ] Stories are generated

--- a/.foundry/epics/epic-097-131-nuzlocke-death-tracking.md
+++ b/.foundry/epics/epic-097-131-nuzlocke-death-tracking.md
@@ -1,0 +1,33 @@
+---
+id: epic-097-131-nuzlocke-death-tracking
+type: EPIC
+title: Automated Death Tracking
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-057-097-automated-nuzlocke-tracker
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Automated Death Tracking
+
+## Objective
+Implement the logic to track dead Pokémon based on HP and Graveyard box assignment.
+
+## Scope
+- Detect Pokémon currently at 0 HP in the party as dead.
+- Implement a UI setting or backend flag for a "Graveyard" PC box.
+- Permanently mark any Pokémon in the Graveyard box as dead, regardless of HP.
+
+## Acceptance Criteria
+- [ ] Stories are generated

--- a/.foundry/epics/epic-097-132-nuzlocke-dashboard-ui.md
+++ b/.foundry/epics/epic-097-132-nuzlocke-dashboard-ui.md
@@ -1,0 +1,36 @@
+---
+id: epic-097-132-nuzlocke-dashboard-ui
+type: EPIC
+title: Run Dashboard UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - epic-097-130-nuzlocke-route-tracking
+  - epic-097-131-nuzlocke-death-tracking
+jules_session_id: null
+pr_number: null
+parent: prd-057-097-automated-nuzlocke-tracker
+tags:
+  - feature
+  - nuzlocke
+  - ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Run Dashboard UI
+
+## Objective
+Create a visual dashboard for the Nuzlocke Tracker.
+
+## Scope
+- Build a view showing the current "Alive" team.
+- Display a checklist of visited routes and caught Pokémon.
+- Display a list of unvisited available routes.
+- Build a Graveyard view displaying dead Pokémon visually distinctly.
+
+## Acceptance Criteria
+- [ ] Stories are generated

--- a/.foundry/prds/prd-057-097-automated-nuzlocke-tracker.md
+++ b/.foundry/prds/prd-057-097-automated-nuzlocke-tracker.md
@@ -56,4 +56,9 @@ Currently, players track this information manually using spreadsheets or third-p
 
 ## Next Steps
 - [ ] Break down into Tasks
-- [ ] Break down into Epics
+- [x] Break down into Epics
+
+## Acceptance Criteria
+- [ ] epic-097-130-nuzlocke-route-tracking
+- [ ] epic-097-131-nuzlocke-death-tracking
+- [ ] epic-097-132-nuzlocke-dashboard-ui


### PR DESCRIPTION
This PR fulfills the Epic Planner persona's requirement to break down the "Automated Nuzlocke Verification and Run Tracker" PRD (`prd-057-097-automated-nuzlocke-tracker`) into discrete Epics.

Three Epics have been generated:
1.  **Automated Route Tracking** (`epic-097-130`)
2.  **Automated Death Tracking** (`epic-097-131`)
3.  **Run Dashboard UI** (`epic-097-132`)

The Dashboard UI Epic depends on the two tracking Epics. The parent PRD has been updated to reflect the new Epics as Acceptance Criteria. The `depends_on` fields correctly use raw Node IDs without file extensions to comply with the schema.

---
*PR created automatically by Jules for task [7902475637881869899](https://jules.google.com/task/7902475637881869899) started by @szubster*