### PR TITLE
docs(foundry): breakdown gen3 lottery predictor PRD into epics

### DIFF
--- a/.foundry/epics/epic-105-133-lottery-matching-logic.md
+++ b/.foundry/epics/epic-105-133-lottery-matching-logic.md
@@ -1,0 +1,33 @@
+---
+id: epic-105-133-lottery-matching-logic
+type: EPIC
+title: Lottery Matching Logic Module
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-098-105-gen3-lottery-predictor-ui
+tags:
+  - feature
+  - gen3
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Lottery Matching Logic Module
+
+## Goal
+Develop a logic module to iterate through the player's party and PC boxes to compare Original Trainer (OT) IDs against the daily winning number.
+
+## Requirements
+- Parse the daily winning number from the extracted save file data.
+- Parse OT IDs from Pokémon in the player's party and PC boxes.
+- Implement matching logic to identify the best match based on matching trailing digits.
+- Determine the corresponding prize tier based on the match.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-105-134-lottery-predictor-ui-component.md
+++ b/.foundry/epics/epic-105-134-lottery-predictor-ui-component.md
@@ -1,0 +1,34 @@
+---
+id: epic-105-134-lottery-predictor-ui-component
+type: EPIC
+title: Lottery Predictor UI Component
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-03'
+updated_at: '2026-07-03'
+depends_on:
+  - epic-105-133-lottery-matching-logic
+jules_session_id: null
+pr_number: null
+parent: prd-098-105-gen3-lottery-predictor-ui
+tags:
+  - feature
+  - gen3
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Lottery Predictor UI Component
+
+## Goal
+Design and implement a UI component (Dashboard widget or dedicated view) to display the lottery prediction.
+
+## Requirements
+- Integrate with the Lottery Matching Logic Module.
+- Display an indicator showing if there is a match.
+- Show the prize tier and the exact Pokémon (box/slot) to claim the prize.
+- Adhere to the tactical hardware aesthetic (ADR 024 and ADR 008 style guidelines) using sharp edges, dashed borders, and monospaced telemetry fonts.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/prds/prd-098-105-gen3-lottery-predictor-ui.md
+++ b/.foundry/prds/prd-098-105-gen3-lottery-predictor-ui.md
@@ -34,4 +34,6 @@ Once the winning lottery number is extracted from the save file, we need to matc
 - Ensure the UI adheres to the tactical hardware aesthetic (ADR 024 and ADR 008 style guidelines).
 
 ## Acceptance Criteria
-- [ ] Break down into Epics
+- [x] Break down into Epics
+- [ ] epic-105-133-lottery-matching-logic
+- [ ] epic-105-134-lottery-predictor-ui-component


### PR DESCRIPTION
This PR transforms the `prd-098-105-gen3-lottery-predictor-ui` node into concrete EPIC breakdowns.

Two new Epics were created:
1. `epic-105-133-lottery-matching-logic`: Focuses on the core logic module to extract daily winning numbers from the save file and match them against OT IDs in the player's party and PC boxes.
2. `epic-105-134-lottery-predictor-ui-component`: Focuses on building the dashboard widget UI to display the prediction results, explicitly depending on the logic module.

The parent PRD has been updated to track these new children as unchecked tasks, and its own 'Break down into Epics' acceptance criteria has been checked.

---
*PR created automatically by Jules for task [1276569396073041963](https://jules.google.com/task/1276569396073041963) started by @szubster*