### PR TITLE
feat(parser): Implement Gen 2 NPC Trade Extraction

### DIFF
--- a/.foundry/tasks/task-258-261-gen2-npc-trade-parsing-impl.md
+++ b/.foundry/tasks/task-258-261-gen2-npc-trade-parsing-impl.md
@@ -28,11 +28,11 @@ In Generation 2 (Gold, Silver, Crystal), we want to extract the state of the 7 i
 - Gold/Silver: `0x250F`
 
 ## Acceptance Criteria
-- [ ] Define the magic number constants `NPC_TRADE_FLAGS_OFFSET_CRYSTAL = 0x24EB;` and `NPC_TRADE_FLAGS_OFFSET_GS = 0x250F;` at the module level in `src/engine/saveParser/parsers/gen2.ts` (forbidding inline magic numbers).
-- [ ] Extend the `SaveData` interface or create a new property for `npcTradeFlags` in the parsed output (as a boolean array of length 7) representing `[MIKE, KYLE, TIM, EMY, CHRIS, KIM, FOREST]`.
-- [ ] Update the `parseGen2Save` function to read the byte at the appropriate offset (`isCrystal ? NPC_TRADE_FLAGS_OFFSET_CRYSTAL : NPC_TRADE_FLAGS_OFFSET_GS`).
-- [ ] Extract the 7 boolean flags using bitwise masking (`byte & (1 << i)`).
-- [ ] Add the `npcTradeFlags` array to the returned data structure.
-- [ ] If transient failures require retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- [ ] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- [x] Define the magic number constants `NPC_TRADE_FLAGS_OFFSET_CRYSTAL = 0x24EB;` and `NPC_TRADE_FLAGS_OFFSET_GS = 0x250F;` at the module level in `src/engine/saveParser/parsers/gen2.ts` (forbidding inline magic numbers).
+- [x] Extend the `SaveData` interface or create a new property for `npcTradeFlags` in the parsed output (as a boolean array of length 7) representing `[MIKE, KYLE, TIM, EMY, CHRIS, KIM, FOREST]`.
+- [x] Update the `parseGen2Save` function to read the byte at the appropriate offset (`isCrystal ? NPC_TRADE_FLAGS_OFFSET_CRYSTAL : NPC_TRADE_FLAGS_OFFSET_GS`).
+- [x] Extract the 7 boolean flags using bitwise masking (`byte & (1 << i)`).
+- [x] Add the `npcTradeFlags` array to the returned data structure.
+- [x] If transient failures require retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- [x] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- [x] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -449,7 +449,7 @@ describe('generateSuggestions', () => {
       party: [],
       inventory: [],
       currentMapId: 0,
-      npcTradeFlags: 1 << 1, // Set tradeIndex 1
+      npcTradeFlags: Array.from({ length: 16 }, (_, i) => i === 1), // Set tradeIndex 1 to true
       partyDetails: [],
       pcDetails: [],
       trainerName: 'ASH',

--- a/src/engine/assistant/generators/tradeGenerator.ts
+++ b/src/engine/assistant/generators/tradeGenerator.ts
@@ -115,7 +115,7 @@ export function generateGiftAndTradeSuggestions(
     if (!missingIds.has(trade.receivedId)) continue;
 
     if (trade.tradeIndex !== undefined && saveData.npcTradeFlags !== undefined) {
-      const isClaimed = (saveData.npcTradeFlags & (1 << trade.tradeIndex)) !== 0;
+      const isClaimed = saveData.npcTradeFlags[trade.tradeIndex];
       if (isClaimed) continue;
     }
 

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -188,7 +188,7 @@ export interface SaveData {
   /** Raw byte array containing hidden coin event flags. */
   hiddenCoinFlags?: Uint8Array;
   /** Bitflags representing which in-game NPC trades have already been completed. */
-  npcTradeFlags?: number;
+  npcTradeFlags?: boolean[];
   /** Detailed structural data for Pokémon currently left in the Daycare (Gen 2). */
   daycare?: PokemonInstance[];
   /** Gen 2 specific: Indicates if an Egg is currently waiting to be picked up from the Daycare. */

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -717,6 +717,10 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
     eventFlags,
     hiddenItemFlags,
     hiddenCoinFlags,
-    npcTradeFlags: view.getUint8(eventFlagsOffset - 16) | (view.getUint8(eventFlagsOffset - 15) << 8),
+    // Gen 1 trades: The 2 bytes are at eventFlagsOffset - 16 and - 15. We convert this into a boolean array.
+    npcTradeFlags: Array.from({ length: 16 }, (_, i) => {
+      const byte = view.getUint8(eventFlagsOffset - 16 + Math.floor(i / 8));
+      return (byte & (1 << (i % 8))) !== 0;
+    }),
   };
 }

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -18,6 +18,8 @@ const POKEMON_NAME_LENGTH = 11;
 const POKEMON_OFFSET_OT_NAME = POKEMON_DATA_BLOCK_SIZE;
 const POKEMON_OFFSET_NICKNAME = POKEMON_DATA_BLOCK_SIZE + POKEMON_NAME_LENGTH;
 const POKEMON_OFFSET_CURRENT_HP = 34;
+const NPC_TRADE_FLAGS_OFFSET_CRYSTAL = 0x24eb;
+const NPC_TRADE_FLAGS_OFFSET_GS = 0x250f;
 const GEN2_EGG_SPECIES_ID = 253;
 const GEN2_EGG_CYCLE_STEPS = 256;
 
@@ -635,6 +637,13 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
   }
   const hiddenItemFlags = eventFlags;
 
+  const npcTradeFlagsOffset = isCrystal ? NPC_TRADE_FLAGS_OFFSET_CRYSTAL : NPC_TRADE_FLAGS_OFFSET_GS;
+  const npcTradeByte = view.getUint8(npcTradeFlagsOffset);
+  const npcTradeFlags: boolean[] = [];
+  for (let i = 0; i < 7; i++) {
+    npcTradeFlags.push((npcTradeByte & (1 << i)) !== 0);
+  }
+
   return {
     generation: 2,
     owned,
@@ -661,5 +670,6 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
     roamingLegendaries,
     eventFlags,
     hiddenItemFlags,
+    npcTradeFlags,
   };
 }


### PR DESCRIPTION
Implement Gen 2 NPC Trade Extraction by reading the NPC trade flags byte from the save file and returning an array of 7 booleans.

This resolves the issue described in `.foundry/tasks/task-258-261-gen2-npc-trade-parsing-impl.md`.
Also updated Gen 1 parser and Trade Generator to use the new `boolean[]` format for `npcTradeFlags` instead of `number` bitmasks.

---
*PR created automatically by Jules for task [2080824182611884773](https://jules.google.com/task/2080824182611884773) started by @szubster*