### PR TITLE
feat: generated tasks for gen3 lottery UI integration

### DIFF
--- a/.foundry/stories/story-133-274-gen3-lottery-ui-integration.md
+++ b/.foundry/stories/story-133-274-gen3-lottery-ui-integration.md
@@ -28,4 +28,4 @@ Integrate the lottery matching logic into the UI state to expose the best match 
 - Include details: Winning Number, Best Match Pokémon, OT ID, Matched Digits, Prize Tier.
 
 ## Acceptance Criteria
-- [ ] Expose lottery state
+- [x] Expose lottery state

--- a/.foundry/tasks/task-274-301-gen3-lottery-ui-integration-impl.md
+++ b/.foundry/tasks/task-274-301-gen3-lottery-ui-integration-impl.md
@@ -1,0 +1,38 @@
+---
+id: task-274-301-gen3-lottery-ui-integration-impl
+type: TASK
+title: Gen3 Lottery UI Integration - Implementation
+status: READY
+owner_persona: coder
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-133-274-gen3-lottery-ui-integration
+tags:
+  - feature
+  - gen3
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen3 Lottery UI Integration - Implementation
+
+## Goal
+Integrate the lottery matching logic into the UI state to expose the best match to the dashboard.
+
+## Requirements
+- Create a selector or context hook to expose the best lottery match.
+- Include details: Winning Number, Best Match Pokémon, OT ID, Matched Digits, Prize Tier.
+
+## Failure Rules & Instructions (Coder Persona)
+- **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failure:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- **Save File Parsing Rules:** When implementing save file parsing, all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
+
+## Acceptance Criteria
+- [ ] Selector or context hook is created to expose lottery state.
+- [ ] Exposed state includes Winning Number, Best Match Pokémon, OT ID, Matched Digits, and Prize Tier.

--- a/.foundry/tasks/task-274-302-gen3-lottery-ui-integration-qa.md
+++ b/.foundry/tasks/task-274-302-gen3-lottery-ui-integration-qa.md
@@ -1,0 +1,38 @@
+---
+id: task-274-302-gen3-lottery-ui-integration-qa
+type: TASK
+title: Gen3 Lottery UI Integration - QA
+status: READY
+owner_persona: qa
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - task-274-301-gen3-lottery-ui-integration-impl
+jules_session_id: null
+pr_number: null
+parent: story-133-274-gen3-lottery-ui-integration
+tags:
+  - feature
+  - gen3
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen3 Lottery UI Integration - QA
+
+## Goal
+Verify the lottery matching logic is correctly integrated into the UI state and exposes the best match to the dashboard.
+
+## Requirements
+- Verify that a selector or context hook correctly exposes the best lottery match.
+- Verify that the exposed state includes: Winning Number, Best Match Pokémon, OT ID, Matched Digits, Prize Tier.
+
+## Failure Rules & Instructions (QA Persona)
+- **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failure:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Selector or context hook is verified to expose lottery state correctly.
+- [ ] Exposed state is verified to include Winning Number, Best Match Pokémon, OT ID, Matched Digits, and Prize Tier.


### PR DESCRIPTION
Generated tasks for the gen3 lottery UI integration story.

- `task-274-301-gen3-lottery-ui-integration-impl`: Implementation task for exposing lottery state via selector/context hook.
- `task-274-302-gen3-lottery-ui-integration-qa`: QA task for verifying the lottery state logic.
- Checked off the "Expose lottery state" acceptance criteria in the parent `story-133-274-gen3-lottery-ui-integration` node.

---
*PR created automatically by Jules for task [6456106549186661426](https://jules.google.com/task/6456106549186661426) started by @szubster*