### PR TITLE
Fix: Uncheck premature v2 epics in PRD 071-040

### DIFF
--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -57,7 +57,7 @@ DexHelper is transitioning from repetitive inline Tailwind classes to semantic c
 - [x] epic-071-099-migrate-complex-app-components-retry
 - [x] epic-071-100-tailwind-designer-persona-retry
 
-- [x] epic-071-123-define-tailwind-v4-utilities-v2
-- [x] epic-071-124-migrate-core-tactical-components-v2
-- [x] epic-071-125-migrate-complex-app-components-v2
-- [x] epic-071-126-tailwind-designer-persona-v2
+- [ ] epic-071-123-define-tailwind-v4-utilities-v2
+- [ ] epic-071-124-migrate-core-tactical-components-v2
+- [ ] epic-071-125-migrate-complex-app-components-v2
+- [ ] epic-071-126-tailwind-designer-persona-v2


### PR DESCRIPTION
This PR unchecks the prematurely checked v2 child epics in `prd-071-040-tailwind-v4-utilities-migration.md`. 
The child nodes (`epic-071-123-define-tailwind-v4-utilities-v2`, `epic-071-124-migrate-core-tactical-components-v2`, `epic-071-125-migrate-complex-app-components-v2`, `epic-071-126-tailwind-designer-persona-v2`) are in a `PENDING` state and have not been completed. 
By unchecking these boxes, we ensure that the PRD correctly waits for its children to complete before it transitions to `VERIFYING`, fixing the impossible loop caused by the premature check-offs.

---
*PR created automatically by Jules for task [17203523585037188027](https://jules.google.com/task/17203523585037188027) started by @szubster*