### PR TITLE
Foundry: Submit completed story empty PR

### DIFF
--- a/.foundry/stories/story-117-283-pokegear-predictor-engine.md
+++ b/.foundry/stories/story-117-283-pokegear-predictor-engine.md
@@ -30,5 +30,5 @@ Break down the implementation of the Pokegear Predictor logic into tasks.
 
 ## Acceptance Criteria
 - [x] Create tasks for the predictor engine logic
-- [ ] task-283-314-predictor-engine-logic-impl
-- [ ] task-283-315-predictor-engine-logic-qa
+- [x] task-283-314-predictor-engine-logic-impl
+- [x] task-283-315-predictor-engine-logic-qa


### PR DESCRIPTION
Submitted an Empty PR checking off the completed child task checkboxes in the story node markdown body because the task files already unexpectedly existed and were `COMPLETED`. No new tasks were created as part of the Tech Lead blueprint drafting since they already existed.

---
*PR created automatically by Jules for task [7170982970206895348](https://jules.google.com/task/7170982970206895348) started by @szubster*