### PR TITLE
feat: Implement Gen 3 Volcanic Ash Count DataView Extraction

### DIFF
--- a/.foundry/tasks/task-267-261-gen3-ash-dataview-extraction-impl.md
+++ b/.foundry/tasks/task-267-261-gen3-ash-dataview-extraction-impl.md
@@ -35,10 +35,10 @@ Based on research findings, the Volcanic Ash gather count is stored as game vari
 3. All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
 
 ## Acceptance Criteria
-- [ ] Implement the extraction logic for Gen 3 Volcanic Ash count.
-- [ ] Define reusable constants for all memory offsets (`0x142C`, `0x13D0`).
-- [ ] Properly catch `RangeError` to handle out-of-bounds reads.
-- [ ] Write unit tests for the extraction logic.
+- [x] Implement the extraction logic for Gen 3 Volcanic Ash count.
+- [x] Define reusable constants for all memory offsets (`0x142C`, `0x13D0`).
+- [x] Properly catch `RangeError` to handle out-of-bounds reads.
+- [x] Write unit tests for the extraction logic.
 
 ## Persona Instructions
 - **Coder**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -230,6 +230,8 @@ export interface SaveData {
   /** Gen 3 specific: Battle Points (BP) balance */
   gen3TotalBattlePoints?: number;
   gen3BattlePoints?: number;
+  /** Gen 3 specific: Volcanic Ash gather count */
+  gen3VolcanicAsh?: number;
 }
 
 // Removed byte helper as DataView provides getUint8 natively.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -16,6 +16,7 @@ import {
   parseGen3Roamer,
   parseGen3SecretBases,
   parseGen3TotalBattlePoints,
+  parseGen3VolcanicAsh,
 } from './gen3';
 
 describe('gen3 parser scaffolding', () => {
@@ -950,6 +951,36 @@ describe('parseGen3SecretBases', () => {
     const view = new DataView(buffer);
 
     expect(() => parseGen3SecretBases(view, 0, 'ruby')).toThrowError('The save file is corrupted or incomplete.');
+  });
+});
+
+describe('parseGen3VolcanicAsh', () => {
+  it('should parse Gen 3 Volcanic Ash gather count for Emerald', () => {
+    // Offset for Emerald is 0x142C. Let saveBlock1Offset = 0.
+    const buffer = new ArrayBuffer(0x142c + 2);
+    const view = new DataView(buffer);
+    view.setUint16(0x142c, 1234, true);
+
+    const ash = parseGen3VolcanicAsh(view, 0, 'emerald');
+    expect(ash).toBe(1234);
+  });
+
+  it('should parse Gen 3 Volcanic Ash gather count for Ruby/Sapphire', () => {
+    // Offset for R/S is 0x13D0. Let saveBlock1Offset = 100.
+    const buffer = new ArrayBuffer(100 + 0x13d0 + 2);
+    const view = new DataView(buffer);
+    view.setUint16(100 + 0x13d0, 5678, true);
+
+    const ash = parseGen3VolcanicAsh(view, 100, 'ruby');
+    expect(ash).toBe(5678);
+  });
+
+  it('should throw RangeError on out-of-bounds reads', () => {
+    // Buffer too small for Emerald offset
+    const buffer = new ArrayBuffer(10);
+    const view = new DataView(buffer);
+
+    expect(() => parseGen3VolcanicAsh(view, 0, 'emerald')).toThrowError('The save file is corrupted or incomplete.');
   });
 });
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -150,6 +150,9 @@ const IS_EGG_BIT_SHIFT = 30;
 const GROWTH_FRIENDSHIP_OFFSET = 4;
 const EGG_CYCLE_STEPS = 256;
 
+export const GEN3_EMERALD_ASH_OFFSET = 0x142c;
+export const GEN3_RS_ASH_OFFSET = 0x13d0;
+
 /**
  * Locates the most recent memory offset for a specific save section in Gen 3 flash memory.
  *
@@ -497,6 +500,27 @@ export function parseGen3MixRecords(view: DataView, offset: number) {
  * @returns An object containing the extracted Gen3ActiveSwarm data or undefined if none found.
  * @throws Error - "The save file is corrupted or incomplete: Invalid TV block struct." on out-of-bounds reads.
  */
+/**
+ * Extracts the Volcanic Ash gather count from a Gen 3 save file.
+ *
+ * @param view - The raw save file DataView.
+ * @param saveBlock1Offset - The absolute offset of SaveBlock1.
+ * @param version - The specific game version.
+ * @returns The amount of Volcanic Ash gathered.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3VolcanicAsh(view: DataView, saveBlock1Offset: number, version: GameVersion): number {
+  try {
+    const offset = version === 'emerald' ? GEN3_EMERALD_ASH_OFFSET : GEN3_RS_ASH_OFFSET;
+    return view.getUint16(saveBlock1Offset + offset, true);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
 export function parseGen3ActiveSwarm(view: DataView, offset: number): Gen3ActiveSwarm | undefined {
   try {
     const shows = parseGen3TVBlock(view, offset);
@@ -805,6 +829,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     const gen3PokeNews = parseGen3PokeNews(view, section1Offset + POKE_NEWS_OFFSET);
     const gen3MixRecords = parseGen3MixRecords(view, section1Offset + TV_SHOWS_OFFSET);
     const gen3ActiveSwarm = parseGen3ActiveSwarm(view, section1Offset + TV_SHOWS_OFFSET);
+    const gen3VolcanicAsh = parseGen3VolcanicAsh(view, section1Offset, _forcedVersion || 'ruby');
 
     const roamingLegendaries = [];
     try {
@@ -888,6 +913,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       gen3MixRecords,
       ...(gen3ActiveSwarm !== undefined ? { gen3ActiveSwarm } : {}),
       roamingLegendaries,
+      gen3VolcanicAsh,
     };
     if (gen3BattleFrontierWinStreaks) {
       result.gen3BattleFrontierWinStreaks = gen3BattleFrontierWinStreaks;


### PR DESCRIPTION
This PR implements the DataView extraction logic for the Gen 3 Volcanic Ash gather count, based on the offset research (Emerald: `0x142C`, Ruby/Sapphire: `0x13D0` within SaveBlock1). The logic safely handles `RangeError` and unit tests were provided for all constraints.

---
*PR created automatically by Jules for task [222727710770471921](https://jules.google.com/task/222727710770471921) started by @szubster*