### PR TITLE
story-058-280-feebas-backend-integration: Spawn replacement tasks for Feebas offset implementation

### DIFF
--- a/.foundry/research/research-280-324-feebas-offset-investigation.md
+++ b/.foundry/research/research-280-324-feebas-offset-investigation.md
@@ -3,7 +3,7 @@ id: research-280-324-feebas-offset-investigation
 type: RESEARCH
 title: Investigate Gen 3 Relative Offsets for Feebas Seed
 status: READY
-owner_persona: coder
+owner_persona: researcher
 created_at: '2026-07-14'
 updated_at: '2026-07-14'
 depends_on: []

--- a/.foundry/research/research-280-324-feebas-offset-investigation.md
+++ b/.foundry/research/research-280-324-feebas-offset-investigation.md
@@ -1,0 +1,33 @@
+---
+id: research-280-324-feebas-offset-investigation
+type: RESEARCH
+title: Investigate Gen 3 Relative Offsets for Feebas Seed
+status: READY
+owner_persona: coder
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-058-280-feebas-backend-integration
+tags:
+  - gen3
+  - backend
+  - save-parsing
+  - research
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 3 Relative Offsets for Feebas Seed
+
+## Objective
+Investigate how to correctly calculate relative memory offsets using `section1Offset` for the Feebas seed extraction in Gen 3 save files, due to the A/B bank flash memory system.
+
+## Context
+The previous implementation failed permanently because it used hardcoded absolute offsets instead of making them relative to the dynamically resolved `section1Offset`. The save blocks in Gen 3 can be either in Bank A or Bank B, meaning absolute offsets will cause the parser to read incorrect data when Bank B is active.
+
+## Expected Outcome
+- Document the correct relative offsets for both Ruby/Sapphire and Emerald.
+- Ensure the extraction functions explicitly receive `section1Offset` (or similar required base offsets) from the parser engine and use it for calculations.

--- a/.foundry/stories/story-058-280-feebas-backend-integration.md
+++ b/.foundry/stories/story-058-280-feebas-backend-integration.md
@@ -29,5 +29,11 @@ Integrate the Feebas seed extraction and tile calculation utilities (`extractFee
 - [ ] Update the `SaveData` interface in `src/engine/saveParser/parsers/common.ts` to include the Feebas tile coordinates.
 - [ ] Map the calculated coordinates to the updated `SaveData` schema during hydration.
 - [ ] Add unit/integration tests to verify Feebas data is correctly populated during save parsing.
-- [ ] task-280-304-feebas-backend-integration
-- [ ] task-280-305-feebas-backend-integration-qa
+- [x] task-280-304-feebas-backend-integration
+- [x] task-280-305-feebas-backend-integration-qa
+- [ ] research-280-324-feebas-offset-investigation
+- [ ] task-280-325-feebas-backend-integration-retry-impl
+- [ ] task-280-326-feebas-backend-integration-retry-qa
+
+### Auditor Rejection
+The previous child tasks failed permanently because the absolute offsets were used instead of calculating relative to section1Offset. The newly spawned child dependencies (research-280-324-feebas-offset-investigation, task-280-325-feebas-backend-integration-retry-impl, and task-280-326-feebas-backend-integration-retry-qa) are still active, so this parent verification is explicitly failed to stay open in the DAG.

--- a/.foundry/tasks/task-280-325-feebas-backend-integration-retry-impl.md
+++ b/.foundry/tasks/task-280-325-feebas-backend-integration-retry-impl.md
@@ -1,0 +1,40 @@
+---
+id: task-280-325-feebas-backend-integration-retry-impl
+type: TASK
+title: Retry Integrate Feebas Logic into Gen 3 Save Parser
+status: READY
+owner_persona: coder
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on:
+  - research-280-324-feebas-offset-investigation
+jules_session_id: null
+pr_number: null
+parent: story-058-280-feebas-backend-integration
+tags:
+  - gen3
+  - backend
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Retry Integrate Feebas Logic into Gen 3 Save Parser
+
+## Objective
+Update the `SaveData` interface and the parsing logic to extract and calculate Feebas tile locations for RSE saves, ensuring correct usage of relative offsets based on `section1Offset`.
+
+## Acceptance Criteria
+- [ ] Add `gen3FeebasTiles?: number[]` to the `SaveData` interface.
+- [ ] Modify the parsing logic to safely extract the seed and calculate the tiles for 'ruby', 'sapphire', or 'emerald' versions. Wrap this in a try-catch to prevent a malformed seed from failing the entire save parse.
+- [ ] Ensure the extraction function receives the `section1Offset` from the parsing engine to correctly calculate the seed position relative to the active save block, resolving the A/B bank issue.
+- [ ] Return the calculated tiles as `gen3FeebasTiles` in the returned `SaveData` object.
+- [ ] Update the corresponding tests to verify `gen3FeebasTiles` populates correctly when valid versions are passed.
+- [ ] Explicitly define all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level, forbidding inline magic numbers.
+- [ ] Explicitly use the resolved section offset (`section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
+
+## Failure Rules & Instructions
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-280-326-feebas-backend-integration-retry-qa.md
+++ b/.foundry/tasks/task-280-326-feebas-backend-integration-retry-qa.md
@@ -1,0 +1,40 @@
+---
+id: task-280-326-feebas-backend-integration-retry-qa
+type: TASK
+title: QA - Retry Feebas Backend Integration
+status: READY
+owner_persona: qa
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on:
+  - task-280-325-feebas-backend-integration-retry-impl
+jules_session_id: null
+pr_number: null
+parent: story-058-280-feebas-backend-integration
+tags:
+  - gen3
+  - backend
+  - save-parsing
+  - qa
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Retry Feebas Backend Integration
+
+## Objective
+Verify the `coder` correctly implemented the Feebas tile extraction logic using relative offsets from `section1Offset` in the parsing engine.
+
+## Acceptance Criteria
+- [ ] Review PR/code for modifications to ensure `gen3FeebasTiles` is correctly populated in the `SaveData` interface.
+- [ ] Verify that the extraction function correctly calculates the memory offset relative to `section1Offset` rather than using absolute hardcoded offsets.
+- [ ] Verify that the parsing logic handles RSE save files correctly and gracefully ignores versions without a Feebas seed.
+- [ ] Verify corresponding tests pass and cover the integration.
+- [ ] Ensure that memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level, preventing inline magic numbers.
+
+## Failure Rules & Instructions
+- If the coder's implementation is flawed (e.g. using absolute offsets instead of relative to `section1Offset`), reject the task by setting the coder task's frontmatter to `status: FAILED` with a detailed `rejection_reason`.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR transitions `story-058-280-feebas-backend-integration` by keeping the parent pending while spawning newly defined child dependencies:
- `research-280-324-feebas-offset-investigation.md`
- `task-280-325-feebas-backend-integration-retry-impl.md`
- `task-280-326-feebas-backend-integration-retry-qa.md`

These tasks will instruct the `coder` and `qa` to rework the Feebas seed extraction using relative offsets based on `section1Offset` to address the Gen 3 A/B flash memory architecture properly. By not checking the parent's acceptance criteria in the markdown body while checking off the permanently failed initial tasks, this empty PR correctly hands back control to the Orchestrator without prematurely verifying the parent.

---
*PR created automatically by Jules for task [7569992483094700117](https://jules.google.com/task/7569992483094700117) started by @szubster*