### PR TITLE
Fix Impossible Loop in Foundry Orchestrator parent wake-up logic

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -2305,4 +2305,45 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     expect(epicContent).toContain('status: READY');
   });
 
+  test("Impossible Loop: does not wake up parent if child was cancelled due to cascading cancellation", () => {
+    createValidTestNode(tmpDir, ".foundry/prds/prd-001.md", {
+      id: "prd-001",
+      type: "PRD",
+      title: "Pending PRD",
+      status: "PENDING",
+      owner_persona: "epic_planner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+    createValidTestNode(tmpDir, ".foundry/epics/epic-001.md", {
+      id: "epic-001",
+      type: "EPIC",
+      title: "Cancelled Epic",
+      status: "CANCELLED",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: "prd-001",
+      depends_on: [],
+      jules_session_id: null,
+      rejection_reason: "Cancelled due to cascading cancellation from parent",
+    });
+    createValidTestNode(tmpDir, ".foundry/epics/epic-002.md", {
+      id: "epic-002",
+      type: "EPIC",
+      title: "Incomplete Epic",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: "prd-001",
+      depends_on: [],
+      jules_session_id: null,
+    });
+    main();
+    const prdContent = fs.readFileSync(path.join(tmpDir, ".foundry/prds/prd-001.md"), "utf-8");
+    expect(prdContent).toContain("status: PENDING");
+  });
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -651,7 +651,12 @@ function main(): void {
       }
     }
 
-    if ((node.frontmatter.status === 'FAILED' || node.frontmatter.status === 'CANCELLED') && node.frontmatter.rejection_reason) {
+    if (
+      (node.frontmatter.status === 'FAILED' || node.frontmatter.status === 'CANCELLED') &&
+      node.frontmatter.rejection_reason &&
+      node.frontmatter.rejection_reason !== 'Cancelled due to cascading cancellation from parent' &&
+      !node.frontmatter.rejection_reason.startsWith('Cancelled due to permanent failure of dependency:')
+    ) {
       // Skip waking up parent if the child is merely suspended (waiting for dependencies/children).
       // We ignore the parent node itself during this check because it's exactly what we want to find out
       // (if something OTHER than the parent is blocking the child).


### PR DESCRIPTION
Fixed an issue in the Foundry Orchestrator where parent nodes in a PENDING state were being incorrectly woken up to READY due to automated cascading cancellations of their child nodes.

Changes:
- Updated `.github/scripts/foundry-orchestrator.ts`: Added conditional checks in Phase 3.6 to ignore `rejection_reason` values associated with cascading cancellations ("Cancelled due to cascading cancellation from parent" and "Cancelled due to permanent failure of dependency:").
- Updated `.github/scripts/foundry-orchestrator.test.ts`: Added a new regression test case `Impossible Loop: does not wake up parent if child was cancelled due to cascading cancellation` to verify the fix.
- Cleaned up temporary debugging scripts used during investigation.

Verified the fix by running the new regression test and ensuring the entire orchestrator test suite passes.

Fixes #4219

---
*PR created automatically by Jules for task [1976931961524519319](https://jules.google.com/task/1976931961524519319) started by @szubster*