### PR TITLE
chore(foundry): fix prd acceptance criteria checkboxes for v2 epics

### DIFF
--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -57,7 +57,7 @@ DexHelper is transitioning from repetitive inline Tailwind classes to semantic c
 - [x] epic-071-099-migrate-complex-app-components-retry
 - [x] epic-071-100-tailwind-designer-persona-retry
 
-- [x] epic-071-123-define-tailwind-v4-utilities-v2
-- [x] epic-071-124-migrate-core-tactical-components-v2
-- [x] epic-071-125-migrate-complex-app-components-v2
-- [x] epic-071-126-tailwind-designer-persona-v2
+- [ ] epic-071-123-define-tailwind-v4-utilities-v2
+- [ ] epic-071-124-migrate-core-tactical-components-v2
+- [ ] epic-071-125-migrate-complex-app-components-v2
+- [ ] epic-071-126-tailwind-designer-persona-v2


### PR DESCRIPTION
Unchecked the checkboxes for `epic-071-123`, `epic-071-124`, `epic-071-125`, and `epic-071-126` in `prd-071-040-tailwind-v4-utilities-migration.md`. These nodes are still `PENDING`, and checking them prematurely violated the empty PR policy and strict completion rules, causing the node to be rejected by the orchestrator in the previous iteration.

---
*PR created automatically by Jules for task [5146561294449571651](https://jules.google.com/task/5146561294449571651) started by @szubster*