### PR TITLE
chore(tasks): create tasks for Gen 2 NPC trade parsing

### DIFF
--- a/.foundry/stories/story-119-258-gen2-npc-trade-parsing.md
+++ b/.foundry/stories/story-119-258-gen2-npc-trade-parsing.md
@@ -26,4 +26,6 @@ notes: ''
 Implement extraction of NPC trade completion flags from Gen 2 (Gold, Silver, Crystal) save files.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break down into tasks for identifying and extracting Gen 2 trade flags.
+- [x] Tech Lead: Break down into tasks for identifying and extracting Gen 2 trade flags.
+- [ ] task-258-261-gen2-npc-trade-parsing-impl
+- [ ] task-258-262-gen2-npc-trade-parsing-qa

--- a/.foundry/tasks/task-258-261-gen2-npc-trade-parsing-impl.md
+++ b/.foundry/tasks/task-258-261-gen2-npc-trade-parsing-impl.md
@@ -1,0 +1,38 @@
+---
+id: task-258-261-gen2-npc-trade-parsing-impl
+type: TASK
+title: "Implement Gen 2 NPC Trade Extraction"
+status: PENDING
+owner_persona: coder
+created_at: "2026-07-04"
+updated_at: "2026-07-04"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-119-258-gen2-npc-trade-parsing
+tags:
+  - backend
+  - save-parsing
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Implement Gen 2 NPC Trade Extraction
+
+## Context
+In Generation 2 (Gold, Silver, Crystal), we want to extract the state of the 7 in-game NPC trades to track completion. The completion flags are stored as an array of 7 bits (a single byte) where each bit corresponds to an NPC trade in order. The offsets in memory are:
+- Crystal: `0x24EB`
+- Gold/Silver: `0x250F`
+
+## Acceptance Criteria
+- [ ] Define the magic number constants `NPC_TRADE_FLAGS_OFFSET_CRYSTAL = 0x24EB;` and `NPC_TRADE_FLAGS_OFFSET_GS = 0x250F;` at the module level in `src/engine/saveParser/parsers/gen2.ts` (forbidding inline magic numbers).
+- [ ] Extend the `SaveData` interface or create a new property for `npcTradeFlags` in the parsed output (as a boolean array of length 7) representing `[MIKE, KYLE, TIM, EMY, CHRIS, KIM, FOREST]`.
+- [ ] Update the `parseGen2Save` function to read the byte at the appropriate offset (`isCrystal ? NPC_TRADE_FLAGS_OFFSET_CRYSTAL : NPC_TRADE_FLAGS_OFFSET_GS`).
+- [ ] Extract the 7 boolean flags using bitwise masking (`byte & (1 << i)`).
+- [ ] Add the `npcTradeFlags` array to the returned data structure.
+- [ ] If transient failures require retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- [ ] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-258-262-gen2-npc-trade-parsing-qa.md
+++ b/.foundry/tasks/task-258-262-gen2-npc-trade-parsing-qa.md
@@ -1,0 +1,36 @@
+---
+id: task-258-262-gen2-npc-trade-parsing-qa
+type: TASK
+title: "QA Gen 2 NPC Trade Extraction"
+status: PENDING
+owner_persona: qa
+created_at: "2026-07-04"
+updated_at: "2026-07-04"
+depends_on:
+  - task-258-261-gen2-npc-trade-parsing-impl
+jules_session_id: null
+pr_number: null
+parent: story-119-258-gen2-npc-trade-parsing
+tags:
+  - backend
+  - save-parsing
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA Gen 2 NPC Trade Extraction
+
+## Context
+The `coder` has implemented parsing logic to extract Gen 2 NPC trade flags from save files.
+
+## Acceptance Criteria
+- [ ] Verify unit tests have been added/updated in `src/engine/saveParser/parsers/gen2.test.ts`.
+- [ ] Ensure tests cover both Gold/Silver and Crystal offsets.
+- [ ] Ensure the tests assert correct extraction of the 7 bitwise flags into a boolean array.
+- [ ] Run the tests (`npx vitest run src/engine/saveParser/parsers/gen2.test.ts`) and ensure they pass.
+- [ ] If transient failures require retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- [ ] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Breaks down \`story-119-258-gen2-npc-trade-parsing\` into technical blueprints to implement extraction of Gen 2 NPC trade completion flags.

- Creates `task-258-261-gen2-npc-trade-parsing-impl` for the parser implementation.
- Creates `task-258-262-gen2-npc-trade-parsing-qa` for QA verification.
- Updates the parent story node with the acceptance criteria and child nodes.

---
*PR created automatically by Jules for task [7153710896196149525](https://jules.google.com/task/7153710896196149525) started by @szubster*