### PR TITLE
QA Validation: Gen 2 NPC Trade Parsing

### DIFF
--- a/.foundry/tasks/task-258-262-gen2-npc-trade-parsing-qa.md
+++ b/.foundry/tasks/task-258-262-gen2-npc-trade-parsing-qa.md
@@ -27,10 +27,10 @@ notes: ''
 The `coder` has implemented parsing logic to extract Gen 2 NPC trade flags from save files.
 
 ## Acceptance Criteria
-- [ ] Verify unit tests have been added/updated in `src/engine/saveParser/parsers/gen2.test.ts`.
-- [ ] Ensure tests cover both Gold/Silver and Crystal offsets.
-- [ ] Ensure the tests assert correct extraction of the 7 bitwise flags into a boolean array.
-- [ ] Run the tests (`npx vitest run src/engine/saveParser/parsers/gen2.test.ts`) and ensure they pass.
-- [ ] If transient failures require retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- [ ] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- [ ] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- [x] Verify unit tests have been added/updated in `src/engine/saveParser/parsers/gen2.test.ts`.
+- [x] Ensure tests cover both Gold/Silver and Crystal offsets.
+- [x] Ensure the tests assert correct extraction of the 7 bitwise flags into a boolean array.
+- [x] Run the tests (`npx vitest run src/engine/saveParser/parsers/gen2.test.ts`) and ensure they pass.
+- [x] If transient failures require retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- [x] If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- [x] If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -477,4 +477,40 @@ describe('gen2 parsers', () => {
       );
     });
   });
+
+  describe('Gen 2 NPC Trade Flags Parsing', () => {
+    it('should correctly extract npcTradeFlags for Gold/Silver', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x288a, 1);
+      view.setUint8(0x288b, 1);
+      view.setUint8(0x288b + 7, 1);
+
+      // Gold/Silver NPC trade flags offset is 0x250f
+      // Set to 85 (0b01010101). Flags are extracted from bit 0 to 6.
+      view.setUint8(0x250f, 85);
+
+      const data = parseGen2(view, false);
+      expect(data.npcTradeFlags).toBeDefined();
+      expect(data.npcTradeFlags).toHaveLength(7);
+      expect(data.npcTradeFlags).toEqual([true, false, true, false, true, false, true]);
+    });
+
+    it('should correctly extract npcTradeFlags for Crystal', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x2865, 1);
+      view.setUint8(0x2866, 1);
+      view.setUint8(0x2866 + 7, 1);
+
+      // Crystal NPC trade flags offset is 0x24eb
+      // Set to 42 (0b00101010). Flags are extracted from bit 0 to 6.
+      view.setUint8(0x24eb, 42);
+
+      const data = parseGen2(view, true);
+      expect(data.npcTradeFlags).toBeDefined();
+      expect(data.npcTradeFlags).toHaveLength(7);
+      expect(data.npcTradeFlags).toEqual([false, true, false, true, false, true, false]);
+    });
+  });
 });


### PR DESCRIPTION
QA validation of Gen 2 NPC Trade flag extraction.

This PR adds unit tests for `npcTradeFlags` logic in `src/engine/saveParser/parsers/gen2.ts`, specifically ensuring the bits map to a boolean array correctly for GS/C offsets. The tests verify extraction of 7 bitwise flags. It also checks off the corresponding Acceptance Criteria in `.foundry/tasks/task-258-262-gen2-npc-trade-parsing-qa.md`.

---
*PR created automatically by Jules for task [7600040783913859597](https://jules.google.com/task/7600040783913859597) started by @szubster*