### PR TITLE
chore(epic): update completed node checkboxes in epic-047-081

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -44,8 +44,8 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 
 - [ ] story-081-121-gen3-tv-block-dataview-parser
 - [x] story-081-122-gen3-rtc-extraction
-- [ ] story-081-123-gen3-active-swarm-parsing
-- [ ] story-081-124-gen3-event-forecast-schedule
-- [ ] research-081-144-gen3-rtc-strategy
+- [x] story-081-123-gen3-active-swarm-parsing
+- [x] story-081-124-gen3-event-forecast-schedule
+- [x] research-081-144-gen3-rtc-strategy
 - [x] story-081-144-gen3-rtc-fallback-strategy
 - [ ] story-081-279-gen3-ignore-emulator-trailing-bytes


### PR DESCRIPTION
This PR updates `.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md` to check off the following child nodes that have transitioned to `COMPLETED`:

- `story-081-123-gen3-active-swarm-parsing`
- `story-081-124-gen3-event-forecast-schedule`
- `research-081-144-gen3-rtc-strategy`

This adheres to the hierarchical completion rules and prepares the epic for eventual transition to VERIFYING once all child stories are complete.

---
*PR created automatically by Jules for task [5642242165613181147](https://jules.google.com/task/5642242165613181147) started by @szubster*