### PR TITLE
Complete QA for Gen 3 Secret Base Trainer and Party Parsing

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -13,3 +13,12 @@ The implementer (`coder`) failed `task-121-219-gen3-tv-block-parser-retry-impl` 
 - **Date**: 2026-07-05
 - **Node**: task-253-260-shiny-carrier-ui-badge-impl
 - **Reason**: The developer implemented the Shiny Carrier UI badges (e.g., animate-[pulse...] divs in PokemonDetails.tsx and StorageGrid.tsx) without the mandated `border-dashed` class, violating ADR 008's strict tactical hardware aesthetic constraints.
+
+## 2026-07-09
+
+**Task**: task-109-248-parse-secret-base-trainer-party-qa (QA for task-109-247-parse-secret-base-trainer-party)
+**Outcome**: Passed Validation
+**Notes**:
+- Verified that `DataView` API is used exclusively in `src/engine/gen3/secretBase/parser.ts` for all read operations (e.g. `getUint32`, `getUint16`, `getUint8`).
+- Verified that all offsets, lengths, and bit locations are defined as reusable constants at the module level.
+- Verified that comprehensive unit tests are present, including checking for out-of-bounds reads throwing `The save file is corrupted or incomplete.` when catching `RangeError`.

--- a/.foundry/tasks/task-109-248-parse-secret-base-trainer-party-qa.md
+++ b/.foundry/tasks/task-109-248-parse-secret-base-trainer-party-qa.md
@@ -38,6 +38,6 @@ The coder has implemented the parsing logic for Gen 3 Secret Base trainer inform
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verify `DataView` API is used exclusively.
-- [ ] Verify module-level constants are used instead of magic numbers for offsets.
-- [ ] Verify comprehensive unit tests are present.
+- [x] Verify `DataView` API is used exclusively.
+- [x] Verify module-level constants are used instead of magic numbers for offsets.
+- [x] Verify comprehensive unit tests are present.


### PR DESCRIPTION
I have run the test suite successfully and validated that the coder used exclusively the DataView API in `src/engine/gen3/secretBase/parser.ts` for all reads, and that they used module-level constants instead of inline magic numbers. Tests check for bounds checking and graceful failure via throwing a specific error message upon catching `RangeError`. Since this constitutes a successful QA validation, I have appended the findings to the QA journal and checked off the acceptance criteria in the markdown body without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [15726844382950780990](https://jules.google.com/task/15726844382950780990) started by @szubster*