### PR TITLE
Fix PRD Formatting for Roamer Tracking Dashboard

### DIFF
--- a/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
+++ b/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
@@ -53,8 +53,6 @@ Based on an initial evaluation of the codebase:
 - [ ] A dedicated UI component displays the current location of any active roamers.
 - [ ] The feature only displays roamers that have actually been released in the save file's event flags.
 - [x] Break down this PRD into Epics.
-
-## 5. Next Steps
 - [x] Epic Planner: Break this PRD down into executable Epics (e.g., Engine Parsing, Mapping Translation, UI Dashboard).
 - [x] ~epic-043-067-roamer-data-extraction~ (CANCELLED)
 - [x] ~epic-043-068-roamer-map-translation~ (CANCELLED)
@@ -65,3 +63,5 @@ Based on an initial evaluation of the codebase:
 - [x] ~epic-043-141-gen2-roamer-radar-ui~ (CANCELLED)
 - [ ] epic-043-142-gen2-roamer-radar-widget
 - [ ] epic-043-143-gen2-roamer-map-integration
+
+## 5. Next Steps


### PR DESCRIPTION
- Moved the list of child Epics from the "Next Steps" section into the "Acceptance Criteria" section within `prd-070-043-roamer-tracking-dashboard.md`.
- This ensures the orchestrator properly enforces dependency checks and prevents the PRD from prematurely transitioning to VERIFYING before all its children are complete.

---
*PR created automatically by Jules for task [10865853625157687474](https://jules.google.com/task/10865853625157687474) started by @szubster*