### PR TITLE
Generate FRLG Move Tutor Story Node

### DIFF
--- a/.foundry/epics/epic-055-119-gen3-move-tutor-save-parsing.md
+++ b/.foundry/epics/epic-055-119-gen3-move-tutor-save-parsing.md
@@ -43,4 +43,4 @@ Implement the logic to parse Gen 3 save files and extract the event flags indica
 - [ ] The parser correctly distinguishes between "Available" (flag unset) and "Used" (flag set) tutors.
 - [ ] Out-of-bounds reads or malformed saves are handled gracefully without application crashes.
 - [ ] story-119-267-gen3-move-tutor-emerald-parsing
-- [ ] story-119-268-gen3-move-tutor-frlg-parsing
+- [ ] story-119-318-gen3-move-tutor-frlg-parsing

--- a/.foundry/stories/story-119-318-gen3-move-tutor-frlg-parsing.md
+++ b/.foundry/stories/story-119-318-gen3-move-tutor-frlg-parsing.md
@@ -1,0 +1,38 @@
+---
+id: story-119-318-gen3-move-tutor-frlg-parsing
+type: STORY
+title: Parse Gen 3 FireRed/LeafGreen Move Tutor Flags
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+depends_on:
+  - epic-055-119-gen3-move-tutor-save-parsing
+jules_session_id: null
+pr_number: null
+parent: epic-055-119-gen3-move-tutor-save-parsing
+tags:
+  - gen3
+  - save-parsing
+  - move-tutor
+  - firered
+  - leafgreen
+research_references:
+  - research-055-247-gen3-move-tutor-offsets
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Parse Gen 3 FireRed/LeafGreen Move Tutor Flags
+
+## Objective
+Design a parser that extracts FireRed and LeafGreen Move Tutor flags from the save file's `event_flags`.
+
+## Context
+As described in `research-055-247-gen3-move-tutor-offsets` (detailed in `gen3_move_tutor_offsets.md`), FireRed and LeafGreen track Move Tutor usages within a continuous bit array of `event_flags` starting at a specific offset. Note that the event flag base offset in FRLG is different from Emerald and must be correctly identified and used.
+- Data must be extracted using `DataView` as mandated by ADR 010.
+- Extract the 18 specific Move Tutors available in FRLG.
+
+## Acceptance Criteria
+- [ ] Create tasks for implementing DataView-based extraction of FRLG Move Tutor bits.


### PR DESCRIPTION
Dynamically created `story-119-318-gen3-move-tutor-frlg-parsing.md` based on the acceptance criteria in `epic-055-119-gen3-move-tutor-save-parsing.md` and updated the epic to reference the correct story ID.

---
*PR created automatically by Jules for task [6881032131933812567](https://jules.google.com/task/6881032131933812567) started by @szubster*