### PR TITLE
Check off Acceptance Criteria for QA Max Rejection Cancellation

### DIFF
--- a/.foundry/tasks/task-153-255-orchestrator-max-rejection-cancellation-qa.md
+++ b/.foundry/tasks/task-153-255-orchestrator-max-rejection-cancellation-qa.md
@@ -29,4 +29,7 @@ notes: ''
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Review `foundry-orchestrator.ts` to verify the cancellation logic for max rejection threshold is correctly implemented and works as expected.
+- [x] Review `foundry-orchestrator.ts` to verify the cancellation logic for max rejection threshold is correctly implemented and works as expected.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/list_all_md.py
+++ b/list_all_md.py
@@ -1,8 +1,0 @@
-import os
-files = []
-for root, dirs, filenames in os.walk('.foundry/docs'):
-    for filename in filenames:
-        if filename.endswith('.md'):
-            files.append(os.path.join(root, filename))
-for f in sorted(files):
-    print(f)

--- a/list_all_md.py
+++ b/list_all_md.py
@@ -1,0 +1,8 @@
+import os
+files = []
+for root, dirs, filenames in os.walk('.foundry/docs'):
+    for filename in filenames:
+        if filename.endswith('.md'):
+            files.append(os.path.join(root, filename))
+for f in sorted(files):
+    print(f)


### PR DESCRIPTION
This PR updates the QA Max Rejection Cancellation task to check off the acceptance criteria as the underlying `foundry-orchestrator.ts` review was completed.

---
*PR created automatically by Jules for task [3648207962258004008](https://jules.google.com/task/3648207962258004008) started by @szubster*