### PR TITLE
chore: complete task to detect party zero HP as dead

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -105,3 +105,6 @@ Biome and Oxlint do not currently support custom JS linting rules. The built-in 
 
 ## 2026-07-08: Impossible Task - Wrapping run_in_bash_session
 Task task-267-262-bash-timeout-wrapper-impl was cancelled because `run_in_bash_session` is a built-in platform tool provided to agents, not a script or function defined within this repository's codebase. It is therefore impossible to implement a wrapper or linter for it from within the repo.
+
+## 2026-07-10: Self-Verification of Party Zero HP Detection
+In task `task-269-263-detect-party-zero-hp-impl`, I verified the existing implementation of `getDeadPokemon` in `src/engine/nuzlocke/tracker.ts`. The function correctly extracts party Pokémon that have fainted (HP is 0). I ran `pnpm test` and confirmed that the tests in `src/engine/nuzlocke/tracker.test.ts` cover this functionality and pass successfully. Per the Intelligent Verification Protocol, I have self-verified this simple, low-risk task and am submitting an empty PR with the checked acceptance criteria.

--- a/.foundry/tasks/task-269-263-detect-party-zero-hp-impl.md
+++ b/.foundry/tasks/task-269-263-detect-party-zero-hp-impl.md
@@ -36,4 +36,4 @@ We need to implement logic to detect Pokémon in the party with 0 HP and mark th
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Logic for detecting party Pokémon with 0 HP as dead is implemented and tested.
+- [x] Logic for detecting party Pokémon with 0 HP as dead is implemented and tested.


### PR DESCRIPTION
Verified the existing implementation of `getDeadPokemon` in `src/engine/nuzlocke/tracker.ts`. The logic to detect Pokémon in the party with 0 HP as dead is already fully implemented and covered by tests in `src/engine/nuzlocke/tracker.test.ts`. 

Following the Intelligent Verification Protocol for simple tasks, I have self-verified the functionality and documented it in my journal (`.foundry/journals/coder.md`). 

As per the Empty PR policy, I am submitting this PR to check off the acceptance criteria in the task node (`.foundry/tasks/task-269-263-detect-party-zero-hp-impl.md`) without altering any source code or the YAML frontmatter.

---
*PR created automatically by Jules for task [2391853084338771484](https://jules.google.com/task/2391853084338771484) started by @szubster*