### PR TITLE
feat: implement shiny carrier UI badge

### DIFF
--- a/.foundry/tasks/task-253-260-shiny-carrier-ui-badge-impl.md
+++ b/.foundry/tasks/task-253-260-shiny-carrier-ui-badge-impl.md
@@ -33,9 +33,9 @@ Implement a distinct UI badge/indicator for "Shiny Carrier" Pokémon in PC boxes
 - Ensure the visual distinction between Shiny Carriers and actual Shiny Pokémon is clear.
 
 ## Acceptance Criteria
-- [ ] Badge component implemented and styled correctly according to ADR 008.
-- [ ] Badge integrated into PC Box view.
-- [ ] Badge integrated into Pokémon Detailed view.
+- [x] Badge component implemented and styled correctly according to ADR 008.
+- [x] Badge integrated into PC Box view.
+- [x] Badge integrated into Pokémon Detailed view.
 
 ## Reminders
 - If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -196,6 +196,7 @@ export function PokemonDetails({
   }, [saveData, pokemonId]);
 
   const isShiny = yourPokemon.some((p) => p.isShiny);
+  const isShinyCarrier = !isShiny && yourPokemon.some((p) => p.isShinyCarrier);
 
   return (
     <TacticalModal
@@ -228,11 +229,15 @@ export function PokemonDetails({
               />
             </div>
 
-            {isShiny && (
+            {isShiny ? (
               <div className="absolute -top-3 -right-3 z-20 animate-[pulse_3s_ease-in-out_infinite] rounded-none border border-amber-500/50 bg-amber-500/20 p-2 text-amber-400 shadow-[0_0_20px_rgba(245,158,11,0.5)] backdrop-blur-sm">
                 <Sparkles size={18} />
               </div>
-            )}
+            ) : isShinyCarrier ? (
+              <div className="absolute -top-3 -right-3 z-20 animate-[pulse_3s_ease-in-out_infinite] rounded-none border border-cyan-500/50 bg-cyan-500/20 p-2 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.5)] backdrop-blur-sm">
+                <Sparkles size={18} />
+              </div>
+            ) : null}
           </div>
 
           <div className="w-full text-center sm:text-left">

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -31,11 +31,14 @@ const StorageCard = React.memo(
   }) => {
     const handleClick = React.useCallback(() => onNavigate(pokemon.id), [onNavigate, pokemon.id]);
 
-    let variant: 'storage-default' | 'storage-emerald' | 'storage-amber' | 'storage-red' = 'storage-default';
+    let variant: 'storage-default' | 'storage-emerald' | 'storage-amber' | 'storage-red' | 'storage-cyan' =
+      'storage-default';
     if (isDead) {
       variant = 'storage-red';
     } else if (p.isShiny) {
       variant = 'storage-amber';
+    } else if (p.isShinyCarrier) {
+      variant = 'storage-cyan';
     } else if (location === 'Party') {
       variant = 'storage-red';
     } else {
@@ -68,7 +71,11 @@ const StorageCard = React.memo(
         )}
         <div className="absolute top-3 left-3 font-bold font-mono text-[10px] text-zinc-600">LV.{p.level}</div>
         <div className="absolute top-3 right-3 z-10 flex flex-col items-end gap-1.5">
-          {p.isShiny && <Sparkles size={14} className="text-amber-400 drop-shadow-sm" />}
+          {p.isShiny ? (
+            <Sparkles size={14} className="text-amber-400 drop-shadow-sm" />
+          ) : p.isShinyCarrier ? (
+            <Sparkles size={14} className="text-cyan-400 drop-shadow-sm" />
+          ) : null}
           {p.otName && (
             <TacticalBadge variant="zinc" className="max-w-[60px] truncate px-1.5 py-0.5 font-mono">
               {p.otName}
@@ -197,6 +204,11 @@ export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: 
 
                     {/* Status LEDs */}
                     <div className="flex gap-2">
+                      {/* Carrier Anomaly LED */}
+                      <div
+                        className={`h-2 w-2 rounded-none border ${pokemonInLocation.some((p) => !p.p.isShiny && p.p.isShinyCarrier) ? 'animate-[pulse_1.5s_ease-in-out_infinite] border-cyan-400 bg-cyan-400 shadow-[0_0_8px_rgba(34,211,238,0.8)]' : 'border-zinc-700 bg-zinc-900'}`}
+                        title="Carrier Detector"
+                      />
                       {/* Shiny Anomaly LED */}
                       <div
                         className={`h-2 w-2 rounded-none border ${pokemonInLocation.some((p) => p.p.isShiny) ? 'animate-pulse border-amber-400 bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.8)]' : 'border-zinc-700 bg-zinc-900'}`}

--- a/src/components/TacticalCard.tsx
+++ b/src/components/TacticalCard.tsx
@@ -12,7 +12,15 @@ interface TacticalCardProps {
   className?: string;
   style?: React.CSSProperties;
   disabled?: boolean;
-  variant?: 'default' | 'emerald' | 'amber' | 'storage-default' | 'storage-emerald' | 'storage-amber' | 'storage-red';
+  variant?:
+    | 'default'
+    | 'emerald'
+    | 'amber'
+    | 'storage-default'
+    | 'storage-emerald'
+    | 'storage-amber'
+    | 'storage-red'
+    | 'storage-cyan';
 }
 
 // ⚡ Bolt: Wrapped TacticalCard in React.memo to prevent unnecessary DOM re-renders of up to 400 PC boxes when parent states change
@@ -33,6 +41,9 @@ export const TacticalCard = React.memo(
           break;
         case 'default':
           variantClasses = 'border-white/20 bg-zinc-900/50 hover:border-white/40 hover:bg-zinc-800/80';
+          break;
+        case 'storage-cyan':
+          variantClasses = 'bg-cyan-900/10 border-cyan-500/30 hover:bg-cyan-900/20';
           break;
         case 'storage-amber':
           variantClasses = 'bg-amber-900/10 border-amber-500/30 hover:bg-amber-900/20';

--- a/src/components/TacticalPanel.tsx
+++ b/src/components/TacticalPanel.tsx
@@ -4,7 +4,7 @@ import { CornerCrosshairs } from './CornerCrosshairs';
 import { LcdGrid } from './LcdGrid';
 
 interface TacticalPanelProps extends React.HTMLAttributes<HTMLDivElement> {
-  variant?: 'emerald' | 'amber' | 'red' | 'purple' | 'blue' | 'pink' | 'white' | 'default';
+  variant?: 'emerald' | 'amber' | 'red' | 'purple' | 'blue' | 'pink' | 'white' | 'default' | 'cyan';
   className?: string;
   children?: React.ReactNode;
 }
@@ -20,6 +20,7 @@ export const TacticalPanel = React.forwardRef<HTMLDivElement, TacticalPanelProps
             'border-emerald-500/30 bg-emerald-500/5 hover:border-emerald-500/50 hover:bg-emerald-500/10':
               variant === 'emerald',
             'border-amber-500/30 bg-amber-500/5 hover:border-amber-500/50 hover:bg-amber-500/10': variant === 'amber',
+            'border-cyan-500/30 bg-cyan-500/5 hover:border-cyan-500/50 hover:bg-cyan-500/10': variant === 'cyan',
             'border-red-500/30 bg-red-500/5 hover:border-red-500/50 hover:bg-red-500/10': variant === 'red',
             'border-purple-500/30 bg-purple-500/5 hover:border-purple-500/50 hover:bg-purple-500/10':
               variant === 'purple',
@@ -44,6 +45,7 @@ export const TacticalPanel = React.forwardRef<HTMLDivElement, TacticalPanelProps
           className={cn('h-2 w-2 transition-colors', {
             'border-emerald-500/40 group-hover:border-emerald-400': variant === 'emerald',
             'border-amber-500/40 group-hover:border-amber-400': variant === 'amber',
+            'border-cyan-500/40 group-hover:border-cyan-400': variant === 'cyan',
             'border-red-500/40 group-hover:border-red-400': variant === 'red',
             'border-purple-500/40 group-hover:border-purple-400': variant === 'purple',
             'border-blue-500/40 group-hover:border-blue-400': variant === 'blue',

--- a/src/components/__tests__/StorageGrid.test.tsx
+++ b/src/components/__tests__/StorageGrid.test.tsx
@@ -53,7 +53,10 @@ test('renders grid with pokemon', async () => {
         saveData: {
           generation: 1,
           partyDetails: [{ speciesId: 1, storageLocation: 'Party', level: 5, isShiny: false, otName: 'RED' }],
-          pcDetails: [{ speciesId: 4, storageLocation: 'Box 1', level: 10, isShiny: true, otName: 'BLUE' }],
+          pcDetails: [
+            { speciesId: 4, storageLocation: 'Box 1', level: 10, isShiny: true, otName: 'BLUE' },
+            { speciesId: 7, storageLocation: 'Box 1', level: 5, isShiny: false, isShinyCarrier: true, otName: 'GREEN' },
+          ],
         },
       }),
   );
@@ -63,6 +66,7 @@ test('renders grid with pokemon', async () => {
       pokemonList={[
         { id: 1, name: 'Bulbasaur' },
         { id: 4, name: 'Charmander' },
+        { id: 7, name: 'Squirtle' },
       ]}
     />,
   );
@@ -74,6 +78,8 @@ test('renders grid with pokemon', async () => {
   // Check box pokemon
   await expect.element(page.getByText('Charmander')).toBeInTheDocument();
   await expect.element(page.getByText('BLUE')).toBeInTheDocument();
+  await expect.element(page.getByText('Squirtle')).toBeInTheDocument();
+  await expect.element(page.getByText('GREEN')).toBeInTheDocument();
 
   // Click navigation
   const btn = page.getByText('Bulbasaur');

--- a/src/components/pokemon/details/PokemonCaughtDetails.tsx
+++ b/src/components/pokemon/details/PokemonCaughtDetails.tsx
@@ -29,16 +29,16 @@ export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps)
         {yourPokemon.map((p, i) => (
           <TacticalPanel
             key={`${p.storageLocation}-${p.slot || i}`}
-            variant={p.isShiny ? 'amber' : 'emerald'}
+            variant={p.isShiny ? 'amber' : p.isShinyCarrier ? 'cyan' : 'emerald'}
             className="group !p-0 relative flex flex-col gap-0 rounded-none border border-dashed"
           >
             <LcdGrid className="opacity-[0.03]" />
             <HoverScanner />
 
             <TelemetryDecoration
-              label={p.isShiny ? 'ANOMALY DETECTED' : 'STANDARD ISSUE'}
+              label={p.isShiny ? 'ANOMALY DETECTED' : p.isShinyCarrier ? 'CARRIER ANOMALY' : 'STANDARD ISSUE'}
               className="top-0 right-0 left-0 justify-center border-r-0 border-l-0"
-              textClassName={p.isShiny ? 'text-amber-400' : 'text-emerald-500'}
+              textClassName={p.isShiny ? 'text-amber-400' : p.isShinyCarrier ? 'text-cyan-400' : 'text-emerald-500'}
             />
 
             <div className="relative z-10 mt-6 flex items-start justify-between border-white/5 border-b border-dashed bg-black/40 p-4">
@@ -67,6 +67,8 @@ export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps)
               <div className="opacity-80 mix-blend-screen transition-transform duration-500 group-hover:scale-110">
                 {p.isShiny ? (
                   <Sparkles size={48} className="text-amber-500 drop-shadow-[0_0_15px_rgba(245,158,11,0.5)]" />
+                ) : p.isShinyCarrier ? (
+                  <Dna size={48} className="text-cyan-500 drop-shadow-[0_0_15px_rgba(34,211,238,0.5)]" />
                 ) : (
                   <Activity size={48} className="text-emerald-500 drop-shadow-[0_0_15px_rgba(16,185,129,0.5)]" />
                 )}

--- a/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
+++ b/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
@@ -29,6 +29,22 @@ describe('PokemonCaughtDetails', () => {
     item: 0,
   };
 
+  it('renders correctly for shiny carrier', async () => {
+    (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
+      (selector: unknown) =>
+        (selector as (state: unknown) => unknown)({
+          saveData: {
+            generation: 1,
+          },
+        }),
+    );
+
+    const carrierPokemon = { ...mockPokemon, isShinyCarrier: true };
+    await render(<PokemonCaughtDetails yourPokemon={[carrierPokemon]} />);
+
+    await expect.element(page.getByText('CARRIER ANOMALY')).toBeInTheDocument();
+  });
+
   it('renders correctly', async () => {
     (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
       (selector: unknown) =>


### PR DESCRIPTION
Implemented distinct UI badge/indicator for "Shiny Carrier" Pokémon in PC boxes and detailed views, ensuring it is visually distinct from actual "Shiny" indicator, and following ADR 008 constraints.

---
*PR created automatically by Jules for task [6049250407777009676](https://jules.google.com/task/6049250407777009676) started by @szubster*