### PR TITLE
Update task-270-264-graveyard-box-logic-qa acceptance criteria

### DIFF
--- a/.foundry/tasks/task-270-264-graveyard-box-logic-qa.md
+++ b/.foundry/tasks/task-270-264-graveyard-box-logic-qa.md
@@ -26,9 +26,9 @@ notes: ''
 Verify the backend state and calculation logic for identifying Pokémon in the designated Graveyard Box as permanently dead.
 
 ## Contract / Acceptance Criteria
-- [ ] Verify that there is a backend configuration/state for specifying a "Graveyard Box".
-- [ ] Verify the logic correctly marks any Pokémon in the Graveyard Box as dead, regardless of HP.
-- [ ] Ensure all relevant tests pass.
+- [x] Verify that there is a backend configuration/state for specifying a "Graveyard Box".
+- [x] Verify the logic correctly marks any Pokémon in the Graveyard Box as dead, regardless of HP.
+- [x] Ensure all relevant tests pass.
 
 ## Instructions & Reminders for QA
 - **Transient Failures:** If you experience a transient failure requiring a retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Checked off acceptance criteria for task-270-264-graveyard-box-logic-qa. The underlying code implementation in `src/engine/nuzlocke/tracker.ts` properly uses the `graveyardBox` to mark Pokémon dead, and `src/store.ts` correctly manages the state for it. The logic was verified as correct through reading code and running the full test suite.

---
*PR created automatically by Jules for task [6639683274573177621](https://jules.google.com/task/6639683274573177621) started by @szubster*