### PR TITLE
Fix: Spawn research node for TV block parser failure loop

### DIFF
--- a/.foundry/research/research-121-285-gen3-tv-block-parser-retry3-failure.md
+++ b/.foundry/research/research-121-285-gen3-tv-block-parser-retry3-failure.md
@@ -1,0 +1,31 @@
+---
+id: research-121-285-gen3-tv-block-parser-retry3-failure
+type: RESEARCH
+title: Investigate Gen 3 TV Block Parser Retry 4 Failure
+status: READY
+owner_persona: researcher
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-081-121-gen3-tv-block-dataview-parser
+tags:
+  - research
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Investigate Gen 3 TV Block Parser Retry 4 Failure
+
+## Objective
+Investigate the root cause of the `task-121-278-gen3-tv-block-parser-retry3-impl` failure (which reached its max rejection count). Determine why the coder failed to adhere to the strict constraint regarding module-level reusable constants, and define explicit instructions and memory offsets/constants that MUST be used in the next iteration to prevent a recurring QA rejection.
+
+## Instructions
+1. Analyze the failure feedback from QA or the Auditor for `task-121-278` and determine the exact root cause.
+2. Identify the correct module-level constant names and values that should replace these magic numbers based on the `gen3_tv_shows_and_events.md` or related knowledge base documents.
+3. Document these explicit constants so the next implementer blueprint can mandate their exact usage.

--- a/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
+++ b/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
@@ -28,6 +28,7 @@ Implement the foundational logic to locate and read the TV broadcast data block 
 ## Acceptance Criteria
 - [ ] Implement parser logic using `DataView` to read the TV event block.
 - [ ] Handle bounds checking and corrupted reads gracefully.
+- [x] Break down into Tasks
 
 ## Child Tasks
 - [x] task-121-171-gen3-tv-block-parser-impl
@@ -44,5 +45,6 @@ Implement the foundational logic to locate and read the TV broadcast data block 
 - [x] task-121-277-gen3-tv-block-parser-retry2-qa
 - [x] task-121-278-gen3-tv-block-parser-retry3-impl
 - [x] task-121-279-gen3-tv-block-parser-retry3-qa
+- [ ] research-121-285-gen3-tv-block-parser-retry3-failure
 - [ ] task-121-280-gen3-tv-block-parser-retry4-impl
 - [ ] task-121-281-gen3-tv-block-parser-retry4-qa

--- a/.foundry/tasks/task-121-279-gen3-tv-block-parser-retry3-qa.md
+++ b/.foundry/tasks/task-121-279-gen3-tv-block-parser-retry3-qa.md
@@ -36,3 +36,6 @@ Verify the implementation of the Gen 3 TV block `DataView` parser to ensure it c
 - **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
 - **Permanent Failure:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - **Empty PR Protocol:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### Auditor Rejection
+**CANCELLED:** This task has been cancelled and replaced by task-121-281 because its implementation task reached the max rejection count.

--- a/.foundry/tasks/task-121-280-gen3-tv-block-parser-retry4-impl.md
+++ b/.foundry/tasks/task-121-280-gen3-tv-block-parser-retry4-impl.md
@@ -6,7 +6,8 @@ status: READY
 owner_persona: coder
 created_at: '2026-07-06'
 updated_at: '2026-07-06'
-depends_on: []
+depends_on:
+  - research-121-285-gen3-tv-block-parser-retry3-failure
 jules_session_id: null
 pr_number: null
 parent: story-081-121-gen3-tv-block-dataview-parser


### PR DESCRIPTION
This PR addresses the failure loop in the Gen 3 TV Block Parser implementation. The previous agent correctly cancelled the old tasks and created replacement ones, but violated system protocols by skipping the required research step and illegally modifying the orphaned QA node's frontmatter.

Changes:
1. Created `research-121-285` to explicitly require an investigation into the coder's failure to use module-level constants.
2. Updated `task-121-280` to safely block until this research is completed.
3. Restored `task-121-279`'s YAML frontmatter to PENDING while explicitly marking it CANCELLED in the markdown body as required by the Orphaned Node policy.
4. Appended the missing references to the `story-081-121` parent node.

---
*PR created automatically by Jules for task [300024693789568190](https://jules.google.com/task/300024693789568190) started by @szubster*