### PR TITLE
Break down Gen3 Lottery Offsets Research Epic into Story

### DIFF
--- a/.foundry/epics/epic-104-133-gen3-lottery-offsets-research.md
+++ b/.foundry/epics/epic-104-133-gen3-lottery-offsets-research.md
@@ -23,4 +23,8 @@ notes: ''
 Research and identify the memory offsets for the daily lottery PRNG seed in Ruby, Sapphire, and Emerald save files.
 
 ## Acceptance Criteria
-- [ ] Break down into Stories
+- [x] Break down into Stories
+- [ ] story-133-272-research-lottery-offsets
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/stories/story-133-272-research-lottery-offsets.md
+++ b/.foundry/stories/story-133-272-research-lottery-offsets.md
@@ -1,0 +1,29 @@
+---
+id: story-133-272-research-lottery-offsets
+type: STORY
+title: Research Lottery Offsets
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-05'
+updated_at: '2026-07-05'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-104-133-gen3-lottery-offsets-research
+tags:
+  - gen3
+  - research
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research Lottery Offsets
+
+Research the memory offsets for the daily lottery PRNG seed in Ruby, Sapphire, and Emerald save files.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
This PR creates the necessary Story node to research memory offsets for the daily lottery PRNG seed in Gen 3 save files, as outlined in the parent Epic 104-133.

The parent epic's YAML frontmatter remains untouched, and the `- [ ] Break down into Stories` acceptance criterion in its markdown body has been checked off (`- [x]`). The new story is appended as an unchecked task (`- [ ] story-133-272-research-lottery-offsets`).

---
*PR created automatically by Jules for task [14911342463393623895](https://jules.google.com/task/14911342463393623895) started by @szubster*