### PR TITLE
chore: Break down Save State Storage PRD into Epics

### DIFF
--- a/.foundry/epics/epic-099-130-indexeddb-schema-design.md
+++ b/.foundry/epics/epic-099-130-indexeddb-schema-design.md
@@ -1,0 +1,31 @@
+---
+id: epic-099-130-indexeddb-schema-design
+type: EPIC
+title: IndexedDB Storage Schema Design
+status: PENDING
+owner_persona: story_owner
+created_at: '2024-05-24'
+updated_at: '2024-05-24'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-066-099-save-state-history-storage
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: IndexedDB Storage Schema Design
+
+## Overview
+Define the storage schema for the save state history, including DB name, object stores, and indexes. This forms the foundation for storing sequential `.sav` file uploads for a given playthrough.
+
+## Acceptance Criteria
+- [ ] Define the database name and version.
+- [ ] Define object stores for storing save files, metadata, and indexes for efficient retrieval.
+- [ ] Document the schema.

--- a/.foundry/epics/epic-099-131-save-state-read-write-api.md
+++ b/.foundry/epics/epic-099-131-save-state-read-write-api.md
@@ -1,0 +1,32 @@
+---
+id: epic-099-131-save-state-read-write-api
+type: EPIC
+title: Save State Read/Write API
+status: PENDING
+owner_persona: story_owner
+created_at: '2024-05-24'
+updated_at: '2024-05-24'
+depends_on:
+  - epic-099-130-indexeddb-schema-design
+jules_session_id: null
+pr_number: null
+parent: prd-066-099-save-state-history-storage
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Save State Read/Write API
+
+## Overview
+Implement the core read and write APIs to store new save states and retrieve them, ordered by time.
+
+## Acceptance Criteria
+- [ ] Implement write API to store a new save state file along with its metadata (timestamp, playthrough ID).
+- [ ] Implement read API to retrieve the most recent save state for a playthrough.
+- [ ] Implement read API to retrieve the *previous* state relative to a given state for diffing purposes.

--- a/.foundry/epics/epic-099-132-save-state-lru-eviction-and-limits.md
+++ b/.foundry/epics/epic-099-132-save-state-lru-eviction-and-limits.md
@@ -1,0 +1,32 @@
+---
+id: epic-099-132-save-state-lru-eviction-and-limits
+type: EPIC
+title: Save State Storage Limits and LRU Eviction
+status: PENDING
+owner_persona: story_owner
+created_at: '2024-05-24'
+updated_at: '2024-05-24'
+depends_on:
+  - epic-099-131-save-state-read-write-api
+jules_session_id: null
+pr_number: null
+parent: prd-066-099-save-state-history-storage
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Save State Storage Limits and LRU Eviction
+
+## Overview
+Implement mechanisms to handle storage limits gracefully, including maximum number of states per playthrough and LRU eviction if necessary.
+
+## Acceptance Criteria
+- [ ] Define and implement the maximum number of save states allowed per playthrough.
+- [ ] Implement LRU (Least Recently Used) eviction logic to remove older states when limits are reached.
+- [ ] Ensure the storage engine handles quota exceeded errors gracefully.

--- a/.foundry/prds/prd-066-099-save-state-history-storage.md
+++ b/.foundry/prds/prd-066-099-save-state-history-storage.md
@@ -36,3 +36,6 @@ To support save state version history, we need a robust local storage solution. 
 - [ ] Define storage schema (DB name, object stores, indexes).
 - [ ] Implement write API to store a new save state.
 - [ ] Implement read API to retrieve states (by playthrough, ordered by time).
+- [ ] epic-099-130-indexeddb-schema-design
+- [ ] epic-099-131-save-state-read-write-api
+- [ ] epic-099-132-save-state-lru-eviction-and-limits


### PR DESCRIPTION
This PR breaks down PRD 066-099 (IndexedDB Storage Engine for Save State History) into three distinct Epic nodes according to the Foundry Node Generation guidelines. 

The three epics cover:
1. Schema Design
2. Read/Write API
3. Storage Limits and LRU Eviction

The new Epic IDs have been appended as unchecked tasks to the PRD's Acceptance Criteria section without modifying its YAML frontmatter, ensuring the macro node does not complete prematurely.

---
*PR created automatically by Jules for task [14936860676491518175](https://jules.google.com/task/14936860676491518175) started by @szubster*