### PR TITLE
chore: check off completed tasks in story-090-133

### DIFF
--- a/.foundry/stories/story-090-133-remediation-state-transition-logic.md
+++ b/.foundry/stories/story-090-133-remediation-state-transition-logic.md
@@ -34,5 +34,8 @@ Following the detection of "zombie" nodes (nodes incorrectly stuck in the `ACTIV
 
 ### Next Steps
 - [x] Break down into Tasks.
-- [ ] task-133-251-remediation-state-transition-logic-impl
-- [ ] task-133-252-remediation-state-transition-logic-qa
+- [x] task-133-251-remediation-state-transition-logic-impl
+- [x] task-133-252-remediation-state-transition-logic-qa
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Checked off the completed child task checkboxes (`task-133-251-remediation-state-transition-logic-impl` and `task-133-252-remediation-state-transition-logic-qa`) in `.foundry/stories/story-090-133-remediation-state-transition-logic.md` to allow the story to transition to VERIFYING as per the Empty PR policy.

---
*PR created automatically by Jules for task [10087894287776808483](https://jules.google.com/task/10087894287776808483) started by @szubster*