### PR TITLE
Cancel impossible bash timeout wrapper task

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -102,3 +102,6 @@ In Generation 2, two Shiny or Shiny Carrier Pokémon cannot breed with each othe
 
 ## Investigation: Linter for Save Parsing Offsets
 Biome and Oxlint do not currently support custom JS linting rules. The built-in `noMagicNumbers` rule in Biome does not allow the granularity needed to specifically target `DataView` offset arguments, making it unsuitable for our strict save parsing guidelines. Introducing ESLint solely for this purpose would contradict our current tooling choices and add bloat. We should fall back to an ADR and code-review enforcement.
+
+## 2026-07-08: Impossible Task - Wrapping run_in_bash_session
+Task task-267-262-bash-timeout-wrapper-impl was cancelled because `run_in_bash_session` is a built-in platform tool provided to agents, not a script or function defined within this repository's codebase. It is therefore impossible to implement a wrapper or linter for it from within the repo.

--- a/.foundry/tasks/task-267-262-bash-timeout-wrapper-impl.md
+++ b/.foundry/tasks/task-267-262-bash-timeout-wrapper-impl.md
@@ -2,7 +2,7 @@
 id: task-267-262-bash-timeout-wrapper-impl
 type: TASK
 title: Implement timeout wrapper for bash sessions
-status: ACTIVE
+status: CANCELLED
 owner_persona: coder
 created_at: '2026-07-04'
 updated_at: '2026-07-08'
@@ -16,7 +16,7 @@ tags:
   - resilience
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'run_in_bash_session is a platform tool and cannot be modified from within the repo'
 notes: ''
 ---
 


### PR DESCRIPTION
Cancels `task-267-262-bash-timeout-wrapper-impl` as the `run_in_bash_session` tool is a built-in platform-level capability and cannot be wrapped or modified from within the codebase.

---
*PR created automatically by Jules for task [14704755007060772781](https://jules.google.com/task/14704755007060772781) started by @szubster*