### PR TITLE
Orchestrator demotion for story-081-121-gen3-tv-block-dataview-parser

### DIFF
--- a/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
+++ b/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
@@ -42,7 +42,7 @@ Implement the foundational logic to locate and read the TV broadcast data block 
 - [x] task-121-257-gen3-tv-block-parser-retry2-qa
 - [x] task-121-276-gen3-tv-block-parser-retry2-impl
 - [x] task-121-277-gen3-tv-block-parser-retry2-qa
-- [ ] task-121-278-gen3-tv-block-parser-retry3-impl
-- [ ] task-121-279-gen3-tv-block-parser-retry3-qa
+- [x] task-121-278-gen3-tv-block-parser-retry3-impl
+- [x] task-121-279-gen3-tv-block-parser-retry3-qa
 - [ ] task-121-280-gen3-tv-block-parser-retry4-impl
 - [ ] task-121-281-gen3-tv-block-parser-retry4-qa


### PR DESCRIPTION
Orchestrator demotion for `story-081-121-gen3-tv-block-dataview-parser`.

- Checked off permanently failed/orphaned child tasks (`task-121-278-gen3-tv-block-parser-retry3-impl` and `task-121-279-gen3-tv-block-parser-retry3-qa`).
- Left overarching acceptance criteria unchecked to allow orchestrator to demote this parent node back to PENDING while it waits for its newly generated child tasks (`task-121-280` and `task-121-281`).

---
*PR created automatically by Jules for task [12792633470012993210](https://jules.google.com/task/12792633470012993210) started by @szubster*