### PR TITLE
chore: spawn story for emulator trailing bytes

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -40,11 +40,12 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - Extract data indicating if events were inherited from another player's save file via the "Mix Record" feature.
 
 ## 3. Acceptance Criteria
-- [ ] Story Owner: Break down into Stories.
+- [x] Story Owner: Break down into Stories.
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
 - [x] story-081-122-gen3-rtc-extraction
 - [ ] story-081-123-gen3-active-swarm-parsing
 - [ ] story-081-124-gen3-event-forecast-schedule
 - [ ] research-081-144-gen3-rtc-strategy
-- [ ] story-081-144-gen3-rtc-fallback-strategy
+- [x] story-081-144-gen3-rtc-fallback-strategy
+- [ ] story-081-279-gen3-ignore-emulator-trailing-bytes

--- a/.foundry/stories/story-081-279-gen3-ignore-emulator-trailing-bytes.md
+++ b/.foundry/stories/story-081-279-gen3-ignore-emulator-trailing-bytes.md
@@ -1,0 +1,29 @@
+---
+id: story-081-279-gen3-ignore-emulator-trailing-bytes
+type: STORY
+title: Gracefully Ignore Emulator Trailing Bytes in Gen 3 Save Files
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - rtc
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gracefully Ignore Emulator Trailing Bytes in Gen 3 Save Files
+
+## Description
+As required by ADR 025 and to replace the cancelled tasks from the previous fallback strategy story, we need to ensure that the save file parsing engines for Gen 3 gracefully ignore trailing emulator bytes without crashing.
+
+## Acceptance Criteria
+- [ ] Ensure that save file parsing engines gracefully ignore trailing emulator bytes without crashing.


### PR DESCRIPTION
Spawns new story to handle emulator trailing bytes after parent cancellation

---
*PR created automatically by Jules for task [5977740881908355145](https://jules.google.com/task/5977740881908355145) started by @szubster*