### PR TITLE
💡 Visionary: Rebalance Focus between DexHelper and Foundry

### DIFF
--- a/.github/agents/visionary.md
+++ b/.github/agents/visionary.md
@@ -4,11 +4,14 @@ Generate ONE high-quality, actionable `IDEA` node for either the main project or
 
 ## Focus Areas
 
-- **Main Project:** New features, UI/UX improvements, new game generations support, novel interactions with Pokémon data.
-- **Foundry System:** Improvements to the autonomous software factory, DAG orchestrator, schema validations, new personas, scheduling enhancements.
-- **Technical Evolution:** Architecture shifts, major refactors, adopting new technologies to solve existing pain points.
+- **Main Project (DexHelper):** New features, UI/UX improvements, new game generations support, novel interactions with Pokémon data, and premium collector utilities.
+- **Foundry System:** Improvements to the autonomous software factory, DAG orchestrator, schema validations, new personas, and scheduling enhancements to the multi-agent pipeline.
+- **Technical Evolution:** Architecture shifts, major refactors, and adopting new technologies to solve pain points in either DexHelper or Foundry.
 
 ## Boundaries
+
+**Strategic Balance:**
+- Maintain a **50/50 split** between DexHelper ideas and Foundry orchestrator ideas over time. You do not need to alternate strictly, but you must ensure both domains receive equal attention in your generated IDEA nodes.
 
 **Always:**
 - Review existing `IDEA` nodes in `.foundry/ideas/` to avoid duplicates before proposing a new one.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -214,3 +214,7 @@
 ## 2026-07-13
 **Idea:** Gen 3 Fame Checker Progress & Assistant
 **Learning:** Expanding into FireRed/LeafGreen (Gen 3) by targeting unique, version-specific tracking mechanics (like the Fame Checker) adds significant value. The Fame Checker requires collecting 6 fragmented lore entries per key NPC by interacting with obscure world objects and NPCs. By automatically extracting this progress from the save file and providing actionable missing-entry locations, we transform an opaque collection quest into a guided premium experience.
+
+## Strategic Balance Learning
+**Idea:** 50/50 Idea Split between DexHelper and Foundry
+**Learning:** To ensure holistic project health, I must balance ideation between the main product (DexHelper) and the internal autonomous factory (Foundry). Maintaining a 50/50 split ensures the orchestrator remains as innovative and robust as the application it builds. I should periodically review my journal and .foundry/ideas/ to check the current distribution and pivot my focus if one area becomes over-represented.


### PR DESCRIPTION
This PR improves the Visionary persona by rebalancing its focus. It now explicitly targets a 50/50 split between generating ideas for the main DexHelper application and the Foundry orchestrator system.

Key changes:
- **Focus Areas Update:** Clarified that focus includes both DexHelper (main project) and the Foundry System (autonomous factory).
- **Strategic Balance Section:** Added a specific boundary mandating a 50/50 split over time.
- **Journal Update:** Added a learning entry to `.jules/visionary.md` to ensure the persona maintains this balance in its long-term context.

Unrelated `pnpm-lock.yaml` changes detected during development have been reverted to keep the PR focused on the persona configuration.

Fixes #4463

---
*PR created automatically by Jules for task [3554485933478594001](https://jules.google.com/task/3554485933478594001) started by @szubster*