### PR TITLE
docs: create relative offsets ADR

### DIFF
--- a/.foundry/docs/adrs/adr-246-028-relative-offsets.md
+++ b/.foundry/docs/adrs/adr-246-028-relative-offsets.md
@@ -1,0 +1,38 @@
+---
+id: adr-246-028-relative-offsets
+type: ADR
+title: Relative Offsets & Magic Numbers
+status: COMPLETED
+owner_persona: architect
+created_at: '2026-07-05'
+updated_at: '2026-07-05'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-103-246-create-relative-offsets-adr
+tags:
+  - architecture
+  - save-parsing
+  - offset-mapping
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# ADR 028: Relative Offsets & Magic Numbers
+
+## Context
+When extracting dynamic save blocks in the save parsing engine, developers sometimes use inline magic numbers for memory offsets, lengths, bit locations, and shifts. This practice makes the code harder to read, maintain, and review. Based on the offset linter investigation (`.foundry/docs/architecture/offset_linter_investigation.md`), automated linting tools (like Biome or Oxlint) currently lack the custom rule capabilities needed to enforce this without introducing significant bloat.
+
+## Decision
+We formally mandate that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level.
+- **Forbid Inline Magic Numbers**: The use of inline magic numbers for offsets or bit operations during dynamic save block extraction is strictly prohibited.
+- **Enforcement**: This rule will be enforced through architectural guidelines and mandatory code-review checks.
+
+## Consequences
+- **Positive**: Improved readability, maintainability, and consistency of the save parsing engine.
+- **Negative**: Adds a slight overhead to development, requiring developers to extract and define constants even for one-off memory reads.
+
+## Acceptance Criteria
+- [x] Mandate relative offsets and the use of reusable constants.

--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -303,3 +303,11 @@ As defined in ADR 015, with the transition to MsgPack (`msgpackr`) and the confi
 *   `sprite` (formerly `spr`)
 
 Enum-to-number optimizations (e.g., mapping encounter methods or string triggers to integer values) are preserved.
+
+---
+
+## 13. Dynamic Save Block Extraction Guidelines
+
+As defined in ADR 028, to ensure maintainability and readability within the save parsing engine, the following rules apply when extracting dynamic save blocks:
+*   **Module-Level Constants:** All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level.
+*   **No Magic Numbers:** The use of inline magic numbers for memory operations during dynamic save block extraction is strictly forbidden. This constraint must be enforced during code reviews.

--- a/.foundry/tasks/task-246-262-create-relative-offsets-adr.md
+++ b/.foundry/tasks/task-246-262-create-relative-offsets-adr.md
@@ -29,8 +29,8 @@ Establish a strict architectural ADR mandating that all memory offsets, lengths,
 Based on the offset linter investigation (`.foundry/docs/architecture/offset_linter_investigation.md`), tooling limitations make a custom ESLint or Biome rule unfeasible or bloated. We are falling back to an ADR and code-review enforcement to ensure that dynamic save block extraction does not use inline magic numbers.
 
 ## Acceptance Criteria
-- [ ] Create a new ADR in `.foundry/docs/adrs/` mandating relative offsets and the use of reusable constants.
-- [ ] Ensure all documentation specifies the requirements for dynamic save block extraction.
+- [x] Create a new ADR in `.foundry/docs/adrs/` mandating relative offsets and the use of reusable constants.
+- [x] Ensure all documentation specifies the requirements for dynamic save block extraction.
 
 ## Developer Reminders
 - **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Created ADR 028 to mandate reusable constants for memory offsets and updated schema.md to include dynamic save block extraction guidelines. Checked off task acceptance criteria without modifying YAML frontmatter.

---
*PR created automatically by Jules for task [4680703567719832282](https://jules.google.com/task/4680703567719832282) started by @szubster*