### PR TITLE
Create tasks for Pokegear Predictor Engine Logic

### DIFF
--- a/.foundry/stories/story-117-283-pokegear-predictor-engine.md
+++ b/.foundry/stories/story-117-283-pokegear-predictor-engine.md
@@ -29,4 +29,6 @@ Break down the implementation of the Pokegear Predictor logic into tasks.
 - Create tasks to implement the RNG mechanics and probability calculations based on research.
 
 ## Acceptance Criteria
-- [ ] Create tasks for the predictor engine logic
+- [x] Create tasks for the predictor engine logic
+- [ ] task-283-314-predictor-engine-logic-impl
+- [ ] task-283-315-predictor-engine-logic-qa

--- a/.foundry/tasks/task-283-314-predictor-engine-logic-impl.md
+++ b/.foundry/tasks/task-283-314-predictor-engine-logic-impl.md
@@ -1,0 +1,41 @@
+---
+id: task-283-314-predictor-engine-logic-impl
+type: TASK
+title: Implement Gen 2 Pokegear Predictor Engine Logic
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-117-283-pokegear-predictor-engine
+tags:
+  - feature
+  - gen2
+  - mechanics
+research_references:
+  - .foundry/docs/knowledge_base/engine/save_parsing/gen2_phone_mechanics.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 2 Pokegear Predictor Engine Logic
+
+## Objective
+Implement the Pokegear Predictor logic covering the RNG mechanics, probability calculations, and call triggers as defined by Generation 2 mechanics.
+
+## Constraints & Contract
+- **Architecture**: Your logic should be placed in `src/engine/saveParser/parsers/` or the appropriate predictor engine directory and correctly handle Gen 2 RNG algorithms.
+- **RNG Mechanics**: The implementation must include `CheckPhoneCall`, `ChooseRandomCaller`, and handle the cooling-off period/timer evaluation properly.
+- **Constants**: You MUST explicitly define all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+- **Transient Failures**: If you experience a transient failure requiring retry during your task, you MUST update the node's YAML frontmatter to `status: FAILED` and provide a `rejection_reason`.
+- **Permanent Failures**: If you must abort or permanently fail this task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PRs**: If you submit an empty PR for a completed task (e.g., passthrough), you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement the `CheckPhoneCall` probability checks (timer evaluation and 50% RNG trigger).
+- [ ] Implement `ChooseRandomCaller` to uniformly sample registered contacts available at the current time of day.
+- [ ] Define reusable constants for all associated bitmasks and magic numbers at the module level.
+- [ ] Ensure all code passes linting, tests, and formatting checks before submission.

--- a/.foundry/tasks/task-283-315-predictor-engine-logic-qa.md
+++ b/.foundry/tasks/task-283-315-predictor-engine-logic-qa.md
@@ -1,0 +1,43 @@
+---
+id: task-283-315-predictor-engine-logic-qa
+type: TASK
+title: Verify Gen 2 Pokegear Predictor Engine Logic
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on:
+  - .foundry/tasks/task-283-314-predictor-engine-logic-impl.md
+jules_session_id: null
+pr_number: null
+parent: story-117-283-pokegear-predictor-engine
+tags:
+  - feature
+  - gen2
+  - mechanics
+  - qa
+research_references:
+  - .foundry/docs/knowledge_base/engine/save_parsing/gen2_phone_mechanics.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Verify Gen 2 Pokegear Predictor Engine Logic
+
+## Objective
+Verify the implementation of the Pokegear Predictor engine logic against the Gen 2 mechanics requirements.
+
+## Constraints & Contract
+- **Architecture**: Validate that all RNG probability checks, `ChooseRandomCaller`, and timer evaluations function as described in the mechanics specification.
+- **Constants Validation**: Ensure that ALL memory offsets, lengths, bit locations, and shifts have been defined as reusable module-level constants. If inline magic numbers are found in the implementation, you MUST reject the target task.
+- **Rejection Protocol**: If you reject the implementation, you MUST update the TARGET task's YAML frontmatter (`status: FAILED`, increment `rejection_count`, add `rejection_reason`) and uncheck its Acceptance Criteria. Do NOT modify this QA task's YAML; instead, note the failure in its markdown body and document it in your QA journal.
+- **Transient Failures**: If you experience a transient failure requiring retry during your task, you MUST update the node's YAML frontmatter to `status: FAILED` and provide a `rejection_reason`.
+- **Permanent Failures**: If you must abort or permanently fail this task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PRs**: If you submit an empty PR for a completed task (e.g., passthrough), you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Review code for correct implementation of `CheckPhoneCall` probability checks (timer evaluation and 50% RNG trigger).
+- [ ] Review code for correct implementation of `ChooseRandomCaller` to sample available contacts based on time of day.
+- [ ] Ensure that no magic numbers are used and all required constants are defined at the module level.
+- [ ] Run all relevant unit tests and end-to-end tests to verify functional correctness.


### PR DESCRIPTION
This PR creates the task blueprints for implementing and testing the Pokegear Predictor logic.

- Created `task-283-314-predictor-engine-logic-impl` for the Coder persona to handle RNG mechanics and probability calculations.
- Created `task-283-315-predictor-engine-logic-qa` for the QA persona to verify the logic and explicitly check for missing module-level constants.
- Appended task references and checked off the requirement criteria in the parent `story-117-283-pokegear-predictor-engine` without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [747662263206873469](https://jules.google.com/task/747662263206873469) started by @szubster*