### PR TITLE
chore: complete task-288-304-gen3-mix-record-inherited-events-impl

### DIFF
--- a/.foundry/tasks/task-288-304-gen3-mix-record-inherited-events-impl.md
+++ b/.foundry/tasks/task-288-304-gen3-mix-record-inherited-events-impl.md
@@ -61,7 +61,7 @@ Mix Record shows are those where the `kind` ID is between `21` and `40` (inclusi
    - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Module-level constants are defined for `TVShow` offsets, lengths, and kind ID bounds.
-- [ ] Logic correctly parses the `TVShow` array from `SaveBlock1` at offset `0x27CC`.
-- [ ] Active Mix Record shows (kinds 21-40) are successfully isolated and extracted.
-- [ ] No inline magic numbers are used in the parsing implementation.
+- [x] Module-level constants are defined for `TVShow` offsets, lengths, and kind ID bounds.
+- [x] Logic correctly parses the `TVShow` array from `SaveBlock1` at offset `0x27CC`.
+- [x] Active Mix Record shows (kinds 21-40) are successfully isolated and extracted.
+- [x] No inline magic numbers are used in the parsing implementation.


### PR DESCRIPTION
Checked off the acceptance criteria for Extract Gen 3 Mix Record Inherited Events Implementation as the logic is already implemented.

---
*PR created automatically by Jules for task [18259113806749011983](https://jules.google.com/task/18259113806749011983) started by @szubster*