### PR TITLE
Generate PRD and ADR Task for Foundry Node Content Consolidation (idea-103)

### DIFF
--- a/.foundry/ideas/idea-103-foundry-node-content-consolidation.md
+++ b/.foundry/ideas/idea-103-foundry-node-content-consolidation.md
@@ -38,9 +38,13 @@ Analyze and consolidate repeated content into centralized locations.
 - **Consistency:** All agents and nodes adhere to the same version of the rules.
 
 ## Next Steps
-- [ ] Product Manager: Audit current TASK/STORY templates for redundancy.
+- [x] Product Manager: Audit current TASK/STORY templates for redundancy.
 - [ ] Agile Coach: Update persona prompts to use centralized policy references.
 - [ ] Architect: Propose a technical mechanism for dynamic policy injection into Foundry nodes.
+
+## Acceptance Criteria
+- [ ] task-103-304-propose-dynamic-policy-injection-adr
+- [ ] prd-103-109-foundry-node-content-consolidation
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/prds/prd-103-109-foundry-node-content-consolidation.md
+++ b/.foundry/prds/prd-103-109-foundry-node-content-consolidation.md
@@ -1,0 +1,41 @@
+---
+id: prd-103-109-foundry-node-content-consolidation
+type: PRD
+title: Foundry Node and Prompt Content Consolidation
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - .foundry/tasks/task-103-304-propose-dynamic-policy-injection-adr.md
+jules_session_id: null
+pr_number: null
+parent: idea-103-foundry-node-content-consolidation
+tags:
+  - foundry
+  - agents
+  - meta
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Foundry Node and Prompt Content Consolidation
+
+## 1. Context & Motivation
+A significant amount of content in Foundry nodes (TASKS, STORIES) and persona prompts is redundant. This includes boilerplate reminders about transient failures, empty PR policies, and environment setup instructions. This duplication leads to "prompt rot", increases token usage, and makes it difficult to update policies consistently across the system.
+
+## 2. Product Requirements
+We need to consolidate repeated content into centralized locations and use dynamic policy injection (defined by the Architect in `task-103-304-propose-dynamic-policy-injection-adr`) to streamline nodes.
+
+- **Centralized Policies**: Move common instructions and reminders to centralized documentation or configuration.
+- **Dynamic Injection**: Implement the mechanism proposed in the ADR to inject these policies into nodes or agent contexts dynamically.
+- **Clean Node Templates**: Update the node templates to remove the boilerplate and rely on the new injection mechanism.
+
+## 3. Scope & Constraints
+- Must depend on the outcome of `task-103-304-propose-dynamic-policy-injection-adr.md`.
+- Should reduce token usage and improve prompt maintainability.
+
+## 4. Acceptance Criteria
+- [ ] Epic Planner: Break down this PRD into manageable Epics based on the Architect's ADR.

--- a/.foundry/tasks/task-103-304-propose-dynamic-policy-injection-adr.md
+++ b/.foundry/tasks/task-103-304-propose-dynamic-policy-injection-adr.md
@@ -1,0 +1,35 @@
+---
+id: task-103-304-propose-dynamic-policy-injection-adr
+type: TASK
+title: Propose Dynamic Policy Injection ADR
+status: PENDING
+owner_persona: architect
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-103-foundry-node-content-consolidation
+tags:
+  - foundry
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Propose Dynamic Policy Injection ADR
+
+## Context
+A significant amount of content in Foundry nodes (TASKS, STORIES) and persona prompts is redundant. This includes boilerplate reminders about transient failures, empty PR policies, and environment setup instructions. This duplication leads to "prompt rot", increases token usage, and makes it difficult to update policies consistently across the system.
+
+The Product Manager is initiating a consolidation effort (via `idea-103-foundry-node-content-consolidation`). As part of this, we need a technical mechanism to dynamically inject policies into Foundry nodes or reference them directly.
+
+## Requirements
+- Propose an ADR (Architecture Decision Record) outlining the technical mechanism for dynamic policy injection into Foundry nodes.
+- Consider how the Orchestrator or PM agents can insert these rules dynamically or by reference.
+- Evaluate the impact on token count and prompt maintenance.
+
+## Acceptance Criteria
+- [ ] Create and merge an ADR in `.foundry/docs/adrs/` defining the dynamic policy injection mechanism.


### PR DESCRIPTION
This PR handles the Product Manager processing of `idea-103-foundry-node-content-consolidation`.

It accomplishes the following:
1. Created `task-103-304-propose-dynamic-policy-injection-adr.md` assigned to the Architect to define the dynamic policy injection technical mechanism.
2. Created `prd-103-109-foundry-node-content-consolidation.md` assigned to the Epic Planner to drive the consolidation effort, depending on the architect's ADR.
3. Updated the Acceptance Criteria in `idea-103-foundry-node-content-consolidation.md` to track these child nodes.

The changes adhere strictly to the Foundry node rules (no frontmatter modifications to the parent node, correct child sequence generation, and safe empty PR passthrough behavior). Tests and linters passed cleanly.

---
*PR created automatically by Jules for task [906308884410537116](https://jules.google.com/task/906308884410537116) started by @szubster*