### PR TITLE
feat: tech lead breakdown for gen 1 event flags

### DIFF
--- a/.foundry/stories/story-136-294-gen1-event-flag-parsing.md
+++ b/.foundry/stories/story-136-294-gen1-event-flag-parsing.md
@@ -24,4 +24,6 @@ notes: ''
 Extract and parse the event flags for Gen 1 static encounters from the save file.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks
+- [x] Break down into Tasks
+- [ ] task-294-316-gen1-event-flag-parsing-impl
+- [ ] task-294-317-gen1-event-flag-parsing-qa

--- a/.foundry/tasks/task-294-316-gen1-event-flag-parsing-impl.md
+++ b/.foundry/tasks/task-294-316-gen1-event-flag-parsing-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-294-316-gen1-event-flag-parsing-impl
+type: TASK
+title: Gen 1 Event Flag Parsing Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-136-294-gen1-event-flag-parsing
+tags:
+  - gen1
+  - feature
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 1 Event Flag Parsing Implementation
+
+Implement the extraction and parsing of the event flags for Gen 1 static encounters from the save file. Currently the `eventFlags` array is extracted in `src/engine/saveParser/parsers/gen1.ts`, but we need to integrate this with `STATIC_GIFT_DATA` (from `src/engine/data/gen1/assistantData.ts`) to make actionable sense of these flags.
+
+Specifically, create a mechanism (e.g. `src/engine/saveParser/utils/eventFlags.ts` or directly within the parser/generators) to evaluate which Gen 1 static encounters (like Mewtwo, Snorlax, Legendary Birds, fossil choices) have already been claimed or defeated by the player.
+
+## Constraints & Requirements
+
+1.  **Adhere to ADR 026 (Explicit Bitwise Logic)**: Use explicit bitwise shifting (`>>`) and masking (`&`) to isolate the event flags from the raw byte array. Do not rely on implicit boolean coercion of full bytes.
+2.  **Adhere to ADR 028 (Module-Level Constants)**: All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. **No inline magic numbers** for evaluating the flags.
+3.  **Handle Empty/Traded States**: Be mindful that some event flags might only be set upon specific in-game interactions. Ensure you are evaluating the correct bits. The `STATIC_GIFT_DATA` provides `eventFlag` properties that point to the specific flag ID.
+
+## Process Reminders
+
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task (e.g. if the implementation already exists), you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Create constants for event flag bits/offsets according to ADR 028.
+- [ ] Implement parsing logic using explicit bitwise operators according to ADR 026.
+- [ ] Map the raw `eventFlags` to the `STATIC_GIFT_DATA` Gen 1 definitions.
+- [ ] Write unit tests to verify the extraction logic, explicitly testing edge cases (e.g. absolute zero state, boundary states).

--- a/.foundry/tasks/task-294-317-gen1-event-flag-parsing-qa.md
+++ b/.foundry/tasks/task-294-317-gen1-event-flag-parsing-qa.md
@@ -1,0 +1,48 @@
+---
+id: task-294-317-gen1-event-flag-parsing-qa
+type: TASK
+title: Gen 1 Event Flag Parsing QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+depends_on:
+  - task-294-316-gen1-event-flag-parsing-impl
+jules_session_id: null
+pr_number: null
+parent: story-136-294-gen1-event-flag-parsing
+tags:
+  - gen1
+  - feature
+  - save-parsing
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 1 Event Flag Parsing QA
+
+Verify the implementation of Gen 1 static encounter event flag parsing.
+
+## Constraints & Requirements
+
+Ensure the implementation in `task-294-316-gen1-event-flag-parsing-impl` satisfies the following architectural rules:
+
+1.  **ADR 026 (Explicit Bitwise Logic)**: The coder must have used explicit bitwise shifting (`>>`) and masking (`&`) to isolate the event flags, avoiding implicit coercion or unsafe byte reading.
+2.  **ADR 028 (Module-Level Constants)**: All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+3.  **Correct Integration**: The logic must correctly integrate with `STATIC_GIFT_DATA` for Gen 1, effectively mapping the raw `eventFlags` to actionable insights on which static encounters are claimed.
+4.  **Testing**: Comprehensive unit tests must be written to verify the bitwise extraction and mapping logic, including boundary states.
+
+## Process Reminders
+
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify ADR 026 adherence (explicit bitwise shifting/masking).
+- [ ] Verify ADR 028 adherence (module-level constants, no inline magic numbers).
+- [ ] Verify mapping of `eventFlags` to `STATIC_GIFT_DATA`.
+- [ ] Verify unit tests cover absolute zero state and boundary states.


### PR DESCRIPTION
Broke down story `story-136-294-gen1-event-flag-parsing` into actionable tasks. Created `task-294-316-gen1-event-flag-parsing-impl` and `task-294-317-gen1-event-flag-parsing-qa` to extract and verify event flags according to ADR 026 and ADR 028. Updated parent node checkboxes and child links.

---
*PR created automatically by Jules for task [17572551416232385564](https://jules.google.com/task/17572551416232385564) started by @szubster*