### PR TITLE
Document SaveHistoryDB IndexedDB Schema

### DIFF
--- a/.foundry/docs/knowledge_base/db/save_history_schema.md
+++ b/.foundry/docs/knowledge_base/db/save_history_schema.md
@@ -1,0 +1,32 @@
+# SaveHistoryDB IndexedDB Schema
+
+## Context
+The `SaveHistoryDB` is used to store Pokemon save history, including raw save files, metadata, and indexes, to allow users to view, manage, and extract data from their save history.
+
+## Configuration
+The database configuration is defined in `src/db/schema.ts` as `SAVE_HISTORY_DB_CONFIG`.
+
+- **Name**: `SaveHistoryDB`
+- **Version**: 1
+
+## Object Stores
+
+The `SaveHistoryDB` contains three object stores, as defined by `SAVE_HISTORY_DB_CONFIG.STORES` and strictly typed by `SaveHistoryDBSchema`.
+
+### 1. `saves`
+Stores the raw binary save file data.
+
+- **Key**: `string` (Typically a generated unique ID or filename)
+- **Value**: `Uint8Array` (The raw binary save data)
+
+### 2. `metadata`
+Stores metadata associated with each save file (e.g., trainer name, play time, save date, game version).
+
+- **Key**: `string` (References the corresponding key in the `saves` store)
+- **Value**: `Record<string, unknown>` (A flexible object containing the metadata properties)
+
+### 3. `indexes`
+Stores indexing data used to quickly search, filter, or categorize saves without needing to parse the raw data or metadata.
+
+- **Key**: `string` (References the corresponding key in the `saves` store)
+- **Value**: `Record<string, unknown>` (A flexible object containing index properties)

--- a/.foundry/tasks/task-268-284-document-indexeddb-schema-impl.md
+++ b/.foundry/tasks/task-268-284-document-indexeddb-schema-impl.md
@@ -26,8 +26,8 @@ notes: ''
 The IndexedDB schema for `SaveHistoryDB` has been implemented in `src/db/schema.ts`. We need to document this schema in the knowledge base.
 
 ## Acceptance Criteria
-- [ ] Create a new documentation file or update an existing one under `.foundry/docs/knowledge_base/db/` to describe the `SaveHistoryDB` schema. It should detail the database name, version, and the three object stores (`saves`, `metadata`, `indexes`) as defined in `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema`.
-- [ ] The coder is responsible for self-verifying these changes by ensuring the markdown is properly formatted.
+- [x] Create a new documentation file or update an existing one under `.foundry/docs/knowledge_base/db/` to describe the `SaveHistoryDB` schema. It should detail the database name, version, and the three object stores (`saves`, `metadata`, `indexes`) as defined in `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema`.
+- [x] The coder is responsible for self-verifying these changes by ensuring the markdown is properly formatted.
 
 ## Rules
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Added `.foundry/docs/knowledge_base/db/save_history_schema.md` to document the `SaveHistoryDB` IndexedDB schema, and marked the acceptance criteria in `task-268-284-document-indexeddb-schema-impl.md` as completed.

---
*PR created automatically by Jules for task [9402239597968558786](https://jules.google.com/task/9402239597968558786) started by @szubster*