### PR TITLE
feat: implement living dex ghost tracker data utility

### DIFF
--- a/.foundry/tasks/task-272-304-living-dex-ghost-tracker-impl.md
+++ b/.foundry/tasks/task-272-304-living-dex-ghost-tracker-impl.md
@@ -25,12 +25,12 @@ notes: ''
 As part of the Living Dex Tracker epic, we need a data engine utility to determine which Pokémon are missing from the regional/national Pokédex (the "ghosts"). This data will power the Living Dex Tracker UI.
 
 ## Acceptance Criteria
-- [ ] Create a new module `src/engine/livingDex/ghostTracker.ts`.
-- [ ] Implement and export a function `getLivingDexGhosts(saveData: SaveData, regionalOnly: boolean = false): number[]`.
-- [ ] The function must evaluate `saveData.pc` and `saveData.party` to build an exact physical owned set. (Note: do not rely solely on `saveData.owned`, as a Living Dex requires physical copies, not just Pokédex seen/caught flags).
-- [ ] Iterate through `1` to `maxDex` (retrieved via `getGenerationConfig(saveData.generation)`) to output the missing IDs.
-- [ ] If `regionalOnly` is `true`, filter the output or adjust the loop based on the regional dex bounds for the game version (e.g. 151 for Gen 1, 251 for Gen 2, etc. Gen 3 Hoenn dex is 202, you will need to map Hoenn numbers to National numbers or just support National for now if regional is complex, but attempt to support regional bounds). Actually, simpler: for MVP, default to National (`maxDex`), and if `regionalOnly` is provided, handle it based on the available data or throw a NotImplemented error for regional logic if mapping is unavailable yet.
-- [ ] Write unit tests for this utility using vitest in `src/engine/livingDex/ghostTracker.test.ts`.
+- [x] Create a new module `src/engine/livingDex/ghostTracker.ts`.
+- [x] Implement and export a function `getLivingDexGhosts(saveData: SaveData, regionalOnly: boolean = false): number[]`.
+- [x] The function must evaluate `saveData.pc` and `saveData.party` to build an exact physical owned set. (Note: do not rely solely on `saveData.owned`, as a Living Dex requires physical copies, not just Pokédex seen/caught flags).
+- [x] Iterate through `1` to `maxDex` (retrieved via `getGenerationConfig(saveData.generation)`) to output the missing IDs.
+- [x] If `regionalOnly` is `true`, filter the output or adjust the loop based on the regional dex bounds for the game version (e.g. 151 for Gen 1, 251 for Gen 2, etc. Gen 3 Hoenn dex is 202, you will need to map Hoenn numbers to National numbers or just support National for now if regional is complex, but attempt to support regional bounds). Actually, simpler: for MVP, default to National (`maxDex`), and if `regionalOnly` is provided, handle it based on the available data or throw a NotImplemented error for regional logic if mapping is unavailable yet.
+- [x] Write unit tests for this utility using vitest in `src/engine/livingDex/ghostTracker.test.ts`.
 
 ## Constraints & Architecture
 - **No Side Effects**: The function must be pure and synchronous.

--- a/src/engine/livingDex/ghostTracker.test.ts
+++ b/src/engine/livingDex/ghostTracker.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as configModule from '../../utils/generationConfig';
+import type { SaveData } from '../saveParser/parsers/common';
+import { getLivingDexGhosts } from './ghostTracker';
+
+// Mock getGenerationConfig
+vi.mock('../../utils/generationConfig', () => ({
+  getGenerationConfig: vi.fn<typeof configModule.getGenerationConfig>(),
+}));
+
+describe('ghostTracker', () => {
+  it('identifies missing physical pokemon correctly up to maxDex', () => {
+    // Mock Gen 1 with 151
+    vi.mocked(configModule.getGenerationConfig).mockReturnValueOnce({
+      maxDex: 151,
+    } as import('../../utils/generationConfig').GenerationConfig);
+
+    const mockSave: Partial<SaveData> = {
+      generation: 1,
+      party: [1, 2, 3, 0, 0, 0], // Bulbasaur, Ivysaur, Venusaur
+      pc: [4, 5, 200, 0], // Charmander, Charmeleon (200 is invalid/egg/beyond maxDex)
+    };
+
+    const ghosts = getLivingDexGhosts(mockSave as SaveData);
+
+    // We have 1,2,3,4,5. We are missing 6-151.
+    // Length should be 151 - 5 = 146
+    expect(ghosts.length).toBe(146);
+    expect(ghosts.includes(1)).toBe(false);
+    expect(ghosts.includes(5)).toBe(false);
+    expect(ghosts.includes(6)).toBe(true);
+    expect(ghosts.includes(151)).toBe(true);
+    expect(ghosts.includes(200)).toBe(false); // Out of bounds
+  });
+
+  it('throws NotImplemented when regionalOnly is true', () => {
+    const mockSave: Partial<SaveData> = {
+      generation: 1,
+      party: [],
+      pc: [],
+    };
+    expect(() => getLivingDexGhosts(mockSave as SaveData, true)).toThrowError(/NotImplemented/);
+  });
+});

--- a/src/engine/livingDex/ghostTracker.ts
+++ b/src/engine/livingDex/ghostTracker.ts
@@ -1,0 +1,34 @@
+import { getGenerationConfig } from '../../utils/generationConfig';
+import type { SaveData } from '../saveParser/parsers/common';
+
+export function getLivingDexGhosts(saveData: SaveData, regionalOnly = false): number[] {
+  if (regionalOnly) {
+    throw new Error('NotImplemented: Regional dex filtering is not yet supported.');
+  }
+
+  const genConfig = getGenerationConfig(saveData.generation);
+  const maxDex = genConfig.maxDex;
+
+  const physicalOwned = new Set<number>();
+
+  for (const id of saveData.party) {
+    if (id > 0 && id <= maxDex) {
+      physicalOwned.add(id);
+    }
+  }
+
+  for (const id of saveData.pc) {
+    if (id > 0 && id <= maxDex) {
+      physicalOwned.add(id);
+    }
+  }
+
+  const ghosts: number[] = [];
+  for (let i = 1; i <= maxDex; i++) {
+    if (!physicalOwned.has(i)) {
+      ghosts.push(i);
+    }
+  }
+
+  return ghosts;
+}


### PR DESCRIPTION
This PR implements the `getLivingDexGhosts` utility function as defined in `task-272-304-living-dex-ghost-tracker-impl`. It evaluates the physical `pc` and `party` arrays in the `SaveData` to determine the missing Pokémon needed for a Living Dex, returning an array of missing IDs up to the generation's `maxDex`. It also implements unit testing to ensure the function works as designed and safely throws a `NotImplementedError` for `regionalOnly` as required.

---
*PR created automatically by Jules for task [14741441115105170322](https://jules.google.com/task/14741441115105170322) started by @szubster*