### PR TITLE
Draft Gen 3 TV Block DataView Parser Tasks (Retry 6)

### DIFF
--- a/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
+++ b/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
@@ -48,5 +48,7 @@ Implement the foundational logic to locate and read the TV broadcast data block 
 - [x] research-121-285-gen3-tv-block-parser-retry3-failure
 - [x] task-121-280-gen3-tv-block-parser-retry4-impl
 - [x] task-121-281-gen3-tv-block-parser-retry4-qa
-- [ ] task-121-304-gen3-tv-block-parser-retry5-impl
-- [ ] task-121-305-gen3-tv-block-parser-retry5-qa
+- [x] task-121-304-gen3-tv-block-parser-retry5-impl
+- [x] task-121-305-gen3-tv-block-parser-retry5-qa
+- [ ] task-121-309-gen3-tv-block-parser-retry6-impl
+- [ ] task-121-310-gen3-tv-block-parser-retry6-qa

--- a/.foundry/tasks/task-121-309-gen3-tv-block-parser-retry6-impl.md
+++ b/.foundry/tasks/task-121-309-gen3-tv-block-parser-retry6-impl.md
@@ -1,0 +1,59 @@
+---
+id: task-121-309-gen3-tv-block-parser-retry6-impl
+type: TASK
+title: Implement Gen 3 TV Block DataView Parser (Retry 6)
+status: READY
+owner_persona: coder
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on:
+  - research-121-285-gen3-tv-block-parser-retry3-failure
+jules_session_id: null
+pr_number: null
+parent: story-081-121-gen3-tv-block-dataview-parser
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Gen 3 TV Block DataView Parser (Retry 6)
+
+## Description
+This task requires you to implement the foundational logic to locate and read the TV broadcast data block from the Gen 3 save file structure, addressing the feedback from `research-121-285-gen3-tv-block-parser-retry3-failure`.
+
+As mandated by **ADR 010**, you MUST strictly utilize the `DataView` API for all new Gen 3 data parsing logic to ensure robustness and safety. You must avoid legacy `Uint8Array` manual read methods and instead use `DataView` methods such as `getUint8`, `getUint16`, etc., to enforce native bounds checking.
+
+Any out-of-bounds reads or structurally corrupt states within the TV block MUST trigger a gracefully caught `RangeError` which the parser translates into a descriptive structural error, rather than crashing the application.
+
+**CRITICAL CONSTRAINT:** All memory offsets, lengths, bit locations, and shifts MUST be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden. You MUST explicitly use the following module-level constants (or similar semantic names) based on the research findings:
+- `TVGROUP_RECORD_MIX_START = 21`
+- `TVGROUP_RECORD_MIX_END = 40`
+- `TVSHOW_STRUCT_SIZE = 36`
+- `TV_SHOWS_COUNT = 25`
+- `TVSHOW_MASS_OUTBREAK = 41`
+- `OUTBREAK_MOVES_OFFSET = 0x04`
+- `OUTBREAK_SPECIES_OFFSET = 0x0C`
+- `OUTBREAK_MAP_NUM_OFFSET = 0x10`
+- `OUTBREAK_MAP_GROUP_OFFSET = 0x11`
+- `OUTBREAK_PROBABILITY_OFFSET = 0x13`
+- `OUTBREAK_LEVEL_OFFSET = 0x14`
+- `OUTBREAK_DAYS_BEFORE_OFFSET = 0x16`
+- `OUTBREAK_LANGUAGE_OFFSET = 0x18`
+
+Any size or ID constants must NOT be hardcoded inline inside parsing functions.
+
+## Acceptance Criteria
+- [ ] The TV block extraction logic is built entirely using `DataView`.
+- [ ] All memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level.
+- [ ] Explicit error handling is in place to catch `RangeError` exceptions natively thrown by `DataView` on malformed saves.
+- [ ] New parsing functions conform to the existing Gen 1 and Gen 2 backward-compatible parsing interfaces without breaking them.
+
+## Important Protocols (For Coder)
+- **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failure:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Protocol:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-121-310-gen3-tv-block-parser-retry6-qa.md
+++ b/.foundry/tasks/task-121-310-gen3-tv-block-parser-retry6-qa.md
@@ -1,0 +1,56 @@
+---
+id: task-121-310-gen3-tv-block-parser-retry6-qa
+type: TASK
+title: QA - Implement Gen 3 TV Block DataView Parser (Retry 6)
+status: READY
+owner_persona: qa
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on:
+  - task-121-309-gen3-tv-block-parser-retry6-impl
+jules_session_id: null
+pr_number: null
+parent: story-081-121-gen3-tv-block-dataview-parser
+tags:
+  - feature
+  - gen3
+  - data-parsing
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Task: Verify Gen 3 TV Block DataView Parser (Retry 6)
+
+## Description
+This task requires you to verify the implementation of the Gen 3 TV Block DataView parser performed in `task-121-309-gen3-tv-block-parser-retry6-impl`.
+
+You must strictly verify that the coder has adhered to **ADR 010** and used the `DataView` API exclusively. You must also verify that **ALL** memory offsets, lengths, bit locations, and shifts have been defined as module-level constants and that no inline magic numbers were used in the parsing logic.
+
+Specifically, check for the presence and usage of the following constants based on research:
+- `TVGROUP_RECORD_MIX_START = 21`
+- `TVGROUP_RECORD_MIX_END = 40`
+- `TVSHOW_STRUCT_SIZE = 36`
+- `TV_SHOWS_COUNT = 25`
+- `TVSHOW_MASS_OUTBREAK = 41`
+- `OUTBREAK_MOVES_OFFSET = 0x04`
+- `OUTBREAK_SPECIES_OFFSET = 0x0C`
+- `OUTBREAK_MAP_NUM_OFFSET = 0x10`
+- `OUTBREAK_MAP_GROUP_OFFSET = 0x11`
+- `OUTBREAK_PROBABILITY_OFFSET = 0x13`
+- `OUTBREAK_LEVEL_OFFSET = 0x14`
+- `OUTBREAK_DAYS_BEFORE_OFFSET = 0x16`
+- `OUTBREAK_LANGUAGE_OFFSET = 0x18`
+
+## Acceptance Criteria
+- [ ] Verified that the TV block extraction logic strictly utilizes `DataView`.
+- [ ] Verified that no inline magic numbers were used, and all offsets/lengths are reusable constants at the module level.
+- [ ] Verified that out-of-bounds reads gracefully throw a caught `RangeError`.
+- [ ] Verified that existing interfaces were not broken.
+
+## Important Protocols (For QA)
+- **Transient Failure:** If you experience a transient failure requiring retry or if the Coder's implementation is incorrect, you MUST update the YAML frontmatter to `status: FAILED` with a detailed `rejection_reason`.
+- **Permanent Failure:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Protocol:** If you submit an empty PR for a completed QA task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Drafted technical blueprints (implementation and QA) for parsing Gen 3 TV broadcast data block with DataView. Replaced the failed retry 5 tasks by mandating module-level constants (e.g., `TVGROUP_RECORD_MIX_START`, `TVSHOW_STRUCT_SIZE`) as discovered in `research-121-285` to ensure native bounds checking without inline magic numbers. Modified `story-081-121-gen3-tv-block-dataview-parser` markdown body to append these tasks.

---
*PR created automatically by Jules for task [17073016714671585004](https://jules.google.com/task/17073016714671585004) started by @szubster*