### PR TITLE
epic: generate Gen 3 roamer epics

### DIFF
--- a/.foundry/epics/epic-043-152-gen3-roamer-data-extraction.md
+++ b/.foundry/epics/epic-043-152-gen3-roamer-data-extraction.md
@@ -1,0 +1,34 @@
+---
+id: epic-043-152-gen3-roamer-data-extraction
+type: EPIC
+title: Gen 3 Roamer Data Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Data Extraction
+
+## Objective
+Extract Gen 3 roamer data and standardize the structure for roaming legendaries.
+
+## Description
+- Implement roamer data extraction for Gen 3 (Ruby, Sapphire, Emerald) in `src/engine/saveParser/parsers/gen3.ts`.
+- Parse the save file for the active roaming Pokémon, its species ID, level, and current map location (map bank/group and map ID).
+- Standardize the `roamingLegendaries` interface in `common.ts` to ensure parity with Gen 2.
+
+## Acceptance Criteria
+- [ ] Gen 3 save parser correctly extracts Latios/Latias map group and ID.
+- [ ] Gen 3 save parser correctly extracts the species ID and level of the roaming Pokémon.
+- [ ] The return structure in `common.ts` is standardized for Gen 3.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-043-153-gen3-roamer-map-translation.md
+++ b/.foundry/epics/epic-043-153-gen3-roamer-map-translation.md
@@ -1,0 +1,31 @@
+---
+id: epic-043-153-gen3-roamer-map-translation
+type: EPIC
+title: Gen 3 Roamer Map Translation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - epic-043-152-gen3-roamer-data-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Map Translation
+
+## Objective
+Translate the raw `mapGroup` and `mapId` bytes extracted from Gen 3 save files into human-readable Route names.
+
+## Description
+- Implement mapping logic to translate raw Gen 3 map coordinates into recognizable route identifiers.
+
+## Acceptance Criteria
+- [ ] Gen 3 raw map coordinates for roamers are translated into human-readable route names.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-043-154-gen3-roamer-radar-widget.md
+++ b/.foundry/epics/epic-043-154-gen3-roamer-radar-widget.md
@@ -1,0 +1,31 @@
+---
+id: epic-043-154-gen3-roamer-radar-widget
+type: EPIC
+title: Gen 3 Roamer Radar Widget
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - epic-043-153-gen3-roamer-map-translation
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Radar Widget
+
+## Objective
+Build a visible dashboard widget that lists all active roaming Pokémon in the Gen 3 save file.
+
+## Description
+- **Roamer Radar Widget**: Construct a UI component that displays a list of active Gen 3 roamers, showing their location and status.
+
+## Acceptance Criteria
+- [ ] A dedicated UI component displays the list of any active Gen 3 roamers.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-043-155-gen3-roamer-map-integration.md
+++ b/.foundry/epics/epic-043-155-gen3-roamer-map-integration.md
@@ -1,0 +1,31 @@
+---
+id: epic-043-155-gen3-roamer-map-integration
+type: EPIC
+title: Gen 3 Roamer Map Integration
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - epic-043-153-gen3-roamer-map-translation
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Map Integration
+
+## Objective
+Highlight the active Gen 3 roamer's current route on the interactive map.
+
+## Description
+- **Map Integration**: Highlight the active roamer's current route on the Gen 3 interactive map.
+
+## Acceptance Criteria
+- [ ] The Gen 3 roamer's current route is highlighted on the map.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -16,3 +16,13 @@
 **Context:** Processing PRD `prd-071-040-tailwind-v4-utilities-migration`.
 **Observation:** The PRD is currently in the READY state. However, its acceptance criteria checkboxes show that the child epics (`epic-071-123...`, `epic-071-124...`, `epic-071-125...`, `epic-071-126...`) have already been correctly generated and appended.
 **Action:** Since the work is already complete (the child nodes exist), and the orchestrator handles demoting READY nodes back to PENDING if their child nodes are not yet COMPLETE (and the PRD's own checkboxes correctly remain unchecked to comply with the Late-Binding Orchestrator Demotion Compliance Rule), I am submitting an empty PR to allow the orchestrator to correctly demote the node to PENDING. No file changes are required.
+
+## Session 2026-07-10
+**Context:** Processing PRD `prd-070-043-roamer-tracking-dashboard`.
+**Observation:** The PRD is currently in the READY state. However, its acceptance criteria checkboxes show that the child epics (`epic-043-139...`, `epic-043-140...`, `epic-043-142...`, `epic-043-143...`) and the `research-043-263-roamer-tracking-remediation` node have already been correctly generated and appended.
+**Action:** Since the work is already complete (the child nodes exist), and the orchestrator handles demoting READY nodes back to PENDING if their child nodes are not yet COMPLETE (and the PRD's own checkboxes correctly remain unchecked to comply with the Late-Binding Orchestrator Demotion Compliance Rule), I am submitting an empty PR to allow the orchestrator to correctly demote the node to PENDING. No file changes are required.
+
+## Session 2026-07-10
+**Context:** Processing PRD `prd-070-043-roamer-tracking-dashboard`.
+**Observation:** The PRD is currently in the READY state. The Gen 2 child Epics were previously created, but the PRD also explicitly outlines scope and requirements for Gen 3 roamer data extraction, map translation, and UI visualization. The Gen 3 Epics were missing.
+**Action:** Generated the missing child Epics (`epic-043-152-gen3-roamer-data-extraction`, `epic-043-153-gen3-roamer-map-translation`, `epic-043-154-gen3-roamer-radar-widget`, `epic-043-155-gen3-roamer-map-integration`) and appended their references to the PRD's Acceptance Criteria. The PRD's own checkboxes correctly remain unchecked to comply with the Late-Binding Orchestrator Demotion Compliance Rule, keeping the node in PENDING status.

--- a/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
+++ b/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
@@ -58,6 +58,10 @@ Based on an initial evaluation of the codebase:
 - [ ] epic-043-140-gen2-roamer-map-translation
 - [ ] epic-043-142-gen2-roamer-radar-widget
 - [ ] epic-043-143-gen2-roamer-map-integration
+- [ ] epic-043-152-gen3-roamer-data-extraction
+- [ ] epic-043-153-gen3-roamer-map-translation
+- [ ] epic-043-154-gen3-roamer-radar-widget
+- [ ] epic-043-155-gen3-roamer-map-integration
 
 ## 5. Next Steps
 - [x] Epic Planner: Break this PRD down into executable Epics (e.g., Engine Parsing, Mapping Translation, UI Dashboard).


### PR DESCRIPTION
Generated the missing Epics for Gen 3 roamer tracking based on the PRD requirements and appended them to the acceptance criteria to prevent premature node verification.

---
*PR created automatically by Jules for task [12488278665478409658](https://jules.google.com/task/12488278665478409658) started by @szubster*