### PR TITLE
chore: replace cancelled stories in epic-047-081

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -52,3 +52,5 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [ ] story-081-281-gen3-system-time-fallback
 - [ ] story-081-282-gen3-manual-time-ui-overrides
 - [ ] story-081-288-gen3-mix-record-inherited-events
+- [ ] story-081-289-gen3-rtc-extraction-replacement
+- [ ] story-081-290-gen3-rtc-fallback-strategy-replacement

--- a/.foundry/stories/story-081-289-gen3-rtc-extraction-replacement.md
+++ b/.foundry/stories/story-081-289-gen3-rtc-extraction-replacement.md
@@ -1,0 +1,29 @@
+---
+id: story-081-289-gen3-rtc-extraction-replacement
+type: STORY
+title: Extract Gen 3 RTC Data Replacement
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Extract Gen 3 RTC Data Replacement
+
+## Description
+Replacement for cancelled story 122.
+
+## Acceptance Criteria
+- [ ] Implement parser logic to extract the RTC value from the save.

--- a/.foundry/stories/story-081-290-gen3-rtc-fallback-strategy-replacement.md
+++ b/.foundry/stories/story-081-290-gen3-rtc-fallback-strategy-replacement.md
@@ -1,0 +1,29 @@
+---
+id: story-081-290-gen3-rtc-fallback-strategy-replacement
+type: STORY
+title: Implement Gen 3 System Time Fallback Strategy Replacement
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-047-081-gen3-tv-swarm-data-extraction
+tags:
+  - feature
+  - gen3
+  - rtc
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Implement Gen 3 System Time Fallback Strategy Replacement
+
+## Description
+Replacement for cancelled story 144.
+
+## Acceptance Criteria
+- [ ] Implement System Time Fallback for Gen 3 time-gated events.


### PR DESCRIPTION
Created replacement nodes for cancelled stories 122 and 144, and updated the epic to track the new nodes.

---
*PR created automatically by Jules for task [4107750494200719119](https://jules.google.com/task/4107750494200719119) started by @szubster*