### PR TITLE
Create Task to Investigate Trick House Offsets

### DIFF
--- a/.foundry/stories/story-111-249-investigate-trick-house-offsets.md
+++ b/.foundry/stories/story-111-249-investigate-trick-house-offsets.md
@@ -30,5 +30,6 @@ Investigate and document the exact memory offsets and bitflags used for Trick Ho
 - Documenting the findings in the `.foundry/docs/knowledge_base/` directory (e.g., as `gen3_trick_house_offsets.md`).
 
 ## Acceptance Criteria
+- [ ] task-249-261-investigate-trick-house-offsets
 - [ ] Locate the memory offset and data structure for Trick House.
 - [ ] Document the findings in the knowledge base.

--- a/.foundry/tasks/task-249-261-investigate-trick-house-offsets.md
+++ b/.foundry/tasks/task-249-261-investigate-trick-house-offsets.md
@@ -1,0 +1,36 @@
+---
+id: task-249-261-investigate-trick-house-offsets
+type: TASK
+title: Investigate Gen 3 Trick House Offsets
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-111-249-investigate-trick-house-offsets
+tags:
+  - feature
+  - gen3
+  - mechanics
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Task: Investigate Gen 3 Trick House Offsets
+
+## Description
+Investigate the decompiled source code (e.g., `pret/pokeemerald`) or other documentation to locate exactly where the Trick House puzzle state is stored in `SaveBlock1` or `SaveBlock2` for Gen 3 save files (Ruby, Sapphire, Emerald). Document the exact memory offsets and bitflags used for Trick House progression.
+
+## Acceptance Criteria
+- [ ] Locate the memory offset and data structure for Trick House.
+- [ ] Document the findings in `.foundry/docs/knowledge_base/gen3_trick_house_offsets.md`.
+
+## Notes
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail the task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.


### PR DESCRIPTION
This PR fulfills the Tech Lead responsibility of breaking down `story-111-249-investigate-trick-house-offsets` by drafting an actionable technical blueprint (`task-249-261-investigate-trick-house-offsets.md`) for the Coder persona to locate and document Gen 3 Trick House memory offsets. The new child task is registered in the parent node's Markdown body per the single-parent ID schema and strict dependency management rules.

---
*PR created automatically by Jules for task [5574182834864354917](https://jules.google.com/task/5574182834864354917) started by @szubster*