### PR TITLE
Investigate Linter for Save Parsing Offsets

### DIFF
--- a/.foundry/docs/architecture/offset_linter_investigation.md
+++ b/.foundry/docs/architecture/offset_linter_investigation.md
@@ -1,0 +1,9 @@
+# Offset Linter Investigation
+
+## Findings
+- Biome does not support custom JavaScript rules yet. The `noMagicNumbers` rule is available but does not allow specific targeting of `DataView` methods or hex strings.
+- Oxlint does not support custom JavaScript rules yet and has limited rules.
+- ESLint supports custom rules, but introducing it would add significant bloat since the project currently uses Biome and Oxlint for linting.
+
+## Proposal
+Given the tooling limitations, I propose falling back to an ADR and code-review enforcement to ensure that memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level rather than as inline magic numbers.

--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -112,3 +112,6 @@ In Generation 2, two Shiny or Shiny Carrier Pokémon cannot breed with each othe
 ### Orchestrator Testing
 - **Observation:** Verified hierarchical completion via markdown links logic by adding unit tests in `.github/scripts/foundry-orchestrator.test.ts`.
 - **Action:** Created explicit tests for markdown link parsing and verification that children completion appropriately blocks and unblocks parents. Checked off acceptance criteria. Tested suite via vitest locally.
+
+## Investigation: Linter for Save Parsing Offsets
+Biome and Oxlint do not currently support custom JS linting rules. The built-in `noMagicNumbers` rule in Biome does not allow the granularity needed to specifically target `DataView` offset arguments, making it unsuitable for our strict save parsing guidelines. Introducing ESLint solely for this purpose would contradict our current tooling choices and add bloat. We should fall back to an ADR and code-review enforcement.

--- a/.foundry/tasks/task-245-249-investigate-offset-linter.md
+++ b/.foundry/tasks/task-245-249-investigate-offset-linter.md
@@ -30,9 +30,9 @@ Investigate if a custom ESLint or Biome rule can be built to flag hardcoded abso
 Currently, save file extraction uses absolute hardcoded offsets for dynamic blocks, which can lead to unpredictable behavior and regressions. We need to investigate tooling options to enforce that memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level rather than as inline magic numbers.
 
 ## Acceptance Criteria
-- [ ] Investigate the feasibility of creating a custom ESLint or Biome rule.
-- [ ] Document findings and propose next steps (either create the rule or fall back to an ADR). The documentation should be placed in `.foundry/docs/architecture/offset_linter_investigation.md` (or similar appropriate location).
-- [ ] Self-verification: The `coder` persona will self-verify the findings in their journal, as this is an exploratory task with no runtime risks.
+- [x] Investigate the feasibility of creating a custom ESLint or Biome rule.
+- [x] Document findings and propose next steps (either create the rule or fall back to an ADR). The documentation should be placed in `.foundry/docs/architecture/offset_linter_investigation.md` (or similar appropriate location).
+- [x] Self-verification: The `coder` persona will self-verify the findings in their journal, as this is an exploratory task with no runtime risks.
 
 ## Developer Reminders
 - **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
This PR fulfills `task-245-249-investigate-offset-linter`.

- Investigated the feasibility of using custom ESLint or Biome rules to enforce reusable constants over inline magic numbers in save parsing logic.
- Found that Biome and Oxlint currently do not support custom JavaScript linting rules, and the built-in `noMagicNumbers` rule lacks the required granularity (cannot specifically target `DataView` offset arguments).
- Proposed falling back to an ADR and code-review enforcement, rather than introducing ESLint solely for this purpose, which would add tooling bloat.
- Documented these findings and the proposal in `.foundry/docs/architecture/offset_linter_investigation.md`.
- Self-verified the investigation in the coder's journal (`.foundry/journals/coder.md`).
- Checked off all acceptance criteria in the task markdown body.

---
*PR created automatically by Jules for task [15291319001689934054](https://jules.google.com/task/15291319001689934054) started by @szubster*