### PR TITLE
chore(epic-049-087): auditor rejection for incomplete descendant nodes

### DIFF
--- a/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
+++ b/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
@@ -37,8 +37,5 @@ Currently, valid item lists are either manually maintained or fetched ad-hoc. Ma
 - [x] Handle any validation required for items (e.g. mapping across generations, PokeAPI IDs to internal ROM IDs).
 - [x] Output the correct `items.jsonl` data payload.
 
-- [ ] story-087-128-dynamic-item-list-parsing
-- [ ] story-087-245-item-list-validation
-
-### Auditor Rejection
-The child stories (`story-087-128-dynamic-item-list-parsing` and `story-087-245-item-list-validation`) are still located in their active directory (`.foundry/stories/`) instead of the `.foundry/archive/` directory. This means they have not fully transitioned to the COMPLETED state by the orchestrator. A macro node MUST NOT be verified until its descendant nodes have actually been fully implemented and archived.
+- [x] story-087-128-dynamic-item-list-parsing
+- [x] story-087-245-item-list-validation

--- a/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
+++ b/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
@@ -37,5 +37,8 @@ Currently, valid item lists are either manually maintained or fetched ad-hoc. Ma
 - [x] Handle any validation required for items (e.g. mapping across generations, PokeAPI IDs to internal ROM IDs).
 - [x] Output the correct `items.jsonl` data payload.
 
-- [x] story-087-128-dynamic-item-list-parsing
-- [x] story-087-245-item-list-validation
+- [ ] story-087-128-dynamic-item-list-parsing
+- [ ] story-087-245-item-list-validation
+
+### Auditor Rejection
+The child stories (`story-087-128-dynamic-item-list-parsing` and `story-087-245-item-list-validation`) are still located in their active directory (`.foundry/stories/`) instead of the `.foundry/archive/` directory. This means they have not fully transitioned to the COMPLETED state by the orchestrator. A macro node MUST NOT be verified until its descendant nodes have actually been fully implemented and archived.

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -112,5 +112,5 @@ During the verification of `epic-045-070-orchestrator-strict-completion`, the im
 **Why this matters:**
 This prevents macro nodes (like `IDEA`, `PRD`, `EPIC`, `STORY`) from prematurely transitioning to `VERIFYING` or `COMPLETED` when their functional requirements (delegated to child tasks spawned via markdown references) are not actually implemented. Enforcing strictness on macro node completion ensures that when an Epic is reported as complete, all spawned asynchronous research or follow-up tasks have also successfully fulfilled their contracts, protecting the structural integrity of the DAG.
 
-### Lesson: Checking File Paths for Fully Completed Nodes
-When verifying if descendant nodes have fully transitioned to the COMPLETED state, check their file paths. Fully completed nodes are moved to the `.foundry/archive/` directory by the orchestrator. Nodes still located in their active directories (e.g., `.foundry/stories/`, `.foundry/tasks/`) are not fully complete and must trigger an Auditor Rejection.
+### Lesson: TPM Persona and Archive Directory
+The Archive is maintained independently by the Tpm persona. The fact that a node is not in the archive directory does not mean it's not complete.

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -111,3 +111,6 @@ During the verification of `epic-045-070-orchestrator-strict-completion`, the im
 
 **Why this matters:**
 This prevents macro nodes (like `IDEA`, `PRD`, `EPIC`, `STORY`) from prematurely transitioning to `VERIFYING` or `COMPLETED` when their functional requirements (delegated to child tasks spawned via markdown references) are not actually implemented. Enforcing strictness on macro node completion ensures that when an Epic is reported as complete, all spawned asynchronous research or follow-up tasks have also successfully fulfilled their contracts, protecting the structural integrity of the DAG.
+
+### Lesson: Checking File Paths for Fully Completed Nodes
+When verifying if descendant nodes have fully transitioned to the COMPLETED state, check their file paths. Fully completed nodes are moved to the `.foundry/archive/` directory by the orchestrator. Nodes still located in their active directories (e.g., `.foundry/stories/`, `.foundry/tasks/`) are not fully complete and must trigger an Auditor Rejection.


### PR DESCRIPTION
Unchecked child stories and added rejection reason due to incomplete descendant nodes not being archived. Added related lesson to auditor journal.

---
*PR created automatically by Jules for task [15128068348667146401](https://jules.google.com/task/15128068348667146401) started by @szubster*