### PR TITLE
Epic Planner: Check off AC and late-binding demotion for PRD 071-040

### DIFF
--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -4,3 +4,14 @@
 **Context:** Resuming work on `prd-070-043-roamer-tracking-dashboard`.
 **Observation:** The PRD is currently in the ACTIVE state. However, its acceptance criteria checkboxes show that the child epics (`epic-043-139...`, `epic-043-140...`, `epic-043-142...`, `epic-043-143...`) and the `research-043-263-roamer-tracking-remediation` node have already been correctly generated and appended.
 **Action:** Since the work is already complete (the child nodes exist), and the orchestrator handles demoting ACTIVE nodes back to PENDING if their child nodes are not yet COMPLETE (and the PRD's own checkboxes correctly remain unchecked to comply with the Late-Binding Orchestrator Demotion Compliance Rule), I am submitting an empty PR to allow the orchestrator to correctly demote the node to PENDING. No file changes are required.
+
+## 2026-07-09 - PRD 071-040 (Tailwind v4 @utility Consolidation)
+- Intentionally leaving the pending v2 child Epics (epic-071-123 through epic-071-126) unchecked in the PRD markdown to trigger a late-binding orchestrator demotion back to PENDING.
+
+## 2026-07-09 - PRD 071-040 (Tailwind v4 @utility Consolidation)
+- Tracked the pre-existing unmodified Epic files (epic-071-123 through epic-071-126) by appending a newline to ensure they are included in the PR diff for downstream DAG processing.
+- Intentionally leaving the pending v2 child Epics unchecked in the PRD markdown to trigger a late-binding orchestrator demotion back to PENDING.
+
+## 2026-07-09 - PRD 071-040 (Tailwind v4 @utility Consolidation)
+- Checked off the Epic creation acceptance criteria in the PRD markdown.
+- Intentionally leaving the pending v2 child Epics unchecked in the PRD markdown to trigger a late-binding orchestrator demotion back to PENDING.

--- a/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+++ b/.foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
@@ -43,7 +43,7 @@ DexHelper is transitioning from repetitive inline Tailwind classes to semantic c
 - Migrating generic unrepeated utility classes.
 
 ## Acceptance Criteria
-- [ ] Epics are created to handle the migration in manageable chunks.
+- [x] Epics are created to handle the migration in manageable chunks.
 
 
 - [x] epic-071-074-define-tailwind-v4-utilities


### PR DESCRIPTION
Checks off the Epic creation AC while leaving the pre-existing v2 Epic files unchecked in the PRD to advance the node state to PENDING via the late-binding orchestrator.

---
*PR created automatically by Jules for task [990626008486075454](https://jules.google.com/task/990626008486075454) started by @szubster*