### PR TITLE
Draft retry 4 for gen3 tv block parser

### DIFF
--- a/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
+++ b/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
@@ -44,3 +44,5 @@ Implement the foundational logic to locate and read the TV broadcast data block 
 - [x] task-121-277-gen3-tv-block-parser-retry2-qa
 - [ ] task-121-278-gen3-tv-block-parser-retry3-impl
 - [ ] task-121-279-gen3-tv-block-parser-retry3-qa
+- [ ] task-121-280-gen3-tv-block-parser-retry4-impl
+- [ ] task-121-281-gen3-tv-block-parser-retry4-qa

--- a/.foundry/tasks/task-121-278-gen3-tv-block-parser-retry3-impl.md
+++ b/.foundry/tasks/task-121-278-gen3-tv-block-parser-retry3-impl.md
@@ -3,7 +3,6 @@ id: task-121-278-gen3-tv-block-parser-retry3-impl
 type: TASK
 title: Implement Gen 3 TV Block DataView Parser (Retry 4)
 status: CANCELLED
-rejection_reason: "Max rejections reached"
 owner_persona: coder
 created_at: '2026-07-06'
 updated_at: '2026-07-06'
@@ -18,7 +17,7 @@ tags:
   - data-parsing
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: "Max rejections reached"
 notes: ''
 ---
 

--- a/.foundry/tasks/task-121-279-gen3-tv-block-parser-retry3-qa.md
+++ b/.foundry/tasks/task-121-279-gen3-tv-block-parser-retry3-qa.md
@@ -3,7 +3,6 @@ id: task-121-279-gen3-tv-block-parser-retry3-qa
 type: TASK
 title: QA Gen 3 TV Block DataView Parser (Retry 4)
 status: CANCELLED
-rejection_reason: "Max rejections reached"
 owner_persona: qa
 created_at: '2026-07-06'
 updated_at: '2026-07-06'
@@ -18,7 +17,7 @@ tags:
   - data-parsing
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: "Max rejections reached"
 notes: ''
 ---
 

--- a/.foundry/tasks/task-121-280-gen3-tv-block-parser-retry4-impl.md
+++ b/.foundry/tasks/task-121-280-gen3-tv-block-parser-retry4-impl.md
@@ -1,14 +1,12 @@
 ---
-id: task-121-278-gen3-tv-block-parser-retry3-impl
+id: task-121-280-gen3-tv-block-parser-retry4-impl
 type: TASK
-title: Implement Gen 3 TV Block DataView Parser (Retry 4)
-status: CANCELLED
-rejection_reason: "Max rejections reached"
+title: Implement Gen 3 TV Block DataView Parser (Retry 5)
+status: READY
 owner_persona: coder
 created_at: '2026-07-06'
 updated_at: '2026-07-06'
-depends_on:
-  - research-121-246-gen3-tv-block-parser-retry-failure
+depends_on: []
 jules_session_id: null
 pr_number: null
 parent: story-081-121-gen3-tv-block-dataview-parser
@@ -22,7 +20,7 @@ rejection_reason: ''
 notes: ''
 ---
 
-# Task: Implement Gen 3 TV Block DataView Parser (Retry 4)
+# Task: Implement Gen 3 TV Block DataView Parser (Retry 5)
 
 ## Description
 This task requires you to implement the foundational logic to locate and read the TV broadcast data block from the Gen 3 save file structure, addressing the feedback from `research-121-246-gen3-tv-block-parser-retry-failure`.

--- a/.foundry/tasks/task-121-281-gen3-tv-block-parser-retry4-qa.md
+++ b/.foundry/tasks/task-121-281-gen3-tv-block-parser-retry4-qa.md
@@ -1,14 +1,13 @@
 ---
-id: task-121-279-gen3-tv-block-parser-retry3-qa
+id: task-121-281-gen3-tv-block-parser-retry4-qa
 type: TASK
-title: QA Gen 3 TV Block DataView Parser (Retry 4)
-status: CANCELLED
-rejection_reason: "Max rejections reached"
+title: QA Gen 3 TV Block DataView Parser (Retry 5)
+status: PENDING
 owner_persona: qa
 created_at: '2026-07-06'
 updated_at: '2026-07-06'
 depends_on:
-  - task-121-278-gen3-tv-block-parser-retry3-impl
+  - task-121-280-gen3-tv-block-parser-retry4-impl
 jules_session_id: null
 pr_number: null
 parent: story-081-121-gen3-tv-block-dataview-parser
@@ -22,7 +21,7 @@ rejection_reason: ''
 notes: ''
 ---
 
-# Task: QA Gen 3 TV Block DataView Parser (Retry 4)
+# Task: QA Gen 3 TV Block DataView Parser (Retry 5)
 
 ## Description
 Verify the implementation of the Gen 3 TV block `DataView` parser to ensure it correctly and safely parses the data according to the architecture guidelines and the findings from `research-121-246-gen3-tv-block-parser-retry-failure`.


### PR DESCRIPTION
The previous attempts (`task-121-278` and `task-121-279`) were rejected due to modifying source files (`src/engine/saveParser/parsers/gen3.ts`). The `tech_lead` persona is strictly responsible for translating stories into actionable blueprint nodes and orchestrating node states, never modifying application source code.

This PR cancels the previous failed iterations and drafts new replacement tasks (`task-121-280` and `task-121-281`) for the next retry iteration. The new tasks are appended to the parent story node (`story-081-121-gen3-tv-block-dataview-parser`).

---
*PR created automatically by Jules for task [2557161250743784840](https://jules.google.com/task/2557161250743784840) started by @szubster*