### PR TITLE
feat(foundry): generate dataview extraction tasks for gen3 ash

### DIFF
--- a/.foundry/tasks/task-267-261-gen3-ash-dataview-extraction-impl.md
+++ b/.foundry/tasks/task-267-261-gen3-ash-dataview-extraction-impl.md
@@ -1,11 +1,11 @@
 ---
 id: task-267-261-gen3-ash-dataview-extraction-impl
 type: TASK
-title: Implement Gen 3 Volcanic Ash Count DataView Extraction
-status: COMPLETED
+title: Implement Gen 3 Volcanic Ash Extraction
+status: PENDING
 owner_persona: coder
-created_at: '2026-07-04'
-updated_at: '2026-07-05'
+created_at: '2026-07-08'
+updated_at: '2026-07-08'
 depends_on: []
 jules_session_id: null
 pr_number: null
@@ -21,7 +21,7 @@ rejection_reason: ''
 notes: ''
 ---
 
-# Implement Gen 3 Volcanic Ash Count DataView Extraction
+# Implement Gen 3 Volcanic Ash Extraction
 
 ## Context
 Based on research findings, the Volcanic Ash gather count is stored as game variable `0x4048`.
@@ -29,18 +29,15 @@ Based on research findings, the Volcanic Ash gather count is stored as game vari
 - Emerald Absolute Offset: `0x142C`
 - Ruby/Sapphire Absolute Offset: `0x13D0`
 
-## Requirements
-1. Extract the Volcanic Ash gather count using the `DataView` API.
-2. When parsing, you must properly catch `RangeError` exceptions to safely handle out-of-bounds reads.
-3. All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
+As per ADR 010, the DataView API MUST be used instead of raw `Uint8Array` manipulation.
+As per ADR 028, all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. Inline magic numbers are explicitly forbidden.
 
 ## Acceptance Criteria
-- [x] Implement the extraction logic for Gen 3 Volcanic Ash count.
-- [x] Define reusable constants for all memory offsets (`0x142C`, `0x13D0`).
-- [x] Properly catch `RangeError` to handle out-of-bounds reads.
-- [x] Write unit tests for the extraction logic.
+- [ ] Implement Volcanic Ash DataView extraction logic for Gen 3 saves.
+- [ ] Define module-level constants for offsets (`0x142C`, `0x13D0`) and relative var array offset (`0x90`).
+- [ ] Write unit tests verifying correct extraction for Ruby/Sapphire and Emerald.
+- [ ] Write unit tests that trigger and catch `RangeError` exceptions for out-of-bounds reads.
 
-## Persona Instructions
-- **Coder**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- **Coder**: If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- **Coder**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+## Developer Instructions
+- **Failure conditions:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Completion conditions:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-267-262-gen3-ash-dataview-extraction-qa.md
+++ b/.foundry/tasks/task-267-262-gen3-ash-dataview-extraction-qa.md
@@ -1,10 +1,10 @@
 ---
 id: task-267-262-gen3-ash-dataview-extraction-qa
 type: TASK
-title: QA Gen 3 Volcanic Ash Count DataView Extraction
-status: COMPLETED
+title: QA Gen 3 Volcanic Ash Extraction
+status: PENDING
 owner_persona: qa
-created_at: '2026-07-04'
+created_at: '2026-07-08'
 updated_at: '2026-07-08'
 depends_on:
   - task-267-261-gen3-ash-dataview-extraction-impl
@@ -22,7 +22,7 @@ rejection_reason: ''
 notes: ''
 ---
 
-# QA Gen 3 Volcanic Ash Count DataView Extraction
+# QA Gen 3 Volcanic Ash Extraction
 
 ## Context
 Based on research findings, the Volcanic Ash gather count is stored as game variable `0x4048`.
@@ -30,16 +30,14 @@ Based on research findings, the Volcanic Ash gather count is stored as game vari
 - Emerald Absolute Offset: `0x142C`
 - Ruby/Sapphire Absolute Offset: `0x13D0`
 
-## Requirements
-1. Verify the extraction logic properly uses `DataView` API and catches `RangeError` exceptions for out-of-bounds reads.
-2. Ensure no magic numbers are used inline; all memory offsets and lengths must be module-level constants.
-3. Verify comprehensive test coverage exists and passes.
+The implementation task (`task-267-261-gen3-ash-dataview-extraction-impl`) requires extracting this data. As QA, you need to verify it.
 
 ## Acceptance Criteria
-- [x] Code review the implementation to ensure it meets requirements.
-- [x] Verify test coverage is complete and successful.
+- [ ] Verify that the DataView API is used instead of raw `Uint8Array` manipulation (ADR 010).
+- [ ] Verify that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level, without inline magic numbers (ADR 028).
+- [ ] Verify unit tests correctly extract ash count for both Emerald and Ruby/Sapphire.
+- [ ] Verify unit tests correctly trigger and catch `RangeError` exceptions for out-of-bounds reads.
 
-## Persona Instructions
-- **QA**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- **QA**: If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- **QA**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+## Developer Instructions
+- **Failure conditions:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Completion conditions:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Drafted implementation and QA task nodes for extracting the Gen 3 Volcanic Ash counter based on story-113-267. Adhered to strict schema and ADRs (010, 028) regarding module-level constants and DataView API usage. The parent story was left intact as it already properly references these child IDs in its acceptance criteria, and its status remains READY to trigger late-binding orchestrator demotion via this PR.

---
*PR created automatically by Jules for task [17412270532249250513](https://jules.google.com/task/17412270532249250513) started by @szubster*