### PR TITLE
QA: Reject Gen 3 Ash Extraction

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -31,3 +31,7 @@ The implementer (`coder`) failed `task-121-219-gen3-tv-block-parser-retry-impl` 
 The coder implemented the Feebas extraction logic using absolute memory offsets (`0x2dd6`) instead of making them relative to `section1Offset`. In Generation 3, save files utilize an A/B bank rotation system where data can either reside in `0x0000` or `0xE000`. By hardcoding the absolute offset, the parser will fail to read the active save data if it currently resides in Bank B.
 
 To enforce the architecture correctly, all dynamic save block extraction functions must receive the resolved offset from the parser engine (e.g., `section1Offset` or `section2Offset`) and apply relative memory offsets to correctly extract the active save data block. I have failed `task-280-304-feebas-backend-integration` and incremented its rejection count.
+
+## Gen 3 Volcanic Ash Extraction Validation
+- **Pattern**: When validating Gen 3 dynamic save block extraction, ensure that offsets are not hardcoded absolute values (e.g. `0x13D0` or `0x142C`). They must be calculated relative to the dynamically resolved `section1Offset`.
+- **Outcome**: Rejected `task-267-261-gen3-ash-dataview-extraction-impl` due to hardcoded absolute offsets instead of using the `section1Offset + offset` calculation.

--- a/.foundry/tasks/task-267-261-gen3-ash-dataview-extraction-impl.md
+++ b/.foundry/tasks/task-267-261-gen3-ash-dataview-extraction-impl.md
@@ -2,7 +2,7 @@
 id: task-267-261-gen3-ash-dataview-extraction-impl
 type: TASK
 title: Implement Gen 3 Volcanic Ash Extraction
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-08'
 updated_at: '2026-07-12'
@@ -16,8 +16,8 @@ tags:
   - parsing
 research_references:
   - .foundry/archive/research/research-054-243-gen3-ash-gathering-offsets.md
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Implementation uses absolute memory offsets (0x13D0 / 0x142C) without adding the section1Offset, which will read the wrong memory location for Gen 3 dynamic save blocks.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-267-262-gen3-ash-dataview-extraction-qa.md
+++ b/.foundry/tasks/task-267-262-gen3-ash-dataview-extraction-qa.md
@@ -41,3 +41,6 @@ The implementation task (`task-267-261-gen3-ash-dataview-extraction-impl`) requi
 ## Developer Instructions
 - **Failure conditions:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - **Completion conditions:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### QA Validation Failure
+Task rejected. The implementation uses absolute memory offsets (`0x13D0` / `0x142C`) instead of calculating relative offsets from the resolved `section1Offset`. This violates the rules for extracting Gen 3 dynamic save blocks and will result in reading from the wrong memory location.


### PR DESCRIPTION
The coder's implementation of Gen 3 Volcanic Ash Extraction correctly used DataView but failed to calculate relative memory offsets using `section1Offset`. By hardcoding `0x13D0` and `0x142C`, the logic violated ADR 028 rules and would result in reading from the wrong A/B bank.

I have updated the target task to FAILED, logged the rejection in the QA journal, and appended notes to the QA node.

---
*PR created automatically by Jules for task [9437539741674065171](https://jules.google.com/task/9437539741674065171) started by @szubster*