### PR TITLE
Gen 3 Roamer Core Extraction Implementation

### DIFF
--- a/.foundry/tasks/task-291-314-gen3-roamer-core-extraction-impl.md
+++ b/.foundry/tasks/task-291-314-gen3-roamer-core-extraction-impl.md
@@ -77,7 +77,7 @@ Be sure to define constants for the new offsets (cool, beauty, cute, smart, toug
 4. **Magic Numbers:** When modifying save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts MUST be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
 
 ## Acceptance Criteria
-- [ ] Ensure `parseGen3Roamer` in `src/engine/saveParser/parsers/gen3.ts` fully implements the `Gen3RoamerState` structure.
-- [ ] Define reusable constants at the module level for all new memory offsets (cool, beauty, cute, smart, tough). No inline magic numbers.
-- [ ] Ensure the returned object keys exactly match `Gen3RoamerState` (`isActive`, `personality`, `status`, `ivs` as a number, plus the contest stats).
-- [ ] Update `src/engine/saveParser/parsers/gen3.test.ts` to reflect the new return shape of `parseGen3Roamer`.
+- [x] Ensure `parseGen3Roamer` in `src/engine/saveParser/parsers/gen3.ts` fully implements the `Gen3RoamerState` structure.
+- [x] Define reusable constants at the module level for all new memory offsets (cool, beauty, cute, smart, tough). No inline magic numbers.
+- [x] Ensure the returned object keys exactly match `Gen3RoamerState` (`isActive`, `personality`, `status`, `ivs` as a number, plus the contest stats).
+- [x] Update `src/engine/saveParser/parsers/gen3.test.ts` to reflect the new return shape of `parseGen3Roamer`.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -789,19 +789,31 @@ describe('parseGen3Roamer', () => {
     // Set statusCondition (e.g. 1 for Sleep)
     view.setUint8(offset + 13, 1);
 
+    // Set contest stats
+    view.setUint8(offset + 0x0e, 10); // cool
+    view.setUint8(offset + 0x0f, 20); // beauty
+    view.setUint8(offset + 0x10, 30); // cute
+    view.setUint8(offset + 0x11, 40); // smart
+    view.setUint8(offset + 0x12, 50); // tough
+
     // Set active
     view.setUint8(offset + 19, 1);
 
     const result = parseGen3Roamer(view, 0, 'ruby');
 
     expect(result).toEqual({
-      ivs: { hp: 31, atk: 10, def: 15, spd: 20, spAtk: 25, spDef: 30 },
-      personalityValue: 0x12345678,
+      isActive: true,
       speciesId: 380,
-      hp: 150,
       level: 40,
-      statusCondition: 1,
-      active: true,
+      hp: 150,
+      status: 1,
+      personality: 0x12345678,
+      ivs: 0x3d9a3d5f,
+      cool: 10,
+      beauty: 20,
+      cute: 30,
+      smart: 40,
+      tough: 50,
     });
   });
 
@@ -821,13 +833,18 @@ describe('parseGen3Roamer', () => {
     const result = parseGen3Roamer(view, 0, 'ruby');
 
     expect(result).toEqual({
-      ivs: { hp: 0, atk: 0, def: 0, spd: 0, spAtk: 0, spDef: 0 },
-      personalityValue: 0x12345678,
+      isActive: true,
       speciesId: 380,
-      hp: 150,
       level: 40,
-      statusCondition: 1,
-      active: true,
+      hp: 150,
+      status: 1,
+      personality: 0x12345678,
+      ivs: 0,
+      cool: 0,
+      beauty: 0,
+      cute: 0,
+      smart: 0,
+      tough: 0,
     });
   });
 
@@ -848,13 +865,18 @@ describe('parseGen3Roamer', () => {
     const result = parseGen3Roamer(view, 0, 'ruby');
 
     expect(result).toEqual({
-      ivs: { hp: 31, atk: 31, def: 31, spd: 31, spAtk: 31, spDef: 31 },
-      personalityValue: 0x12345678,
+      isActive: true,
       speciesId: 380,
-      hp: 150,
       level: 40,
-      statusCondition: 1,
-      active: true,
+      hp: 150,
+      status: 1,
+      personality: 0x12345678,
+      ivs: 1073741823,
+      cool: 0,
+      beauty: 0,
+      cute: 0,
+      smart: 0,
+      tough: 0,
     });
   });
 
@@ -882,13 +904,18 @@ describe('parseGen3Roamer', () => {
     const result = parseGen3Roamer(view, 0, 'emerald');
 
     expect(result).toEqual({
-      ivs: { hp: 0, atk: 0, def: 0, spd: 0, spAtk: 0, spDef: 0 },
-      personalityValue: 0x12345678,
+      isActive: true,
       speciesId: 381,
-      hp: 150,
       level: 40,
-      statusCondition: 0,
-      active: true,
+      hp: 150,
+      status: 0,
+      personality: 0x12345678,
+      ivs: 0,
+      cool: 0,
+      beauty: 0,
+      cute: 0,
+      smart: 0,
+      tough: 0,
     });
   });
 
@@ -908,13 +935,18 @@ describe('parseGen3Roamer', () => {
     const result = parseGen3Roamer(view, 0, 'firered');
 
     expect(result).toEqual({
-      ivs: { hp: 0, atk: 0, def: 0, spd: 0, spAtk: 0, spDef: 0 },
-      personalityValue: 0x12345678,
+      isActive: true,
       speciesId: 244,
-      hp: 150,
       level: 50,
-      statusCondition: 0,
-      active: true,
+      hp: 150,
+      status: 0,
+      personality: 0x12345678,
+      ivs: 0,
+      cool: 0,
+      beauty: 0,
+      cute: 0,
+      smart: 0,
+      tough: 0,
     });
   });
 
@@ -933,12 +965,12 @@ describe('parseGen3Roamer', () => {
     // False case
     view.setUint8(offset + 19, 0);
     let result = parseGen3Roamer(view, 0, 'ruby');
-    expect(result.active).toBe(false);
+    expect(result.isActive).toBe(false);
 
     // True case (anything != 0)
     view.setUint8(offset + 19, 2);
     result = parseGen3Roamer(view, 0, 'ruby');
-    expect(result.active).toBe(true);
+    expect(result.isActive).toBe(true);
   });
 });
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -57,6 +57,11 @@ const ROAMER_HP_OFFSET = 10;
 const ROAMER_LEVEL_OFFSET = 12;
 const ROAMER_STATUS_OFFSET = 13;
 const ROAMER_ACTIVE_OFFSET = 19;
+const ROAMER_COOL_OFFSET = 0x0e;
+const ROAMER_BEAUTY_OFFSET = 0x0f;
+const ROAMER_CUTE_OFFSET = 0x10;
+const ROAMER_SMART_OFFSET = 0x11;
+const ROAMER_TOUGH_OFFSET = 0x12;
 
 const CONDITION_COOL_OFFSET = 0x06;
 const CONDITION_BEAUTY_OFFSET = 0x07;
@@ -72,13 +77,13 @@ const RIBBON_CUTE_SHIFT = 6;
 const RIBBON_SMART_SHIFT = 9;
 const RIBBON_TOUGH_SHIFT = 12;
 
-const IV_MASK = 0x1f;
-const IV_SHIFT_HP = 0;
-const IV_SHIFT_ATK = 5;
-const IV_SHIFT_DEF = 10;
-const IV_SHIFT_SPD = 15;
-const IV_SHIFT_SPATK = 20;
-const IV_SHIFT_SPDEF = 25;
+export const IV_MASK = 0x1f;
+export const IV_SHIFT_HP = 0;
+export const IV_SHIFT_ATK = 5;
+export const IV_SHIFT_DEF = 10;
+export const IV_SHIFT_SPD = 15;
+export const IV_SHIFT_SPATK = 20;
+export const IV_SHIFT_SPDEF = 25;
 
 const TOWER_WIN_STREAKS_OFFSET = 0x0ce0;
 const TOWER_RECORD_WIN_STREAKS_OFFSET = 0x0cf0;
@@ -493,24 +498,27 @@ export function parseGen3Roamer(view: DataView, saveBlock1Offset: number, gameVe
     const speciesId = view.getUint16(offset + ROAMER_SPECIES_ID_OFFSET, true);
     const hp = view.getUint16(offset + ROAMER_HP_OFFSET, true);
     const level = view.getUint8(offset + ROAMER_LEVEL_OFFSET);
-    const statusCondition = view.getUint8(offset + ROAMER_STATUS_OFFSET);
-    const active = view.getUint8(offset + ROAMER_ACTIVE_OFFSET) !== 0;
-
-    const ivHp = (ivs >> IV_SHIFT_HP) & IV_MASK;
-    const atk = (ivs >> IV_SHIFT_ATK) & IV_MASK;
-    const def = (ivs >> IV_SHIFT_DEF) & IV_MASK;
-    const spd = (ivs >> IV_SHIFT_SPD) & IV_MASK;
-    const spAtk = (ivs >> IV_SHIFT_SPATK) & IV_MASK;
-    const spDef = (ivs >> IV_SHIFT_SPDEF) & IV_MASK;
+    const status = view.getUint8(offset + ROAMER_STATUS_OFFSET);
+    const cool = view.getUint8(offset + ROAMER_COOL_OFFSET);
+    const beauty = view.getUint8(offset + ROAMER_BEAUTY_OFFSET);
+    const cute = view.getUint8(offset + ROAMER_CUTE_OFFSET);
+    const smart = view.getUint8(offset + ROAMER_SMART_OFFSET);
+    const tough = view.getUint8(offset + ROAMER_TOUGH_OFFSET);
+    const isActive = view.getUint8(offset + ROAMER_ACTIVE_OFFSET) !== 0;
 
     return {
-      ivs: { hp: ivHp, atk, def, spd, spAtk, spDef },
-      personalityValue,
+      isActive,
       speciesId,
-      hp,
       level,
-      statusCondition,
-      active,
+      hp,
+      status,
+      personality: personalityValue,
+      ivs,
+      cool,
+      beauty,
+      cute,
+      smart,
+      tough,
     };
   } catch (error) {
     if (error instanceof RangeError) {
@@ -958,15 +966,22 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     const roamingLegendaries = [];
     try {
       const roamer = parseGen3Roamer(view, section1Offset, _forcedVersion || 'ruby');
-      if (roamer?.active) {
+      if (roamer?.isActive) {
         roamingLegendaries.push({
           speciesId: roamer.speciesId,
           level: roamer.level,
-          isActive: roamer.active,
-          ivs: roamer.ivs,
-          personalityValue: roamer.personalityValue,
+          isActive: roamer.isActive,
+          ivs: {
+            hp: (roamer.ivs >> IV_SHIFT_HP) & IV_MASK,
+            atk: (roamer.ivs >> IV_SHIFT_ATK) & IV_MASK,
+            def: (roamer.ivs >> IV_SHIFT_DEF) & IV_MASK,
+            spd: (roamer.ivs >> IV_SHIFT_SPD) & IV_MASK,
+            spAtk: (roamer.ivs >> IV_SHIFT_SPATK) & IV_MASK,
+            spDef: (roamer.ivs >> IV_SHIFT_SPDEF) & IV_MASK,
+          },
+          personalityValue: roamer.personality,
           hp: roamer.hp,
-          statusCondition: roamer.statusCondition,
+          statusCondition: roamer.status,
         });
       }
     } catch {


### PR DESCRIPTION
Update `parseGen3Roamer` to extract contest stats and return the exact `Gen3RoamerState` type, and use the unpacked IVs correctly in `parseGen3` so data is not lost.

---
*PR created automatically by Jules for task [16749667053303794390](https://jules.google.com/task/16749667053303794390) started by @szubster*