### PR TITLE
feat: implement Gen 3 Secret Base Daily Rematch parsing

### DIFF
--- a/.foundry/tasks/task-110-299-gen3-secret-base-daily-rematch-impl.md
+++ b/.foundry/tasks/task-110-299-gen3-secret-base-daily-rematch-impl.md
@@ -34,8 +34,8 @@ notes: ''
 - Ensure this Boolean value is returned alongside the trainer data.
 
 ## Acceptance Criteria
-- [ ] Parse the `battledOwnerToday` flag.
-- [ ] Define reusable module-level constants for the offset and bitmask.
+- [x] Parse the `battledOwnerToday` flag.
+- [x] Define reusable module-level constants for the offset and bitmask.
 
 ## Important Notes
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/engine/gen3/secretBase/parser.test.ts
+++ b/src/engine/gen3/secretBase/parser.test.ts
@@ -55,6 +55,8 @@ describe('Secret Base Parser', () => {
 
       view.setUint8(0, 15); // Base ID
 
+      view.setUint8(1, 1 << 5); // Set battledOwnerToday flag
+
       // "ASH\0\0\0\0"
       // Wait, A is 0x80, S is 0x92, H is 0x87 in GEN12_CHAR_MAP (or 0xFF for end)
       view.setUint8(2, 0x80);
@@ -78,6 +80,7 @@ describe('Secret Base Parser', () => {
       expect(record?.secretBaseId).toBe(15);
       expect(record?.trainerName).toBe('ASH');
       expect(record?.trainerId).toBe(1234567);
+      expect(record?.battledOwnerToday).toBe(true);
       expect(record?.party[0]?.species).toBe(1);
     });
 

--- a/src/engine/gen3/secretBase/parser.ts
+++ b/src/engine/gen3/secretBase/parser.ts
@@ -1,6 +1,8 @@
 import { decodeGen12String, type GameVersion, type Gen3SecretBasePartyMember } from '../../saveParser/parsers/common';
 
 export const SECRET_BASE_SIZE = 160;
+export const FLAGS_OFFSET = 0x01;
+export const BATTLED_OWNER_TODAY_MASK = 1 << 5;
 export const SECRET_BASES_COUNT = 20;
 
 export const TRAINER_NAME_OFFSET = 0x02;
@@ -99,6 +101,9 @@ export function parseSecretBaseRecord(view: DataView, offset: number, gameVersio
       return null;
     }
 
+    const flags = view.getUint8(offset + FLAGS_OFFSET);
+    const battledOwnerToday = (flags & BATTLED_OWNER_TODAY_MASK) !== 0;
+
     const isEmerald = gameVersion === 'emerald';
     const trainerNameLength = isEmerald ? TRAINER_NAME_LENGTH_EMERALD : TRAINER_NAME_LENGTH_RS;
     const trainerIdOffset = isEmerald ? TRAINER_ID_OFFSET_EMERALD : TRAINER_ID_OFFSET_RS;
@@ -114,6 +119,7 @@ export function parseSecretBaseRecord(view: DataView, offset: number, gameVersio
       secretBaseId,
       trainerName,
       trainerId,
+      battledOwnerToday,
       party,
     };
   } catch (error) {

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -109,6 +109,7 @@ export interface Gen3SecretBase {
   secretBaseId: number;
   trainerName: string;
   trainerId: number;
+  battledOwnerToday?: boolean;
   party: Gen3SecretBasePartyMember[];
 }
 


### PR DESCRIPTION
Implemented parsing for the `battledOwnerToday` flag from Gen 3 Secret Base save data.

---
*PR created automatically by Jules for task [6433082707031953359](https://jules.google.com/task/6433082707031953359) started by @szubster*