### PR TITLE
feat: Implement Gen 2 static encounter flag parsing

### DIFF
--- a/.foundry/tasks/task-294-316-gen2-static-encounter-flags-impl.md
+++ b/.foundry/tasks/task-294-316-gen2-static-encounter-flags-impl.md
@@ -36,10 +36,10 @@ Extract the event flags for Gen 2 static encounters from the save file. This inv
    - *Note: Exact byte/bit offsets within the 256-byte array may require referencing pokecrystal `constants/event_flags.asm`. Do not guess these; if you lack the exact constants, use late-binding and spawn a RESEARCH node to map the specific byte offsets and bits within the event flag array.*
 
 ## Acceptance Criteria
-- [ ] Module-level constants are defined for the offset of the event flags block and the specific byte/bit offsets for each static encounter flag.
-- [ ] The `gen2` save parser reads the event flag block and extracts the required static encounter flags (Sudowoodo, Snorlax, Red Gyarados, Ho-Oh, Lugia) into a clean, typed object/structure.
-- [ ] Explicit bitwise logic (`&`, `>>`) is used per ADR 026.
-- [ ] Unit tests are written to verify that flags are correctly extracted (0/1 states).
+- [x] Module-level constants are defined for the offset of the event flags block and the specific byte/bit offsets for each static encounter flag.
+- [x] The `gen2` save parser reads the event flag block and extracts the required static encounter flags (Sudowoodo, Snorlax, Red Gyarados, Ho-Oh, Lugia) into a clean, typed object/structure.
+- [x] Explicit bitwise logic (`&`, `>>`) is used per ADR 026.
+- [x] Unit tests are written to verify that flags are correctly extracted (0/1 states).
 
 ## Error Handling
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -235,6 +235,14 @@ export interface SaveData {
   hiddenCoinFlags?: Uint8Array;
   /** Bitflags representing which in-game NPC trades have already been completed. */
   npcTradeFlags?: boolean[];
+  /** Gen 2 specific: Static encounter event flags. */
+  gen2StaticEncounters?: {
+    sudowoodo: boolean;
+    snorlax: boolean;
+    redGyarados: boolean;
+    hoOh: boolean;
+    lugia: boolean;
+  };
   /** Detailed structural data for Pokémon currently left in the Daycare (Gen 2). */
   daycare?: PokemonInstance[];
   /** Gen 2 specific: Indicates if an Egg is currently waiting to be picked up from the Daycare. */

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -28,8 +28,22 @@ const DAYCARE_SLOT_2_OFFSET_GS = 0x2817;
 const DAYCARE_EGG_FLAG_OFFSET_GS = 0x284f;
 const DAYCARE_SLOT_1_OFFSET_CRYSTAL = 0x282c;
 const DAYCARE_SLOT_2_OFFSET_CRYSTAL = 0x27f3;
+const EVENT_FLAGS_OFFSET_CRYSTAL = 0x2600;
+const EVENT_FLAGS_OFFSET_GS = 0x2624;
+
 const DAYCARE_EGG_FLAG_OFFSET_CRYSTAL = 0x282b;
 const DAYCARE_EGG_FLAG_MASK = 0x01;
+
+const EVENT_FLAG_SUDOWOODO_BYTE = Math.floor(51 / 8);
+const EVENT_FLAG_SUDOWOODO_BIT = 51 % 8;
+const EVENT_FLAG_HO_OH_BYTE = Math.floor(470 / 8);
+const EVENT_FLAG_HO_OH_BIT = 470 % 8;
+const EVENT_FLAG_LUGIA_BYTE = Math.floor(471 / 8);
+const EVENT_FLAG_LUGIA_BIT = 471 % 8;
+const EVENT_FLAG_SNORLAX_BYTE = Math.floor(1326 / 8);
+const EVENT_FLAG_SNORLAX_BIT = 1326 % 8;
+const EVENT_FLAG_RED_GYARADOS_BYTE = Math.floor(1327 / 8);
+const EVENT_FLAG_RED_GYARADOS_BIT = 1327 % 8;
 
 function isValidLandmark(id: string): id is keyof typeof gen2Landmarks {
   return id in gen2Landmarks;
@@ -629,7 +643,7 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
 
   const roamingLegendaries = parseRoamingLegendaries(view, isCrystal);
 
-  const eventFlagsOffset = isCrystal ? 0x2600 : 0x2624;
+  const eventFlagsOffset = isCrystal ? EVENT_FLAGS_OFFSET_CRYSTAL : EVENT_FLAGS_OFFSET_GS;
   const eventFlags = new Uint8Array(0x100);
   try {
     for (let i = 0; i < 0x100; i++) {
@@ -677,5 +691,12 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
     eventFlags,
     hiddenItemFlags,
     npcTradeFlags,
+    gen2StaticEncounters: {
+      sudowoodo: (((eventFlags[EVENT_FLAG_SUDOWOODO_BYTE] ?? 0) >> EVENT_FLAG_SUDOWOODO_BIT) & 1) === 1,
+      snorlax: (((eventFlags[EVENT_FLAG_SNORLAX_BYTE] ?? 0) >> EVENT_FLAG_SNORLAX_BIT) & 1) === 1,
+      redGyarados: (((eventFlags[EVENT_FLAG_RED_GYARADOS_BYTE] ?? 0) >> EVENT_FLAG_RED_GYARADOS_BIT) & 1) === 1,
+      hoOh: (((eventFlags[EVENT_FLAG_HO_OH_BYTE] ?? 0) >> EVENT_FLAG_HO_OH_BIT) & 1) === 1,
+      lugia: (((eventFlags[EVENT_FLAG_LUGIA_BYTE] ?? 0) >> EVENT_FLAG_LUGIA_BIT) & 1) === 1,
+    },
   };
 }

--- a/src/engine/saveParser/parsers/gen2_encounter_flags.test.ts
+++ b/src/engine/saveParser/parsers/gen2_encounter_flags.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { parseGen2 } from './gen2';
+
+describe('Gen 2 Static Encounter Flags', () => {
+  it('should correctly parse the event flags for static encounters', () => {
+    // Generate a mock save block
+    const buffer = new ArrayBuffer(0x8000);
+    const view = new DataView(buffer);
+
+    // Set some valid data to get past initial checks
+    view.setUint8(0x288a, 6); // gsPartyCount
+    view.setUint8(0x2865, 0); // cPartyCount - makes it GS
+
+    // Offset for Event Flags in GS is 0x2624
+    const offset = 0x2624;
+
+    const EVENT_FLAG_SUDOWOODO_BYTE = Math.floor(51 / 8);
+    const EVENT_FLAG_SUDOWOODO_BIT = 51 % 8;
+    const EVENT_FLAG_HO_OH_BYTE = Math.floor(470 / 8);
+    const EVENT_FLAG_HO_OH_BIT = 470 % 8;
+
+    // Set Sudowoodo (byte 6, bit 3)
+    view.setUint8(offset + EVENT_FLAG_SUDOWOODO_BYTE, 1 << EVENT_FLAG_SUDOWOODO_BIT);
+    // Set Ho-Oh (byte 58, bit 6)
+    view.setUint8(offset + EVENT_FLAG_HO_OH_BYTE, 1 << EVENT_FLAG_HO_OH_BIT);
+
+    const result = parseGen2(view, false);
+
+    expect(result.gen2StaticEncounters).toBeDefined();
+    expect(result.gen2StaticEncounters?.sudowoodo).toBe(true);
+    expect(result.gen2StaticEncounters?.hoOh).toBe(true);
+
+    // Should be false
+    expect(result.gen2StaticEncounters?.snorlax).toBe(false);
+    expect(result.gen2StaticEncounters?.redGyarados).toBe(false);
+    expect(result.gen2StaticEncounters?.lugia).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR implements the logic to parse static encounter flags from Generation 2 save files (Gold, Silver, Crystal) by explicitly defining module-level offset and bit constants. The parsed flags are exposed to the state management layer via the `SaveData` interface.

Key changes:
- Defined byte offset constants `EVENT_FLAGS_OFFSET_CRYSTAL` and `EVENT_FLAGS_OFFSET_GS`.
- Defined bit/byte position constants for Sudowoodo, Snorlax, Red Gyarados, Ho-Oh, and Lugia encounters.
- Added `gen2StaticEncounters` property to the `SaveData` interface.
- Extracted and safely converted bit states from the `eventFlags` array.
- Wrote tests to verify logic correctness using mocked DataViews.
- Adhered strictly to ADR 026 explicitly.

---
*PR created automatically by Jules for task [15547622517759826593](https://jules.google.com/task/15547622517759826593) started by @szubster*