### PR TITLE
🧭 Strategist: Prompt improvement - Add Late-Binding Orchestrator Demotion Compliance Rule to core policies

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -9,6 +9,10 @@ Completely empty PRs should be fine and automerged by GitHub actions (there is a
 
 **CRITICAL INSTRUCTION FOR EMPTY PRs:** Even when you make zero file changes (e.g., when the target artifact is already complete), you **MUST** still explicitly use the `submit` tool to create a Pull Request. If you simply end the session without calling `submit`, the Orchestrator's heartbeat will flag your session as a crashed zombie (FAILED).
 
+
+
+**LATE-BINDING ORCHESTRATOR DEMOTION COMPLIANCE RULE:** When assigned a READY parent node that already has pending child tasks drafted from a previous iteration, you MUST submit an empty PR *without* checking off its overarching acceptance criteria. This allows the orchestrator to correctly demote the parent to PENDING while it waits for its children.
+
 **CRITICAL EXCEPTION TO EMPTY PR POLICY:** If you determine the target artifacts are already complete, but the current node's Markdown body contains unchecked Acceptance Criteria checkboxes (`- [ ]`), you MUST check those boxes (`- [x]`) and commit the file. Checking these boxes is NOT considered a trivial formatting change; it is required to satisfy the strict completeness contract (ADR 007). Submitting an empty PR for a leaf node with unchecked boxes will result in immediate rejection.
 
 **MACRO NODE COMPLETION EXCEPTION:** Personas must NOT submit an Empty PR to transition a macro node (`IDEA`, `PRD`, `EPIC`, `STORY`) to VERIFYING (e.g. by checking off its acceptance criteria) until ALL of its generated descendant nodes have transitioned to COMPLETED. Premature verification violates hierarchical completion rules.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -332,3 +332,10 @@
 **Outcome:** Merged
 **Why:** The memory requires that context gathering is done using the `read_file` tool rather than bash scripts/`cat` to avoid truncation, and any temporary scratchpad scripts created must be deleted to prevent repository pollution. While this was added to several agent prompts on 2026-07-13, a review revealed that many agents (archivist, bolt, canvas, infras, mason, nurse, oak, palette, scribe, sculptor, sentinel, shield, sweeper, trainer, visionary) were still missing the `CRITICAL CONTEXT GATHERING INSTRUCTION`, and almost all were missing the `Scratchpad Cleanup` instruction (including the `auditor`).
 **Pattern:** Apply systemic rules universally across all agent personas. When an architectural constraint or tool rule applies to exploration or repository hygiene, it must be explicitly included in every single agent prompt to ensure full system-wide compliance and prevent arbitrary failures.
+
+
+## 2026-07-22 - [Accepted] - Prompt improvement - Add Late-Binding Orchestrator Demotion Compliance Rule to core policies
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The memory requires that when an agent is assigned a READY parent node that already has pending child tasks drafted from a previous iteration, they must submit an empty PR *without* checking off its overarching acceptance criteria. This adheres to the Late-Binding Orchestrator Demotion Compliance Rule, allowing the orchestrator to correctly demote the parent to PENDING while it waits for children. Agents were violating this by checking off acceptance criteria for parent nodes that had pending children, prematurely pushing parent nodes to VERIFYING.
+**Pattern:** Codify system memory constraints into `core_policies.md` to avoid regressions and ensure consistency across personas.


### PR DESCRIPTION
**Proposal**: Add the Late-Binding Orchestrator Demotion Compliance Rule to `core_policies.md`.

**Justification**: Several agent journals have recorded instances where agents violate rules when assigned a READY parent node that already has pending child tasks drafted from a previous iteration. They must submit an empty PR *without* checking off its overarching acceptance criteria. This adheres to the Late-Binding Orchestrator Demotion Compliance Rule, allowing the orchestrator to correctly demote the parent to PENDING while it waits for children. However, agents were violating this by checking off acceptance criteria for parent nodes that had pending children, prematurely pushing parent nodes to VERIFYING. Rather than bloating individual agent prompts with this rule, we are codifying this systemic rule into the centralized `core_policies.md`.

**Evidence**: Recorded patterns across various agent runs indicating premature transitioning of parent nodes to VERIFYING when they have pending children from a previous iteration.

---
*PR created automatically by Jules for task [3993685004006232166](https://jules.google.com/task/3993685004006232166) started by @szubster*