### PR TITLE
Create story nodes for epic-099-130-indexeddb-schema-design

### DIFF
--- a/.foundry/epics/epic-099-130-indexeddb-schema-design.md
+++ b/.foundry/epics/epic-099-130-indexeddb-schema-design.md
@@ -29,5 +29,5 @@ Define the storage schema for the save state history, including DB name, object 
 - [ ] Define the database name and version.
 - [ ] Define object stores for storing save files, metadata, and indexes for efficient retrieval.
 - [ ] Document the schema.
-- [ ] story-130-267-define-indexeddb-schema
-- [ ] story-130-268-document-indexeddb-schema
+- [ ] story-130-315-define-indexeddb-schema
+- [ ] story-130-316-document-indexeddb-schema

--- a/.foundry/stories/story-130-315-define-indexeddb-schema.md
+++ b/.foundry/stories/story-130-315-define-indexeddb-schema.md
@@ -1,0 +1,33 @@
+---
+id: story-130-315-define-indexeddb-schema
+type: STORY
+title: Define IndexedDB Schema
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-099-130-indexeddb-schema-design
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Define IndexedDB Schema
+
+## Overview
+Define the `SaveHistoryDB` IndexedDB schema within the application codebase. This involves creating the database configuration with the correct name, version, and defining the object stores needed for saving raw files, metadata, and indexes.
+
+## Acceptance Criteria
+- [ ] Define the `SaveHistoryDB` configuration.
+- [ ] Implement the database configuration and schema initialization logic.
+- [ ] Define the `saves` object store for raw binary save files (`Uint8Array`).
+- [ ] Define the `metadata` object store for save file metadata.
+- [ ] Define the `indexes` object store for fast retrieval of save data without parsing raw saves.

--- a/.foundry/stories/story-130-316-document-indexeddb-schema.md
+++ b/.foundry/stories/story-130-316-document-indexeddb-schema.md
@@ -1,0 +1,34 @@
+---
+id: story-130-316-document-indexeddb-schema
+type: STORY
+title: Document IndexedDB Schema
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+depends_on:
+  - .foundry/stories/story-130-315-define-indexeddb-schema.md
+jules_session_id: null
+pr_number: null
+parent: epic-099-130-indexeddb-schema-design
+tags:
+  - storage
+  - indexeddb
+  - history
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Document IndexedDB Schema
+
+## Overview
+Document the structure and specifications of the `SaveHistoryDB` IndexedDB schema that was defined. This documentation should outline the overall configuration, database name, version, and the structure of each object store (`saves`, `metadata`, `indexes`).
+
+## Acceptance Criteria
+- [ ] Create or update schema documentation to reflect the `SaveHistoryDB` configuration.
+- [ ] Detail the structure and key-value types for the `saves` object store.
+- [ ] Detail the structure and key-value types for the `metadata` object store.
+- [ ] Detail the structure and key-value types for the `indexes` object store.


### PR DESCRIPTION
This PR creates the two late-binding story nodes for `epic-099-130-indexeddb-schema-design`: `story-130-315-define-indexeddb-schema` and `story-130-316-document-indexeddb-schema`. It updates the epic's markdown checklist to reflect these new IDs, leaving them unchecked as per the system rules to prevent premature transitioning to VERIFYING. The YAML frontmatter of the epic was intentionally unmodified.

---
*PR created automatically by Jules for task [14897408323703193005](https://jules.google.com/task/14897408323703193005) started by @szubster*