### PR TITLE
Product Manager: Generate PRD for Orchestrator Phase 3.6 fix

### DIFF
--- a/.foundry/ideas/idea-086-fix-orchestrator-phase-3-6.md
+++ b/.foundry/ideas/idea-086-fix-orchestrator-phase-3-6.md
@@ -37,3 +37,4 @@ Update Phase 3.6 in `foundry-orchestrator.ts` to ensure that `CANCELLED` nodes w
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md
+- [ ] prd-086-108-fix-orchestrator-phase-3-6

--- a/.foundry/prds/prd-086-108-fix-orchestrator-phase-3-6.md
+++ b/.foundry/prds/prd-086-108-fix-orchestrator-phase-3-6.md
@@ -1,0 +1,35 @@
+---
+id: prd-086-108-fix-orchestrator-phase-3-6
+type: PRD
+title: Fix orchestrator phase 3.6 for CANCELLED nodes
+status: PENDING
+owner_persona: epic_planner
+created_at: "2026-07-06"
+updated_at: "2026-07-06"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-086-fix-orchestrator-phase-3-6
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+# Fix orchestrator phase 3.6 for CANCELLED nodes
+
+## Problem
+In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` status with `rejection_reason === 'Max rejection count reached'` fail to trigger the parent awakening ("Impossible Loop") logic, which previously only applied to `FAILED` nodes. This causes system deadlocks.
+
+## Solution Requirements
+- Phase 3.6 logic in `foundry-orchestrator.ts` must be extended.
+- It must explicitly check for nodes with `status === 'CANCELLED'`.
+- It must ensure that if a node is CANCELLED due to max rejection, the parent node is properly awakened (reverted to PENDING/READY) to handle the failure and regenerate nodes.
+
+## Acceptance Criteria
+- [ ] Phase 3.6 awakening logic supports `CANCELLED` nodes.
+- [ ] Parent nodes correctly awaken when child nodes are cancelled due to hitting max rejections.
+- [ ] Tests verify this exact behavior in `foundry-orchestrator.test.ts`.


### PR DESCRIPTION
Creates a new PRD node (`prd-086-108-fix-orchestrator-phase-3-6.md`) describing the requirements to fix `foundry-orchestrator.ts` Phase 3.6. Appends the new PRD to the parent `idea-086-fix-orchestrator-phase-3-6.md` node.

---
*PR created automatically by Jules for task [10534472287149271423](https://jules.google.com/task/10534472287149271423) started by @szubster*