### PR TITLE
feat(foundry): breakdown Pokerus Strain UI Grid View epic

### DIFF
--- a/.foundry/epics/epic-112-323-pokerus-strain-ui-grid-view.md
+++ b/.foundry/epics/epic-112-323-pokerus-strain-ui-grid-view.md
@@ -36,4 +36,7 @@ Incorporate a visual indicator in the party/box (list or grid) views to quickly 
 None.
 
 ## 5. Acceptance Criteria
-- [ ] Story Owner: Break down this Epic into actionable Stories.
+- [x] Story Owner: Break down this Epic into actionable Stories.
+- [ ] story-323-322-pokerus-strain-badge-component
+- [ ] story-323-323-integrate-pokerus-strain-party-view
+- [ ] story-323-324-integrate-pokerus-strain-box-view

--- a/.foundry/stories/story-323-322-pokerus-strain-badge-component.md
+++ b/.foundry/stories/story-323-322-pokerus-strain-badge-component.md
@@ -1,0 +1,31 @@
+---
+id: story-323-322-pokerus-strain-badge-component
+type: STORY
+title: "Pokerus Strain Badge UI Component"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-07-14"
+updated_at: "2026-07-14"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-112-323-pokerus-strain-ui-grid-view
+tags: [pokerus, ui]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Pokerus Strain Badge UI Component
+
+## 1. Objective
+Develop a reusable UI component that visually displays the Pokerus strain (e.g., Strain 1, Strain 2) following the "tactical hardware" aesthetic.
+
+## 2. Scope
+- Create a `PokerusBadge` React component.
+- Apply styling based on ADR 008 and ADR 024 (e.g., `rounded-none`, `border-dashed`, monospaced fonts).
+- Ensure the badge clearly distinguishes between different strains visually (colors or labels).
+
+## 3. Acceptance Criteria
+- [ ] Tech Lead: Break down into Tasks.

--- a/.foundry/stories/story-323-323-integrate-pokerus-strain-party-view.md
+++ b/.foundry/stories/story-323-323-integrate-pokerus-strain-party-view.md
@@ -1,0 +1,30 @@
+---
+id: story-323-323-integrate-pokerus-strain-party-view
+type: STORY
+title: "Integrate Pokerus Strain Badge in Party View"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-07-14"
+updated_at: "2026-07-14"
+depends_on: [story-323-322-pokerus-strain-badge-component]
+jules_session_id: null
+pr_number: null
+parent: epic-112-323-pokerus-strain-ui-grid-view
+tags: [pokerus, ui]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Integrate Pokerus Strain Badge in Party View
+
+## 1. Objective
+Integrate the newly created Pokerus Strain badge into the Party view so players can quickly identify an infected Pokémon's strain.
+
+## 2. Scope
+- Update the Party list/grid components to consume and render the `PokerusBadge` component.
+- Extract the Pokerus strain data from the parsed Pokémon structure and pass it down.
+
+## 3. Acceptance Criteria
+- [ ] Tech Lead: Break down into Tasks.

--- a/.foundry/stories/story-323-324-integrate-pokerus-strain-box-view.md
+++ b/.foundry/stories/story-323-324-integrate-pokerus-strain-box-view.md
@@ -1,0 +1,30 @@
+---
+id: story-323-324-integrate-pokerus-strain-box-view
+type: STORY
+title: "Integrate Pokerus Strain Badge in Box View"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-07-14"
+updated_at: "2026-07-14"
+depends_on: [story-323-322-pokerus-strain-badge-component]
+jules_session_id: null
+pr_number: null
+parent: epic-112-323-pokerus-strain-ui-grid-view
+tags: [pokerus, ui]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Integrate Pokerus Strain Badge in Box View
+
+## 1. Objective
+Integrate the Pokerus Strain badge into the PC Box list/grid view components.
+
+## 2. Scope
+- Update the Box item cards/list rows to render the `PokerusBadge`.
+- Ensure it aligns correctly within the dense PC UI while adhering to the tactical design.
+
+## 3. Acceptance Criteria
+- [ ] Tech Lead: Break down into Tasks.


### PR DESCRIPTION
Broke down the Pokerus Strain UI Tracker epic into actionable stories for the Tech Lead to consume.

- Created `story-323-322-pokerus-strain-badge-component.md` for building the UI component.
- Created `story-323-323-integrate-pokerus-strain-party-view.md` for Party View integration.
- Created `story-323-324-integrate-pokerus-strain-box-view.md` for Box View integration.
- Checked off the Epic's acceptance criteria and added the new stories to the checklist.
- Verified state using `pnpm lint`, `pnpm test`, and `pnpm test:e2e` successfully.

---
*PR created automatically by Jules for task [15198159539528747523](https://jules.google.com/task/15198159539528747523) started by @szubster*