### PR TITLE
🧹 [Tech Debt] Remove unused database schema exports and stale knip rules

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -5,3 +5,4 @@
 * Sweeper PRs must use the title format `🧹 [description]` and include `🎯 What`, `💡 Why`, `✅ Verification`, and `✨ Result` in the body.
 
 - If `pnpm install` hangs or fails during git hook setup (e.g., `lefthook install`), run `git config --unset-all --global core.hooksPath` before retrying the installation.
+- Cloudflare Pages functions in 'functions/' should not be removed based on static analysis, as they are endpoints.

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,6 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreExportsUsedInFile": true,
   "ignoreBinaries": [
-    "gh"
   ],
   "ignoreDependencies": [
     "wrangler",
@@ -15,7 +14,6 @@
     ".github/scripts/verify-dag-refs.ts",
     "scripts/gen3-fetch-locations.ts",
     "functions/_middleware.ts",
-    "scripts/data/gen3/match_call/etl.ts"
   ],
   "rules": {
     "files": "warn",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -191,28 +191,3 @@ export interface PokeDBSchema extends DBSchema {
     value: { key: string; value: string };
   };
 }
-
-export const SAVE_HISTORY_DB_CONFIG = {
-  NAME: 'SaveHistoryDB',
-  VERSION: 1,
-  STORES: {
-    SAVES: 'saves',
-    METADATA: 'metadata',
-    INDEXES: 'indexes',
-  },
-} as const;
-
-export interface SaveHistoryDBSchema extends DBSchema {
-  [SAVE_HISTORY_DB_CONFIG.STORES.SAVES]: {
-    key: string;
-    value: Uint8Array;
-  };
-  [SAVE_HISTORY_DB_CONFIG.STORES.METADATA]: {
-    key: string;
-    value: Record<string, unknown>;
-  };
-  [SAVE_HISTORY_DB_CONFIG.STORES.INDEXES]: {
-    key: string;
-    value: Record<string, unknown>;
-  };
-}


### PR DESCRIPTION
🎯 What
    - Removed unused `SAVE_HISTORY_DB_CONFIG` export in `src/db/schema.ts`
    - Removed unused `SaveHistoryDBSchema` type in `src/db/schema.ts`
    - Removed stale ignore references to `scripts/data/gen3/match_call/etl.ts` and `gh` binary in `knip.json`
    
    💡 Why
    - Cleaning up dead code / constants discovered via `knip` static analysis. Note: `functions/api/saves` files are endpoints not directly imported, and were preserved.
    
    ✅ Verification
    - Ran `pnpm knip` locally with clean output.
    - Tests and e2e pass cleanly.
    
    ✨ Result
    - Healthier, leaner schema definition.

---
*PR created automatically by Jules for task [14513320936676184681](https://jules.google.com/task/14513320936676184681) started by @szubster*