### PR TITLE
🧹 refactor: extract roamer tracking logic into reusable utility

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -3,3 +3,5 @@
 * When using static analysis tools like `knip` to find unused exports, you must explicitly verify candidates using a global repository search (e.g., `grep`) before removal to ensure they are not implicitly required by tests, mocks, or CI scripts.
 * Scheduled or foundry agents can dynamically spawn new IDEA, TASK, RESEARCH, or ADR nodes in the `.foundry/` directory to handle larger architectural changes or missing context, ensuring the `owner_persona` is set to the appropriate role (e.g., 'researcher' for RESEARCH).
 * Sweeper PRs must use the title format `🧹 [description]` and include `🎯 What`, `💡 Why`, `✅ Verification`, and `✨ Result` in the body.
+
+- If `pnpm install` hangs or fails during git hook setup (e.g., `lefthook install`), run `git config --unset-all --global core.hooksPath` before retrying the installation.

--- a/src/engine/assistant/strategies/gen2Strategy.ts
+++ b/src/engine/assistant/strategies/gen2Strategy.ts
@@ -3,6 +3,7 @@ import { getGen2UnobtainableReason } from '../../exclusives/gen2Exclusives';
 import { getDistanceToMap, resolveOutdoorMapId } from '../../mapGraph/gen2Graph';
 import type { SaveData } from '../../saveParser/index';
 import type { AssistantStrategy, Suggestion } from './types';
+import { getRoamerSuggestions } from './utils/roamer';
 
 export const gen2Strategy: AssistantStrategy = {
   generation: 2,
@@ -24,36 +25,12 @@ export const gen2Strategy: AssistantStrategy = {
     const missingSet = new Set(missingIds);
 
     // 1. Roamer tracking
-    // ⚡ Bolt: converted roamingLegendaries to a Map keyed by speciesId to optimize O(N) loop lookup
-    const roamerMap = new Map(saveData.roamingLegendaries?.map((r) => [r.speciesId, r]));
     const roamers = [
       { id: 243, name: 'Raikou' },
       { id: 244, name: 'Entei' },
       { id: 245, name: 'Suicune' },
     ];
-    for (const roamer of roamers) {
-      // In Crystal, Suicune is a static encounter, not a roamer. Suppress roamer logic for it.
-      if (roamer.id === 245 && saveData.gameVersion === 'crystal') continue;
-
-      if (missingSet.has(roamer.id)) {
-        let isTracked = false;
-        const rData = roamerMap.get(roamer.id);
-        if (rData && rData.mapId !== 0) {
-          isTracked = true;
-        }
-
-        suggestions.push({
-          id: `roamer-${roamer.id}`,
-          category: 'Catch',
-          title: `Track ${roamer.name}`,
-          description: isTracked
-            ? `${roamer.name} is currently roaming! Check your Pokédex to see its current route.`
-            : `Encounter ${roamer.name} in the wild, then use your Pokédex to track its location!`,
-          pokemonId: roamer.id,
-          priority: 85,
-        });
-      }
-    }
+    suggestions.push(...getRoamerSuggestions(saveData, missingSet, roamers, saveData.gameVersion === 'crystal'));
 
     // 2. Headbutt / Rock Smash
     // TM08 (Rock Smash) is Item ID 198 (0xC6), TM02 (Headbutt) is Item ID 192 (0xC0)

--- a/src/engine/assistant/strategies/gen3Strategy.ts
+++ b/src/engine/assistant/strategies/gen3Strategy.ts
@@ -3,6 +3,7 @@ import { getGen3UnobtainableReason } from '../../exclusives/gen3Exclusives';
 import { getDistanceToMap, resolveOutdoorMapId } from '../../mapGraph/gen3Graph';
 import type { SaveData } from '../../saveParser/index';
 import type { AssistantStrategy, Suggestion } from './types';
+import { getRoamerSuggestions } from './utils/roamer';
 
 export const gen3Strategy: AssistantStrategy = {
   generation: 3,
@@ -23,32 +24,11 @@ export const gen3Strategy: AssistantStrategy = {
     const suggestions: Suggestion[] = [];
     const missingSet = new Set(missingIds);
 
-    const roamerMap = new Map(saveData.roamingLegendaries?.map((r) => [r.speciesId, r]));
     const roamers = [
       { id: 380, name: 'Latias' },
       { id: 381, name: 'Latios' },
     ];
-
-    for (const roamer of roamers) {
-      if (missingSet.has(roamer.id)) {
-        let isTracked = false;
-        const rData = roamerMap.get(roamer.id);
-        if (rData && rData.mapId !== 0) {
-          isTracked = true;
-        }
-
-        suggestions.push({
-          id: `roamer-${roamer.id}`,
-          category: 'Catch',
-          title: `Track ${roamer.name}`,
-          description: isTracked
-            ? `${roamer.name} is currently roaming! Check your Pokédex to see its current route.`
-            : `Encounter ${roamer.name} in the wild, then use your Pokédex to track its location!`,
-          pokemonId: roamer.id,
-          priority: 85,
-        });
-      }
-    }
+    suggestions.push(...getRoamerSuggestions(saveData, missingSet, roamers));
 
     return suggestions;
   },

--- a/src/engine/assistant/strategies/utils/roamer.ts
+++ b/src/engine/assistant/strategies/utils/roamer.ts
@@ -1,0 +1,40 @@
+import type { SaveData } from '../../../saveParser/index';
+import type { Suggestion } from '../types';
+
+export function getRoamerSuggestions(
+  saveData: SaveData,
+  missingSet: Set<number>,
+  roamers: { id: number; name: string }[],
+  isCrystal: boolean = false,
+): Suggestion[] {
+  const suggestions: Suggestion[] = [];
+
+  // ⚡ Bolt: converted roamingLegendaries to a Map keyed by speciesId to optimize O(N) loop lookup
+  const roamerMap = new Map(saveData.roamingLegendaries?.map((r) => [r.speciesId, r]));
+
+  for (const roamer of roamers) {
+    // In Crystal, Suicune is a static encounter, not a roamer. Suppress roamer logic for it.
+    if (isCrystal && roamer.id === 245) continue;
+
+    if (missingSet.has(roamer.id)) {
+      let isTracked = false;
+      const rData = roamerMap.get(roamer.id);
+      if (rData && rData.mapId !== 0) {
+        isTracked = true;
+      }
+
+      suggestions.push({
+        id: `roamer-${roamer.id}`,
+        category: 'Catch',
+        title: `Track ${roamer.name}`,
+        description: isTracked
+          ? `${roamer.name} is currently roaming! Check your Pokédex to see its current route.`
+          : `Encounter ${roamer.name} in the wild, then use your Pokédex to track its location!`,
+        pokemonId: roamer.id,
+        priority: 85,
+      });
+    }
+  }
+
+  return suggestions;
+}


### PR DESCRIPTION
🎯 What
Extracted the duplicated roamer tracking logic from `gen2Strategy.ts` and `gen3Strategy.ts` into a new, shared utility function `getRoamerSuggestions` in `utils/roamer.ts`.

💡 Why
This resolves technical debt by consolidating the logic that checks for active roaming legendaries across different generations. This prevents code drift, simplifies the strategy files, and makes future roamer-related updates safer to apply in one place.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no regressions were introduced to the assistant logic.

✨ Result
Cleaner, DRY-compliant codebase for Gen 2 and Gen 3 assistant strategies, with fully verified test coverage.

---
*PR created automatically by Jules for task [2387608123799646162](https://jules.google.com/task/2387608123799646162) started by @szubster*