### PR TITLE
chore: QA reject task-276-304-gen3-trick-house-parser-impl

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -22,3 +22,8 @@ The implementer (`coder`) failed `task-121-219-gen3-tv-block-parser-retry-impl` 
 - Verified that `DataView` API is used exclusively in `src/engine/gen3/secretBase/parser.ts` for all read operations (e.g. `getUint32`, `getUint16`, `getUint8`).
 - Verified that all offsets, lengths, and bit locations are defined as reusable constants at the module level.
 - Verified that comprehensive unit tests are present, including checking for out-of-bounds reads throwing `The save file is corrupted or incomplete.` when catching `RangeError`.
+
+## 2026-07-11: Trick House Parser Rejection
+- **Date**: 2026-07-11
+- **Node**: task-276-304-gen3-trick-house-parser-impl
+- **Reason**: The developer failed to handle `RangeError` from the `DataView` API when checking for out-of-bounds reads. This is a critical requirement for parsers working with save file data to prevent crashes when dealing with corrupted or incomplete saves.

--- a/.foundry/tasks/task-276-304-gen3-trick-house-parser-impl.md
+++ b/.foundry/tasks/task-276-304-gen3-trick-house-parser-impl.md
@@ -2,7 +2,7 @@
 id: task-276-304-gen3-trick-house-parser-impl
 type: TASK
 title: Implement Gen 3 Trick House Parser Core Logic
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-06'
 updated_at: '2026-07-11'
@@ -15,8 +15,8 @@ tags:
   - gen3
   - mechanics
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Missing RangeError handling for DataView out-of-bounds reads'
 notes: ''
 ---
 
@@ -44,10 +44,10 @@ The specific offsets needed to implement this are defined in:
 - `.foundry/docs/knowledge_base/gen3_trick_house_offsets.md`
 
 ## Acceptance Criteria
-- [x] Module-level reusable constants are defined for all variables and flag offsets.
-- [x] A parsing utility or class is implemented to extract Trick House data from `SaveBlock1`.
-- [x] No inline magic numbers are used in the memory parsing logic.
-- [x] Proper extraction of Little-Endian 16-bit variables using `DataView.getUint16`.
+- [ ] Module-level reusable constants are defined for all variables and flag offsets.
+- [ ] A parsing utility or class is implemented to extract Trick House data from `SaveBlock1`.
+- [ ] No inline magic numbers are used in the memory parsing logic.
+- [ ] Proper extraction of Little-Endian 16-bit variables using `DataView.getUint16`.
 
 ## Review Contracts
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/.foundry/tasks/task-276-305-gen3-trick-house-parser-qa.md
+++ b/.foundry/tasks/task-276-305-gen3-trick-house-parser-qa.md
@@ -47,3 +47,6 @@ Validate the logic implemented for extracting Gen 3 Trick House progression stat
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
 - If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### QA Rejection
+- **Reason**: Implementation is missing a `try/catch` block for `RangeError` from the `DataView` API to properly handle out-of-bounds reads. Tests must also ensure that reading out-of-bounds throws an appropriate error, such as `The save file is corrupted or incomplete.`


### PR DESCRIPTION
QA Agent rejecting the implementation of the Gen 3 Trick House parser due to missing RangeError handling for DataView out-of-bounds reads. Marked target task as FAILED, updated its count, documented rejection in journal and QA task.

---
*PR created automatically by Jules for task [13317230494474928902](https://jules.google.com/task/13317230494474928902) started by @szubster*