### PR TITLE
Reject epic-036-053-shared-dag-utilities verification

### DIFF
--- a/.foundry/epics/epic-036-053-shared-dag-utilities.md
+++ b/.foundry/epics/epic-036-053-shared-dag-utilities.md
@@ -44,6 +44,9 @@ This epic extracts pure functions from `.github/scripts/foundry-orchestrator.ts`
   - Spawned: `.foundry/stories/story-053-107-update-dag-orchestration-tests.md`
 
 ## Acceptance Criteria
-- [x] `dag-utils.ts` is created and contains the extracted pure functions and utilities.
+- [ ] `dag-utils.ts` is created and contains the extracted pure functions and utilities.
 - [x] New unit tests are written for `dag-utils.ts`.
 - [x] Existing tests still pass.
+
+### Auditor Rejection
+The `logToJournal` function was not extracted into `dag-utils.ts` and is still missing. `dag-utils.ts` only contains `todayISO`, `buildReverseDependencyGraph`, and `getOrphanedNodes`.


### PR DESCRIPTION
The Auditor persona is rejecting the verification of `epic-036-053-shared-dag-utilities` because the `logToJournal` function was not extracted into `dag-utils.ts` as specified in the Scope. The acceptance criteria has been unchecked, and a rejection reason was appended to the Markdown body to trigger the Resurrection Loop.

---
*PR created automatically by Jules for task [10446187514110851067](https://jules.google.com/task/10446187514110851067) started by @szubster*