### PR TITLE
feat: breakdown PRD 104 into epics for Missed Trainer Radar

### DIFF
--- a/.foundry/epics/epic-109-306-missed-trainer-data-extraction-gen1-gen2.md
+++ b/.foundry/epics/epic-109-306-missed-trainer-data-extraction-gen1-gen2.md
@@ -1,0 +1,35 @@
+---
+id: epic-109-306-missed-trainer-data-extraction-gen1-gen2
+type: EPIC
+title: Missed Trainer Radar - Data Extraction (Gen 1 & Gen 2)
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-07-12"
+updated_at: "2026-07-12"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-104-109-missed-trainer-radar
+tags:
+  - data-extraction
+  - gen1
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Missed Trainer Radar - Data Extraction (Gen 1 & Gen 2)
+
+## Objective
+Implement the data extraction layer for the "Missed Trainer Radar" feature specifically targeting Generation 1 and Generation 2 games. This will involve mapping and parsing trainer defeat flags from the save files.
+
+## Requirements
+1.  **Gen 1 Extraction:** Map and parse trainer defeat flags for Generation 1 games.
+2.  **Gen 2 Extraction:** Map and parse trainer defeat event flags from Bank 1 for Generation 2 games.
+3.  **Adherence to Cured Boundaries ADR (ADR 026):** All flag extractions must utilize explicit bitwise masking and shifting, and absolute zero boundary states must be comprehensively tested.
+4.  **Relative Offsets & Constants (ADR 028):** All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-109-307-missed-trainer-data-extraction-gen3.md
+++ b/.foundry/epics/epic-109-307-missed-trainer-data-extraction-gen3.md
@@ -1,0 +1,35 @@
+---
+id: epic-109-307-missed-trainer-data-extraction-gen3
+type: EPIC
+title: Missed Trainer Radar - Data Extraction (Gen 3)
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-07-12"
+updated_at: "2026-07-12"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-104-109-missed-trainer-radar
+tags:
+  - data-extraction
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Missed Trainer Radar - Data Extraction (Gen 3)
+
+## Objective
+Implement the data extraction layer for the "Missed Trainer Radar" feature specifically targeting Generation 3 games. This will involve mapping and parsing trainer defeat flags from the save files.
+
+## Requirements
+1.  **Gen 3 Extraction:** Map and parse trainer defeat flags (including Rematch flags) for Generation 3 games.
+2.  **Data Structure:** The extracted flags must be structured for use in the UI.
+3.  **Adherence to Gen 3 Data Parsing (ADR 010):** All new Gen3 save parsing logic MUST exclusively use the native `DataView` API rather than raw `Uint8Array` manipulations.
+4.  **Adherence to Cured Boundaries ADR (ADR 026):** All flag extractions must utilize explicit bitwise masking and shifting.
+5.  **Relative Offsets & Constants (ADR 028):** All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-109-308-missed-trainer-radar-ui.md
+++ b/.foundry/epics/epic-109-308-missed-trainer-radar-ui.md
@@ -1,0 +1,36 @@
+---
+id: epic-109-308-missed-trainer-radar-ui
+type: EPIC
+title: Missed Trainer Radar - UI Dashboard
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-07-12"
+updated_at: "2026-07-12"
+depends_on:
+  - epic-109-306-missed-trainer-data-extraction-gen1-gen2
+  - epic-109-307-missed-trainer-data-extraction-gen3
+jules_session_id: null
+pr_number: null
+parent: prd-104-109-missed-trainer-radar
+tags:
+  - ui
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Missed Trainer Radar - UI Dashboard
+
+## Objective
+Implement the UI Dashboard for the "Missed Trainer Radar" feature to display trainers the player has encountered but not yet defeated.
+
+## Requirements
+1.  **Encounter Filter:** The UI must display trainers the player has encountered (based on story progress, badges, or visited locations) but not yet defeated.
+2.  **Trainer Information Display:** Each entry must display the trainer's exact route/location, Pokémon team composition, and aggregate rewards.
+3.  **Aesthetics:** The UI should follow the project's tactical, snooping aesthetic as defined by existing ADRs and the UI style guides (ADR 008, ADR 024).
+4.  **Smart Route Radar Integration:** The UI map components will integrate dynamically with the data using the Smart Route Radar architecture defined in ADR 018.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -38,3 +38,19 @@ I have generated the necessary child epic nodes (`epic-071-123-define-tailwind-v
 **Context:** Processing PRD `prd-086-108-fix-orchestrator-phase-3-6`.
 **Observation:** The PRD requires a fix to extend Phase 3.6 of the `foundry-orchestrator.ts` logic to correctly handle nodes transitioning to `CANCELLED` status.
 **Action:** Generated the child Epic node `epic-108-303-extend-phase-3-6-cancelled-nodes` and appended it to the parent PRD's acceptance criteria as an unchecked task. Since all the required Epic generation is complete, but the generated child node must be completed before the PRD is finished, I will submit an empty PR directly to passthrough validation. This allows the Orchestrator to correctly calculate the DAG dependencies and demote the READY PRD node to PENDING state to enforce the strict macro node completion lifecycle. No other file changes are required for this PR.
+
+## Missed Trainer Radar PRD Breakdown
+Successfully broke down the "Missed Trainer Radar" PRD (`prd-104-109-missed-trainer-radar`) into three granular epics:
+- Gen 1 & 2 Data Extraction (`epic-109-306-missed-trainer-data-extraction-gen1-gen2`)
+- Gen 3 Data Extraction (`epic-109-307-missed-trainer-data-extraction-gen3`)
+- UI Dashboard (`epic-109-308-missed-trainer-radar-ui`)
+
+**Key Architectural Insights Applied:**
+- Included constraints for bitwise extraction and cured boundaries (ADR 026) for the flag parsing.
+- Included constraints for explicit relative offsets and constants (ADR 028) for the extraction layer.
+- Enforced the `DataView` API (ADR 010) specifically for the Gen 3 extraction layer.
+- Linked the UI epic to the "Smart Route Radar" architecture (ADR 018) for visualizing the missing encounters dynamically on the map.
+
+**Important Reminders:**
+- Temporary processing files (like `batch_*` logs from bash commands) must be manually deleted before committing to avoid polluting the workspace.
+- The `depends_on` array in the YAML frontmatter MUST use the bare node ID (e.g., `epic-109-306-missed-trainer-data-extraction-gen1-gen2`), not the relative file path.

--- a/.foundry/prds/prd-104-109-missed-trainer-radar.md
+++ b/.foundry/prds/prd-104-109-missed-trainer-radar.md
@@ -44,4 +44,7 @@ Players often accidentally or deliberately skip trainers during their initial ro
 3.  **Aesthetics:** The UI should follow the project's tactical, snooping aesthetic as defined by existing ADRs and the UI style guides.
 
 ## Acceptance Criteria
-- [ ] Break down into Epics
+- [ ] .foundry/epics/epic-109-306-missed-trainer-data-extraction-gen1-gen2.md
+- [ ] .foundry/epics/epic-109-307-missed-trainer-data-extraction-gen3.md
+- [ ] .foundry/epics/epic-109-308-missed-trainer-radar-ui.md
+- [x] Break down into Epics


### PR DESCRIPTION
Successfully broke down PRD `prd-104-109-missed-trainer-radar` into three granular Epics (two for data extraction across generations, one for the UI dashboard) and explicitly mapped their dependencies. Updated the PRD's markdown checklist and the epic planner's journal.

---
*PR created automatically by Jules for task [3112296154483612760](https://jules.google.com/task/3112296154483612760) started by @szubster*