### PR TITLE
Generate Epics for Gen 3 Trainer Data Extraction

### DIFF
--- a/.foundry/epics/epic-099-130-gen3-trainer-data-extraction.md
+++ b/.foundry/epics/epic-099-130-gen3-trainer-data-extraction.md
@@ -1,0 +1,34 @@
+---
+id: epic-099-130-gen3-trainer-data-extraction
+type: EPIC
+title: Gen 3 Trainer Data Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-082-099-gen3-trainer-data-extraction
+tags:
+  - feature
+  - gen3
+  - trainer
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Trainer Data Extraction
+
+## Objective
+Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file.
+
+## Requirements
+- [ ] Identify memory offsets for Trainer ID, and Secret ID in a save file.
+- [ ] Update the relevant interface to include Secret ID.
+- [ ] Implement extraction logic in `src/engine/saveParser/parsers/gen3.ts`.
+
+## Acceptance Criteria
+- [ ] Story Owner: Convert this Epic into Stories.

--- a/.foundry/prds/prd-082-099-gen3-trainer-data-extraction.md
+++ b/.foundry/prds/prd-082-099-gen3-trainer-data-extraction.md
@@ -30,4 +30,5 @@ Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file and disp
 - Implement extraction logic in `src/engine/saveParser/parsers/gen3.ts`.
 
 ## Acceptance Criteria
-- [ ] Epic Planner: Convert this PRD into Epics.
+- [x] Epic Planner: Convert this PRD into Epics.
+- [ ] epic-099-130-gen3-trainer-data-extraction


### PR DESCRIPTION
Generated epic-099-130-gen3-trainer-data-extraction based on prd-082-099-gen3-trainer-data-extraction and updated the PRD's checklist to reflect the new dependency.

---
*PR created automatically by Jules for task [5654781344642398498](https://jules.google.com/task/5654781344642398498) started by @szubster*