### PR TITLE
Track Gen 3 Secret Base Daily Rematch Status

### DIFF
--- a/.foundry/stories/story-070-110-track-daily-rematch-status.md
+++ b/.foundry/stories/story-070-110-track-daily-rematch-status.md
@@ -33,5 +33,5 @@ Players can battle the NPC trainers in Secret Bases once per day. We need to tra
 
 ## Acceptance Criteria
 - [x] Break down into Tasks.
-- [ ] task-110-299-gen3-secret-base-daily-rematch-impl
-- [ ] task-110-300-gen3-secret-base-daily-rematch-qa
+- [x] task-110-299-gen3-secret-base-daily-rematch-impl
+- [x] task-110-300-gen3-secret-base-daily-rematch-qa


### PR DESCRIPTION
Track Gen 3 Secret Base Daily Rematch Status

Checked off the acceptance criteria checkboxes in `.foundry/stories/story-070-110-track-daily-rematch-status.md` as the target child tasks have already been fully implemented.

---
*PR created automatically by Jules for task [1984380207182788449](https://jules.google.com/task/1984380207182788449) started by @szubster*