### PR TITLE
Fix Roamer Tracking Dashboard child Epics setup

### DIFF
--- a/.foundry/epics/epic-043-139-gen2-roamer-data-extraction.md
+++ b/.foundry/epics/epic-043-139-gen2-roamer-data-extraction.md
@@ -2,7 +2,7 @@
 id: epic-043-139-gen2-roamer-data-extraction
 type: EPIC
 title: Gen 2 Roamer Data Extraction
-status: PENDING
+status: READY
 owner_persona: story_owner
 created_at: '2026-07-06'
 updated_at: '2026-07-06'

--- a/.foundry/epics/epic-043-140-gen2-roamer-map-translation.md
+++ b/.foundry/epics/epic-043-140-gen2-roamer-map-translation.md
@@ -2,7 +2,7 @@
 id: epic-043-140-gen2-roamer-map-translation
 type: EPIC
 title: Gen 2 Roamer Map Translation
-status: PENDING
+status: READY
 owner_persona: story_owner
 created_at: '2026-07-06'
 updated_at: '2026-07-06'

--- a/.foundry/epics/epic-043-141-gen2-roamer-radar-ui.md
+++ b/.foundry/epics/epic-043-141-gen2-roamer-radar-ui.md
@@ -2,7 +2,7 @@
 id: epic-043-141-gen2-roamer-radar-ui
 type: EPIC
 title: Gen 2 Roamer Radar UI
-status: CANCELLED
+status: READY
 owner_persona: story_owner
 created_at: '2026-07-06'
 updated_at: '2026-07-06'
@@ -14,7 +14,7 @@ parent: prd-070-043-roamer-tracking-dashboard
 tags: []
 research_references: []
 rejection_count: 0
-rejection_reason: Cancelled due to cascading cancellation from parent
+rejection_reason: ''
 notes: ''
 ---
 

--- a/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
+++ b/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
@@ -49,16 +49,16 @@ Based on an initial evaluation of the codebase:
 
 ## 4. Acceptance Criteria
 - [x] ~Gen 3 save parser correctly extracts Latios/Latias map group and ID.~ (Gen 3 impossible)
-- [x] Gen 2 raw map coordinates are translated into recognizable Route names.
-- [x] A dedicated UI component displays the current location of any active roamers.
-- [x] The feature only displays roamers that have actually been released in the save file's event flags.
+- [ ] Gen 2 raw map coordinates are translated into recognizable Route names.
+- [ ] A dedicated UI component displays the current location of any active roamers.
+- [ ] The feature only displays roamers that have actually been released in the save file's event flags.
 - [x] Break down this PRD into Epics.
 
 ## 5. Next Steps
 - [x] Epic Planner: Break this PRD down into executable Epics (e.g., Engine Parsing, Mapping Translation, UI Dashboard).
-- [ ] ~epic-043-067-roamer-data-extraction~ (CANCELLED)
-- [ ] ~epic-043-068-roamer-map-translation~ (CANCELLED)
-- [ ] ~epic-043-069-roamer-radar-ui~ (CANCELLED)
+- [x] ~epic-043-067-roamer-data-extraction~ (CANCELLED)
+- [x] ~epic-043-068-roamer-map-translation~ (CANCELLED)
+- [x] ~epic-043-069-roamer-radar-ui~ (CANCELLED)
 - [ ] research-043-263-roamer-tracking-remediation
 - [ ] epic-043-139-gen2-roamer-data-extraction
 - [ ] epic-043-140-gen2-roamer-map-translation


### PR DESCRIPTION
Fixed issues with the Roamer Tracking Dashboard PRD and child Epics setup. I unchecked functional acceptance criteria in the PRD, removed the hallucinated `142` epic, reset the statuses of epics `139`, `140`, and `141` to `READY`, and fixed the PRD checkboxes to match.

---
*PR created automatically by Jules for task [7621204710680155236](https://jules.google.com/task/7621204710680155236) started by @szubster*