### PR TITLE
Demote epic-045-070-gen3-secret-base-parsing to wait for child node

### DIFF
--- a/.foundry/epics/epic-045-070-gen3-secret-base-parsing.md
+++ b/.foundry/epics/epic-045-070-gen3-secret-base-parsing.md
@@ -35,4 +35,4 @@ As part of the Gen 3 Secret Base and Mixed Record Viewer, we need to parse the s
 - [x] Story Owner: Break this Epic down into actionable Stories.
 - [x] story-070-108-parse-secret-base-locations
 - [x] story-070-109-extract-mixed-record-trainer-data
-- [ ] story-070-110-track-daily-rematch-status
+- [x] story-070-110-track-daily-rematch-status

--- a/.foundry/epics/epic-045-070-gen3-secret-base-parsing.md
+++ b/.foundry/epics/epic-045-070-gen3-secret-base-parsing.md
@@ -33,6 +33,6 @@ As part of the Gen 3 Secret Base and Mixed Record Viewer, we need to parse the s
 
 ## Acceptance Criteria
 - [x] Story Owner: Break this Epic down into actionable Stories.
-- [x] .foundry/archive/stories/story-070-108-parse-secret-base-locations.md
-- [x] .foundry/archive/stories/story-070-109-extract-mixed-record-trainer-data.md
-- [x] .foundry/stories/story-070-110-track-daily-rematch-status.md
+- [x] story-070-108-parse-secret-base-locations
+- [x] story-070-109-extract-mixed-record-trainer-data
+- [ ] story-070-110-track-daily-rematch-status


### PR DESCRIPTION
As a Story Owner, I am demoting `epic-045-070-gen3-secret-base-parsing` because it already has the required child stories drafted from a previous iteration, but one of them (`story-070-110-track-daily-rematch-status`) is not yet fully completed (not in archive). I have unchecked it in the acceptance criteria to allow the orchestrator to correctly demote the parent to `PENDING` while it waits for its children.

---
*PR created automatically by Jules for task [17889728379538352280](https://jules.google.com/task/17889728379538352280) started by @szubster*