### PR TITLE
tech lead: cancel bash timeout wrapper impl, research alternatives

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -149,3 +149,8 @@ When decomposing a STORY into TASK nodes, strictly follow the Intelligent Verifi
 ## 2026-07-07: Premature Story Verification
 - **Observation**: Attempted to transition a Story to VERIFYING by checking off its child tasks, violating a core directive.
 - **Constraint Enforced**: CRITICAL: Do NOT submit an Empty PR to transition a Story to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child TASK nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints. If a parent node has incomplete children (e.g. pending or active), you must leave its own acceptance criteria checkboxes unchecked to keep it in PENDING status.
+
+## 2026-07-09: Platform Tool Modification Constraints
+- **Observation**: Attempted to implement a timeout wrapper for `run_in_bash_session` but the task was rejected because platform tools cannot be modified from within the repo.
+- **Action**: Drafted a RESEARCH node to investigate alternative architectural solutions before drafting replacement TASK nodes.
+- **Lesson**: Platform tools like `run_in_bash_session` are outside the repository's control. Always research alternative architectural solutions or system-level constraints before assigning tasks to modify platform behavior.

--- a/.foundry/research/research-267-296-bash-timeout-wrapper-alternatives.md
+++ b/.foundry/research/research-267-296-bash-timeout-wrapper-alternatives.md
@@ -1,0 +1,41 @@
+---
+id: research-267-296-bash-timeout-wrapper-alternatives
+type: RESEARCH
+title: Research alternatives for bash timeout wrapper
+status: READY
+owner_persona: researcher
+created_at: '2026-07-09'
+updated_at: '2026-07-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-127-267-bash-timeout-wrapper
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research alternatives for bash timeout wrapper
+
+## Overview
+Investigate alternative ways to implement a timeout wrapper for bash sessions. The previous implementation task failed because `run_in_bash_session` is a platform tool and cannot be modified from within the repo.
+
+## Context
+The goal is to interrupt commands that run over a specific threshold (e.g., 30 seconds) to prevent infinite hangs caused by blocking commands like `tail -f`. Since modifying the platform tool `run_in_bash_session` is not possible, we need to find other ways to enforce this timeout.
+
+## Research Objectives
+1.  **Identify Alternative Mechanisms**: Explore ways to wrap bash execution or enforce timeouts at a level that *can* be modified from within the repository.
+    *   Could we introduce a wrapper script within the repo that agents are instructed to use instead of calling `run_in_bash_session` directly?
+    *   Are there other platform features or configurations we can leverage?
+    *   Can we enforce a timeout policy via instructions to the agents?
+2.  **Evaluate Feasibility**: Assess the practicality and effectiveness of each identified alternative.
+3.  **Propose a Solution**: Recommend the best approach for implementing the timeout requirement given the constraints.
+
+## Acceptance Criteria
+- [ ] Investigate alternative mechanisms for enforcing a timeout on bash commands.
+- [ ] Document findings and propose a feasible solution.

--- a/.foundry/stories/story-127-267-bash-timeout-wrapper.md
+++ b/.foundry/stories/story-127-267-bash-timeout-wrapper.md
@@ -27,5 +27,8 @@ Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that
 
 ## Acceptance Criteria
 - [ ] Implement timeout wrapper.
-- [ ] task-267-262-bash-timeout-wrapper-impl
-- [ ] task-267-263-bash-timeout-wrapper-qa
+- [x] task-267-262-bash-timeout-wrapper-impl
+- [x] task-267-263-bash-timeout-wrapper-qa
+- [ ] research-267-296-bash-timeout-wrapper-alternatives
+- [ ] task-267-297-bash-timeout-wrapper-impl-v2
+- [ ] task-267-298-bash-timeout-wrapper-qa-v2

--- a/.foundry/tasks/task-267-297-bash-timeout-wrapper-impl-v2.md
+++ b/.foundry/tasks/task-267-297-bash-timeout-wrapper-impl-v2.md
@@ -1,0 +1,40 @@
+---
+id: task-267-297-bash-timeout-wrapper-impl-v2
+type: TASK
+title: Implement timeout wrapper for bash sessions (v2)
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-09'
+updated_at: '2026-07-09'
+depends_on:
+  - research-267-296-bash-timeout-wrapper-alternatives
+jules_session_id: null
+pr_number: null
+parent: story-127-267-bash-timeout-wrapper
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement timeout wrapper for bash sessions (v2)
+
+## Overview
+Implement the recommended alternative solution for a timeout wrapper for bash sessions, based on the findings from `research-267-296-bash-timeout-wrapper-alternatives`.
+
+## Constraints & Requirements
+- Follow the proposed solution from the research node to implement a mechanism that interrupts commands running over a specific threshold (e.g., 30 seconds).
+- Since `run_in_bash_session` is a platform tool and cannot be modified, this implementation must be an alternative architectural solution that *can* be modified from within the repo.
+- If a command runs beyond the threshold, it must be interrupted and return a helpful error message to the agent, suggesting non-blocking alternatives like `cat` or `tail -n`.
+
+## Instructions for Coder
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement timeout wrapper alternative based on research findings.

--- a/.foundry/tasks/task-267-298-bash-timeout-wrapper-qa-v2.md
+++ b/.foundry/tasks/task-267-298-bash-timeout-wrapper-qa-v2.md
@@ -1,13 +1,13 @@
 ---
-id: task-267-263-bash-timeout-wrapper-qa
+id: task-267-298-bash-timeout-wrapper-qa-v2
 type: TASK
-title: QA timeout wrapper for bash sessions
+title: QA timeout wrapper for bash sessions (v2)
 status: PENDING
 owner_persona: qa
-created_at: '2026-07-04'
-updated_at: '2026-07-04'
+created_at: '2026-07-09'
+updated_at: '2026-07-09'
 depends_on:
-  - task-267-262-bash-timeout-wrapper-impl
+  - task-267-297-bash-timeout-wrapper-impl-v2
 jules_session_id: null
 pr_number: null
 parent: story-127-267-bash-timeout-wrapper
@@ -21,18 +21,17 @@ rejection_reason: ''
 notes: ''
 ---
 
-# QA timeout wrapper for bash sessions
-
-**STATUS:** CANCELLED. Replaced by `task-267-298-bash-timeout-wrapper-qa-v2` because the implementation strategy required architectural changes.
+# QA timeout wrapper for bash sessions (v2)
 
 ## Overview
-Verify that the timeout wrapper for `run_in_bash_session` works correctly and interrupts commands that run over the specified threshold (e.g., 30 seconds).
+Verify that the alternative timeout wrapper solution for bash sessions works correctly and interrupts commands that run over the specified threshold (e.g., 30 seconds).
 
 ## Instructions for QA
-- Test the wrapper with a deliberate long sleep command or a blocking command like `tail -f` and verify it interrupts after the threshold and returns the expected error message.
+- Test the new solution with a deliberate long sleep command or a blocking command like `tail -f` and verify it interrupts after the threshold and returns the expected error message.
+- Ensure the solution functions within the constraints identified in the research phase.
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
 - If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verify timeout wrapper interrupts long commands.
+- [ ] Verify alternative timeout wrapper solution interrupts long commands.


### PR DESCRIPTION
Modifying platform tools like `run_in_bash_session` is impossible from within the repository. This PR:
- Cancels the orphaned QA node `task-267-263-bash-timeout-wrapper-qa`.
- Creates a `RESEARCH` node `research-267-296-bash-timeout-wrapper-alternatives` to find alternative architectural solutions.
- Creates replacement v2 implementation and QA task blueprints `task-267-297-bash-timeout-wrapper-impl-v2` and `task-267-298-bash-timeout-wrapper-qa-v2`.
- Updates the parent story node `story-127-267-bash-timeout-wrapper`.
- Updates the tech lead journal `tech_lead.md` with this platform constraint.

---
*PR created automatically by Jules for task [8551280250648888266](https://jules.google.com/task/8551280250648888266) started by @szubster*