### PR TITLE
Automated Max Rejection Cancellation Fixes

### DIFF
--- a/.foundry/ideas/idea-085-lift-rejection-count-state.md
+++ b/.foundry/ideas/idea-085-lift-rejection-count-state.md
@@ -1,0 +1,36 @@
+---
+id: idea-085-lift-rejection-count-state
+type: IDEA
+title: Lift rejection_count state to DagContext
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - refactor
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: 'Created by Agile Coach to address orphaned requirements'
+---
+
+# Lift rejection_count state to DagContext
+
+## Context
+When reviewing the DAG Dashboard code, it was observed that the permanent failure threshold filtering logic (`rejection_count >= 3`) is tightly coupled within `DagDashboard.tsx` and `DagNode.tsx`, and hardcodes the threshold instead of using a lifted state or constant. This tight coupling makes it difficult to maintain and adjust the `MAX_REJECTION_THRESHOLD`. The requirement from ADR 017 to display permanent failures on the DAG dashboard was thus abandoned. When a requirement fails permanently at the `TASK` level without a parent node actively managing it, the Agile Coach should spawn new `IDEA` or replacement `TASK` nodes to ensure the requirement is fulfilled.
+
+## Idea
+1. Expose `MAX_REJECTION_THRESHOLD` in `DagContext.tsx` or a shared utility.
+2. Update `DagDashboard.tsx`, `DagNode.tsx`, and relevant test files to use this shared threshold instead of hardcoding `3`.
+
+## Acceptance Criteria
+- [ ] DagDashboard and DagNode no longer hardcode the threshold for rejection_count.
+- [ ] The threshold is properly lifted or shared.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/ideas/idea-086-fix-orchestrator-phase-3-6.md
+++ b/.foundry/ideas/idea-086-fix-orchestrator-phase-3-6.md
@@ -1,0 +1,37 @@
+---
+id: idea-086-fix-orchestrator-phase-3-6
+type: IDEA
+title: Fix orchestrator phase 3.6 for CANCELLED nodes
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-07-04'
+updated_at: '2026-07-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: 'Created by Agile Coach to address auditor rejection of max rejection cancellation'
+---
+
+# Fix orchestrator phase 3.6 for CANCELLED nodes
+
+## Context
+While implementing "Automated Max Rejection Cancellation" (idea-079), the Auditor rejected the PR because nodes that are transitioned to `CANCELLED` bypass the parent awakening logic in Phase 3.6 of `foundry-orchestrator.ts`. The condition `node.frontmatter.status === 'FAILED'` was not fully expanded to correctly wake up parents for `CANCELLED` nodes with a rejection reason (like max rejection reached).
+
+## Idea
+Update Phase 3.6 in `foundry-orchestrator.ts` to ensure that `CANCELLED` nodes with `rejection_reason === 'Max rejection count reached'` properly trigger the parent awakening ("Impossible Loop") logic, in addition to `FAILED` nodes.
+
+## Acceptance Criteria
+- [ ] Phase 3.6 of `foundry-orchestrator.ts` is updated to handle CANCELLED nodes properly.
+- [ ] The Impossible Loop logic successfully awakens parents when a child is CANCELLED due to reaching the max rejection threshold.
+- [ ] Tests are updated or added to verify this behavior.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
This PR contains the output of the Agile Coach's analysis of the `task-153-254-orchestrator-max-rejection-cancellation-impl` failure. The Agile Coach determined that the requirement from ADR 017 to display permanent failures on the DAG dashboard was abandoned due to the tight coupling of the `rejection_count` state inside `DagDashboard.tsx` and `DagNode.tsx`, and that `CANCELLED` nodes with a `rejection_reason` of `Max rejection count reached` were bypassing the Impossible Loop logic in `foundry-orchestrator.ts`. The Agile Coach has generated two new `IDEA` nodes to address these issues.

---
*PR created automatically by Jules for task [12185486666971901635](https://jules.google.com/task/12185486666971901635) started by @szubster*