### PR TITLE
Create story to extract Gen 3 Trainer ID and Secret ID

### DIFF
--- a/.foundry/epics/epic-099-130-gen3-trainer-data-extraction.md
+++ b/.foundry/epics/epic-099-130-gen3-trainer-data-extraction.md
@@ -31,4 +31,5 @@ Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file.
 - [ ] Implement extraction logic in `src/engine/saveParser/parsers/gen3.ts`.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Convert this Epic into Stories.
+- [x] Story Owner: Convert this Epic into Stories.
+- [ ] story-130-269-extract-gen3-trainer-id-secret-id

--- a/.foundry/stories/story-130-269-extract-gen3-trainer-id-secret-id.md
+++ b/.foundry/stories/story-130-269-extract-gen3-trainer-id-secret-id.md
@@ -1,0 +1,32 @@
+---
+id: story-130-269-extract-gen3-trainer-id-secret-id
+type: STORY
+title: Extract Gen 3 Trainer ID and Secret ID
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-099-130-gen3-trainer-data-extraction
+tags:
+  - feature
+  - gen3
+  - trainer
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extract Gen 3 Trainer ID and Secret ID
+
+## Objective
+Update the parser and interface to properly extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file.
+
+## Context
+Based on Bulbapedia's "Save data structure (Generation III)" documentation, the Trainer ID is a 4-byte value located at offset `0x000A` within Section 0 (Trainer Info).
+
+## Acceptance Criteria
+- [ ] Create Tasks for the implementation.


### PR DESCRIPTION
Creates a new STORY node `story-130-269-extract-gen3-trainer-id-secret-id.md` to track the extraction of Gen 3 Trainer ID and Secret ID. Updates the parent Epic node (`epic-099-130-gen3-trainer-data-extraction.md`) to mark the current story breakdown as complete and link the new child node.

---
*PR created automatically by Jules for task [7855089928063975865](https://jules.google.com/task/7855089928063975865) started by @szubster*