### PR TITLE
🧭 Strategist: prompt improvement - Enforce Gen 3 relative memory offsets

### DIFF
--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -19,6 +19,8 @@ When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.t
 ## Save File Parsing & Magic Numbers
 When implementing save file parsing or data definitions, you MUST explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Strictly avoid using inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions. This ensures robustness against version-specific shifts and prevents brittle code. Furthermore, when using the `DataView` API for array bounds checking or extraction limits (e.g., max record counts), you MUST NOT use inline magic numbers; these bounds must also be defined as reusable constants at the module level.
 
+When writing Gen 3 save block extraction functions, you must pass and utilize the resolved section offset (e.g., `section1Offset` or `section2Offset`) to calculate relative memory offsets, rather than using absolute hardcoded offsets, to properly support the Gen 3 A/B bank flash memory architecture.
+
 When parsing bitwise blocks (like event flag arrays) using the `DataView` API, you must explicitly map the specific bit offsets corresponding to target events. Just extracting the array is insufficient; explicitly identifying the individual bit offsets is required for downstream consumption.
 
 ## UI Aesthetic Constraints (ADR 008)

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -17,7 +17,7 @@ Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/001-the-f
 
 ## Responsibilities
 
-1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria. You MUST explicitly reject tasks that use inline magic numbers (e.g., `0x2dd6`, `>> 4`) for save file data extraction instead of defined reusable constants at the module level. You MUST ensure that any tasks involving parsers for save files properly catch `RangeError` from the `DataView` API when checking for out-of-bounds reads.
+1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria. You MUST explicitly reject tasks that use inline magic numbers (e.g., `0x2dd6`, `>> 4`) for save file data extraction instead of defined reusable constants at the module level. You MUST also explicitly reject tasks that use absolute memory offsets (e.g., `0x2dd6`) for Gen 3 dynamic save block extraction instead of calculating relative offsets from the resolved section offset (e.g., `section1Offset`). You MUST ensure that any tasks involving parsers for save files properly catch `RangeError` from the `DataView` API when checking for out-of-bounds reads.
 2. **Review**: Ensure implemented code follows architectural constraints (especially ADR 001).
 3. **Approval/Rejection**: If the implementation is valid, approve it. If not, detail what is missing or incorrect according to the contract and architecture.
 4. **Specify Results**: Explicitly specify the results of your validation work. Depending on the scope and need for further analysis, this output can include new tests, documentation updates, or the creation of new tasks, stories, PRDs, or ideas.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -12,6 +12,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
     - If they must abort or permanently fail a task (impossible or max rejections reached), they MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
     - If they submit an empty PR for a completed task, they MUST check off all Acceptance Criteria checkboxes before submitting.
     - When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
+    - When drafting blueprints for Gen 3 save file parsing, explicitly require that the Coder uses the resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
 5.  **Intelligent Verification Protocol**: Intelligently decide when a STORY requires a separate QA verification task:
     - If a story involves complex logic or risk, create a matching TASK for the `qa` persona to verify the `coder`'s work.
     - If simple/low-risk, designate the `coder` to self-verify (documented in the task journal).

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -363,3 +363,9 @@
 **Outcome:** Merged
 **Why:** The `qa.md` journal recorded a persistent failure pattern (`2026-06-30: Magic Numbers in Gen 3 Parser Retry`) where the `coder` repeatedly ignored the architectural constraint against using inline magic numbers for array bounds checking in save file parsers (like `parseGen3MixRecords`), despite explicit task instructions and previous rejections.
 **Pattern:** Codify specific, recurring architectural violations (like ignoring module-level constant requirements for DataView extraction limits) directly into the implementer's prompt (`coder.md`) to prevent brittle code and repetitive QA rejections.
+
+## 2026-07-27 - [Accepted] - Prompt improvement - Enforce Gen 3 relative memory offsets
+**Type:** Prompt improvement
+**Outcome:** Accepted
+**Why:** The `qa.md` journal recorded a failure pattern where the coder implemented Gen 3 save file extraction using absolute memory offsets (e.g., `0x2dd6`) instead of calculating them relative to the resolved section offset (e.g., `section1Offset`). In Gen 3, the A/B bank flash memory architecture requires relative offsets.
+**Pattern:** Codify architectural constraints (like relative memory offsets for Gen 3 A/B bank rotation) explicitly in the prompts of all involved personas (`coder`, `qa`, and `tech_lead`) to prevent recurring QA rejections and ensure correct implementation.


### PR DESCRIPTION
**Proposal**: Update `coder`, `qa`, and `tech_lead` prompts to explicitly enforce using relative memory offsets (calculated from the resolved section offset) rather than absolute memory offsets when extracting dynamic save blocks for Generation 3.
**Justification**: Generation 3 uses an A/B bank rotation system for flash memory. Hardcoding absolute offsets (like `0x2dd6`) assumes the data is always in a specific bank, which breaks if the data is currently residing in the alternate bank. Using the resolved section offset (like `section1Offset`) dynamically calculates the correct relative position.
**Evidence**: The `.foundry/journals/qa.md` journal recorded a failure pattern (`2026-07-11 - Feebas Extraction Failed`) where the coder implemented Gen 3 save file extraction using absolute memory offsets instead of calculating them relative to the resolved section offset.

---
*PR created automatically by Jules for task [2532124129545871478](https://jules.google.com/task/2532124129545871478) started by @szubster*