### PR TITLE
feat: generate epics for safari zone tracker prd

### DIFF
--- a/.foundry/epics/epic-113-324-safari-zone-data-integration.md
+++ b/.foundry/epics/epic-113-324-safari-zone-data-integration.md
@@ -1,0 +1,36 @@
+---
+id: epic-113-324-safari-zone-data-integration
+type: EPIC
+title: Gen 1 & Gen 3 Safari Zone Data Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-111-113-safari-zone-tracker
+tags:
+  - backend
+  - safari-zone
+  - gen1
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 1 & Gen 3 Safari Zone Data Extraction
+
+## Overview
+This Epic covers the backend and data extraction logic necessary to power the Safari Zone Tracking Dashboard. It involves parsing the user's save state to determine game version and Pokédex/PC box state, and mapping that against static encounter tables for the Safari Zone in Gen 1 and Gen 3.
+
+## Technical Scope
+- Extract current Pokédex and PC Box state from the save file.
+- Implement static data mappings for Safari Zone areas and encounter rates per game version.
+- Create utility functions to determine "missing" or "uncaught" Safari Zone encounters based on the current save state.
+
+## Acceptance Criteria
+- [ ] Create STORY nodes for Gen 1 and Gen 3 save state integration for Safari Zone encounters.
+- [ ] Create STORY nodes for compiling the static encounter tables for Safari Zones.

--- a/.foundry/epics/epic-113-325-safari-zone-dashboard-ui.md
+++ b/.foundry/epics/epic-113-325-safari-zone-dashboard-ui.md
@@ -1,0 +1,39 @@
+---
+id: epic-113-325-safari-zone-dashboard-ui
+type: EPIC
+title: Safari Zone Tracking Dashboard UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on:
+  - epic-113-324-safari-zone-data-integration
+jules_session_id: null
+pr_number: null
+parent: prd-111-113-safari-zone-tracker
+tags:
+  - frontend
+  - ui
+  - safari-zone
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Safari Zone Tracking Dashboard UI
+
+## Overview
+This Epic focuses on building the frontend components for the Safari Zone Tracking Dashboard, leveraging the tactical UI primitives defined in ADR 024. The dashboard will allow users to select target Pokémon, see which Safari Zone area they spawn in, and view a "bounty board" of missing encounters.
+
+## Technical Scope
+- Create a new Safari Zone route and container component.
+- Implement a visual representation (map or area cards) of the Safari Zone that highlights based on target selection.
+- Implement a dropdown/search for valid Safari encounters for the user's game version.
+- Implement the "bounty board" side panel showing uncaught rare encounters.
+- Apply tactical UI CSS utilities for styling.
+
+## Acceptance Criteria
+- [ ] Create STORY nodes for the main layout and route integration.
+- [ ] Create STORY nodes for the Area Highlighting and Target Selection components.
+- [ ] Create STORY nodes for the Bounty Board panel.

--- a/.foundry/prds/prd-111-113-safari-zone-tracker.md
+++ b/.foundry/prds/prd-111-113-safari-zone-tracker.md
@@ -46,5 +46,7 @@ The Safari Zone is a staple mechanic in Generation 1 (Kanto) and Generation 3 (H
 - **UI Components:** Create a new Safari Zone Dashboard route/component, integrating with existing tactical hardware aesthetics (`tactical-panel`, etc., from ADR 024).
 
 ## Acceptance Criteria
-- [ ] Create EPIC(s) for the backend data integration (determining Safari Zone encounter lists per version).
-- [ ] Create EPIC(s) for the frontend dashboard UI and state management.
+- [ ] epic-113-325-safari-zone-dashboard-ui
+- [ ] epic-113-324-safari-zone-data-integration
+- [x] Create EPIC(s) for the backend data integration (determining Safari Zone encounter lists per version).
+- [x] Create EPIC(s) for the frontend dashboard UI and state management.


### PR DESCRIPTION
I've broken down the PRD for the Gen 1 & Gen 3 Safari Zone Tracking Dashboard into two distinct epics:

1. **epic-113-324-safari-zone-data-integration**: This epic handles the backend data extraction, parsing the save state for game version and pokedex state, and mapping that to static encounter tables.
2. **epic-113-325-safari-zone-dashboard-ui**: This epic handles the frontend UI, including area highlighting, target selection, and the bounty board display, leveraging tactical UI components.

I've correctly mapped the dependency of the UI epic on the data integration epic.

I also updated the PRD (`prd-111-113-safari-zone-tracker`) by checking off its internal instruction tasks to create the epics, and injecting the two new epic node IDs as unchecked tasks within the acceptance criteria so that the orchestrator will suspend this node and wait for its children to complete.

Tests (`pnpm lint`, `pnpm test`, `pnpm test:e2e`) were run after installing playwright dependencies to confirm no regressions were introduced.

---
*PR created automatically by Jules for task [7281935047639469302](https://jules.google.com/task/7281935047639469302) started by @szubster*