### PR TITLE
docs(foundry): verify FRLG Move Tutor parsing story

### DIFF
--- a/.foundry/stories/story-119-268-gen3-move-tutor-frlg-parsing.md
+++ b/.foundry/stories/story-119-268-gen3-move-tutor-frlg-parsing.md
@@ -33,5 +33,5 @@ As described in `research-055-247-gen3-move-tutor-offsets` (detailed in `gen3_mo
 
 ## Acceptance Criteria
 - [x] Create tasks for implementing DataView-based extraction of FRLG Move Tutor bits.
-- [ ] task-268-261-gen3-move-tutor-frlg-parsing-impl
-- [ ] task-268-262-gen3-move-tutor-frlg-parsing-qa
+- [x] task-268-261-gen3-move-tutor-frlg-parsing-impl
+- [x] task-268-262-gen3-move-tutor-frlg-parsing-qa


### PR DESCRIPTION
Checked off the completed child tasks (`task-268-261-gen3-move-tutor-frlg-parsing-impl` and `task-268-262-gen3-move-tutor-frlg-parsing-qa`) in the `story-119-268-gen3-move-tutor-frlg-parsing` node.

These tasks were successfully created and completed in prior sessions. This empty PR (only modifying the markdown file's body checkboxes) is submitted to allow the Orchestrator to demote the parent node appropriately.

---
*PR created automatically by Jules for task [17186250015802170125](https://jules.google.com/task/17186250015802170125) started by @szubster*