### PR TITLE
chore(styling): define tactical form and text utilities

### DIFF
--- a/.foundry/tasks/task-270-311-define-tactical-form-utilities-impl.md
+++ b/.foundry/tasks/task-270-311-define-tactical-form-utilities-impl.md
@@ -37,9 +37,9 @@ As per ADR 024, we are migrating to Tailwind v4 and need to define our tactical 
 4. Ensure no components were accidentally broken by these definitions. Perform a self-verification.
 
 ## Acceptance Criteria
-- [ ] `tactical-input` is defined in `src/index.css` with sharp edges and dark background.
-- [ ] `tactical-focus` is defined in `src/index.css`.
-- [ ] `tactical-text` is defined in `src/index.css` using `font-mono`.
+- [x] `tactical-input` is defined in `src/index.css` with sharp edges and dark background.
+- [x] `tactical-focus` is defined in `src/index.css`.
+- [x] `tactical-text` is defined in `src/index.css` using `font-mono`.
 
 ## Blueprint Notes for Coder
 - **Transient Failures**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
This is an empty PR to advance the DAG. The required `@utility tactical-input`, `@utility tactical-focus`, and `@utility tactical-text` are already defined in `src/index.css` and meet the requirements specified in ADR 024. The acceptance criteria checkboxes in `.foundry/tasks/task-270-311-define-tactical-form-utilities-impl.md` have been checked off.

---
*PR created automatically by Jules for task [6445176788183506441](https://jules.google.com/task/6445176788183506441) started by @szubster*