### PR TITLE
Implement E2E safeguards on Epics

### DIFF
--- a/.foundry/tasks/task-269-263-implement-e2e-safeguard.md
+++ b/.foundry/tasks/task-269-263-implement-e2e-safeguard.md
@@ -48,10 +48,10 @@ Implement logic in `.github/scripts/foundry-orchestrator.ts` and `.github/script
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement E2E enforcement logic in `foundry-orchestrator.ts` (Phase 4.1 / 4.5).
-- [ ] Implement E2E enforcement logic in `foundry-heartbeat.ts` (`transitionNodeToCompleted`).
-- [ ] Add unit tests in `foundry-orchestrator.test.ts` covering the new rules for EPICs.
-- [ ] Add unit tests in `foundry-heartbeat.test.ts` covering the new rules for EPICs.
+- [x] Implement E2E enforcement logic in `foundry-orchestrator.ts` (Phase 4.1 / 4.5).
+- [x] Implement E2E enforcement logic in `foundry-heartbeat.ts` (`transitionNodeToCompleted`).
+- [x] Add unit tests in `foundry-orchestrator.test.ts` covering the new rules for EPICs.
+- [x] Add unit tests in `foundry-heartbeat.test.ts` covering the new rules for EPICs.
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -33,6 +33,85 @@ describe('Foundry Heartbeat', () => {
     vi.restoreAllMocks();
   });
 
+  it('should transition an EPIC to FAILED instead of VERIFYING if it lacks an E2E story', async () => {
+    const mockEpic = {
+      filePath: '/mock/repo/.foundry/epics/epic-1.md',
+      repoPath: '.foundry/epics/epic-1.md',
+      frontmatter: {
+        id: 'epic-1',
+        type: 'EPIC',
+        status: 'ACTIVE',
+        jules_session_id: 'session-1'
+      },
+      rawContent: '---\ntype: EPIC\nstatus: ACTIVE\njules_session_id: "session-1"\n---\nBody'
+    };
+
+    const mockChild = {
+      filePath: '/mock/repo/.foundry/stories/story-1.md',
+      repoPath: '.foundry/stories/story-1.md',
+      frontmatter: {
+        id: 'story-1',
+        type: 'STORY',
+        parent: 'epic-1',
+        tags: ['frontend']
+      }
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/epics/epic-1.md', '/mock/repo/.foundry/stories/story-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockImplementation((fp) => {
+      if (fp === '/mock/repo/.foundry/epics/epic-1.md') return mockEpic as any;
+      if (fp === '/mock/repo/.foundry/stories/story-1.md') return mockChild as any;
+      return null;
+    });
+
+    await transitionNodeToCompleted(mockEpic, mockRepoRoot, 123);
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(writeCall[0]).toBe(mockEpic.filePath);
+    expect(writeCall[1]).toContain('status: FAILED');
+    expect(writeCall[1]).toContain('Missing E2E');
+  });
+
+  it('should transition an EPIC to VERIFYING if it has an E2E story', async () => {
+    const mockEpic = {
+      filePath: '/mock/repo/.foundry/epics/epic-1.md',
+      repoPath: '.foundry/epics/epic-1.md',
+      frontmatter: {
+        id: 'epic-1',
+        type: 'EPIC',
+        status: 'ACTIVE',
+        jules_session_id: 'session-1'
+      },
+      rawContent: '---\ntype: EPIC\nstatus: ACTIVE\njules_session_id: "session-1"\n---\nBody'
+    };
+
+    const mockChild = {
+      filePath: '/mock/repo/.foundry/stories/story-1.md',
+      repoPath: '.foundry/stories/story-1.md',
+      frontmatter: {
+        id: 'story-1',
+        type: 'STORY',
+        parent: 'epic-1',
+        tags: ['integration']
+      }
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/epics/epic-1.md', '/mock/repo/.foundry/stories/story-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockImplementation((fp) => {
+      if (fp === '/mock/repo/.foundry/epics/epic-1.md') return mockEpic as any;
+      if (fp === '/mock/repo/.foundry/stories/story-1.md') return mockChild as any;
+      return null;
+    });
+
+    await transitionNodeToCompleted(mockEpic, mockRepoRoot, 123);
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(writeCall[0]).toBe(mockEpic.filePath);
+    expect(writeCall[1]).toContain('status: VERIFYING');
+  });
+
   it('should transition a node to READY without penalty if its Jules session is in a terminal state without a PR', async () => {
     const mockNode = {
       filePath: '/mock/repo/.foundry/tasks/task-1.md',

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -114,6 +114,40 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
   }
 
   const nodeType = parsed.data.type || node.frontmatter.type;
+
+  if (nodeType === 'EPIC') {
+    const filePaths = discoverNodeFiles(path.join(repoRoot, '.foundry'));
+    let hasE2EStory = false;
+    for (const fp of filePaths) {
+      if (fp === node.filePath) continue;
+      const childNode = parseNodeFile(fp, repoRoot);
+      if (childNode &&
+         (childNode.frontmatter.parent === node.repoPath || childNode.frontmatter.parent === node.frontmatter.id) &&
+          childNode.frontmatter.type === 'STORY' &&
+          childNode.frontmatter.tags &&
+          childNode.frontmatter.tags.some(t => t.toLowerCase() === 'e2e' || t.toLowerCase() === 'integration')
+      ) {
+        hasE2EStory = true;
+        break;
+      }
+    }
+
+    if (!hasE2EStory) {
+      parsed.data.status = "FAILED";
+      parsed.data.jules_session_id = null;
+      parsed.data.updated_at = dateStr;
+      parsed.data.rejection_reason = "Merged with unfulfilled acceptance criteria: Missing E2E/integration story";
+
+      const newContent = matter.stringify(parsed.content, parsed.data);
+
+      if (!DRY_RUN) {
+        fs.writeFileSync(node.filePath, newContent, 'utf-8');
+      }
+      info(`${dryTag}Transitioned ACTIVE → FAILED: ${node.repoPath} (PR #${prNumber}) (Missing E2E)`);
+      return;
+    }
+  }
+
   if (["IDEA", "PRD", "EPIC"].includes(nodeType)) {
     parsed.data.status = "VERIFYING";
     parsed.data.jules_session_id = null;

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -77,6 +77,73 @@ vi.doMock('node:url', async (importOriginal) => {
     expect(fileContent).toContain("rejection_reason: ''");
   });
 
+  test('Late-Binding Parent fails to COMPLETED if EPIC lacks E2E story', () => {
+    createValidTestNode(tmpDir, '.foundry/epics/epic-e2e.md', {
+      id: "epic-e2e",
+      type: "EPIC",
+      title: "Epic E2E",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null
+    }, "## Acceptance Criteria\n- [x] Task\n");
+
+    createValidTestNode(tmpDir, '.foundry/stories/story-no-e2e.md', {
+      id: "story-no-e2e",
+      type: "STORY",
+      title: "Story No E2E",
+      status: "COMPLETED",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: "epic-e2e",
+      tags: ["frontend"],
+      jules_session_id: null
+    });
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    main();
+    const fileContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-e2e.md'), 'utf-8');
+    expect(fileContent).toContain('status: FAILED');
+    expect(fileContent).toContain('Missing E2E/integration story');
+  });
+
+  test('Late-Binding Parent promotes to COMPLETED if EPIC has E2E story', () => {
+    createValidTestNode(tmpDir, '.foundry/epics/epic-with-e2e.md', {
+      id: "epic-with-e2e",
+      type: "EPIC",
+      title: "Epic E2E",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null
+    }, "## Acceptance Criteria\n- [x] Task\n");
+
+    createValidTestNode(tmpDir, '.foundry/stories/story-e2e.md', {
+      id: "story-e2e",
+      type: "STORY",
+      title: "Story E2E",
+      status: "COMPLETED",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: "epic-with-e2e",
+      tags: ["e2E", "frontend"],
+      jules_session_id: null
+    });
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    main();
+    const fileContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-with-e2e.md'), 'utf-8');
+    expect(fileContent).toContain('status: COMPLETED');
+  });
+
   test('Happy Path: promotes PENDING to READY when all dependencies are COMPLETED', () => {
     createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
       id: "idea-001",
@@ -408,6 +475,7 @@ vi.doMock('node:url', async (importOriginal) => {
       updated_at: "2026-04-20",
       depends_on: [],
       parent: ".foundry/epics/epic-001.md",
+      tags: ["integration"],
       jules_session_id: null,
     });
 
@@ -495,6 +563,7 @@ vi.doMock('node:url', async (importOriginal) => {
       updated_at: "2026-04-20",
       depends_on: [],
       parent: ".foundry/epics/epic-001.md",
+      tags: ["e2e"],
       jules_session_id: null,
     });
 
@@ -581,6 +650,7 @@ vi.doMock('node:url', async (importOriginal) => {
       updated_at: "2026-04-20",
       depends_on: [],
       parent: ".foundry/epics/epic-001.md",
+      tags: ["integration"],
       jules_session_id: null,
     });
 
@@ -2245,6 +2315,7 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
       updated_at: "2026-04-20",
       depends_on: [],
       parent: "story-001",
+      tags: ["e2e"],
       jules_session_id: null,
     });
 

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -925,6 +925,23 @@ function main(): void {
               }
               // Prevent promotion to COMPLETED by bypassing the else branch
             } else {
+              if (node.frontmatter.type === 'EPIC') {
+                const hasE2E = children.some(child =>
+                  child.frontmatter.type === 'STORY' &&
+                  child.frontmatter.tags &&
+                  child.frontmatter.tags.some(t => t.toLowerCase() === 'e2e' || t.toLowerCase() === 'integration')
+                );
+                if (!hasE2E) {
+                  info(`Late-Binding Parent Complete: ${node.repoPath} has completed children, but lacks an E2E/integration STORY. Promoting to FAILED.`);
+                  promoteNodeToFailedWithReason(node, 'Merged with unfulfilled acceptance criteria: Missing E2E/integration story');
+                  const idx = eligible.indexOf(node);
+                  if (idx !== -1) {
+                    eligible.splice(idx, 1);
+                  }
+                  continue; // Skip promoting to COMPLETED
+                }
+              }
+
               info(`Late-Binding Parent Complete: ${node.repoPath} has children and all are COMPLETED. Promoting directly to COMPLETED.`);
               promoteNodeStatus(node, 'PENDING', 'COMPLETED');
               // Remove from eligible if it was added
@@ -977,6 +994,24 @@ function main(): void {
         info(`Idempotent check: Artifacts for ${node.repoPath} already exist, but node still has unchecked tasks. Promoting to READY.`);
         finalEligible.push(node);
       } else {
+        if (node.frontmatter.type === 'EPIC') {
+          // Check for E2E story in its generated links
+          const bodyLinks = [...node.body.matchAll(/\]\((?:\.\/)?(\.foundry\/(?:ideas|prds|epics|stories|tasks)\/[^)]+\.md)\)/g)].map(m => m[1]);
+          const e2eChildExists = bodyLinks.some(l => {
+            const childNode = nodeMap.get(l);
+            return childNode &&
+                   childNode.frontmatter.type === 'STORY' &&
+                   childNode.frontmatter.tags &&
+                   childNode.frontmatter.tags.some(t => t.toLowerCase() === 'e2e' || t.toLowerCase() === 'integration');
+          });
+
+          if (!e2eChildExists) {
+            info(`Idempotent check failed for ${node.repoPath}: artifacts exist but lacks an E2E/integration STORY. Promoting to FAILED.`);
+            promoteNodeToFailedWithReason(node, 'Merged with unfulfilled acceptance criteria: Missing E2E/integration story');
+            continue;
+          }
+        }
+
         info(`Idempotent check bypassed dispatch for ${node.repoPath} (artifacts already exist).`);
         promoteNodeStatus(node, 'PENDING', 'COMPLETED');
 


### PR DESCRIPTION
Implement E2E safeguards logic in orchestrator and heartbeat scripts. Add required tests to verify behavior and transition states accurately. Check off acceptance criteria in task document.

---
*PR created automatically by Jules for task [10746462168544523673](https://jules.google.com/task/10746462168544523673) started by @szubster*