### PR TITLE
Draft implementation and QA blueprints for swarm and item caller filtering

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -178,3 +178,6 @@ When decomposing a STORY into TASK nodes, strictly follow the Intelligent Verifi
 
 ## 2026-07-11: RangeError Handling
 When drafting save parser blueprints using DataView, explicitly mandate catching RangeError and throwing 'The save file is corrupted or incomplete.' to prevent QA rejections.
+
+## 2026-07-11: Filter Swarm & Item Calls
+Drafted technical blueprints (`task-286-314-filter-swarm-item-calls-impl` and `task-286-315-filter-swarm-item-calls-qa`) to implement filtering of active Gen 2 Pokegear callers based on `wSwarmFlags`, `wDailyPhoneItemFlags`, and `wDailyPhoneTimeOfDayFlags`. Due to the complexity and risk of parsing memory states directly, I applied the Intelligent Verification Protocol to require a dedicated QA verification pass. Explicit architectural constraints forbidding the use of inline magic numbers for memory offsets were mandated in both blueprints to comply with ADR 028.

--- a/.foundry/stories/story-118-286-filter-swarm-item-calls.md
+++ b/.foundry/stories/story-118-286-filter-swarm-item-calls.md
@@ -30,3 +30,5 @@ Filter the list of active callers to isolate NPCs that offer rare items or swarm
 
 ## Acceptance Criteria
 - [ ] Implement data logic for identifying high-value Pokegear calls
+- [ ] task-286-314-filter-swarm-item-calls-impl
+- [ ] task-286-315-filter-swarm-item-calls-qa

--- a/.foundry/tasks/task-286-314-filter-swarm-item-calls-impl.md
+++ b/.foundry/tasks/task-286-314-filter-swarm-item-calls-impl.md
@@ -1,0 +1,43 @@
+---
+id: task-286-314-filter-swarm-item-calls-impl
+type: TASK
+title: Implement High-Value Pokegear Call Filtering
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-118-286-filter-swarm-item-calls
+tags:
+  - feature
+  - gen2
+  - data
+  - implement
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement High-Value Pokegear Call Filtering
+
+## Objective
+Implement data logic to identify and filter high-value Pokegear calls in Gen 2 (Gold, Silver, Crystal), specifically targeting swarm and item-giving callers, based on known game logic and state flags.
+
+## Context & Rules
+This task requires understanding of Gen 2 phone mechanics:
+- `wSwarmFlags` (1 byte): Active swarms.
+- `wDailyPhoneItemFlags` / `wDailyPhoneTimeOfDayFlags` (4 bytes each): Manage item-giving states.
+
+### Crucial Architectural Constraints & Reminders (Must Read!)
+- **NO INLINE MAGIC NUMBERS:** When extracting dynamic save blocks or parsing flags, all memory offsets, lengths, bit locations, and shifts **MUST be defined as reusable constants at the module level.** You are strictly forbidden from using inline magic numbers.
+- **Handling Failures:** If you experience a transient failure requiring a retry, update this YAML frontmatter to `status: FAILED` with a clear `rejection_reason`. If the task is permanently impossible or max rejections are reached, update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Policy:** If the required logic is already present or you must submit an empty PR, you **MUST check off all Acceptance Criteria checkboxes** below before submitting. Submitting an empty PR with unchecked boxes violates ADR 007/009 and will result in immediate rejection.
+
+## Acceptance Criteria
+- [ ] Create or update the logic layer to identify callers associated with swarms.
+- [ ] Create or update the logic layer to identify callers that offer rare items.
+- [ ] Implement a filtering mechanism or add a flag to the data structure that distinguishes these "high-value" calls from standard calls.
+- [ ] Ensure all necessary flags and bitmasks (`wSwarmFlags`, `wDailyPhoneItemFlags`, etc.) are mapped correctly without using magic numbers in inline logic.

--- a/.foundry/tasks/task-286-315-filter-swarm-item-calls-qa.md
+++ b/.foundry/tasks/task-286-315-filter-swarm-item-calls-qa.md
@@ -1,0 +1,42 @@
+---
+id: task-286-315-filter-swarm-item-calls-qa
+type: TASK
+title: QA High-Value Pokegear Call Filtering
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-11'
+updated_at: '2026-07-11'
+depends_on:
+  - task-286-314-filter-swarm-item-calls-impl
+jules_session_id: null
+pr_number: null
+parent: story-118-286-filter-swarm-item-calls
+tags:
+  - feature
+  - gen2
+  - data
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA High-Value Pokegear Call Filtering
+
+## Objective
+Verify the implementation of the high-value Pokegear call filtering logic in Gen 2, ensuring it correctly identifies swarm and item-giving callers and strictly adheres to architectural guidelines.
+
+## Context & Rules
+This task follows the implementation of `task-286-314-filter-swarm-item-calls-impl`. The implementation must correctly map `wSwarmFlags`, `wDailyPhoneItemFlags`, and `wDailyPhoneTimeOfDayFlags`.
+
+### Crucial Architectural Enforcement (Must Read!)
+- **REJECT INLINE MAGIC NUMBERS:** You are required to strictly enforce the rule against inline magic numbers. All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. **If you find any magic numbers in the implemented logic, you MUST reject the PR.**
+- **Handling Failures/Rejections:** If you must reject the implementation, update the **TARGET task's** (the `impl` task) YAML frontmatter to `status: FAILED`, increment its `rejection_count`, add a `rejection_reason`, and uncheck its Acceptance Criteria. **DO NOT** modify this QA task's YAML. Instead, note the failure in this markdown body and document it in `.foundry/journals/qa.md`.
+- **Empty PR Policy:** If you verify the implementation is correct and must submit an empty PR to transition this node, you **MUST check off all Acceptance Criteria checkboxes** below before submitting.
+
+## Acceptance Criteria
+- [ ] Verify that logic correctly identifies swarm-related callers based on `wSwarmFlags`.
+- [ ] Verify that logic correctly identifies item-giving callers based on `wDailyPhoneItemFlags`.
+- [ ] Verify that a filtering mechanism or flag correctly distinguishes high-value calls.
+- [ ] **ARCHITECTURAL CHECK:** Verify that NO inline magic numbers are used for memory offsets, lengths, or bitwise operations. All such values must be extracted into module-level constants.


### PR DESCRIPTION
- Created implementation task blueprint for coder persona (`task-286-314-filter-swarm-item-calls-impl`).
- Created QA task blueprint for qa persona (`task-286-315-filter-swarm-item-calls-qa`).
- Updated parent story node (`story-118-286-filter-swarm-item-calls`) with unchecked task checkboxes.
- Updated `.foundry/journals/tech_lead.md` to document the breakdown and architectural constraints.

---
*PR created automatically by Jules for task [6440739727327696486](https://jules.google.com/task/6440739727327696486) started by @szubster*