### PR TITLE
Epic breakdown for RNG TID and SID display

### DIFF
--- a/.foundry/epics/epic-100-130-rng-tid-sid-display.md
+++ b/.foundry/epics/epic-100-130-rng-tid-sid-display.md
@@ -27,4 +27,6 @@ Provide UI elements to clearly display both the Trainer ID (TID) and Secret ID (
 ## Acceptance Criteria
 - [ ] Ensure TID and SID are displayed together in the UI.
 - [ ] Implement a copy-to-clipboard button for the TID/SID combination.
-- [ ] Story Owner: Convert this Epic into actionable Stories.
+- [x] Story Owner: Convert this Epic into actionable Stories.
+- [ ] story-130-269-rng-tid-sid-component
+- [ ] story-130-270-rng-tid-sid-integration

--- a/.foundry/stories/story-130-269-rng-tid-sid-component.md
+++ b/.foundry/stories/story-130-269-rng-tid-sid-component.md
@@ -1,0 +1,30 @@
+---
+id: story-130-269-rng-tid-sid-component
+type: STORY
+title: RNG TID and SID Display Component
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-100-130-rng-tid-sid-display
+tags:
+  - feature
+  - rng
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# RNG TID and SID Display Component
+
+## Objective
+Design and implement a reusable UI component that clearly displays both the Trainer ID (TID) and Secret ID (SID) side-by-side. The component must adhere to the tactical hardware aesthetic.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Generate actionable Tasks.
+- [ ] Component displays TID and SID.
+- [ ] Component includes a "Copy to Clipboard" feature that formats them appropriately for RNG tools.

--- a/.foundry/stories/story-130-270-rng-tid-sid-integration.md
+++ b/.foundry/stories/story-130-270-rng-tid-sid-integration.md
@@ -1,0 +1,31 @@
+---
+id: story-130-270-rng-tid-sid-integration
+type: STORY
+title: RNG TID and SID UI Integration
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on:
+  - story-130-269-rng-tid-sid-component
+jules_session_id: null
+pr_number: null
+parent: epic-100-130-rng-tid-sid-display
+tags:
+  - feature
+  - rng
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# RNG TID and SID UI Integration
+
+## Objective
+Integrate the newly created TID/SID display component into the main Trainer dashboard or relevant save data summary views so users can readily access this information.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Generate actionable Tasks.
+- [ ] The TID/SID component is rendered in the appropriate dashboard view.
+- [ ] Ensure the component receives the correct data from the save state.


### PR DESCRIPTION
Break down epic-100-130-rng-tid-sid-display into granular story nodes:
- `story-130-269-rng-tid-sid-component`
- `story-130-270-rng-tid-sid-integration`

Appended children to parent markdown body and checked off the `Story Owner` acceptance criteria checkbox.

---
*PR created automatically by Jules for task [4072554652805957814](https://jules.google.com/task/4072554652805957814) started by @szubster*