### PR TITLE
chore(foundry): mark task-133-251 as completed

### DIFF
--- a/.foundry/tasks/task-133-251-remediation-state-transition-logic-impl.md
+++ b/.foundry/tasks/task-133-251-remediation-state-transition-logic-impl.md
@@ -33,5 +33,5 @@ Following the detection of "zombie" nodes (nodes incorrectly stuck in the `ACTIV
 - **Reminder**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## 3. Acceptance Criteria
-- [ ] Implement utility function to update node frontmatter status to `FAILED`.
-- [ ] Create unit tests to verify state transition logic.
+- [x] Implement utility function to update node frontmatter status to `FAILED`.
+- [x] Create unit tests to verify state transition logic.


### PR DESCRIPTION
The remediation state transition logic was already fully implemented in `.github/scripts/remediate-zombie.ts` and tested in `.github/scripts/remediate-zombie.test.ts`. This empty PR simply checks off the Acceptance Criteria in the task markdown file to transition it to the VERIFYING state, per the Empty PR policy.

---
*PR created automatically by Jules for task [10904164063796251610](https://jules.google.com/task/10904164063796251610) started by @szubster*