### PR TITLE
feat: generate story node to extract logToJournal utility

### DIFF
--- a/.foundry/epics/epic-036-053-shared-dag-utilities.md
+++ b/.foundry/epics/epic-036-053-shared-dag-utilities.md
@@ -34,6 +34,7 @@ This epic extracts pure functions from `.github/scripts/foundry-orchestrator.ts`
 - Update the DAG orchestration tests to use the new module.
 
 ## Next Steps
+- [ ] story-053-278-extract-log-to-journal
 - [x] Story Owner: Write Story to create the `dag-utils.ts` module with pure functions and basic utilities.
   - Spawned: `.foundry/archive/stories/story-053-090-extract-dag-utilities.md`
 

--- a/.foundry/stories/story-053-278-extract-log-to-journal.md
+++ b/.foundry/stories/story-053-278-extract-log-to-journal.md
@@ -1,0 +1,33 @@
+---
+id: story-053-278-extract-log-to-journal
+type: STORY
+title: Extract logToJournal Utility
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+parent: epic-036-053-shared-dag-utilities
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extract logToJournal Utility
+
+## 1. Introduction
+The `logToJournal` function was missed in the initial extraction of DAG utilities. We need to implement this utility in `.github/scripts/dag-utils.ts` and refactor `.github/scripts/foundry-orchestrator.ts` to use it instead of its inline journal logging logic.
+
+## 2. Technical Details
+- Create a `logToJournal(logPath: string, logEntry: string)` function in `dag-utils.ts` that safely appends the log entry using `fs.appendFileSync`.
+- Refactor the idempotent check logging in `.github/scripts/foundry-orchestrator.ts` (around line 958) to use the new `logToJournal` function.
+
+## Acceptance Criteria
+- [ ] `logToJournal` is exported from `dag-utils.ts`.
+- [ ] `foundry-orchestrator.ts` uses `logToJournal` instead of inline `fs.appendFileSync`.


### PR DESCRIPTION
Generated a new Story node (`story-053-278-extract-log-to-journal`) to address the auditor rejection on `epic-036-053-shared-dag-utilities`. The story instructs the `tech_lead` to implement the missing `logToJournal` function in `dag-utils.ts` and refactor `foundry-orchestrator.ts` to use it. Appended the new story ID as an unchecked task in the EPIC's Next Steps.

---
*PR created automatically by Jules for task [4455905215614017206](https://jules.google.com/task/4455905215614017206) started by @szubster*