### PR TITLE
chore(foundry): break down epic-108 into story-303-299

### DIFF
--- a/.foundry/epics/epic-108-303-extend-phase-3-6-cancelled-nodes.md
+++ b/.foundry/epics/epic-108-303-extend-phase-3-6-cancelled-nodes.md
@@ -35,4 +35,5 @@ In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` statu
 - Update tests in `foundry-orchestrator.test.ts` to verify this exact behavior.
 
 ## Acceptance Criteria
-- [ ] Break down into Stories
+- [x] Break down into Stories
+- [ ] story-303-299-extend-phase-3-6-cancelled-nodes

--- a/.foundry/stories/story-303-299-extend-phase-3-6-cancelled-nodes.md
+++ b/.foundry/stories/story-303-299-extend-phase-3-6-cancelled-nodes.md
@@ -1,0 +1,35 @@
+---
+id: story-303-299-extend-phase-3-6-cancelled-nodes
+type: STORY
+title: Extend Phase 3.6 for CANCELLED nodes
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-108-303-extend-phase-3-6-cancelled-nodes
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extend Phase 3.6 for CANCELLED nodes
+
+## Objective
+Update `.github/scripts/foundry-orchestrator.ts` Phase 3.6 logic to correctly awaken parent nodes for nodes transitioning to `CANCELLED` status with `rejection_reason === 'Max rejection count reached'`.
+
+## Requirements
+- Locate the Phase 3.6 impossible loop checks in `.github/scripts/foundry-orchestrator.ts`.
+- Ensure the condition includes `node.frontmatter.status === 'CANCELLED'`.
+- Ensure the condition `node.frontmatter.rejection_reason === 'Max rejection count reached'` is properly checked for parent awakening.
+- Update tests in `.github/scripts/foundry-orchestrator.test.ts` to assert that parent nodes are awakened when child nodes are cancelled due to max rejections.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
This PR acts on `epic-108-303-extend-phase-3-6-cancelled-nodes` by breaking it down into a new Story node: `story-303-299-extend-phase-3-6-cancelled-nodes`.

- Created the new Story node with appropriate requirements and assigned to `tech_lead`.
- Updated the parent Epic node's acceptance criteria to reflect the new story.

---
*PR created automatically by Jules for task [10616910474714528591](https://jules.google.com/task/10616910474714528591) started by @szubster*