### PR TITLE
chore: permanently fail and cancel ash extraction implementation

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -35,3 +35,8 @@ To enforce the architecture correctly, all dynamic save block extraction functio
 ## Gen 3 Volcanic Ash Extraction Validation
 - **Pattern**: When validating Gen 3 dynamic save block extraction, ensure that offsets are not hardcoded absolute values (e.g. `0x13D0` or `0x142C`). They must be calculated relative to the dynamically resolved `section1Offset`.
 - **Outcome**: Rejected `task-267-261-gen3-ash-dataview-extraction-impl` due to hardcoded absolute offsets instead of using the `section1Offset + offset` calculation.
+
+## Gen 3 Volcanic Ash Extraction Permanent Failure
+- **Date**: 2026-07-12
+- **Node**: task-267-261-gen3-ash-dataview-extraction-impl
+- **Reason**: The developer reached max rejections by faking the relative offset calculation fix. They kept the absolute memory offsets and performed math manipulation, violating ADR 028.

--- a/.foundry/tasks/task-267-261-gen3-ash-dataview-extraction-impl.md
+++ b/.foundry/tasks/task-267-261-gen3-ash-dataview-extraction-impl.md
@@ -2,7 +2,7 @@
 id: task-267-261-gen3-ash-dataview-extraction-impl
 type: TASK
 title: Implement Gen 3 Volcanic Ash Extraction
-status: COMPLETED
+status: CANCELLED
 owner_persona: coder
 created_at: '2026-07-08'
 updated_at: '2026-07-12'
@@ -16,8 +16,8 @@ tags:
   - parsing
 research_references:
   - .foundry/archive/research/research-054-243-gen3-ash-gathering-offsets.md
-rejection_count: 2
-rejection_reason: ''
+rejection_count: 3
+rejection_reason: 'Developer repeatedly ignored ADR 028 and faked fix for relative offsets.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-267-262-gen3-ash-dataview-extraction-qa.md
+++ b/.foundry/tasks/task-267-262-gen3-ash-dataview-extraction-qa.md
@@ -33,10 +33,10 @@ Based on research findings, the Volcanic Ash gather count is stored as game vari
 The implementation task (`task-267-261-gen3-ash-dataview-extraction-impl`) requires extracting this data. As QA, you need to verify it.
 
 ## Acceptance Criteria
-- [ ] Verify that the DataView API is used instead of raw `Uint8Array` manipulation (ADR 010).
-- [ ] Verify that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level, without inline magic numbers (ADR 028).
-- [ ] Verify unit tests correctly extract ash count for both Emerald and Ruby/Sapphire.
-- [ ] Verify unit tests correctly trigger and catch `RangeError` exceptions for out-of-bounds reads.
+- [x] Verify that the DataView API is used instead of raw `Uint8Array` manipulation (ADR 010).
+- [x] Verify that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level, without inline magic numbers (ADR 028).
+- [x] Verify unit tests correctly extract ash count for both Emerald and Ruby/Sapphire.
+- [x] Verify unit tests correctly trigger and catch `RangeError` exceptions for out-of-bounds reads.
 
 ## Developer Instructions
 - **Failure conditions:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
@@ -44,3 +44,6 @@ The implementation task (`task-267-261-gen3-ash-dataview-extraction-impl`) requi
 
 ### QA Validation Failure
 Task rejected. The implementation uses absolute memory offsets (`0x13D0` / `0x142C`) instead of calculating relative offsets from the resolved `section1Offset`. This violates the rules for extracting Gen 3 dynamic save blocks and will result in reading from the wrong memory location.
+
+### QA Validation Failure 2
+Task permanently rejected and cancelled due to max rejections. Developer faked the fix by keeping absolute offsets and mathematically combining them.


### PR DESCRIPTION
Permanently fail task-267-261-gen3-ash-dataview-extraction-impl and cancel it from the DAG due to max rejections. The developer repeatedly ignored ADR 028 and faked the relative offset calculation fix by keeping absolute memory offsets and manipulating them mathematically. Update the QA task markdown and QA journal to reflect the permanent failure pattern.

---
*PR created automatically by Jules for task [1500708077768282096](https://jules.google.com/task/1500708077768282096) started by @szubster*