### PR TITLE
🛠️ Infras: Optimize Playwright CI browser installation

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,7 +32,7 @@ jobs:
       run: pnpm install --frozen-lockfile
 
     - name: Install Playwright Browsers
-      run: pnpm exec playwright install --with-deps
+      run: pnpm exec playwright install chromium --with-deps
 
     - name: Run Playwright E2E tests
       run: pnpm test:e2e


### PR DESCRIPTION
### What
Modified `.github/workflows/playwright.yml` to use `pnpm exec playwright install chromium --with-deps` instead of `pnpm exec playwright install --with-deps`.

### Why
The project's `playwright.config.ts` only configures tests to run on `chromium` (via the `Desktop Chrome` and mobile profiles). Downloading WebKit and Firefox in CI is unnecessary and wastes time and bandwidth.

### Impact on DX/CI
This change speeds up the "Install Playwright Browsers" step in the CI pipeline by skipping the download and extraction of unused browser binaries, leading to faster E2E test feedback.

### Setup Notes
None.

---
*PR created automatically by Jules for task [15917009468050544469](https://jules.google.com/task/15917009468050544469) started by @szubster*