### PR TITLE
feat(gen3): implement lottery matching core logic

### DIFF
--- a/.foundry/tasks/task-273-303-lottery-matching-core-logic.md
+++ b/.foundry/tasks/task-273-303-lottery-matching-core-logic.md
@@ -36,8 +36,8 @@ Implement the logic to compare Pokémon OT IDs against the daily winning number.
 - Return the highest matching tier and the corresponding winning Pokémon.
 
 ## Acceptance Criteria
-- [ ] Implement matching algorithm for comparing OT ID and winning number
-- [ ] Write unit tests to cover different matching scenarios (no match, partial match, full match, zero-padded cases)
+- [x] Implement matching algorithm for comparing OT ID and winning number
+- [x] Write unit tests to cover different matching scenarios (no match, partial match, full match, zero-padded cases)
 
 ## Failure Rules & Instructions
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/engine/gen3/lottery/lottery.test.ts
+++ b/src/engine/gen3/lottery/lottery.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { calculateLotteryTier, getBestLotteryMatch } from './lottery';
+
+describe('Lottery Matching Logic', () => {
+  describe('calculateLotteryTier', () => {
+    it('should return 1 for a 5-digit match', () => {
+      expect(calculateLotteryTier(12345, 12345)).toBe(1);
+    });
+
+    it('should return 2 for a 4-digit match', () => {
+      expect(calculateLotteryTier(92345, 12345)).toBe(2);
+    });
+
+    it('should return 3 for a 3-digit match', () => {
+      expect(calculateLotteryTier(99345, 12345)).toBe(3);
+    });
+
+    it('should return 4 for a 2-digit match', () => {
+      expect(calculateLotteryTier(99945, 12345)).toBe(4);
+    });
+
+    it('should return 0 for a 1-digit match or no match', () => {
+      expect(calculateLotteryTier(99995, 12345)).toBe(0);
+      expect(calculateLotteryTier(99999, 12345)).toBe(0);
+    });
+
+    it('should handle zero-padding correctly', () => {
+      expect(calculateLotteryTier(12, 12)).toBe(1); // 00012 == 00012 -> 5 matches -> tier 1
+      expect(calculateLotteryTier(112, 12)).toBe(4); // 00112 vs 00012 -> 2 matches -> tier 4
+      expect(calculateLotteryTier(1112, 12)).toBe(4); // 01112 vs 00012 -> 2 matches -> tier 4
+      expect(calculateLotteryTier(11112, 12)).toBe(4); // 11112 vs 00012 -> 2 matches -> tier 4
+      expect(calculateLotteryTier(12, 99012)).toBe(3); // 00012 vs 99012 -> 3 matches -> tier 3
+      expect(calculateLotteryTier(12, 90012)).toBe(2); // 00012 vs 90012 -> 4 matches -> tier 2
+    });
+  });
+
+  describe('getBestLotteryMatch', () => {
+    it('should return the best match and corresponding pokemon', () => {
+      const pokemonList = [
+        { otId: 11111 }, // No match
+        { otId: 99345 }, // Tier 3
+        { otId: 92345 }, // Tier 2
+      ];
+      const winningNumber = 12345;
+
+      const result = getBestLotteryMatch(pokemonList, winningNumber);
+      expect(result.tier).toBe(2);
+      expect(result.winningPokemon).toEqual({ otId: 92345 });
+    });
+
+    it('should return tier 0 if no match found', () => {
+      const pokemonList = [{ otId: 11111 }, { otId: 22222 }];
+      const winningNumber = 12345;
+
+      const result = getBestLotteryMatch(pokemonList, winningNumber);
+      expect(result.tier).toBe(0);
+      expect(result.winningPokemon).toBeNull();
+    });
+  });
+});

--- a/src/engine/gen3/lottery/lottery.ts
+++ b/src/engine/gen3/lottery/lottery.ts
@@ -1,0 +1,52 @@
+export interface LotteryPokemon {
+  otId: number;
+}
+
+export const TIER_1_MATCHES = 5;
+export const TIER_2_MATCHES = 4;
+export const TIER_3_MATCHES = 3;
+export const TIER_4_MATCHES = 2;
+
+export interface LotteryResult {
+  tier: 0 | 1 | 2 | 3 | 4;
+  winningPokemon: LotteryPokemon | null; // Replace any with appropriate Pokemon type
+}
+
+export function calculateLotteryTier(otId: number, winningNumber: number): 0 | 1 | 2 | 3 | 4 {
+  const otIdStr = otId.toString().padStart(5, '0');
+  const winningNumberStr = winningNumber.toString().padStart(5, '0');
+
+  let matches = 0;
+  for (let i = 4; i >= 0; i--) {
+    if (otIdStr[i] === winningNumberStr[i]) {
+      matches++;
+    } else {
+      break;
+    }
+  }
+
+  if (matches === 5) return 1;
+  if (matches === 4) return 2;
+  if (matches === 3) return 3;
+  if (matches === 2) return 4;
+  return 0;
+}
+
+export function getBestLotteryMatch(pokemonList: LotteryPokemon[], winningNumber: number): LotteryResult {
+  let bestTier: 0 | 1 | 2 | 3 | 4 = 0;
+  let bestPokemon = null;
+
+  for (const pokemon of pokemonList) {
+    const tier = calculateLotteryTier(pokemon.otId, winningNumber);
+    if (tier !== 0 && (bestTier === 0 || tier < bestTier)) {
+      // tier 1 is best, tier 4 is worst
+      bestTier = tier;
+      bestPokemon = pokemon;
+      if (bestTier === 1) {
+        break; // Found the best possible match
+      }
+    }
+  }
+
+  return { tier: bestTier, winningPokemon: bestPokemon };
+}


### PR DESCRIPTION
This PR implements the requested logic for comparing Pokémon OT IDs against a daily winning number, which corresponds to `task-273-303-lottery-matching-core-logic`. 

### Changes:
*   Added `src/engine/gen3/lottery/lottery.ts` exporting `calculateLotteryTier` and `getBestLotteryMatch`.
*   Added `src/engine/gen3/lottery/lottery.test.ts` with test coverage for different scenarios (including zero padding).
*   Addressed linter issues by providing a well-defined interface instead of using `any` or trying to force-fit `PokemonInstance` which does not currently have `otId`.
*   Updated `.foundry/tasks/task-273-303-lottery-matching-core-logic.md` acceptance criteria checkboxes to reflect completion.

---
*PR created automatically by Jules for task [13107346277851090907](https://jules.google.com/task/13107346277851090907) started by @szubster*