### PR TITLE
fix(engine): integrate relative offset logic for Gen 3 Feebas parsing

### DIFF
--- a/src/engine/gen3/feebas.test.ts
+++ b/src/engine/gen3/feebas.test.ts
@@ -12,12 +12,12 @@ describe('extractFeebasSeed', () => {
     // 0x2dd6 + 2 bytes = 11736 bytes
     const buffer = new ArrayBuffer(12000);
     const view = new DataView(buffer);
-    view.setUint16(FEEBAS_SEED_OFFSET_RS, 0x1234, true);
+    view.setUint16(0x2000 + FEEBAS_SEED_OFFSET_RS, 0x1234, true);
 
-    const seedRuby = extractFeebasSeed(view, 'ruby');
+    const seedRuby = extractFeebasSeed(view, 'ruby', 0x2000);
     expect(seedRuby).toBe(0x1234);
 
-    const seedSapphire = extractFeebasSeed(view, 'sapphire');
+    const seedSapphire = extractFeebasSeed(view, 'sapphire', 0x2000);
     expect(seedSapphire).toBe(0x1234);
   });
 
@@ -25,9 +25,9 @@ describe('extractFeebasSeed', () => {
     // 0x2e66 + 2 bytes = 11880 bytes
     const buffer = new ArrayBuffer(12000);
     const view = new DataView(buffer);
-    view.setUint16(FEEBAS_SEED_OFFSET_EMERALD, 0x5678, true);
+    view.setUint16(0x2000 + FEEBAS_SEED_OFFSET_EMERALD, 0x5678, true);
 
-    const seedEmerald = extractFeebasSeed(view, 'emerald');
+    const seedEmerald = extractFeebasSeed(view, 'emerald', 0x2000);
     expect(seedEmerald).toBe(0x5678);
   });
 
@@ -35,9 +35,9 @@ describe('extractFeebasSeed', () => {
     const buffer = new ArrayBuffer(12000);
     const view = new DataView(buffer);
 
-    expect(() => extractFeebasSeed(view, 'firered')).toThrow('Unsupported game version');
-    expect(() => extractFeebasSeed(view, 'leafgreen')).toThrow('Unsupported game version');
-    expect(() => extractFeebasSeed(view, 'red')).toThrow('Unsupported game version');
+    expect(() => extractFeebasSeed(view, 'firered', 0x2000)).toThrow('Unsupported game version');
+    expect(() => extractFeebasSeed(view, 'leafgreen', 0x2000)).toThrow('Unsupported game version');
+    expect(() => extractFeebasSeed(view, 'red', 0x2000)).toThrow('Unsupported game version');
   });
 
   it('catches RangeError and re-throws specific corrupted file error', () => {
@@ -45,7 +45,7 @@ describe('extractFeebasSeed', () => {
     const buffer = new ArrayBuffer(100);
     const view = new DataView(buffer);
 
-    expect(() => extractFeebasSeed(view, 'ruby')).toThrow('The save file is corrupted or incomplete.');
+    expect(() => extractFeebasSeed(view, 'ruby', 0x2000)).toThrow('The save file is corrupted or incomplete.');
   });
 });
 

--- a/src/engine/gen3/feebas.ts
+++ b/src/engine/gen3/feebas.ts
@@ -1,7 +1,7 @@
 import type { GameVersion } from '../saveParser/parsers/common';
 
-export const FEEBAS_SEED_OFFSET_RS = 0x2dd6;
-export const FEEBAS_SEED_OFFSET_EMERALD = 0x2e66;
+export const FEEBAS_SEED_OFFSET_RS = 0x0dd6;
+export const FEEBAS_SEED_OFFSET_EMERALD = 0x0e66;
 
 export const LCG_MULTIPLIER = 1103515245;
 export const LCG_ADDEND = 12345;
@@ -18,14 +18,14 @@ export const FEEBAS_BOUNDARY = 4;
  * @returns The 16-bit Feebas seed.
  * @throws Error if the save file is corrupted or incomplete.
  */
-export function extractFeebasSeed(saveData: DataView, gameVersion: GameVersion): number {
+export function extractFeebasSeed(saveData: DataView, gameVersion: GameVersion, section2Offset: number): number {
   try {
     let offset = 0;
 
     if (gameVersion === 'ruby' || gameVersion === 'sapphire') {
-      offset = FEEBAS_SEED_OFFSET_RS;
+      offset = section2Offset + FEEBAS_SEED_OFFSET_RS;
     } else if (gameVersion === 'emerald') {
-      offset = FEEBAS_SEED_OFFSET_EMERALD;
+      offset = section2Offset + FEEBAS_SEED_OFFSET_EMERALD;
     } else {
       throw new Error(`Unsupported game version for Feebas seed extraction: ${gameVersion}`);
     }

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -50,7 +50,7 @@ describe('gen3 parser scaffolding', () => {
     }
 
     // Mock a seed at the expected offset for Ruby/Sapphire
-    view.setUint16(FEEBAS_SEED_OFFSET_RS, 12345, true);
+    view.setUint16(0x2000 + FEEBAS_SEED_OFFSET_RS, 12345, true);
 
     try {
       const resultRS = parseGen3(view, 'ruby');

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -1047,7 +1047,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     let gen3FeebasTiles: number[] | undefined;
     if (_forcedVersion === 'ruby' || _forcedVersion === 'sapphire' || _forcedVersion === 'emerald') {
       try {
-        const seed = extractFeebasSeed(view, _forcedVersion);
+        const seed = extractFeebasSeed(view, _forcedVersion, section2Offset);
         gen3FeebasTiles = calculateFeebasTiles(seed);
       } catch {
         // Ignored


### PR DESCRIPTION
This PR fixes the `extractFeebasSeed` function to use relative section offsets (`section2Offset`) rather than absolute offset values, correctly supporting the A/B bank flash memory architecture in Generation 3 games. It also updates the related tests to accommodate the signature change.

---
*PR created automatically by Jules for task [16905220841728979285](https://jules.google.com/task/16905220841728979285) started by @szubster*