### PR TITLE
Auto-merge Checkbox-only PRs

### DIFF
--- a/.github/scripts/analyze-diff.js
+++ b/.github/scripts/analyze-diff.js
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+
+const diff = fs.readFileSync(0, 'utf-8');
+
+function analyzeDiff(diffText) {
+  const lines = diffText.split('\n');
+  let hasCheckboxChanges = false;
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Skip headers and unchanged lines
+    if (
+      line.startsWith('diff --git') ||
+      line.startsWith('index') ||
+      line.startsWith('---') ||
+      line.startsWith('+++') ||
+      line.startsWith('@@') ||
+      line.startsWith(' ') ||
+      line === '' ||
+      line.startsWith('\\ No newline at end of file')
+    ) {
+      i++;
+      continue;
+    }
+
+    // Process hunks of additions/removals
+    if (line.startsWith('-') || line.startsWith('+')) {
+      const removed = [];
+      const added = [];
+
+      while (i < lines.length && (lines[i].startsWith('-') || lines[i].startsWith('+'))) {
+        if (lines[i].startsWith('-')) removed.push(lines[i].slice(1));
+        else added.push(lines[i].slice(1));
+        i++;
+      }
+
+      // Every removal must have a corresponding addition for it to be a pure "checkbox mark"
+      if (removed.length !== added.length) return false;
+
+      for (let j = 0; j < removed.length; j++) {
+        const r = removed[j];
+        const a = added[j];
+
+        // Match checkboxes: [ ] -> [x] or [X]
+        // Note: The leading dash/plus prefix was already sliced off above.
+        // But the checkbox line itself contains a hyphen-bullet like "- [ ] task"
+
+        const rReplaced = r.replace(/^\s*-\s*\[\s\]/, 'CHECKBOX_MARKER');
+        const aReplaced = a.replace(/^\s*-\s*\[[xX]\]/, 'CHECKBOX_MARKER');
+
+        const isCheckboxChange = (rReplaced === aReplaced) && /^\s*-\s*\[\s\]/.test(r);
+
+        if (!isCheckboxChange) return false;
+        hasCheckboxChanges = true;
+      }
+    } else {
+      // Any other unexpected line prefix means it's not a clean diff we want to auto-merge
+      return false;
+    }
+  }
+
+  return hasCheckboxChanges;
+}
+
+if (analyzeDiff(diff)) {
+  process.exit(0);
+} else {
+  process.exit(1);
+}

--- a/.github/workflows/auto-close-empty-pr.yml
+++ b/.github/workflows/auto-close-empty-pr.yml
@@ -1,20 +1,39 @@
-name: Auto-merge Empty PRs
+name: Auto-merge Empty or Checkbox-only PRs
 
 on:
   pull_request:
     types: [opened, synchronize]
 
 jobs:
-  merge-empty:
+  merge:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       contents: write
     steps:
-      - name: Check for empty PR
-        if: github.event.pull_request.changed_files == 0
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for auto-merge eligibility
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body "Automatically merged empty PR to progress DAG." --repo ${{ github.repository }}
-          gh pr merge ${{ github.event.pull_request.number }} --squash --admin --repo ${{ github.repository }}
+          MERGE=false
+          if [ "${{ github.event.pull_request.changed_files }}" -eq "0" ]; then
+            echo "Empty PR detected."
+            MERGE=true
+          else
+            echo "Non-empty PR. Analyzing diff for checkbox-only changes..."
+            if gh pr diff $PR_NUMBER --repo ${{ github.repository }} | node .github/scripts/analyze-diff.js; then
+              echo "Checkbox-only changes detected."
+              MERGE=true
+            else
+              echo "Not an auto-mergable PR."
+            fi
+          fi
+
+          if [ "$MERGE" = "true" ]; then
+            gh pr comment $PR_NUMBER --body "Automatically merged PR (empty or checkbox-only) to progress DAG." --repo ${{ github.repository }}
+            gh pr merge $PR_NUMBER --squash --admin --repo ${{ github.repository }}
+          fi


### PR DESCRIPTION
This PR enables automatic merging for Pull Requests that only contain changes to markdown checkboxes (Acceptance Criteria). 

A new script `.github/scripts/analyze-diff.js` is introduced to strictly validate that:
1. Every removed line was an unchecked checkbox: `- [ ]`.
2. Every added line is the same line but with a marked checkbox: `- [x]` or `- [X]`.
3. No other content, file changes, or metadata modifications exist in the PR.

The `Auto-merge Empty PRs` workflow has been updated to `Auto-merge Empty or Checkbox-only PRs` and now utilizes this script when a PR is not empty.

Fixes #3922

---
*PR created automatically by Jules for task [6896808544234269976](https://jules.google.com/task/6896808544234269976) started by @szubster*