### PR TITLE
Break down Gen 1-3 Static Encounter PRD into Epics

### DIFF
--- a/.foundry/epics/epic-106-136-gen1-static-encounters.md
+++ b/.foundry/epics/epic-106-136-gen1-static-encounters.md
@@ -1,0 +1,31 @@
+---
+id: epic-106-136-gen1-static-encounters
+type: EPIC
+title: Gen 1 Static Encounters
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-100-106-static-encounter-tracker
+tags:
+  - gen1
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 1 Static Encounters
+
+Break down the Gen 1 static encounter checklist into stories.
+
+## Acceptance Criteria
+- [ ] Create story for Gen 1 event flag parsing
+- [ ] Create story for Gen 1 checklist UI
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/epics/epic-106-137-gen2-static-encounters.md
+++ b/.foundry/epics/epic-106-137-gen2-static-encounters.md
@@ -1,0 +1,31 @@
+---
+id: epic-106-137-gen2-static-encounters
+type: EPIC
+title: Gen 2 Static Encounters
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-100-106-static-encounter-tracker
+tags:
+  - gen2
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Static Encounters
+
+Break down the Gen 2 static encounter checklist into stories.
+
+## Acceptance Criteria
+- [ ] Create story for Gen 2 event flag parsing
+- [ ] Create story for Gen 2 checklist UI
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/epics/epic-106-138-gen3-static-encounters.md
+++ b/.foundry/epics/epic-106-138-gen3-static-encounters.md
@@ -1,0 +1,31 @@
+---
+id: epic-106-138-gen3-static-encounters
+type: EPIC
+title: Gen 3 Static Encounters
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-100-106-static-encounter-tracker
+tags:
+  - gen3
+  - feature
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Static Encounters
+
+Break down the Gen 3 static encounter checklist into stories.
+
+## Acceptance Criteria
+- [ ] Create story for Gen 3 event flag parsing
+- [ ] Create story for Gen 3 checklist UI
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/prds/prd-100-106-static-encounter-tracker.md
+++ b/.foundry/prds/prd-100-106-static-encounter-tracker.md
@@ -34,4 +34,10 @@ Completionists and players revisiting old save files who want to track their pro
 - Provide actionable hints (location, level, prerequisites) for available encounters.
 
 ## Acceptance Criteria
-- [ ] Epic Planner: Break this PRD down into EPIC nodes for Gen 1, Gen 2, and Gen 3 event flag parsing and checklist UI implementation.
+- [x] Epic Planner: Break this PRD down into EPIC nodes for Gen 1, Gen 2, and Gen 3 event flag parsing and checklist UI implementation.
+- [ ] epic-106-136-gen1-static-encounters
+- [ ] epic-106-137-gen2-static-encounters
+- [ ] epic-106-138-gen3-static-encounters
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
This PR fulfills the Epic Planner's responsibilities for PRD `prd-100-106-static-encounter-tracker`. It breaks down the requirements for the Gen 1-3 Static Encounter & Legendary Checklist into three distinct Epic nodes, one for each generation. The parent PRD has been updated to track these new Epics.

---
*PR created automatically by Jules for task [12905265120070037452](https://jules.google.com/task/12905265120070037452) started by @szubster*