### PR TITLE
Empty PR: Verify Epic 104-133

### DIFF
--- a/.foundry/epics/epic-104-133-gen3-lottery-offsets-research.md
+++ b/.foundry/epics/epic-104-133-gen3-lottery-offsets-research.md
@@ -28,3 +28,7 @@ Research and identify the memory offsets for the daily lottery PRNG seed in Ruby
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md
+
+## Learnings & Follow-ups
+During this research epic, we discovered that the 32-bit Lottery PRNG seed is split across two 16-bit variables, and the High/Low ordering is swapped between R/S and Emerald. A follow-up IDEA node has been created to propose an architectural strategy for extracting these split variables:
+- [ ] idea-112-gen3-split-variable-extraction-strategy

--- a/.foundry/ideas/idea-112-gen3-split-variable-extraction-strategy.md
+++ b/.foundry/ideas/idea-112-gen3-split-variable-extraction-strategy.md
@@ -1,0 +1,38 @@
+---
+id: idea-112-gen3-split-variable-extraction-strategy
+type: IDEA
+title: Gen3 Split Variable Extraction Strategy
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - gen3
+  - architecture
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen3 Split Variable Extraction Strategy
+
+## Context
+During the verification of `epic-104-133-gen3-lottery-offsets-research`, it was identified that some 32-bit values in Gen 3 save files (specifically the Lottery PRNG seed) are stored as two separate 16-bit variables.
+
+Crucially, the ordering of the High and Low 16-bit words is swapped between game versions:
+- Ruby/Sapphire stores the Low 16 bits first, then the High 16 bits.
+- Emerald stores the High 16 bits first, then the Low 16 bits.
+
+## Goal
+We need a standardized architectural strategy or utility to extract these split 32-bit values reliably across game versions without hardcoding version checks inline throughout the data extraction layer.
+
+## Proposed Actions
+1. Have the Architect draft an ADR to formalize how to handle multi-word variables where endianness/ordering is version-dependent.
+2. Consider adding a generic helper utility for reading split 32-bit variables.
+
+## Acceptance Criteria
+- [ ] Transition this Idea into a PRD.

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -116,3 +116,6 @@ When verifying `epic-038-061-pokerus-state-exfiltration`, the implementation suc
 - **Node**: `epic-104-133-gen3-lottery-offsets-research`
 - **Result**: Verification Passed.
 - **Notes**: The Epic was simply to break down the task of researching Gen 3 lottery offsets. The child story `story-133-272-research-lottery-offsets` and its child task `task-272-301-research-gen3-lottery-offsets` successfully ran and produced the research document `.foundry/docs/knowledge_base/gen3_lottery_offsets.md`. All child nodes are marked as COMPLETED. The Acceptance Criteria in the epic are checked. Submitting an empty PR to transition to COMPLETED.
+
+### Gen 3 Lottery Offsets Extraction
+When verifying `epic-104-133-gen3-lottery-offsets-research`, I learned that the 32-bit lottery PRNG seed in Gen 3 is split across two 16-bit variables. Crucially, the order of these variables (High/Low words) is swapped between Ruby/Sapphire and Emerald. Ruby/Sapphire stores the Low 16 bits first (at index 0x404B) and the High 16 bits second (at 0x404C), while Emerald stores the High 16 bits first (at 0x404B) and the Low 16 bits second (at 0x404C). This introduces a complexity in extracting a 32-bit value that we need to standardize.


### PR DESCRIPTION
This is an empty PR to transition `epic-104-133-gen3-lottery-offsets-research` from VERIFYING to COMPLETED.

The epic has been verified:
- The research was conducted successfully.
- Offsets for Ruby, Sapphire, and Emerald lottery PRNG seed were found.
- The offsets were properly documented in `.foundry/docs/knowledge_base/gen3_lottery_offsets.md`.
- All generated tasks and stories were completed.
- Acceptance criteria in the Epic are checked.

I have updated the auditor journal with the finding about the split variable differences between RS and Emerald and created a follow-up IDEA node (`idea-112-gen3-split-variable-extraction-strategy`) to standardize the data extraction. This follow up node was linked in the epic.

---
*PR created automatically by Jules for task [13326451692144426734](https://jules.google.com/task/13326451692144426734) started by @szubster*