### PR TITLE
feat(tasks): create technical blueprints for Gen 3 Trainer ID extraction

### DIFF
--- a/.foundry/stories/story-130-269-extract-gen3-trainer-id-secret-id.md
+++ b/.foundry/stories/story-130-269-extract-gen3-trainer-id-secret-id.md
@@ -29,4 +29,9 @@ Update the parser and interface to properly extract the Trainer ID (TID) and Sec
 Based on Bulbapedia's "Save data structure (Generation III)" documentation, the Trainer ID is a 4-byte value located at offset `0x000A` within Section 0 (Trainer Info).
 
 ## Acceptance Criteria
-- [ ] Create Tasks for the implementation.
+- [x] Create Tasks for the implementation.
+- [ ] task-269-263-gen3-trainer-id-secret-id-impl
+- [ ] task-269-264-gen3-trainer-id-secret-id-qa
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/tasks/task-269-263-gen3-trainer-id-secret-id-impl.md
+++ b/.foundry/tasks/task-269-263-gen3-trainer-id-secret-id-impl.md
@@ -1,0 +1,41 @@
+---
+id: task-269-263-gen3-trainer-id-secret-id-impl
+type: TASK
+title: Implement Gen 3 Trainer ID and Secret ID Extraction
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-05'
+updated_at: '2026-07-05'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-130-269-extract-gen3-trainer-id-secret-id
+tags:
+  - feature
+  - gen3
+  - trainer
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Trainer ID and Secret ID Extraction
+
+## Objective
+Update the parser and interface to properly extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file.
+
+## Context
+Based on Bulbapedia's "Save data structure (Generation III)" documentation, the Trainer ID is a 4-byte value located at offset `0x000A` within Section 0 (Trainer Info).
+The 4-byte value actually contains both the TID and SID. It is typically split as the lower 2 bytes (16-bit integer) being the public Trainer ID and the upper 2 bytes being the Secret ID.
+The extraction logic needs to be implemented in `src/engine/saveParser/parsers/gen3.ts`.
+
+## Constraints & Memory Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- When parsing save files, all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level; inline magic numbers are forbidden.
+
+## Acceptance Criteria
+- [ ] Implement extraction logic for Trainer ID and Secret ID from Gen 3 save files.
+- [ ] Verify functionality via appropriate tests.

--- a/.foundry/tasks/task-269-264-gen3-trainer-id-secret-id-qa.md
+++ b/.foundry/tasks/task-269-264-gen3-trainer-id-secret-id-qa.md
@@ -1,0 +1,38 @@
+---
+id: task-269-264-gen3-trainer-id-secret-id-qa
+type: TASK
+title: QA Gen 3 Trainer ID and Secret ID Extraction
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-05'
+updated_at: '2026-07-05'
+depends_on:
+  - task-269-263-gen3-trainer-id-secret-id-impl
+jules_session_id: null
+pr_number: null
+parent: story-130-269-extract-gen3-trainer-id-secret-id
+tags:
+  - feature
+  - gen3
+  - trainer
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 Trainer ID and Secret ID Extraction
+
+## Objective
+Verify the parser and interface correctly extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file.
+
+## Constraints & Memory Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- When parsing save files, all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level; inline magic numbers are forbidden.
+
+## Acceptance Criteria
+- [ ] Verify the TID and SID extraction logic in `src/engine/saveParser/parsers/gen3.ts` works as intended.
+- [ ] Verify tests adequately cover the extraction scenarios.


### PR DESCRIPTION
Drafts technical blueprints for extracting Gen 3 Trainer ID and Secret ID.

- Creates `task-269-263-gen3-trainer-id-secret-id-impl` for implementation.
- Creates `task-269-264-gen3-trainer-id-secret-id-qa` for QA verification.
- Updates `story-130-269-extract-gen3-trainer-id-secret-id` to track these tasks.
- Adheres to all Tech Lead directives including the Intelligent Verification Protocol and explicit contract constraints for save file parsing.

---
*PR created automatically by Jules for task [15911079436436618530](https://jules.google.com/task/15911079436436618530) started by @szubster*