### PR TITLE
chore(qa): reject shiny carrier ui implementation for ADR 008 violation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -10,3 +10,8 @@ I rejected the implementation of the `calculateBreedingPairs` algorithm because 
 
 ## 2026-06-30: Magic Numbers in Gen 3 Parser Retry
 The implementer (`coder`) failed `task-121-219-gen3-tv-block-parser-retry-impl` because they used inline magic numbers (`21` and `40`) in `parseGen3MixRecords` to check for Mix Record events, despite the task description explicitly forbidding inline magic numbers and a previous rejection for the same reason (documented in `research-121-216`). This indicates a recurring failure pattern where the coder ignores module-level constant requirements for bounds checking. We must enforce this architectural constraint strictly to prevent fragile parsing logic.
+
+## Shiny Carrier Badge Rejection
+- **Date**: 2026-07-05
+- **Node**: task-253-260-shiny-carrier-ui-badge-impl
+- **Reason**: The developer implemented the Shiny Carrier UI badges (e.g., animate-[pulse...] divs in PokemonDetails.tsx and StorageGrid.tsx) without the mandated `border-dashed` class, violating ADR 008's strict tactical hardware aesthetic constraints.

--- a/.foundry/tasks/task-253-260-shiny-carrier-ui-badge-impl.md
+++ b/.foundry/tasks/task-253-260-shiny-carrier-ui-badge-impl.md
@@ -2,7 +2,7 @@
 id: task-253-260-shiny-carrier-ui-badge-impl
 type: TASK
 title: Implement Shiny Carrier UI Badge
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-02'
 updated_at: '2026-07-05'
@@ -16,8 +16,8 @@ tags:
   - gen2
   - frontend
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Shiny Carrier UI badges in PokemonDetails.tsx and StorageGrid.tsx lack border-dashed, violating ADR 008.'
 notes: ''
 ---
 
@@ -33,9 +33,9 @@ Implement a distinct UI badge/indicator for "Shiny Carrier" Pokémon in PC boxes
 - Ensure the visual distinction between Shiny Carriers and actual Shiny Pokémon is clear.
 
 ## Acceptance Criteria
-- [x] Badge component implemented and styled correctly according to ADR 008.
-- [x] Badge integrated into PC Box view.
-- [x] Badge integrated into Pokémon Detailed view.
+- [ ] Badge component implemented and styled correctly according to ADR 008.
+- [ ] Badge integrated into PC Box view.
+- [ ] Badge integrated into Pokémon Detailed view.
 
 ## Reminders
 - If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/.foundry/tasks/task-253-261-shiny-carrier-ui-badge-qa.md
+++ b/.foundry/tasks/task-253-261-shiny-carrier-ui-badge-qa.md
@@ -37,3 +37,6 @@ Verify the implementation of the "Shiny Carrier" UI badge in PC boxes and detail
 - If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
 - If you must abort or permanently fail the task, update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### QA Note
+Implementation rejected: Shiny Carrier badges lack border-dashed.


### PR DESCRIPTION
Rejected the implementation of the "Shiny Carrier UI Badge" (task-253-260-shiny-carrier-ui-badge-impl) because the developer failed to adhere to the strictly mandated `border-dashed` tactical hardware aesthetic constraint defined in ADR 008. The target task's frontmatter has been updated to `FAILED`, the `rejection_count` incremented, and the acceptance criteria reset. A corresponding entry was logged in the QA journal documenting the specific violation.

---
*PR created automatically by Jules for task [9450066256659107405](https://jules.google.com/task/9450066256659107405) started by @szubster*