### PR TITLE
Reject epic-049-086: Missing Runtime Integration

### DIFF
--- a/.foundry/epics/epic-049-086-dynamic-move-pp-parsing.md
+++ b/.foundry/epics/epic-049-086-dynamic-move-pp-parsing.md
@@ -36,6 +36,10 @@ Currently, data such as move PPs are either manually maintained or fetched ad-ho
 - [x] Implement parsing logic in `scripts/generate-pokedata.ts` to extract moves data (including PPs).
 - [x] Handle any discrepancies between generations for moves.
 - [x] Output the correct `moves.jsonl` data payload.
+- [ ] Replace manual/hardcoded tables for move data in the application runtime.
+
+### Auditor Rejection
+The implementation successfully generated `moves.jsonl`, but completely failed Goal 4: "Replace manual/hardcoded tables for move data." The client runtime (`src/db/schema.ts`, `src/db/PokeDB.ts`, etc.) was never updated to actually load, inflate, or use this newly generated data. A follow-up story is required to integrate this data into the application and replace the hardcoded tables.
 
 - [x] story-086-128-move-data-extraction
 - [x] story-086-129-move-generation-discrepancies


### PR DESCRIPTION
The implementation successfully generated `moves.jsonl`, but completely failed Goal 4: "Replace manual/hardcoded tables for move data." The client runtime (`src/db/schema.ts`, `src/db/PokeDB.ts`, etc.) was never updated to actually load, inflate, or use this newly generated data. A follow-up story is required to integrate this data into the application and replace the hardcoded tables.

This PR adds an `### Auditor Rejection` section to the Epic and an unchecked acceptance criteria for the missing runtime integration. This triggers the Resurrection Loop so the missing work can be spawned.

---
*PR created automatically by Jules for task [11382729217018241978](https://jules.google.com/task/11382729217018241978) started by @szubster*