### PR TITLE
feat: Break down Gen 3 Trainer Card Dashboard PRD into Epics

### DIFF
--- a/.foundry/epics/epic-111-304-gen3-trainer-card-data-extraction.md
+++ b/.foundry/epics/epic-111-304-gen3-trainer-card-data-extraction.md
@@ -1,0 +1,51 @@
+---
+id: epic-111-304-gen3-trainer-card-data-extraction
+type: EPIC
+title: "Epic: Gen 3 Trainer Card Stars Data Extraction"
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-07-12"
+updated_at: "2026-07-12"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-102-111-gen3-trainer-card-stars
+tags:
+  - data-extraction
+  - gen3
+  - achievements
+research_references:
+  - .foundry/docs/knowledge_base/engine/save_parsing/gen3_hall_of_fame.md
+  - .foundry/docs/knowledge_base/gen3_battle_frontier_data.md
+  - .foundry/docs/knowledge_base/gen3_pokemon_data_structure.md
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Gen 3 Trainer Card Stars Data Extraction
+
+## Objective
+Implement the logic to extract the requisite achievements from the Gen 3 (Emerald) save file using the native `DataView` API to power the Trainer Card Stars Dashboard.
+
+## Requirements
+
+1. **Hall of Fame Extraction:**
+   - Extract the `GAME_STAT_ENTERED_HOF` (ID 10) from the `gameStats` array in `SaveBlock1` or an equivalent flag to determine if the player has entered the Hall of Fame.
+
+2. **Hoenn and National Pokédex:**
+   - Extract the number of caught Pokémon in both the Hoenn and National Dex. This involves checking the pokedex bitfields.
+
+3. **Master Rank Contests:**
+   - Extract the contest condition ribbons, specifically checking if Master Rank ribbons are obtained for Cool, Beauty, Cute, Smart, and Tough categories.
+
+4. **Battle Frontier Gold Symbols:**
+   - Extract the `SYSTEM_FLAGS` corresponding to Gold Symbols for Tower, Dome, Palace, Arena, Factory, Pike, and Pyramid.
+   - Example Flags: `FLAG_SYS_TOWER_GOLD` (0x8C5) to `FLAG_SYS_PYRAMID_GOLD` (0x8D1).
+
+5. **Architectural Constraints:**
+   - All extraction must be done using the `DataView` API (ADR 010).
+   - Magic numbers for offsets and flags must be extracted into module-level reusable constants (ADR 028).
+
+## Acceptance Criteria
+- [ ] Break down into Stories for data extraction implementation.

--- a/.foundry/epics/epic-111-305-gen3-trainer-card-dashboard-ui.md
+++ b/.foundry/epics/epic-111-305-gen3-trainer-card-dashboard-ui.md
@@ -1,0 +1,49 @@
+---
+id: epic-111-305-gen3-trainer-card-dashboard-ui
+type: EPIC
+title: "Epic: Gen 3 Trainer Card Stars Dashboard UI"
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-07-12"
+updated_at: "2026-07-12"
+depends_on:
+  - epic-111-304-gen3-trainer-card-data-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-102-111-gen3-trainer-card-stars
+tags:
+  - ui
+  - gen3
+  - achievements
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Gen 3 Trainer Card Stars Dashboard UI
+
+## Objective
+Implement the UI components for the "Trainer Card Stars" dashboard to aggregate and display endgame completion metrics for Pokémon Emerald.
+
+## Requirements
+
+1. **Dashboard View:**
+   - Create a new UI component/dashboard section to display the Trainer Card stars logic.
+   - The UI should reflect the player's progress across the 5 macro-goals defined in the PRD (Hall of Fame, Hoenn Dex, National Dex, Master Rank Contests, Gold Symbols).
+   - Display a visual representation of the Trainer Card or stars earned.
+
+2. **Progress Indicators:**
+   - Use checkmarks or boolean indicators for binary goals (like Hall of Fame).
+   - Use progress bars or fractional text for granular goals (like 150/202 Hoenn Dex).
+
+3. **Styling:**
+   - Must adhere strictly to the 'tactical hardware' aesthetic (ADR 024, ADR 008).
+   - Use `tactical-panel`, `font-mono`, `border-dashed`, and strictly avoid rounded corners (`rounded-none`).
+   - For progress bars, use segmented terminal blocks `[ SHEEN ]` rather than smooth HTML5 progress bars to mimic the rugged CRT look.
+
+4. **Integration:**
+   - The UI must integrate with the data parsing output from Epic 111-304 to display live data from the loaded save file.
+
+## Acceptance Criteria
+- [ ] Break down into Stories for UI implementation.

--- a/.foundry/prds/prd-102-111-gen3-trainer-card-stars.md
+++ b/.foundry/prds/prd-102-111-gen3-trainer-card-stars.md
@@ -62,4 +62,8 @@ Create a dedicated view (or a prominent section on the main Gen 3 dashboard) tha
 - Real-time updates (the dashboard will update upon save file upload).
 
 ## Next Steps
-- [ ] Epic Planner: Break this PRD down into specific Epics (e.g., Data Parsing, UI Implementation).
+- [x] Epic Planner: Break this PRD down into specific Epics (e.g., Data Parsing, UI Implementation).
+
+## Acceptance Criteria
+- [ ] epic-111-304-gen3-trainer-card-data-extraction
+- [ ] epic-111-305-gen3-trainer-card-dashboard-ui


### PR DESCRIPTION
This PR breaks down PRD 102-111 (Gen 3 Trainer Card Stars & Achievements Dashboard) into two actionable epics:
1. `epic-111-304-gen3-trainer-card-data-extraction`: Handles parsing the Emerald save file for the required achievements (Hoenn/National Dex, Hall of Fame, Contests, Battle Frontier).
2. `epic-111-305-gen3-trainer-card-dashboard-ui`: Handles building the UI components to display this data, strictly adhering to the "tactical hardware" aesthetic.

The PRD's Next Steps task has been checked off, and the new epics have been added to its Acceptance Criteria.

---
*PR created automatically by Jules for task [12427313791871988737](https://jules.google.com/task/12427313791871988737) started by @szubster*