### PR TITLE
chore(feebas): Check off acceptance criteria for magic numbers refactor

### DIFF
--- a/.foundry/tasks/task-152-260-refactor-feebas-magic-numbers-impl.md
+++ b/.foundry/tasks/task-152-260-refactor-feebas-magic-numbers-impl.md
@@ -32,7 +32,7 @@ The code in `src/engine/gen3/feebas.ts` has already been updated to extract the 
 *   For save file parsing, all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
 
 ## Acceptance Criteria
-- [ ] Ensure `LCG_MULTIPLIER` and `LCG_ADDEND` constants are present.
-- [ ] Ensure `FEEBAS_SPOT_BIT_SHIFT` constant is present.
-- [ ] Ensure `FEEBAS_TOTAL_SPOTS`, `FEEBAS_VALID_SPOTS`, `FEEBAS_BOUNDARY` constants are present.
-- [ ] Ensure constants are exported at the module level.
+- [x] Ensure `LCG_MULTIPLIER` and `LCG_ADDEND` constants are present.
+- [x] Ensure `FEEBAS_SPOT_BIT_SHIFT` constant is present.
+- [x] Ensure `FEEBAS_TOTAL_SPOTS`, `FEEBAS_VALID_SPOTS`, `FEEBAS_BOUNDARY` constants are present.
+- [x] Ensure constants are exported at the module level.


### PR DESCRIPTION
Checked off the acceptance criteria checkboxes in task-152-260-refactor-feebas-magic-numbers-impl.md as the magic numbers in src/engine/gen3/feebas.ts have already been refactored into explicit constants (`LCG_MULTIPLIER`, `LCG_ADDEND`, `FEEBAS_SPOT_BIT_SHIFT`, `FEEBAS_TOTAL_SPOTS`, `FEEBAS_VALID_SPOTS`, `FEEBAS_BOUNDARY`). Submitted as an empty PR per the Empty PR Policy to allow the node to transition to COMPLETED.

---
*PR created automatically by Jules for task [13613789069987090617](https://jules.google.com/task/13613789069987090617) started by @szubster*