### PR TITLE
Fix PRD checklist formatting for roamer tracking dashboard

### DIFF
--- a/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
+++ b/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
@@ -53,9 +53,6 @@ Based on an initial evaluation of the codebase:
 - [ ] A dedicated UI component displays the current location of any active roamers.
 - [ ] The feature only displays roamers that have actually been released in the save file's event flags.
 - [x] Break down this PRD into Epics.
-
-## 5. Next Steps
-- [x] Epic Planner: Break this PRD down into executable Epics (e.g., Engine Parsing, Mapping Translation, UI Dashboard).
 - [x] ~epic-043-067-roamer-data-extraction~ (CANCELLED)
 - [x] ~epic-043-068-roamer-map-translation~ (CANCELLED)
 - [x] ~epic-043-069-roamer-radar-ui~ (CANCELLED)
@@ -65,3 +62,6 @@ Based on an initial evaluation of the codebase:
 - [x] ~epic-043-141-gen2-roamer-radar-ui~ (CANCELLED)
 - [ ] epic-043-142-gen2-roamer-radar-widget
 - [ ] epic-043-143-gen2-roamer-map-integration
+
+## 5. Next Steps
+- [x] Epic Planner: Break this PRD down into executable Epics (e.g., Engine Parsing, Mapping Translation, UI Dashboard).


### PR DESCRIPTION
Moved the generated descendant node references from the `Next Steps` section to the `Acceptance Criteria` section in the PRD markdown file (`prd-070-043-roamer-tracking-dashboard.md`). This change enforces the parent-node formatting requirement (ADR 007) and allows the orchestrator to correctly demote the node to PENDING while it waits for the completion of its generated children.

---
*PR created automatically by Jules for task [11735229608338830735](https://jules.google.com/task/11735229608338830735) started by @szubster*