### PR TITLE
Story Generation for epic-103-133-living-dex-data-engine

### DIFF
--- a/.foundry/epics/epic-103-133-living-dex-data-engine.md
+++ b/.foundry/epics/epic-103-133-living-dex-data-engine.md
@@ -28,3 +28,9 @@ This epic covers the backend/data layer requirements of the Living Dex Tracker P
 - [ ] Determine how to track missing Pokémon in the regional/national Pokédex.
 - [ ] Implement data mapping to identify existing Pokémon and their PC Box/Slot locations.
 - [ ] Implement logic to detect raw materials for evolution to fill missing slots.
+- [ ] story-133-272-living-dex-ghost-tracker
+- [ ] story-133-273-living-dex-pc-mapping
+- [ ] story-133-274-living-dex-evolution-material
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/stories/story-133-272-living-dex-ghost-tracker.md
+++ b/.foundry/stories/story-133-272-living-dex-ghost-tracker.md
@@ -1,0 +1,31 @@
+---
+id: story-133-272-living-dex-ghost-tracker
+type: STORY
+title: Living Dex Ghost Tracker
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-103-133-living-dex-data-engine
+tags:
+  - feature
+  - living-dex
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Living Dex Ghost Tracker
+
+## Context
+This story focuses on implementing the data engine logic to determine which Pokémon are missing from the regional/national Pokédex (the "ghosts"). This is the first step in creating the Living Dex Tracker data engine.
+
+## Acceptance Criteria
+- [ ] Determine how to track missing Pokémon in the regional/national Pokédex.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/stories/story-133-273-living-dex-pc-mapping.md
+++ b/.foundry/stories/story-133-273-living-dex-pc-mapping.md
@@ -1,0 +1,32 @@
+---
+id: story-133-273-living-dex-pc-mapping
+type: STORY
+title: Living Dex PC Mapping
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - story-133-272-living-dex-ghost-tracker
+jules_session_id: null
+pr_number: null
+parent: epic-103-133-living-dex-data-engine
+tags:
+  - feature
+  - living-dex
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Living Dex PC Mapping
+
+## Context
+This story involves creating the mapping layer to identify which Pokémon the player currently owns, and exactly which PC Box and Slot they reside in. This allows the Living Dex Tracker to display owned Pokémon in their current positions.
+
+## Acceptance Criteria
+- [ ] Implement data mapping to identify existing Pokémon and their PC Box/Slot locations.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/stories/story-133-274-living-dex-evolution-material.md
+++ b/.foundry/stories/story-133-274-living-dex-evolution-material.md
@@ -1,0 +1,32 @@
+---
+id: story-133-274-living-dex-evolution-material
+type: STORY
+title: Living Dex Evolution Material Detection
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - story-133-273-living-dex-pc-mapping
+jules_session_id: null
+pr_number: null
+parent: epic-103-133-living-dex-data-engine
+tags:
+  - feature
+  - living-dex
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Living Dex Evolution Material Detection
+
+## Context
+This story implements the logic to detect raw materials for evolution to fill missing slots. For example, recognizing that the player has a duplicate Bulbasaur that can be evolved to fill a missing Ivysaur slot.
+
+## Acceptance Criteria
+- [ ] Implement logic to detect raw materials for evolution to fill missing slots.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Generates granular STORY nodes for `epic-103-133-living-dex-data-engine` and appends them to the epic's markdown body.

- `story-133-272-living-dex-ghost-tracker`
- `story-133-273-living-dex-pc-mapping`
- `story-133-274-living-dex-evolution-material`

---
*PR created automatically by Jules for task [208956527569696541](https://jules.google.com/task/208956527569696541) started by @szubster*