### PR TITLE
Draft Tasks for R2 Pull Sync Logic

### DIFF
--- a/.foundry/stories/story-039-263-r2-pull-sync-logic.md
+++ b/.foundry/stories/story-039-263-r2-pull-sync-logic.md
@@ -31,4 +31,6 @@ When a user logs in on a new device, the application must pull their latest save
 - Ensure the downloaded data hydrates the local application state.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks.
+- [x] Break down into Tasks.
+- [ ] task-263-285-r2-pull-sync-logic-impl
+- [ ] task-263-286-r2-pull-sync-logic-qa

--- a/.foundry/tasks/task-263-285-r2-pull-sync-logic-impl.md
+++ b/.foundry/tasks/task-263-285-r2-pull-sync-logic-impl.md
@@ -1,0 +1,36 @@
+---
+id: task-263-285-r2-pull-sync-logic-impl
+type: TASK
+title: Cloudflare R2 Pull Sync Logic Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-039-263-r2-pull-sync-logic
+tags:
+  - backend
+  - sync
+  - r2
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Cloudflare R2 Pull Sync Logic Implementation
+
+## Context
+When a user logs in on a new device, the application must pull their latest save data from Cloudflare R2. This implementation task handles fetching the save data from R2 upon successful login and ensuring the downloaded data hydrates the local application state. This relies on the infrastructure built in `task-262-261-r2-client-impl`.
+
+**Important Reminder for Coder/QA:**
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
+
+## Acceptance Criteria
+- [ ] Implement logic to fetch save data from R2 upon successful login.
+- [ ] Ensure the downloaded data hydrates the local application state.

--- a/.foundry/tasks/task-263-286-r2-pull-sync-logic-qa.md
+++ b/.foundry/tasks/task-263-286-r2-pull-sync-logic-qa.md
@@ -1,0 +1,37 @@
+---
+id: task-263-286-r2-pull-sync-logic-qa
+type: TASK
+title: QA - Cloudflare R2 Pull Sync Logic
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
+depends_on:
+  - task-263-285-r2-pull-sync-logic-impl
+jules_session_id: null
+pr_number: null
+parent: story-039-263-r2-pull-sync-logic
+tags:
+  - backend
+  - sync
+  - r2
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Cloudflare R2 Pull Sync Logic
+
+## Context
+Verify the implementation of fetching save data from Cloudflare R2 upon successful login and ensuring the downloaded data hydrates the local application state. This relies on the infrastructure built in `task-262-261-r2-client-impl`.
+
+**Important Reminder for Coder/QA:**
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify that upon successful login, logic correctly fetches the user's save data from R2.
+- [ ] Verify that the downloaded data correctly hydrates the local application state.


### PR DESCRIPTION
This PR breaks down the R2 pull sync logic story into technical blueprints (Tasks).

1.  Created `task-263-285-r2-pull-sync-logic-impl` for the `coder` persona to implement the pull logic.
2.  Created `task-263-286-r2-pull-sync-logic-qa` for the `qa` persona to verify the implementation.
3.  Updated the parent story (`story-039-263-r2-pull-sync-logic`) to include the newly created tasks in the acceptance criteria, preventing it from transitioning to VERIFYING prematurely.

---
*PR created automatically by Jules for task [13673043345491015241](https://jules.google.com/task/13673043345491015241) started by @szubster*