### PR TITLE
🧭 Strategist: Prompt improvement - Enforce explicit generic typing on vi.fn() mocks

### DIFF
--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -28,6 +28,7 @@ When implementing UI components, you MUST adhere strictly to the "tactical hardw
 - Use dashed borders (`border-dashed`) and monospaced telemetry fonts (e.g. `font-mono`).
 
 ## Quality Assurance
+When writing tests, remember that Vitest requires explicit generic typing on `vi.fn()` mocks (e.g. `vi.fn<(type: string) => void>()`) when testing callback props for components, to satisfy `vitest(require-mock-type-parameters)`.
 Before marking a task as COMPLETED, you MUST run `pnpm lint && pnpm test` to ensure project health and that no regressions are introduced.
 To automatically fix code formatting errors flagged by Biome during lint checks, run `pnpm check:fix` or `pnpm format:biome`.
 When modifying central systems like the DAG Orchestrator (`.github/scripts/foundry-orchestrator.ts`), you MUST also explicitly run its test suite (`cd .github/scripts && pnpm install && npx vitest`) and fix any existing tests that your new logic breaks.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -344,3 +344,10 @@
 **Outcome:** Merged
 **Why:** The prompt evaluation identified massive duplication in the agent prompts where a huge block regarding the "Journaling rules" (logging long-term lessons vs execution logs) and "YAML frontmatter modification rules" was repeated verbatim across 26 different agents. This bloated the prompts and made updating the rules error-prone.
 **Pattern:** Consolidate duplicated core prompt instructions (e.g. journaling rules, YAML modification policies) into `.foundry/docs/knowledge_base/agents/core_policies.md` and instruct the agents to read it. This drastically reduces prompt size, creates a single source of truth, and allows global policy updates without touching 26 individual schedule files.
+
+
+## 2026-07-24 - [Accepted] - Prompt improvement - Enforce explicit generic typing on vi.fn() mocks
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `coder` journal recorded that Vitest requires explicit generic typing on `vi.fn()` mocks (e.g. `vi.fn<(type: string) => void>()`) when testing callback props for components, to satisfy `vitest(require-mock-type-parameters)`. This rule is frequently missed during implementation.
+**Pattern:** Codify specific, recurring test framework constraints (like Vitest mock typing rules) directly into the implementer's prompt (Coder) to prevent recurring lint/test failures during the QA phase.


### PR DESCRIPTION
The coder journal recorded that Vitest requires explicit generic typing on `vi.fn()` mocks (e.g. `vi.fn<(type: string) => void>()`) when testing callback props for components, to satisfy `vitest(require-mock-type-parameters)`. This rule is frequently missed during implementation. This PR codifies specific, recurring test framework constraints (like Vitest mock typing rules) directly into the implementer's prompt (Coder) to prevent recurring lint/test failures during the QA phase.

---
*PR created automatically by Jules for task [7888199170191965161](https://jules.google.com/task/7888199170191965161) started by @szubster*