### PR TITLE
Break down PRD-113-114 Gen 3 Pokéblock Stats Viewer into Epics

### DIFF
--- a/.foundry/epics/epic-114-327-gen3-pokeblock-case-parsing.md
+++ b/.foundry/epics/epic-114-327-gen3-pokeblock-case-parsing.md
@@ -1,0 +1,36 @@
+---
+id: epic-114-327-gen3-pokeblock-case-parsing
+type: EPIC
+title: Gen 3 Pokéblock Case Save Parsing
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-113-114-gen3-pokeblock-stats-viewer
+tags:
+  - gen3
+  - contests
+  - pokeblocks
+  - backend
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Pokéblock Case Save Parsing
+
+## Overview
+This Epic covers the backend save parsing necessary to extract exact Pokéblock data from the Pokéblock Case block in Gen 3 save files.
+
+## Goals
+- Identify the memory offsets for the Pokéblock Case in Gen 3.
+- Extract individual Pokéblock structures from the case array.
+- Parse the exact numerical values for all five flavors (Cool, Beauty, Cute, Smart, Tough) and the feel (smoothness) bytes.
+
+## Acceptance Criteria
+- [ ] Create STORY(s) for researching offsets and implementing the Pokéblock extraction logic.

--- a/.foundry/epics/epic-114-328-gen3-pokeblock-dashboard-ui.md
+++ b/.foundry/epics/epic-114-328-gen3-pokeblock-dashboard-ui.md
@@ -1,0 +1,37 @@
+---
+id: epic-114-328-gen3-pokeblock-dashboard-ui
+type: EPIC
+title: Gen 3 Pokéblock Exact Stats Viewer UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on:
+  - epic-114-327-gen3-pokeblock-case-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-113-114-gen3-pokeblock-stats-viewer
+tags:
+  - gen3
+  - contests
+  - pokeblocks
+  - frontend
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Pokéblock Exact Stats Viewer UI
+
+## Overview
+This Epic handles the creation of a dashboard for users to view the exact values of their stored Pokéblocks.
+
+## Goals
+- Create a dashboard UI listing all Pokéblocks in the inventory.
+- Display exact levels for each flavor and the exact Feel value.
+- Adhere to the tactical hardware aesthetic constraints (ADR 024, ADR 008).
+
+## Acceptance Criteria
+- [ ] Create STORY(s) for the frontend dashboard design and implementation.

--- a/.foundry/prds/prd-113-114-gen3-pokeblock-stats-viewer.md
+++ b/.foundry/prds/prd-113-114-gen3-pokeblock-stats-viewer.md
@@ -46,5 +46,7 @@ In Generation 3 (Ruby, Sapphire, Emerald), Pokéblocks are created by blending B
 - **UI Components:** Create a new dashboard route and component for the Pokéblock Viewer, adhering to the tactical hardware aesthetic constraints (ADR 024, ADR 008).
 
 ## Acceptance Criteria
-- [ ] Create EPIC(s) for the backend data integration (parsing the Pokéblock Case).
-- [ ] Create EPIC(s) for the frontend dashboard UI and state management.
+- [x] Create EPIC(s) for the backend data integration (parsing the Pokéblock Case).
+- [x] Create EPIC(s) for the frontend dashboard UI and state management.
+- [ ] epic-114-327-gen3-pokeblock-case-parsing
+- [ ] epic-114-328-gen3-pokeblock-dashboard-ui


### PR DESCRIPTION
Created Epic nodes for the backend save parsing and frontend UI implementation of the Gen 3 Pokéblock Exact Stats Viewer feature. Updated the original PRD node to track these new children.

---
*PR created automatically by Jules for task [5123433311405571485](https://jules.google.com/task/5123433311405571485) started by @szubster*