### PR TITLE
story_owner: Break down epic 109-306 into stories

### DIFF
--- a/.foundry/epics/epic-109-306-missed-trainer-data-extraction-gen1-gen2.md
+++ b/.foundry/epics/epic-109-306-missed-trainer-data-extraction-gen1-gen2.md
@@ -32,4 +32,6 @@ Implement the data extraction layer for the "Missed Trainer Radar" feature speci
 4.  **Relative Offsets & Constants (ADR 028):** All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
 
 ## Acceptance Criteria
-- [ ] Break down into Stories
+- [x] Break down into Stories
+- [ ] story-306-319-gen1-trainer-data-extraction
+- [ ] story-306-320-gen2-trainer-data-extraction

--- a/.foundry/stories/story-306-319-gen1-trainer-data-extraction.md
+++ b/.foundry/stories/story-306-319-gen1-trainer-data-extraction.md
@@ -1,0 +1,34 @@
+---
+id: story-306-319-gen1-trainer-data-extraction
+type: STORY
+title: Gen 1 Trainer Data Extraction
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-13'
+updated_at: '2026-07-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-109-306-missed-trainer-data-extraction-gen1-gen2
+tags:
+  - gen1
+  - save-engine
+  - extraction
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 1 Trainer Data Extraction
+
+## Objective
+Extract and parse the trainer defeat flags for Generation 1 games.
+
+## Requirements
+1. Extract the trainer defeat flags from the save file.
+2. Ensure explicit bitwise logic is used with boundary testing (ADR 026).
+3. Use relative offsets and constants (ADR 028) strictly. No inline magic numbers.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks

--- a/.foundry/stories/story-306-320-gen2-trainer-data-extraction.md
+++ b/.foundry/stories/story-306-320-gen2-trainer-data-extraction.md
@@ -1,0 +1,34 @@
+---
+id: story-306-320-gen2-trainer-data-extraction
+type: STORY
+title: Gen 2 Trainer Data Extraction
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-13'
+updated_at: '2026-07-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-109-306-missed-trainer-data-extraction-gen1-gen2
+tags:
+  - gen2
+  - save-engine
+  - extraction
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Trainer Data Extraction
+
+## Objective
+Extract and parse the trainer defeat flags for Generation 2 games from Bank 1.
+
+## Requirements
+1. Extract the trainer defeat event flags from Bank 1 in Generation 2 games.
+2. Ensure explicit bitwise logic is used with boundary testing (ADR 026).
+3. Use relative offsets and constants (ADR 028) strictly. No inline magic numbers.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
Dynamically broke down the Gen 1 & Gen 2 Data Extraction Epic (`epic-109-306`) into two respective Story nodes.

- `story-306-319-gen1-trainer-data-extraction` created for Gen 1 extraction.
- `story-306-320-gen2-trainer-data-extraction` created for Gen 2 extraction.
- Updated the parent epic (`epic-109-306`) to check off its overarching acceptance criteria and appended the new stories as pending checklist items.

---
*PR created automatically by Jules for task [2692092908402143679](https://jules.google.com/task/2692092908402143679) started by @szubster*