### PR TITLE
feat: Replan Gen 3 Roamer Tracker Dashboard and Radar Epics

### DIFF
--- a/.foundry/epics/epic-044-151-gen3-roamer-dashboard-ui-v6.md
+++ b/.foundry/epics/epic-044-151-gen3-roamer-dashboard-ui-v6.md
@@ -1,0 +1,38 @@
+---
+id: epic-044-151-gen3-roamer-dashboard-ui-v6
+type: EPIC
+title: Gen 3 Roamer Dashboard UI v6
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
+depends_on:
+  - epic-044-149-gen3-roamer-core-extraction-v4
+  - epic-044-150-gen3-roamer-iv-glitch-v4
+  - research-044-207-gen3-roamer-ui-alternatives
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Dashboard UI v6
+
+## Objective
+Create a user interface to display the comprehensive breakdown of the roaming legendary's internal state.
+
+## Description
+Develop a dashboard view that presents the exact state of the roaming Pokémon, utilizing the parsed data. It should clearly display the Pokémon's Nature, individual IVs, current HP, and status condition. It should also provide a prominent warning if the IV Glitch has corrupted its stats.
+
+## Acceptance Criteria
+- [ ] Build a UI component to display the roamer's Nature, IVs, HP, and Status.
+- [ ] Implement a visual warning indicator for the IV Glitch.
+- [ ] Ensure the UI adheres to the alternative design determined by the research phase.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-044-152-gen3-roamer-location-radar-v2.md
+++ b/.foundry/epics/epic-044-152-gen3-roamer-location-radar-v2.md
@@ -1,0 +1,34 @@
+---
+id: epic-044-152-gen3-roamer-location-radar-v2
+type: EPIC
+title: Gen 3 Roamer Location Radar v2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - map
+research_references:
+  - adr-108-027-gen3-roamer-location-impossible
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Location Radar v2
+
+## Objective
+Address the PRD requirement to provide a Route Radar to map the roamer's current location index.
+
+## Description
+Determine if and how the roamer's current location can be tracked or if alternative visualizations should be used, noting the constraints identified in ADR 108-027 where Gen 3 roamer locations cannot be extracted statically from save files.
+
+## Acceptance Criteria
+- [ ] Determine appropriate behavior or visualization for Route Radar based on static extraction limitations.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -16,3 +16,4 @@ When addressing a rejected PRD (`prd-071-044-gen3-roamer-tracker`) resulting fro
 3. Append these new epics as unchecked tasks (`- [ ]`) in the PRD's Acceptance Criteria.
 4. Set the `owner_persona` of the new epics to `story_owner`.
 5. Submit an empty PR for the PRD, allowing it to transition appropriately once all child nodes are completed.
+\nWhen drafting replacement epics, if a project requirement outlined in a parent node is deemed impossible by an architectural decision record (ADR), replacement child nodes must explicitly address the requirement and cite the restricting ADR in their `research_references`, rather than silently dropping it.

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -48,3 +48,8 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - [ ] epic-044-148-gen3-roamer-dashboard-ui-v5
 - [ ] epic-044-149-gen3-roamer-core-extraction-v4
 - [ ] epic-044-150-gen3-roamer-iv-glitch-v4
+- [ ] epic-044-151-gen3-roamer-dashboard-ui-v6
+- [ ] epic-044-152-gen3-roamer-location-radar-v2
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Replaces the cancelled gen3-roamer-dashboard-ui-v5 with v6, keeping the scope focused solely on extracting/displaying data rather than dropping requirements.
Introduces gen3-roamer-location-radar-v2 to satisfy the PRD requirement for a Route Radar, while correctly citing ADR-108-027 (impossibility) as a research constraint to guide story planning.
Appends these new epics strictly as unchecked tasks to PRD 044 without modifying existing pending tasks.
Included the other pending epics to satisfy DAG orchestration.

---
*PR created automatically by Jules for task [6079520624018332742](https://jules.google.com/task/6079520624018332742) started by @szubster*