### PR TITLE
docs(foundry): convert static encounter idea to prd

### DIFF
--- a/.foundry/ideas/idea-100-static-encounter-tracker.md
+++ b/.foundry/ideas/idea-100-static-encounter-tracker.md
@@ -36,4 +36,7 @@ Leverage DexHelper's capability to read event flags and hidden state from the sa
 This directly tackles the anxiety of "Did I already catch the Snorlax on Route 12?" by surfacing hidden event flags. It perfectly complements existing collection trackers by transforming static game knowledge (wiki lists of legendaries/static spawns) into a highly personalized, dynamic "to-do list" based strictly on the player's unique save state. This deepens DexHelper's role as the ultimate completionist companion app.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD to detail the event flags to parse across Gens 1-3 for static encounters and define the UI presentation.
+- [x] Product Manager: Convert this idea into a PRD to detail the event flags to parse across Gens 1-3 for static encounters and define the UI presentation.
+
+## Acceptance Criteria
+- [ ] prd-100-106-static-encounter-tracker

--- a/.foundry/prds/prd-100-106-static-encounter-tracker.md
+++ b/.foundry/prds/prd-100-106-static-encounter-tracker.md
@@ -1,0 +1,36 @@
+---
+id: prd-100-106-static-encounter-tracker
+type: PRD
+title: Gen 1-3 Static Encounter & Legendary Checklist
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-100-static-encounter-tracker
+tags:
+  - feature
+  - gen1
+  - gen2
+  - gen3
+research_references: []
+notes: ''
+---
+
+# PRD: Gen 1-3 Static Encounter & Legendary Checklist
+
+## Problem Statement
+For players revisiting old Pokémon save files (Gens 1-3) or trying to catch everything available, figuring out which static encounters (e.g., Snorlax, Sudowoodo, Mewtwo, Rayquaza) they have already completed requires physical in-game travel and guesswork. These encounters are one-time events, and once completed, the event flag is permanently set. There is currently no easy way to view a checklist of these completed and remaining static encounters based on the actual save file state.
+
+## Target Audience
+Completionists and players revisiting old save files who want to track their progress on legendary and static encounters.
+
+## Scope
+- Extract event flags for all stationary encounters across Generations 1, 2, and 3.
+- Develop a unified checklist UI displaying completed and available static encounters.
+- Provide actionable hints (location, level, prerequisites) for available encounters.
+
+## Acceptance Criteria
+- [ ] Epic Planner: Break this PRD down into EPIC nodes for Gen 1, Gen 2, and Gen 3 event flag parsing and checklist UI implementation.


### PR DESCRIPTION
Converts the Idea for the Gen 1-3 Static Encounter & Legendary Checklist into a PRD. Creates a new PRD node assigned to the Epic Planner, and updates the parent Idea's markdown body to track the new child task, strictly adhering to the Foundry DAG generation rules.

---
*PR created automatically by Jules for task [2827931442751923945](https://jules.google.com/task/2827931442751923945) started by @szubster*