### PR TITLE
Complete Graveyard Box State and Logic Implementation

### DIFF
--- a/.foundry/tasks/task-270-263-graveyard-box-logic-impl.md
+++ b/.foundry/tasks/task-270-263-graveyard-box-logic-impl.md
@@ -25,9 +25,9 @@ notes: ''
 Implement backend state and calculation logic for identifying Pokémon in the designated Graveyard Box as permanently dead.
 
 ## Contract / Acceptance Criteria
-- [ ] Add a backend configuration/state for specifying a "Graveyard Box" (e.g. integer `boxNumber`).
-- [ ] Implement logic so that any Pokémon located in the designated Graveyard Box is evaluated as "dead" (or flagged accordingly), regardless of its HP value.
-- [ ] All new state management patterns should align with current application architecture.
+- [x] Add a backend configuration/state for specifying a "Graveyard Box" (e.g. integer `boxNumber`).
+- [x] Implement logic so that any Pokémon located in the designated Graveyard Box is evaluated as "dead" (or flagged accordingly), regardless of its HP value.
+- [x] All new state management patterns should align with current application architecture.
 
 ## Instructions & Reminders for Coder
 - **Transient Failures:** If you experience a transient failure requiring a retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Completed `task-270-263-graveyard-box-logic-impl`. 
The functionality for identifying Pokémon in a designated Graveyard Box as permanently dead is already fully implemented within `src/engine/nuzlocke/tracker.ts` (via `getGraveyardPokemon`) and `src/store.ts` (via `nuzlockeGraveyardBox`).
Checked off the acceptance criteria checkboxes in the markdown file and submitted as an empty PR as per the project's policy.

---
*PR created automatically by Jules for task [17697720313726735044](https://jules.google.com/task/17697720313726735044) started by @szubster*