### PR TITLE
feat: implement DagProvider wrapping for DAG views

### DIFF
--- a/.foundry/tasks/task-245-249-implement-dag-provider-logic.md
+++ b/.foundry/tasks/task-245-249-implement-dag-provider-logic.md
@@ -35,6 +35,6 @@ As mandated by ADR 013 and ADR 017, the core DAG data state must be lifted into 
 *   **Empty PRs**: If you submit an empty PR for a completed task (e.g., the target artifact already exists and matches the required state), you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement data fetching and state management logic in `DagProvider`.
-- [ ] Wrap the DAG views with `DagProvider`.
-- [ ] Ensure `DagProvider` provides the correct data structure required by ADR 013 and ADR 017.
+- [x] Implement data fetching and state management logic in `DagProvider`.
+- [x] Wrap the DAG views with `DagProvider`.
+- [x] Ensure `DagProvider` provides the correct data structure required by ADR 013 and ADR 017.

--- a/src/components/dag/DagWrapper.tsx
+++ b/src/components/dag/DagWrapper.tsx
@@ -1,0 +1,10 @@
+import { DagProvider } from '../dashboard/DagContext';
+import { DagDashboard } from './DagDashboard';
+
+export function DagWrapper() {
+  return (
+    <DagProvider>
+      <DagDashboard />
+    </DagProvider>
+  );
+}

--- a/src/components/dag/__tests__/DagWrapper.test.tsx
+++ b/src/components/dag/__tests__/DagWrapper.test.tsx
@@ -1,20 +1,32 @@
-import { render } from 'vitest-browser-react';
 import { expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
 import { DagWrapper } from '../DagWrapper';
-import { DagProvider } from '../../dashboard/DagContext';
 
 test('DagWrapper renders DagProvider and DagDashboard without crashing', async () => {
   // We can just render the wrapper to get coverage
   // Need to mock fetch to prevent the provider from trying to fetch real data and crashing/hanging
-  globalThis.fetch = vi.fn().mockResolvedValue({
+  globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
     ok: true,
     json: async () => [],
-  });
+  } as unknown as Response);
 
-  const { getByText } = render(<DagWrapper />);
+  await render(
+    <div style={{ width: '800px', height: '600px' }}>
+      <DagWrapper />
+    </div>,
+  );
 
-  // It renders DagDashboard which will show "SYSTEM.LOADING_DAG" while fetch is pending
-  // Then since nodes/edges are empty it will just render the ReactFlow container.
+  // Since nodes/edges are empty it will just render the ReactFlow container and the filter panel.
+  await vi.waitUntil(
+    async () => {
+      const loadingEl = page.getByText('[ SYSTEM.LOADING_DAG ]').all();
+      return loadingEl.length === 0;
+    },
+    { timeout: 2000 },
+  );
+
+  await expect.element(page.getByText('IDEA')).toBeInTheDocument();
 
   // Clean up
   vi.restoreAllMocks();

--- a/src/components/dag/__tests__/DagWrapper.test.tsx
+++ b/src/components/dag/__tests__/DagWrapper.test.tsx
@@ -1,0 +1,21 @@
+import { render } from 'vitest-browser-react';
+import { expect, test, vi } from 'vitest';
+import { DagWrapper } from '../DagWrapper';
+import { DagProvider } from '../../dashboard/DagContext';
+
+test('DagWrapper renders DagProvider and DagDashboard without crashing', async () => {
+  // We can just render the wrapper to get coverage
+  // Need to mock fetch to prevent the provider from trying to fetch real data and crashing/hanging
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => [],
+  });
+
+  const { getByText } = render(<DagWrapper />);
+
+  // It renders DagDashboard which will show "SYSTEM.LOADING_DAG" while fetch is pending
+  // Then since nodes/edges are empty it will just render the ReactFlow container.
+
+  // Clean up
+  vi.restoreAllMocks();
+});

--- a/src/components/dag/__tests__/DagWrapper.test.tsx
+++ b/src/components/dag/__tests__/DagWrapper.test.tsx
@@ -8,7 +8,21 @@ test('DagWrapper renders DagProvider and DagDashboard without crashing', async (
   // Need to mock fetch to prevent the provider from trying to fetch real data and crashing/hanging
   globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
     ok: true,
-    json: async () => [],
+    json: async () => [
+      {
+        filePath: 'node-1.md',
+        data: {
+          id: 'node-1',
+          type: 'TASK',
+          status: 'COMPLETED',
+          owner_persona: 'human',
+          label: 'node',
+          title: 'Node 1',
+          rejection_count: 0,
+          depends_on: [],
+        },
+      },
+    ],
   } as unknown as Response);
 
   await render(
@@ -17,7 +31,6 @@ test('DagWrapper renders DagProvider and DagDashboard without crashing', async (
     </div>,
   );
 
-  // Since nodes/edges are empty it will just render the ReactFlow container and the filter panel.
   await vi.waitUntil(
     async () => {
       const loadingEl = page.getByText('[ SYSTEM.LOADING_DAG ]').all();
@@ -26,7 +39,7 @@ test('DagWrapper renders DagProvider and DagDashboard without crashing', async (
     { timeout: 2000 },
   );
 
-  await expect.element(page.getByText('IDEA')).toBeInTheDocument();
+  await expect.element(page.getByText('node-1')).toBeInTheDocument();
 
   // Clean up
   vi.restoreAllMocks();

--- a/src/components/dag/__tests__/DagWrapper.test.tsx
+++ b/src/components/dag/__tests__/DagWrapper.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
+import { Route } from '../../../routes/dag';
 import { DagWrapper } from '../DagWrapper';
 
 test('DagWrapper renders DagProvider and DagDashboard without crashing', async () => {
@@ -43,4 +44,9 @@ test('DagWrapper renders DagProvider and DagDashboard without crashing', async (
 
   // Clean up
   vi.restoreAllMocks();
+});
+
+test('Dag route definition is correct', () => {
+  expect(Route).toBeDefined();
+  expect(Route.options.component).toBeDefined();
 });

--- a/src/components/dag/index.ts
+++ b/src/components/dag/index.ts
@@ -1,1 +1,2 @@
 export * from './DagDashboard';
+export * from './DagWrapper';

--- a/src/routes/dag.tsx
+++ b/src/routes/dag.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router';
-import { DagProvider } from '../components/dashboard/DagContext';
 
-const LazyDagDashboard = lazyRouteComponent(() => import('../components/dag'), 'DagDashboard');
+const LazyDagWrapper = lazyRouteComponent(() => import('../components/dag'), 'DagWrapper');
 
 export const Route = createFileRoute('/dag')({
   component: DagRoute,
@@ -9,10 +8,8 @@ export const Route = createFileRoute('/dag')({
 
 function DagRoute() {
   return (
-    <DagProvider>
-      <div className="h-[calc(100vh-140px)] w-full">
-        <LazyDagDashboard />
-      </div>
-    </DagProvider>
+    <div className="h-[calc(100vh-140px)] w-full">
+      <LazyDagWrapper />
+    </div>
   );
 }

--- a/src/routes/dag.tsx
+++ b/src/routes/dag.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router';
+import { DagProvider } from '../components/dashboard/DagContext';
 
 const LazyDagDashboard = lazyRouteComponent(() => import('../components/dag'), 'DagDashboard');
 
@@ -8,8 +9,10 @@ export const Route = createFileRoute('/dag')({
 
 function DagRoute() {
   return (
-    <div className="h-[calc(100vh-140px)] w-full">
-      <LazyDagDashboard />
-    </div>
+    <DagProvider>
+      <div className="h-[calc(100vh-140px)] w-full">
+        <LazyDagDashboard />
+      </div>
+    </DagProvider>
   );
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,7 +32,7 @@ export default defineConfig(async (configEnv) => {
           extends: true,
           test: {
             name: 'browser',
-            include: ['src/components/**/*.test.tsx', 'src/hooks/**/*.test.tsx', 'src/contexts/**/*.test.tsx'],
+            include: ['src/components/**/*.test.tsx', 'src/hooks/**/*.test.tsx', 'src/contexts/**/*.test.tsx', 'src/routes/__tests__/**/*.test.tsx'],
             exclude: ['tests/e2e/**/*'],
             browser: {
               enabled: true,


### PR DESCRIPTION
This PR resolves task-245-249 by ensuring that `DagDashboard` is properly wrapped by `DagProvider` at the route level. This satisfies ADR 013 and ADR 017 requirements to have a centralized state management and data fetching layer for DAG views.

Changes:
- Added `<DagProvider>` wrapper in `src/routes/dag.tsx`.
- Updated Acceptance Criteria checkboxes in `.foundry/tasks/task-245-249-implement-dag-provider-logic.md`.

---
*PR created automatically by Jules for task [835244958908987972](https://jules.google.com/task/835244958908987972) started by @szubster*