### PR TITLE
Break down Gen 3 emulator trailing bytes story into tasks

### DIFF
--- a/.foundry/stories/story-081-279-gen3-ignore-emulator-trailing-bytes.md
+++ b/.foundry/stories/story-081-279-gen3-ignore-emulator-trailing-bytes.md
@@ -27,3 +27,5 @@ As required by ADR 025 and to replace the cancelled tasks from the previous fall
 
 ## Acceptance Criteria
 - [ ] Ensure that save file parsing engines gracefully ignore trailing emulator bytes without crashing.
+- [ ] task-279-304-gen3-ignore-emulator-trailing-bytes-impl
+- [ ] task-279-305-gen3-ignore-emulator-trailing-bytes-qa

--- a/.foundry/tasks/task-279-304-gen3-ignore-emulator-trailing-bytes-impl.md
+++ b/.foundry/tasks/task-279-304-gen3-ignore-emulator-trailing-bytes-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-279-304-gen3-ignore-emulator-trailing-bytes-impl
+type: TASK
+title: Implement Graceful Ignorance of Emulator Trailing Bytes in Gen 3 Save Files
+status: READY
+owner_persona: coder
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-081-279-gen3-ignore-emulator-trailing-bytes
+tags:
+  - feature
+  - gen3
+  - rtc
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Graceful Ignorance of Emulator Trailing Bytes in Gen 3 Save Files
+
+## Context
+Per ADR 025, emulator save files (such as those from VBA-M) often contain appended trailing bytes containing RTC data (typically 44/48 bytes). These appended bytes cause size mismatch errors in our standard parsing engine. We need to implement logic to gracefully ignore these trailing bytes instead of crashing or throwing validation errors. This allows standard Gen 3 `.sav` files to be parsed regardless of the emulator used.
+
+## Instructions
+1. Locate the Gen 3 save file parsing logic (likely where the ArrayBuffer or DataView size is validated).
+2. Modify the size validation to allow for files that are larger than the standard size by up to ~64 bytes (to safely cover the 44/48 byte RTC block). Alternatively, instead of strict equality on the file size, ensure that the file size is *at least* the required standard size.
+3. Ensure that when parsing blocks, the offsets used do not overflow the bounds of the provided DataView/ArrayBuffer.
+4. Ensure no magic numbers are used for bounds checking. Define the acceptable trailing byte limits as reusable constants at the module level.
+5. If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+6. If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+7. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Gen 3 save file parsing engine does not throw size mismatch errors for files containing emulator trailing bytes.
+- [ ] Acceptable trailing byte limits are defined as reusable constants at the module level (no inline magic numbers).

--- a/.foundry/tasks/task-279-305-gen3-ignore-emulator-trailing-bytes-qa.md
+++ b/.foundry/tasks/task-279-305-gen3-ignore-emulator-trailing-bytes-qa.md
@@ -1,0 +1,40 @@
+---
+id: task-279-305-gen3-ignore-emulator-trailing-bytes-qa
+type: TASK
+title: QA Gen 3 Graceful Ignorance of Emulator Trailing Bytes
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - .foundry/tasks/task-279-304-gen3-ignore-emulator-trailing-bytes-impl.md
+jules_session_id: null
+pr_number: null
+parent: story-081-279-gen3-ignore-emulator-trailing-bytes
+tags:
+  - feature
+  - gen3
+  - rtc
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Gen 3 Graceful Ignorance of Emulator Trailing Bytes
+
+## Context
+The Coder has implemented logic to gracefully ignore emulator trailing bytes (e.g. from VBA-M appending RTC data) during Gen 3 save file parsing, as dictated by ADR 025. You are responsible for verifying that this logic works as expected and does not break existing parsing behavior.
+
+## Instructions
+1. Verify that the Coder's implementation in the Gen 3 save file parsing engine correctly handles save files with appended trailing bytes.
+2. Verify that there are no magic numbers used for bounds checking; instead, they must be defined as reusable constants at the module level.
+3. Review the tests (or add them if necessary) to ensure both standard size saves and saves with trailing bytes are handled without throwing size mismatch errors.
+4. If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+5. If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+6. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Confirmed that standard Gen 3 save files parse successfully.
+- [ ] Confirmed that Gen 3 save files with trailing bytes (up to the acceptable limit) parse successfully without size mismatch errors.
+- [ ] Confirmed that trailing byte limits are defined as reusable module-level constants.


### PR DESCRIPTION
This PR breaks down the product story "Gracefully Ignore Emulator Trailing Bytes in Gen 3 Save Files" into actionable technical blueprints. It creates an implementation task for the coder and a QA task for the QA persona, in accordance with the Intelligent Verification Protocol. The original story node has been updated to include these new tasks in its acceptance criteria without modifying its YAML frontmatter. Both task blueprints include required safety clauses (for retries, aborts, empty PRs) and explicit instructions to define offsets/limits as module-level constants instead of inline magic numbers.

---
*PR created automatically by Jules for task [11900293119436006694](https://jules.google.com/task/11900293119436006694) started by @szubster*