### PR TITLE
Draft blueprints for Gen 3 Contest & Battle Frontier Extraction

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -177,3 +177,9 @@ Drafted technical blueprints (`task-286-314-filter-swarm-item-calls-impl` and `t
 
 ## 2026-07-12: Gen 3 Dynamic Save Block Extraction Pattern
 When generating blueprints for Gen 3 dynamic save block extraction (like Volcanic Ash), ensure explicit instructions are provided to use the dynamically resolved `section1Offset` for relative offset calculations rather than hardcoding absolute values. Using absolute offsets breaks A/B bank flash memory parsing.
+
+## 2026-07-14
+- Drafted blueprints for Gen 3 Contest & Battle Frontier Extraction (`story-304-320-gen3-contest-frontier-extraction`).
+- Created implementation task `task-320-322-gen3-contest-frontier-impl`.
+- Created QA task `task-320-323-gen3-contest-frontier-qa` following the Intelligent Verification Protocol due to memory parsing complexity and A/B bank relative offset resolution requirements.
+- Explicitly instructed the Coder and QA personas on error handling, Empty PR requirements, and strict magic number / relative offset rules.

--- a/.foundry/stories/story-304-320-gen3-contest-frontier-extraction.md
+++ b/.foundry/stories/story-304-320-gen3-contest-frontier-extraction.md
@@ -33,3 +33,5 @@ Extract Master Rank Contest condition ribbons and Battle Frontier Gold Symbols f
 ## Acceptance Criteria
 - [ ] Implement Contest extraction logic.
 - [ ] Implement Battle Frontier extraction logic.
+- [ ] task-320-322-gen3-contest-frontier-impl
+- [ ] task-320-323-gen3-contest-frontier-qa

--- a/.foundry/tasks/task-320-322-gen3-contest-frontier-impl.md
+++ b/.foundry/tasks/task-320-322-gen3-contest-frontier-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-320-322-gen3-contest-frontier-impl
+type: TASK
+title: 'Implement Gen 3 Contest & Battle Frontier Extraction'
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-304-320-gen3-contest-frontier-extraction
+tags:
+  - data-extraction
+  - gen3
+research_references:
+  - .foundry/docs/knowledge_base/gen3_battle_frontier_data.md
+  - .foundry/docs/knowledge_base/gen3_pokemon_data_structure.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Contest & Battle Frontier Extraction
+
+## Objective
+Implement extraction logic for Master Rank Contest condition ribbons and Battle Frontier Gold Symbols from Gen 3 save files.
+
+## Contracts & Requirements
+- Use the `DataView` API (ADR 010).
+- Extract magic numbers into module-level reusable constants (ADR 028). For save file parsing, all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
+- For Gen 3 save file parsing, use the resolved section offset (e.g., `section1Offset` or `section2Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement extraction logic for Master Rank Contest condition ribbons.
+- [ ] Implement extraction logic for Battle Frontier Gold Symbols.

--- a/.foundry/tasks/task-320-323-gen3-contest-frontier-qa.md
+++ b/.foundry/tasks/task-320-323-gen3-contest-frontier-qa.md
@@ -1,0 +1,41 @@
+---
+id: task-320-323-gen3-contest-frontier-qa
+type: TASK
+title: 'QA Gen 3 Contest & Battle Frontier Extraction'
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on:
+  - task-320-322-gen3-contest-frontier-impl
+jules_session_id: null
+pr_number: null
+parent: story-304-320-gen3-contest-frontier-extraction
+tags:
+  - data-extraction
+  - gen3
+research_references:
+  - .foundry/docs/knowledge_base/gen3_battle_frontier_data.md
+  - .foundry/docs/knowledge_base/gen3_pokemon_data_structure.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 Contest & Battle Frontier Extraction
+
+## Objective
+Verify the implementation of extraction logic for Master Rank Contest condition ribbons and Battle Frontier Gold Symbols from Gen 3 save files.
+
+## Contracts & Requirements
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- Verify that for save file parsing, all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level, forbidding inline magic numbers.
+- Verify that for Gen 3 save file parsing, the Coder used the resolved section offset (e.g., `section1Offset` or `section2Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets.
+
+## Acceptance Criteria
+- [ ] Verify Contest extraction logic using `DataView`.
+- [ ] Verify Battle Frontier extraction logic using `DataView`.
+- [ ] Verify no magic numbers are used inline for memory operations.
+- [ ] Verify appropriate A/B bank relative offset resolution is used.


### PR DESCRIPTION
Created implementation (`task-320-322-gen3-contest-frontier-impl`) and QA (`task-320-323-gen3-contest-frontier-qa`) blueprints for extracting Gen 3 Contest ribbons and Battle Frontier symbols via the DataView API. Included strict requirements for absolute vs relative offset resolution for A/B bank flash memory. Updated story and journal.

---
*PR created automatically by Jules for task [9213130707659516825](https://jules.google.com/task/9213130707659516825) started by @szubster*