### PR TITLE
feat(foundry): acknowledge cancelled child nodes to prevent repeated parent wake-ups

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1464,7 +1464,7 @@ vi.doMock('node:url', async (importOriginal) => {
 
     const task1Content = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-001.md'), 'utf-8');
     expect(task1Content).toContain('status: CANCELLED');
-    expect(task1Content).toContain('rejection_reason: Max rejection count reached');
+    expect(task1Content).toContain("rejection_reason: '[ACKNOWLEDGED] Max rejection count reached'");
 
     const task2Content = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-002.md'), 'utf-8');
     expect(task2Content).toContain('status: CANCELLED');

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -343,6 +343,29 @@ function promoteNodeToFailedWithReason(node: ParsedNode, reason: string): void {
   info(`${dryTag}Flagged node as FAILED due to ${reason}: ${node.repoPath}`);
 }
 
+function acknowledgeNodeFailure(node: ParsedNode): void {
+  const dateStr = todayISO();
+  const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
+
+  const newReason = `[ACKNOWLEDGED] ${node.frontmatter.rejection_reason || ''}`.trim();
+  const newData = { ...node.frontmatter, rejection_reason: newReason, updated_at: dateStr };
+  const newContent = matter.stringify(node.body, newData);
+
+  if (!DRY_RUN) {
+    try {
+      fs.writeFileSync(node.filePath, newContent, 'utf-8');
+    } catch (e) {
+      warn(`Failed to write file: ${node.repoPath} — ${String(e)}`);
+      return;
+    }
+  }
+
+  node.frontmatter = newData as FoundryFrontmatter;
+  node.rawContent = newContent;
+
+  info(`${dryTag}Acknowledged failure in: ${node.repoPath}`);
+}
+
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
@@ -654,6 +677,7 @@ function main(): void {
     if (
       (node.frontmatter.status === 'FAILED' || node.frontmatter.status === 'CANCELLED') &&
       node.frontmatter.rejection_reason &&
+      !node.frontmatter.rejection_reason.startsWith('[ACKNOWLEDGED]') &&
       node.frontmatter.rejection_reason !== 'Cancelled due to cascading cancellation from parent' &&
       !node.frontmatter.rejection_reason.startsWith('Cancelled due to permanent failure of dependency:')
     ) {
@@ -677,10 +701,12 @@ function main(): void {
           } else {
             promoteNodeStatus(parentNode, parentNode.frontmatter.status, 'READY');
           }
+          acknowledgeNodeFailure(node);
         }
       } else if (node.frontmatter.owner_persona !== 'tpm') {
         info(`Impossible Loop: flagging node without parent for TPM: ${node.repoPath}`);
         promoteNodeToTpm(node);
+        acknowledgeNodeFailure(node);
       }
     }
   }


### PR DESCRIPTION
This PR implements an acknowledgment mechanism for failed or cancelled child nodes in the Foundry orchestrator. 

Previously, if a child node reached a terminal failure state (e.g., `CANCELLED`), the orchestrator would promote its parent to `READY` (or `ACTIVE` for humans) in every run where the parent was not already `READY`/`ACTIVE`/`COMPLETED`. This led to redundant notifications and noise.

The new logic:
1. Detects a terminal failure state with a `rejection_reason`.
2. Checks if the reason is already prefixed with `[ACKNOWLEDGED]`.
3. If not, it promotes the parent/TPM and prepends `[ACKNOWLEDGED] ` to the child's `rejection_reason`.
4. Subsequent runs ignore the acknowledged reason, preventing further wake-ups until a new failure occurs.

Fixes #4247

---
*PR created automatically by Jules for task [17744306822721921717](https://jules.google.com/task/17744306822721921717) started by @szubster*