### PR TITLE
chore: Passthrough validation for epic-104-133-gen3-lottery-offsets-research

### DIFF
--- a/.foundry/epics/epic-104-133-gen3-lottery-offsets-research.md
+++ b/.foundry/epics/epic-104-133-gen3-lottery-offsets-research.md
@@ -24,7 +24,7 @@ Research and identify the memory offsets for the daily lottery PRNG seed in Ruby
 
 ## Acceptance Criteria
 - [x] Break down into Stories
-- [ ] story-133-272-research-lottery-offsets
+- [x] story-133-272-research-lottery-offsets
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Submitted an empty PR to passthrough validate the epic-104-133-gen3-lottery-offsets-research node. The child story `story-133-272-research-lottery-offsets` was already COMPLETED in a previous iteration, so I checked it off in the epic's markdown body.

---
*PR created automatically by Jules for task [12029586561723952173](https://jules.google.com/task/12029586561723952173) started by @szubster*