### PR TITLE
feat: draft emerald move tutor parsing tasks

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -149,3 +149,5 @@ When decomposing a STORY into TASK nodes, strictly follow the Intelligent Verifi
 ## 2026-07-07: Premature Story Verification
 - **Observation**: Attempted to transition a Story to VERIFYING by checking off its child tasks, violating a core directive.
 - **Constraint Enforced**: CRITICAL: Do NOT submit an Empty PR to transition a Story to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child TASK nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints. If a parent node has incomplete children (e.g. pending or active), you must leave its own acceptance criteria checkboxes unchecked to keep it in PENDING status.
+## 2026-07-09
+Drafted implementation and QA tasks for Emerald Move Tutor parsing. Checked off the task creation acceptance criteria on the story node, and appended the new tasks as unchecked checkboxes.

--- a/.foundry/stories/story-119-267-gen3-move-tutor-emerald-parsing.md
+++ b/.foundry/stories/story-119-267-gen3-move-tutor-emerald-parsing.md
@@ -35,3 +35,5 @@ As described in `research-055-247-gen3-move-tutor-offsets` (detailed in `gen3_mo
 - [x] Create tasks for implementing DataView-based extraction of Emerald Move Tutor bits.
 - [ ] task-267-261-gen3-move-tutor-emerald-impl
 - [ ] task-267-262-gen3-move-tutor-emerald-qa
+- [ ] task-267-287-gen3-move-tutor-emerald-impl
+- [ ] task-267-288-gen3-move-tutor-emerald-qa

--- a/.foundry/tasks/task-267-287-gen3-move-tutor-emerald-impl.md
+++ b/.foundry/tasks/task-267-287-gen3-move-tutor-emerald-impl.md
@@ -1,0 +1,55 @@
+---
+id: task-267-287-gen3-move-tutor-emerald-impl
+type: TASK
+title: Implement Emerald Move Tutor Extraction
+status: PENDING
+owner_persona: coder
+created_at: 2026-07-09
+updated_at: 2026-07-09
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-119-267-gen3-move-tutor-emerald-parsing
+tags:
+  - gen3
+  - save-parsing
+  - move-tutor
+  - emerald
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Emerald Move Tutor Extraction
+
+## Context
+We need to extract the Gen 3 Emerald Move Tutor usage flags. The game uses a continuous bit array of "Event Flags" starting at offset `0x1270` within `SaveBlock1` in the save file.
+
+## Requirements
+1.  **Extract Move Tutor Usage**: Implement logic to extract whether the following 10 Move Tutors have been used:
+    - Swagger (`+0x36`, bit `1`)
+    - Rollout (`+0x36`, bit `2`)
+    - Fury Cutter (`+0x36`, bit `3`)
+    - Mimic (`+0x36`, bit `4`)
+    - Metronome (`+0x36`, bit `5`)
+    - Sleep Talk (`+0x36`, bit `6`)
+    - Substitute (`+0x36`, bit `7`)
+    - DynamicPunch (`+0x37`, bit `0`)
+    - Double-Edge (`+0x37`, bit `1`)
+    - Explosion (`+0x37`, bit `2`)
+2.  **DataView API**: You MUST exclusively use the native `DataView` API (e.g., `getUint8`) for bounds checking (ADR 010). Do not use raw `Uint8Array` manipulations.
+3.  **No Inline Magic Numbers**: All memory offsets (like `0x1270`, `0x36`, `0x37`), bit locations, lengths, and shifts MUST be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+4.  **Bounds Checking**: Rely on `DataView` to throw `RangeError` on out-of-bounds reads. Catch these explicitly and gracefully propagate them as specific validation errors.
+5.  **Unit Tests**: Write Gen 3 unit tests to verify the extracted Move Tutor usages.
+
+## Reminders
+*   If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+*   If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+*   If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Create constants for the event flag start offset (`0x1270`), and specific byte offsets and bit positions for each Emerald move tutor flag.
+- [ ] Implement logic to extract these flags using the `DataView` API.
+- [ ] Explicitly catch `RangeError` for out-of-bounds reads during extraction.
+- [ ] Write comprehensive unit tests verifying the logic correctly reads the specific bits for each move tutor.

--- a/.foundry/tasks/task-267-288-gen3-move-tutor-emerald-qa.md
+++ b/.foundry/tasks/task-267-288-gen3-move-tutor-emerald-qa.md
@@ -1,0 +1,46 @@
+---
+id: task-267-288-gen3-move-tutor-emerald-qa
+type: TASK
+title: QA Emerald Move Tutor Extraction
+status: PENDING
+owner_persona: qa
+created_at: 2026-07-09
+updated_at: 2026-07-09
+depends_on:
+  - task-267-287-gen3-move-tutor-emerald-impl
+jules_session_id: null
+pr_number: null
+parent: story-119-267-gen3-move-tutor-emerald-parsing
+tags:
+  - gen3
+  - save-parsing
+  - move-tutor
+  - emerald
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Emerald Move Tutor Extraction
+
+## Context
+The Coder (`task-267-287-gen3-move-tutor-emerald-impl`) will implement logic to extract Emerald Move Tutor usage flags from the `event_flags` bit array starting at `0x1270` in `SaveBlock1`.
+
+## Requirements
+1.  **Validate Offsets and Bits**: Verify that the implemented logic correctly targets the specific byte offsets (e.g., `+0x36`, `+0x37`) and bit positions (e.g., bit `1` for Swagger) for all 10 Emerald move tutors.
+2.  **Validate `DataView` Usage**: Ensure the Coder exclusively used the `DataView` API (e.g., `getUint8`) and correctly relied on it to catch `RangeError` for bounds checking, adhering to ADR 010.
+3.  **Validate No Magic Numbers**: Verify that all memory offsets (`0x1270`, `0x36`, `0x37`), bit locations, lengths, and shifts are defined as reusable constants at the module level. Reject any inline magic numbers.
+4.  **Validate Tests**: Review the unit tests to ensure adequate coverage of the move tutor flag extraction.
+
+## Reminders
+*   If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+*   If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+*   If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify there are absolutely no inline magic numbers for any offsets or bit positions.
+- [ ] Verify `DataView` is used exclusively for memory reads and correctly catches `RangeError`s.
+- [ ] Verify the logic correctly extracts each of the 10 Emerald move tutor flags from the correct byte and bit.
+- [ ] Verify unit tests are comprehensive and pass.


### PR DESCRIPTION
Drafts implementation and QA tasks for parsing Gen 3 Emerald Move Tutor flags. Updates the story node to reflect the drafted tasks. Submit the PR, leaving the pending child nodes unchecked to allow the orchestrator to correctly demote the node to PENDING.

---
*PR created automatically by Jules for task [235667293487078075](https://jules.google.com/task/235667293487078075) started by @szubster*