### PR TITLE
feat(engine): Implement Gen 3 Trick House progression parser

### DIFF
--- a/.foundry/stories/story-111-276-trick-house-parser-impl.md
+++ b/.foundry/stories/story-111-276-trick-house-parser-impl.md
@@ -32,5 +32,5 @@ Implement a parser using `DataView` to extract Trick House progression states fr
 ## Acceptance Criteria
 - [x] Parse `VAR_TRICK_HOUSE_LEVEL_OFFSET` and other progression variables.
 - [x] Parse `FLAG_LANDMARK_TRICK_HOUSE`.
-- [ ] task-276-304-gen3-trick-house-parser-impl
+- [x] task-276-304-gen3-trick-house-parser-impl
 - [ ] task-276-305-gen3-trick-house-parser-qa

--- a/.foundry/tasks/task-276-304-gen3-trick-house-parser-impl.md
+++ b/.foundry/tasks/task-276-304-gen3-trick-house-parser-impl.md
@@ -44,12 +44,15 @@ The specific offsets needed to implement this are defined in:
 - `.foundry/docs/knowledge_base/gen3_trick_house_offsets.md`
 
 ## Acceptance Criteria
-- [ ] Module-level reusable constants are defined for all variables and flag offsets.
-- [ ] A parsing utility or class is implemented to extract Trick House data from `SaveBlock1`.
-- [ ] No inline magic numbers are used in the memory parsing logic.
-- [ ] Proper extraction of Little-Endian 16-bit variables using `DataView.getUint16`.
+- [x] Module-level reusable constants are defined for all variables and flag offsets.
+- [x] A parsing utility or class is implemented to extract Trick House data from `SaveBlock1`.
+- [x] No inline magic numbers are used in the memory parsing logic.
+- [x] Proper extraction of Little-Endian 16-bit variables using `DataView.getUint16`.
 
 ## Review Contracts
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
 - If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/src/engine/saveParser/gen3/trickHouse/parser.test.ts
+++ b/src/engine/saveParser/gen3/trickHouse/parser.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FLAG_LANDMARK_TRICK_HOUSE_BIT,
+  FLAG_LANDMARK_TRICK_HOUSE_BYTE_OFFSET,
+  parseTrickHouse,
+  VAR_TRICK_HOUSE_ENTER_FROM_CORRIDOR_OFFSET,
+  VAR_TRICK_HOUSE_ENTRANCE_STATE_OFFSET,
+  VAR_TRICK_HOUSE_LEVEL_OFFSET,
+  VAR_TRICK_HOUSE_PRIZE_PICKUP_OFFSET,
+  VAR_TRICK_HOUSE_PUZZLE_1_STATE_OFFSET,
+  VAR_TRICK_HOUSE_PUZZLE_2_STATE_OFFSET,
+  VAR_TRICK_HOUSE_PUZZLE_3_STATE_OFFSET,
+  VAR_TRICK_HOUSE_PUZZLE_4_STATE_OFFSET,
+  VAR_TRICK_HOUSE_PUZZLE_5_STATE_OFFSET,
+  VAR_TRICK_HOUSE_PUZZLE_6_STATE_OFFSET,
+  VAR_TRICK_HOUSE_PUZZLE_7_STATE_OFFSET,
+  VAR_TRICK_HOUSE_PUZZLE_8_STATE_OFFSET,
+} from './parser';
+
+describe('parseTrickHouse', () => {
+  it('correctly parses Trick House data', () => {
+    // 0x1500 + 2 is the maximum offset used (for puzzle 8) -> 0x1502
+    // Let's allocate 0x2000 to be safe.
+    const buffer = new ArrayBuffer(0x2000);
+    const view = new DataView(buffer);
+
+    view.setUint16(VAR_TRICK_HOUSE_LEVEL_OFFSET, 3, true);
+    view.setUint16(VAR_TRICK_HOUSE_ENTRANCE_STATE_OFFSET, 1, true);
+    view.setUint16(VAR_TRICK_HOUSE_ENTER_FROM_CORRIDOR_OFFSET, 0, true);
+    view.setUint16(VAR_TRICK_HOUSE_PRIZE_PICKUP_OFFSET, 2, true);
+
+    view.setUint16(VAR_TRICK_HOUSE_PUZZLE_1_STATE_OFFSET, 2, true);
+    view.setUint16(VAR_TRICK_HOUSE_PUZZLE_2_STATE_OFFSET, 2, true);
+    view.setUint16(VAR_TRICK_HOUSE_PUZZLE_3_STATE_OFFSET, 1, true);
+    view.setUint16(VAR_TRICK_HOUSE_PUZZLE_4_STATE_OFFSET, 0, true);
+    view.setUint16(VAR_TRICK_HOUSE_PUZZLE_5_STATE_OFFSET, 0, true);
+    view.setUint16(VAR_TRICK_HOUSE_PUZZLE_6_STATE_OFFSET, 0, true);
+    view.setUint16(VAR_TRICK_HOUSE_PUZZLE_7_STATE_OFFSET, 0, true);
+    view.setUint16(VAR_TRICK_HOUSE_PUZZLE_8_STATE_OFFSET, 0, true);
+
+    view.setUint8(FLAG_LANDMARK_TRICK_HOUSE_BYTE_OFFSET, 1 << FLAG_LANDMARK_TRICK_HOUSE_BIT);
+
+    const result = parseTrickHouse(view);
+
+    expect(result).toEqual({
+      level: 3,
+      entranceState: 1,
+      enterFromCorridor: 0,
+      prizePickup: 2,
+      puzzles: {
+        puzzle1: 2,
+        puzzle2: 2,
+        puzzle3: 1,
+        puzzle4: 0,
+        puzzle5: 0,
+        puzzle6: 0,
+        puzzle7: 0,
+        puzzle8: 0,
+      },
+      landmarkFlag: true,
+    });
+  });
+});

--- a/src/engine/saveParser/gen3/trickHouse/parser.ts
+++ b/src/engine/saveParser/gen3/trickHouse/parser.ts
@@ -1,0 +1,76 @@
+export interface Gen3TrickHouse {
+  level: number;
+  entranceState: number;
+  enterFromCorridor: number;
+  prizePickup: number;
+  puzzles: {
+    puzzle1: number;
+    puzzle2: number;
+    puzzle3: number;
+    puzzle4: number;
+    puzzle5: number;
+    puzzle6: number;
+    puzzle7: number;
+    puzzle8: number;
+  };
+  landmarkFlag: boolean;
+}
+
+export const SAVE_BLOCK_1_VARS_OFFSET = 0x139c;
+export const SAVE_BLOCK_1_FLAGS_OFFSET = 0x1270;
+
+export const VAR_TRICK_HOUSE_LEVEL_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x4044 - 0x4000) * 2;
+export const VAR_TRICK_HOUSE_ENTRANCE_STATE_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40a7 - 0x4000) * 2;
+export const VAR_TRICK_HOUSE_ENTER_FROM_CORRIDOR_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40b5 - 0x4000) * 2;
+export const VAR_TRICK_HOUSE_PRIZE_PICKUP_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40c1 - 0x4000) * 2;
+
+export const VAR_TRICK_HOUSE_PUZZLE_1_STATE_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40ab - 0x4000) * 2;
+export const VAR_TRICK_HOUSE_PUZZLE_2_STATE_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40ac - 0x4000) * 2;
+export const VAR_TRICK_HOUSE_PUZZLE_3_STATE_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40ad - 0x4000) * 2;
+export const VAR_TRICK_HOUSE_PUZZLE_4_STATE_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40ae - 0x4000) * 2;
+export const VAR_TRICK_HOUSE_PUZZLE_5_STATE_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40af - 0x4000) * 2;
+export const VAR_TRICK_HOUSE_PUZZLE_6_STATE_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40b0 - 0x4000) * 2;
+export const VAR_TRICK_HOUSE_PUZZLE_7_STATE_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40b1 - 0x4000) * 2;
+export const VAR_TRICK_HOUSE_PUZZLE_8_STATE_OFFSET = SAVE_BLOCK_1_VARS_OFFSET + (0x40b2 - 0x4000) * 2;
+
+export const FLAG_LANDMARK_TRICK_HOUSE = 0x8a2;
+export const FLAG_LANDMARK_TRICK_HOUSE_BYTE_OFFSET =
+  SAVE_BLOCK_1_FLAGS_OFFSET + Math.floor(FLAG_LANDMARK_TRICK_HOUSE / 8);
+export const FLAG_LANDMARK_TRICK_HOUSE_BIT = FLAG_LANDMARK_TRICK_HOUSE % 8;
+
+export function parseTrickHouse(view: DataView): Gen3TrickHouse {
+  const level = view.getUint16(VAR_TRICK_HOUSE_LEVEL_OFFSET, true);
+  const entranceState = view.getUint16(VAR_TRICK_HOUSE_ENTRANCE_STATE_OFFSET, true);
+  const enterFromCorridor = view.getUint16(VAR_TRICK_HOUSE_ENTER_FROM_CORRIDOR_OFFSET, true);
+  const prizePickup = view.getUint16(VAR_TRICK_HOUSE_PRIZE_PICKUP_OFFSET, true);
+
+  const puzzle1 = view.getUint16(VAR_TRICK_HOUSE_PUZZLE_1_STATE_OFFSET, true);
+  const puzzle2 = view.getUint16(VAR_TRICK_HOUSE_PUZZLE_2_STATE_OFFSET, true);
+  const puzzle3 = view.getUint16(VAR_TRICK_HOUSE_PUZZLE_3_STATE_OFFSET, true);
+  const puzzle4 = view.getUint16(VAR_TRICK_HOUSE_PUZZLE_4_STATE_OFFSET, true);
+  const puzzle5 = view.getUint16(VAR_TRICK_HOUSE_PUZZLE_5_STATE_OFFSET, true);
+  const puzzle6 = view.getUint16(VAR_TRICK_HOUSE_PUZZLE_6_STATE_OFFSET, true);
+  const puzzle7 = view.getUint16(VAR_TRICK_HOUSE_PUZZLE_7_STATE_OFFSET, true);
+  const puzzle8 = view.getUint16(VAR_TRICK_HOUSE_PUZZLE_8_STATE_OFFSET, true);
+
+  const flagByte = view.getUint8(FLAG_LANDMARK_TRICK_HOUSE_BYTE_OFFSET);
+  const landmarkFlag = (flagByte & (1 << FLAG_LANDMARK_TRICK_HOUSE_BIT)) !== 0;
+
+  return {
+    level,
+    entranceState,
+    enterFromCorridor,
+    prizePickup,
+    puzzles: {
+      puzzle1,
+      puzzle2,
+      puzzle3,
+      puzzle4,
+      puzzle5,
+      puzzle6,
+      puzzle7,
+      puzzle8,
+    },
+    landmarkFlag,
+  };
+}

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -170,6 +170,7 @@ export interface Gen3BattleFrontierSymbols {
 }
 
 export interface SaveData {
+  gen3TrickHouse?: import('./../gen3/trickHouse/parser').Gen3TrickHouse;
   /** The generation of the parsed save file (1 or 2). */
   generation: Generation;
   /** A set of Pokémon species IDs that have been caught (O(1) lookup). */

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -19,6 +19,7 @@
  */
 
 import { parseSecretBaseRecord } from '../../gen3/secretBase/parser';
+import { parseTrickHouse } from '../gen3/trickHouse/parser';
 import type {
   GameVersion,
   Gen3ActiveSwarm,
@@ -1050,6 +1051,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       ...(gen3ActiveSwarm !== undefined ? { gen3ActiveSwarm } : {}),
       roamingLegendaries,
       gen3VolcanicAsh,
+      gen3TrickHouse: parseTrickHouse(view),
     };
     if (gen3BattleFrontierWinStreaks) {
       result.gen3BattleFrontierWinStreaks = gen3BattleFrontierWinStreaks;


### PR DESCRIPTION
Implemented parser for Gen 3 Trick House progression via `DataView`. Extracting Level, Entrance States, Puzzle completion, and the Trick House system landmark flag using module-level constants to prevent magic numbers inline. Included comprehensive unit tests.

---
*PR created automatically by Jules for task [18366196878499574542](https://jules.google.com/task/18366196878499574542) started by @szubster*