### PR TITLE
chore: uncheck replaced epic nodes in gen 3 roamer tracker PRD

### DIFF
--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -42,6 +42,6 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - [x] research-044-207-gen3-roamer-ui-alternatives
 - [x] epic-044-096-gen3-roamer-dashboard-ui-v2
 - [x] epic-044-122-gen3-roamer-dashboard-ui-v3
-- [x] epic-044-142-gen3-roamer-core-extraction-v3
-- [x] epic-044-143-gen3-roamer-iv-glitch-v3
-- [x] epic-044-144-gen3-roamer-dashboard-ui-v4
+- [ ] epic-044-142-gen3-roamer-core-extraction-v3
+- [ ] epic-044-143-gen3-roamer-iv-glitch-v3
+- [ ] epic-044-144-gen3-roamer-dashboard-ui-v4


### PR DESCRIPTION
Unchecked the replaced epic nodes (`epic-044-142`, `epic-044-143`, `epic-044-144`) in the Gen 3 Roaming Legendary Tracker PRD (`prd-071-044-gen3-roamer-tracker.md`). These nodes represent the current active breakdown and must remain unchecked (`- [ ]`) to prevent the parent PRD from prematurely transitioning to the `VERIFYING` state before its dependencies are fulfilled, resolving the issue that caused the previous rejection.

---
*PR created automatically by Jules for task [14263033104469645200](https://jules.google.com/task/14263033104469645200) started by @szubster*