### PR TITLE
Draft Detect Party Zero HP Story

### DIFF
--- a/.foundry/epics/epic-097-131-nuzlocke-death-tracking.md
+++ b/.foundry/epics/epic-097-131-nuzlocke-death-tracking.md
@@ -31,6 +31,6 @@ Implement the logic to track dead Pokémon based on HP and Graveyard box assignm
 
 ## Acceptance Criteria
 - [x] Stories are generated
-- [ ] story-131-269-detect-party-zero-hp
+- [ ] story-131-317-detect-party-zero-hp
 - [ ] story-131-270-graveyard-box-state
 - [ ] story-131-271-graveyard-box-ui

--- a/.foundry/stories/story-131-317-detect-party-zero-hp.md
+++ b/.foundry/stories/story-131-317-detect-party-zero-hp.md
@@ -1,0 +1,32 @@
+---
+id: story-131-317-detect-party-zero-hp
+type: STORY
+title: Detect Party Zero HP
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-097-131-nuzlocke-death-tracking
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Detect Party Zero HP
+
+## Objective
+Implement logic to detect Pokémon currently at 0 HP in the party as dead.
+
+## Scope
+- Implement logic to check HP of party Pokémon and mark those with 0 HP as dead for the Nuzlocke Tracker.
+- Ensure the state updates correctly when a Pokémon dies in the party.
+
+## Acceptance Criteria
+- [ ] Breakdown into Tasks


### PR DESCRIPTION
Drafted STORY node `story-131-317-detect-party-zero-hp` and linked it in the parent EPIC `epic-097-131-nuzlocke-death-tracking` to manage the tracking of dead Pokémon based on HP.

---
*PR created automatically by Jules for task [8968921572261317407](https://jules.google.com/task/8968921572261317407) started by @szubster*