### PR TITLE
chore: update story-133-272-research-lottery-offsets with completed task

### DIFF
--- a/.foundry/stories/story-133-272-research-lottery-offsets.md
+++ b/.foundry/stories/story-133-272-research-lottery-offsets.md
@@ -24,7 +24,7 @@ Research the memory offsets for the daily lottery PRNG seed in Ruby, Sapphire, a
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] task-272-301-research-gen3-lottery-offsets
+- [x] task-272-301-research-gen3-lottery-offsets
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Checked off the `task-272-301-research-gen3-lottery-offsets` checkbox in the parent STORY node (`story-133-272-research-lottery-offsets.md`) since the child task has already been completed by the researcher persona in a previous session. This allows the orchestrator to correctly demote the parent node to VERIFYING.

---
*PR created automatically by Jules for task [11626636320302515412](https://jules.google.com/task/11626636320302515412) started by @szubster*