### PR TITLE
feat(foundry): break down move tutor epic into stories

### DIFF
--- a/.foundry/epics/epic-055-119-gen3-move-tutor-save-parsing.md
+++ b/.foundry/epics/epic-055-119-gen3-move-tutor-save-parsing.md
@@ -42,3 +42,5 @@ Implement the logic to parse Gen 3 save files and extract the event flags indica
 - [ ] Move Tutor flags are correctly extracted from FireRed/LeafGreen save files using `DataView`.
 - [ ] The parser correctly distinguishes between "Available" (flag unset) and "Used" (flag set) tutors.
 - [ ] Out-of-bounds reads or malformed saves are handled gracefully without application crashes.
+- [ ] story-119-267-gen3-move-tutor-emerald-parsing
+- [ ] story-119-268-gen3-move-tutor-frlg-parsing

--- a/.foundry/stories/story-119-267-gen3-move-tutor-emerald-parsing.md
+++ b/.foundry/stories/story-119-267-gen3-move-tutor-emerald-parsing.md
@@ -1,0 +1,35 @@
+---
+id: story-119-267-gen3-move-tutor-emerald-parsing
+type: STORY
+title: Parse Gen 3 Emerald Move Tutor Flags
+status: PENDING
+owner_persona: tech_lead
+created_at: 2026-07-03T00:00:00.000Z
+updated_at: 2026-07-03T00:00:00.000Z
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-055-119-gen3-move-tutor-save-parsing
+tags:
+  - gen3
+  - save-parsing
+  - move-tutor
+  - emerald
+research_references:
+  - research-055-247-gen3-move-tutor-offsets
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Parse Gen 3 Emerald Move Tutor Flags
+
+## Objective
+Design a parser that extracts Emerald Move Tutor flags from the save file's `event_flags`.
+
+## Context
+As described in `research-055-247-gen3-move-tutor-offsets` (detailed in `gen3_move_tutor_offsets.md`), Emerald tracks Move Tutor usages within a continuous bit array of `event_flags` starting at offset `0x1270` within `SaveBlock1`.
+- Data must be extracted using `DataView` as mandated by ADR 010.
+
+## Acceptance Criteria
+- [ ] Create tasks for implementing DataView-based extraction of Emerald Move Tutor bits.

--- a/.foundry/stories/story-119-268-gen3-move-tutor-frlg-parsing.md
+++ b/.foundry/stories/story-119-268-gen3-move-tutor-frlg-parsing.md
@@ -1,0 +1,35 @@
+---
+id: story-119-268-gen3-move-tutor-frlg-parsing
+type: STORY
+title: Parse Gen 3 FRLG Move Tutor Flags
+status: PENDING
+owner_persona: tech_lead
+created_at: 2026-07-03T00:00:00.000Z
+updated_at: 2026-07-03T00:00:00.000Z
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-055-119-gen3-move-tutor-save-parsing
+tags:
+  - gen3
+  - save-parsing
+  - move-tutor
+  - frlg
+research_references:
+  - research-055-247-gen3-move-tutor-offsets
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Parse Gen 3 FRLG Move Tutor Flags
+
+## Objective
+Design a parser that extracts FireRed and LeafGreen Move Tutor flags from the save file's `event_flags`.
+
+## Context
+As described in `research-055-247-gen3-move-tutor-offsets` (detailed in `gen3_move_tutor_offsets.md`), FRLG tracks Move Tutor usages within a continuous bit array of `event_flags`.
+- Data must be extracted using `DataView` as mandated by ADR 010.
+
+## Acceptance Criteria
+- [ ] Create tasks for implementing DataView-based extraction of FRLG Move Tutor bits.


### PR DESCRIPTION
This PR handles the Story generation for Epic `epic-055-119-gen3-move-tutor-save-parsing`.

**Changes**
1. Created `.foundry/stories/story-119-267-gen3-move-tutor-emerald-parsing.md`
2. Created `.foundry/stories/story-119-268-gen3-move-tutor-frlg-parsing.md`
3. Updated the Acceptance Criteria in `epic-055-119-gen3-move-tutor-save-parsing.md` to list these new stories.

The parent epic's own acceptance criteria checkboxes intentionally remain unchecked because its child nodes are still pending.

---
*PR created automatically by Jules for task [11883148331797996378](https://jules.google.com/task/11883148331797996378) started by @szubster*