### PR TITLE
Create Gen 3 NPC Trade Extraction Tasks

### DIFF
--- a/.foundry/stories/story-119-259-gen3-npc-trade-parsing.md
+++ b/.foundry/stories/story-119-259-gen3-npc-trade-parsing.md
@@ -27,5 +27,7 @@ notes: ''
 Identify and extract NPC trade flags for all core Gen 3 versions (RSE/FRLG) using `DataView`.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break down into tasks for Gen 3 extraction and offset discovery.
+- [x] Tech Lead: Break down into tasks for Gen 3 extraction and offset discovery.
 - [x] research-259-249-gen3-npc-trade-parsing
+- [ ] task-259-274-gen3-npc-trade-extraction-impl
+- [ ] task-259-275-gen3-npc-trade-extraction-qa

--- a/.foundry/tasks/task-259-274-gen3-npc-trade-extraction-impl.md
+++ b/.foundry/tasks/task-259-274-gen3-npc-trade-extraction-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-259-274-gen3-npc-trade-extraction-impl
+type: TASK
+title: Implement Gen 3 NPC Trade Extraction
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-05'
+updated_at: '2026-07-05'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-119-259-gen3-npc-trade-parsing
+tags:
+  - backend
+  - save-parsing
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 NPC Trade Extraction
+
+## Objective
+Implement DataView-based parsers to extract in-game NPC trade flags for all core Gen 3 versions (RSE/FRLG).
+
+## Context
+Refer to `.foundry/docs/knowledge_base/gen3_npc_trade_offsets.md` for the exact RSE and FRLG flags, as well as the logic for calculating byte offsets and bit indices within the flag block.
+
+## Constraints
+- **NO INLINE MAGIC NUMBERS:** All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level.
+- **DataView:** The parser MUST exclusively use the native `DataView` API.
+
+## Workflow Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail this task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Define memory constants for all RSE and FRLG NPC trade flags at the module level.
+- [ ] Implement Gen 3 DataView parsers to extract NPC trade flags.

--- a/.foundry/tasks/task-259-275-gen3-npc-trade-extraction-qa.md
+++ b/.foundry/tasks/task-259-275-gen3-npc-trade-extraction-qa.md
@@ -1,0 +1,36 @@
+---
+id: task-259-275-gen3-npc-trade-extraction-qa
+type: TASK
+title: QA Gen 3 NPC Trade Extraction
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-05'
+updated_at: '2026-07-05'
+depends_on:
+  - task-259-274-gen3-npc-trade-extraction-impl
+jules_session_id: null
+pr_number: null
+parent: story-119-259-gen3-npc-trade-parsing
+tags:
+  - backend
+  - save-parsing
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 NPC Trade Extraction
+
+## Objective
+Verify the Gen 3 NPC Trade Extraction parser implementation.
+
+## Workflow Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail this task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify that no magic numbers are used in the parsing logic for Gen 3 NPC trades.
+- [ ] Validate parser correctness against unit tests or mock Gen 3 save data.


### PR DESCRIPTION
Created the task blueprints for Gen 3 NPC Trade Extraction based on research findings. Added one implementation task (`coder`) and one QA task (`qa`) with specific instructions regarding DataView parsers and explicit module-level constants. Updated the parent story to reflect the created tasks.

---
*PR created automatically by Jules for task [3485266502118272229](https://jules.google.com/task/3485266502118272229) started by @szubster*