### PR TITLE
Add Gen 3 Trick House Parser Stories

### DIFF
--- a/.foundry/epics/epic-054-111-trick-house-save-parsing.md
+++ b/.foundry/epics/epic-054-111-trick-house-save-parsing.md
@@ -34,4 +34,6 @@ Extract the Trick House puzzle state from Gen 3 save files using the `DataView` 
 - [ ] Determine the exact memory offset for Trick House data.
 - [ ] Implement a parser using `DataView`.
 - [ ] Write tests ensuring accurate data extraction across progression states.
-- [ ] story-111-249-investigate-trick-house-offsets
+- [x] story-111-249-investigate-trick-house-offsets
+- [ ] story-111-276-trick-house-parser-impl
+- [ ] story-111-277-trick-house-parser-qa

--- a/.foundry/stories/story-111-276-trick-house-parser-impl.md
+++ b/.foundry/stories/story-111-276-trick-house-parser-impl.md
@@ -1,0 +1,34 @@
+---
+id: story-111-276-trick-house-parser-impl
+type: STORY
+title: Implement Gen 3 Trick House Parser
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-054-111-trick-house-save-parsing
+tags:
+  - feature
+  - gen3
+  - mechanics
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Implement Gen 3 Trick House Parser
+
+## Objective
+Implement a parser using `DataView` to extract Trick House progression states from Gen 3 save files, using the documented offsets.
+
+## Scope
+- Create technical blueprint tasks to parse the variables from `SaveBlock1` defined in `.foundry/docs/knowledge_base/gen3_trick_house_offsets.md`.
+- Extract puzzle states, entrance state, and completion flags.
+
+## Acceptance Criteria
+- [ ] Parse `VAR_TRICK_HOUSE_LEVEL_OFFSET` and other progression variables.
+- [ ] Parse `FLAG_LANDMARK_TRICK_HOUSE`.

--- a/.foundry/stories/story-111-277-trick-house-parser-qa.md
+++ b/.foundry/stories/story-111-277-trick-house-parser-qa.md
@@ -1,0 +1,35 @@
+---
+id: story-111-277-trick-house-parser-qa
+type: STORY
+title: QA Gen 3 Trick House Parser
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - story-111-276-trick-house-parser-impl
+jules_session_id: null
+pr_number: null
+parent: epic-054-111-trick-house-save-parsing
+tags:
+  - feature
+  - gen3
+  - mechanics
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: QA Gen 3 Trick House Parser
+
+## Objective
+Write and execute unit tests for the Trick House `DataView` parser to ensure accurate data extraction.
+
+## Scope
+- Validate parser logic against mock data for various Trick House progression states.
+- Ensure correct bitwise operations and bounds handling in accordance with ADR 010 and ADR 026.
+
+## Acceptance Criteria
+- [ ] Unit tests written and passing for all Trick House parsing paths.


### PR DESCRIPTION
Creates new STORY nodes `story-111-276-trick-house-parser-impl` and `story-111-277-trick-house-parser-qa` for the active epic `epic-054-111-trick-house-save-parsing` based on the knowledge base research, and updates the epic's markdown.

---
*PR created automatically by Jules for task [2868960942674138000](https://jules.google.com/task/2868960942674138000) started by @szubster*