### PR TITLE
feat: Generate missing Gen 3 Roamer Epics

### DIFF
--- a/.foundry/epics/epic-043-152-gen3-roamer-data-extraction.md
+++ b/.foundry/epics/epic-043-152-gen3-roamer-data-extraction.md
@@ -1,0 +1,37 @@
+---
+id: epic-043-152-gen3-roamer-data-extraction
+type: EPIC
+title: Gen 3 Roamer Data Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - research-043-263-roamer-tracking-remediation
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Data Extraction
+
+## Objective
+Extract Gen 3 roamer data and standardize the structure for roaming legendaries.
+
+## Description
+- Parse the save file for the active roaming Pokémon (Latios/Latias), its species ID, level, and current map location (map bank/group and map ID) for Gen 3.
+- Ensure the extracted data populates the `saveData.roamingLegendaries` object.
+- Review and standardize the `roamingLegendaries` interface in `common.ts` to guarantee parity in the structure returned by both Gen 2 and Gen 3.
+- Only consider roamers that have been formally released in the save file's event flags.
+
+## Acceptance Criteria
+- [ ] Gen 3 save parser correctly extracts Latios/Latias map group and ID.
+- [ ] Gen 3 save parser correctly extracts the species ID and level of the roaming Pokémon.
+- [ ] Only released roamers are considered active.
+- [ ] The return structure in `common.ts` is standardized for both Gen 2 and Gen 3.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-043-153-gen3-roamer-map-translation.md
+++ b/.foundry/epics/epic-043-153-gen3-roamer-map-translation.md
@@ -1,0 +1,34 @@
+---
+id: epic-043-153-gen3-roamer-map-translation
+type: EPIC
+title: Gen 3 Roamer Map Translation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - epic-043-152-gen3-roamer-data-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Map Translation
+
+## Objective
+Translate the raw `mapGroup` and `mapId` bytes extracted from the Gen 3 save files into human-readable Route names corresponding to the UI's routing system and map rendering components.
+
+## Description
+- The raw `mapGroup` and `mapId` bytes are internal engine concepts.
+- Implement mapping logic to translate these raw bytes into recognizable route identifiers (e.g., "Route 110").
+- Ensure the translation logic leverages existing `gen3Graph.ts` mapping structures or creates specific lookup tables if necessary.
+
+## Acceptance Criteria
+- [ ] Gen 3 raw map coordinates for roamers are translated into human-readable route names.
+- [ ] Fallback logic is present if a map coordinate cannot be translated (e.g., "Unknown Location").
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-043-154-gen3-roamer-radar-widget.md
+++ b/.foundry/epics/epic-043-154-gen3-roamer-radar-widget.md
@@ -1,0 +1,35 @@
+---
+id: epic-043-154-gen3-roamer-radar-widget
+type: EPIC
+title: Gen 3 Roamer Radar Widget
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - epic-043-153-gen3-roamer-map-translation
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Radar Widget
+
+## Objective
+Build a visible dashboard widget that lists all active roaming Pokémon in the Gen 3 save file, displaying their current location and status tags.
+
+## Description
+- **Roamer Radar Widget**: Construct a UI component that displays a list of active Gen 3 roamers.
+- **Live Location**: The widget should show the human-readable route name where the roamer is currently located, obtained from the Translation Layer.
+- **Status Tags**: Add visual tags to indicate the roamer's status (e.g., "Active", "Caught", "Defeated").
+
+## Acceptance Criteria
+- [ ] A dedicated UI component displays the list of any active Gen 3 roamers.
+- [ ] The component shows the human-readable route location for each roamer.
+- [ ] Status tags ("Active", "Caught", "Defeated") are correctly displayed based on save data.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-043-155-gen3-roamer-map-integration.md
+++ b/.foundry/epics/epic-043-155-gen3-roamer-map-integration.md
@@ -1,0 +1,32 @@
+---
+id: epic-043-155-gen3-roamer-map-integration
+type: EPIC
+title: Gen 3 Roamer Map Integration
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - epic-043-153-gen3-roamer-map-translation
+jules_session_id: null
+pr_number: null
+parent: prd-070-043-roamer-tracking-dashboard
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Roamer Map Integration
+
+## Objective
+Highlight the active Gen 3 roamer's current route on the interactive map.
+
+## Description
+- **Map Integration**: Highlight the active roamer's current route on the interactive `.foundry/docs/adrs/010-gen3-map-graph-design.md` style map.
+- Ensure the UI component integrates properly with the broader DexHelper application flow.
+
+## Acceptance Criteria
+- [ ] The roamer's current route is highlighted on the Gen 3 map.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -23,3 +23,13 @@
 **Action:** Since the work is already complete (the child nodes exist), and the orchestrator handles demoting READY nodes back to PENDING if their child nodes are not yet COMPLETE (and the PRD's own checkboxes correctly remain unchecked to comply with the Late-Binding Orchestrator Demotion Compliance Rule), I am submitting an empty PR to allow the orchestrator to correctly demote the node to PENDING. No file changes are required.
 ## Tailwind v4 @utility Consolidation Epic Creation
 I have generated the necessary child epic nodes (`epic-071-123-define-tailwind-v4-utilities-v2`, `epic-071-124-migrate-core-tactical-components-v2`, `epic-071-125-migrate-complex-app-components-v2`, `epic-071-126-tailwind-designer-persona-v2`) and appended them as unchecked boxes to the PRD `prd-071-040-tailwind-v4-utilities-migration`. As per the Late-Binding Orchestrator Demotion Compliance Rule, I will submit an empty PR directly via the `submit` tool, which will allow the Orchestrator to calculate the dependencies and demote the PRD node from READY to PENDING until the generated Epics are COMPLETED. I am intentionally not checking off the child epic checkboxes on the parent PRD to respect this lifecycle.
+
+## Session 2026-07-10 (Later)
+**Context:** Processing PRD `prd-070-043-roamer-tracking-dashboard`.
+**Observation:** The PRD is currently in the ACTIVE state. However, its acceptance criteria checkboxes show that the child epics (`epic-043-139-gen2-roamer-data-extraction`, `epic-043-140-gen2-roamer-map-translation`, `epic-043-142-gen2-roamer-radar-widget`, `epic-043-143-gen2-roamer-map-integration`) and the `research-043-263-roamer-tracking-remediation` node have already been correctly generated and appended.
+**Action:** Since the work is already complete (the child nodes exist), and the orchestrator handles demoting ACTIVE nodes back to PENDING if their child nodes are not yet COMPLETE (and the PRD's own checkboxes correctly remain unchecked to comply with the Late-Binding Orchestrator Demotion Compliance Rule), I am submitting an empty PR to allow the orchestrator to correctly demote the node to PENDING. No file changes are required.
+
+## Session 2026-07-10
+**Context:** Processing PRD prd-070-043-roamer-tracking-dashboard.
+**Observation:** The PRD scoping explicitly includes Gen 3, but only Gen 2 Epics were generated. Created 4 missing Gen 3 Epics (epic-043-152 to 155).
+**Action:** Submitted PR with new epics and updated PRD checkboxes.

--- a/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
+++ b/.foundry/prds/prd-070-043-roamer-tracking-dashboard.md
@@ -58,6 +58,10 @@ Based on an initial evaluation of the codebase:
 - [ ] epic-043-140-gen2-roamer-map-translation
 - [ ] epic-043-142-gen2-roamer-radar-widget
 - [ ] epic-043-143-gen2-roamer-map-integration
+- [ ] epic-043-152-gen3-roamer-data-extraction
+- [ ] epic-043-153-gen3-roamer-map-translation
+- [ ] epic-043-154-gen3-roamer-radar-widget
+- [ ] epic-043-155-gen3-roamer-map-integration
 
 ## 5. Next Steps
 - [x] Epic Planner: Break this PRD down into executable Epics (e.g., Engine Parsing, Mapping Translation, UI Dashboard).


### PR DESCRIPTION
- Created missing Gen 3 Epic markdown files based on the PRD scope.
- Appended the Gen 3 Epics to the PRD acceptance criteria checklist as unchecked boxes.
- Appended a journal entry for the Epic Planner to record this demotion cycle.

---
*PR created automatically by Jules for task [10281785755306328415](https://jules.google.com/task/10281785755306328415) started by @szubster*