### PR TITLE
Auditor Verification: Detect Party Zero HP as Dead

### DIFF
--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -116,3 +116,8 @@ When verifying `epic-038-061-pokerus-state-exfiltration`, the implementation suc
 - **Node**: `epic-104-133-gen3-lottery-offsets-research`
 - **Result**: Verification Passed.
 - **Notes**: The Epic was simply to break down the task of researching Gen 3 lottery offsets. The child story `story-133-272-research-lottery-offsets` and its child task `task-272-301-research-gen3-lottery-offsets` successfully ran and produced the research document `.foundry/docs/knowledge_base/gen3_lottery_offsets.md`. All child nodes are marked as COMPLETED. The Acceptance Criteria in the epic are checked. Submitting an empty PR to transition to COMPLETED.
+
+## epic-097-131-nuzlocke-death-tracking
+- **Node**: `story-131-269-detect-party-zero-hp`
+- **Result**: Verification Passed.
+- **Notes**: The Story was simply to detect party zero HP as dead. The child task `task-269-263-detect-party-zero-hp-impl` successfully implemented the `getDeadPokemon` function in `src/engine/nuzlocke/tracker.ts`. The child task is marked as COMPLETED. The Acceptance Criteria in the story are checked. Tests pass. Submitting an empty PR to transition to COMPLETED.


### PR DESCRIPTION
Auditor persona verified `story-131-269-detect-party-zero-hp`.

- Verified that child task `task-269-263-detect-party-zero-hp-impl` successfully implemented the required logic (`getDeadPokemon`).
- Verified acceptance criteria checkboxes are marked as completed.
- Logged verification findings in the auditor journal.
- Submitting an empty PR to transition the node to `COMPLETED`.

---
*PR created automatically by Jules for task [13943582420741362274](https://jules.google.com/task/13943582420741362274) started by @szubster*