### PR TITLE
chore: Replace impossible bash timeout task with architectural alternative

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -149,3 +149,8 @@ When decomposing a STORY into TASK nodes, strictly follow the Intelligent Verifi
 ## 2026-07-07: Premature Story Verification
 - **Observation**: Attempted to transition a Story to VERIFYING by checking off its child tasks, violating a core directive.
 - **Constraint Enforced**: CRITICAL: Do NOT submit an Empty PR to transition a Story to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child TASK nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints. If a parent node has incomplete children (e.g. pending or active), you must leave its own acceptance criteria checkboxes unchecked to keep it in PENDING status.
+
+## 2026-07-09: Platform Tool Limitations
+- **Observation**: Task `task-267-262-bash-timeout-wrapper-impl` failed because `run_in_bash_session` is a platform tool and cannot be modified from within the repo.
+- **Action**: Spawned `research-267-287-bash-timeout-alternative` to investigate alternative architectural solutions and replaced the implementation and QA tasks.
+- **Lesson**: Platform tools like `run_in_bash_session` are outside the repository's control. Tasks attempting to modify them must be rejected or cancelled in favor of researching alternative architectural solutions.

--- a/.foundry/research/research-267-287-bash-timeout-alternative.md
+++ b/.foundry/research/research-267-287-bash-timeout-alternative.md
@@ -1,0 +1,36 @@
+---
+id: research-267-287-bash-timeout-alternative
+type: RESEARCH
+title: Investigate alternative bash timeout mechanisms
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-09'
+updated_at: '2026-07-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-127-267-bash-timeout-wrapper
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate alternative bash timeout mechanisms
+
+## Overview
+The platform tool `run_in_bash_session` cannot be modified from within the repository. We need to research alternative ways to enforce a timeout on commands executed by agents, such as pre-pending `timeout` to commands, enforcing a linter rule on execution plans, or injecting a bash alias.
+
+## Instructions for Researcher
+- Investigate options for enforcing timeouts on long-running commands without modifying the platform tool.
+- Propose architectural alternatives that can be implemented within the repository (e.g., in the `.foundry/docs/` guidelines, or a custom wrapper script that agents are instructed to use).
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Investigate and propose alternative bash timeout mechanisms.

--- a/.foundry/stories/story-127-267-bash-timeout-wrapper.md
+++ b/.foundry/stories/story-127-267-bash-timeout-wrapper.md
@@ -27,5 +27,8 @@ Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that
 
 ## Acceptance Criteria
 - [ ] Implement timeout wrapper.
-- [ ] task-267-262-bash-timeout-wrapper-impl
-- [ ] task-267-263-bash-timeout-wrapper-qa
+- [x] task-267-262-bash-timeout-wrapper-impl
+- [x] task-267-263-bash-timeout-wrapper-qa
+- [ ] research-267-287-bash-timeout-alternative
+- [ ] task-267-288-bash-timeout-alternative-impl
+- [ ] task-267-289-bash-timeout-alternative-qa

--- a/.foundry/tasks/task-267-263-bash-timeout-wrapper-qa.md
+++ b/.foundry/tasks/task-267-263-bash-timeout-wrapper-qa.md
@@ -34,3 +34,5 @@ Verify that the timeout wrapper for `run_in_bash_session` works correctly and in
 
 ## Acceptance Criteria
 - [ ] Verify timeout wrapper interrupts long commands.
+
+CANCELLED: The implementation task was permanently cancelled because run_in_bash_session cannot be modified from within the repo. Replaced by task-267-289-bash-timeout-alternative-qa.

--- a/.foundry/tasks/task-267-288-bash-timeout-alternative-impl.md
+++ b/.foundry/tasks/task-267-288-bash-timeout-alternative-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-267-288-bash-timeout-alternative-impl
+type: TASK
+title: Implement alternative bash timeout mechanisms
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-09'
+updated_at: '2026-07-09'
+depends_on:
+  - research-267-287-bash-timeout-alternative
+jules_session_id: null
+pr_number: null
+parent: story-127-267-bash-timeout-wrapper
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement alternative bash timeout mechanisms
+
+## Overview
+Based on the findings from `research-267-287-bash-timeout-alternative`, implement the proposed alternative timeout mechanism to prevent commands from running over a specific threshold.
+
+## Constraints & Requirements
+- Follow the architectural guidelines proposed in the research node.
+- Ensure the implementation is fully tested and verified.
+
+## Instructions for Coder
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement the alternative bash timeout mechanism.

--- a/.foundry/tasks/task-267-289-bash-timeout-alternative-qa.md
+++ b/.foundry/tasks/task-267-289-bash-timeout-alternative-qa.md
@@ -1,0 +1,36 @@
+---
+id: task-267-289-bash-timeout-alternative-qa
+type: TASK
+title: QA alternative bash timeout mechanisms
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-09'
+updated_at: '2026-07-09'
+depends_on:
+  - task-267-288-bash-timeout-alternative-impl
+jules_session_id: null
+pr_number: null
+parent: story-127-267-bash-timeout-wrapper
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA alternative bash timeout mechanisms
+
+## Overview
+Verify that the alternative bash timeout mechanism works correctly and interrupts commands that run over the specified threshold (e.g., 30 seconds).
+
+## Instructions for QA
+- Test the mechanism as specified in the research and implementation nodes.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify the alternative bash timeout mechanism interrupts long commands.


### PR DESCRIPTION
Replaced the impossible task of modifying `run_in_bash_session` (a platform tool outside the repo) with a new RESEARCH node to investigate alternative timeout mechanisms. Cancelled the orphaned QA task and updated the parent Story node. Submitted via Empty PR pattern for late-binding demotion.

---
*PR created automatically by Jules for task [533673845880642653](https://jules.google.com/task/533673845880642653) started by @szubster*