### PR TITLE
chore(tech-lead): generate tasks for gen3 mix record events extraction

### DIFF
--- a/.foundry/stories/story-081-288-gen3-mix-record-inherited-events.md
+++ b/.foundry/stories/story-081-288-gen3-mix-record-inherited-events.md
@@ -27,3 +27,5 @@ Based on requirement 2.2, we must accurately extract data indicating if events w
 
 ## Acceptance Criteria
 - [ ] Implement extraction logic to parse inherited events data from Mix Records.
+- [ ] task-288-304-gen3-mix-record-inherited-events-impl
+- [ ] task-288-305-gen3-mix-record-inherited-events-qa

--- a/.foundry/tasks/task-288-304-gen3-mix-record-inherited-events-impl.md
+++ b/.foundry/tasks/task-288-304-gen3-mix-record-inherited-events-impl.md
@@ -1,0 +1,67 @@
+---
+id: task-288-304-gen3-mix-record-inherited-events-impl
+type: TASK
+title: Extract Gen 3 Mix Record Inherited Events Implementation
+status: READY
+owner_persona: coder
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-081-288-gen3-mix-record-inherited-events
+tags:
+  - feature
+  - gen3
+  - data-parsing
+  - implementation
+research_references:
+  - .foundry/docs/knowledge_base/gen3_tv_shows_and_events.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Blueprint: Gen 3 Mix Record Inherited Events Extraction Implementation
+
+## Objective
+Implement extraction logic to parse inherited events data (TV Shows) originating from other players' save files via the "Mix Record" feature in Gen 3 games (Ruby, Sapphire, Emerald).
+
+## Context
+As detailed in `.foundry/docs/knowledge_base/gen3_tv_shows_and_events.md`, Gen 3 games store TV Show broadcast data in an array within `SaveBlock1` at offset `0x27CC`.
+
+The TV show array contains 25 records. Each record is 36 bytes in size and follows a structure with a common header:
+- Byte `0x00`: `kind` (ID of the broadcast)
+- Byte `0x01`: `active` (boolean flag)
+
+Mix Record shows are those where the `kind` ID is between `21` and `40` (inclusive). Some notable types:
+- `21`: `TVSHOW_POKEMON_TODAY_CAUGHT`
+- `22`: `TVSHOW_SMART_SHOPPER`
+- `23`: `TVSHOW_POKEMON_TODAY_FAILED`
+- `24`: `TVSHOW_FISHING_ADVICE`
+- `25`: `TVSHOW_WORLD_OF_MASTERS`
+- `31`: `TVSHOW_SECRET_BASE_VISIT`
+- `33`: `TVSHOW_BATTLE_SEMINAR`
+
+## Requirements
+
+1. **Memory Map Constants:**
+   - Explicitly define the memory offset for the `TVShow` array (`0x27CC`), the array length (`25`), the struct size (`36`), and any bit locations or shifts as reusable module-level constants. **Do not use inline magic numbers** for array bounds checking, offsets, loop iterations, or bit shifts.
+
+2. **Extraction Logic:**
+   - Iterate over the `TVShow` array.
+   - For each active show (`active` byte is truthy), inspect the `kind` byte.
+   - If the `kind` byte is within the `TVGROUP_RECORD_MIX` range (`21` to `40`), extract its data and identify it as an inherited event.
+   - Extract the payload data correctly based on the TV show kind (you may need to explore the exact payload fields for each relevant kind if needed, or extract a raw buffer/string if not strictly structured yet). Focus primarily on providing an array or object containing these active inherited events with their kind and raw buffer payload, so they can be parsed further or displayed.
+   - Integrate this extraction into the Gen 3 save file parsing pipeline.
+
+3. **Handling Failures:**
+   - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+   - If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+   - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Module-level constants are defined for `TVShow` offsets, lengths, and kind ID bounds.
+- [ ] Logic correctly parses the `TVShow` array from `SaveBlock1` at offset `0x27CC`.
+- [ ] Active Mix Record shows (kinds 21-40) are successfully isolated and extracted.
+- [ ] No inline magic numbers are used in the parsing implementation.

--- a/.foundry/tasks/task-288-305-gen3-mix-record-inherited-events-qa.md
+++ b/.foundry/tasks/task-288-305-gen3-mix-record-inherited-events-qa.md
@@ -1,0 +1,51 @@
+---
+id: task-288-305-gen3-mix-record-inherited-events-qa
+type: TASK
+title: QA Gen 3 Mix Record Inherited Events Extraction
+status: READY
+owner_persona: qa
+created_at: '2026-07-06'
+updated_at: '2026-07-06'
+depends_on:
+  - .foundry/tasks/task-288-304-gen3-mix-record-inherited-events-impl.md
+jules_session_id: null
+pr_number: null
+parent: story-081-288-gen3-mix-record-inherited-events
+tags:
+  - feature
+  - gen3
+  - data-parsing
+  - qa
+research_references:
+  - .foundry/docs/knowledge_base/gen3_tv_shows_and_events.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Blueprint: QA Gen 3 Mix Record Inherited Events Extraction
+
+## Objective
+Verify the implementation for extracting inherited event data (TV Shows) originating from other players' save files via the "Mix Record" feature in Gen 3 games.
+
+## Context
+The coder has implemented logic to parse the `TVShow` array in `SaveBlock1` at offset `0x27CC` to extract inherited events (`kind` IDs 21-40).
+
+## Requirements
+
+1. **Verify Implementation Logic:**
+   - Confirm that the coder explicitly used reusable module-level constants for the `TVShow` array offset (`0x27CC`), array length (`25`), struct size (`36`), and any bit logic. Inline magic numbers for offsets or loop bounds are strictly forbidden per the blueprint contract.
+   - Verify that the parsing logic correctly identifies active Mix Record shows (`kind` between 21 and 40, `active` byte is truthy).
+
+2. **Verify Tests:**
+   - Ensure the coder has written tests for this feature that validate correctness and edge cases (e.g., verifying parsing handles normal shows vs mix record shows correctly, handles inactive shows properly).
+
+3. **Handling Failures:**
+   - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+   - If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+   - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Code is reviewed for correctness in parsing `TVShow` structs.
+- [ ] Magic numbers are not used for bounding loops or defining offsets.
+- [ ] Tests comprehensively cover the new functionality.


### PR DESCRIPTION
Generated implementation and QA blueprints for extracting Gen 3 mix record inherited events, adhering to The Foundry's architectural requirements and avoiding inline magic numbers.

---
*PR created automatically by Jules for task [2170234473892199461](https://jules.google.com/task/2170234473892199461) started by @szubster*