### PR TITLE
chore(foundry): Empty PR for late-binding demotion of prd-071-044-gen3-roamer-tracker

### DIFF
--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -9,3 +9,8 @@
 **Context:** Processing PRD `prd-071-040-tailwind-v4-utilities-migration`.
 **Observation:** The PRD is currently in the READY state. However, its acceptance criteria checkboxes show that the child epics (`epic-071-123...`, `epic-071-124...`, `epic-071-125...`, `epic-071-126...`) have already been correctly generated and appended.
 **Action:** Since the work is already complete (the child nodes exist), and the orchestrator handles demoting READY nodes back to PENDING if their child nodes are not yet COMPLETE (and the PRD's own checkboxes correctly remain unchecked to comply with the Late-Binding Orchestrator Demotion Compliance Rule), I am submitting an empty PR to allow the orchestrator to correctly demote the node to PENDING. No file changes are required.
+
+## Session 2026-07-09
+**Context:** Processing PRD `prd-071-044-gen3-roamer-tracker`.
+**Observation:** The PRD is currently in the READY state. However, its acceptance criteria checkboxes show that the child epics (`epic-044-149-gen3-roamer-core-extraction-v4`, `epic-044-150-gen3-roamer-iv-glitch-v4`, `epic-044-151-gen3-roamer-dashboard-ui-v6`) have already been correctly generated and appended.
+**Action:** Since the work is already complete (the child nodes exist), and the orchestrator handles demoting READY nodes back to PENDING if their child nodes are not yet COMPLETE (and the PRD's own checkboxes correctly remain unchecked to comply with the Late-Binding Orchestrator Demotion Compliance Rule), I am submitting an empty PR to allow the orchestrator to correctly demote the node to PENDING. No file changes are required.


### PR DESCRIPTION
Updates the epic planner journal to indicate that `prd-071-044-gen3-roamer-tracker` has all its child epics correctly generated and appended. An empty PR is being submitted to allow the orchestrator to correctly demote the PRD node from READY back to PENDING. No file changes are required for the target node to comply with the Late-Binding Orchestrator Demotion Compliance Rule.

---
*PR created automatically by Jules for task [13864038413269406532](https://jules.google.com/task/13864038413269406532) started by @szubster*