### PR TITLE
🧭 Strategist: Prompt improvement - Enforce Coder adherence to DataView boundaries

### DIFF
--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -17,7 +17,7 @@ When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.t
 
 
 ## Save File Parsing & Magic Numbers
-When implementing save file parsing or data definitions, you MUST explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Strictly avoid using inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions. This ensures robustness against version-specific shifts and prevents brittle code.
+When implementing save file parsing or data definitions, you MUST explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Strictly avoid using inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions. This ensures robustness against version-specific shifts and prevents brittle code. Furthermore, when using the `DataView` API for array bounds checking or extraction limits (e.g., max record counts), you MUST NOT use inline magic numbers; these bounds must also be defined as reusable constants at the module level.
 
 When parsing bitwise blocks (like event flag arrays) using the `DataView` API, you must explicitly map the specific bit offsets corresponding to target events. Just extracting the array is insufficient; explicitly identifying the individual bit offsets is required for downstream consumption.
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -357,3 +357,9 @@
 **Outcome:** Merged
 **Why:** The prompt evaluation identified massive duplication in the agent prompts where a huge block regarding the "NODE GENERATION RULES" (DAG ID strictness, sequence numbers, pipeline order, premature verification warnings) was repeated verbatim across the generative agents (`product_manager`, `epic_planner`, `story_owner`, `tech_lead`). This bloated the prompts and made updating the rules error-prone.
 **Pattern:** Consolidate duplicated core prompt instructions (e.g. node generation rules) into `.foundry/docs/knowledge_base/agents/core_policies.md` and instruct the agents to read it. This drastically reduces prompt size, creates a single source of truth, and allows global policy updates without touching multiple individual schedule files.
+
+## 2026-07-26 - [Accepted] - Prompt improvement - Enforce Coder adherence to DataView boundaries
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `qa.md` journal recorded a persistent failure pattern (`2026-06-30: Magic Numbers in Gen 3 Parser Retry`) where the `coder` repeatedly ignored the architectural constraint against using inline magic numbers for array bounds checking in save file parsers (like `parseGen3MixRecords`), despite explicit task instructions and previous rejections.
+**Pattern:** Codify specific, recurring architectural violations (like ignoring module-level constant requirements for DataView extraction limits) directly into the implementer's prompt (`coder.md`) to prevent brittle code and repetitive QA rejections.


### PR DESCRIPTION
**Proposal**: Update the `coder.md` prompt to explicitly forbid using inline magic numbers for array bounds checking and limits when parsing data with the `DataView` API, mandating the use of module-level constants.
**Justification**: A persistent failure pattern was identified where the `coder` agent repeatedly failed QA checks for using magic numbers in extraction limits (e.g. `parseGen3MixRecords`), creating brittle code.
**Evidence**: The `qa.md` journal recorded on 2026-06-30 ("Magic Numbers in Gen 3 Parser Retry") that the coder ignored this constraint despite explicit task instructions and previous rejections.

Includes updating the Strategist's journal to record the change.

---
*PR created automatically by Jules for task [2858203722013797625](https://jules.google.com/task/2858203722013797625) started by @szubster*