### PR TITLE
Suspend Gen 3 static encounter parsing pending research on memory offsets

### DIFF
--- a/.foundry/research/research-294-320-gen3-static-encounter-offsets.md
+++ b/.foundry/research/research-294-320-gen3-static-encounter-offsets.md
@@ -1,0 +1,28 @@
+---
+id: research-294-320-gen3-static-encounter-offsets
+type: RESEARCH
+title: Gen 3 Static Encounter Offsets
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-13'
+updated_at: '2026-07-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-138-294-gen3-static-encounters-parsing
+tags:
+  - gen3
+  - research
+  - parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Static Encounter Offsets
+
+Investigate and document the memory offsets and bit locations for Gen 3 static encounter event flags.
+
+## Acceptance Criteria
+- [ ] Find offsets

--- a/.foundry/stories/story-138-294-gen3-static-encounters-parsing.md
+++ b/.foundry/stories/story-138-294-gen3-static-encounters-parsing.md
@@ -2,11 +2,12 @@
 id: story-138-294-gen3-static-encounters-parsing
 type: STORY
 title: Gen 3 Static Encounters Parsing
-status: ACTIVE
+status: FAILED
 owner_persona: tech_lead
 created_at: '2026-07-11'
 updated_at: '2026-07-13'
-depends_on: []
+depends_on:
+  - research-294-320-gen3-static-encounter-offsets
 jules_session_id: '15221877614741500045'
 pr_number: null
 parent: epic-106-138-gen3-static-encounters
@@ -16,7 +17,7 @@ tags:
   - parsing
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Missing context for memory offsets for static encounters.'
 notes: ''
 ---
 
@@ -25,6 +26,7 @@ notes: ''
 Implement the save block extraction logic for Gen 3 event flags related to static encounters.
 
 ## Acceptance Criteria
+- [ ] research-294-320-gen3-static-encounter-offsets
 - [ ] Define module-level constants for static encounter event flag offsets and bit locations.
 - [ ] Implement save file parsing logic to extract static encounter status.
 - [ ] Follow dynamic save block extraction guidelines (ADR 028).


### PR DESCRIPTION
The `story-138-294-gen3-static-encounters-parsing` task requires the Coder to implement Gen 3 save file extraction logic for static encounters and mandates module-level constants for event flag offsets as per ADR 028. However, the exact memory offsets and bit locations for these flags were not provided in the original `epic-106-138-gen3-static-encounters` or the overarching PRD, and they do not currently exist within `.foundry/docs/knowledge_base/`.

Following the Late Binding pattern for missing context, I have:
1. Created `research-294-320-gen3-static-encounter-offsets.md` assigned to the `researcher` persona to investigate the Gen 3 static encounter event flags.
2. Modified the original `story-138-294-gen3-static-encounters-parsing` node to:
    *   Set its status to `FAILED`.
    *   Added a `rejection_reason` explaining the missing context.
    *   Added the new research node to its `depends_on` array.
    *   Appended the new research node as an unchecked checkbox in its Acceptance Criteria section.

---
*PR created automatically by Jules for task [15221877614741500045](https://jules.google.com/task/15221877614741500045) started by @szubster*