### PR TITLE
Add Items Schema and PokeDB Sync

### DIFF
--- a/.foundry/tasks/task-280-304-item-db-schema-and-sync.md
+++ b/.foundry/tasks/task-280-304-item-db-schema-and-sync.md
@@ -42,8 +42,8 @@ This task will configure the `PokeDB` IndexedDB instance to store this item data
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Add `items` to `DB_CONFIG.STORES` in `src/db/schema.ts`.
-- [ ] Define the `ItemMetadata` interface and add the `items` object store to `PokeDBSchema`.
-- [ ] Update `PokeDataExport` to include `items`.
-- [ ] Implement inflation logic for the `items` array inside `syncData` in `src/db/PokeDB.ts`.
-- [ ] Ensure `pnpm type-check` and `pnpm lint` pass successfully.
+- [x] Add `items` to `DB_CONFIG.STORES` in `src/db/schema.ts`.
+- [x] Define the `ItemMetadata` interface and add the `items` object store to `PokeDBSchema`.
+- [x] Update `PokeDataExport` to include `items`.
+- [x] Implement inflation logic for the `items` array inside `syncData` in `src/db/PokeDB.ts`.
+- [x] Ensure `pnpm type-check` and `pnpm lint` pass successfully.

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -83,6 +83,7 @@ export const getDB = () => {
           [DB_CONFIG.STORES.ENCOUNTERS]: 'pid',
           [DB_CONFIG.STORES.LOCATIONS]: 'id',
           [DB_CONFIG.STORES.METADATA]: 'key',
+          [DB_CONFIG.STORES.ITEMS]: 'id',
         };
 
         // Always delete existing stores to ensure keyPaths are applied correctly
@@ -153,7 +154,13 @@ const syncData = async () => {
     };
 
     const tx = db.transaction(
-      [DB_CONFIG.STORES.POKEMON, DB_CONFIG.STORES.ENCOUNTERS, DB_CONFIG.STORES.LOCATIONS, DB_CONFIG.STORES.METADATA],
+      [
+        DB_CONFIG.STORES.POKEMON,
+        DB_CONFIG.STORES.ENCOUNTERS,
+        DB_CONFIG.STORES.LOCATIONS,
+        DB_CONFIG.STORES.ITEMS,
+        DB_CONFIG.STORES.METADATA,
+      ],
       'readwrite',
     );
 
@@ -161,12 +168,13 @@ const syncData = async () => {
     const pStore = tx.objectStore(DB_CONFIG.STORES.POKEMON);
     const eStore = tx.objectStore(DB_CONFIG.STORES.ENCOUNTERS);
     const lStore = tx.objectStore(DB_CONFIG.STORES.LOCATIONS);
+    const iStore = tx.objectStore(DB_CONFIG.STORES.ITEMS);
     const mStore = tx.objectStore(DB_CONFIG.STORES.METADATA);
 
     // Clear old data
-    await Promise.all([pStore.clear(), eStore.clear(), lStore.clear(), mStore.clear()]);
+    await Promise.all([pStore.clear(), eStore.clear(), lStore.clear(), iStore.clear(), mStore.clear()]);
 
-    emit(1, 3, 'Pokemon');
+    emit(1, 4, 'Pokemon');
     const inflateChain = (links: CompactChainLink[] | undefined): CompactChainLink[] => {
       return (links || []).map((l) => ({
         ...l,
@@ -192,7 +200,7 @@ const syncData = async () => {
       });
     }
 
-    emit(2, 3, 'Encounters');
+    emit(2, 4, 'Encounters');
     for (const e of data.enc) {
       const inflatedEnc = e.enc.map((enc) => ({
         ...enc,
@@ -205,13 +213,18 @@ const syncData = async () => {
       void eStore.put({ pid: e.pid, enc: inflatedEnc });
     }
 
-    emit(3, 3, 'Locations');
+    emit(3, 4, 'Locations');
     for (const l of data.loc) {
       void lStore.put({
         ...DEFAULT_LOCATION,
         ...l,
         prnt: l.prnt, // stay undefined if omitted
       });
+    }
+
+    emit(4, 4, 'Items');
+    for (const item of data.items || []) {
+      void iStore.put(item);
     }
 
     await mStore.put({ key: 'hash', value: data.hash });

--- a/src/db/__tests__/PokeDB.test.ts
+++ b/src/db/__tests__/PokeDB.test.ts
@@ -150,16 +150,18 @@ describe('PokeDB', () => {
     const events = dispatchEventMock.mock.calls.map((call) => call[0] as CustomEvent);
     const progressEvents = events.filter((e) => e.type === 'pokedata-sync-progress');
 
-    expect(progressEvents).toHaveLength(3);
-    expect(progressEvents[0]?.detail).toEqual({ current: 1, total: 3, stage: 'Pokemon' });
-    expect(progressEvents[1]?.detail).toEqual({ current: 2, total: 3, stage: 'Encounters' });
-    expect(progressEvents[2]?.detail).toEqual({ current: 3, total: 3, stage: 'Locations' });
+    expect(progressEvents).toHaveLength(4);
+    expect(progressEvents[0]?.detail).toEqual({ current: 1, total: 4, stage: 'Pokemon' });
+    expect(progressEvents[1]?.detail).toEqual({ current: 2, total: 4, stage: 'Encounters' });
+    expect(progressEvents[2]?.detail).toEqual({ current: 3, total: 4, stage: 'Locations' });
+    expect(progressEvents[3]?.detail).toEqual({ current: 4, total: 4, stage: 'Items' });
 
     global.window = originalWindow;
   });
 
   it('syncs data correctly', async () => {
     const mockData = {
+      items: [],
       hash: 'new-hash',
       poke: [
         {
@@ -191,6 +193,7 @@ describe('PokeDB', () => {
 
   it('performs bulk operations for pokemons', async () => {
     const mockData = {
+      items: [],
       hash: 'bulk-hash',
       poke: [
         { id: 1, n: 'P1', cr: 10, gr: 1, baby: false, eto: [], efrm: [], det: [] },
@@ -231,6 +234,7 @@ describe('PokeDB', () => {
 
   it('inflates recursive evo chains correctly', async () => {
     const mockData = {
+      items: [],
       hash: 'evo-chain-hash',
       poke: [
         {
@@ -276,6 +280,7 @@ describe('PokeDB', () => {
 
   it('resolves area names correctly', async () => {
     const mockData = {
+      items: [],
       hash: 'area-hash',
       poke: [],
       enc: [],
@@ -341,6 +346,7 @@ describe('PokeDB', () => {
 
     it('getAllPokemon returns all pokemon', async () => {
       const mockData = {
+        items: [],
         hash: 'new-hash',
         poke: [
           { id: 1, n: 'Bulbasaur', cr: 45, gr: 1, baby: false, eto: [], efrm: [], det: [] },
@@ -366,6 +372,7 @@ describe('PokeDB', () => {
 
     it('getEncounters returns encounter data', async () => {
       const mockData = {
+        items: [],
         hash: 'new-hash',
         poke: [],
         enc: [{ pid: 1, enc: [] }],
@@ -383,6 +390,7 @@ describe('PokeDB', () => {
 
     it('getEncountersBulk returns correctly', async () => {
       const mockData = {
+        items: [],
         hash: 'new-hash',
         poke: [],
         enc: [
@@ -411,6 +419,7 @@ describe('PokeDB', () => {
 
     it('getAllEncounters returns all encounters', async () => {
       const mockData = {
+        items: [],
         hash: 'new-hash',
         poke: [],
         enc: [
@@ -435,6 +444,7 @@ describe('PokeDB', () => {
 
     it('getLocation returns location', async () => {
       const mockData = {
+        items: [],
         hash: 'new-hash',
         poke: [],
         enc: [],
@@ -452,6 +462,7 @@ describe('PokeDB', () => {
 
     it('getLocations returns all locations', async () => {
       const mockData = {
+        items: [],
         hash: 'new-hash',
         poke: [],
         enc: [],
@@ -476,6 +487,7 @@ describe('PokeDB', () => {
 
     it('getAreas returns area if found', async () => {
       const mockData = {
+        items: [],
         hash: 'new-hash',
         poke: [],
         enc: [],
@@ -494,6 +506,7 @@ describe('PokeDB', () => {
 
     it('getAllAreas returns all locations', async () => {
       const mockData = {
+        items: [],
         hash: 'new-hash',
         poke: [],
         enc: [],
@@ -515,6 +528,7 @@ describe('PokeDB', () => {
 
     it('getInverseIndex returns pids array', async () => {
       const mockData = {
+        items: [],
         hash: 'new-hash',
         poke: [],
         enc: [],
@@ -532,6 +546,7 @@ describe('PokeDB', () => {
 
     it('getInverseIndexBulk returns array of pids or undefined', async () => {
       const mockData = {
+        items: [],
         hash: 'new-hash-bulk',
         poke: [],
         enc: [],

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -7,11 +7,12 @@ import type { DBSchema } from 'idb';
 
 export const DB_CONFIG = {
   NAME: 'PokeDB',
-  VERSION: 9,
+  VERSION: 10,
   STORES: {
     POKEMON: 'pokemon',
     ENCOUNTERS: 'encounters',
     LOCATIONS: 'locations',
+    ITEMS: 'items',
     METADATA: 'metadata',
   },
 } as const;
@@ -141,6 +142,16 @@ export interface PokemonMetadata {
   det: CompactEvolutionDetail[]; // Evolutionary requirements to reach THIS pokemon from parent
 }
 
+export interface ItemMetadata {
+  id: number;
+  name: string;
+  cost?: number | undefined;
+  category?: number | undefined;
+  fling_p?: number | undefined;
+  effect?: string | undefined;
+  sprite?: string | undefined;
+}
+
 export interface HiddenItemData {
   flagOffset: number;
   flagBit: number;
@@ -153,6 +164,7 @@ export interface PokeDataExport {
   poke: PokemonMetadata[];
   enc: LocationAreaEncounters[];
   loc: UnifiedLocation[];
+  items: ItemMetadata[];
   hash: string;
   sourceSha?: string;
 }
@@ -165,6 +177,10 @@ export interface PokeDBSchema extends DBSchema {
   [DB_CONFIG.STORES.ENCOUNTERS]: {
     key: number;
     value: LocationAreaEncounters;
+  };
+  [DB_CONFIG.STORES.ITEMS]: {
+    key: number;
+    value: ItemMetadata;
   };
   [DB_CONFIG.STORES.LOCATIONS]: {
     key: number;


### PR DESCRIPTION
Closes `task-280-304-item-db-schema-and-sync`. Implements the IndexedDB schema updates and sync configuration required for the new dynamically built `items` data payload.

---
*PR created automatically by Jules for task [2586275593234808783](https://jules.google.com/task/2586275593234808783) started by @szubster*