### PR TITLE
Break down story-117-284-pokegear-predictor-ui into implementation and QA tasks

### DIFF
--- a/.foundry/stories/story-117-284-pokegear-predictor-ui.md
+++ b/.foundry/stories/story-117-284-pokegear-predictor-ui.md
@@ -30,4 +30,6 @@ Break down the implementation of the Pokegear Predictor UI into tasks.
 - Create tasks to implement the display of call probabilities on the Active Callers Dashboard.
 
 ## Acceptance Criteria
-- [ ] Create tasks for the predictor engine UI
+- [x] Create tasks for the predictor engine UI
+- [ ] task-284-322-predictor-ui-impl
+- [ ] task-284-323-predictor-ui-qa

--- a/.foundry/tasks/task-284-322-predictor-ui-impl.md
+++ b/.foundry/tasks/task-284-322-predictor-ui-impl.md
@@ -1,0 +1,43 @@
+---
+id: task-284-322-predictor-ui-impl
+type: TASK
+title: Implement Active Callers Dashboard UI
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-117-284-pokegear-predictor-ui
+tags:
+  - ui
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Active Callers Dashboard UI
+
+## Objective
+Implement the React UI component for the Active Callers Dashboard to display Pokegear call probabilities.
+
+## Context & Architecture
+As per ADR 008, the UI must strictly adhere to the 'tactical hardware/snooping' aesthetic: use sharp edges (`rounded-none`), avoid all rounded corners, use dashed borders (`border-dashed`), and monospaced telemetry fonts (`font-mono`).
+
+The UI should use the `checkPhoneCall` and `chooseRandomCaller` logic (or visual indicators of probability derived from them) to display which contacts are most likely to call the player. Create an `ActiveCallersDashboard` component.
+
+## Acceptance Criteria
+- [ ] Create `ActiveCallersDashboard.tsx` under `src/components/dashboard/pokegear/` (or similar appropriate path).
+- [ ] Display a list or grid of active callers with their respective call probabilities or status.
+- [ ] Apply the tactical UI aesthetic (e.g., `rounded-none`, `border-dashed`, `font-mono`).
+- [ ] Ensure all necessary Vitest test cases are written for the UI component.
+
+## Coder Constraints & Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- You must self-verify changes by running `pnpm test` and explicitly mention the outcome in your journal.
+- Ensure strict TypeScript typing (`verbatimModuleSyntax` requires `import type`).

--- a/.foundry/tasks/task-284-323-predictor-ui-qa.md
+++ b/.foundry/tasks/task-284-323-predictor-ui-qa.md
@@ -1,0 +1,41 @@
+---
+id: task-284-323-predictor-ui-qa
+type: TASK
+title: QA - Active Callers Dashboard UI
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on:
+  - task-284-322-predictor-ui-impl
+jules_session_id: null
+pr_number: null
+parent: story-117-284-pokegear-predictor-ui
+tags:
+  - qa
+  - ui
+  - gen2
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA - Active Callers Dashboard UI
+
+## Objective
+Verify the implementation of the Active Callers Dashboard UI.
+
+## Context
+The Coder has implemented the Active Callers Dashboard to display Pokegear call probabilities. Ensure it adheres to the tactical aesthetic (ADR 008) and functions correctly without TypeScript or Lint errors.
+
+## Acceptance Criteria
+- [ ] Verify `ActiveCallersDashboard` uses `rounded-none`, `border-dashed`, and `font-mono`.
+- [ ] Verify the UI component correctly surfaces call probability data.
+- [ ] Verify component unit tests exist and pass (`pnpm test`).
+- [ ] Verify no linting errors are introduced (`pnpm lint`).
+
+## QA Constraints & Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
I have read the global context and architectural documents as required by my persona. I evaluated the `story-117-284-pokegear-predictor-ui` node, which requires breaking down the implementation of the Active Callers Dashboard UI. 

Since the UI involves applying specific architectural aesthetics (ADR 008 - tactical hardware/snooping) and surfaces underlying RNG mechanics via `checkPhoneCall` and `chooseRandomCaller`, I applied the Intelligent Verification Protocol and deemed it necessary to create both an implementation task for the `coder` and a verification task for the `qa` persona to ensure adherence to these strict UI guidelines. 

I drafted the blueprints `task-284-322-predictor-ui-impl` and `task-284-323-predictor-ui-qa`, properly linked their dependencies (QA depends on Coder), included all mandatory boilerplate constraints (FAILED/CANCELLED/Empty PR checkboxes), explicitly instructed the Coder on the visual constraints, and appended them to the Story's markdown body. Tests were run to ensure a clean state.

---
*PR created automatically by Jules for task [8122102314469607711](https://jules.google.com/task/8122102314469607711) started by @szubster*