### PR TITLE
feat(foundry): implement safe bash wrapper for timeouts

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -108,3 +108,8 @@ If you lack critical context or specifications (e.g., exact memory offsets) nece
 - **Circular Dependencies**: Do NOT include the parent node in the new child's `depends_on` array to avoid circular dependency deadlocks.
 - **Premature Verification**: Do NOT submit an Empty PR to transition a parent node to VERIFYING (by checking off its acceptance criteria) until ALL of its generated child nodes have transitioned to COMPLETED. Premature verification violates the dependency graph constraints.
 - **Parent Node Syntax**: Parent generation nodes MUST strictly format references to generated child nodes as unchecked task checkboxes (`- [ ] <file_path>`) directly in their markdown body. If the checkbox is omitted, formatted as plain text, or immediately checked, the Orchestrator will prematurely transition the parent to VERIFYING before descendant nodes complete, leading to immediate rejection.
+
+## Bash Session Timeout Policy
+* Never execute blocking commands (e.g., `tail -f`, long-running loops) in `run_in_bash_session` as they will cause the session to hang indefinitely.
+* Use non-blocking alternatives like `cat` or `tail -n`.
+* If a long-running process must be executed, it must be backgrounded (`&`) or wrapped using the standard GNU `timeout` command (e.g., `timeout 30s command`).

--- a/.foundry/tasks/task-267-297-bash-timeout-wrapper-impl-v2.md
+++ b/.foundry/tasks/task-267-297-bash-timeout-wrapper-impl-v2.md
@@ -37,4 +37,4 @@ Implement the recommended alternative solution for a timeout wrapper for bash se
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement timeout wrapper alternative based on research findings.
+- [x] Implement timeout wrapper alternative based on research findings.

--- a/scripts/safe_bash.sh
+++ b/scripts/safe_bash.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Wrapper script to execute bash commands with a timeout
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 <command>"
+    exit 1
+fi
+
+# Set a threshold of 30 seconds
+TIMEOUT_DURATION=30
+
+timeout "$TIMEOUT_DURATION"s "$@"
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 124 ]; then
+    echo "Error: Command exceeded the $TIMEOUT_DURATION second threshold and was terminated." >&2
+    echo "This is to prevent infinite hangs caused by blocking commands (e.g., 'tail -f')." >&2
+    echo "Please use non-blocking alternatives like 'cat' or 'tail -n'." >&2
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
# 🎯 What
Implemented an alternative bash timeout wrapper `scripts/safe_bash.sh` as a workaround for long-running bash session commands.

# 💡 Why
The `run_in_bash_session` platform tool cannot be modified directly to enforce timeouts. Agents sometimes run blocking commands like `tail -f` which causes the session to hang indefinitely. This wrapper enforces a 30-second timeout and advises agents to use non-blocking commands when a timeout is reached. It also updates the agent core policies to reflect this workaround.

# ✅ Verification
Tested `scripts/safe_bash.sh sleep 1` (success, exited with 0) and `scripts/safe_bash.sh sleep 31` (failure, exited with 124 and printed the helpful error message).
Ran `pnpm lint`, `pnpm test` and `pnpm test:e2e` to ensure no regressions.

# ✨ Result
A functional timeout wrapper for bash sessions is now available to agents.

---
*PR created automatically by Jules for task [9515806576569809046](https://jules.google.com/task/9515806576569809046) started by @szubster*