### PR TITLE
chore: breakdown Gen 3 Lottery Data Extraction PRD into Epics

### DIFF
--- a/.foundry/epics/epic-104-133-gen3-lottery-offsets-research.md
+++ b/.foundry/epics/epic-104-133-gen3-lottery-offsets-research.md
@@ -1,0 +1,24 @@
+---
+id: epic-104-133-gen3-lottery-offsets-research
+type: EPIC
+title: Gen3 Lottery Offsets Research
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-098-104-gen3-lottery-data-extraction
+tags: [gen3, research]
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen3 Lottery Offsets Research
+
+Research and identify the memory offsets for the daily lottery PRNG seed in Ruby, Sapphire, and Emerald save files.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-104-134-gen3-lottery-data-extraction.md
+++ b/.foundry/epics/epic-104-134-gen3-lottery-data-extraction.md
@@ -1,0 +1,25 @@
+---
+id: epic-104-134-gen3-lottery-data-extraction
+type: EPIC
+title: Gen3 Lottery Data Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on:
+  - epic-104-133-gen3-lottery-offsets-research
+jules_session_id: null
+pr_number: null
+parent: prd-098-104-gen3-lottery-data-extraction
+tags: [gen3, backend]
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen3 Lottery Data Extraction
+
+Implement data extraction logic in the save parser using the DataView API to read the daily lottery PRNG seed and calculate the winning number.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-104-135-gen3-lottery-ui-integration.md
+++ b/.foundry/epics/epic-104-135-gen3-lottery-ui-integration.md
@@ -1,0 +1,25 @@
+---
+id: epic-104-135-gen3-lottery-ui-integration
+type: EPIC
+title: Gen3 Lottery UI Integration
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on:
+  - epic-104-134-gen3-lottery-data-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-098-104-gen3-lottery-data-extraction
+tags: [gen3, frontend]
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen3 Lottery UI Integration
+
+Expose the daily winning lottery number to the application state and build the UI to display it within the Lottery Predictor feature.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/prds/prd-098-104-gen3-lottery-data-extraction.md
+++ b/.foundry/prds/prd-098-104-gen3-lottery-data-extraction.md
@@ -33,4 +33,7 @@ In Gen 3 games, Lilycove Department Store hosts a Pokémon Lottery Corner. The w
 - Expose the daily winning lottery number to the application state so it can be consumed by the UI.
 
 ## Acceptance Criteria
-- [ ] Break down into Epics
+- [x] Break down into Epics
+- [ ] epic-104-133-gen3-lottery-offsets-research
+- [ ] epic-104-134-gen3-lottery-data-extraction
+- [ ] epic-104-135-gen3-lottery-ui-integration


### PR DESCRIPTION
Broke down the Gen3 Lottery Data Extraction PRD into three Epics: Research, Backend Data Extraction, and Frontend UI Integration. Verified changes to parent PRD check off acceptance criteria.

---
*PR created automatically by Jules for task [15674574689352747709](https://jules.google.com/task/15674574689352747709) started by @szubster*