### PR TITLE
feat(tasks): create blueprint tasks for parse-registered-numbers

### DIFF
--- a/.foundry/stories/story-116-283-parse-registered-numbers.md
+++ b/.foundry/stories/story-116-283-parse-registered-numbers.md
@@ -26,3 +26,5 @@ Parse the registered numbers list from the Generation 2 save file based on resea
 
 ## Acceptance Criteria
 - [ ] Implement parsing logic for Pokegear registered numbers.
+- [ ] task-283-312-parse-registered-numbers-impl
+- [ ] task-283-313-parse-registered-numbers-qa

--- a/.foundry/tasks/task-283-312-parse-registered-numbers-impl.md
+++ b/.foundry/tasks/task-283-312-parse-registered-numbers-impl.md
@@ -1,0 +1,40 @@
+---
+id: task-283-312-parse-registered-numbers-impl
+type: TASK
+title: Implement Gen 2 Pokegear Registered Numbers Parsing
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-116-283-parse-registered-numbers
+tags:
+  - feature
+  - gen2
+  - parser
+research_references:
+  - .foundry/docs/knowledge_base/engine/save_parsing/gen2_phone_mechanics.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 2 Pokegear Registered Numbers Parsing
+
+## Objective
+Implement the parsing logic for Generation 2 Pokegear registered numbers and state flags, strictly adhering to the established rules and constraints.
+
+## Constraints & Contract
+- **ADR 028 (Relative Offsets & Magic Numbers)**: You MUST explicitly define all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+- **Error Handling**: You MUST include explicit `try/catch` blocks handling `RangeError` exceptions for out-of-bounds reads, returning an appropriate error message like "The save file is corrupted or incomplete".
+- **Transient Failures**: If you experience a transient failure requiring retry during your task, you MUST update the node's YAML frontmatter to `status: FAILED` and provide a `rejection_reason`.
+- **Permanent Failures**: If you must abort or permanently fail this task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PRs**: If you submit an empty PR for a completed task (e.g., passthrough), you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Define module-level constants for `wPhoneList` (size 11), `wSwarmFlags`, `wDailyPhoneItemFlags`, `wDailyPhoneTimeOfDayFlags`, and `wSpecialPhoneCallID`.
+- [ ] Implement robust save file parsing logic using the DataView API to extract the Pokegear registered numbers.
+- [ ] Implement explicit `RangeError` handling with `try/catch` block for out-of-bounds reads returning "The save file is corrupted or incomplete".
+- [ ] Ensure all code passes linting, tests, and formatting checks before submission.

--- a/.foundry/tasks/task-283-313-parse-registered-numbers-qa.md
+++ b/.foundry/tasks/task-283-313-parse-registered-numbers-qa.md
@@ -1,0 +1,41 @@
+---
+id: task-283-313-parse-registered-numbers-qa
+type: TASK
+title: QA Gen 2 Pokegear Registered Numbers Parsing
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on:
+  - task-283-312-parse-registered-numbers-impl
+jules_session_id: null
+pr_number: null
+parent: story-116-283-parse-registered-numbers
+tags:
+  - qa
+  - gen2
+  - parser
+research_references:
+  - .foundry/docs/knowledge_base/engine/save_parsing/gen2_phone_mechanics.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 2 Pokegear Registered Numbers Parsing
+
+## Objective
+Verify the implementation of the Generation 2 Pokegear registered numbers parser against architectural guidelines and requirements.
+
+## Constraints & Contract
+- **ADR 028 Validation**: You MUST verify that the coder has explicitly defined all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level. Ensure there are NO inline magic numbers for memory operations.
+- **Error Handling Validation**: You MUST verify that the implementation includes explicit `try/catch` blocks handling `RangeError` exceptions for out-of-bounds reads.
+- **Transient Failures**: If you experience a transient failure requiring retry during your task, you MUST update the node's YAML frontmatter to `status: FAILED` and provide a `rejection_reason`.
+- **Permanent Failures**: If you must abort or permanently fail this task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Rejection Protocol**: If you reject the implementation, you MUST update the TARGET task's (`task-283-312-parse-registered-numbers-impl.md`) YAML frontmatter (`status: FAILED`, increment `rejection_count`, add `rejection_reason`) and uncheck its Acceptance Criteria. Do NOT modify your own QA task's YAML status; instead note it in the markdown and journal.
+
+## Acceptance Criteria
+- [ ] Verify ADR 028 compliance (no magic numbers, constants at module level).
+- [ ] Verify explicit `RangeError` handling.
+- [ ] Verify the parsing logic extracts `wPhoneList` correctly based on the docs.
+- [ ] Ensure the test suite passes.


### PR DESCRIPTION
Drafted technical blueprints (`TASK` nodes) for implementing and verifying the Generation 2 Pokegear registered numbers parser, based on `.foundry/stories/story-116-283-parse-registered-numbers.md` and `epic-055-116-pokegear-active-callers`. The tasks enforce ADR 028 (no inline magic numbers) and explicit RangeError handling.

---
*PR created automatically by Jules for task [16786219095155053341](https://jules.google.com/task/16786219095155053341) started by @szubster*