### PR TITLE
fix: correct VERIFYING allowance logic in Orchestrator dependency checks

### DIFF
--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -94,3 +94,6 @@ In task `task-269-263-detect-party-zero-hp-impl`, I verified the existing implem
 ## Session: task-267-287-gen3-move-tutor-emerald-impl
 
 The target artifact (Emerald Move Tutor extraction logic and tests in `src/engine/saveParser/parsers/gen3.ts` and `src/engine/saveParser/parsers/gen3.test.ts`) already existed prior to the session. Submitted an empty PR to transition the node to COMPLETED.
+
+## 2026-07-13: Self-Verification
+Self-verified task `task-276-304-orchestrator-verifying-block` by running tests (`npx vitest run` in `.github/scripts` and `pnpm test:e2e` in workspace root). Verified that removing `VERIFYING` allowances from `foundry-orchestrator.ts` successfully allows the system tests to pass.

--- a/.foundry/tasks/task-276-304-orchestrator-verifying-block.md
+++ b/.foundry/tasks/task-276-304-orchestrator-verifying-block.md
@@ -36,5 +36,5 @@ The orchestrator's `isHierarchicallyIncomplete` properly returns `true` when a n
 6. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Removed `&& dep.frontmatter.status !== 'VERIFYING'` from the dependency check in `.github/scripts/foundry-orchestrator.ts`.
-- [ ] Removed `&& parentStatus !== 'VERIFYING'` from the parent status check in `.github/scripts/foundry-orchestrator.ts`.
+- [x] Removed `&& dep.frontmatter.status !== 'VERIFYING'` from the dependency check in `.github/scripts/foundry-orchestrator.ts`.
+- [x] Removed `&& parentStatus !== 'VERIFYING'` from the parent status check in `.github/scripts/foundry-orchestrator.ts`.

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -641,7 +641,7 @@ function main(): void {
           break;
         }
       } else {
-        if (dep.frontmatter.status !== 'ACTIVE' && dep.frontmatter.status !== 'COMPLETED' && dep.frontmatter.status !== 'VERIFYING') {
+        if (dep.frontmatter.status !== 'ACTIVE' && dep.frontmatter.status !== 'COMPLETED') {
           shouldSuspend = true;
           break;
         }
@@ -743,7 +743,7 @@ function main(): void {
       }
 
       const parentStatus = parentNode.frontmatter.status;
-      if (parentStatus !== 'ACTIVE' && parentStatus !== 'COMPLETED' && parentStatus !== 'VERIFYING') {
+      if (parentStatus !== 'ACTIVE' && parentStatus !== 'COMPLETED') {
         const parentChildren = parentToChildren.get(currParent) || [];
         if (parentStatus === 'PENDING' && parentChildren.length > 0) {
           // Exception for Late-Binding: If parent is PENDING and has children,


### PR DESCRIPTION
Removes `VERIFYING` status exceptions in the Orchestrator's Phase 3.5 (SUSPEND) and Phase 4 (RESOLVE) logic. This ensures that parent macro-nodes are properly blocked or suspended to `PENDING` when a dependent descendant transitions to `VERIFYING`, fixing a bug where `VERIFYING` was incorrectly treated as a "complete" state.

Also checks off acceptance criteria in `.foundry/tasks/task-276-304-orchestrator-verifying-block.md` and records the verification outcome in the coder journal.

---
*PR created automatically by Jules for task [8104441445389634699](https://jules.google.com/task/8104441445389634699) started by @szubster*