### PR TITLE
test: Add deadlock prevention mechanism unit tests

### DIFF
--- a/.foundry/tasks/task-031-048-implement-deadlock-tests.md
+++ b/.foundry/tasks/task-031-048-implement-deadlock-tests.md
@@ -22,9 +22,9 @@ rejection_reason: ''
 Implement unit tests in `.github/scripts/foundry-orchestrator.test.ts` to verify that the orchestrator correctly identifies and prevents deadlocks when resolving dependencies. The tests should validate logic ensuring no infinite dependency loops or blocked states fail silently or lock up the workflow.
 
 ## Acceptance Criteria
-- [ ] Unit tests are added to verify deadlock prevention mechanisms function correctly.
-- [ ] The orchestrator logic handles circular dependencies safely and correctly prevents deadlocks.
-- [ ] All tests in `.github/scripts/` pass successfully.
+- [x] Unit tests are added to verify deadlock prevention mechanisms function correctly.
+- [x] The orchestrator logic handles circular dependencies safely and correctly prevents deadlocks.
+- [x] All tests in `.github/scripts/` pass successfully.
 
 ## Intelligent Verification Protocol
 This is considered a low-risk/simple task because it specifically adds unit tests to an existing test suite.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -2345,4 +2345,43 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     const prdContent = fs.readFileSync(path.join(tmpDir, ".foundry/prds/prd-001.md"), "utf-8");
     expect(prdContent).toContain("status: PENDING");
   });
+
+  test('Deadlock Prevention: Handles circular dependencies safely and correctly prevents deadlocks', () => {
+    createValidTestNode(tmpDir, '.foundry/tasks/task-a.md', {
+      id: "task-a",
+      type: "TASK",
+      title: "Task A",
+      status: "PENDING",
+      owner_persona: "coder",
+      depends_on: [".foundry/tasks/task-b.md"],
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-b.md', {
+      id: "task-b",
+      type: "TASK",
+      title: "Task B",
+      status: "PENDING",
+      owner_persona: "coder",
+      depends_on: [".foundry/tasks/task-c.md"],
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-c.md', {
+      id: "task-c",
+      type: "TASK",
+      title: "Task C",
+      status: "PENDING",
+      owner_persona: "coder",
+      depends_on: [".foundry/tasks/task-a.md"],
+    });
+
+    main();
+
+    const aContent = fs.readFileSync(path.join(tmpDir, ".foundry/tasks/task-a.md"), "utf-8");
+    const bContent = fs.readFileSync(path.join(tmpDir, ".foundry/tasks/task-b.md"), "utf-8");
+    const cContent = fs.readFileSync(path.join(tmpDir, ".foundry/tasks/task-c.md"), "utf-8");
+
+    expect(aContent).toContain("status: PENDING");
+    expect(bContent).toContain("status: PENDING");
+    expect(cContent).toContain("status: PENDING");
+  });
 });

--- a/.jules/coder.md
+++ b/.jules/coder.md
@@ -1,0 +1,1 @@
+Added tests for deadlock prevention mechanisms in .github/scripts/foundry-orchestrator.test.ts


### PR DESCRIPTION
Added unit tests for deadlock prevention and circular dependency handling in `foundry-orchestrator.test.ts`. This completes `task-031-048-implement-deadlock-tests`.

Also cleaned up transient files and restored package.json.

---
*PR created automatically by Jules for task [8244589087903244410](https://jules.google.com/task/8244589087903244410) started by @szubster*