### PR TITLE
Draft blueprints for Gen 3 Volcanic Ash extraction retry

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -174,3 +174,6 @@ When drafting save parser blueprints using DataView, explicitly mandate catching
 
 ## 2026-07-11: Filter Swarm & Item Calls
 Drafted technical blueprints (`task-286-314-filter-swarm-item-calls-impl` and `task-286-315-filter-swarm-item-calls-qa`) to implement filtering of active Gen 2 Pokegear callers based on `wSwarmFlags`, `wDailyPhoneItemFlags`, and `wDailyPhoneTimeOfDayFlags`. Due to the complexity and risk of parsing memory states directly, I applied the Intelligent Verification Protocol to require a dedicated QA verification pass. Explicit architectural constraints forbidding the use of inline magic numbers for memory offsets were mandated in both blueprints to comply with ADR 028.
+
+## 2026-07-12: Gen 3 Dynamic Save Block Extraction Pattern
+When generating blueprints for Gen 3 dynamic save block extraction (like Volcanic Ash), ensure explicit instructions are provided to use the dynamically resolved `section1Offset` for relative offset calculations rather than hardcoding absolute values. Using absolute offsets breaks A/B bank flash memory parsing.

--- a/.foundry/research/research-267-297-gen3-ash-dataview-relative-offsets.md
+++ b/.foundry/research/research-267-297-gen3-ash-dataview-relative-offsets.md
@@ -4,6 +4,9 @@ type: RESEARCH
 title: Gen 3 Volcanic Ash Relative Offsets
 status: PENDING
 owner_persona: researcher
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+jules_session_id: null
 depends_on: []
 parent: story-113-267-gen3-ash-dataview-extraction
 tags:

--- a/.foundry/research/research-267-297-gen3-ash-dataview-relative-offsets.md
+++ b/.foundry/research/research-267-297-gen3-ash-dataview-relative-offsets.md
@@ -1,0 +1,32 @@
+---
+id: research-267-297-gen3-ash-dataview-relative-offsets
+type: RESEARCH
+title: Gen 3 Volcanic Ash Relative Offsets
+status: PENDING
+owner_persona: researcher
+depends_on: []
+parent: story-113-267-gen3-ash-dataview-extraction
+tags:
+  - gen3
+  - ash
+  - parsing
+research_references:
+  - .foundry/archive/research/research-054-243-gen3-ash-gathering-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Volcanic Ash Relative Offsets
+
+## Context
+The previous implementation task for extracting Volcanic Ash count (`task-267-261-gen3-ash-dataview-extraction-impl`) failed permanently because it used hardcoded absolute offsets (`0x142C` / `0x13D0`). Gen 3 saves use an A/B bank rotation system for flash memory. Using absolute offsets will fail when the active bank rotates. We must determine the correct relative offset calculation.
+
+## Acceptance Criteria
+- [ ] Investigate the root cause of the previous implementation failure regarding absolute offsets vs relative offsets.
+- [ ] Document how to calculate the correct relative memory offset for Volcanic Ash using the dynamically resolved `section1Offset` provided by the parsing engine.
+- [ ] Define what the module-level constant values should be for these relative offsets, adhering to ADR 028.
+
+## Developer Instructions
+- **Failure conditions:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Completion conditions:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/stories/story-113-267-gen3-ash-dataview-extraction.md
+++ b/.foundry/stories/story-113-267-gen3-ash-dataview-extraction.md
@@ -31,5 +31,8 @@ Based on research findings, the Volcanic Ash gather count is stored as game vari
 
 ## Acceptance Criteria
 - [x] Create tasks for the DataView extraction using the identified offsets.
-- [ ] task-267-261-gen3-ash-dataview-extraction-impl
-- [ ] task-267-262-gen3-ash-dataview-extraction-qa
+- [x] task-267-261-gen3-ash-dataview-extraction-impl
+- [x] task-267-262-gen3-ash-dataview-extraction-qa
+- [ ] research-267-297-gen3-ash-dataview-relative-offsets
+- [ ] task-267-320-gen3-ash-dataview-extraction-retry-impl
+- [ ] task-267-321-gen3-ash-dataview-extraction-retry-qa

--- a/.foundry/tasks/task-267-262-gen3-ash-dataview-extraction-qa.md
+++ b/.foundry/tasks/task-267-262-gen3-ash-dataview-extraction-qa.md
@@ -47,3 +47,5 @@ Task rejected. The implementation uses absolute memory offsets (`0x13D0` / `0x14
 
 ### QA Validation Failure 2
 Task permanently rejected and cancelled due to max rejections. Developer faked the fix by keeping absolute offsets and mathematically combining them.
+### Task Cancelled
+This task has been CANCELLED and replaced by task-267-320-gen3-ash-dataview-extraction-retry-impl and task-267-321-gen3-ash-dataview-extraction-retry-qa due to the implementation reaching max rejections.

--- a/.foundry/tasks/task-267-320-gen3-ash-dataview-extraction-retry-impl.md
+++ b/.foundry/tasks/task-267-320-gen3-ash-dataview-extraction-retry-impl.md
@@ -1,0 +1,43 @@
+---
+id: task-267-320-gen3-ash-dataview-extraction-retry-impl
+type: TASK
+title: Implement Gen 3 Volcanic Ash Extraction (Retry)
+status: PENDING
+owner_persona: coder
+depends_on:
+  - research-267-297-gen3-ash-dataview-relative-offsets
+parent: story-113-267-gen3-ash-dataview-extraction
+tags:
+  - gen3
+  - ash
+  - parsing
+research_references:
+  - .foundry/archive/research/research-054-243-gen3-ash-gathering-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Volcanic Ash Extraction (Retry)
+
+## Context
+Based on research findings, the Volcanic Ash gather count is stored as game variable `0x4048`.
+- It's a `u16` located at byte offset `0x90` within the `SaveBlock1` vars array.
+- Emerald Absolute Offset: `0x142C`
+- Ruby/Sapphire Absolute Offset: `0x13D0`
+
+The previous implementation failed because it hardcoded these absolute offsets. Gen 3 save files use an A/B bank rotation system for flash memory. To properly support this, we must dynamically resolve the offset based on `section1Offset`.
+
+As per ADR 010, the DataView API MUST be used instead of raw `Uint8Array` manipulation.
+As per ADR 028, all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. Inline magic numbers are explicitly forbidden.
+
+## Acceptance Criteria
+- [ ] Implement Volcanic Ash DataView extraction logic for Gen 3 saves.
+- [ ] Calculate the relative memory offset using the dynamically resolved `section1Offset` (i.e., `section1Offset + 0x90` or equivalent relative mapping) instead of hardcoding `0x142C` or `0x13D0`.
+- [ ] Define the necessary relative offsets as reusable module-level constants.
+- [ ] Write unit tests verifying correct extraction for Ruby/Sapphire and Emerald using `section1Offset`.
+- [ ] Write unit tests that trigger and catch `RangeError` exceptions for out-of-bounds reads.
+
+## Developer Instructions
+- **Failure conditions:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Completion conditions:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-267-320-gen3-ash-dataview-extraction-retry-impl.md
+++ b/.foundry/tasks/task-267-320-gen3-ash-dataview-extraction-retry-impl.md
@@ -4,6 +4,9 @@ type: TASK
 title: Implement Gen 3 Volcanic Ash Extraction (Retry)
 status: PENDING
 owner_persona: coder
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+jules_session_id: null
 depends_on:
   - research-267-297-gen3-ash-dataview-relative-offsets
 parent: story-113-267-gen3-ash-dataview-extraction

--- a/.foundry/tasks/task-267-321-gen3-ash-dataview-extraction-retry-qa.md
+++ b/.foundry/tasks/task-267-321-gen3-ash-dataview-extraction-retry-qa.md
@@ -4,6 +4,9 @@ type: TASK
 title: QA Gen 3 Volcanic Ash Extraction (Retry)
 status: PENDING
 owner_persona: qa
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+jules_session_id: null
 depends_on:
   - task-267-320-gen3-ash-dataview-extraction-retry-impl
 parent: story-113-267-gen3-ash-dataview-extraction

--- a/.foundry/tasks/task-267-321-gen3-ash-dataview-extraction-retry-qa.md
+++ b/.foundry/tasks/task-267-321-gen3-ash-dataview-extraction-retry-qa.md
@@ -1,0 +1,40 @@
+---
+id: task-267-321-gen3-ash-dataview-extraction-retry-qa
+type: TASK
+title: QA Gen 3 Volcanic Ash Extraction (Retry)
+status: PENDING
+owner_persona: qa
+depends_on:
+  - task-267-320-gen3-ash-dataview-extraction-retry-impl
+parent: story-113-267-gen3-ash-dataview-extraction
+tags:
+  - gen3
+  - ash
+  - parsing
+research_references:
+  - .foundry/archive/research/research-054-243-gen3-ash-gathering-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 Volcanic Ash Extraction (Retry)
+
+## Context
+Based on research findings, the Volcanic Ash gather count is stored as game variable `0x4048`.
+- It's a `u16` located at byte offset `0x90` within the `SaveBlock1` vars array.
+- Emerald Absolute Offset: `0x142C`
+- Ruby/Sapphire Absolute Offset: `0x13D0`
+
+The implementation task (`task-267-320-gen3-ash-dataview-extraction-retry-impl`) requires extracting this data. As QA, you need to verify it. The previous implementation was permanently rejected because the developer repeatedly faked the fix for the A/B bank flash memory relative offsets.
+
+## Acceptance Criteria
+- [ ] Verify that the DataView API is used instead of raw `Uint8Array` manipulation (ADR 010).
+- [ ] Verify that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level, without inline magic numbers (ADR 028).
+- [ ] Verify that the implementation uses the resolved `section1Offset` to calculate the relative memory offset (e.g. `section1Offset + 0x90`) instead of absolute offsets.
+- [ ] Verify unit tests correctly extract ash count for both Emerald and Ruby/Sapphire.
+- [ ] Verify unit tests correctly trigger and catch `RangeError` exceptions for out-of-bounds reads.
+
+## Developer Instructions
+- **Failure conditions:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Completion conditions:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Replaced permanently failed and orphaned child nodes for story-113-267-gen3-ash-dataview-extraction with a new set of nodes. Added research-267-297-gen3-ash-dataview-relative-offsets to investigate root cause of absolute offset failure, and spawned dependent task-267-320-gen3-ash-dataview-extraction-retry-impl and task-267-321-gen3-ash-dataview-extraction-retry-qa enforcing the use of section1Offset relative offsets and module-level constants.

---
*PR created automatically by Jules for task [12218380316934714554](https://jules.google.com/task/12218380316934714554) started by @szubster*