### PR TITLE
feat: breakdown epic-055-116-pokegear-active-callers into stories

### DIFF
--- a/.foundry/epics/epic-055-116-pokegear-active-callers.md
+++ b/.foundry/epics/epic-055-116-pokegear-active-callers.md
@@ -35,3 +35,6 @@ Create a dashboard view displaying all registered Pokegear NPCs and their curren
 - [ ] Create UI for Active Callers Dashboard
 - [ ] Implement save file parsing for registered numbers
 - [ ] Integrate parsed data with dashboard UI
+- [ ] story-116-283-parse-registered-numbers
+- [ ] story-116-284-active-callers-dashboard-ui
+- [ ] story-116-285-integrate-registered-numbers-ui

--- a/.foundry/stories/story-116-283-parse-registered-numbers.md
+++ b/.foundry/stories/story-116-283-parse-registered-numbers.md
@@ -1,0 +1,28 @@
+---
+id: story-116-283-parse-registered-numbers
+type: STORY
+title: Parse Registered Numbers
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-07'
+updated_at: '2026-07-07'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-055-116-pokegear-active-callers
+tags:
+  - feature
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Parse Registered Numbers
+
+## Objective
+Parse the registered numbers list from the Generation 2 save file based on research findings.
+
+## Acceptance Criteria
+- [ ] Implement parsing logic for Pokegear registered numbers.

--- a/.foundry/stories/story-116-284-active-callers-dashboard-ui.md
+++ b/.foundry/stories/story-116-284-active-callers-dashboard-ui.md
@@ -1,0 +1,28 @@
+---
+id: story-116-284-active-callers-dashboard-ui
+type: STORY
+title: Active Callers Dashboard UI
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-07'
+updated_at: '2026-07-07'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-055-116-pokegear-active-callers
+tags:
+  - ui
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Active Callers Dashboard UI
+
+## Objective
+Create a dashboard view displaying all registered Pokegear NPCs.
+
+## Acceptance Criteria
+- [ ] Build the active callers dashboard UI.

--- a/.foundry/stories/story-116-285-integrate-registered-numbers-ui.md
+++ b/.foundry/stories/story-116-285-integrate-registered-numbers-ui.md
@@ -1,0 +1,30 @@
+---
+id: story-116-285-integrate-registered-numbers-ui
+type: STORY
+title: Integrate Registered Numbers UI
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-07'
+updated_at: '2026-07-07'
+depends_on:
+  - story-116-283-parse-registered-numbers
+  - story-116-284-active-callers-dashboard-ui
+jules_session_id: null
+pr_number: null
+parent: epic-055-116-pokegear-active-callers
+tags:
+  - ui
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Integrate Registered Numbers UI
+
+## Objective
+Integrate the parsed registered numbers data with the dashboard UI, displaying the current status of each registered NPC.
+
+## Acceptance Criteria
+- [ ] Render the current status of each registered NPC on the dashboard.


### PR DESCRIPTION
This PR breaks down `epic-055-116-pokegear-active-callers` into three granular, highly-focused story nodes:
- `story-116-283-parse-registered-numbers`
- `story-116-284-active-callers-dashboard-ui`
- `story-116-285-integrate-registered-numbers-ui`

The stories are assigned to the `tech_lead` persona for the next transition, and are appended as unchecked tasks to the parent's `## Acceptance Criteria`.
No frontmatter changes were made to the parent Epic to avoid premature validation.

---
*PR created automatically by Jules for task [12021747070001929386](https://jules.google.com/task/12021747070001929386) started by @szubster*