### PR TITLE
Auditor: Handle permanently failed child epics for Gen3 Secret Base Viewer

### DIFF
--- a/.foundry/epics/epic-045-324-gen3-secret-base-parsing-v2.md
+++ b/.foundry/epics/epic-045-324-gen3-secret-base-parsing-v2.md
@@ -1,0 +1,36 @@
+---
+id: epic-045-324-gen3-secret-base-parsing-v2
+type: EPIC
+title: Gen 3 Secret Base Save File Parsing (v2)
+status: ACTIVE
+owner_persona: story_owner
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on:
+  - research-045-321-investigate-secret-base-failure
+jules_session_id: '1338371455821373157'
+pr_number: null
+parent: prd-073-045-gen3-secret-base-viewer
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Gen 3 Secret Base Save File Parsing (v2)
+
+## Context
+As part of the Gen 3 Secret Base and Mixed Record Viewer, we need to parse the save file to identify all active Secret Bases and extract NPC trainer data from mixed records. This is the v2 attempt after the previous epic failed.
+
+## Objectives
+- Implement save parsing logic using `DataView` (per ADR 010) for Gen 3 Secret Base locations.
+- Extract mixed record data, including NPC trainer names, teams, and EV yields.
+- Track daily rematch status for these NPC trainers.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into actionable Stories.

--- a/.foundry/epics/epic-045-325-gen3-secret-base-radar-integration-v2.md
+++ b/.foundry/epics/epic-045-325-gen3-secret-base-radar-integration-v2.md
@@ -1,0 +1,36 @@
+---
+id: epic-045-325-gen3-secret-base-radar-integration-v2
+type: EPIC
+title: Gen 3 Secret Base Smart Route Radar Integration (v2)
+status: ACTIVE
+owner_persona: story_owner
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on:
+  - epic-045-324-gen3-secret-base-parsing-v2
+jules_session_id: '1338371455821373157'
+pr_number: null
+parent: prd-073-045-gen3-secret-base-viewer
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - map-radar
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Gen 3 Secret Base Smart Route Radar Integration (v2)
+
+## Context
+Once Secret Base data is parsed from the save file, we need to map their exact locations on the Smart Route Radar. This allows players to visually locate where their friends' Secret Bases have spawned.
+
+## Objectives
+- Map the parsed Secret Base locations to the UnifiedLocation map graph.
+- Update the Smart Route Radar to display Secret Base markers.
+- Ensure integration respects the Smart Route Radar Architecture (ADR 018).
+
+## Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into actionable Stories.

--- a/.foundry/epics/epic-045-326-gen3-secret-base-dashboard-v2.md
+++ b/.foundry/epics/epic-045-326-gen3-secret-base-dashboard-v2.md
@@ -1,0 +1,36 @@
+---
+id: epic-045-326-gen3-secret-base-dashboard-v2
+type: EPIC
+title: Gen 3 Secret Base NPC Trainer Dashboard (v2)
+status: ACTIVE
+owner_persona: story_owner
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on:
+  - epic-045-324-gen3-secret-base-parsing-v2
+jules_session_id: '1338371455821373157'
+pr_number: null
+parent: prd-073-045-gen3-secret-base-viewer
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Gen 3 Secret Base NPC Trainer Dashboard (v2)
+
+## Context
+With the NPC trainer intel extracted from mixed records, we need a dashboard to display this information to the user. This includes trainer names, team compositions, EV yields, and daily rematch availability.
+
+## Objectives
+- Build a UI component to list active Secret Base NPC trainers.
+- Display each trainer's team composition and calculated EV yields for efficient training.
+- Indicate daily rematch status clearly on the dashboard.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break this Epic down into actionable Stories.

--- a/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
+++ b/.foundry/prds/prd-073-045-gen3-secret-base-viewer.md
@@ -33,9 +33,13 @@ Leverage DexHelper's programmatic save parsing to expose hidden Secret Base and 
 
 ## Next Steps
 - [ ] Epic Planner: Break this down into Epics (e.g., Save File Parsing, UI/Dashboard updates).
-  - [ ] .foundry/epics/epic-045-070-gen3-secret-base-parsing.md
-  - [ ] .foundry/epics/epic-045-071-gen3-secret-base-radar-integration.md
-  - [ ] .foundry/epics/epic-045-072-gen3-secret-base-dashboard.md
+  - [x] .foundry/epics/epic-045-070-gen3-secret-base-parsing.md
+  - [x] .foundry/epics/epic-045-071-gen3-secret-base-radar-integration.md
+  - [x] .foundry/epics/epic-045-072-gen3-secret-base-dashboard.md
+  - [ ] .foundry/research/research-045-321-investigate-secret-base-failure.md
+  - [ ] .foundry/epics/epic-045-324-gen3-secret-base-parsing-v2.md
+  - [ ] .foundry/epics/epic-045-325-gen3-secret-base-radar-integration-v2.md
+  - [ ] .foundry/epics/epic-045-326-gen3-secret-base-dashboard-v2.md
 
 ### Auditor Rejection
-Verification failed. The PRD is stuck in VERIFYING state, but its child EPICs (epic-045-070-gen3-secret-base-parsing, epic-045-071-gen3-secret-base-radar-integration, epic-045-072-gen3-secret-base-dashboard) have been permanently failed and CANCELLED. Therefore, this macro node's functional requirements have not been implemented and it cannot be verified as COMPLETED. The PRD must spawn a RESEARCH node to investigate the failure, create replacement nodes, and check off the failed children.
+Verification failed. The PRD's new child dependencies are still active and must be completed before the PRD can be verified.

--- a/.foundry/research/research-045-321-investigate-secret-base-failure.md
+++ b/.foundry/research/research-045-321-investigate-secret-base-failure.md
@@ -1,0 +1,35 @@
+---
+id: research-045-321-investigate-secret-base-failure
+type: RESEARCH
+title: Investigate Gen 3 Secret Base Parsing Permanent Failure
+status: ACTIVE
+owner_persona: researcher
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on: []
+jules_session_id: '1338371455821373157'
+pr_number: null
+parent: prd-073-045-gen3-secret-base-viewer
+tags:
+  - research
+  - gen3
+  - secret-base
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# RESEARCH: Investigate Gen 3 Secret Base Parsing Permanent Failure
+
+## Context
+The epic `epic-045-070-gen3-secret-base-parsing` reached its Max Rejection Count and was permanently cancelled. This caused its dependent epics (`epic-045-071-gen3-secret-base-radar-integration` and `epic-045-072-gen3-secret-base-dashboard`) to also be cancelled. We need to investigate the root cause of this failure before proceeding with replacement tasks.
+
+## Objectives
+- Investigate why the Gen 3 Secret Base Save File Parsing epic failed.
+- Identify missing architectural requirements, offsets, or logic that caused the rejections.
+- Propose a revised approach or updated offsets to ensure the replacement tasks succeed.
+
+## Acceptance Criteria
+- [ ] Researcher: Produce a research document detailing the root cause of the failure and providing correct offsets/logic.


### PR DESCRIPTION
This empty PR updates `prd-073-045-gen3-secret-base-viewer.md` to trigger the resurrection loop. Its child Epics were permanently cancelled due to reaching Max Rejection Count. I have checked off the cancelled child Epics in the PRD, spawned a new Research node (`research-045-321-investigate-secret-base-failure`), and created three new v2 Epics (`epic-045-324`, `epic-045-325`, `epic-045-326`) to replace them. Finally, I added an Auditor Rejection section to ensure the PRD remains in the DAG while the new dependencies are fulfilled.

---
*PR created automatically by Jules for task [1338371455821373157](https://jules.google.com/task/1338371455821373157) started by @szubster*