### PR TITLE
feat: Implement SaveHistoryDB IndexedDB Schema

### DIFF
--- a/.foundry/tasks/task-267-261-impl-indexeddb-schema.md
+++ b/.foundry/tasks/task-267-261-impl-indexeddb-schema.md
@@ -26,15 +26,15 @@ notes: ''
 We need to define a new IndexedDB schema (`SaveHistoryDB`) to store save files. This database will run alongside the existing `PokeDB` (which is used for read-only static game data). The new database will be used for persisting the user's sequential save states.
 
 ## Acceptance Criteria
-- [ ] In `src/db/schema.ts`, define a new constant `SAVE_HISTORY_DB_CONFIG` containing:
+- [x] In `src/db/schema.ts`, define a new constant `SAVE_HISTORY_DB_CONFIG` containing:
   - `NAME`: 'SaveHistoryDB'
   - `VERSION`: 1
   - `STORES`: `{ SAVES: 'saves', METADATA: 'metadata', INDEXES: 'indexes' }`
-- [ ] In `src/db/schema.ts`, define the TypeScript interface `SaveHistoryDBSchema` extending `DBSchema` from `idb`.
+- [x] In `src/db/schema.ts`, define the TypeScript interface `SaveHistoryDBSchema` extending `DBSchema` from `idb`.
   - The `saves` store should store save files.
   - The `metadata` store should store metadata.
   - The `indexes` store should store indexes for efficient retrieval.
-- [ ] The coder is responsible for self-verifying these changes by running `pnpm test` and ensuring no regressions, as this is a low-risk structural typing task.
+- [x] The coder is responsible for self-verifying these changes by running `pnpm test` and ensuring no regressions, as this is a low-risk structural typing task.
 
 ## Rules
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -175,3 +175,28 @@ export interface PokeDBSchema extends DBSchema {
     value: { key: string; value: string };
   };
 }
+
+export const SAVE_HISTORY_DB_CONFIG = {
+  NAME: 'SaveHistoryDB',
+  VERSION: 1,
+  STORES: {
+    SAVES: 'saves',
+    METADATA: 'metadata',
+    INDEXES: 'indexes',
+  },
+} as const;
+
+export interface SaveHistoryDBSchema extends DBSchema {
+  [SAVE_HISTORY_DB_CONFIG.STORES.SAVES]: {
+    key: string;
+    value: Uint8Array;
+  };
+  [SAVE_HISTORY_DB_CONFIG.STORES.METADATA]: {
+    key: string;
+    value: Record<string, unknown>;
+  };
+  [SAVE_HISTORY_DB_CONFIG.STORES.INDEXES]: {
+    key: string;
+    value: Record<string, unknown>;
+  };
+}


### PR DESCRIPTION
Defined `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema` in `src/db/schema.ts` to support storing save file history in IndexedDB. Completed task acceptance criteria.

---
*PR created automatically by Jules for task [15955742087342046380](https://jules.google.com/task/15955742087342046380) started by @szubster*