### PR TITLE
epic-planner-fix-orchestrator-phase-3-6

### DIFF
--- a/.foundry/epics/epic-108-303-extend-phase-3-6-cancelled-nodes.md
+++ b/.foundry/epics/epic-108-303-extend-phase-3-6-cancelled-nodes.md
@@ -1,0 +1,38 @@
+---
+id: epic-108-303-extend-phase-3-6-cancelled-nodes
+type: EPIC
+title: Extend Phase 3.6 for CANCELLED nodes
+status: READY
+owner_persona: story_owner
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-086-108-fix-orchestrator-phase-3-6
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extend Phase 3.6 for CANCELLED nodes
+
+## Objective
+Extend Phase 3.6 logic in `foundry-orchestrator.ts` to properly handle nodes transitioning to `CANCELLED` status due to max rejections.
+
+## Context
+In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` status with `rejection_reason === 'Max rejection count reached'` fail to trigger the parent awakening ("Impossible Loop") logic, which previously only applied to `FAILED` nodes. This causes system deadlocks. The parent node needs to be properly awakened (reverted to PENDING/READY) to handle the failure and regenerate nodes.
+
+## Requirements
+- Identify where Phase 3.6 logic is located in `foundry-orchestrator.ts`.
+- Add an explicit check for nodes with `status === 'CANCELLED'` and `rejection_reason === 'Max rejection count reached'`.
+- Ensure the parent node is properly awakened (reverted to PENDING/READY) for these cancelled nodes.
+- Update tests in `foundry-orchestrator.test.ts` to verify this exact behavior.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -33,3 +33,8 @@ I have generated the necessary child epic nodes (`epic-071-123-define-tailwind-v
 **Context:** Processing PRD prd-070-043-roamer-tracking-dashboard.
 **Observation:** The PRD scoping explicitly includes Gen 3, but only Gen 2 Epics were generated. Created 4 missing Gen 3 Epics (epic-043-152 to 155).
 **Action:** Submitted PR with new epics and updated PRD checkboxes.
+
+## Session 2026-07-11
+**Context:** Processing PRD `prd-086-108-fix-orchestrator-phase-3-6`.
+**Observation:** The PRD requires a fix to extend Phase 3.6 of the `foundry-orchestrator.ts` logic to correctly handle nodes transitioning to `CANCELLED` status.
+**Action:** Generated the child Epic node `epic-108-303-extend-phase-3-6-cancelled-nodes` and appended it to the parent PRD's acceptance criteria as an unchecked task. Since all the required Epic generation is complete, but the generated child node must be completed before the PRD is finished, I will submit an empty PR directly to passthrough validation. This allows the Orchestrator to correctly calculate the DAG dependencies and demote the READY PRD node to PENDING state to enforce the strict macro node completion lifecycle. No other file changes are required for this PR.

--- a/.foundry/prds/prd-086-108-fix-orchestrator-phase-3-6.md
+++ b/.foundry/prds/prd-086-108-fix-orchestrator-phase-3-6.md
@@ -33,3 +33,4 @@ In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` statu
 - [ ] Phase 3.6 awakening logic supports `CANCELLED` nodes.
 - [ ] Parent nodes correctly awaken when child nodes are cancelled due to hitting max rejections.
 - [ ] Tests verify this exact behavior in `foundry-orchestrator.test.ts`.
+- [ ] epic-108-303-extend-phase-3-6-cancelled-nodes


### PR DESCRIPTION
Generated child epic `epic-108-303-extend-phase-3-6-cancelled-nodes` from PRD `prd-086-108-fix-orchestrator-phase-3-6` and linked it via acceptance criteria.

---
*PR created automatically by Jules for task [4742368586600164807](https://jules.google.com/task/4742368586600164807) started by @szubster*