### PR TITLE
🗃️ Archivist: Correct aesthetic contradictions in testing_rules.md

### DIFF
--- a/.agents/rules/testing_rules.md
+++ b/.agents/rules/testing_rules.md
@@ -15,9 +15,9 @@ Whenever a new feature is implemented, you **must** add appropriate tests. Choos
 
 ## 2. Visual Excellence & Design Standards
 The USER expects a **premium, "WOW" experience**. Follow these design axioms strictly:
-- **Modern Retro Aesthetics**: Blend retro Pokédex vibes with modern design systems (vibrant colors, dark modes, glassmorphism, dynamic animations).
+- **Tactical Hardware Aesthetics**: Blend retro Pokédex vibes with utility-driven tactical hardware design patterns (sharp edges, dashed borders, monospaced telemetry fonts, dark modes). Avoid generic glassmorphism or overly smooth elements (see ADR 024).
 - **Prohibit Placeholders**: NEVER use placeholder images. Use the `generate_image` tool to create high-quality assets.
-- **Micro-animations**: Implement hover effects and interactive transitions to make the UI feel alive.
+- **Micro-animations**: Prefer immediate, utilitarian state changes or blocky segmented effects over smooth web-standard transitions.
 - **Predefined Styles**: Use Tailwind v4 standard tokens. Avoid ad-hoc utilities.
 
 ## 3. Bug & Regression Prevention


### PR DESCRIPTION
**Goal**: Correct contradictory information regarding project design standards in `.agents/rules/testing_rules.md`.
**Details**:
- The file incorrectly advised using "glassmorphism".
- I replaced it with the "tactical hardware" design patterns, specifically referencing ADR 024.
- Also updated the micro-animations bullet to match the tactical aesthetic.
**Verification**: Checked the updated contents and ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no issues were introduced.

---
*PR created automatically by Jules for task [2723425011897074110](https://jules.google.com/task/2723425011897074110) started by @szubster*