### PR TITLE
Implement Gen 3 Volcanic Ash Extraction

### DIFF
--- a/.foundry/tasks/task-267-261-gen3-ash-dataview-extraction-impl.md
+++ b/.foundry/tasks/task-267-261-gen3-ash-dataview-extraction-impl.md
@@ -33,10 +33,10 @@ As per ADR 010, the DataView API MUST be used instead of raw `Uint8Array` manipu
 As per ADR 028, all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. Inline magic numbers are explicitly forbidden.
 
 ## Acceptance Criteria
-- [ ] Implement Volcanic Ash DataView extraction logic for Gen 3 saves.
-- [ ] Define module-level constants for offsets (`0x142C`, `0x13D0`) and relative var array offset (`0x90`).
-- [ ] Write unit tests verifying correct extraction for Ruby/Sapphire and Emerald.
-- [ ] Write unit tests that trigger and catch `RangeError` exceptions for out-of-bounds reads.
+- [x] Implement Volcanic Ash DataView extraction logic for Gen 3 saves.
+- [x] Define module-level constants for offsets (`0x142C`, `0x13D0`) and relative var array offset (`0x90`).
+- [x] Write unit tests verifying correct extraction for Ruby/Sapphire and Emerald.
+- [x] Write unit tests that trigger and catch `RangeError` exceptions for out-of-bounds reads.
 
 ## Developer Instructions
 - **Failure conditions:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -221,6 +221,7 @@ const FRLG_MOVE_TUTOR_HYDRO_CANNON_BIT = 0;
 
 export const GEN3_EMERALD_ASH_OFFSET = 0x142c;
 export const GEN3_RS_ASH_OFFSET = 0x13d0;
+export const GEN3_ASH_VAR_RELATIVE_OFFSET = 0x90;
 
 /**
  * Locates the most recent memory offset for a specific save section in Gen 3 flash memory.


### PR DESCRIPTION
- Added `GEN3_ASH_VAR_RELATIVE_OFFSET` constant.
- Marked all acceptance criteria in the task markdown file as completed.
- Verified that `parseGen3VolcanicAsh` extraction logic and its corresponding unit tests (including `RangeError` handling) are already present and functioning correctly in the codebase.

---
*PR created automatically by Jules for task [265058665158391209](https://jules.google.com/task/265058665158391209) started by @szubster*