### PR TITLE
feat(foundry): break down gen 2 static encounters epic into stories

### DIFF
--- a/.foundry/epics/epic-106-137-gen2-static-encounters.md
+++ b/.foundry/epics/epic-106-137-gen2-static-encounters.md
@@ -24,8 +24,10 @@ notes: ''
 Break down the Gen 2 static encounter checklist into stories.
 
 ## Acceptance Criteria
-- [ ] Create story for Gen 2 event flag parsing
-- [ ] Create story for Gen 2 checklist UI
+- [x] Create story for Gen 2 event flag parsing
+- [x] Create story for Gen 2 checklist UI
+- [ ] story-137-294-gen2-event-flag-parsing
+- [ ] story-137-295-gen2-checklist-ui
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/stories/story-137-294-gen2-event-flag-parsing.md
+++ b/.foundry/stories/story-137-294-gen2-event-flag-parsing.md
@@ -1,0 +1,27 @@
+---
+id: story-137-294-gen2-event-flag-parsing
+type: STORY
+title: Gen 2 Event Flag Parsing
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-106-137-gen2-static-encounters
+tags:
+  - gen2
+  - backend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Event Flag Parsing
+
+Extract the event flags for Gen 2 static encounters from the save file. This involves finding the offsets and bit positions for encounters like Sudowoodo, Snorlax, Red Gyarados, and Ho-Oh/Lugia, and exposing this data to the state management layer.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks

--- a/.foundry/stories/story-137-295-gen2-checklist-ui.md
+++ b/.foundry/stories/story-137-295-gen2-checklist-ui.md
@@ -1,0 +1,28 @@
+---
+id: story-137-295-gen2-checklist-ui
+type: STORY
+title: Gen 2 Checklist UI
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - .foundry/stories/story-137-294-gen2-event-flag-parsing.md
+jules_session_id: null
+pr_number: null
+parent: epic-106-137-gen2-static-encounters
+tags:
+  - gen2
+  - frontend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Checklist UI
+
+Create the UI component to display the checklist of Gen 2 static encounters (Sudowoodo, Snorlax, Red Gyarados, and Ho-Oh/Lugia) based on the event flags parsed from the backend. The design must adhere strictly to the project's 'tactical hardware/snooping' aesthetic (sharp edges, dashed borders, monospaced telemetry fonts).
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
This PR breaks down the Gen 2 static encounters epic into two manageable stories (backend event flag parsing and frontend UI checklist) per the Story Owner instructions, and updates the parent epic's markdown checklist without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [10971393235570232619](https://jules.google.com/task/10971393235570232619) started by @szubster*