### PR TITLE
docs(epic): complete feebas magic numbers refactoring acceptance criteria

### DIFF
--- a/.foundry/epics/epic-036-058-feebas-backend-parsing.md
+++ b/.foundry/epics/epic-036-058-feebas-backend-parsing.md
@@ -30,7 +30,4 @@ Create a utility module that reads the parsed save file's data at the identified
 - [x] Ensure fast calculation concurrent with save file hydration.
 - [x] .foundry/stories/story-058-095-feebas-seed-extraction.md
 - [x] .foundry/stories/story-058-096-feebas-tile-calculation.md
-- [ ] .foundry/stories/story-058-152-refactor-feebas-magic-numbers.md
-
-### Auditor Rejection
-Inline magic numbers are used for memory offsets (0x2dd6, 0x2e66) in `src/engine/gen3/feebas.ts` instead of explicitly defined and reusable constants, violating the memory rule.
+- [x] .foundry/stories/story-058-152-refactor-feebas-magic-numbers.md


### PR DESCRIPTION
This PR checks off the completed `.foundry/stories/story-058-152-refactor-feebas-magic-numbers.md` child node in the `epic-036-058-feebas-backend-parsing.md` Epic and removes the `Auditor Rejection` block, as the magic numbers were already successfully refactored and extracted to explicit constants during the completion of that story. Since all child stories are now marked completed, this allows the parent Epic to transition forward to `VERIFYING`.

---
*PR created automatically by Jules for task [7045964756604328909](https://jules.google.com/task/7045964756604328909) started by @szubster*