### PR TITLE
Break down PRD 107 into Epics

### DIFF
--- a/.foundry/epics/epic-107-301-lift-rejection-count-state.md
+++ b/.foundry/epics/epic-107-301-lift-rejection-count-state.md
@@ -1,0 +1,36 @@
+---
+id: epic-107-301-lift-rejection-count-state
+type: EPIC
+title: Lift Constant and Update Context
+status: READY
+owner_persona: story_owner
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-085-107-lift-rejection-count-state
+tags:
+  - refactor
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Lift Constant and Update Context
+
+## Objective
+Extract the `MAX_REJECTION_THRESHOLD` constant (value: 3) from local file scopes into `DagContext.tsx` or a dedicated shared constants utility, and expose it through the React context layer.
+
+## Context
+Currently, the threshold for determining if a node has permanently failed (`rejection_count >= 3`) is hardcoded in several components (e.g., `DagDashboard.tsx` and `DagNode.tsx`). This tight coupling makes maintaining and modifying the threshold difficult. Lifting this state is required by ADR 017 to display permanent failures correctly on the dashboard.
+
+## Requirements
+1. Define `MAX_REJECTION_THRESHOLD = 3` in `DagContext.tsx` (or a shared constants file).
+2. Expose this value through the `DagContextState` interface.
+3. Provide the value in the `DagProvider`.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-107-302-update-dashboard-rejection-count.md
+++ b/.foundry/epics/epic-107-302-update-dashboard-rejection-count.md
@@ -1,0 +1,37 @@
+---
+id: epic-107-302-update-dashboard-rejection-count
+type: EPIC
+title: Update UI Views with Lifted Constant
+status: READY
+owner_persona: story_owner
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - epic-107-301-lift-rejection-count-state
+jules_session_id: null
+pr_number: null
+parent: prd-085-107-lift-rejection-count-state
+tags:
+  - refactor
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update UI Views with Lifted Constant
+
+## Objective
+Update UI components and related tests to use the `MAX_REJECTION_THRESHOLD` constant exposed by `DagContext` instead of a hardcoded value.
+
+## Context
+With the threshold for permanent failures extracted to the React Context (in Epic 301), the UI components need to be refactored to consume this value. This ensures consistency and fulfills the requirements of PRD 107 and ADR 017.
+
+## Requirements
+1. Update `DagDashboard.tsx` to use the exposed threshold when filtering nodes for the "Permanent Failures" view.
+2. Update `DagNode.tsx` to use the exposed threshold when applying permanent failure styles.
+3. Update `DagNode.test.tsx` and any other related test files to use the shared constant.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/prds/prd-085-107-lift-rejection-count-state.md
+++ b/.foundry/prds/prd-085-107-lift-rejection-count-state.md
@@ -31,4 +31,8 @@ When reviewing the DAG Dashboard code, it was observed that the permanent failur
 4. Ensure all related test files are updated to reflect this shared constant.
 
 ## Acceptance Criteria
-- [ ] Break down into Epics
+- [x] Break down into Epics
+
+## Generated Epics
+- [ ] epic-107-301-lift-rejection-count-state
+- [ ] epic-107-302-update-dashboard-rejection-count

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,0 @@
-1. **Create Epic 1: Lift Constant & Context**: Create `epic-107-301-lift-rejection-count-state.md` to extract `MAX_REJECTION_THRESHOLD` and update `DagContext`.
-2. **Create Epic 2: Update UI Views**: Create `epic-107-302-update-dashboard-rejection-count.md` to update `DagDashboard` and `DagNode` to use the context property.
-3. **Update PRD**: Update `.foundry/prds/prd-085-107-lift-rejection-count-state.md` to check the breakdown acceptance criteria and add the generated epics.
-4. **Pre-commit**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-5. **Submit**: Submit the branch with an empty PR (just the markdown file changes).

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+1. **Create Epic 1: Lift Constant & Context**: Create `epic-107-301-lift-rejection-count-state.md` to extract `MAX_REJECTION_THRESHOLD` and update `DagContext`.
+2. **Create Epic 2: Update UI Views**: Create `epic-107-302-update-dashboard-rejection-count.md` to update `DagDashboard` and `DagNode` to use the context property.
+3. **Update PRD**: Update `.foundry/prds/prd-085-107-lift-rejection-count-state.md` to check the breakdown acceptance criteria and add the generated epics.
+4. **Pre-commit**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. **Submit**: Submit the branch with an empty PR (just the markdown file changes).


### PR DESCRIPTION
Broke down PRD `prd-085-107-lift-rejection-count-state.md` into actionable Epics as instructed.

Epics generated:
- `epic-107-301-lift-rejection-count-state.md`
- `epic-107-302-update-dashboard-rejection-count.md`

---
*PR created automatically by Jules for task [4232500696146694026](https://jules.google.com/task/4232500696146694026) started by @szubster*