### PR TITLE
Reject Feebas Extraction Implementation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -22,3 +22,8 @@ The implementer (`coder`) failed `task-121-219-gen3-tv-block-parser-retry-impl` 
 - Verified that `DataView` API is used exclusively in `src/engine/gen3/secretBase/parser.ts` for all read operations (e.g. `getUint32`, `getUint16`, `getUint8`).
 - Verified that all offsets, lengths, and bit locations are defined as reusable constants at the module level.
 - Verified that comprehensive unit tests are present, including checking for out-of-bounds reads throwing `The save file is corrupted or incomplete.` when catching `RangeError`.
+
+## 2026-07-11 - Feebas Extraction Failed (Task: task-280-305-feebas-backend-integration-qa)
+The coder implemented the Feebas extraction logic using absolute memory offsets (`0x2dd6`) instead of making them relative to `section1Offset`. In Generation 3, save files utilize an A/B bank rotation system where data can either reside in `0x0000` or `0xE000`. By hardcoding the absolute offset, the parser will fail to read the active save data if it currently resides in Bank B.
+
+To enforce the architecture correctly, all dynamic save block extraction functions must receive the resolved offset from the parser engine (e.g., `section1Offset` or `section2Offset`) and apply relative memory offsets to correctly extract the active save data block. I have failed `task-280-304-feebas-backend-integration` and incremented its rejection count.

--- a/.foundry/tasks/task-280-304-feebas-backend-integration.md
+++ b/.foundry/tasks/task-280-304-feebas-backend-integration.md
@@ -2,7 +2,7 @@
 id: task-280-304-feebas-backend-integration
 type: TASK
 title: Integrate Feebas Logic into Gen 3 Save Parser
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-06'
 updated_at: '2026-07-11'
@@ -14,8 +14,8 @@ tags:
   - gen3
   - backend
   - save-parsing
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'The `extractFeebasSeed` function reads from an absolute memory offset (e.g. 0x2dd6) instead of being relative to `section1Offset` (SaveBlock1) as required by the Gen 3 A/B bank rotation system architecture. This will read from the wrong location if the active SaveBlock1 is in Bank B (0xE000).'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-280-305-feebas-backend-integration-qa.md
+++ b/.foundry/tasks/task-280-305-feebas-backend-integration-qa.md
@@ -37,3 +37,8 @@ Verify the `coder` correctly implemented the Feebas tile extraction logic in the
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
 - If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### QA Result: FAILED
+The implementation of `extractFeebasSeed` correctly calculates the tiles but fails the architectural requirements of the Gen 3 A/B bank flash memory system. The constants `FEEBAS_SEED_OFFSET_RS` and `FEEBAS_SEED_OFFSET_EMERALD` are absolute offsets (e.g. `0x2DD6`) instead of being relative offsets from the base of SaveBlock1. Because the `extractFeebasSeed` function does not receive `section1Offset` from `parseGen3`, it always reads from bank A (`0x0000`). If the active SaveBlock1 is currently stored in Bank B (`0xE000`), it will read corrupt or outdated data.
+
+The coder task has been transitioned to `status: FAILED` and needs to be reworked to properly pass `section1Offset` into the extraction function.


### PR DESCRIPTION
The implementation of `extractFeebasSeed` correctly calculates the tiles but fails the architectural requirements of the Gen 3 A/B bank flash memory system. The constants `FEEBAS_SEED_OFFSET_RS` and `FEEBAS_SEED_OFFSET_EMERALD` are absolute offsets (e.g. `0x2DD6`) instead of being relative offsets from the base of SaveBlock1. Because the `extractFeebasSeed` function does not receive `section1Offset` from `parseGen3`, it always reads from bank A (`0x0000`). If the active SaveBlock1 is currently stored in Bank B (`0xE000`), it will read corrupt or outdated data.

The coder task has been transitioned to `status: FAILED` and needs to be reworked to properly pass `section1Offset` into the extraction function.

---
*PR created automatically by Jules for task [15558151757017912203](https://jules.google.com/task/15558151757017912203) started by @szubster*