### PR TITLE
feat: Generate EPICs for Gen 3 data parsing infrastructure

### DIFF
--- a/.foundry/epics/epic-097-130-gen3-data-structure-extraction.md
+++ b/.foundry/epics/epic-097-130-gen3-data-structure-extraction.md
@@ -1,0 +1,31 @@
+---
+id: epic-097-130-gen3-data-structure-extraction
+type: EPIC
+title: Gen 3 Data Structure Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-080-097-gen3-data-parsing-infrastructure
+tags:
+  - gen3
+  - save-engine
+research_references:
+  - .foundry/research/research-175-176-gen3-pokerus-extraction.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Data Structure Extraction
+
+## Objective
+Implement functionality to extract the raw 100-byte Pokémon data structure for each party Pokémon from an active Gen 3 save file section. This includes ensuring correct offset parsing across all Gen 3 games using the DataView API.
+
+## Requirements
+1. Extract the 100-byte structure.
+2. Must use `DataView` API exclusively.
+3. Handle gracefully and properly parse across Ruby, Sapphire, Emerald, FireRed, LeafGreen.

--- a/.foundry/epics/epic-097-131-gen3-data-decryption-mapping.md
+++ b/.foundry/epics/epic-097-131-gen3-data-decryption-mapping.md
@@ -1,0 +1,32 @@
+---
+id: epic-097-131-gen3-data-decryption-mapping
+type: EPIC
+title: Gen 3 Data Decryption and Mapping
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-01'
+updated_at: '2026-07-01'
+depends_on:
+  - epic-097-130-gen3-data-structure-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-080-097-gen3-data-parsing-infrastructure
+tags:
+  - gen3
+  - save-engine
+research_references:
+  - .foundry/research/research-175-176-gen3-pokerus-extraction.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Data Decryption and Mapping
+
+## Objective
+Implement decryption and mapping logic for the 48-byte encrypted Data block extracted from the 100-byte Gen 3 Pokémon data structure.
+
+## Requirements
+1. Calculate the decryption key using `PV XOR OT ID`.
+2. Decrypt the 48-byte Data block using the calculated key.
+3. Resolve the substructure order using `PV % 24` to correctly map the Growth (G), Attacks (A), EVs & Condition (E), and Miscellaneous (M) components.

--- a/.foundry/prds/prd-080-097-gen3-data-parsing-infrastructure.md
+++ b/.foundry/prds/prd-080-097-gen3-data-parsing-infrastructure.md
@@ -30,3 +30,7 @@ Implement the core infrastructure to parse and decrypt the 100-byte Gen 3 Pokém
 2. Calculate the decryption key using `PV XOR OT ID`.
 3. Resolve the substructure order using `PV % 24` to map the decrypted 48-byte block to G, A, E, M components.
 4. Support all Gen 3 games (Ruby, Sapphire, Emerald, FireRed, LeafGreen).
+
+## Acceptance Criteria
+- [ ] epic-097-130-gen3-data-structure-extraction
+- [ ] epic-097-131-gen3-data-decryption-mapping


### PR DESCRIPTION
This PR generates two EPICs out of the parent PRD `prd-080-097-gen3-data-parsing-infrastructure.md`.
The new EPIC nodes are `epic-097-130-gen3-data-structure-extraction.md` and `epic-097-131-gen3-data-decryption-mapping.md`.
The parent PRD was updated with the necessary Acceptance Criteria checkboxes.

---
*PR created automatically by Jules for task [117904704488365652](https://jules.google.com/task/117904704488365652) started by @szubster*