### PR TITLE
feat(epic): break down diff engine epic into stories

### DIFF
--- a/.foundry/epics/epic-106-137-pc-box-diff-engine-move-planner.md
+++ b/.foundry/epics/epic-106-137-pc-box-diff-engine-move-planner.md
@@ -31,6 +31,9 @@ Develop a background process (diff engine) that compares the current layout of P
 3. **Format Operations:** Output the operations in a structured, actionable format suitable for UI display.
 
 ## Acceptance Criteria
-- [ ] Break down epic into stories for the diff engine logic.
-- [ ] Break down epic into stories for the move planner algorithm and minimal operation calculation.
-- [ ] Break down epic into stories for comprehensive unit tests of complex move scenarios.
+- [x] Break down epic into stories for the diff engine logic.
+- [x] Break down epic into stories for the move planner algorithm and minimal operation calculation.
+- [x] Break down epic into stories for comprehensive unit tests of complex move scenarios.
+- [ ] story-137-294-diff-engine-logic
+- [ ] story-137-295-move-planner-algorithm
+- [ ] story-137-296-move-planner-unit-tests

--- a/.foundry/stories/story-137-294-diff-engine-logic.md
+++ b/.foundry/stories/story-137-294-diff-engine-logic.md
@@ -1,0 +1,33 @@
+---
+id: story-137-294-diff-engine-logic
+type: STORY
+title: PC Box Diff Engine Logic
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-106-137-pc-box-diff-engine-move-planner
+tags:
+  - algorithm
+  - organization
+  - diff
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: PC Box Diff Engine Logic
+
+## Objective
+Implement the core diffing engine that takes a current state of PC boxes and a target (sorted) state of PC boxes, and computes the exact differences (additions, removals, and relocations).
+
+## Description
+The diff engine must iterate through the current and target box arrays. Pokémon should be uniquely identified (e.g., using PID/TID/SID or specific hashes).
+The engine will return a set of differences detailing which specific entity is currently at what location (box, slot) and where its final target location (box, slot) should be.
+
+## Acceptance Criteria
+- [ ] Break down story into tasks for diff engine implementation.

--- a/.foundry/stories/story-137-295-move-planner-algorithm.md
+++ b/.foundry/stories/story-137-295-move-planner-algorithm.md
@@ -1,0 +1,35 @@
+---
+id: story-137-295-move-planner-algorithm
+type: STORY
+title: PC Box Move Planner Algorithm
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - .foundry/stories/story-137-294-diff-engine-logic.md
+jules_session_id: null
+pr_number: null
+parent: epic-106-137-pc-box-diff-engine-move-planner
+tags:
+  - algorithm
+  - organization
+  - planner
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: PC Box Move Planner Algorithm
+
+## Objective
+Develop the algorithm that takes the diff output and translates it into a minimal, actionable sequence of manual user operations to transition the PC layout to the target state.
+
+## Description
+The algorithm must determine the exact sequence of moves (e.g., Move from Box 1 Slot 5 to Box 3 Slot 12).
+It needs to account for constraints such as full boxes or "swap" operations if a target slot is already occupied by another Pokémon that also needs to move, and potentially use a temporary "party" holding space or an empty slot to resolve cyclic dependencies.
+The algorithm should output structured operations that the UI can step the user through.
+
+## Acceptance Criteria
+- [ ] Break down story into tasks for move planner algorithm implementation.

--- a/.foundry/stories/story-137-296-move-planner-unit-tests.md
+++ b/.foundry/stories/story-137-296-move-planner-unit-tests.md
@@ -1,0 +1,33 @@
+---
+id: story-137-296-move-planner-unit-tests
+type: STORY
+title: PC Box Move Planner Comprehensive Unit Tests
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-10'
+updated_at: '2026-07-10'
+depends_on:
+  - .foundry/stories/story-137-295-move-planner-algorithm.md
+jules_session_id: null
+pr_number: null
+parent: epic-106-137-pc-box-diff-engine-move-planner
+tags:
+  - testing
+  - algorithm
+  - organization
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: PC Box Move Planner Comprehensive Unit Tests
+
+## Objective
+Write comprehensive unit tests for the diff engine and move planner algorithms to ensure correct operation sequence generation for various edge cases.
+
+## Description
+The move planner logic involves complex states (full boxes, swap chains, cyclic moves). This story requires building robust test fixtures covering these scenarios to guarantee the generated operations are minimal, correct, and do not lead to invalid states (like moving a Pokémon into a full box without swapping).
+
+## Acceptance Criteria
+- [ ] Break down story into tasks to implement unit tests for diff engine and move planner scenarios.


### PR DESCRIPTION
- Created `.foundry/stories/story-137-294-diff-engine-logic.md`
- Created `.foundry/stories/story-137-295-move-planner-algorithm.md`
- Created `.foundry/stories/story-137-296-move-planner-unit-tests.md`
- Updated `.foundry/epics/epic-106-137-pc-box-diff-engine-move-planner.md`
  - Checked off completed abstract story generation AC
  - Appended newly generated story IDs as unchecked child node checkboxes
- Validated tests pass via `pnpm lint && pnpm test`

---
*PR created automatically by Jules for task [17891548805154540216](https://jules.google.com/task/17891548805154540216) started by @szubster*