### PR TITLE
chore: breakdown story 154 into tasks for orchestrator phase 3.6 fix

### DIFF
--- a/.foundry/stories/story-096-154-parent-awakening-logic.md
+++ b/.foundry/stories/story-096-154-parent-awakening-logic.md
@@ -24,5 +24,6 @@ notes: ''
 # Story: Parent Awakening Logic for Cancelled Nodes
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks.
+- [x] Break down into Tasks.
 - [ ] Update Phase 3.6 of `foundry-orchestrator.ts` to expand the condition `node.frontmatter.status === 'FAILED'` to include `CANCELLED` nodes with a `rejection_reason`.
+- [ ] task-154-278-update-orchestrator-phase36-cancelled-logic-impl

--- a/.foundry/tasks/task-154-278-update-orchestrator-phase36-cancelled-logic-impl.md
+++ b/.foundry/tasks/task-154-278-update-orchestrator-phase36-cancelled-logic-impl.md
@@ -1,0 +1,32 @@
+---
+id: task-154-278-update-orchestrator-phase36-cancelled-logic-impl
+type: TASK
+title: Update Orchestrator Phase 3.6 Cancelled Logic
+status: READY
+owner_persona: coder
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-096-154-parent-awakening-logic
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update Orchestrator Phase 3.6 Cancelled Logic
+
+## Overview
+Update Phase 3.6 of `.github/scripts/foundry-orchestrator.ts` to expand the condition `node.frontmatter.status === 'FAILED'` to include `CANCELLED` nodes with a `rejection_reason`.
+
+## Acceptance Criteria
+- [ ] Locate Phase 3.6 in `.github/scripts/foundry-orchestrator.ts`.
+- [ ] Expand the condition checking for `FAILED` status and `rejection_reason` to also include `CANCELLED` nodes with a `rejection_reason`.
+
+**Note for Coder:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR breaks down `story-096-154-parent-awakening-logic` into actionable TASK nodes according to the Tech Lead persona instructions.

- Created new TASK node `task-154-278-update-orchestrator-phase36-cancelled-logic-impl`.
- Updated the parent STORY node's acceptance criteria checkboxes without modifying YAML frontmatter.
- Executed `pnpm lint` and `pnpm test` to ensure stability.

---
*PR created automatically by Jules for task [15829948011637876882](https://jules.google.com/task/15829948011637876882) started by @szubster*