### PR TITLE
Break down PC Box sorting epic into stories

### DIFF
--- a/.foundry/epics/epic-106-136-pc-box-sorting-algorithms.md
+++ b/.foundry/epics/epic-106-136-pc-box-sorting-algorithms.md
@@ -33,6 +33,9 @@ Implement reusable sorting strategies (e.g., National Dex order, Type, Level, et
 3. **Cross-Generation Compatibility:** Ensure the sorting logic works correctly with Gen 1, Gen 2, and Gen 3 `PokeData` structures.
 
 ## Acceptance Criteria
-- [ ] Break down epic into stories for the standard interface and base implementations.
-- [ ] Break down epic into stories for standard strategies (Dex, Level, Type).
-- [ ] Break down epic into stories for Gen 1, Gen 2, and Gen 3 specific considerations and tests.
+- [x] Break down epic into stories for the standard interface and base implementations.
+- [x] Break down epic into stories for standard strategies (Dex, Level, Type).
+- [x] Break down epic into stories for Gen 1, Gen 2, and Gen 3 specific considerations and tests.
+- [ ] story-136-294-sorting-interface-base
+- [ ] story-136-295-sorting-standard-strategies
+- [ ] story-136-296-sorting-cross-gen-considerations

--- a/.foundry/stories/story-136-294-sorting-interface-base.md
+++ b/.foundry/stories/story-136-294-sorting-interface-base.md
@@ -1,0 +1,35 @@
+---
+id: story-136-294-sorting-interface-base
+type: STORY
+title: PC Box Sorting Interface and Base Implementations
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-07-10"
+updated_at: "2026-07-10"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-106-136-pc-box-sorting-algorithms
+tags:
+  - feature
+  - sorting
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: PC Box Sorting Interface and Base Implementations
+
+## Objective
+Design and implement the core `SortingStrategy` interface and base classes required for the PC Box sorting engine. This interface must be flexible enough to handle various sorting criteria (Dex number, Type, Level) and compatible with cross-generation `PokeData` payloads.
+
+## Context
+As part of the PC Box Sorting Algorithms epic, we need a standard interface for defining how a collection of Pokémon should be sorted. This will serve as the foundation for the diff engine that calculates optimal layout states.
+
+## Acceptance Criteria
+- [ ] Define a standard `SortingStrategy` interface or pattern (e.g., `(a: PokeData, b: PokeData) => number`).
+- [ ] Implement a base `MultiCriterionSorter` that allows chaining multiple strategies (e.g., sort by Level, then by Dex Number).
+- [ ] Ensure the interface accepts standard `PokeData` application objects.
+- [ ] Break down story into tasks for technical blueprinting and implementation.

--- a/.foundry/stories/story-136-295-sorting-standard-strategies.md
+++ b/.foundry/stories/story-136-295-sorting-standard-strategies.md
@@ -1,0 +1,36 @@
+---
+id: story-136-295-sorting-standard-strategies
+type: STORY
+title: Implement Standard PC Box Sorting Strategies
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-07-10"
+updated_at: "2026-07-10"
+depends_on:
+  - .foundry/stories/story-136-294-sorting-interface-base.md
+jules_session_id: null
+pr_number: null
+parent: epic-106-136-pc-box-sorting-algorithms
+tags:
+  - feature
+  - sorting
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Implement Standard PC Box Sorting Strategies
+
+## Objective
+Implement concrete sorting strategies using the base `SortingStrategy` interface defined in `story-136-294`. These standard strategies will allow users to sort their PC Boxes by common criteria such as Dex Number, Level, and Type.
+
+## Context
+Building upon the standard interface, we need specific, actionable sorters that understand the `PokeData` structure.
+
+## Acceptance Criteria
+- [ ] Implement a `DexNumberSorter` (supports both National and Regional variants).
+- [ ] Implement a `LevelSorter` (supports ascending/descending).
+- [ ] Implement a `TypeSorter` (sorts by primary type, then secondary type).
+- [ ] Implement an `AlphaSorter` (alphabetical by nickname/species name).
+- [ ] Break down story into tasks for technical blueprinting and implementation.

--- a/.foundry/stories/story-136-296-sorting-cross-gen-considerations.md
+++ b/.foundry/stories/story-136-296-sorting-cross-gen-considerations.md
@@ -1,0 +1,38 @@
+---
+id: story-136-296-sorting-cross-gen-considerations
+type: STORY
+title: Cross-Generation Sorting Considerations and Compatibility
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-07-10"
+updated_at: "2026-07-10"
+depends_on:
+  - .foundry/stories/story-136-295-sorting-standard-strategies.md
+jules_session_id: null
+pr_number: null
+parent: epic-106-136-pc-box-sorting-algorithms
+tags:
+  - feature
+  - gen1
+  - gen2
+  - gen3
+  - sorting
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Cross-Generation Sorting Considerations and Compatibility
+
+## Objective
+Ensure that the standard sorting strategies function correctly across Gen 1, Gen 2, and Gen 3 save data. This involves writing adapter logic or edge-case handling for structural differences in `PokeData` payloads across generations, as well as comprehensive cross-generation testing.
+
+## Context
+While `PokeData` provides a unified interface, certain properties (e.g., regional dex mappings, internal ID differences, absence of modern properties in Gen 1/2) require specific handling to prevent sorting failures or incorrect layouts.
+
+## Acceptance Criteria
+- [ ] Implement Generation-specific Regional Dex adapters for sorting (Gen 1 Kanto, Gen 2 Johto, Gen 3 Hoenn/Kanto).
+- [ ] Ensure `TypeSorter` correctly handles Gen 1 type differences (e.g., Magnemite missing Steel type) if data mapping does not already normalize this.
+- [ ] Implement robust handling for null/undefined properties that may be missing in older generations.
+- [ ] Break down story into tasks for technical blueprinting, implementation, and cross-generation test suites.


### PR DESCRIPTION
Breaks down the `epic-106-136-pc-box-sorting-algorithms` into three child `STORY` nodes for technical implementation (Interface base, Standard strategies, and Cross-generation considerations) and updates the epic's markdown body.

---
*PR created automatically by Jules for task [2149921529113643968](https://jules.google.com/task/2149921529113643968) started by @szubster*