### PR TITLE
feat(gen3): implement mix record event payload extraction

### DIFF
--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -79,11 +79,13 @@ export interface Gen3PokeNews {
 export interface Gen3MixRecord {
   kind: number;
   active: boolean;
+  payload?: Uint8Array;
 }
 
 export interface Gen3TVShow {
   kind: number;
   active: boolean;
+  payload?: Uint8Array;
   itemOffset: number;
 }
 

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -473,8 +473,8 @@ describe('parseGen3MixRecords', () => {
     const result = parseGen3MixRecords(view, 0);
 
     expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({ kind: 22, active: true });
-    expect(result[1]).toEqual({ kind: 31, active: true });
+    expect(result[0]).toEqual({ kind: 22, active: true, payload: new Uint8Array(34) });
+    expect(result[1]).toEqual({ kind: 31, active: true, payload: new Uint8Array(34) });
   });
 
   it('should explicitly catch RangeError on out-of-bounds reads and throw a corrupted file error', () => {

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -103,6 +103,8 @@ const TV_SHOWS_COUNT = 25;
 const TVSHOW_STRUCT_SIZE = 36;
 const TV_SHOW_KIND_OFFSET = 0;
 const TV_SHOW_ACTIVE_OFFSET = 1;
+const TV_SHOW_PAYLOAD_OFFSET = 2;
+const TV_SHOW_PAYLOAD_LENGTH = 34;
 
 const TVGROUP_RECORD_MIX_START = 21;
 const TVGROUP_RECORD_MIX_END = 40;
@@ -563,16 +565,27 @@ export function parseGen3TVBlock(view: DataView, offset: number): Gen3TVShow[] {
  * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
  */
 export function parseGen3MixRecords(view: DataView, offset: number) {
-  const mixRecords = [];
-  const shows = parseGen3TVBlock(view, offset);
+  try {
+    const mixRecords = [];
+    const shows = parseGen3TVBlock(view, offset);
 
-  for (const show of shows) {
-    // Check if the show is a Mix Record event (21 to 40)
-    if (show.active && show.kind >= TVGROUP_RECORD_MIX_START && show.kind <= TVGROUP_RECORD_MIX_END) {
-      mixRecords.push({ kind: show.kind, active: show.active });
+    for (const show of shows) {
+      // Check if the show is a Mix Record event (21 to 40)
+      if (show.active && show.kind >= TVGROUP_RECORD_MIX_START && show.kind <= TVGROUP_RECORD_MIX_END) {
+        const payloadStart = show.itemOffset + TV_SHOW_PAYLOAD_OFFSET;
+        const payload = new Uint8Array(
+          view.buffer.slice(view.byteOffset + payloadStart, view.byteOffset + payloadStart + TV_SHOW_PAYLOAD_LENGTH),
+        );
+        mixRecords.push({ kind: show.kind, active: show.active, payload });
+      }
     }
+    return mixRecords;
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
   }
-  return mixRecords;
 }
 
 /**


### PR DESCRIPTION
This PR implements the extraction logic for Gen 3 Mix Record inherited events (TV shows) as specified in `task-288-304-gen3-mix-record-inherited-events-impl`.

### Implementation Details:
- Updated `Gen3MixRecord` in `src/engine/saveParser/parsers/common.ts` to include the `payload` as a `Uint8Array`. (Made it optional so `Gen3TVShow` is not strictly broken, then resolved locally inside the function).
- Defined constants in `src/engine/saveParser/parsers/gen3.ts` (`TV_SHOW_PAYLOAD_OFFSET` and `TV_SHOW_PAYLOAD_LENGTH`) to strictly adhere to the no-magic-number policy.
- Modified `parseGen3MixRecords` to extract the 34 bytes by utilizing `view.buffer.slice` wrapped within a `try/catch` to correctly intercept bounds issues and emit a corrupted file `Error`.
- Verified implementation and regression testing by supplementing `gen3.test.ts`.

All Acceptance Criteria from the task node have been manually checked off. All tests, including `pnpm check:fix`, pass.

---
*PR created automatically by Jules for task [9428336432462450616](https://jules.google.com/task/9428336432462450616) started by @szubster*