### PR TITLE
chore(foundry): break down tailwind v4 utilities epic into stories

### DIFF
--- a/.foundry/epics/epic-071-123-define-tailwind-v4-utilities-v2.md
+++ b/.foundry/epics/epic-071-123-define-tailwind-v4-utilities-v2.md
@@ -40,3 +40,5 @@ Extract and consolidate common, repetitive Tailwind class patterns used througho
 ## Acceptance Criteria
 - [ ] Appropriate `@utility` primitives are defined in `src/index.css`.
 - [ ] Tailwind v4 formatting and structure is respected.
+- [ ] story-123-269-define-tactical-layout-utilities
+- [ ] story-123-270-define-tactical-form-utilities

--- a/.foundry/stories/story-123-269-define-tactical-layout-utilities.md
+++ b/.foundry/stories/story-123-269-define-tactical-layout-utilities.md
@@ -1,0 +1,34 @@
+---
+id: story-123-269-define-tactical-layout-utilities
+type: STORY
+title: Define Tactical Layout Utilities
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-071-123-define-tailwind-v4-utilities-v2
+tags:
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Story: Define Tactical Layout Utilities
+
+## Objective
+Define the base layout-related `@utility` primitives in `src/index.css` to consolidate repetitive tactical styling.
+
+## Scope
+1. Analyze the codebase for repetitive patterns representing panels, cards, and buttons that fit the "tactical hardware" aesthetic.
+2. Add `@utility` definitions in `src/index.css` for `tactical-panel`, `tactical-card`, and `tactical-button`.
+3. Ensure hover and focus states are correctly handled within the utility definition using nested states or leveraging Tailwind v4's native variant inheritance.
+
+## Acceptance Criteria
+- [ ] `tactical-panel` utility is defined.
+- [ ] `tactical-card` utility is defined.
+- [ ] `tactical-button` utility is defined.

--- a/.foundry/stories/story-123-270-define-tactical-form-utilities.md
+++ b/.foundry/stories/story-123-270-define-tactical-form-utilities.md
@@ -1,0 +1,35 @@
+---
+id: story-123-270-define-tactical-form-utilities
+type: STORY
+title: Define Tactical Form and Text Utilities
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on:
+  - story-123-269-define-tactical-layout-utilities
+jules_session_id: null
+pr_number: null
+parent: epic-071-123-define-tailwind-v4-utilities-v2
+tags:
+  - styling
+  - tailwind
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Story: Define Tactical Form and Text Utilities
+
+## Objective
+Define the form and text-related `@utility` primitives in `src/index.css` to consolidate repetitive tactical styling, after the base layout utilities are defined.
+
+## Scope
+1. Analyze the codebase for repetitive patterns representing inputs, focused states, and specific text styles that fit the "tactical hardware" aesthetic.
+2. Add `@utility` definitions in `src/index.css` for `tactical-input`, `tactical-focus`, and `tactical-text`.
+3. Ensure these utilities adhere to ADR 024 constraints (sharp edges, monospaced fonts, etc.).
+
+## Acceptance Criteria
+- [ ] `tactical-input` utility is defined.
+- [ ] `tactical-focus` utility is defined.
+- [ ] `tactical-text` utility is defined.


### PR DESCRIPTION
This PR breaks down `epic-071-123-define-tailwind-v4-utilities-v2` into two granular `STORY` nodes for defining tactical Tailwind v4 utilities, assigning ownership to the `tech_lead` persona. The parent Epic has been updated to include these child nodes as unchecked tasks.

---
*PR created automatically by Jules for task [8900030872334964349](https://jules.google.com/task/8900030872334964349) started by @szubster*