### PR TITLE
🧹 Remove unused SaveHistoryDB schema and config

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -14,8 +14,7 @@
     ".github/scripts/extract-research.ts",
     ".github/scripts/verify-dag-refs.ts",
     "scripts/gen3-fetch-locations.ts",
-    "functions/_middleware.ts",
-    "scripts/data/gen3/match_call/etl.ts"
+    "functions/_middleware.ts"
   ],
   "rules": {
     "files": "warn",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -175,28 +175,3 @@ export interface PokeDBSchema extends DBSchema {
     value: { key: string; value: string };
   };
 }
-
-export const SAVE_HISTORY_DB_CONFIG = {
-  NAME: 'SaveHistoryDB',
-  VERSION: 1,
-  STORES: {
-    SAVES: 'saves',
-    METADATA: 'metadata',
-    INDEXES: 'indexes',
-  },
-} as const;
-
-export interface SaveHistoryDBSchema extends DBSchema {
-  [SAVE_HISTORY_DB_CONFIG.STORES.SAVES]: {
-    key: string;
-    value: Uint8Array;
-  };
-  [SAVE_HISTORY_DB_CONFIG.STORES.METADATA]: {
-    key: string;
-    value: Record<string, unknown>;
-  };
-  [SAVE_HISTORY_DB_CONFIG.STORES.INDEXES]: {
-    key: string;
-    value: Record<string, unknown>;
-  };
-}


### PR DESCRIPTION
🎯 What: Removed the unused `SaveHistoryDBSchema` type and `SAVE_HISTORY_DB_CONFIG` constant from `src/db/schema.ts`, and updated `knip.json` to no longer ignore `scripts/data/gen3/match_call/etl.ts`.
💡 Why: These were flagged by `knip` as unused exports/dead code. Removing them cleans up technical debt and ensures `knip` runs cleanly without warnings.
✅ Verification: Ran `pnpm knip`, `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to verify no regressions were introduced.
✨ Result: Cleaned up dead code and improved static analysis accuracy.

---
*PR created automatically by Jules for task [12517358992946896219](https://jules.google.com/task/12517358992946896219) started by @szubster*