### PR TITLE
Update DAG Orchestration Tests

### DIFF
--- a/.foundry/tasks/task-107-253-update-dag-orchestration-tests.md
+++ b/.foundry/tasks/task-107-253-update-dag-orchestration-tests.md
@@ -39,5 +39,5 @@ A recent refactor moved DAG utilities (like `todayISO`, `buildReverseDependencyG
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Existing orchestration tests are verified to pass successfully.
-- [ ] Any necessary imports are updated, or if no changes are needed, an empty PR is submitted with this checkbox checked.
+- [x] Existing orchestration tests are verified to pass successfully.
+- [x] Any necessary imports are updated, or if no changes are needed, an empty PR is submitted with this checkbox checked.


### PR DESCRIPTION
Checked off the acceptance criteria for updating DAG orchestration tests since they already pass and use the correct methods.

---
*PR created automatically by Jules for task [9127575521615074271](https://jules.google.com/task/9127575521615074271) started by @szubster*