### PR TITLE
feat: generate stories for pokegear high-value alerts

### DIFF
--- a/.foundry/epics/epic-055-118-pokegear-alerts.md
+++ b/.foundry/epics/epic-055-118-pokegear-alerts.md
@@ -34,3 +34,5 @@ Implement specific UI alerts and filtering for high-value Pokegear calls (swarms
 ## Acceptance Criteria
 - [ ] Implement filtering for swarm and item-giving calls
 - [ ] Create distinct UI alerts for high-value calls
+- [ ] story-118-286-filter-swarm-item-calls
+- [ ] story-118-287-highlight-high-value-calls-ui

--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -12,3 +12,5 @@ While the orchestrator's graph resolution logic relies on the exact string value
 
 ## Empty PRs for Pre-existing Child Nodes
 When an Epic transitions to ACTIVE and assigns you as the Story Owner, check if the acceptance criteria already encompass all required child stories from previous iterations or cancelled task replacements (the "Impossible Loop"). If the required stories are already generated and appended to the markdown body, do not blindly generate duplicate stories. Instead, verify that any CANCELLED child nodes are properly checked off in the parent's markdown, and submit an empty PR to allow the DAG to progress, acting strictly as a passthrough validation step.
+
+- When breaking down epics with UI components, the 'tactical hardware/snooping' design constraint must be explicitly mandated in the story's requirements.

--- a/.foundry/stories/story-118-286-filter-swarm-item-calls.md
+++ b/.foundry/stories/story-118-286-filter-swarm-item-calls.md
@@ -1,0 +1,32 @@
+---
+id: story-118-286-filter-swarm-item-calls
+type: STORY
+title: Filter Swarm & Item Calls
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-07'
+updated_at: '2026-07-07'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-055-118-pokegear-alerts
+tags:
+  - feature
+  - gen2
+  - data
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+# Story: Filter Swarm & Item Calls
+
+## Objective
+Filter the list of active callers to isolate NPCs that offer rare items or swarm notifications.
+
+## Requirements
+- Identify swarm and item-giving callers based on research offsets.
+- Create a filtering layer or flag in the data structure for high-value calls.
+
+## Acceptance Criteria
+- [ ] Implement data logic for identifying high-value Pokegear calls

--- a/.foundry/stories/story-118-287-highlight-high-value-calls-ui.md
+++ b/.foundry/stories/story-118-287-highlight-high-value-calls-ui.md
@@ -1,0 +1,33 @@
+---
+id: story-118-287-highlight-high-value-calls-ui
+type: STORY
+title: Highlight High Value Calls UI
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-07'
+updated_at: '2026-07-07'
+depends_on:
+  - story-118-286-filter-swarm-item-calls
+jules_session_id: null
+pr_number: null
+parent: epic-055-118-pokegear-alerts
+tags:
+  - feature
+  - gen2
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+# Story: Highlight High Value Calls UI
+
+## Objective
+Create the UI components to highlight swarm and item-giving Pokegear callers.
+
+## Requirements
+- Adhere to the tactical hardware/snooping design aesthetic.
+- Visually differentiate high-value calls from standard rematches.
+
+## Acceptance Criteria
+- [ ] Implement UI elements for high-value calls


### PR DESCRIPTION
This PR breaks down `epic-055-118-pokegear-alerts` into actionable, granular STORY nodes according to the schema.

### What
1. Discovered the next sequence IDs for stories.
2. Created `story-118-286-filter-swarm-item-calls` (Data layer logic).
3. Created `story-118-287-highlight-high-value-calls-ui` (UI components).
4. Appended the newly generated child IDs as unchecked tasks directly into the markdown body of the parent Epic.
5. Logged a long-term architectural UX constraint into the Story Owner journal.

### Why
To allow the DAG orchestrator to proceed with unblocking work for the tech lead.

### Verification
- `pnpm lint` passed.
- `pnpm test` passed.
- `pnpm test:e2e` passed.
- All YAML frontmatter rules and schema formatting have been strictly adhered to.

---
*PR created automatically by Jules for task [6311008894706904311](https://jules.google.com/task/6311008894706904311) started by @szubster*