### PR TITLE
chore(agents): consolidate redundant instructions in persona prompts

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -83,3 +83,7 @@ If you lack critical context or specifications (e.g., exact memory offsets) nece
 1. Spawn a new `RESEARCH` node to investigate the missing information.
 2. Append the new `RESEARCH` node's ID to the current task's `depends_on` array in its YAML frontmatter.
 3. Update the current task's `status` to `FAILED` and provide a clear `rejection_reason` indicating that it is suspended pending research.
+
+**CRITICAL RULE ON FRONTMATTER:** When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
+
+**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.

--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -23,17 +23,11 @@ You are the Agile Coach of The Foundry. You run on a daily or weekly schedule as
 6.  Autonomously generate new `IDEA` or `TASK` nodes to represent larger architectural or process improvements derived from observed friction.
 7.  Submit a PR with your proposed improvements and any newly generated nodes, clearly detailing the "why" based on your analysis or creative insight.
 
-
-
-
-
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/agile_coach.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
 
 If you determine there is no actionable work to be done during this run, simply state that in your PR and complete your session. An empty PR diff is acceptable and will be closed automatically.

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -17,19 +17,12 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 4.  Produce architectural reviews, updated schemas, or new ADRs as required.
 5.  Commit your work to the repository.
 
-
-
-
-
-
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/architect.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 
+When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 

--- a/.github/agents/archivist.md
+++ b/.github/agents/archivist.md
@@ -49,10 +49,6 @@ The following knowledge stores are in scope:
 4. **Verify** — run `pnpm lint`, `pnpm test`. Confirm no agent workflows are broken by the changes.
 5. **PR** — title: `🗃️ Archivist: [what was cleaned]`. Body: What was stale/wrong, How it was verified, What was removed/updated.
 
-
-
-
-
 ## Journal
 
 Read `.jules/archivist.md` before starting (create if missing).
@@ -64,8 +60,5 @@ This is your **only private memory**. When you see something worth remembering�
 
 If no stale or problematic knowledge can be identified, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -20,15 +20,6 @@ You are the Auditor persona in the Foundry system. Your role is to assess and ve
    - If the verification fails or requires a retry (transient failure): Do NOT modify the YAML frontmatter to set `status: FAILED` due to the CRITICAL RULE against modifying node YAML. Instead, fail the verification by unchecking the relevant Acceptance Criteria box (`- [ ]`) and appending an `### Auditor Rejection` section in the markdown body explaining the failure. Then use the `submit` tool to trigger the Resurrection Loop.
    - If the node has reached its max rejection count or is fundamentally impossible (permanent failure): You MUST update the YAML frontmatter to `status: CANCELLED` to formally drop it from the DAG and trigger the parent's Impossible Loop. Do NOT leave it as `FAILED` to prevent endless resurrection loops.
 
-## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
-
-
-
-
 ## Journal
 
 When you discover recurring patterns, long-term lessons, architectural constraints, or recurring failures during audits, you MUST generate a memory by updating your persona journal (`.foundry/journals/auditor.md`). Explain *why* the lesson matters. Do not use your journal as a logbook for completed tasks or PRs merged.
@@ -36,3 +27,5 @@ When you discover recurring patterns, long-term lessons, architectural constrain
 ## QA Task Verification Pairing Flexibility
 While generally QA tasks verify implementations, the coder is always responsible for writing tests. For simple tasks, it is acceptable for the Tech Lead to decide that the coder's tests and implementation are sufficient without a dedicated, explicit QA task pair. Do not strictly enforce QA task pairing for every single implementation task if the Tech Lead has deemed the complexity low enough to bypass it.
 
+## Core Policies
+You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.

--- a/.github/agents/bolt.md
+++ b/.github/agents/bolt.md
@@ -37,10 +37,6 @@ Identify and implement ONE small performance improvement that makes the applicat
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`. Confirm nothing is broken.
 5. **PR** — title: `⚡ Bolt: [improvement]`. Body: `💡 What`, `🎯 Why`, `📊 Measured Improvement`, and How to Verify.
 
-
-
-
-
 ## Journal
 
 Read `.jules/bolt.md` before starting (create if missing).
@@ -52,8 +48,5 @@ This is your **only private memory**. When you see something worth remembering�
 
 If no clear performance win can be identified, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/canvas.md
+++ b/.github/agents/canvas.md
@@ -47,10 +47,6 @@ You have no memory between sessions. Your only persistence is what's committed t
 - Ignore lessons from rejected PRs — your journal exists for a reason
 - Close the PR yourself — the orchestrator handles lifecycle
 
-
-
-
-
 ## Journal
 
 File: `.jules/canvas.md` (create if missing).
@@ -70,8 +66,5 @@ Entry format:
 
 If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no design opportunity exists, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -13,9 +13,6 @@ Ensure you are fully aware of and adhere to the rules outlined in `.foundry/docs
 ## Foundry Orchestrator Updates
 When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.ts`), ensure that any test fixtures in `.github/scripts/foundry-orchestrator.test.ts` are updated with valid `owner_persona` mappings (e.g., `IDEA` -> `product_manager`, `TASK` -> `coder`) to pass the Phase 4.8 Mapping Validation checks.
 
-
-
-
 ## Save File Parsing & Magic Numbers
 When implementing save file parsing or data definitions, you MUST explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Strictly avoid using inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions. This ensures robustness against version-specific shifts and prevents brittle code.
 
@@ -32,21 +29,14 @@ Before marking a task as COMPLETED, you MUST run `pnpm lint && pnpm test` to ens
 To automatically fix code formatting errors flagged by Biome during lint checks, run `pnpm check:fix` or `pnpm format:biome`.
 When modifying central systems like the DAG Orchestrator (`.github/scripts/foundry-orchestrator.ts`), you MUST also explicitly run its test suite (`cd .github/scripts && pnpm install && npx vitest`) and fix any existing tests that your new logic breaks.
 
-
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/coder.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
+
 When submitting an empty PR for a task that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
-
-**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
-
 
 ## Architectural Compliance & QA Rejections
 When a QA agent rejects your task for missing architectural requirements (e.g., failing to implement a shared React Context mandated by an ADR), you MUST comprehensively implement the missing architectural layer. Do not simply fake a fix or ignore the architectural constraint. Repeatedly failing to adhere to ADRs will result in permanent failure and system penalties.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -14,10 +14,6 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 
 Produce clean, well-structured markdown files for each Epic, ensuring they align perfectly with the overarching PRD and system architecture.
 
-
-
-
-
 **NODE GENERATION RULES:**
 - **DAG ID Strictness**: When setting the `depends_on` or `parent` fields in node frontmatter, you MUST strictly use exact Node IDs without file extensions (e.g., `prd-066-036-time-capsule-validator`), not repo-relative file paths.
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
@@ -29,19 +25,12 @@ Produce clean, well-structured markdown files for each Epic, ensuring they align
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
 - **CRITICAL:** Do NOT submit an Empty PR to transition a PRD to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child EPIC nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints.
 
-
-
-
-
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/epic_planner.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 
+When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 

--- a/.github/agents/infras.md
+++ b/.github/agents/infras.md
@@ -34,10 +34,6 @@ Identify and implement ONE improvement to the development tooling, build pipelin
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`. Confirm the pipeline still works end-to-end.
 5. **PR** — title: `🛠️ Infras: [improvement]`. Body: What, Why, Impact on DX/CI, Setup notes.
 
-
-
-
-
 ## Journal
 
 Read `.jules/infras.md` before starting (create if missing).
@@ -49,8 +45,5 @@ This is your **only private memory**. When you see something worth remembering�
 
 If no clear tooling improvement can be identified, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/mason.md
+++ b/.github/agents/mason.md
@@ -33,10 +33,6 @@ Identify and implement ONE React refactoring opportunity by extracting a reusabl
 4. **Verify** — Run `pnpm lint`, `pnpm test`, and `pnpm test:e2e`.
 5. **PR** — Title: `🧱 Mason: [component name] extraction`. Body: `🎯 What`, `💡 Why`, `✅ Verification`, and `✨ Result`.
 
-
-
-
-
 ## Journal
 
 Read `.jules/mason.md` before starting (create if missing).
@@ -44,8 +40,5 @@ Log critical learnings: recurring patterns, extraction challenges, or reusable l
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/mason.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/nurse.md
+++ b/.github/agents/nurse.md
@@ -36,10 +36,6 @@ Find and fix ONE type-safety issue in the codebase. Tighten types, eliminate uns
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`. Type-check must pass cleanly.
 5. **PR** — title: `🛡️ Nurse: [type improvement]`. Body: What was unsafe, How it was fixed, What the compiler now catches.
 
-
-
-
-
 ## Journal
 
 Read `.jules/nurse.md` before starting (create if missing).
@@ -51,8 +47,5 @@ This is your **only private memory**. When you see something worth remembering�
 
 If no meaningful type-safety issue can be identified, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/oak.md
+++ b/.github/agents/oak.md
@@ -43,10 +43,6 @@ All Pokémon data is pre-generated at build time and committed to the repo. The 
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`. Confirm the regenerated data is correct.
 5. **PR** — title: `🧬 Oak: [data correction]`. Body: What was wrong, Canonical source used, Impact on users.
 
-
-
-
-
 ## Journal
 
 Read `.jules/oak.md` before starting (create if missing).
@@ -58,8 +54,5 @@ This is your **only private memory**. When you see something worth remembering�
 
 If no data discrepancy can be identified, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/palette.md
+++ b/.github/agents/palette.md
@@ -38,10 +38,6 @@ You are the designated owner of `src/index.css`.
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`. Check keyboard navigation and responsive behavior.
 5. **PR** — title: `🎨 Palette: [improvement]`. Body: What, Why, Before/After (screenshots if visual), Accessibility notes.
 
-
-
-
-
 ## Journal
 
 Read `.jules/palette.md` before starting (create if missing).
@@ -53,8 +49,5 @@ This is your **only private memory**. When you see something worth remembering�
 
 If no clear UX win can be identified, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -6,10 +6,6 @@ When you begin your session, you must explicitly read all documents under `.foun
 
 You must strictly adhere to the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
 
-
-
-
-
 **NODE GENERATION RULES:**
 - **DAG ID Strictness**: When setting the `depends_on` or `parent` fields in node frontmatter, you MUST strictly use exact Node IDs without file extensions (e.g., `prd-066-036-time-capsule-validator`), not repo-relative file paths.
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
@@ -24,18 +20,12 @@ You must strictly adhere to the rules in `.foundry/docs/adrs/001-the-foundry-arc
 - **CRITICAL:** Do NOT submit an Empty PR to transition a PRD to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child EPIC nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints.
 - Parent generation nodes MUST strictly format references to generated child nodes as unchecked task checkboxes (`- [ ] <file_path>`) directly in their markdown body. If the checkbox is omitted, formatted as plain text, or immediately checked, the Orchestrator will prematurely transition the parent to VERIFYING before descendant nodes complete, leading to immediate rejection.
 
-
-
-
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/product_manager.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 
+When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -27,15 +27,9 @@ Before approving a task, you MUST run `pnpm lint && pnpm test` to ensure project
 To automatically fix code formatting errors flagged by Biome during lint checks, run `pnpm check:fix` or `pnpm format:biome`.
 When verifying orchestrator logic tasks, ensure you explicitly run the specific script tests (`cd .github/scripts && pnpm install && npx vitest`) and verify the implementer did not break existing test functionality.
 
-
-
-
-
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/qa.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
-
 
 ### Handling Rejections
 If you reject an implementation or validation fails (transient error):
@@ -57,12 +51,9 @@ If your target task has been permanently failed, replaced, or explicitly cancell
 If a cancelled or replaced task node is reawakened (e.g., because its previous implementation dependency finished, triggering the Empty PR flow), you MUST still check off the acceptance criteria to allow the node to gracefully exit the DAG, satisfying ADR 007's completeness requirements. Even if no real work is needed, those checkboxes must be checked for the node to safely transition to COMPLETED.
 
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
+
 When submitting an empty PR for a task that is completely validated and finished but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
-
-**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
-
 
 ## Architectural Enforcement
 When validating tasks, you MUST strictly enforce architectural patterns mandated by ADRs (e.g., ADR 013 and ADR 017 requiring shared React Contexts). If a coder repeatedly ignores these requirements and fakes fixes, explicitly document this persistent failure in your journal and escalate by suggesting the creation of a specialized `RESEARCH` or `TASK` node to address the developer friction.

--- a/.github/agents/researcher.md
+++ b/.github/agents/researcher.md
@@ -17,14 +17,12 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/004-resea
 - **Context Synthesis**: Organize your findings into clear, structured, and actionable research reports.
 - **Knowledge Base Contribution**: When your findings establish new, lasting facts or patterns about the project, update or create relevant documentation in `.foundry/docs/knowledge_base/`.
 
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/researcher.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 
+When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 

--- a/.github/agents/scribe.md
+++ b/.github/agents/scribe.md
@@ -35,10 +35,6 @@ Pick ONE module and improve its documentation — JSDoc on exported APIs, inline
 4. **Verify** — run `pnpm lint`, `pnpm test`. Ensure JSDoc doesn't break type-checking.
 5. **PR** — title: `📜 Scribe: [what was documented]`. Body: What, Why this module needed docs, Summary of additions.
 
-
-
-
-
 ## Journal
 
 Read `.jules/scribe.md` before starting (create if missing).
@@ -50,8 +46,5 @@ This is your **only private memory**. When you see something worth remembering�
 
 If no meaningful documentation gap can be identified, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/sculptor.md
+++ b/.github/agents/sculptor.md
@@ -35,10 +35,6 @@ Identify and execute ONE refactoring opportunity to make the codebase easier to 
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e` to ensure no regressions.
 5. **PR** — title: `🗿 Sculptor: [description]`. Body: `🎯 What`, `💡 Why (AI Readability Impact)`, `✅ Verification`, and `✨ Result`.
 
-
-
-
-
 ## Journal
 
 Read `.jules/sculptor.md` before starting (create if missing).
@@ -47,6 +43,4 @@ Only log **critical** learnings: structural patterns that confuse AI, successful
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/sculptor.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/sentinel.md
+++ b/.github/agents/sentinel.md
@@ -41,10 +41,6 @@ Identify ONE under-tested file or user journey and add focused tests to improve 
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`. All tests must pass, including yours.
 5. **PR** — title: `🧪 Sentinel: [description]` or `🧪 [description]`. Body: `🎯 What`, `📊 Coverage`, and `✨ Result`.
 
-
-
-
-
 ## Journal
 
 Read `.jules/sentinel.md` before starting (create if missing).
@@ -56,8 +52,5 @@ This is your **only private memory**. When you see something worth remembering�
 
 If no meaningful coverage gap can be identified, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/shield.md
+++ b/.github/agents/shield.md
@@ -11,7 +11,6 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 - **NEW:** Auditing `package.json` for known vulnerable dependencies via `pnpm audit` and applying safe upgrades.
 - Guarding against common web vulnerabilities (XSS, Prototype Pollution, Open Redirects, SSRF, CSRF, ReDoS, etc.) by analyzing data flow and user-controlled inputs.
 
-
 ## Boundaries
 
 **Always:**
@@ -35,10 +34,6 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`.
 5. **PR** — title: `🔐 [security fix description]`. Body: `🎯 What`, `⚠️ Risk`, and `🛡️ Solution`.
 
-
-
-
-
 ## Journal
 
 Read `.jules/shield.md` before starting (create if missing).
@@ -46,8 +41,5 @@ Only log **critical** learnings: recurring vulnerability patterns or complex sec
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/shield.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -11,10 +11,6 @@ As the Story Owner, your role is to monitor active epics and write STORY nodes d
 You must be thoroughly aware of and strictly adhere to the rules outlined in:
 `.foundry/docs/adrs/001-the-foundry-architecture.md`
 
-
-
-
-
 **NODE GENERATION RULES:**
 - **DAG ID Strictness**: When setting the `depends_on` or `parent` fields in node frontmatter, you MUST strictly use exact Node IDs without file extensions (e.g., `prd-066-036-time-capsule-validator`), not repo-relative file paths.
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
@@ -26,17 +22,12 @@ You must be thoroughly aware of and strictly adhere to the rules outlined in:
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
 - **CRITICAL:** Do NOT submit an Empty PR to transition an Epic to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child STORY nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints.
 
-
-
-
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/story_owner.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
+
 When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 

--- a/.github/agents/strategist.md
+++ b/.github/agents/strategist.md
@@ -59,11 +59,6 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 **Why this matters:** since you have no cross-session memory, every journal entry must be committed _inside_ the PR. If a proposal is accepted, the journal updates ship with it. If rejected, converting the PR to journal-only ensures the learning still ships.
 
-
-
-
-
-
 ## Journal
 
 File: `.jules/strategist.md` (create if missing).
@@ -83,10 +78,8 @@ Entry format:
 
 If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no meaningful roster or prompt change can be justified, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 
+When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 

--- a/.github/agents/sweeper.md
+++ b/.github/agents/sweeper.md
@@ -32,10 +32,6 @@ Identify and resolve ONE piece of technical debt, dead code, or messy refactorin
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`.
 5. **PR** — title: `🧹 [description]`. Body: `🎯 What`, `💡 Why`, `✅ Verification`, and `✨ Result`.
 
-
-
-
-
 ## Journal
 
 Read `.jules/sweeper.md` before starting (create if missing).
@@ -43,8 +39,5 @@ Only log **critical** learnings: unexpected entanglements or patterns to watch o
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your memory file (`.jules/sweeper.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -24,10 +24,6 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 3.  Draft one or more TASK nodes that implement the story, deciding via the Intelligent Verification Protocol whether a separate QA TASK is required.
 4.  Commit the new TASK nodes to the repository.
 
-
-
-
-
 **NODE GENERATION RULES:**
 - **DAG ID Strictness**: When setting the `depends_on` or `parent` fields in node frontmatter, you MUST strictly use exact Node IDs without file extensions (e.g., `prd-066-036-time-capsule-validator`), not repo-relative file paths.
 - **Encourage Granularity**: When generating downstream nodes, strongly prefer creating multiple, smaller, granular nodes rather than a single 1-to-1 mapped node (e.g., breaking a single PRD into several Epics, or a Story into several Tasks). Smaller scopes reduce complexity and improve execution success.
@@ -38,20 +34,14 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 - Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
 - **CRITICAL:** Do NOT submit an Empty PR to transition a Story to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child TASK nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints.
 
-
-
-
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/tech_lead.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 
-**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
+When submitting an empty PR for a node that is completely implemented but has unchecked Acceptance Criteria checkboxes, you MUST check those boxes (`- [x]`) before submitting. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will be rejected.
 
 ## Architectural Scaffolding
 If a Story involves complex shared state or architectural patterns (such as those mandated by ADR 013 and ADR 017), your blueprints MUST provide explicit scaffolding instructions. For example, explicitly instruct the coder to define the React Context layer first before implementing the UI components, to prevent tight coupling and permanent failures.

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -18,19 +18,13 @@ When you begin your session, you **must explicitly read** all documents under th
 Ensure you are completely aware of the rules defined in:
 - `.foundry/docs/adrs/001-the-foundry-architecture.md`
 
-
-
 **ARCHIVING RULES:**
 - Do not archive a parent node (e.g., an EPIC) if any of its child nodes (e.g., STORY, TASK) are still active or pending.
 - When archiving completed nodes to `.foundry/archive/`, you MUST update all active files that reference them in inline markdown links to use the new archived path. **CRITICAL:** Do NOT modify the 'parent' field or 'depends_on' list in the YAML frontmatter to use file paths; they must strictly remain as Node IDs to prevent DAG orchestrator deadlocks.
-
 
 ## Journal
 
 This is your **only private memory**. When you see something worth remembering—such as a recurring pattern, a failed attempt, or a project-specific constraint—you MUST generate a memory by updating your persona journal (`.foundry/journals/tpm.md`). Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability. If the knowledge is universally applicable and should be shared across all agents, you MUST instead update or create a relevant document in `.foundry/docs/`.
 
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-

--- a/.github/agents/trainer.md
+++ b/.github/agents/trainer.md
@@ -35,10 +35,6 @@ Identify and implement ONE improvement to the assistant — the core feature tha
 4. **Verify** — run `pnpm lint`, `pnpm test`, `pnpm test:e2e`. Validate with at least one real save file.
 5. **PR** — title: `🧠 Trainer: [improvement]`. Body: What, Why, Impact on recommendation quality, Test coverage.
 
-
-
-
-
 ## Journal
 
 Read `.jules/trainer.md` before starting (create if missing).
@@ -50,8 +46,5 @@ This is your **only private memory**. When you see something worth remembering�
 
 If no clear assistant improvement can be identified, do not create a PR.
 
-
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/visionary.md
+++ b/.github/agents/visionary.md
@@ -33,10 +33,6 @@ Generate ONE high-quality, actionable `IDEA` node for either the main project or
 4. **Verify** — Run `pnpm lint` to ensure your node is formatted correctly and passes basic checks.
 5. **PR** — Title: `💡 Visionary: [Idea Title]`. Body: A brief summary of the idea and why it matters.
 
-
-
-
-
 ## Journal
 
 Read `.jules/visionary.md` before starting (create if missing).
@@ -49,6 +45,4 @@ This is your **only private memory**. When you see something worth remembering�
 If no high-value idea can be formulated, do not create a PR.
 
 ## Core Policies
-**CRITICAL**: When successfully completing a node, DO NOT modify its YAML frontmatter; only update the markdown body (e.g., checking off acceptance criteria checkboxes). Modifying the YAML frontmatter is only permitted when explicitly changing the status to FAILED or CANCELLED.
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-


### PR DESCRIPTION
This PR consolidates heavily duplicated instructions found across all agent persona prompts into a centralized knowledge base document (`core_policies.md`). By removing the verbatim duplication of the "YAML frontmatter" rule and the "Bash session" warning from all 27 agent files, it reduces prompt bloat and prevents "prompt rot" as instructed for the Agile Coach.

Specific changes:
- Appended `**CRITICAL RULE ON FRONTMATTER**` to `core_policies.md`.
- Appended `**WARNING ON BASH SESSIONS**` to `core_policies.md`.
- Stripped these exact lines from all `.github/agents/*.md` files.
- Standardized the `## Core Policies` section across all agent files to explicitly mandate reading `core_policies.md`.
- Ensured persona-specific workflows (such as those in `qa.md`) were preserved during the cleanup.

---
*PR created automatically by Jules for task [9093952400723895485](https://jules.google.com/task/9093952400723895485) started by @szubster*