### PR TITLE
chore: Break down PC Box Diff Engine story into tasks

### DIFF
--- a/.foundry/stories/story-137-294-diff-engine-logic.md
+++ b/.foundry/stories/story-137-294-diff-engine-logic.md
@@ -30,4 +30,6 @@ The diff engine must iterate through the current and target box arrays. Pokémon
 The engine will return a set of differences detailing which specific entity is currently at what location (box, slot) and where its final target location (box, slot) should be.
 
 ## Acceptance Criteria
-- [ ] Break down story into tasks for diff engine implementation.
+- [ ] task-294-316-diff-engine-impl
+- [ ] task-294-317-diff-engine-qa
+- [x] Break down story into tasks for diff engine implementation.

--- a/.foundry/tasks/task-294-316-diff-engine-impl.md
+++ b/.foundry/tasks/task-294-316-diff-engine-impl.md
@@ -1,0 +1,48 @@
+---
+id: task-294-316-diff-engine-impl
+type: TASK
+title: Implement PC Box Diff Engine Logic
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-137-294-diff-engine-logic
+tags:
+  - algorithm
+  - diff
+  - implementation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement PC Box Diff Engine Logic
+
+## Objective
+Implement the diffing algorithm that compares the `current` state of PC boxes and a `target` state of PC boxes, computing the precise differences: additions, removals, and relocations.
+
+## Description
+This engine is the core logic that will eventually power the "Move Planner" UI. It takes an array of the user's current `PokemonInstance` list from the parsed save state and compares it against an array of the desired/target `PokemonInstance` state.
+The output should be a structured object or list of diffs explaining what needs to happen to transition from `current` to `target`.
+
+## Constraints & Requirements
+1. The diff engine must identify Pokémon uniquely to track relocations across boxes. Since DVs/IVs, species, and level might not be globally unique (e.g., catching 10 identical Pidgeys), the diff engine must use a combination of fields (PID/TID/SID if available, or generate a robust hash/identifier based on static stats, moves, DVs) or rely on reference equality if the objects are the same instances. For our use-case, relying on the unique `hash` field already present on the parsed `PokemonInstance` is strictly required.
+2. The output should be a typed structure detailing:
+   - Entities to **Move**: Currently at `(sourceBox, sourceSlot)`, needs to go to `(targetBox, targetSlot)`.
+   - Entities to **Add**: Exists in `target` but not in `current`.
+   - Entities to **Remove**: Exists in `current` but not in `target`.
+3. The implementation should be placed in `src/engine/saveParser/utils/boxDiff.ts` (or similar appropriate utility file).
+
+## Tech Lead Instructions
+- **Empty PR Policy Reminder**: If you submit an empty PR because the logic already exists, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- **Error Handling Reminder**: If you experience a transient failure requiring retry, update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort (impossible or max rejections reached), update to `status: CANCELLED` with a `rejection_reason`.
+- **Offset Constants Rule**: When writing any save file parsing logic (if applicable here, though this is primarily algorithmic), explicitly require that all memory offsets, lengths, bit locations, and shifts be defined as reusable constants at the module level. Inline magic numbers are forbidden.
+
+## Acceptance Criteria
+- [ ] Implement the box diffing logic function (e.g., `calculateBoxDiff`).
+- [ ] Write unit tests verifying additions, removals, and complex relocations.
+- [ ] Ensure Pokémon are uniquely tracked by their `hash`.

--- a/.foundry/tasks/task-294-317-diff-engine-qa.md
+++ b/.foundry/tasks/task-294-317-diff-engine-qa.md
@@ -1,0 +1,49 @@
+---
+id: task-294-317-diff-engine-qa
+type: TASK
+title: QA PC Box Diff Engine Logic
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+depends_on:
+  - task-294-316-diff-engine-impl
+jules_session_id: null
+pr_number: null
+parent: story-137-294-diff-engine-logic
+tags:
+  - qa
+  - diff
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA PC Box Diff Engine Logic
+
+## Objective
+Verify the correctness and robustness of the PC Box Diff Engine logic implemented by the coder.
+
+## Description
+The coder has implemented a diffing algorithm (`src/engine/saveParser/utils/boxDiff.ts` or similar) to compute additions, removals, and relocations between two arrays of `PokemonInstance`. The logic must strictly use the unique `hash` field on the Pokemon instances to track identities across boxes.
+
+Your role as QA is to review the code for edge cases and ensure the tests adequately cover all possible scenarios.
+
+## Validation Requirements
+1.  **Code Review**: Verify that the implemented `calculateBoxDiff` (or equivalent) strictly uses the `hash` property to match Pokémon between the `current` and `target` states.
+2.  **Test Coverage**: Review the unit tests associated with the diff engine. Ensure they cover:
+    - Pure additions.
+    - Pure removals.
+    - Pure relocations (e.g., swapping two Pokémon, or moving one to an empty slot).
+    - Complex combinations of the above.
+    - Cases with duplicate species/levels where `hash` disambiguates them.
+
+## Tech Lead Instructions
+- **Empty PR Policy Reminder**: If you submit an empty PR because the logic already exists and is fully verified, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- **Error Handling Reminder**: If you experience a transient failure requiring retry (or if the coder's implementation fails your checks), update the YAML frontmatter to `status: FAILED` with a detailed `rejection_reason` explaining what the coder missed. If you must permanently abort (impossible or max rejections reached), update to `status: CANCELLED` with a `rejection_reason`.
+
+## Acceptance Criteria
+- [ ] Verify the diff algorithm correctly computes additions, removals, and relocations using the `hash` field.
+- [ ] Verify unit test coverage is comprehensive for edge cases.


### PR DESCRIPTION
Breaks down `story-137-294-diff-engine-logic` into actionable implementation and QA tasks.
- Created `task-294-316-diff-engine-impl` for the Coder persona.
- Created `task-294-317-diff-engine-qa` for the QA persona to verify the complex logic.
- Updated the parent story to track the new tasks as acceptance criteria.

---
*PR created automatically by Jules for task [4367068874300355870](https://jules.google.com/task/4367068874300355870) started by @szubster*