### PR TITLE
Foundry: Update checkboxes for completed research tasks in Gen 3 TV block parser story

### DIFF
--- a/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
+++ b/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
@@ -32,11 +32,11 @@ Implement the foundational logic to locate and read the TV broadcast data block 
 ## Child Tasks
 - [x] task-121-171-gen3-tv-block-parser-impl
 - [x] task-121-172-gen3-tv-block-parser-qa
-- [ ] research-121-216-gen3-tv-block-parser-failure
+- [x] research-121-216-gen3-tv-block-parser-failure
 - [x] task-121-217-gen3-tv-block-parser-retry-impl
 - [x] task-121-218-gen3-tv-block-parser-retry-qa
 - [x] task-121-219-gen3-tv-block-parser-retry-impl
 - [x] task-121-220-gen3-tv-block-parser-retry-qa
-- [ ] research-121-246-gen3-tv-block-parser-retry-failure
+- [x] research-121-246-gen3-tv-block-parser-retry-failure
 - [ ] task-121-256-gen3-tv-block-parser-retry2-impl
 - [ ] task-121-257-gen3-tv-block-parser-retry2-qa


### PR DESCRIPTION
Checked off the completed research tasks (`research-121-216` and `research-121-246`) in the Child Tasks list of `story-081-121-gen3-tv-block-dataview-parser.md`. The target implementation and QA tasks for the parser retry (`task-121-256` and `task-121-257`) already exist and are currently pending, so no new tasks were generated. This empty PR (only markdown checkbox updates) is submitted to allow the orchestrator to correctly demote the story node while it waits for its pending children.

---
*PR created automatically by Jules for task [1987821131559869373](https://jules.google.com/task/1987821131559869373) started by @szubster*