### PR TITLE
Automated Death Tracking Stories

### DIFF
--- a/.foundry/epics/epic-097-131-nuzlocke-death-tracking.md
+++ b/.foundry/epics/epic-097-131-nuzlocke-death-tracking.md
@@ -30,4 +30,7 @@ Implement the logic to track dead Pokémon based on HP and Graveyard box assignm
 - Permanently mark any Pokémon in the Graveyard box as dead, regardless of HP.
 
 ## Acceptance Criteria
-- [ ] Stories are generated
+- [x] Stories are generated
+- [ ] story-131-269-detect-party-zero-hp
+- [ ] story-131-270-graveyard-box-state
+- [ ] story-131-271-graveyard-box-ui

--- a/.foundry/stories/story-131-269-detect-party-zero-hp.md
+++ b/.foundry/stories/story-131-269-detect-party-zero-hp.md
@@ -1,0 +1,32 @@
+---
+id: story-131-269-detect-party-zero-hp
+type: STORY
+title: Detect Party Zero HP as Dead
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-097-131-nuzlocke-death-tracking
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Detect Party Zero HP as Dead
+
+## Objective
+Implement logic to detect Pokémon in the party with 0 HP and mark them as dead.
+
+## Scope
+- Analyze party Pokémon HP data.
+- Add logic to identify Pokémon with 0 HP as dead.
+
+## Acceptance Criteria
+- [ ] Tasks are generated

--- a/.foundry/stories/story-131-270-graveyard-box-state.md
+++ b/.foundry/stories/story-131-270-graveyard-box-state.md
@@ -1,0 +1,32 @@
+---
+id: story-131-270-graveyard-box-state
+type: STORY
+title: Graveyard Box State and Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-097-131-nuzlocke-death-tracking
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Graveyard Box State and Logic
+
+## Objective
+Implement backend state and calculation logic for identifying Pokémon in the designated Graveyard Box as permanently dead.
+
+## Scope
+- Implement a backend flag/state for the Graveyard Box.
+- Implement logic to mark any Pokémon in the Graveyard Box as dead regardless of HP.
+
+## Acceptance Criteria
+- [ ] Tasks are generated

--- a/.foundry/stories/story-131-271-graveyard-box-ui.md
+++ b/.foundry/stories/story-131-271-graveyard-box-ui.md
@@ -1,0 +1,33 @@
+---
+id: story-131-271-graveyard-box-ui
+type: STORY
+title: Graveyard Box UI
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on:
+  - story-131-270-graveyard-box-state
+jules_session_id: null
+pr_number: null
+parent: epic-097-131-nuzlocke-death-tracking
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Graveyard Box UI
+
+## Objective
+Implement a UI setting to allow users to designate a specific PC box as the Graveyard Box.
+
+## Scope
+- Create a UI component/setting for Graveyard Box selection.
+- Connect the UI setting to the backend state.
+
+## Acceptance Criteria
+- [ ] Tasks are generated


### PR DESCRIPTION
Generated stories for tracking deaths in Nuzlocke runs.

This PR introduces three new STORY nodes based on the epic:
1. `story-131-269-detect-party-zero-hp.md` - Detect Party Zero HP as Dead
2. `story-131-270-graveyard-box-state.md` - Graveyard Box State and Logic
3. `story-131-271-graveyard-box-ui.md` - Graveyard Box UI

The parent `epic-097-131-nuzlocke-death-tracking.md` has been updated to reflect these new tasks in its Acceptance Criteria.

---
*PR created automatically by Jules for task [17470011512367675514](https://jules.google.com/task/17470011512367675514) started by @szubster*