### PR TITLE
chore: Verify Tailwind v4 Utility Consolidation Epic Breakdown

### DIFF
--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -57,7 +57,7 @@ DexHelper is transitioning from repetitive inline Tailwind classes to semantic c
 - [x] epic-071-099-migrate-complex-app-components-retry
 - [x] epic-071-100-tailwind-designer-persona-retry
 
-- [ ] epic-071-123-define-tailwind-v4-utilities-v2
-- [ ] epic-071-124-migrate-core-tactical-components-v2
-- [ ] epic-071-125-migrate-complex-app-components-v2
-- [ ] epic-071-126-tailwind-designer-persona-v2
+- [x] epic-071-123-define-tailwind-v4-utilities-v2
+- [x] epic-071-124-migrate-core-tactical-components-v2
+- [x] epic-071-125-migrate-complex-app-components-v2
+- [x] epic-071-126-tailwind-designer-persona-v2


### PR DESCRIPTION
Checked off structural acceptance criteria for generated Epics in the Tailwind v4 utilities migration PRD, complying with ADR 007 strict completeness checks before macro node verification.

---
*PR created automatically by Jules for task [5207073777655543082](https://jules.google.com/task/5207073777655543082) started by @szubster*