### PR TITLE
feat: Breakdown Pokerus Strain Tracker PRD into Epics

### DIFF
--- a/.foundry/epics/epic-112-322-pokerus-strain-ui-detail-view.md
+++ b/.foundry/epics/epic-112-322-pokerus-strain-ui-detail-view.md
@@ -1,0 +1,39 @@
+---
+id: epic-112-322-pokerus-strain-ui-detail-view
+type: EPIC
+title: Pokerus Strain UI Tracker - Detail View
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-13'
+updated_at: '2026-07-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-107-112-pokerus-strain-ui-tracker
+tags:
+  - pokerus
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Pokerus Strain UI Tracker - Detail View
+
+## 1. Objective
+Implement the UI presentation layer to display the specific Pokerus strain data in the detailed view of a Pokémon, allowing users to track the strain of infected or cured Pokémon.
+
+## 2. Prerequisites
+- The underlying engine must correctly parse out the "days remaining" and "strain" (0-15) of the Pokerus infection (completed via ADR 026 and `parsePokerus` in `common.ts`).
+
+## 3. Scope
+- Modify the detailed view component of a specific Pokémon to render the `pokerus.strain` value.
+- The UI must only display the strain if the Pokémon is currently "Infected" or "Cured".
+- Ensure the presentation adheres to the "tactical hardware" aesthetic (sharp edges `rounded-none`, dashed borders `border-dashed`, monospaced telemetry fonts) as defined by ADR 008 and ADR 024.
+
+## 4. Dependencies
+None.
+
+## 5. Acceptance Criteria
+- [ ] Story Owner: Break down this Epic into actionable Stories.

--- a/.foundry/epics/epic-112-323-pokerus-strain-ui-grid-view.md
+++ b/.foundry/epics/epic-112-323-pokerus-strain-ui-grid-view.md
@@ -1,0 +1,39 @@
+---
+id: epic-112-323-pokerus-strain-ui-grid-view
+type: EPIC
+title: Pokerus Strain UI Tracker - List/Grid View
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-13'
+updated_at: '2026-07-13'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-107-112-pokerus-strain-ui-tracker
+tags:
+  - pokerus
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Pokerus Strain UI Tracker - List/Grid View
+
+## 1. Objective
+Incorporate a visual indicator in the party/box (list or grid) views to quickly identify different Pokerus strains.
+
+## 2. Prerequisites
+- The underlying engine must correctly parse out the "days remaining" and "strain" (0-15) of the Pokerus infection (completed via ADR 026 and `parsePokerus` in `common.ts`).
+
+## 3. Scope
+- Modify the party and box list/grid views to include a visual indicator (e.g., distinct color, badge number) denoting the specific Pokerus strain (e.g., Strain A, Strain B, Strain 1, Strain 2).
+- Ensure the indicator is visible and clearly distinguishes between different strains.
+- Ensure the visual styling adheres to the "tactical hardware" aesthetic (sharp edges `rounded-none`, dashed borders `border-dashed`, monospaced telemetry fonts) as defined by ADR 008 and ADR 024.
+
+## 4. Dependencies
+None.
+
+## 5. Acceptance Criteria
+- [ ] Story Owner: Break down this Epic into actionable Stories.

--- a/.foundry/prds/prd-107-112-pokerus-strain-ui-tracker.md
+++ b/.foundry/prds/prd-107-112-pokerus-strain-ui-tracker.md
@@ -43,4 +43,6 @@ Currently, the UI only displays whether a Pokémon is "Infected" or "Cured". It 
 - Tracking historical strains or "patient zero" beyond what is currently existing in the save file. The tracker only shows the current state.
 
 ## 4. Acceptance Criteria
-- [ ] Epic Planner: Break this PRD down into one or more Epics.
+- [x] Epic Planner: Break this PRD down into one or more Epics.
+- [ ] epic-112-322-pokerus-strain-ui-detail-view
+- [ ] epic-112-323-pokerus-strain-ui-grid-view


### PR DESCRIPTION
Broken down `prd-107-112-pokerus-strain-ui-tracker` into `epic-112-322-pokerus-strain-ui-detail-view` and `epic-112-323-pokerus-strain-ui-grid-view`

---
*PR created automatically by Jules for task [11742299006224736652](https://jules.google.com/task/11742299006224736652) started by @szubster*