### PR TITLE
feat: extract logToJournal utility

### DIFF
--- a/.foundry/tasks/task-278-304-extract-log-to-journal.md
+++ b/.foundry/tasks/task-278-304-extract-log-to-journal.md
@@ -38,5 +38,5 @@ notes: ''
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] `logToJournal` is exported from `dag-utils.ts`.
-- [ ] `foundry-orchestrator.ts` uses `logToJournal` instead of inline `fs.appendFileSync`.
+- [x] `logToJournal` is exported from `dag-utils.ts`.
+- [x] `foundry-orchestrator.ts` uses `logToJournal` instead of inline `fs.appendFileSync`.

--- a/.github/scripts/dag-utils.ts
+++ b/.github/scripts/dag-utils.ts
@@ -1,4 +1,6 @@
 
+import * as fs from 'node:fs';
+
 export function todayISO(): string {
   const d = new Date();
   const yyyy = d.getFullYear();
@@ -38,4 +40,12 @@ export function getOrphanedNodes(startNodePath: string, dependents: Map<string, 
     }
   }
   return visited;
+}
+
+export function logToJournal(logPath: string, logEntry: string): void {
+  let entry = logEntry;
+  if (!entry.endsWith('\n')) {
+    entry += '\n';
+  }
+  fs.appendFileSync(logPath, entry, 'utf-8');
 }

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -28,7 +28,7 @@ import * as fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import * as path from 'node:path';
 import { createRequire } from 'node:module';
-import { todayISO, buildReverseDependencyGraph, getOrphanedNodes } from './dag-utils.ts';
+import { todayISO, buildReverseDependencyGraph, getOrphanedNodes, logToJournal } from './dag-utils.ts';
 
 // gray-matter is CJS; import via require() for clean ESM interop.
 const require = createRequire(import.meta.url);
@@ -1021,7 +1021,7 @@ function main(): void {
 
         if (!DRY_RUN) {
           try {
-            fs.appendFileSync(logPath, logEntry, 'utf-8');
+            logToJournal(logPath, logEntry);
             info(`Logged anomaly to ${logPath}`);
           } catch (e) {
             warn(`Failed to log anomaly to Agile Coach journal: ${String(e)}`);


### PR DESCRIPTION
Extracts the inline journal logging logic into a reusable `logToJournal` utility within `.github/scripts/dag-utils.ts` and updates `foundry-orchestrator.ts` to utilize it. Ensures a trailing newline is added before appending to the log file.

Closes `.foundry/tasks/task-278-304-extract-log-to-journal.md`.

---
*PR created automatically by Jules for task [17268054709640071262](https://jules.google.com/task/17268054709640071262) started by @szubster*