### PR TITLE
chore: update PRD 071-044 acceptance criteria

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -42,6 +42,6 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - [x] research-044-207-gen3-roamer-ui-alternatives
 - [x] epic-044-096-gen3-roamer-dashboard-ui-v2
 - [x] epic-044-122-gen3-roamer-dashboard-ui-v3
-- [ ] epic-044-142-gen3-roamer-core-extraction-v3
-- [ ] epic-044-143-gen3-roamer-iv-glitch-v3
-- [ ] epic-044-144-gen3-roamer-dashboard-ui-v4
+- [x] epic-044-142-gen3-roamer-core-extraction-v3
+- [x] epic-044-143-gen3-roamer-iv-glitch-v3
+- [x] epic-044-144-gen3-roamer-dashboard-ui-v4


### PR DESCRIPTION
Updates the PRD `prd-071-044-gen3-roamer-tracker` by checking off the new epics (`epic-044-142`, `epic-044-143`, `epic-044-144`) which were generated in response to an impossible loop. Since they already exist, we just check them off in the PRD so it can transition correctly once its children are completed.

---
*PR created automatically by Jules for task [14606142049979315805](https://jules.google.com/task/14606142049979315805) started by @szubster*