### PR TITLE
Create tasks for Gen 3 Met Location extraction

### DIFF
--- a/.foundry/stories/story-097-261-extract-pokemon-met-locations.md
+++ b/.foundry/stories/story-097-261-extract-pokemon-met-locations.md
@@ -29,4 +29,6 @@ Parse save files to extract the `met_location` for all Pokémon in the Party and
 - Extract `met_location` property for all caught Pokémon.
 
 ## Acceptance Criteria
-- [ ] Tasks are generated
+- [x] Tasks are generated
+- [ ] task-261-282-gen3-met-location-impl
+- [ ] task-261-283-gen3-met-location-qa

--- a/.foundry/tasks/task-261-282-gen3-met-location-impl.md
+++ b/.foundry/tasks/task-261-282-gen3-met-location-impl.md
@@ -1,0 +1,46 @@
+---
+id: task-261-282-gen3-met-location-impl
+type: TASK
+title: Implement Gen 3 Met Location Extraction
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-097-261-extract-pokemon-met-locations
+tags:
+  - feature
+  - nuzlocke
+  - gen3
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement Gen 3 Met Location Extraction
+
+## Objective
+Implement extraction of the `metLocation` data from Gen 3 Pokémon structures.
+
+## Context
+In Gen 3, the `metLocation` is stored in the 48-byte Encrypted Data block, specifically in the Miscellaneous (M) substructure.
+The M substructure is 12 bytes long. The `metLocation` is a 1-byte value located at offset 1 within the M substructure (the second byte).
+Currently, the `met_location` field does not exist in `PokemonInstance.caughtData` in `src/engine/saveParser/parsers/common.ts`.
+
+## Requirements
+1.  **Update Interface:** Modify `PokemonInstance` in `src/engine/saveParser/parsers/common.ts`. Ensure `caughtData` is updated to include the raw `metLocation` byte value (e.g. `metLocation?: number;` inside `caughtData`, alongside existing `location: number` used by other gens). **Ensure you check existing types** to see the best place to add it, likely inside the `caughtData` object.
+2.  **Avoid Magic Numbers:** Define a reusable constant at the module level for the offset, e.g., `MET_LOCATION_OFFSET_IN_M = 1`. Do not use inline magic numbers.
+3.  **Use DataView:** Ensure all new parsing logic strictly uses the `DataView` API. If reading from the decrypted M substructure block (which might be an array or dataview), use the proper bounds and API.
+4.  **Parse Logic:** Update `src/engine/saveParser/parsers/gen3.ts` (or the relevant file where Pokémon party/PC data is decrypted/parsed, such as wherever `parseGen3PersonalityValue` or `parseGen3Ribbons` is used to read from the M block) to extract this byte and attach it to the parsed `PokemonInstance`.
+
+## Hand-off Instructions
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] `metLocation` parsing logic added for Gen 3.
+- [ ] Constant defined for the offset (no magic numbers).
+- [ ] `DataView` API utilized.

--- a/.foundry/tasks/task-261-283-gen3-met-location-qa.md
+++ b/.foundry/tasks/task-261-283-gen3-met-location-qa.md
@@ -1,0 +1,42 @@
+---
+id: task-261-283-gen3-met-location-qa
+type: TASK
+title: QA Gen 3 Met Location Extraction
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
+depends_on:
+  - task-261-282-gen3-met-location-impl
+jules_session_id: null
+pr_number: null
+parent: story-097-261-extract-pokemon-met-locations
+tags:
+  - verification
+  - nuzlocke
+  - gen3
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Gen 3 Met Location Extraction
+
+## Objective
+Verify that the `metLocation` parsing logic for Gen 3 Pokémon is correctly implemented and tested.
+
+## Requirements
+1.  **Code Review:** Verify that `task-261-282-gen3-met-location-impl` was implemented correctly.
+2.  **No Magic Numbers:** Verify that the `MET_LOCATION_OFFSET_IN_M` offset is defined as a module-level constant and inline magic numbers are not used.
+3.  **DataView API:** Verify that `DataView` API is used for bounds-checked reads and `RangeError` is handled.
+4.  **Tests:** Verify that unit tests cover the new parsing logic (e.g., verifying a known met location byte is extracted properly from a mock DataView/M block).
+5.  **Rejection Protocol:** If the implementation uses inline magic numbers instead of defined reusable constants, or fails to catch `RangeError` from the `DataView` API for out-of-bounds reads, you MUST reject the task.
+
+## Hand-off Instructions
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Code correctly parses `metLocation` using constants and `DataView`.
+- [ ] Tests verify the parsing logic.


### PR DESCRIPTION
Created the blueprints (TASK nodes) to parse the `metLocation` for Gen 3 Pokémon. I have created an implementation task for the `coder` persona and a verification task for the `qa` persona to ensure that the code review protocol runs successfully and avoids the use of magic numbers inline. These have been appended as children in the parent story.

---
*PR created automatically by Jules for task [13898229958813249371](https://jules.google.com/task/13898229958813249371) started by @szubster*