### PR TITLE
Add Item Runtime Integration Story for Dynamic Items Epic

### DIFF
--- a/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
+++ b/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
@@ -39,3 +39,4 @@ Currently, valid item lists are either manually maintained or fetched ad-hoc. Ma
 
 - [x] story-087-128-dynamic-item-list-parsing
 - [x] story-087-245-item-list-validation
+- [ ] story-087-280-item-runtime-integration

--- a/.foundry/stories/story-087-280-item-runtime-integration.md
+++ b/.foundry/stories/story-087-280-item-runtime-integration.md
@@ -1,0 +1,36 @@
+---
+id: story-087-280-item-runtime-integration
+type: STORY
+title: Item Data Runtime Integration
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-049-087-dynamic-item-list-parsing
+tags:
+  - refactor
+  - db
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Item Data Runtime Integration
+
+## Background
+We have successfully generated `items.jsonl` dynamically and integrated it into the `msgpackr` payload (`pokedata.msgpack`) via the Vite plugin. Now, we need to integrate this dynamically generated item data into the application runtime, specifically by adding the `items` object store to `PokeDB` and replacing the remaining hardcoded item mapping tables.
+
+## Goals
+1. Add an `items` object store to `DB_CONFIG.STORES` and `PokeDBSchema` in `src/db/schema.ts`.
+2. Update the `syncData` process in `src/db/PokeDB.ts` to inflate and store the decoded `items` array from the msgpack payload.
+3. Replace manual/hardcoded tables for item data (like `EVO_ITEM_NAMES` in `src/engine/assistant/strategies/items/gameItemMap.ts`) to use the dynamically populated runtime DB.
+
+## Acceptance Criteria
+- [ ] Add the `items` object store in IndexedDB.
+- [ ] Implement inflation and storage logic for items in `PokeDB.ts` during `syncData`.
+- [ ] Replace usage of hardcoded item maps with queries to the new database store.
+- [ ] Break down this STORY into concrete TASK nodes for implementation.


### PR DESCRIPTION
As the Story Owner, I have identified that Goal #4 ("Replace manual/hardcoded tables for item data") of the `epic-049-087-dynamic-item-list-parsing` epic was not covered by the existing stories. I have generated a new STORY node (`story-087-280-item-runtime-integration.md`) detailing the runtime IndexedDB integration for the newly generated `items.jsonl` data, and appended it to the Epic's Acceptance Criteria.

This empty PR satisfies the orchestrator requirements to progress the DAG.

---
*PR created automatically by Jules for task [10396644324535709627](https://jules.google.com/task/10396644324535709627) started by @szubster*