### PR TITLE
Foundry Node and Prompt Content Consolidation

### DIFF
--- a/.foundry/ideas/idea-103-foundry-node-content-consolidation.md
+++ b/.foundry/ideas/idea-103-foundry-node-content-consolidation.md
@@ -1,0 +1,46 @@
+---
+id: idea-103-foundry-node-content-consolidation
+type: IDEA
+title: Foundry Node and Prompt Content Consolidation
+status: READY
+owner_persona: product_manager
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - agents
+  - meta
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Foundry Node and Prompt Content Consolidation
+
+## Context
+A significant amount of content in Foundry nodes (TASKS, STORIES) and persona prompts is redundant. This includes boilerplate reminders about transient failures, empty PR policies, and environment setup instructions. This duplication leads to "prompt rot", increases token usage, and makes it difficult to update policies consistently across the system.
+
+## Proposal
+Analyze and consolidate repeated content into centralized locations.
+- Identify common "Mandates", "Reminders", and "Instructions" that appear across multiple TASK and STORY nodes.
+- Leverage `.foundry/docs/knowledge_base/agents/core_policies.md` more effectively by referencing it instead of duplicating its content in every agent prompt.
+- Create a shared "Node Templates" or "Policy Injection" mechanism so that the Orchestrator or PM agents can insert these rules dynamically or by reference.
+- Ensure that meta-agents like the Agile Coach and Strategist are tasked with maintaining this consolidation to prevent future bloat.
+
+## Impact
+- **Maintainability:** Policy updates only need to happen in one place.
+- **Efficiency:** Reduced token count for agent sessions.
+- **Consistency:** All agents and nodes adhere to the same version of the rules.
+
+## Next Steps
+- [ ] Product Manager: Audit current TASK/STORY templates for redundancy.
+- [ ] Agile Coach: Update persona prompts to use centralized policy references.
+- [ ] Architect: Propose a technical mechanism for dynamic policy injection into Foundry nodes.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -11,6 +11,7 @@ You are the Agile Coach of The Foundry. You run on a daily or weekly schedule as
 5.  **Evolve Personas**: Based on your analysis of rejections AND your creative insights, update the prompt files of the relevant personas (e.g., Tech Lead, Coder, QA) to address issues, prevent future rejections, and boost efficiency.
 6.  **Refine Processes**: Propose or directly implement changes to workflow definitions, templates, or automation scripts to streamline operations.
 7.  **Generate Improvements**: Autonomously generate new `IDEA` or `TASK` nodes in `.foundry/` directories based on observed friction (e.g., repeating merge conflicts, failed sessions) to systematically improve The Foundry codebase and its processes.
+8.  **Consolidate Redundancy**: Proactively identify and eliminate repeated content across persona prompts and Foundry nodes. Favor referencing centralized documents (e.g., `.foundry/docs/knowledge_base/agents/core_policies.md`) over duplicating instructions to prevent "prompt rot" and ensure system-wide consistency.
 
 ## Workflow
 

--- a/.github/agents/strategist.md
+++ b/.github/agents/strategist.md
@@ -13,6 +13,7 @@ The current agent roster lives in `.github/agents/`. Before proposing anything, 
 - **Retired agents** — existing schedules whose focus area no longer exists or has been fully addressed
 - **Prompt quality** — existing prompts that are too vague, too broad, producing low-value PRs, or missing important constraints. Review agent journals to identify prompts that consistently lead to rejected or unhelpful PRs
 - **Self-improvement** — this prompt itself may need updating as the roster evolves. If you identify a way to make Strategist more effective, propose it
+- **Prompt Consolidation** — identify opportunities to move duplicated prompt logic and policies into centralized documents, ensuring all agents operate from a single source of truth for core rules.
 
 ## Boundaries
 


### PR DESCRIPTION
This change addresses the issue of redundant content across Foundry nodes and agent prompts. It creates a new IDEA node to analyze and pull repeated content into centralized files and updates the Agile Coach and Strategist persona prompts to ensure this is prioritized and maintained in the future.

Fixes #3926

---
*PR created automatically by Jules for task [13340279664605270894](https://jules.google.com/task/13340279664605270894) started by @szubster*