### PR TITLE
🖼️ Canvas: Tactical Sheen Display Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -270,3 +270,9 @@
 **Outcome:** Accepted
 **Why:** Transforms a simple collectible tracker into an active intelligence deciphering interface, perfectly aligning with the established specialized hardware/snooping motif.
 **Pattern:** Elevate simple collection grids (like Unown forms or items) into active "Encryption/Decryption Matrices" by wrapping them in `TacticalPanel`, utilizing data pipe visuals, and adding strict uppercase bracketed telemetry copy to reinforce the tactical intelligence readout aesthetic.
+
+## 2026-07-12 - [Accepted] - 🖼️ Canvas: Tactical Sheen Display Redesign
+**What:** Redesigned the `ContestSheenDisplay` component to replace the generic continuous progress bar with a segmented tactical display mimicking a low-resolution CRT. Also updated labels to use bracketed monospaced telemetry fonts (e.g., `[ SHEEN ]`).
+**Outcome:** Accepted
+**Why:** Continuous smooth progress bars break the "specialized hardware" illusion, whereas segmented terminal bars effectively mimic a rugged, low-resolution device.
+**Pattern:** Avoid continuous progress bars. Consistently use segmented bars built from distinct block elements for statistics to reinforce the hardware simulation.

--- a/src/components/pokemon/details/ContestSheenDisplay.tsx
+++ b/src/components/pokemon/details/ContestSheenDisplay.tsx
@@ -9,25 +9,49 @@ interface ContestSheenDisplayProps {
 
 export const ContestSheenDisplay: React.FC<ContestSheenDisplayProps> = ({ sheen, className }) => {
   const maxSheen = 255;
-  const percentage = Math.min(Math.max((sheen / maxSheen) * 100, 0), 100);
   const isMaxed = sheen >= maxSheen;
+  const segments = 15;
 
   return (
     <TacticalPanel
       variant={isMaxed ? 'emerald' : 'blue'}
-      className={cn('flex flex-col gap-2 p-4 font-mono', className)}
+      className={cn(
+        '!p-4 relative flex flex-col gap-1.5 border-zinc-800 border-l border-dashed pl-3 transition-colors hover:border-zinc-500',
+        className,
+      )}
     >
-      <div className="flex items-center justify-between font-semibold text-xs uppercase tracking-wider">
-        <span className="text-zinc-400">Sheen</span>
-        <span className={cn(isMaxed ? 'text-emerald-400' : 'text-zinc-300')}>
-          {sheen} / {maxSheen} {isMaxed && '(MAX)'}
+      <div className="tactical-text flex justify-between text-[9px] text-zinc-400">
+        <span className="font-black uppercase tracking-widest">[ SHEEN ]</span>
+        <span className={cn('font-mono', isMaxed ? 'text-emerald-400' : 'text-zinc-500')}>
+          {sheen} {isMaxed && '(MAX)'}
         </span>
       </div>
-      <div className="h-2 w-full rounded-none border border-zinc-700 border-dashed bg-zinc-800/50">
-        <div
-          className={cn('h-full rounded-none transition-all duration-500', isMaxed ? 'bg-emerald-500' : 'bg-blue-500')}
-          style={{ width: `${percentage}%` }}
-        />
+      {/* oxlint-disable jsx-a11y/prefer-tag-over-role */}
+      <div
+        className="flex h-2 w-full gap-px bg-black p-px"
+        role="progressbar"
+        aria-valuenow={sheen}
+        aria-valuemax={maxSheen}
+      >
+        {Array.from({ length: segments }).map((_, i) => {
+          const ratio = sheen / maxSheen;
+          const threshold = (i + 1) / segments;
+          const isActive = ratio >= threshold;
+
+          const colorClass = isMaxed
+            ? 'bg-emerald-500 shadow-[0_0_5px_rgba(16,185,129,0.8)]'
+            : 'bg-blue-500 shadow-[0_0_5px_rgba(59,130,246,0.8)]';
+
+          const emptyColorClass = isMaxed ? 'bg-emerald-950/30' : 'bg-blue-950/30';
+
+          return (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: Array index is stable and safe here
+              key={`sheen-segment-${i}`}
+              className={cn('h-full flex-1', isActive ? colorClass : emptyColorClass)}
+            />
+          );
+        })}
       </div>
     </TacticalPanel>
   );

--- a/src/components/pokemon/details/__tests__/ContestSheenDisplay.test.tsx
+++ b/src/components/pokemon/details/__tests__/ContestSheenDisplay.test.tsx
@@ -8,20 +8,20 @@ describe('ContestSheenDisplay', () => {
     await render(<ContestSheenDisplay sheen={0} />);
 
     await expect.element(page.getByText('Sheen')).toBeVisible();
-    await expect.element(page.getByText('0 / 255')).toBeVisible();
+    await expect.element(page.getByText('0')).toBeVisible();
   });
 
   it('renders correctly with max sheen', async () => {
     await render(<ContestSheenDisplay sheen={255} />);
 
     await expect.element(page.getByText('Sheen')).toBeVisible();
-    await expect.element(page.getByText('255 / 255 (MAX)')).toBeVisible();
+    await expect.element(page.getByText('255 (MAX)')).toBeVisible();
   });
 
   it('renders correctly with partial sheen', async () => {
     await render(<ContestSheenDisplay sheen={127} />);
 
     await expect.element(page.getByText('Sheen')).toBeVisible();
-    await expect.element(page.getByText('127 / 255')).toBeVisible();
+    await expect.element(page.getByText('127')).toBeVisible();
   });
 });

--- a/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
+++ b/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
@@ -145,6 +145,6 @@ describe('PokemonCaughtDetails', () => {
 
     await expect.element(page.getByText('SYS.CONTEST_STATS')).toBeInTheDocument();
     await expect.element(page.getByText('Sheen')).toBeInTheDocument();
-    await expect.element(page.getByText('200 / 255')).toBeInTheDocument();
+    await expect.element(page.getByText('200')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Redesigned the `ContestSheenDisplay` component into a segmented tactical CRT-style display, matching the project's specialized hardware aesthetic. Continuous progress bars break the illusion, so it now uses individual block segments with precise bracketed labels.

Journal updated in `.jules/canvas.md`. Tests verified successfully. Playwright visualization confirms correct rendering across states.

---
*PR created automatically by Jules for task [1829199035503024703](https://jules.google.com/task/1829199035503024703) started by @szubster*