### PR TITLE
feat(parser): implement Gen 3 egg hatch data extraction

### DIFF
--- a/.foundry/tasks/task-159-249-gen3-egg-hatch-parsing-impl.md
+++ b/.foundry/tasks/task-159-249-gen3-egg-hatch-parsing-impl.md
@@ -40,8 +40,8 @@ Similar to Gen 2, Gen 3 repurposes the Friendship byte to store remaining "Egg C
 - Explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
 
 ## Acceptance Criteria
-- [ ] Implement module-level constants for offsets, lengths, and bit shifts.
-- [ ] Extract the "Is Egg" bit flag from the Miscellaneous (M) substructure using `DataView`.
-- [ ] If it is an egg, parse the Friendship byte from the Growth (G) substructure using `DataView`.
-- [ ] Multiply the parsed cycle count by 256 to calculate exact steps.
-- [ ] Write unit tests verifying the calculation and ensuring `RangeError` handling.
+- [x] Implement module-level constants for offsets, lengths, and bit shifts.
+- [x] Extract the "Is Egg" bit flag from the Miscellaneous (M) substructure using `DataView`.
+- [x] If it is an egg, parse the Friendship byte from the Growth (G) substructure using `DataView`.
+- [x] Multiply the parsed cycle count by 256 to calculate exact steps.
+- [x] Write unit tests verifying the calculation and ensuring `RangeError` handling.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -7,6 +7,7 @@ import {
   parseGen3BattleFrontierWinStreaks,
   parseGen3BattlePoints,
   parseGen3ConditionStats,
+  parseGen3EggSteps,
   parseGen3MirageIslandValue,
   parseGen3MixRecords,
   parseGen3PersonalityValue,
@@ -446,6 +447,54 @@ describe('parseGen3MixRecords', () => {
 
     expect(() => parseGen3MixRecords(view, 0)).toThrowError(
       'The save file is corrupted or incomplete: Invalid TV block struct.',
+    );
+  });
+});
+
+describe('parseGen3EggSteps', () => {
+  it('should return null if the Pokémon is not an egg', () => {
+    const buffer = new ArrayBuffer(100);
+    const view = new DataView(buffer);
+    const miscSubstructureOffset = 0;
+    const growthSubstructureOffset = 50;
+
+    // Set "Is Egg" bit flag to 0 (bit 30)
+    view.setUint32(miscSubstructureOffset + 4, 0, true);
+
+    const result = parseGen3EggSteps(view, miscSubstructureOffset, growthSubstructureOffset);
+    expect(result).toBeNull();
+  });
+
+  it('should calculate the remaining egg steps if the Pokémon is an egg', () => {
+    const buffer = new ArrayBuffer(100);
+    const view = new DataView(buffer);
+    const miscSubstructureOffset = 0;
+    const growthSubstructureOffset = 50;
+
+    // Set "Is Egg" bit flag to 1 (bit 30)
+    // 1 << 30 = 1073741824 (0x40000000)
+    view.setUint32(miscSubstructureOffset + 4, 0x40000000, true);
+
+    // Set egg cycles to 10
+    view.setUint8(growthSubstructureOffset + 4, 10);
+
+    const result = parseGen3EggSteps(view, miscSubstructureOffset, growthSubstructureOffset);
+    // 10 cycles * 256 steps = 2560 steps
+    expect(result).toBe(2560);
+  });
+
+  it('should explicitly catch RangeError and throw corrupted file error on out-of-bounds reads', () => {
+    // Buffer too small for reading the egg cycles at growthSubstructureOffset + 4
+    const buffer = new ArrayBuffer(50);
+    const view = new DataView(buffer);
+    const miscSubstructureOffset = 0;
+    const growthSubstructureOffset = 50;
+
+    // We can read IV/Egg/Ability here since misc is at 0 and +4 is within 50 bytes.
+    view.setUint32(miscSubstructureOffset + 4, 0x40000000, true);
+
+    expect(() => parseGen3EggSteps(view, miscSubstructureOffset, growthSubstructureOffset)).toThrowError(
+      'The save file is corrupted or incomplete.',
     );
   });
 });

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -145,6 +145,11 @@ const PYRAMID_SILVER_BIT = 0;
 const PYRAMID_GOLD_OFFSET = 0x138a;
 const PYRAMID_GOLD_BIT = 1;
 
+const MISC_IV_EGG_ABILITY_OFFSET = 4;
+const IS_EGG_BIT_SHIFT = 30;
+const GROWTH_FRIENDSHIP_OFFSET = 4;
+const EGG_CYCLE_STEPS = 256;
+
 /**
  * Locates the most recent memory offset for a specific save section in Gen 3 flash memory.
  *
@@ -301,6 +306,43 @@ export function isGen3Save(view: DataView): boolean {
   } catch (error) {
     if (error instanceof RangeError) {
       return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Calculates the exact remaining steps for an Egg to hatch in Gen 3.
+ *
+ * @remarks
+ * In Gen 3, the "Is Egg" bit flag is located at bit 30 of the 32-bit IVs/Egg/Ability bitfield
+ * within the Miscellaneous (M) substructure. If set, the Friendship byte in the Growth (G)
+ * substructure is repurposed to store the remaining Egg Cycles. Each cycle takes 256 steps.
+ *
+ * @param view - The raw save file DataView.
+ * @param miscSubstructureOffset - The resolved memory offset to the Miscellaneous (M) substructure.
+ * @param growthSubstructureOffset - The resolved memory offset to the Growth (G) substructure.
+ * @returns The exact remaining steps to hatch, or null if the Pokémon is not an egg.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3EggSteps(
+  view: DataView,
+  miscSubstructureOffset: number,
+  growthSubstructureOffset: number,
+): number | null {
+  try {
+    const ivEggAbility = view.getUint32(miscSubstructureOffset + MISC_IV_EGG_ABILITY_OFFSET, true);
+    const isEgg = (ivEggAbility >> IS_EGG_BIT_SHIFT) & 1;
+
+    if (!isEgg) {
+      return null;
+    }
+
+    const eggCycles = view.getUint8(growthSubstructureOffset + GROWTH_FRIENDSHIP_OFFSET);
+    return eggCycles * EGG_CYCLE_STEPS;
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
     }
     throw error;
   }


### PR DESCRIPTION
Implemented Gen 3 Egg Hatch data extraction as requested in `task-159-249-gen3-egg-hatch-parsing-impl`. The implementation utilizes the DataView API, relies on module-level constants (no inline magic numbers), safely handles out-of-bounds parsing, and is fully tested. All project lint and tests passed locally.

---
*PR created automatically by Jules for task [657138697970413617](https://jules.google.com/task/657138697970413617) started by @szubster*