### PR TITLE
Fix: Create follow-up story for dynamic move PP parsing integration

### DIFF
--- a/.foundry/epics/epic-049-086-dynamic-move-pp-parsing.md
+++ b/.foundry/epics/epic-049-086-dynamic-move-pp-parsing.md
@@ -38,9 +38,8 @@ Currently, data such as move PPs are either manually maintained or fetched ad-ho
 - [x] Output the correct `moves.jsonl` data payload.
 - [ ] Replace manual/hardcoded tables for move data in the application runtime.
 
-### Auditor Rejection
-The implementation successfully generated `moves.jsonl`, but completely failed Goal 4: "Replace manual/hardcoded tables for move data." The client runtime (`src/db/schema.ts`, `src/db/PokeDB.ts`, etc.) was never updated to actually load, inflate, or use this newly generated data. A follow-up story is required to integrate this data into the application and replace the hardcoded tables.
-
 - [x] story-086-128-move-data-extraction
 - [x] story-086-129-move-generation-discrepancies
 - [x] story-086-130-move-jsonl-compaction
+
+- [ ] story-086-275-move-runtime-integration

--- a/.foundry/stories/story-086-275-move-runtime-integration.md
+++ b/.foundry/stories/story-086-275-move-runtime-integration.md
@@ -1,0 +1,36 @@
+---
+id: story-086-275-move-runtime-integration
+type: STORY
+title: Move Data Runtime Integration
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - story-086-130-move-jsonl-compaction
+jules_session_id: null
+pr_number: null
+parent: epic-049-086-dynamic-move-pp-parsing
+tags:
+  - refactor
+  - db
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Move Data Runtime Integration
+
+## Background
+The `moves.jsonl` data has been successfully generated via `scripts/generate-pokedata.ts`. However, the client runtime has not been updated to load, inflate, or use this newly generated data. We need to integrate this data into the application and replace hardcoded tables as requested by the Auditor.
+
+## Goals
+1. Integrate the `moves.jsonl` data into the client runtime (`src/db/schema.ts`, `src/db/PokeDB.ts`, etc.).
+2. Ensure the compact representations from `moves.jsonl` are inflated correctly before being stored in IndexedDB.
+3. Replace manual/hardcoded tables for move data in the application runtime, enabling accurate PP limit calculations dynamically.
+
+## Acceptance Criteria
+- [ ] Integrate the parsed `moves` dataset into the client database schema and sync process.
+- [ ] Implement inflation logic in the client runtime to restore omitted default values for move data.
+- [ ] Remove hardcoded manual move data tables and switch the runtime to utilize the dynamic PokeDB data.


### PR DESCRIPTION
This PR addresses the auditor's rejection on `epic-049-086-dynamic-move-pp-parsing` by creating a follow-up STORY node (`story-086-275-move-runtime-integration`) to integrate the dynamically generated `moves.jsonl` data into the client runtime. It also updates the parent EPIC node to track this new story as a dependency before verification.

---
*PR created automatically by Jules for task [10523885244488852798](https://jules.google.com/task/10523885244488852798) started by @szubster*