### PR TITLE
chore: Complete Gen 3 TV Block Parser task (Empty PR)

### DIFF
--- a/.foundry/tasks/task-121-280-gen3-tv-block-parser-retry4-impl.md
+++ b/.foundry/tasks/task-121-280-gen3-tv-block-parser-retry4-impl.md
@@ -38,10 +38,10 @@ Any out-of-bounds reads or structurally corrupt states within the TV block MUST 
 - Any size or ID constants must NOT be hardcoded inline inside `parseGen3MixRecords` or any other parsing function.
 
 ## Acceptance Criteria
-- [ ] The TV block extraction logic is built entirely using `DataView`.
-- [ ] All memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. Inline magic numbers like 21 or 40 are completely removed.
-- [ ] Explicit error handling is in place to catch `RangeError` exceptions natively thrown by `DataView` on malformed saves.
-- [ ] New parsing functions conform to the existing Gen 1 and Gen 2 backward-compatible parsing interfaces without breaking them.
+- [x] The TV block extraction logic is built entirely using `DataView`.
+- [x] All memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. Inline magic numbers like 21 or 40 are completely removed.
+- [x] Explicit error handling is in place to catch `RangeError` exceptions natively thrown by `DataView` on malformed saves.
+- [x] New parsing functions conform to the existing Gen 1 and Gen 2 backward-compatible parsing interfaces without breaking them.
 
 ## Important Protocols (For Coder)
 - **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
This PR marks the completion of the `task-121-280-gen3-tv-block-parser-retry4-impl` task. Upon reviewing the codebase (`src/engine/saveParser/parsers/gen3.ts`), it was determined that the `DataView` API usage, bounds checking with graceful error handling, and the module-level constants (e.g. `TVSHOW_STRUCT_SIZE`, `TVGROUP_RECORD_MIX_START`, `TVSHOW_MASS_OUTBREAK`) are already fully implemented as per the requirements of ADR 010. Therefore, no further code modifications were required. The acceptance criteria checkboxes in the corresponding markdown file have been checked off.

---
*PR created automatically by Jules for task [14238422213153822540](https://jules.google.com/task/14238422213153822540) started by @szubster*