### PR TITLE
docs: Update Mechanic persona with empty PR policy

### DIFF
--- a/.github/agents/mechanic.md
+++ b/.github/agents/mechanic.md
@@ -16,3 +16,8 @@ Your private journal is `.foundry/journals/mechanic.md`. You MUST adhere to the 
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies.
+
+If you determine there is no actionable work to be done during this run, simply state that in your PR and complete your session. An empty PR diff is acceptable and will be closed automatically.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Updates `.github/agents/mechanic.md` to include instructions for submitting an empty PR if there is no actionable work, and appends a link to the schema document in accordance with the issue description.

---
*PR created automatically by Jules for task [3943702045686780003](https://jules.google.com/task/3943702045686780003) started by @szubster*