### PR TITLE
🧹 Remove unused SaveHistoryDBSchema and SAVE_HISTORY_DB_CONFIG

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -5,3 +5,4 @@
 * Sweeper PRs must use the title format `🧹 [description]` and include `🎯 What`, `💡 Why`, `✅ Verification`, and `✨ Result` in the body.
 
 - If `pnpm install` hangs or fails during git hook setup (e.g., `lefthook install`), run `git config --unset-all --global core.hooksPath` before retrying the installation.
+If `pnpm lint` or `biome check` fails due to formatting issues, use `pnpm biome format --write <filepath>` to resolve them.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -175,28 +175,3 @@ export interface PokeDBSchema extends DBSchema {
     value: { key: string; value: string };
   };
 }
-
-export const SAVE_HISTORY_DB_CONFIG = {
-  NAME: 'SaveHistoryDB',
-  VERSION: 1,
-  STORES: {
-    SAVES: 'saves',
-    METADATA: 'metadata',
-    INDEXES: 'indexes',
-  },
-} as const;
-
-export interface SaveHistoryDBSchema extends DBSchema {
-  [SAVE_HISTORY_DB_CONFIG.STORES.SAVES]: {
-    key: string;
-    value: Uint8Array;
-  };
-  [SAVE_HISTORY_DB_CONFIG.STORES.METADATA]: {
-    key: string;
-    value: Record<string, unknown>;
-  };
-  [SAVE_HISTORY_DB_CONFIG.STORES.INDEXES]: {
-    key: string;
-    value: Record<string, unknown>;
-  };
-}


### PR DESCRIPTION
🎯 What
Removed `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema` from `src/db/schema.ts`.

💡 Why
These were flagged by Knip as unused exports and a global search confirmed they were not referenced anywhere else in the codebase, acting as dead code.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no regressions. Also verified they are not implicitly required by tests or CI.

✨ Result
Cleaner schema file and reduced dead code/tech debt in the codebase.

---
*PR created automatically by Jules for task [11024034557665259072](https://jules.google.com/task/11024034557665259072) started by @szubster*