### PR TITLE
fix: demote PRD and set pending children to ready

### DIFF
--- a/.foundry/epics/epic-071-123-define-tailwind-v4-utilities-v2.md
+++ b/.foundry/epics/epic-071-123-define-tailwind-v4-utilities-v2.md
@@ -2,7 +2,7 @@
 id: epic-071-123-define-tailwind-v4-utilities-v2
 type: EPIC
 title: Define Tailwind v4 Tactical Utilities V2
-status: PENDING
+status: READY
 owner_persona: story_owner
 created_at: '2026-07-03'
 updated_at: '2026-07-05'

--- a/.foundry/epics/epic-071-124-migrate-core-tactical-components-v2.md
+++ b/.foundry/epics/epic-071-124-migrate-core-tactical-components-v2.md
@@ -2,7 +2,7 @@
 id: epic-071-124-migrate-core-tactical-components-v2
 type: EPIC
 title: Migrate Core Tactical Components V2
-status: PENDING
+status: READY
 owner_persona: story_owner
 created_at: '2026-07-03'
 updated_at: '2026-07-03'

--- a/.foundry/epics/epic-071-125-migrate-complex-app-components-v2.md
+++ b/.foundry/epics/epic-071-125-migrate-complex-app-components-v2.md
@@ -2,7 +2,7 @@
 id: epic-071-125-migrate-complex-app-components-v2
 type: EPIC
 title: Migrate Complex App Components V2
-status: PENDING
+status: READY
 owner_persona: story_owner
 created_at: '2026-07-03'
 updated_at: '2026-07-03'

--- a/.foundry/epics/epic-071-126-tailwind-designer-persona-v2.md
+++ b/.foundry/epics/epic-071-126-tailwind-designer-persona-v2.md
@@ -2,7 +2,7 @@
 id: epic-071-126-tailwind-designer-persona-v2
 type: EPIC
 title: Implement Tailwind Designer Persona Ownership V2
-status: PENDING
+status: READY
 owner_persona: story_owner
 created_at: '2026-07-03'
 updated_at: '2026-07-03'

--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -43,7 +43,7 @@ DexHelper is transitioning from repetitive inline Tailwind classes to semantic c
 - Migrating generic unrepeated utility classes.
 
 ## Acceptance Criteria
-- [x] Epics are created to handle the migration in manageable chunks.
+- [ ] Epics are created to handle the migration in manageable chunks.
 
 
 - [x] epic-071-074-define-tailwind-v4-utilities
@@ -57,7 +57,7 @@ DexHelper is transitioning from repetitive inline Tailwind classes to semantic c
 - [x] epic-071-099-migrate-complex-app-components-retry
 - [x] epic-071-100-tailwind-designer-persona-retry
 
-- [x] epic-071-123-define-tailwind-v4-utilities-v2
-- [x] epic-071-124-migrate-core-tactical-components-v2
-- [x] epic-071-125-migrate-complex-app-components-v2
-- [x] epic-071-126-tailwind-designer-persona-v2
+- [ ] epic-071-123-define-tailwind-v4-utilities-v2
+- [ ] epic-071-124-migrate-core-tactical-components-v2
+- [ ] epic-071-125-migrate-complex-app-components-v2
+- [ ] epic-071-126-tailwind-designer-persona-v2


### PR DESCRIPTION
- Unchecks the Acceptance Criteria checkboxes in `prd-071-040-tailwind-v4-utilities-migration.md` for the overarching requirement and its incomplete v2 child Epics (`epic-071-123`, `epic-071-124`, `epic-071-125`, `epic-071-126`). This adheres to the Late-Binding Orchestrator Demotion Compliance Rule, preventing the parent from prematurely transitioning to VERIFYING.
- Updates the YAML frontmatter status of the aforementioned child Epics from `PENDING` to `READY` to resolve the pipeline deadlock and allow the next persona (`story_owner`) to pick them up.

---
*PR created automatically by Jules for task [4166126570901794354](https://jules.google.com/task/4166126570901794354) started by @szubster*