### PR TITLE
💡 Visionary: Gen 3 Trainer Card Stars & Achievements Dashboard

### DIFF
--- a/.foundry/ideas/idea-102-gen3-trainer-card-stars.md
+++ b/.foundry/ideas/idea-102-gen3-trainer-card-stars.md
@@ -1,0 +1,42 @@
+---
+id: idea-102-gen3-trainer-card-stars
+type: IDEA
+title: Gen 3 Trainer Card Stars & Achievements Dashboard
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-07-05'
+updated_at: '2026-07-05'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - feature
+  - gen3
+  - achievements
+  - completionist
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Gen 3 Trainer Card Stars & Achievements Dashboard
+
+## Context
+In Generation 3 (specifically Emerald), players can earn up to 4 stars on their Trainer Card by completing macroscopic, game-spanning goals: entering the Hall of Fame, completing the Hoenn Pokédex, completing the National Pokédex, winning all Master Rank Contests, and earning all Gold Symbols in the Battle Frontier. Tracking progress towards these goals in-game requires checking multiple disparate screens and menus, which is tedious for completionist players.
+
+## Proposal
+Create a centralized "Trainer Card Stars & Achievements Dashboard" that aggregates these distinct completion flags from the save file into a single view.
+- Extract the specific flags or counters for HoF entry, Pokédex completion (Hoenn and National), Contest Master Rank victories, and Battle Frontier Gold Symbols.
+- Present these as a clear checklist or visual dashboard (e.g., a digital Trainer Card that updates as goals are met).
+- Provide granular progress for each star (e.g., 3/5 Contest Master Ranks won, 4/7 Gold Symbols earned).
+
+## Value Proposition
+This feature strongly aligns with DexHelper's vision as a premium companion app for hardcore players. By centralizing widely distributed, hard-to-track completion data into a single, unified dashboard, we eliminate tedious in-game menu navigation and provide a highly satisfying "macro-view" of the player's ultimate endgame progress.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD outlining the specific save file offsets to parse and the UI layout for the dashboard.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -179,3 +179,7 @@
 ## 2026-07-04
 **Idea:** Gen 1-3 PC Box Organization Assistant
 **Learning:** When faced with a hard technical limitation (e.g., we cannot write to the save file to auto-sort boxes), we can still provide immense value by creating a "guided assistant." Providing a visual comparison of the "current state" vs "optimal sorted state" and a move planner turns our read-only constraint into an actionable, premium QoL feature for hardcore collectors.
+
+## 2026-07-05
+**Idea:** Gen 3 Trainer Card Stars & Achievements Dashboard
+**Learning:** Consolidating disparate game-spanning goals (like the 4-star Trainer Card in Emerald, which spans HoF, Pokédex, Contests, Battle Frontier) into a unified dashboard significantly increases user value for hardcore completionists. This pattern of turning fragmented in-game UI states into a cohesive macro-view should be repeated for other complex end-game challenges across generations.


### PR DESCRIPTION
Creates a new `IDEA` node proposing a Gen 3 Trainer Card Stars & Achievements Dashboard for DexHelper, which centralizes macroscopic completion flags (like HoF entry, Pokédex completion, Contest Master Ranks, and Battle Frontier Gold Symbols) from the Emerald save file into a single view. The visionary journal has also been updated to record the learning that consolidating fragmented in-game UI states into a cohesive macro-view significantly increases user value for hardcore completionists.

---
*PR created automatically by Jules for task [15873393816265546836](https://jules.google.com/task/15873393816265546836) started by @szubster*