### PR TITLE
Break down Pokegear Predictor epic into stories

### DIFF
--- a/.foundry/epics/epic-055-117-pokegear-predictor.md
+++ b/.foundry/epics/epic-055-117-pokegear-predictor.md
@@ -34,3 +34,6 @@ Implement the logic to predict Pokegear call probability based on Gen 2 save fil
 ## Acceptance Criteria
 - [ ] Implement predictor logic based on RNG mechanics
 - [ ] Display call probabilities on the UI
+
+- [ ] story-117-283-pokegear-predictor-engine
+- [ ] story-117-284-pokegear-predictor-ui

--- a/.foundry/stories/story-117-283-pokegear-predictor-engine.md
+++ b/.foundry/stories/story-117-283-pokegear-predictor-engine.md
@@ -1,0 +1,32 @@
+---
+id: story-117-283-pokegear-predictor-engine
+type: STORY
+title: Implement Predictor Engine Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-07'
+updated_at: '2026-07-07'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-055-117-pokegear-predictor
+tags:
+  - feature
+  - gen2
+  - mechanics
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Implement Predictor Engine Logic
+
+## Objective
+Break down the implementation of the Pokegear Predictor logic into tasks.
+
+## Requirements
+- Create tasks to implement the RNG mechanics and probability calculations based on research.
+
+## Acceptance Criteria
+- [ ] Create tasks for the predictor engine logic

--- a/.foundry/stories/story-117-284-pokegear-predictor-ui.md
+++ b/.foundry/stories/story-117-284-pokegear-predictor-ui.md
@@ -1,0 +1,33 @@
+---
+id: story-117-284-pokegear-predictor-ui
+type: STORY
+title: Implement Predictor Engine UI
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-07'
+updated_at: '2026-07-07'
+depends_on:
+  - story-117-283-pokegear-predictor-engine
+jules_session_id: null
+pr_number: null
+parent: epic-055-117-pokegear-predictor
+tags:
+  - feature
+  - gen2
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Implement Predictor Engine UI
+
+## Objective
+Break down the implementation of the Pokegear Predictor UI into tasks.
+
+## Requirements
+- Create tasks to implement the display of call probabilities on the Active Callers Dashboard.
+
+## Acceptance Criteria
+- [ ] Create tasks for the predictor engine UI


### PR DESCRIPTION
This PR breaks down the `epic-055-117-pokegear-predictor` epic into two actionable story nodes: `story-117-283-pokegear-predictor-engine` and `story-117-284-pokegear-predictor-ui`. The new stories are appended to the epic's acceptance criteria without prematurely marking the epic as complete.

---
*PR created automatically by Jules for task [18146347888712885333](https://jules.google.com/task/18146347888712885333) started by @szubster*