### PR TITLE
chore: audit epic-052-096-automated-max-rejection-cancellation

### DIFF
--- a/.foundry/epics/epic-052-096-automated-max-rejection-cancellation.md
+++ b/.foundry/epics/epic-052-096-automated-max-rejection-cancellation.md
@@ -26,3 +26,6 @@ notes: ''
 - [x] Break down into Stories.
 - [x] story-096-153-max-rejection-cancellation
 - [x] story-096-154-parent-awakening-logic
+
+## Learnings & Follow-ups
+- [idea-114-update-permanent-failure-dashboard-ui](.foundry/ideas/idea-114-update-permanent-failure-dashboard-ui.md) - The automatic cancellation of nodes causes them to disappear from the Permanent Failure Dashboard UI. Created an IDEA to fix the filtering logic.

--- a/.foundry/ideas/idea-114-update-permanent-failure-dashboard-ui.md
+++ b/.foundry/ideas/idea-114-update-permanent-failure-dashboard-ui.md
@@ -1,0 +1,27 @@
+---
+id: idea-114-update-permanent-failure-dashboard-ui
+type: IDEA
+title: Update Permanent Failure Dashboard UI for Cancelled Nodes
+status: PENDING
+owner_persona: product_manager
+created_at: "2026-07-12"
+updated_at: "2026-07-12"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - ui
+research_references: []
+notes: ""
+---
+
+# Idea: Update Permanent Failure Dashboard UI for Cancelled Nodes
+
+## Context
+With the implementation of `epic-052-096-automated-max-rejection-cancellation`, nodes that reach the maximum rejection count (3) are now automatically transitioned to the `CANCELLED` status by the orchestrator.
+Previously, the Permanent Failure Dashboard UI (`src/components/dag/DagDashboard.tsx` and `src/components/dag/DagNode.tsx`) filtered for nodes with `status === 'FAILED'` and `rejection_count >= 3`. Since these permanently failed nodes are now `CANCELLED`, they no longer appear in the Permanent Failure Dashboard.
+
+## Proposed Solution
+Update the filtering logic in the DAG UI components to include nodes that are `status === 'CANCELLED'` and have `rejection_count >= 3` (or check for the specific `rejection_reason`) so they are correctly highlighted as permanent failures.

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -133,3 +133,7 @@ Successfully verified that the Automated Max Rejection Cancellation epic was cor
 - **Node**: `epic-052-096-automated-max-rejection-cancellation`
 - **Result**: Verification Passed.
 - **Notes**: The Epic was successfully broken down into stories `story-096-153-max-rejection-cancellation` and `story-096-154-parent-awakening-logic`. Both stories and their descendant task nodes were implemented, merged, and moved to COMPLETED status. The `foundry-orchestrator.ts` Phase 3.0 and Phase 3.6 correctly implemented the logic to handle max rejections and CANCELLED nodes, as verified by reading the scripts and running the test suite. All child nodes and their tasks are completely marked as `[x]`. I am submitting an empty PR to transition this node to COMPLETED.
+
+## 2026-07-12
+**Architectural Constraint (State Machine UI Consistency):**
+When changing node state transitions (e.g., from FAILED to CANCELLED for max rejections), we must explicitly audit downstream UI consumers (like the DAG Dashboard) that may be relying on the previous status to render information correctly.


### PR DESCRIPTION
Audited `epic-052-096-automated-max-rejection-cancellation`. All child stories and tasks were successfully completed and merged. The Acceptance Criteria are met. Discovered that the DAG Dashboard UI will not render CANCELLED nodes, breaking the Permanent Failures feature. Created `idea-114-update-permanent-failure-dashboard-ui` to address this issue, updated the Auditor journal with the learning, and appended the IDEA node to the Epic's Markdown body. Submitting an empty PR to transition the Epic to COMPLETED.

---
*PR created automatically by Jules for task [14238479558320805323](https://jules.google.com/task/14238479558320805323) started by @szubster*