### PR TITLE
Break down RNG calculator PRD into epics

### DIFF
--- a/.foundry/epics/epic-100-130-rng-tid-sid-display.md
+++ b/.foundry/epics/epic-100-130-rng-tid-sid-display.md
@@ -1,0 +1,30 @@
+---
+id: epic-100-130-rng-tid-sid-display
+type: EPIC
+title: RNG TID and SID Display UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-082-100-rng-calculator-integration
+tags:
+  - feature
+  - rng
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# RNG TID and SID Display UI
+
+## Objective
+Provide UI elements to clearly display both the Trainer ID (TID) and Secret ID (SID) together, including an easy way to copy these values to the clipboard for external RNG tool usage.
+
+## Acceptance Criteria
+- [ ] Ensure TID and SID are displayed together in the UI.
+- [ ] Implement a copy-to-clipboard button for the TID/SID combination.
+- [ ] Story Owner: Convert this Epic into actionable Stories.

--- a/.foundry/epics/epic-100-131-rng-explainer-section.md
+++ b/.foundry/epics/epic-100-131-rng-explainer-section.md
@@ -1,0 +1,31 @@
+---
+id: epic-100-131-rng-explainer-section
+type: EPIC
+title: RNG Tool Explainer Integration
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-02'
+updated_at: '2026-07-02'
+depends_on:
+  - epic-100-130-rng-tid-sid-display
+jules_session_id: null
+pr_number: null
+parent: prd-082-100-rng-calculator-integration
+tags:
+  - feature
+  - rng
+  - explainer
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# RNG Tool Explainer Integration
+
+## Objective
+Provide a brief, user-friendly explainer section within the RNG calculator UI that instructs users on how to input and utilize their TID/SID combination with external RNG manipulation tools.
+
+## Acceptance Criteria
+- [ ] Provide a brief text explainer in the UI on how to use TID/SID values with external RNG tools.
+- [ ] Ensure the explanation is accessible and easy to understand for users new to RNG manipulation.
+- [ ] Story Owner: Convert this Epic into actionable Stories.

--- a/.foundry/prds/prd-082-100-rng-calculator-integration.md
+++ b/.foundry/prds/prd-082-100-rng-calculator-integration.md
@@ -29,4 +29,6 @@ Provide utilities and UI that displays TID and SID and formats this combo for RN
 - Provide a brief explainer in the UI on how to use these values with RNG tools.
 
 ## Acceptance Criteria
-- [ ] Epic Planner: Convert this PRD into Epics.
+- [x] Epic Planner: Convert this PRD into Epics.
+- [ ] epic-100-130-rng-tid-sid-display
+- [ ] epic-100-131-rng-explainer-section


### PR DESCRIPTION
Breaks down PRD `prd-082-100-rng-calculator-integration` into two Epics: `epic-100-130-rng-tid-sid-display` and `epic-100-131-rng-explainer-section`. Updates the PRD's checklist correctly.

---
*PR created automatically by Jules for task [1160459720360475784](https://jules.google.com/task/1160459720360475784) started by @szubster*