### PR TITLE
Research Gen3 Lottery Offsets

### DIFF
--- a/.foundry/docs/knowledge_base/gen3_lottery_offsets.md
+++ b/.foundry/docs/knowledge_base/gen3_lottery_offsets.md
@@ -1,0 +1,35 @@
+# Gen 3 Lottery Offsets
+
+This document describes the memory offsets for the daily lottery PRNG seed in Pokémon Ruby, Sapphire, and Emerald.
+
+## Emerald
+In Emerald, the lottery number is stored in `SaveBlock1`. It is a 32-bit number, but it's split into two 16-bit variables stored in the `vars` array.
+
+- **Block**: SaveBlock1
+- **Array**: vars
+- **Array Offset in Block**: 0x139C
+- **Var Indices**:
+  - `VAR_POKELOT_RND1` (0x404B) stores the high 16 bits.
+  - `VAR_POKELOT_RND2` (0x404C) stores the low 16 bits.
+- **Index Offset**: The `vars` array starts at index `0x4000`. So the indices are:
+  - High 16 bits offset: (0x404B - 0x4000) * 2 bytes = 0x4B * 2 = 0x96 bytes.
+  - Low 16 bits offset: (0x404C - 0x4000) * 2 bytes = 0x4C * 2 = 0x98 bytes.
+- **Total Offsets in SaveBlock1**:
+  - High 16 bits: 0x139C + 0x96 = 0x1432
+  - Low 16 bits: 0x139C + 0x98 = 0x1434
+
+## Ruby / Sapphire
+In Ruby and Sapphire, the lottery number is also stored in `SaveBlock1`. It is a 32-bit number split into two 16-bit variables stored in the `vars` array.
+
+- **Block**: SaveBlock1
+- **Array**: vars
+- **Array Offset in Block**: 0x1340
+- **Var Indices**:
+  - `VAR_LOTTERY_RND_L` (0x404B) stores the low 16 bits.
+  - `VAR_LOTTERY_RND_H` (0x404C) stores the high 16 bits.
+- **Index Offset**: The `vars` array starts at index `0x4000`. So the indices are:
+  - Low 16 bits offset: (0x404B - 0x4000) * 2 bytes = 0x4B * 2 = 0x96 bytes.
+  - High 16 bits offset: (0x404C - 0x4000) * 2 bytes = 0x4C * 2 = 0x98 bytes.
+- **Total Offsets in SaveBlock1**:
+  - Low 16 bits: 0x1340 + 0x96 = 0x13D6
+  - High 16 bits: 0x1340 + 0x98 = 0x13D8

--- a/.foundry/tasks/task-272-301-research-gen3-lottery-offsets.md
+++ b/.foundry/tasks/task-272-301-research-gen3-lottery-offsets.md
@@ -38,6 +38,6 @@ We need to extract the daily lottery PRNG seed to predict lottery numbers for th
 - **Empty PRs**: If you submit an empty PR for a completed task (e.g. simply creating the markdown file was the scope), you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Create or update a document in `.foundry/docs/knowledge_base/` detailing the lottery offsets for Ruby, Sapphire, and Emerald.
-- [ ] Include the memory offset, data type/length, and the block in which it resides (e.g. SaveBlock1, SaveBlock2).
-- [ ] Verify that the offsets align with standard Gen 3 save file documentation (e.g., bulbapedia, smogon, or other romhacking resources).
+- [x] Create or update a document in `.foundry/docs/knowledge_base/` detailing the lottery offsets for Ruby, Sapphire, and Emerald.
+- [x] Include the memory offset, data type/length, and the block in which it resides (e.g. SaveBlock1, SaveBlock2).
+- [x] Verify that the offsets align with standard Gen 3 save file documentation (e.g., bulbapedia, smogon, or other romhacking resources).


### PR DESCRIPTION
- Researched memory offsets for the daily lottery PRNG seed in Ruby, Sapphire, and Emerald.
- Created `.foundry/docs/knowledge_base/gen3_lottery_offsets.md` with the details.
- Ticked off acceptance criteria in the `.foundry/tasks/task-272-301-research-gen3-lottery-offsets.md` file without changing YAML frontmatter.

---
*PR created automatically by Jules for task [7878602475012188042](https://jules.google.com/task/7878602475012188042) started by @szubster*