### PR TITLE
fix: correct parent ID sequence for e2e safeguard story

### DIFF
--- a/.foundry/epics/epic-057-127-orchestrator-safeguard-investigation.md
+++ b/.foundry/epics/epic-057-127-orchestrator-safeguard-investigation.md
@@ -27,5 +27,6 @@ As part of enforcing macro node functional boundaries, we need to ensure that an
 Investigate `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts` to see if there are programmatic ways to enforce that an EPIC cannot bypass the verification stage without a dedicated Integration/E2E story.
 
 ## Acceptance Criteria
-- [ ] Analyze orchestrator scripts for programmatic safeguards.
-- [ ] Create necessary STORY nodes for investigation and implementation if viable.
+- [x] Analyze orchestrator scripts for programmatic safeguards.
+- [x] Create necessary STORY nodes for investigation and implementation if viable.
+- [ ] story-127-269-epic-e2e-safeguard

--- a/.foundry/stories/story-127-269-epic-e2e-safeguard.md
+++ b/.foundry/stories/story-127-269-epic-e2e-safeguard.md
@@ -1,0 +1,31 @@
+---
+id: story-127-269-epic-e2e-safeguard
+type: STORY
+title: Enforce E2E Safeguards on Epics
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-057-127-orchestrator-safeguard-investigation
+tags:
+  - process
+  - orchestrator
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Enforce E2E Safeguards on Epics
+
+## Context
+As part of enforcing macro node functional boundaries, we need to ensure that an EPIC cannot be marked `COMPLETED` until its functional requirements are verifiably integrated and tested.
+
+## Goal
+Implement logic in `.github/scripts/foundry-orchestrator.ts` (or `foundry-heartbeat.ts`) to ensure that an EPIC node cannot be promoted to VERIFYING or COMPLETED unless it contains at least one child STORY that explicitly represents integration or E2E testing (e.g., tags contain `e2e` or `integration`).
+
+## Acceptance Criteria
+- [ ] Implement E2E enforcement logic in orchestrator scripts.
+- [ ] Add unit tests for this new verification rule.


### PR DESCRIPTION
Fixes a bug where the `epic-057-127-orchestrator-safeguard-investigation` created a child story node but assigned it an incorrect parent ID in the sequence (`057` instead of `127`).

The story was renamed to `story-127-269-epic-e2e-safeguard.md` and the ID in the file was updated, as well as the reference in the epic markdown.

---
*PR created automatically by Jules for task [11444623019702749079](https://jules.google.com/task/11444623019702749079) started by @szubster*