### PR TITLE
📜 Story Owner: Draft Stories for Gen 3 Trainer Card Data Extraction

### DIFF
--- a/.foundry/epics/epic-111-304-gen3-trainer-card-data-extraction.md
+++ b/.foundry/epics/epic-111-304-gen3-trainer-card-data-extraction.md
@@ -49,3 +49,5 @@ Implement the logic to extract the requisite achievements from the Gen 3 (Emeral
 
 ## Acceptance Criteria
 - [ ] Break down into Stories for data extraction implementation.
+- [ ] story-304-319-gen3-hof-pokedex-extraction
+- [ ] story-304-320-gen3-contest-frontier-extraction

--- a/.foundry/stories/story-304-319-gen3-hof-pokedex-extraction.md
+++ b/.foundry/stories/story-304-319-gen3-hof-pokedex-extraction.md
@@ -1,0 +1,35 @@
+---
+id: story-304-319-gen3-hof-pokedex-extraction
+type: STORY
+title: "Story: Gen 3 Hall of Fame & Pokédex Data Extraction"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-07-13"
+updated_at: "2026-07-13"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-111-304-gen3-trainer-card-data-extraction
+tags:
+  - data-extraction
+  - gen3
+research_references:
+  - .foundry/docs/knowledge_base/engine/save_parsing/gen3_hall_of_fame.md
+  - .foundry/docs/knowledge_base/gen3_pokemon_data_structure.md
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Gen 3 Hall of Fame & Pokédex Data Extraction
+
+## Objective
+Extract the `GAME_STAT_ENTERED_HOF` (ID 10) to determine Hall of Fame entry and extract the number of caught Pokémon in both Hoenn and National Dex.
+
+## Requirements
+- Use the `DataView` API (ADR 010).
+- Extract magic numbers into module-level reusable constants (ADR 028).
+
+## Acceptance Criteria
+- [ ] Implement Hall of Fame extraction logic.
+- [ ] Implement Pokédex extraction logic.

--- a/.foundry/stories/story-304-320-gen3-contest-frontier-extraction.md
+++ b/.foundry/stories/story-304-320-gen3-contest-frontier-extraction.md
@@ -1,0 +1,35 @@
+---
+id: story-304-320-gen3-contest-frontier-extraction
+type: STORY
+title: "Story: Gen 3 Contest & Battle Frontier Extraction"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-07-13"
+updated_at: "2026-07-13"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-111-304-gen3-trainer-card-data-extraction
+tags:
+  - data-extraction
+  - gen3
+research_references:
+  - .foundry/docs/knowledge_base/gen3_battle_frontier_data.md
+  - .foundry/docs/knowledge_base/gen3_pokemon_data_structure.md
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Gen 3 Contest & Battle Frontier Extraction
+
+## Objective
+Extract Master Rank Contest condition ribbons and Battle Frontier Gold Symbols from Gen 3 save files.
+
+## Requirements
+- Use the `DataView` API (ADR 010).
+- Extract magic numbers into module-level reusable constants (ADR 028).
+
+## Acceptance Criteria
+- [ ] Implement Contest extraction logic.
+- [ ] Implement Battle Frontier extraction logic.


### PR DESCRIPTION
I have broken down the Epic for Gen 3 Trainer Card Stars Data Extraction into two distinct Story nodes. 

1. `story-304-319-gen3-hof-pokedex-extraction`: Handles extracting the Hall of Fame flag and the Pokédex caught counts.
2. `story-304-320-gen3-contest-frontier-extraction`: Handles extracting the Master Rank Contest ribbons and Battle Frontier Gold Symbols.

Both stories enforce the `DataView` API (ADR 010) and reusable constants (ADR 028) constraints. The new stories have been correctly appended to the original Epic node as unchecked acceptance criteria without marking the parent node as verified, complying with the Late-Binding Orchestrator Demotion Compliance Rule.

---
*PR created automatically by Jules for task [2734154445678395653](https://jules.google.com/task/2734154445678395653) started by @szubster*