### PR TITLE
fix: enforce ADR 008 aesthetic on shiny carrier badges

### DIFF
--- a/.foundry/tasks/task-253-260-shiny-carrier-ui-badge-impl.md
+++ b/.foundry/tasks/task-253-260-shiny-carrier-ui-badge-impl.md
@@ -33,9 +33,9 @@ Implement a distinct UI badge/indicator for "Shiny Carrier" Pokémon in PC boxes
 - Ensure the visual distinction between Shiny Carriers and actual Shiny Pokémon is clear.
 
 ## Acceptance Criteria
-- [ ] Badge component implemented and styled correctly according to ADR 008.
-- [ ] Badge integrated into PC Box view.
-- [ ] Badge integrated into Pokémon Detailed view.
+- [x] Badge component implemented and styled correctly according to ADR 008.
+- [x] Badge integrated into PC Box view.
+- [x] Badge integrated into Pokémon Detailed view.
 
 ## Reminders
 - If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -234,7 +234,7 @@ export function PokemonDetails({
                 <Sparkles size={18} />
               </div>
             ) : isShinyCarrier ? (
-              <div className="absolute -top-3 -right-3 z-20 animate-[pulse_3s_ease-in-out_infinite] rounded-none border border-cyan-500/50 bg-cyan-500/20 p-2 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.5)] backdrop-blur-sm">
+              <div className="absolute -top-3 -right-3 z-20 animate-[pulse_3s_ease-in-out_infinite] rounded-none border border-cyan-500/50 border-dashed bg-cyan-500/20 p-2 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.5)] backdrop-blur-sm">
                 <Sparkles size={18} />
               </div>
             ) : null}

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -206,7 +206,7 @@ export function StorageGrid({ pokemonList }: { pokemonList: { id: number; name: 
                     <div className="flex gap-2">
                       {/* Carrier Anomaly LED */}
                       <div
-                        className={`h-2 w-2 rounded-none border ${pokemonInLocation.some((p) => !p.p.isShiny && p.p.isShinyCarrier) ? 'animate-[pulse_1.5s_ease-in-out_infinite] border-cyan-400 bg-cyan-400 shadow-[0_0_8px_rgba(34,211,238,0.8)]' : 'border-zinc-700 bg-zinc-900'}`}
+                        className={`h-2 w-2 rounded-none border ${pokemonInLocation.some((p) => !p.p.isShiny && p.p.isShinyCarrier) ? 'animate-[pulse_1.5s_ease-in-out_infinite] border-cyan-400 border-dashed bg-cyan-400 shadow-[0_0_8px_rgba(34,211,238,0.8)]' : 'border-zinc-700 bg-zinc-900'}`}
                         title="Carrier Detector"
                       />
                       {/* Shiny Anomaly LED */}

--- a/src/components/__tests__/PokemonDetails.test.tsx
+++ b/src/components/__tests__/PokemonDetails.test.tsx
@@ -109,4 +109,56 @@ describe('PokemonDetails', () => {
     // Check that we render the empty locations string "External cross-version extraction required" or similar from PokemonLocations component
     await expect.element(page.getByText(/DATA-SRC: UNKNOWN/i)).toBeVisible();
   });
+
+  it('renders shiny carrier badge correctly', async () => {
+    vi.spyOn(dexDataLoader, 'getPokemonDetails').mockResolvedValue({
+      pokemon: {
+        id: 7,
+        efrm: [],
+        eto: [],
+        det: [],
+        cr: 45,
+        baby: false,
+      } as unknown as import('../../db/schema').PokemonMetadata,
+      enc: [],
+      nameMap: { 7: 'Squirtle' },
+      areaNames: {},
+    });
+
+    const mockSaveData: SaveData = {
+      generation: 2,
+      party: [],
+      pc: [7],
+      owned: new Set([7]),
+      partyDetails: [],
+      // @ts-expect-error - strict typing allows partial structure for test
+      pcDetails: [{ speciesId: 7, isShiny: false, isShinyCarrier: true }],
+      badges: 0,
+      money: 0,
+      id: 1,
+      playerName: 'Ash',
+      timePlayed: '10:00',
+    };
+
+    const { container } = await render(
+      <QueryClientProvider client={queryClient}>
+        <PokemonDetails
+          pokemonId={7}
+          pokemonName="Squirtle"
+          gameVersion="crystal"
+          saveData={mockSaveData}
+          isLivingDex={true}
+          pokeball="poke"
+          onClose={() => {}}
+          onNavigate={() => {}}
+        />
+      </QueryClientProvider>,
+    );
+
+    await expect.element(page.getByRole('heading', { name: 'Squirtle' })).toBeVisible();
+
+    // Test for the cyan colored border dashed element for shiny carrier badge
+    const badge = container.querySelector('.border-cyan-500\\/50.border-dashed');
+    expect(badge).toBeInTheDocument();
+  });
 });

--- a/src/components/__tests__/StorageGrid.test.tsx
+++ b/src/components/__tests__/StorageGrid.test.tsx
@@ -85,3 +85,23 @@ test('renders grid with pokemon', async () => {
   const btn = page.getByText('Bulbasaur');
   await btn.click();
 });
+
+test('renders carrier anomaly LED correctly', async () => {
+  (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
+    (selector: unknown) =>
+      (selector as (state: unknown) => unknown)({
+        saveData: {
+          generation: 1,
+          partyDetails: [],
+          pcDetails: [
+            { speciesId: 4, storageLocation: 'Box 1', level: 10, isShiny: false, isShinyCarrier: true, otName: 'BLUE' },
+          ],
+        },
+      }),
+  );
+
+  const { container } = await render(<StorageGrid pokemonList={[{ id: 4, name: 'Charmander' }]} />);
+
+  const led = container.querySelector('.border-cyan-400.border-dashed');
+  expect(led).toBeInTheDocument();
+});


### PR DESCRIPTION
Added missing `border-dashed` utility class to Shiny Carrier UI badges in `PokemonDetails.tsx` and `StorageGrid.tsx` to strictly enforce the tactical hardware aesthetic constraints outlined in ADR 008.

Also updated task markdown checkboxes.

---
*PR created automatically by Jules for task [16311627936967244678](https://jules.google.com/task/16311627936967244678) started by @szubster*