### PR TITLE
Tech Lead: NPC Trade Mapping Task Breakdown

### DIFF
--- a/.foundry/stories/story-119-260-npc-trade-data-mapping.md
+++ b/.foundry/stories/story-119-260-npc-trade-data-mapping.md
@@ -27,4 +27,6 @@ notes: ''
 Create a standard mapping connecting raw bitflags to specific NPC trade encounters (e.g., MUSCLE the Machop).
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break down into tasks for creating data maps across generations.
+- [x] Tech Lead: Break down into tasks for creating data maps across generations.
+- [ ] task-260-318-npc-trade-data-mapping-impl
+- [ ] task-260-319-npc-trade-data-mapping-qa

--- a/.foundry/tasks/task-260-318-npc-trade-data-mapping-impl.md
+++ b/.foundry/tasks/task-260-318-npc-trade-data-mapping-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-260-318-npc-trade-data-mapping-impl
+type: TASK
+title: NPC Trade Data Mapping Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-13'
+updated_at: '2026-07-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-119-260-npc-trade-data-mapping
+tags:
+  - backend
+  - mapping
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: NPC Trade Data Mapping Implementation
+
+## Objective
+Implement a standard mapping connecting raw bitflags to specific NPC trade encounters (e.g., MUSCLE the Machop) for Gen 2 and Gen 3.
+
+## Context and Constraints
+- The `coder` MUST map the raw bitflags successfully extracted in previous tasks to specific, human-readable NPC trade encounters.
+- If a transient failure requiring retry is experienced, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If the task must be permanently aborted, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If an empty PR is submitted for a completed task, all Acceptance Criteria checkboxes MUST be checked off before submitting.
+- **CRITICAL:** When implementing parsing or data definitions, explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Inline magic numbers are strictly forbidden.
+- **CRITICAL:** For Gen 3 data, use relative memory offsets rather than absolute hardcoded ones if applicable, ensuring compatibility across different flash memory bank structures.
+
+## Acceptance Criteria
+- [ ] Implement mapping for Gen 2 NPC trade flags to specific encounters.
+- [ ] Implement mapping for Gen 3 NPC trade flags (RSE/FRLG) to specific encounters.
+- [ ] Ensure the mapping correctly identifies the encounter species and nickname (e.g., MUSCLE the Machop).
+- [ ] Module-level reusable constants are explicitly defined for any required offsets or locations. No inline magic numbers are used.

--- a/.foundry/tasks/task-260-319-npc-trade-data-mapping-qa.md
+++ b/.foundry/tasks/task-260-319-npc-trade-data-mapping-qa.md
@@ -1,0 +1,40 @@
+---
+id: task-260-319-npc-trade-data-mapping-qa
+type: TASK
+title: NPC Trade Data Mapping QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-13'
+updated_at: '2026-07-13'
+depends_on:
+  - task-260-318-npc-trade-data-mapping-impl
+jules_session_id: null
+pr_number: null
+parent: story-119-260-npc-trade-data-mapping
+tags:
+  - backend
+  - mapping
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: NPC Trade Data Mapping QA
+
+## Objective
+Verify the standard mapping connecting raw bitflags to specific NPC trade encounters for Gen 2 and Gen 3.
+
+## Context and Constraints
+- The `qa` persona MUST verify that the `coder` correctly implemented the mappings.
+- If a transient failure requiring retry is experienced, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If the task must be permanently aborted, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If an empty PR is submitted for a completed task, all Acceptance Criteria checkboxes MUST be checked off before submitting.
+- **CRITICAL:** Ensure that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. Inline magic numbers are strictly forbidden. If any are found, reject the implementation task.
+
+## Acceptance Criteria
+- [ ] Verify that Gen 2 NPC trade flag mapping is correctly implemented.
+- [ ] Verify that Gen 3 NPC trade flag mapping (RSE/FRLG) is correctly implemented.
+- [ ] Verify that there are no inline magic numbers used for offsets or data lengths.
+- [ ] Verify that the `SaveData` correctly maps the extracted flags to the encounters.


### PR DESCRIPTION
This PR implements the Tech Lead breakdown for the NPC Trade Data Mapping story (story-119-260-npc-trade-data-mapping).

It creates two new tasks:
1. `task-260-318-npc-trade-data-mapping-impl`: The implementation blueprint for the coder, including explicit instructions to avoid inline magic numbers and to use relative offsets for Gen 3.
2. `task-260-319-npc-trade-data-mapping-qa`: The QA verification task, properly linked via `depends_on` to the implementation task to prevent premature execution by the DAG orchestrator.

The parent story's markdown has been updated to check off the Tech Lead acceptance criteria and include the new generated tasks as unchecked dependencies. The YAML frontmatter of the parent story was preserved intact.

---
*PR created automatically by Jules for task [6675245560623280460](https://jules.google.com/task/6675245560623280460) started by @szubster*