### PR TITLE
Fix Foundry Orchestrator Phase 3.6 Deadlock

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -2206,4 +2206,103 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     expect(ideaContent).toContain('status: READY');
   });
 
+  test('Impossible Loop: Wakes up parent even if FAILED child has incomplete sub-children', () => {
+    // Epic 1: PENDING
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    // Story 1: Child of Epic 1, FAILED
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "FAILED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: "epic-001",
+      rejection_reason: "Manual rejection",
+      jules_session_id: "sess-1",
+    });
+
+    // Task 1: Child of Story 1, PENDING
+    createValidTestNode(tmpDir, '.foundry/tasks/task-001.md', {
+      id: "task-001",
+      type: "TASK",
+      title: "Task 1",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: "story-001",
+      jules_session_id: null,
+    });
+
+    main();
+
+    const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
+    // Epic 1 SHOULD be promoted to READY so that story_owner can fix Story 1
+    expect(epicContent).toContain('status: READY');
+  });
+
+  test('Impossible Loop: Wakes up parent even if CANCELLED child has incomplete sub-children', () => {
+    // Epic 1: PENDING
+    createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Epic 1",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    // Story 1: Child of Epic 1, CANCELLED
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "CANCELLED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: "epic-001",
+      rejection_reason: "Max rejection count reached",
+      jules_session_id: "sess-1",
+    });
+
+    // Task 1: Child of Story 1, PENDING
+    createValidTestNode(tmpDir, '.foundry/tasks/task-001.md', {
+      id: "task-001",
+      type: "TASK",
+      title: "Task 1",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: "story-001",
+      jules_session_id: null,
+    });
+
+    main();
+
+    const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
+    expect(epicContent).toContain('status: READY');
+  });
+
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -656,16 +656,8 @@ function main(): void {
       // We ignore the parent node itself during this check because it's exactly what we want to find out
       // (if something OTHER than the parent is blocking the child).
       const parentPath = resolveNodePath(node.frontmatter.parent);
-      const ignoredPaths = [node.repoPath];
-      if (parentPath) ignoredPaths.push(parentPath);
 
-      if (isHierarchicallyIncomplete(node.repoPath, ignoredPaths)) {
-        continue;
-      }
       if (parentPath) {
-        if (isHierarchicallyIncomplete(parentPath, ignoredPaths)) {
-          continue;
-        }
         const parentNode = nodeMap.get(parentPath);
         if (
           parentNode &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7878,10 +7878,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fdir@6.5.0(picomatch@4.0.5):
-    optionalDependencies:
-      picomatch: 4.0.5
-
   fflate@0.8.3: {}
 
   filelist@1.0.6:


### PR DESCRIPTION
This PR resolves a functional deadlock in the Foundry DAG Orchestrator where parent nodes were not being awakened when a child node failed or was cancelled if that child still had pending descendants. The removal of 'isHierarchicallyIncomplete' guards in Phase 3.6 ('Impossible Loop') ensures that terminal failure states are properly escalated, allowing the parent's owner to intervene. Regression tests have been added to verify this behavior for both FAILED and CANCELLED states.

Fixes #3971

---
*PR created automatically by Jules for task [147307383472075829](https://jules.google.com/task/147307383472075829) started by @szubster*