### PR TITLE
docs: transform idea 115 to prd for gen 3 fame checker assistant

### DIFF
--- a/.foundry/ideas/idea-115-gen3-fame-checker-assistant.md
+++ b/.foundry/ideas/idea-115-gen3-fame-checker-assistant.md
@@ -28,3 +28,7 @@ In Pokémon FireRed and LeafGreen, the Fame Checker is a unique Key Item used to
 
 ## Solution
 Leverage the DexHelper save parsing engine to read the hidden event flags associated with the Fame Checker progress. By extracting exactly which entries the player has unlocked for each NPC, we can create an actionable dashboard. Instead of showing the player what they already know, the dashboard will explicitly tell them *what* they are missing and *exactly where* to go in their specific save file to find it. This perfectly aligns with our vision of a premium companion app: replacing tedious backtracking and wiki lookups with targeted, dynamically generated to-do lists based on their actual save state.
+
+## Acceptance Criteria
+- [x] Create PRD
+- [ ] prd-115-115-gen3-fame-checker-assistant

--- a/.foundry/prds/prd-115-115-gen3-fame-checker-assistant.md
+++ b/.foundry/prds/prd-115-115-gen3-fame-checker-assistant.md
@@ -1,0 +1,35 @@
+---
+id: prd-115-115-gen3-fame-checker-assistant
+type: PRD
+title: Gen 3 Fame Checker Progress & Assistant
+status: READY
+owner_persona: epic_planner
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-115-gen3-fame-checker-assistant
+tags:
+  - gen3
+  - firered
+  - leafgreen
+  - fame-checker
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Gen 3 Fame Checker Progress & Assistant
+
+## 1. Problem Statement
+The Fame Checker in Pokémon FireRed and LeafGreen tracks lore about prominent NPCs. Tracking missing entries is tedious because the in-game UI only shows acquired entries. Players have to guess missing entries and use external wikis.
+
+## 2. Solution
+Leverage DexHelper's save parsing to read hidden event flags for Fame Checker progress. Create a dashboard that explicitly shows players what entries they are missing and exactly where to find them in their specific save state.
+
+## 3. Scope
+- Parse event flags related to the Fame Checker in FireRed/LeafGreen.
+- Create UI dashboard to display unlocked and missing Fame Checker entries for each NPC.
+- Provide actionable location/action hints for missing entries.


### PR DESCRIPTION
- Created `.foundry/prds/prd-115-115-gen3-fame-checker-assistant.md` based on `idea-115`.
- Updated `.foundry/ideas/idea-115-gen3-fame-checker-assistant.md` to append the `## Acceptance Criteria` section.
- Added a checked checkbox for creating the PRD and an unchecked checkbox referencing the newly generated PRD.

---
*PR created automatically by Jules for task [3827567801261068384](https://jules.google.com/task/3827567801261068384) started by @szubster*