### PR TITLE
chore: verify gen3 FRLG move tutor flags parsing

### DIFF
--- a/.foundry/tasks/task-268-262-gen3-move-tutor-frlg-parsing-qa.md
+++ b/.foundry/tasks/task-268-262-gen3-move-tutor-frlg-parsing-qa.md
@@ -34,7 +34,7 @@ Verify the implementation of FireRed and LeafGreen Move Tutor flags extraction.
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verify that the coder used DataView API to extract data.
-- [ ] Verify that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level.
-- [ ] Verify that `RangeError` is properly caught for out-of-bounds reads.
-- [ ] Verify that unit tests pass and cover the Move Tutor extraction for FRLG.
+- [x] Verify that the coder used DataView API to extract data.
+- [x] Verify that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level.
+- [x] Verify that `RangeError` is properly caught for out-of-bounds reads.
+- [x] Verify that unit tests pass and cover the Move Tutor extraction for FRLG.


### PR DESCRIPTION
Checked off Acceptance Criteria for the QA task verifying FRLG move tutor flag parsing. The tests pass and logic looks solid.

---
*PR created automatically by Jules for task [5832614855898466515](https://jules.google.com/task/5832614855898466515) started by @szubster*