### PR TITLE
chore: complete QA for bash timeout wrapper

### DIFF
--- a/.foundry/tasks/task-267-298-bash-timeout-wrapper-qa-v2.md
+++ b/.foundry/tasks/task-267-298-bash-timeout-wrapper-qa-v2.md
@@ -34,4 +34,4 @@ Verify that the alternative timeout wrapper solution for bash sessions works cor
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verify alternative timeout wrapper solution interrupts long commands.
+- [x] Verify alternative timeout wrapper solution interrupts long commands.


### PR DESCRIPTION
Completed QA task `task-267-298-bash-timeout-wrapper-qa-v2` by checking the acceptance criteria checkbox. Verified that the implementation via instructional policy works by checking core policies and running a sample `timeout` command. Tests run locally pass. Submitted as an empty PR for the completed task.

---
*PR created automatically by Jules for task [7665521453119244049](https://jules.google.com/task/7665521453119244049) started by @szubster*