### PR TITLE
Draft bash timeout wrapper tasks

### DIFF
--- a/.foundry/stories/story-127-267-bash-timeout-wrapper.md
+++ b/.foundry/stories/story-127-267-bash-timeout-wrapper.md
@@ -27,3 +27,5 @@ Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that
 
 ## Acceptance Criteria
 - [ ] Implement timeout wrapper.
+- [ ] task-267-262-bash-timeout-wrapper-impl
+- [ ] task-267-263-bash-timeout-wrapper-qa

--- a/.foundry/tasks/task-267-262-bash-timeout-wrapper-impl.md
+++ b/.foundry/tasks/task-267-262-bash-timeout-wrapper-impl.md
@@ -1,0 +1,38 @@
+---
+id: task-267-262-bash-timeout-wrapper-impl
+type: TASK
+title: Implement timeout wrapper for bash sessions
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-127-267-bash-timeout-wrapper
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement timeout wrapper for bash sessions
+
+## Overview
+Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that run over a specific threshold (e.g., 30 seconds).
+
+## Constraints & Requirements
+- Update the system or linter responsible for executing `run_in_bash_session` to wrap its execution in a timeout mechanism.
+- If a command runs beyond 30 seconds, it must be interrupted and return a helpful error message to the agent, suggesting non-blocking alternatives like `cat` or `tail -n`.
+
+## Instructions for Coder
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement timeout wrapper.

--- a/.foundry/tasks/task-267-263-bash-timeout-wrapper-qa.md
+++ b/.foundry/tasks/task-267-263-bash-timeout-wrapper-qa.md
@@ -1,0 +1,36 @@
+---
+id: task-267-263-bash-timeout-wrapper-qa
+type: TASK
+title: QA timeout wrapper for bash sessions
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on:
+  - task-267-262-bash-timeout-wrapper-impl
+jules_session_id: null
+pr_number: null
+parent: story-127-267-bash-timeout-wrapper
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA timeout wrapper for bash sessions
+
+## Overview
+Verify that the timeout wrapper for `run_in_bash_session` works correctly and interrupts commands that run over the specified threshold (e.g., 30 seconds).
+
+## Instructions for QA
+- Test the wrapper with a deliberate long sleep command or a blocking command like `tail -f` and verify it interrupts after the threshold and returns the expected error message.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify timeout wrapper interrupts long commands.


### PR DESCRIPTION
Breaks down `story-127-267-bash-timeout-wrapper.md` into technical task nodes (`task-267-262-bash-timeout-wrapper-impl.md` and `task-267-263-bash-timeout-wrapper-qa.md`). The parent story has been updated with the appended task checkboxes.

---
*PR created automatically by Jules for task [8049501380722084719](https://jules.google.com/task/8049501380722084719) started by @szubster*