### PR TITLE
feat(foundry): Create PRD for PC Box Organization Assistant

### DIFF
--- a/.foundry/ideas/idea-101-pc-box-organization-assistant.md
+++ b/.foundry/ideas/idea-101-pc-box-organization-assistant.md
@@ -36,4 +36,7 @@ Create a "PC Box Organization Assistant" view within DexHelper that acts as a ma
 This feature transforms the limitation of read-only save parsing into an actionable utility. It significantly reduces the cognitive load of organizing large collections in retro games, turning a daunting, chaotic manual task into a guided, satisfying checklist. This perfectly aligns with DexHelper's vision as a premium companion app.
 
 ## Next Steps
-- [ ] Product Manager: Convert this idea into a PRD to explore sorting algorithms and the UI design for a move planner.
+- [x] Product Manager: Convert this idea into a PRD to explore sorting algorithms and the UI design for a move planner.
+
+## Acceptance Criteria
+- [ ] prd-101-106-pc-box-organization-assistant

--- a/.foundry/prds/prd-101-106-pc-box-organization-assistant.md
+++ b/.foundry/prds/prd-101-106-pc-box-organization-assistant.md
@@ -1,0 +1,36 @@
+---
+id: prd-101-106-pc-box-organization-assistant
+type: PRD
+title: Gen 1-3 PC Box Organization Assistant
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-101-pc-box-organization-assistant
+tags:
+  - feature
+  - gen1
+  - gen2
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Gen 1-3 PC Box Organization Assistant
+
+## Objective
+Provide an intelligent, side-by-side guided sorting tool for Generation 1, 2, and 3 games that calculates an optimal PC Box layout and generates a step-by-step "move plan" checklist for the user to execute manually.
+
+## Features
+1.  **Dual-Pane View:** A UI displaying the current save state's PC boxes next to the proposed optimal layout.
+2.  **Sorting Strategies:** Allow users to choose sorting algorithms (e.g., National Dex order, Type, Level).
+3.  **Diff Engine & Move Planner:** A background process that compares the current layout to the target layout and generates a minimal set of manual move operations.
+4.  **Interactive Checklist:** A step-by-step checklist of operations (e.g., "Move Pikachu from Box 1 to Box 5").
+
+## Acceptance Criteria
+- [ ] Break down this PRD into distinct Epics covering UI, diff engine logic, and sorting algorithms.


### PR DESCRIPTION
Transformed the `idea-101-pc-box-organization-assistant` into a concrete PRD node (`prd-101-106-pc-box-organization-assistant`) per the Foundry pipeline rules. The new PRD is owned by the `epic_planner` persona to begin breaking down the PC Box Organization Assistant feature into actionable Epics. The parent IDEA node has been updated to track the child PRD in its Acceptance Criteria.

---
*PR created automatically by Jules for task [15006018774896473315](https://jules.google.com/task/15006018774896473315) started by @szubster*