### PR TITLE
🧱 Mason: EdgeLabel extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -148,3 +148,8 @@
 - **Why**: Standardizes the usage of the scanline overlay and ensures it's consistent across the application.
 - **Key Learnings**:
   - The `ScanlineOverlay` component already includes `pointer-events-none` and `absolute inset-0` classes, so we can replace raw `div` elements with it directly.
+## EdgeLabel Extraction
+- **What**: Extracted a repeated JSX pattern for absolute-positioned edge labels into a reusable `EdgeLabel` component.
+- **Why**: Reduced duplication of the verbose tactical utility classes `tactical-text absolute bg-zinc-950 px-1 text-[9px] text-zinc-500` across multiple components (`TacticalInput`, `SearchAndFilters`, `AssistantPanel`, `SyncProgress`).
+- **Key Learnings**:
+  - The extraction allows callers to pass specific positioning (like `-top-2.5 left-4`) or specific color overrides (like `text-[var(--theme-primary)]`) via the `className` prop while the internal component handles the shared tactical typography and background.

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -9,6 +9,7 @@ import { pokemonListQueryOptions } from '../utils/pokemonQueries';
 import { AssistantDebugView } from './assistant/AssistantDebugView';
 import { AssistantSuggestionCard } from './assistant/AssistantSuggestionCard';
 import { CornerCrosshairs } from './CornerCrosshairs';
+import { EdgeLabel } from './EdgeLabel';
 
 interface AssistantPanelProps {
   saveData: SaveData;
@@ -103,9 +104,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
       <div className="relative flex flex-col justify-between gap-4 border border-zinc-800/80 bg-zinc-900/50 p-6 sm:flex-row sm:items-center">
         <CornerCrosshairs thickness={2} className="h-2 w-2 border-white/20" />
         <div className="absolute top-0 left-0 h-[2px] w-full bg-gradient-to-r from-emerald-500/50 via-amber-500/50 to-purple-500/50" />
-        <div className="tactical-text pointer-events-none absolute -top-2.5 left-4 bg-zinc-950 px-1 text-[9px] text-[var(--theme-primary)]">
-          SYS.ASST
-        </div>
+        <EdgeLabel className="pointer-events-none -top-2.5 left-4 text-[var(--theme-primary)]">SYS.ASST</EdgeLabel>
 
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-3">
@@ -180,9 +179,7 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
                       <div
                         className={`flex items-center gap-3 border border-zinc-800 border-dashed bg-zinc-900/80 px-4 py-2`}
                       >
-                        <div className="tactical-text absolute -top-2 left-2 bg-zinc-950 px-1 text-[8px] text-zinc-500">
-                          SYS.CAT
-                        </div>
+                        <EdgeLabel className="-top-2 left-2 text-[8px]">SYS.CAT</EdgeLabel>
                         <div className={`${catStyle.bg} ${catStyle.color.replace('border-', 'text-')} p-1`}>
                           {catStyle.icon}
                         </div>

--- a/src/components/EdgeLabel.tsx
+++ b/src/components/EdgeLabel.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { cn } from '../utils/cn';
+
+export interface EdgeLabelProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const EdgeLabel = React.forwardRef<HTMLDivElement, EdgeLabelProps>(({ className, children, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn('tactical-text absolute bg-zinc-950 px-1 text-[9px] text-zinc-500', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+});
+
+EdgeLabel.displayName = 'EdgeLabel';

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -2,8 +2,8 @@ import { Search } from 'lucide-react';
 import { useMemo, useRef } from 'react';
 import { FILTER_TYPES, type FilterType, useStore } from '../store';
 import { ClearFiltersBadge } from './ClearFiltersBadge';
+import { EdgeLabel } from './EdgeLabel';
 import { FilterBadge } from './FilterBadge';
-
 import { LocationSuggestions } from './LocationSuggestions';
 import { TacticalInput } from './TacticalInput';
 import { TacticalMultiSelectControl } from './TacticalMultiSelectControl';
@@ -43,9 +43,7 @@ export function SearchAndFilters() {
         <div className="flex flex-col gap-6 pt-3 xl:flex-row">
           {/* Left Pane: Query Uplink */}
           <div className="relative flex-1 border border-zinc-800 border-dashed bg-black/40 p-3">
-            <span className="tactical-text absolute -top-2 left-2 bg-zinc-950 px-1 text-[9px] text-zinc-500">
-              [ QUERY_UPLINK ]
-            </span>
+            <EdgeLabel className="-top-2 left-2">[ QUERY_UPLINK ]</EdgeLabel>
             <div className="flex items-center gap-3">
               <div className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden border border-[var(--theme-primary)]/30 bg-[var(--theme-primary)]/5">
                 <Search size={16} className="relative z-10 text-[var(--theme-primary)]" />
@@ -74,9 +72,7 @@ export function SearchAndFilters() {
 
           {/* Right Pane: Parameter Matrix */}
           <div className="relative flex-1 border border-zinc-800 border-dashed bg-black/40 p-3 xl:max-w-2xl">
-            <span className="tactical-text absolute -top-2 left-2 bg-zinc-950 px-1 text-[9px] text-zinc-500">
-              [ PARAMETER_MATRIX ]
-            </span>
+            <EdgeLabel className="-top-2 left-2">[ PARAMETER_MATRIX ]</EdgeLabel>
             <TacticalMultiSelectControl<FilterType>
               ariaLabel="Filter Pokémon"
               containerClassName="h-full justify-center"

--- a/src/components/SyncProgress.tsx
+++ b/src/components/SyncProgress.tsx
@@ -2,6 +2,7 @@ import { ArrowRightCircle, CheckCircle2, Database, Loader2 } from 'lucide-react'
 import { useEffect, useState } from 'react';
 import { pokeDB } from '../db/PokeDB';
 import { cn } from '../utils/cn';
+import { EdgeLabel } from './EdgeLabel';
 import { LcdGrid } from './LcdGrid';
 import { ScanlineOverlay } from './ScanlineOverlay';
 import { TacticalPanel } from './TacticalPanel';
@@ -127,9 +128,7 @@ export function SyncProgress() {
         <div className="flex flex-col bg-zinc-950/50 md:flex-row">
           {/* Left Pane: Uplink Status */}
           <div className="relative flex-1 border-white/5 border-r border-dashed p-6">
-            <span className="tactical-text absolute -top-2 left-4 bg-zinc-950 px-1 text-[9px] text-zinc-500">
-              [ UPLINK_STATUS ]
-            </span>
+            <EdgeLabel className="-top-2 left-4">[ UPLINK_STATUS ]</EdgeLabel>
 
             <div className="relative mx-auto flex aspect-square w-full max-w-[240px] items-center justify-center overflow-hidden border border-white/5 bg-zinc-900/50">
               <LcdGrid className="opacity-[0.05]" />
@@ -160,9 +159,7 @@ export function SyncProgress() {
 
           {/* Right Pane: Data Stream Matrix */}
           <div className="relative flex-[2] p-6">
-            <span className="tactical-text absolute -top-2 left-4 bg-zinc-950 px-1 text-[9px] text-zinc-500">
-              [ DATA_STREAM ]
-            </span>
+            <EdgeLabel className="-top-2 left-4">[ DATA_STREAM ]</EdgeLabel>
 
             <div className="grid h-full min-h-[200px] grid-cols-[repeat(20,minmax(0,1fr))] content-start gap-1">
               {Array.from({ length: matrixBlocks }).map((_, i) => {

--- a/src/components/TacticalInput.tsx
+++ b/src/components/TacticalInput.tsx
@@ -2,6 +2,7 @@ import { X } from 'lucide-react';
 import React from 'react';
 import { cn } from '../utils/cn';
 import { CornerCrosshairs } from './CornerCrosshairs';
+import { EdgeLabel } from './EdgeLabel';
 import { TacticalIconButton } from './TacticalIconButton';
 
 interface TacticalInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value'> {
@@ -40,9 +41,9 @@ export const TacticalInput = React.forwardRef<HTMLInputElement, TacticalInputPro
         />
 
         {label && (
-          <div className="tactical-text pointer-events-none absolute -top-2 left-4 bg-zinc-950 px-1 text-[9px] text-zinc-500 transition-colors group-focus-within:text-[var(--theme-primary)]">
+          <EdgeLabel className="pointer-events-none -top-2 left-4 transition-colors group-focus-within:text-[var(--theme-primary)]">
             {label}
-          </div>
+          </EdgeLabel>
         )}
 
         {onClear && value && (


### PR DESCRIPTION
## What
Extracted a repeated JSX pattern for absolute-positioned edge labels into a reusable `EdgeLabel` component.

## Why
Reduced duplication of the verbose tactical utility classes `tactical-text absolute bg-zinc-950 px-1 text-[9px] text-zinc-500` across multiple components (`TacticalInput`, `SearchAndFilters`, `AssistantPanel`, `SyncProgress`). The extraction allows callers to pass specific positioning (like `-top-2.5 left-4`) or specific color overrides (like `text-[var(--theme-primary)]`) via the `className` prop while the internal component handles the shared tactical typography and background.

## Verification
- Code review complete and passed.
- All tests passing locally.
- Extracted code maintains all styles without breaking existing layouts.
- `pnpm lint` and `pnpm test` completed successfully.

## Result
Refactored multiple components to use the new `EdgeLabel` component, improving modularity and codebase consistency.

---
*PR created automatically by Jules for task [10480034091168267943](https://jules.google.com/task/10480034091168267943) started by @szubster*