### PR TITLE
Update epic-045-070-gen3-secret-base-parsing with completed story

### DIFF
--- a/.foundry/epics/epic-045-070-gen3-secret-base-parsing.md
+++ b/.foundry/epics/epic-045-070-gen3-secret-base-parsing.md
@@ -35,4 +35,4 @@ As part of the Gen 3 Secret Base and Mixed Record Viewer, we need to parse the s
 - [x] Story Owner: Break this Epic down into actionable Stories.
 - [x] .foundry/archive/stories/story-070-108-parse-secret-base-locations.md
 - [x] .foundry/archive/stories/story-070-109-extract-mixed-record-trainer-data.md
-- [ ] .foundry/stories/story-070-110-track-daily-rematch-status.md
+- [x] .foundry/stories/story-070-110-track-daily-rematch-status.md


### PR DESCRIPTION
Checked off the final Acceptance Criteria checkbox for the daily rematch status story in `epic-045-070-gen3-secret-base-parsing.md` since its corresponding child tasks are completed. This allows the Epic to be progressed and properly verified by the Orchestrator without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [8045523487054923532](https://jules.google.com/task/8045523487054923532) started by @szubster*