### PR TITLE
🧹 Remove unused SaveHistoryDBSchema types

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -5,3 +5,6 @@
 * Sweeper PRs must use the title format `🧹 [description]` and include `🎯 What`, `💡 Why`, `✅ Verification`, and `✨ Result` in the body.
 
 - If `pnpm install` hangs or fails during git hook setup (e.g., `lefthook install`), run `git config --unset-all --global core.hooksPath` before retrying the installation.
+* The Sweeper persona's private memory is strictly `.jules/sweeper.md` and must be used solely to log long-term lessons, architectural constraints, and recurring failures, never as an execution logbook.
+* Sweeper persona Pull Requests must use the title format `🧹 [description]` and include `🎯 What`, `💡 Why`, `✅ Verification`, and `✨ Result` in the body.
+* To automatically fix formatting errors detected during linting, use `pnpm exec biome format --write <file>`.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -175,28 +175,3 @@ export interface PokeDBSchema extends DBSchema {
     value: { key: string; value: string };
   };
 }
-
-export const SAVE_HISTORY_DB_CONFIG = {
-  NAME: 'SaveHistoryDB',
-  VERSION: 1,
-  STORES: {
-    SAVES: 'saves',
-    METADATA: 'metadata',
-    INDEXES: 'indexes',
-  },
-} as const;
-
-export interface SaveHistoryDBSchema extends DBSchema {
-  [SAVE_HISTORY_DB_CONFIG.STORES.SAVES]: {
-    key: string;
-    value: Uint8Array;
-  };
-  [SAVE_HISTORY_DB_CONFIG.STORES.METADATA]: {
-    key: string;
-    value: Record<string, unknown>;
-  };
-  [SAVE_HISTORY_DB_CONFIG.STORES.INDEXES]: {
-    key: string;
-    value: Record<string, unknown>;
-  };
-}


### PR DESCRIPTION
🎯 What
Removed `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema` from `src/db/schema.ts`.

💡 Why
These types and configurations were dead code/unused exports as identified by static analysis (`pnpm knip`), helping to clean up technical debt and ensure codebase health.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to verify no existing functionality was broken by removing the unused code.

✨ Result
A cleaner `schema.ts` file with no unused interfaces or redundant objects, resolving tech debt around unused exports.

---
*PR created automatically by Jules for task [10501340412003212054](https://jules.google.com/task/10501340412003212054) started by @szubster*