### PR TITLE
docs(foundry): remove obsolete orphaned node manual cancellation rule

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -75,8 +75,7 @@ If you are woken up by the Orchestrator because a child node reached its Max Rej
 1. Spawn a `RESEARCH` node to investigate the root cause of the failure.
 2. Create a new set of replacement nodes that explicitly depend on the `RESEARCH` node being completed.
 3. Append these new nodes to your own markdown body.
-4. **CRITICAL:** Do NOT update the YAML frontmatter of any orphaned pending nodes (like `QA` task nodes) associated with the failed implementation. Instead, update the orphaned node's Markdown body indicating that it is CANCELLED and replaced by the new tasks.
-5. **CRITICAL:** You MUST check off the markdown checkboxes (`- [x]`) of the permanently failed and orphaned child nodes in your own markdown body. If they remain unchecked, ADR 007 will prevent this parent node from ever transitioning to COMPLETED.
+4. **CRITICAL:** You MUST check off the markdown checkboxes (`- [x]`) of the permanently failed child nodes in your own markdown body. (Note: The Orchestrator will automatically cascade cancellations to any orphaned dependent child nodes). If they remain unchecked, ADR 007 will prevent this parent node from ever transitioning to COMPLETED.
 
 ## Late Binding for Missing Context
 If you lack critical context or specifications (e.g., exact memory offsets) necessary to implement a task or generate actionable blueprints, DO NOT guess or implement generic fallbacks. Instead, you MUST utilize the late binding pattern to suspend the task:

--- a/.foundry/ideas/idea-115-remove-obsolete-orphaned-node-manual-cancellation.md
+++ b/.foundry/ideas/idea-115-remove-obsolete-orphaned-node-manual-cancellation.md
@@ -1,0 +1,24 @@
+---
+id: idea-115-remove-obsolete-orphaned-node-manual-cancellation
+type: IDEA
+title: Remove Obsolete Orphaned Node Manual Cancellation Rule
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-07-12'
+updated_at: '2026-07-12'
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - foundry
+  - orchestrator
+  - agile-coach
+---
+
+# Remove Obsolete Orphaned Node Manual Cancellation Rule
+
+## Description
+The Agile Coach identified friction caused by the obsolete "Orphaned QA Task Cancellation Rule" in `core_policies.md`. The orchestrator's Phase 3.6 cascade cancellation logic now automatically cancels PENDING nodes that depend on permanently failed nodes, making the manual markdown body updates redundant and conflict-prone. This rule has been removed from `core_policies.md` to streamline the agent workflow and align with the Orchestrator's automated capabilities.
+
+## Acceptance Criteria
+- [ ] Product Manager: Convert this idea into a PRD to formalize the removal of manual orphaned node cancellation rules across the documentation.


### PR DESCRIPTION
The Agile Coach identified friction caused by the obsolete "Orphaned QA Task Cancellation Rule" in `core_policies.md`. The orchestrator's Phase 3.6 cascade cancellation logic now automatically cancels PENDING nodes that depend on permanently failed nodes, making the manual markdown body updates redundant and conflict-prone.

This PR removes the obsolete manual rule from `core_policies.md` and generates a new `IDEA` node (`idea-115-remove-obsolete-orphaned-node-manual-cancellation.md`) to formalize this architectural improvement.

---
*PR created automatically by Jules for task [6172687250326890987](https://jules.google.com/task/6172687250326890987) started by @szubster*