### PR TITLE
feat: Generate Gen 3 RTC Fallback STORY nodes

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -49,3 +49,5 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [x] research-081-144-gen3-rtc-strategy
 - [x] story-081-144-gen3-rtc-fallback-strategy
 - [ ] story-081-279-gen3-ignore-emulator-trailing-bytes
+- [ ] story-081-281-gen3-system-time-fallback
+- [ ] story-081-282-gen3-manual-time-ui-overrides

--- a/.foundry/stories/story-081-281-gen3-system-time-fallback.md
+++ b/.foundry/stories/story-081-281-gen3-system-time-fallback.md
@@ -1,0 +1,30 @@
+---
+id: story-081-281-gen3-system-time-fallback
+type: STORY
+title: Implement Gen 3 System Time Fallback
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - research-081-144-gen3-rtc-strategy
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - rtc
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Implement Gen 3 System Time Fallback
+
+## Description
+Based on ADR 025 and the findings from `research-081-144-gen3-rtc-strategy`, extracting Real-Time Clock (RTC) values directly from Gen 3 `.sav` files is unreliable. This story covers the implementation of the RTC-Independent Fallback Strategy by defaulting to the host device's current system time for time-based events in Gen 3.
+
+## Acceptance Criteria
+- [ ] Implement System Time Fallback for Gen 3 time-gated events.

--- a/.foundry/stories/story-081-282-gen3-manual-time-ui-overrides.md
+++ b/.foundry/stories/story-081-282-gen3-manual-time-ui-overrides.md
@@ -1,0 +1,30 @@
+---
+id: story-081-282-gen3-manual-time-ui-overrides
+type: STORY
+title: Implement Gen 3 Manual Time UI Overrides
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - research-081-144-gen3-rtc-strategy
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - rtc
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Implement Gen 3 Manual Time UI Overrides
+
+## Description
+Based on ADR 025 and the findings from `research-081-144-gen3-rtc-strategy`, this story covers the implementation of Manual UI Overrides for Gen 3. We will provide UI controls to allow users to manually set or override the time state (e.g., simulating day/night or specific days for time-gated events).
+
+## Acceptance Criteria
+- [ ] Implement Manual UI Overrides to allow users to force a specific time state.


### PR DESCRIPTION
This PR dynamically generates two new replacement STORY nodes for the cancelled RTC extraction story (`story-081-122-gen3-rtc-extraction`):
1. **Implement Gen 3 System Time Fallback** (`story-081-281-gen3-system-time-fallback`)
2. **Implement Gen 3 Manual Time UI Overrides** (`story-081-282-gen3-manual-time-ui-overrides`)

These stories correspond to the fallback strategies outlined in `ADR 025` and the findings from `research-081-144-gen3-rtc-strategy`. Both stories have been properly formatted according to the schema and correctly linked in the dependencies graph. They have also been appended as unchecked tasks to the `epic-047-081-gen3-tv-swarm-data-extraction` acceptance criteria.

---
*PR created automatically by Jules for task [5715041277048875213](https://jules.google.com/task/5715041277048875213) started by @szubster*