### PR TITLE
fix: implement Shiny Carrier UI Badge with ADR 008 aesthetic

### DIFF
--- a/.foundry/tasks/task-253-260-shiny-carrier-ui-badge-impl.md
+++ b/.foundry/tasks/task-253-260-shiny-carrier-ui-badge-impl.md
@@ -33,9 +33,9 @@ Implement a distinct UI badge/indicator for "Shiny Carrier" Pokémon in PC boxes
 - Ensure the visual distinction between Shiny Carriers and actual Shiny Pokémon is clear.
 
 ## Acceptance Criteria
-- [ ] Badge component implemented and styled correctly according to ADR 008.
-- [ ] Badge integrated into PC Box view.
-- [ ] Badge integrated into Pokémon Detailed view.
+- [x] Badge component implemented and styled correctly according to ADR 008.
+- [x] Badge integrated into PC Box view.
+- [x] Badge integrated into Pokémon Detailed view.
 
 ## Reminders
 - If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { AlertCircle, CheckCircle2, Monitor, Sparkles, X } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Monitor, X } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { dexDataLoader } from '../db/DexDataLoader';
 import { POKE_VERSION_MAP } from '../db/schema';
@@ -18,6 +18,7 @@ import { PokemonLocations } from './pokemon/details/PokemonLocations';
 import { PokemonSprite } from './pokemon/PokemonSprite';
 import { UnownDexPanel } from './pokemon/unown/UnownDexPanel';
 import { ScanlineOverlay } from './ScanlineOverlay';
+import { ShinyBadge } from './ShinyBadge';
 import { TacticalIconButton } from './TacticalIconButton';
 import { TacticalModal } from './TacticalModal';
 
@@ -229,15 +230,7 @@ export function PokemonDetails({
               />
             </div>
 
-            {isShiny ? (
-              <div className="absolute -top-3 -right-3 z-20 animate-[pulse_3s_ease-in-out_infinite] rounded-none border border-amber-500/50 bg-amber-500/20 p-2 text-amber-400 shadow-[0_0_20px_rgba(245,158,11,0.5)] backdrop-blur-sm">
-                <Sparkles size={18} />
-              </div>
-            ) : isShinyCarrier ? (
-              <div className="absolute -top-3 -right-3 z-20 animate-[pulse_3s_ease-in-out_infinite] rounded-none border border-cyan-500/50 border-dashed bg-cyan-500/20 p-2 text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.5)] backdrop-blur-sm">
-                <Sparkles size={18} />
-              </div>
-            ) : null}
+            <ShinyBadge isShiny={isShiny} isShinyCarrier={isShinyCarrier} size="md" />
           </div>
 
           <div className="w-full text-center sm:text-left">

--- a/src/components/ShinyBadge.tsx
+++ b/src/components/ShinyBadge.tsx
@@ -1,0 +1,32 @@
+import { Sparkles } from 'lucide-react';
+
+interface ShinyBadgeProps {
+  isShiny: boolean;
+  isShinyCarrier: boolean;
+  size?: 'sm' | 'md';
+}
+
+export function ShinyBadge({ isShiny, isShinyCarrier, size = 'sm' }: ShinyBadgeProps) {
+  if (!isShiny && !isShinyCarrier) return null;
+
+  const iconSize = size === 'md' ? 18 : 14;
+  const padding = size === 'md' ? 'p-2' : 'p-1';
+
+  if (isShiny) {
+    return (
+      <div
+        className={`absolute -top-3 -right-3 z-20 animate-[pulse_3s_ease-in-out_infinite] rounded-none border border-amber-500/50 bg-amber-500/20 ${padding} text-amber-400 shadow-[0_0_20px_rgba(245,158,11,0.5)] backdrop-blur-sm`}
+      >
+        <Sparkles size={iconSize} className="drop-shadow-sm" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`absolute -top-3 -right-3 z-20 animate-[pulse_3s_ease-in-out_infinite] rounded-none border border-cyan-500/50 border-dashed bg-cyan-500/20 ${padding} text-cyan-400 shadow-[0_0_20px_rgba(34,211,238,0.5)] backdrop-blur-sm`}
+    >
+      <Sparkles size={iconSize} className="drop-shadow-sm" />
+    </div>
+  );
+}

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from '@tanstack/react-router';
-import { Skull, Sparkles } from 'lucide-react';
+import { Skull } from 'lucide-react';
 import React from 'react';
 import type { PokemonInstance } from '../engine/saveParser/index';
 import { useStore } from '../store';
@@ -7,6 +7,7 @@ import { getGenerationConfig } from '../utils/generationConfig';
 import { getTimeCapsuleValidation } from '../utils/timeCapsule';
 import { CapacitySegmentedBar } from './CapacitySegmentedBar';
 import { PokemonSprite } from './pokemon/PokemonSprite';
+import { ShinyBadge } from './ShinyBadge';
 import { TacticalBadge } from './TacticalBadge';
 import { TacticalCard } from './TacticalCard';
 import { TacticalPanel } from './TacticalPanel';
@@ -71,11 +72,7 @@ const StorageCard = React.memo(
         )}
         <div className="absolute top-3 left-3 font-bold font-mono text-[10px] text-zinc-600">LV.{p.level}</div>
         <div className="absolute top-3 right-3 z-10 flex flex-col items-end gap-1.5">
-          {p.isShiny ? (
-            <Sparkles size={14} className="text-amber-400 drop-shadow-sm" />
-          ) : p.isShinyCarrier ? (
-            <Sparkles size={14} className="text-cyan-400 drop-shadow-sm" />
-          ) : null}
+          <ShinyBadge isShiny={p.isShiny || false} isShinyCarrier={p.isShinyCarrier || false} size="sm" />
           {p.otName && (
             <TacticalBadge variant="zinc" className="max-w-[60px] truncate px-1.5 py-0.5 font-mono">
               {p.otName}


### PR DESCRIPTION
This PR implements a distinct UI badge indicator for Shiny Carrier Pokemon that adheres to the tactical hardware aesthetic guidelines in ADR 008.

- Created a reusable `ShinyBadge` component to prevent duplicate styles.
- Updated `PokemonDetails` to use the badge for detailed views.
- Updated `StorageGrid` to use the badge in PC Boxes.
- Ensured `border-dashed` and `rounded-none` styling was applied properly.

---
*PR created automatically by Jules for task [4601125719641070841](https://jules.google.com/task/4601125719641070841) started by @szubster*