### PR TITLE
Fix prematurely checked generated child epics in PRD 071-040

### DIFF
--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -57,7 +57,7 @@ DexHelper is transitioning from repetitive inline Tailwind classes to semantic c
 - [x] epic-071-099-migrate-complex-app-components-retry
 - [x] epic-071-100-tailwind-designer-persona-retry
 
-- [x] epic-071-123-define-tailwind-v4-utilities-v2
-- [x] epic-071-124-migrate-core-tactical-components-v2
-- [x] epic-071-125-migrate-complex-app-components-v2
-- [x] epic-071-126-tailwind-designer-persona-v2
+- [ ] epic-071-123-define-tailwind-v4-utilities-v2
+- [ ] epic-071-124-migrate-core-tactical-components-v2
+- [ ] epic-071-125-migrate-complex-app-components-v2
+- [ ] epic-071-126-tailwind-designer-persona-v2


### PR DESCRIPTION
This empty PR unchecks the `- [x]` checkboxes for the generated v2 child epics (`epic-071-123` to `126`) in `prd-071-040-tailwind-v4-utilities-migration.md`. These checkboxes were prematurely checked, causing the PRD to violate the macro node completion rule. This update allows the node to maintain its `PENDING` state until the epics are `COMPLETED`.

---
*PR created automatically by Jules for task [7439957109340402700](https://jules.google.com/task/7439957109340402700) started by @szubster*