### PR TITLE
chore(foundry): cancel obsolete Gen 3 RTC tasks

### DIFF
--- a/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
+++ b/.foundry/epics/epic-047-081-gen3-tv-swarm-data-extraction.md
@@ -52,5 +52,5 @@ This epic covers the backend logic to extract TV broadcast events and swarm trac
 - [ ] story-081-281-gen3-system-time-fallback
 - [ ] story-081-282-gen3-manual-time-ui-overrides
 - [ ] story-081-288-gen3-mix-record-inherited-events
-- [ ] story-081-289-gen3-rtc-extraction-replacement
-- [ ] story-081-290-gen3-rtc-fallback-strategy-replacement
+- [x] story-081-289-gen3-rtc-extraction-replacement
+- [x] story-081-290-gen3-rtc-fallback-strategy-replacement

--- a/.foundry/stories/story-081-282-gen3-manual-time-ui-overrides.md
+++ b/.foundry/stories/story-081-282-gen3-manual-time-ui-overrides.md
@@ -28,3 +28,4 @@ Based on ADR 025 and the findings from `research-081-144-gen3-rtc-strategy`, thi
 
 ## Acceptance Criteria
 - [ ] Implement Manual UI Overrides to allow users to force a specific time state.
+- [ ] Adhere strictly to ADR 008 tactical hardware/snooping aesthetic: use sharp edges (rounded-none), avoid rounded corners, and use dashed borders (border-dashed) with monospaced telemetry fonts (font-mono).

--- a/.foundry/stories/story-081-289-gen3-rtc-extraction-replacement.md
+++ b/.foundry/stories/story-081-289-gen3-rtc-extraction-replacement.md
@@ -2,7 +2,7 @@
 id: story-081-289-gen3-rtc-extraction-replacement
 type: STORY
 title: Extract Gen 3 RTC Data Replacement
-status: PENDING
+status: CANCELLED
 owner_persona: tech_lead
 created_at: '2026-07-08'
 updated_at: '2026-07-08'
@@ -16,7 +16,7 @@ tags:
   - data-parsing
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'RTC data in Gen 3 is emulator dependent and highly unreliable. Event mapping must be RTC-independent.'
 notes: ''
 ---
 

--- a/.foundry/stories/story-081-290-gen3-rtc-fallback-strategy-replacement.md
+++ b/.foundry/stories/story-081-290-gen3-rtc-fallback-strategy-replacement.md
@@ -2,7 +2,7 @@
 id: story-081-290-gen3-rtc-fallback-strategy-replacement
 type: STORY
 title: Implement Gen 3 System Time Fallback Strategy Replacement
-status: PENDING
+status: CANCELLED
 owner_persona: tech_lead
 created_at: '2026-07-08'
 updated_at: '2026-07-08'
@@ -16,7 +16,7 @@ tags:
   - rtc
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'RTC data in Gen 3 is emulator dependent and highly unreliable. Event mapping must be RTC-independent.'
 notes: ''
 ---
 


### PR DESCRIPTION
- Cancelled obsolete tasks `story-081-289` and `story-081-290` replacing RTC data extraction, as Gen 3 RTC data is emulator-dependent and unreliable.
- Checked off cancelled tasks in parent Epic `epic-047-081-gen3-tv-swarm-data-extraction`.
- Injected ADR 008 "tactical hardware" UI constraints into `story-081-282-gen3-manual-time-ui-overrides`.
- Empty PR submission intentionally leaves pending child nodes unchecked to demote the Epic back to PENDING.

---
*PR created automatically by Jules for task [6784153921581714654](https://jules.google.com/task/6784153921581714654) started by @szubster*