### PR TITLE
chore: break down Gen 2 roamer data Epic into executable Stories

### DIFF
--- a/.foundry/epics/epic-043-139-gen2-roamer-data-extraction.md
+++ b/.foundry/epics/epic-043-139-gen2-roamer-data-extraction.md
@@ -31,4 +31,6 @@ Extract Gen 2 roamer data and standardize the structure for roaming legendaries.
 - [ ] Gen 2 save parser correctly extracts the species ID, level, and map coordinates of roaming Pokémon.
 - [ ] Only released/active roamers are considered active.
 - [ ] The return structure in `common.ts` is standardized for Gen 2.
-- [ ] Story Owner: Break down this Epic into executable Stories.
+- [x] Story Owner: Break down this Epic into executable Stories.
+- [ ] story-139-297-gen2-roamer-core-extraction
+- [ ] story-139-298-gen2-roamer-status-and-standardization

--- a/.foundry/stories/story-139-297-gen2-roamer-core-extraction.md
+++ b/.foundry/stories/story-139-297-gen2-roamer-core-extraction.md
@@ -1,0 +1,33 @@
+---
+id: story-139-297-gen2-roamer-core-extraction
+type: STORY
+title: Parse Gen 2 Roamer Core Data
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-043-139-gen2-roamer-data-extraction
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Parse Gen 2 Roamer Core Data
+
+## Objective
+Extract the 7-byte `roam_struct` for the Gen 2 roamers (Raikou, Entei, Suicune) and the map tracking variables from the `sPokemonData` block.
+
+## Description
+- The roamer data is located starting at offset `0x02F8` within the `sPokemonData` block (which begins at `0xDCD7` in WRAM).
+- Read the species, level, HP, and map variables for Raikou (`+0x02F8`), Entei (`+0x02FF`), and Suicune (`+0x0306`).
+- Extract `wRoamMons_CurMapGroup` and `wRoamMons_CurMapNumber` (at `+0x030C` and `+0x030B` respectively) to track their current location.
+
+## Acceptance Criteria
+- [ ] Implement data extraction for the 3 Gen 2 roaming legendaries based on the 7-byte `roam_struct`.
+- [ ] Extract the map tracking variables correctly.
+- [ ] Break down this Story into Tasks.

--- a/.foundry/stories/story-139-298-gen2-roamer-status-and-standardization.md
+++ b/.foundry/stories/story-139-298-gen2-roamer-status-and-standardization.md
@@ -1,0 +1,34 @@
+---
+id: story-139-298-gen2-roamer-status-and-standardization
+type: STORY
+title: Determine Roamer Status and Standardize Output
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on:
+  - story-139-297-gen2-roamer-core-extraction
+jules_session_id: null
+pr_number: null
+parent: epic-043-139-gen2-roamer-data-extraction
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Determine Roamer Status and Standardize Output
+
+## Objective
+Apply logic to determine if each Gen 2 roamer is currently active, and map the data into the standardized `roamingLegendaries` return structure.
+
+## Description
+- Check each roamer's `MapGroup` value: if it is `0xFF`, the roamer is inactive (not roaming).
+- Check each roamer's `HP`: if it is `0`, the roamer is defeated/caught and no longer active.
+- Format the active roamers and their parsed `Species`, `Level`, and map coordinates to match the standardized structure in `common.ts`.
+
+## Acceptance Criteria
+- [ ] Determine roamer activity based on `MapGroup != 0xFF` and `HP > 0`.
+- [ ] Standardize the parsed data and add it to `saveData.roamingLegendaries`.
+- [ ] Break down this Story into Tasks.


### PR DESCRIPTION
As the Story Owner, broke down the Gen 2 Roamer Data Extraction Epic into executable Story nodes. Included the correct `roam_struct` offsets for Gen 2 memory extraction and defined the specific logic required to determine when a roamer is considered actively roaming. Appended the generated stories to the parent Epic without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [9371062284325539318](https://jules.google.com/task/9371062284325539318) started by @szubster*