### PR TITLE
docs(research): investigate Gen 3 static encounter memory offsets

### DIFF
--- a/.foundry/docs/knowledge_base/gen3_static_encounters/gen3_static_encounter_offsets.md
+++ b/.foundry/docs/knowledge_base/gen3_static_encounters/gen3_static_encounter_offsets.md
@@ -1,0 +1,61 @@
+# Gen 3 Static Encounter Event Flag Offsets
+
+This document tracks the event flags used in Gen 3 games (Emerald, FireRed, LeafGreen, Ruby, Sapphire) to determine if a static encounter (legendaries, interactables like Sudowoodo, Snorlax, Voltorb/Electrode) has been defeated/caught/cleared.
+
+## Memory Offset Calculation
+The "Event Flags" section starts at `0x1270` within `SaveBlock1`.
+To calculate the specific byte and bit for an event flag:
+`Byte Offset = (Flag_ID / 8)`
+`Bit Position = (Flag_ID % 8)`
+
+## Emerald (`pret/pokeemerald`)
+
+| Encounter | Flag ID (Hex) | Byte Offset (Hex) | Bit |
+| :--- | :--- | :--- | :--- |
+| Deoxys | `0x1AC` | `0x35` | 4 |
+| Regirock | `0x1BB` | `0x37` | 3 |
+| Regice | `0x1BC` | `0x37` | 4 |
+| Registeel | `0x1BD` | `0x37` | 5 |
+| Kyogre | `0x1BE` | `0x37` | 6 |
+| Groudon | `0x1BF` | `0x37` | 7 |
+| Rayquaza | `0x1C0` | `0x38` | 0 |
+| Voltorb 1 (New Mauville) | `0x1C1` | `0x38` | 1 |
+| Voltorb 2 (New Mauville) | `0x1C2` | `0x38` | 2 |
+| Voltorb 3 (New Mauville) | `0x1C3` | `0x38` | 3 |
+| Electrode 1 (Aqua Hideout) | `0x1C4` | `0x38` | 4 |
+| Electrode 2 (Aqua Hideout) | `0x1C5` | `0x38` | 5 |
+| Sudowoodo | `0x1C6` | `0x38` | 6 |
+| Mew (Defeated) | `0x1C7` | `0x38` | 7 |
+| Mew (Caught) | `0x1CA` | `0x39` | 2 |
+| Ho-Oh | `0x1DC` | `0x3B` | 4 |
+| Lugia | `0x1DD` | `0x3B` | 5 |
+
+
+## FireRed & LeafGreen (`pret/pokefirered`)
+
+| Encounter | Flag ID (Hex) | Byte Offset (Hex) | Bit | Notes |
+| :--- | :--- | :--- | :--- | :--- |
+| Mewtwo | `0x2BC` | `0x57` | 4 | Fought |
+| Moltres | `0x2BD` | `0x57` | 5 | Fought |
+| Articuno | `0x2BE` | `0x57` | 6 | Fought |
+| Zapdos | `0x2BF` | `0x57` | 7 | Fought |
+| Deoxys | `0x2E4` | `0x5C` | 4 | Fought |
+| Lugia | `0x2F2` | `0x5E` | 2 | Fought |
+| Ho-Oh | `0x2F3` | `0x5E` | 3 | Fought |
+| Snorlax (Route 12) | `0x253` | `0x4A` | 3 | Woke up flag |
+| Snorlax (Route 16) | `0x080` | `0x10` | 0 | Hide flag |
+
+## Ruby & Sapphire (`pret/pokeruby`)
+
+| Encounter | Flag ID (Hex) | Byte Offset (Hex) | Bit | Notes |
+| :--- | :--- | :--- | :--- | :--- |
+| Groudon/Kyogre | `0x71` | `0x0E` | 1 | Cave of Origin Legendary Battle Completed |
+| Rayquaza | `0x305` | `0x60` | 5 | Hide flag |
+| Regirock | `0x3A7` | `0x74` | 7 | Hide flag |
+| Regice | `0x3A8` | `0x75` | 0 | Hide flag |
+| Registeel | `0x3A9` | `0x75` | 1 | Hide flag |
+| Voltorb 1 (New Mauville) | `0x3CE` | `0x79` | 6 | Hide flag |
+| Voltorb 2 (New Mauville) | `0x3CF` | `0x79` | 7 | Hide flag |
+| Voltorb 3 (New Mauville) | `0x3D0` | `0x7A` | 0 | Hide flag |
+| Electrode 1 (Aqua Hideout) | `0x3D1` | `0x7A` | 1 | Hide flag |
+| Electrode 2 (Aqua Hideout) | `0x3D2` | `0x7A` | 2 | Hide flag |

--- a/.foundry/journals/researcher.md
+++ b/.foundry/journals/researcher.md
@@ -79,3 +79,7 @@ For applications utilizing Cloudflare Zero Trust (Cloudflare Access), the built-
 **Finding:** Modifying the `run_in_bash_session` platform tool from within the repository to enforce timeouts is impossible. The previous task (`task-267-262-bash-timeout-wrapper-impl`) failed permanently because of this.
 **Why it matters:** When addressing problems with sandbox execution environments (e.g., preventing infinite hangs on `tail -f`), we cannot build wrapper scripts and expect them to be seamlessly adopted.
 **Constraint:** The most reliable way to enforce tool behavior constraints is through **instructional policy enforcement**. The rules must be added to `.foundry/docs/knowledge_base/agents/core_policies.md` so that the agent context is explicitly updated to forbid blocking commands and recommend `cat`, `tail -n`, or backgrounding with `&`.
+
+## Gen 3 Static Encounter Offsets
+
+When parsing Gen 3 event flags for static encounters (like legendaries or Snorlax), the flag IDs map to byte and bit offsets within the Event Flags block (which starts at `0x1270` in `SaveBlock1`). To calculate the exact offset, divide the flag ID by 8 for the byte offset, and use modulo 8 for the bit position (e.g. `Flag_ID / 8` and `Flag_ID % 8`). Note that Pokémon FireRed/LeafGreen often track `FOUGHT` instead of `DEFEATED`, and Ruby/Sapphire uses `HIDE` flags for static encounters like the Regis.

--- a/.foundry/research/research-294-320-gen3-static-encounter-offsets.md
+++ b/.foundry/research/research-294-320-gen3-static-encounter-offsets.md
@@ -25,4 +25,4 @@ notes: ''
 Investigate and document the memory offsets and bit locations for Gen 3 static encounter event flags.
 
 ## Acceptance Criteria
-- [ ] Find offsets
+- [x] Find offsets


### PR DESCRIPTION
Investigated and documented the memory offsets and bit locations for Gen 3 static encounter event flags (e.g., Legendaries, Snorlax, Voltorb/Electrode) across Emerald, FRLG, and R/S. Also updated the researcher journal with relevant learnings.

---
*PR created automatically by Jules for task [18299571615588828694](https://jules.google.com/task/18299571615588828694) started by @szubster*