### PR TITLE
chore(foundry): update roamer tracking dashboard PRD and epics

### DIFF
--- a/.foundry/epics/epic-043-142-gen2-roamer-radar-widget.md
+++ b/.foundry/epics/epic-043-142-gen2-roamer-radar-widget.md
@@ -1,0 +1,35 @@
+---
+id: epic-043-142-gen2-roamer-radar-widget
+type: EPIC
+title: Gen 2 Roamer Radar Widget
+status: READY
+owner_persona: story_owner
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - epic-043-140-gen2-roamer-map-translation
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Roamer Radar Widget
+
+## Objective
+Build a visible dashboard widget that lists all active roaming Pokémon in the Gen 2 save file, displaying their current location and status tags.
+
+## Description
+- **Roamer Radar Widget**: Construct a UI component that displays a list of active Gen 2 roamers.
+- **Live Location**: The widget should show the human-readable route name where the roamer is currently located, obtained from the Translation Layer.
+- **Status Tags**: Add visual tags to indicate the roamer's status (e.g., "Active", "Caught", "Defeated").
+
+## Acceptance Criteria
+- [ ] A dedicated UI component displays the list of any active Gen 2 roamers.
+- [ ] The component shows the human-readable route location for each roamer.
+- [ ] Status tags ("Active", "Caught", "Defeated") are correctly displayed based on save data.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-043-143-gen2-roamer-map-integration.md
+++ b/.foundry/epics/epic-043-143-gen2-roamer-map-integration.md
@@ -1,0 +1,32 @@
+---
+id: epic-043-143-gen2-roamer-map-integration
+type: EPIC
+title: Gen 2 Roamer Map Integration
+status: READY
+owner_persona: story_owner
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - epic-043-140-gen2-roamer-map-translation
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Roamer Map Integration
+
+## Objective
+Highlight the active Gen 2 roamer's current route on the interactive map.
+
+## Description
+- **Map Integration**: Highlight the active roamer's current route on the interactive `.foundry/docs/adrs/010-gen3-map-graph-design.md` style map.
+- Ensure the UI component integrates properly with the broader DexHelper application flow.
+
+## Acceptance Criteria
+- [ ] The roamer's current route is highlighted on the map.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
+++ b/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
@@ -49,9 +49,9 @@ Based on an initial evaluation of the codebase:
 
 ## 4. Acceptance Criteria
 - [x] ~Gen 3 save parser correctly extracts Latios/Latias map group and ID.~ (Gen 3 impossible)
-- [x] Gen 2 raw map coordinates are translated into recognizable Route names.
-- [x] A dedicated UI component displays the current location of any active roamers.
-- [x] The feature only displays roamers that have actually been released in the save file's event flags.
+- [ ] Gen 2 raw map coordinates are translated into recognizable Route names.
+- [ ] A dedicated UI component displays the current location of any active roamers.
+- [ ] The feature only displays roamers that have actually been released in the save file's event flags.
 - [x] Break down this PRD into Epics.
 
 ## 5. Next Steps
@@ -62,4 +62,6 @@ Based on an initial evaluation of the codebase:
 - [ ] research-043-263-roamer-tracking-remediation
 - [ ] epic-043-139-gen2-roamer-data-extraction
 - [ ] epic-043-140-gen2-roamer-map-translation
-- [ ] epic-043-141-gen2-roamer-radar-ui
+- [x] ~epic-043-141-gen2-roamer-radar-ui~ (CANCELLED)
+- [ ] epic-043-142-gen2-roamer-radar-widget
+- [ ] epic-043-143-gen2-roamer-map-integration


### PR DESCRIPTION
Created new epics `epic-043-142-gen2-roamer-radar-widget.md` and `epic-043-143-gen2-roamer-map-integration.md`. Updated PRD `prd-070-043-roamer-tracking-dashboard.md` to reflect the new epics, marked the cancelled one, and unchecked functional acceptance criteria.

---
*PR created automatically by Jules for task [11488978433505427869](https://jules.google.com/task/11488978433505427869) started by @szubster*