### PR TITLE
Draft blueprint for IndexedDB schema documentation

### DIFF
--- a/.foundry/stories/story-130-268-document-indexeddb-schema.md
+++ b/.foundry/stories/story-130-268-document-indexeddb-schema.md
@@ -28,3 +28,4 @@ Document the defined IndexedDB schema for storing save state history.
 
 ## Acceptance Criteria
 - [ ] Document the schema.
+- [ ] task-268-284-document-indexeddb-schema-impl

--- a/.foundry/tasks/task-268-284-document-indexeddb-schema-impl.md
+++ b/.foundry/tasks/task-268-284-document-indexeddb-schema-impl.md
@@ -1,0 +1,36 @@
+---
+id: task-268-284-document-indexeddb-schema-impl
+type: TASK
+title: Document SaveHistoryDB IndexedDB Schema
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-130-268-document-indexeddb-schema
+tags:
+  - storage
+  - indexeddb
+  - schema
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Document SaveHistoryDB IndexedDB Schema
+
+## Context
+The IndexedDB schema for `SaveHistoryDB` has been implemented in `src/db/schema.ts`. We need to document this schema in the knowledge base.
+
+## Acceptance Criteria
+- [ ] Create a new documentation file or update an existing one under `.foundry/docs/knowledge_base/db/` to describe the `SaveHistoryDB` schema. It should detail the database name, version, and the three object stores (`saves`, `metadata`, `indexes`) as defined in `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema`.
+- [ ] The coder is responsible for self-verifying these changes by ensuring the markdown is properly formatted.
+
+## Rules
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.


### PR DESCRIPTION
Creates a new technical blueprint task (`task-268-284-document-indexeddb-schema-impl.md`) for the coder to document the SaveHistoryDB IndexedDB schema defined in `src/db/schema.ts`. Updates the parent story (`story-130-268-document-indexeddb-schema.md`) to include this new child task in its acceptance criteria, without improperly modifying the YAML frontmatter or marking it as completed early.

Ran pre-commit linting and testing which all succeeded.

---
*PR created automatically by Jules for task [1648987664640770995](https://jules.google.com/task/1648987664640770995) started by @szubster*