### PR TITLE
Fix Foundry DAG Mapping Warnings and ID Collisions

### DIFF
--- a/.foundry/epics/epic-103-133-living-dex-data-engine.md
+++ b/.foundry/epics/epic-103-133-living-dex-data-engine.md
@@ -28,7 +28,7 @@ This epic covers the backend/data layer requirements of the Living Dex Tracker P
 - [ ] Determine how to track missing Pokémon in the regional/national Pokédex.
 - [ ] Implement data mapping to identify existing Pokémon and their PC Box/Slot locations.
 - [ ] Implement logic to detect raw materials for evolution to fill missing slots.
-- [ ] story-133-272-living-dex-ghost-tracker
+- [ ] story-133-295-living-dex-ghost-tracker
 - [ ] story-133-273-living-dex-pc-mapping
 - [ ] story-133-274-living-dex-evolution-material
 

--- a/.foundry/epics/epic-105-133-lottery-matching-logic.md
+++ b/.foundry/epics/epic-105-133-lottery-matching-logic.md
@@ -31,7 +31,7 @@ Develop a logic module to iterate through the player's party and PC boxes to com
 
 ## Acceptance Criteria
 - [x] Break down into Stories
-- [ ] story-133-272-gen3-lottery-data-extraction
+- [ ] story-133-294-gen3-lottery-data-extraction
 - [ ] story-133-273-gen3-lottery-matching-algorithm
 - [ ] story-133-274-gen3-lottery-ui-integration
 

--- a/.foundry/research/research-272-297-gen3-lottery-offsets.md
+++ b/.foundry/research/research-272-297-gen3-lottery-offsets.md
@@ -1,11 +1,11 @@
 ---
-id: task-272-301-research-gen3-lottery-offsets
-type: TASK
+id: research-272-297-gen3-lottery-offsets
+type: RESEARCH
 title: Research Gen3 Lottery Offsets
-status: FAILED
+status: PENDING
 owner_persona: researcher
 created_at: '2026-07-05'
-updated_at: '2026-07-10'
+updated_at: '2026-07-12'
 depends_on: []
 jules_session_id: null
 pr_number: null

--- a/.foundry/stories/story-133-272-research-lottery-offsets.md
+++ b/.foundry/stories/story-133-272-research-lottery-offsets.md
@@ -5,7 +5,7 @@ title: Research Lottery Offsets
 status: PENDING
 owner_persona: tech_lead
 created_at: '2026-07-05'
-updated_at: '2026-07-10'
+updated_at: '2026-07-12'
 depends_on: []
 jules_session_id: null
 pr_number: null
@@ -24,7 +24,7 @@ Research the memory offsets for the daily lottery PRNG seed in Ruby, Sapphire, a
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] task-272-301-research-gen3-lottery-offsets
+- [ ] research-272-297-gen3-lottery-offsets
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/stories/story-133-273-living-dex-pc-mapping.md
+++ b/.foundry/stories/story-133-273-living-dex-pc-mapping.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-07-06'
 updated_at: '2026-07-06'
 depends_on:
-  - story-133-272-living-dex-ghost-tracker
+  - .foundry/stories/story-133-295-living-dex-ghost-tracker.md
 jules_session_id: null
 pr_number: null
 parent: epic-103-133-living-dex-data-engine

--- a/.foundry/stories/story-133-294-gen3-lottery-data-extraction.md
+++ b/.foundry/stories/story-133-294-gen3-lottery-data-extraction.md
@@ -1,11 +1,11 @@
 ---
-id: story-133-272-gen3-lottery-data-extraction
+id: story-133-294-gen3-lottery-data-extraction
 type: STORY
 title: Gen3 Lottery Data Extraction
 status: PENDING
 owner_persona: tech_lead
 created_at: '2026-07-05'
-updated_at: '2026-07-10'
+updated_at: '2026-07-12'
 depends_on: []
 jules_session_id: null
 pr_number: null
@@ -30,5 +30,5 @@ Extract the daily winning lottery number from Gen3 save files.
 
 ## Acceptance Criteria
 - [x] Implement parser
-- [ ] task-272-301-gen3-lottery-data-extraction-impl
-- [ ] task-272-302-gen3-lottery-data-extraction-qa
+- [ ] task-294-301-gen3-lottery-data-extraction-impl
+- [ ] task-294-302-gen3-lottery-data-extraction-qa

--- a/.foundry/stories/story-133-295-living-dex-ghost-tracker.md
+++ b/.foundry/stories/story-133-295-living-dex-ghost-tracker.md
@@ -1,11 +1,11 @@
 ---
-id: story-133-272-living-dex-ghost-tracker
+id: story-133-295-living-dex-ghost-tracker
 type: STORY
 title: Living Dex Ghost Tracker
 status: READY
 owner_persona: tech_lead
 created_at: '2026-07-06'
-updated_at: '2026-07-05'
+updated_at: '2026-07-12'
 depends_on: []
 jules_session_id: null
 pr_number: null

--- a/.foundry/tasks/task-294-301-gen3-lottery-data-extraction-impl.md
+++ b/.foundry/tasks/task-294-301-gen3-lottery-data-extraction-impl.md
@@ -1,15 +1,15 @@
 ---
-id: task-272-301-gen3-lottery-data-extraction-impl
+id: task-294-301-gen3-lottery-data-extraction-impl
 type: TASK
 title: Implement Gen3 Lottery Data Extraction
 status: READY
 owner_persona: coder
 created_at: '2026-07-10'
-updated_at: '2026-07-10'
+updated_at: '2026-07-12'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: story-133-272-gen3-lottery-data-extraction
+parent: story-133-294-gen3-lottery-data-extraction
 tags:
   - feature
   - gen3

--- a/.foundry/tasks/task-294-302-gen3-lottery-data-extraction-qa.md
+++ b/.foundry/tasks/task-294-302-gen3-lottery-data-extraction-qa.md
@@ -1,16 +1,16 @@
 ---
-id: task-272-302-gen3-lottery-data-extraction-qa
+id: task-294-302-gen3-lottery-data-extraction-qa
 type: TASK
 title: QA Gen3 Lottery Data Extraction
 status: PENDING
 owner_persona: qa
 created_at: '2026-07-10'
-updated_at: '2026-07-10'
+updated_at: '2026-07-12'
 depends_on:
-  - task-272-301-gen3-lottery-data-extraction-impl
+  - .foundry/tasks/task-294-301-gen3-lottery-data-extraction-impl.md
 jules_session_id: null
 pr_number: null
-parent: story-133-272-gen3-lottery-data-extraction
+parent: story-133-294-gen3-lottery-data-extraction
 tags:
   - feature
   - gen3


### PR DESCRIPTION
Resolved the invalid `owner_persona` mapping for the Gen3 lottery research task by converting it to a `RESEARCH` node and moving it to the correct directory. Simultaneously resolved DAG ID collisions where multiple stories shared the sequence number `272`, remapping them to new unique IDs (`294`, `295`) and updating all downstream tasks and upstream epic references to ensure DAG integrity and unblock the orchestrator.

Fixes #4284

---
*PR created automatically by Jules for task [10544308929754793967](https://jules.google.com/task/10544308929754793967) started by @szubster*