### PR TITLE
Foundry: Break down epic-107-301-lift-rejection-count-state into a story

### DIFF
--- a/.foundry/epics/epic-107-301-lift-rejection-count-state.md
+++ b/.foundry/epics/epic-107-301-lift-rejection-count-state.md
@@ -33,4 +33,5 @@ Currently, the threshold for determining if a node has permanently failed (`reje
 3. Provide the value in the `DagProvider`.
 
 ## Acceptance Criteria
-- [ ] Break down into Stories
+- [x] Break down into Stories
+- [ ] story-301-314-lift-rejection-count-state

--- a/.foundry/stories/story-301-314-lift-rejection-count-state.md
+++ b/.foundry/stories/story-301-314-lift-rejection-count-state.md
@@ -1,0 +1,33 @@
+---
+id: story-301-314-lift-rejection-count-state
+type: STORY
+title: "Lift MAX_REJECTION_THRESHOLD Constant to Context"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-07-12"
+updated_at: "2026-07-12"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-107-301-lift-rejection-count-state
+tags:
+  - refactor
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Lift MAX_REJECTION_THRESHOLD Constant to Context
+
+## Objective
+Extract the `MAX_REJECTION_THRESHOLD` constant (value: 3) from local file scopes into `DagContext.tsx` or a dedicated shared constants utility, and expose it through the React context layer.
+
+## Requirements
+1. Define `MAX_REJECTION_THRESHOLD = 3` in `DagContext.tsx`.
+2. Expose this value through the `DagContextState` interface.
+3. Provide the value in the `DagProvider`.
+
+## Acceptance Criteria
+- [ ] Break down this STORY into TASK nodes


### PR DESCRIPTION
Created a STORY node `story-301-314-lift-rejection-count-state.md` and linked it to `epic-107-301-lift-rejection-count-state.md`.

---
*PR created automatically by Jules for task [11551314767187091633](https://jules.google.com/task/11551314767187091633) started by @szubster*