### PR TITLE
feat: implement gen3 lottery extraction parser

### DIFF
--- a/.foundry/tasks/task-272-301-gen3-lottery-data-extraction-impl.md
+++ b/.foundry/tasks/task-272-301-gen3-lottery-data-extraction-impl.md
@@ -35,5 +35,5 @@ We need to extract the daily winning lottery number from Gen3 save files. This r
 - If you submit an empty PR for a completed task (e.g. if the parser was already implemented in another PR), you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Locate and define exact memory offsets as module-level constants.
-- [ ] Implement robust `DataView` parsing logic for the 16-bit lottery number.
+- [x] Locate and define exact memory offsets as module-level constants.
+- [x] Implement robust `DataView` parsing logic for the 16-bit lottery number.

--- a/src/engine/saveParser/gen3/lottery/parser.test.ts
+++ b/src/engine/saveParser/gen3/lottery/parser.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { EMERALD_LOTTERY_LOW_OFFSET, parseGen3LotteryNumber, RS_LOTTERY_LOW_OFFSET } from './parser';
+
+describe('parseGen3LotteryNumber', () => {
+  it('should parse lottery number for emerald', () => {
+    const buffer = new ArrayBuffer(0x2000);
+    const view = new DataView(buffer);
+    const saveBlock1Offset = 0x0;
+
+    // Set low 16 bits of lottery number
+    view.setUint16(saveBlock1Offset + EMERALD_LOTTERY_LOW_OFFSET, 12345, true);
+
+    const result = parseGen3LotteryNumber(view, saveBlock1Offset, 'emerald');
+    expect(result).toBe(12345);
+  });
+
+  it('should parse lottery number for ruby/sapphire', () => {
+    const buffer = new ArrayBuffer(0x2000);
+    const view = new DataView(buffer);
+    const saveBlock1Offset = 0x100;
+
+    // Set low 16 bits of lottery number
+    view.setUint16(saveBlock1Offset + RS_LOTTERY_LOW_OFFSET, 54321, true);
+
+    const result = parseGen3LotteryNumber(view, saveBlock1Offset, 'ruby');
+    expect(result).toBe(54321);
+
+    const result2 = parseGen3LotteryNumber(view, saveBlock1Offset, 'sapphire');
+    expect(result2).toBe(54321);
+  });
+
+  it('should throw error for unsupported game version', () => {
+    const buffer = new ArrayBuffer(0x2000);
+    const view = new DataView(buffer);
+    const saveBlock1Offset = 0x0;
+
+    expect(() => parseGen3LotteryNumber(view, saveBlock1Offset, 'firered')).toThrow(
+      'Unsupported game version for lottery extraction.',
+    );
+  });
+
+  it('should throw error for out of bounds read', () => {
+    const buffer = new ArrayBuffer(0x10);
+    const view = new DataView(buffer);
+    const saveBlock1Offset = 0x0;
+
+    expect(() => parseGen3LotteryNumber(view, saveBlock1Offset, 'emerald')).toThrow(
+      'The save file is corrupted or incomplete.',
+    );
+  });
+});

--- a/src/engine/saveParser/gen3/lottery/parser.ts
+++ b/src/engine/saveParser/gen3/lottery/parser.ts
@@ -1,0 +1,30 @@
+export const EMERALD_LOTTERY_HIGH_OFFSET = 0x1432;
+export const EMERALD_LOTTERY_LOW_OFFSET = 0x1434;
+export const RS_LOTTERY_LOW_OFFSET = 0x13d6;
+export const RS_LOTTERY_HIGH_OFFSET = 0x13d8;
+
+/**
+ * Parses the daily lottery number from a Gen 3 save file.
+ * The daily lottery PRNG seed is a 32-bit number, but the winning lottery number
+ * itself is the lower 16 bits of this seed. We reconstruct the 16-bit number.
+ *
+ * @param view The raw save file DataView
+ * @param saveBlock1Offset The offset to SaveBlock1
+ * @param gameVersion The game version ('emerald', 'ruby', 'sapphire')
+ * @returns The 16-bit daily lottery number
+ */
+export function parseGen3LotteryNumber(view: DataView, saveBlock1Offset: number, gameVersion: string): number {
+  try {
+    if (gameVersion === 'emerald') {
+      return view.getUint16(saveBlock1Offset + EMERALD_LOTTERY_LOW_OFFSET, true);
+    } else if (gameVersion === 'ruby' || gameVersion === 'sapphire') {
+      return view.getUint16(saveBlock1Offset + RS_LOTTERY_LOW_OFFSET, true);
+    }
+    throw new Error('Unsupported game version for lottery extraction.');
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -1249,6 +1249,8 @@ export function parseGen3EmeraldMoveTutors(view: DataView, saveBlock1Offset: num
  * @returns An object containing boolean statuses for each RSE NPC trade.
  * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
  */
+export { parseGen3LotteryNumber } from '../gen3/lottery/parser';
+
 export function parseGen3RSENPCTrades(view: DataView, saveBlock1Offset: number): Record<string, boolean> {
   try {
     const baseOffset = saveBlock1Offset + GEN3_EVENT_FLAGS_OFFSET;


### PR DESCRIPTION
Closes task-272-301-gen3-lottery-data-extraction-impl. Implements robust extraction of the daily Gen 3 lottery winning numbers from save blocks. Converts relative offset knowledge into structured constants, avoiding all magic numbers, and integrates with the existing save parser hierarchy.

---
*PR created automatically by Jules for task [3518004521435660697](https://jules.google.com/task/3518004521435660697) started by @szubster*