### PR TITLE
🗃️ Archivist: Clean up stale memory entries and execution trace spam

### DIFF
--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -121,11 +121,6 @@ When verifying `epic-038-061-pokerus-state-exfiltration`, the implementation suc
 ### Gen 3 Lottery Offsets Extraction
 When verifying `epic-104-133-gen3-lottery-offsets-research`, I learned that the 32-bit lottery PRNG seed in Gen 3 is split across two 16-bit variables. Crucially, the order of these variables (High/Low words) is swapped between Ruby/Sapphire and Emerald. Ruby/Sapphire stores the Low 16 bits first (at index 0x404B) and the High 16 bits second (at 0x404C), while Emerald stores the High 16 bits first (at 0x404B) and the Low 16 bits second (at 0x404C). This introduces a complexity in extracting a 32-bit value that we need to standardize.
 
-### epic-052-096-automated-max-rejection-cancellation
-- **Node**: `epic-052-096-automated-max-rejection-cancellation`
-- **Result**: Verification Passed.
-- **Notes**: The Epic was successfully broken down into stories `story-096-153-max-rejection-cancellation` and `story-096-154-parent-awakening-logic`. Both stories and their descendant task nodes were implemented, merged, and moved to COMPLETED status. The `foundry-orchestrator.ts` Phase 3.0 and Phase 3.6 correctly implemented the logic to handle max rejections and CANCELLED nodes, as verified by reading the scripts and running the test suite. All child nodes and their tasks are completely marked as `[x]`. I am submitting an empty PR to transition this node to COMPLETED.
-
 ## 2026-07-11: Automated Max Rejection Cancellation
 Successfully verified that the Automated Max Rejection Cancellation epic was correctly broken down into two child stories (`story-096-153-max-rejection-cancellation` and `story-096-154-parent-awakening-logic`) and that both stories were successfully completed.
 

--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -88,12 +88,3 @@ Biome and Oxlint do not currently support custom JS linting rules. The built-in 
 ## 2026-07-08: Impossible Task - Wrapping run_in_bash_session
 Task task-267-262-bash-timeout-wrapper-impl was cancelled because `run_in_bash_session` is a built-in platform tool provided to agents, not a script or function defined within this repository's codebase. It is therefore impossible to implement a wrapper or linter for it from within the repo.
 
-## 2026-07-10: Self-Verification of Party Zero HP Detection
-In task `task-269-263-detect-party-zero-hp-impl`, I verified the existing implementation of `getDeadPokemon` in `src/engine/nuzlocke/tracker.ts`. The function correctly extracts party Pokémon that have fainted (HP is 0). I ran `pnpm test` and confirmed that the tests in `src/engine/nuzlocke/tracker.test.ts` cover this functionality and pass successfully. Per the Intelligent Verification Protocol, I have self-verified this simple, low-risk task and am submitting an empty PR with the checked acceptance criteria.
-
-## Session: task-267-287-gen3-move-tutor-emerald-impl
-
-The target artifact (Emerald Move Tutor extraction logic and tests in `src/engine/saveParser/parsers/gen3.ts` and `src/engine/saveParser/parsers/gen3.test.ts`) already existed prior to the session. Submitted an empty PR to transition the node to COMPLETED.
-
-## 2026-07-13: Self-Verification
-Self-verified task `task-276-304-orchestrator-verifying-block` by running tests (`npx vitest run` in `.github/scripts` and `pnpm test:e2e` in workspace root). Verified that removing `VERIFYING` allowances from `foundry-orchestrator.ts` successfully allows the system tests to pass.

--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -27,19 +27,7 @@ The implementer (`coder`) failed `task-121-219-gen3-tv-block-parser-retry-impl` 
 - **Date**: 2026-07-11
 - **Node**: task-276-304-gen3-trick-house-parser-impl
 - **Reason**: The developer failed to handle `RangeError` from the `DataView` API when checking for out-of-bounds reads. This is a critical requirement for parsers working with save file data to prevent crashes when dealing with corrupted or incomplete saves.
-## 2026-07-11 - Feebas Extraction Failed (Task: task-280-305-feebas-backend-integration-qa)
-The coder implemented the Feebas extraction logic using absolute memory offsets (`0x2dd6`) instead of making them relative to `section1Offset`. In Generation 3, save files utilize an A/B bank rotation system where data can either reside in `0x0000` or `0xE000`. By hardcoding the absolute offset, the parser will fail to read the active save data if it currently resides in Bank B.
-
-To enforce the architecture correctly, all dynamic save block extraction functions must receive the resolved offset from the parser engine (e.g., `section1Offset` or `section2Offset`) and apply relative memory offsets to correctly extract the active save data block. I have failed `task-280-304-feebas-backend-integration` and incremented its rejection count.
-
-## Gen 3 Volcanic Ash Extraction Validation
-- **Pattern**: When validating Gen 3 dynamic save block extraction, ensure that offsets are not hardcoded absolute values (e.g. `0x13D0` or `0x142C`). They must be calculated relative to the dynamically resolved `section1Offset`.
-- **Outcome**: Rejected `task-267-261-gen3-ash-dataview-extraction-impl` due to hardcoded absolute offsets instead of using the `section1Offset + offset` calculation.
-
-## Gen 3 Volcanic Ash Extraction Permanent Failure
-- **Date**: 2026-07-12
-- **Node**: task-267-261-gen3-ash-dataview-extraction-impl
-- **Reason**: The developer reached max rejections by faking the relative offset calculation fix. They kept the absolute memory offsets and performed math manipulation, violating ADR 028.
-
-## 2026-07-13 - Feebas Extraction Permanent Failure (Task: task-280-305-feebas-backend-integration-qa)
-The coder failed to properly implement relative memory offsets using `section1Offset` for Feebas seed extraction after multiple rejections. They used `section2Offset` instead of `section1Offset`, violating the architecture requirements of the Gen 3 A/B bank flash memory system. As they have reached the maximum rejection count, I have permanently failed the `task-280-304-feebas-backend-integration` by setting its status to `CANCELLED`.
+## Canonical Pattern: Enforcing Gen 3 A/B Bank Relative Offsets (ADR 028)
+- **Constraint**: When validating Gen 3 dynamic save block extraction (e.g., Feebas seed, Volcanic Ash), ensure that offsets are never hardcoded as absolute values (e.g., `0x2dd6`, `0x13D0`).
+- **Why**: Generation 3 save files utilize an A/B bank rotation system where data can reside in `0x0000` or `0xE000`. Absolute offsets will fail to read the active save data if it resides in Bank B.
+- **Enforcement**: All dynamic save block extraction functions must receive the resolved offset from the parser engine (e.g., `section1Offset` or `section2Offset`) and apply relative memory calculations (`section1Offset + offset`). Recurring rejections and permanent failures have occurred because developers fake the fix or use the wrong section offset.

--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -62,3 +62,10 @@
 ## 2026-07-12 - Archivist Run Learnings
 
 **Action:** Systematically cleaned up more operational execution trace lines ("I did", "Permanently failed", "I verified", "Anomaly") from `.foundry/journals/coder.md`, `.foundry/journals/architect.md`, `.foundry/journals/agile_coach.md` and `.foundry/journals/tech_lead.md`.
+
+## 2026-07-21 - Archivist Run Learnings
+**Learning:** The `.foundry/journals/qa.md` accumulated redundant learnings about absolute offsets vs relative offsets (ADR 028) across multiple tasks (e.g. Feebas and Volcanic Ash).
+**Action:** Consolidated these multiple entries into a single canonical entry in `qa.md` to reduce duplication and improve clarity for future agents reading the journal.
+
+**Learning:** Execution traces (e.g., 'I verified', 'Permanently failed', 'I implemented') continued to bloat journals like `coder.md` and `qa.md`.
+**Action:** Ran cleanup scripts to strip out these purely operational lines from the journals to keep them focused on critical learnings.


### PR DESCRIPTION
This PR addresses knowledge hygiene as requested by the Archivist directive:
- **Duplicates**: Consolidated repeated entries regarding Gen 3 offset bounds checking (ADR 028) in `.foundry/journals/qa.md` into a canonical constraint pattern. Removed duplicate "epic-052-096-automated-max-rejection-cancellation" logic notes in `.foundry/journals/auditor.md`.
- **Trace Spam**: Removed routine execution traces ("I verified", "Self-verified", "In task...") that were polluting `.foundry/journals/coder.md`.
- **Journaling**: Added findings to `.jules/archivist.md`.

No changes were made to source files or `.github/agents/`. All changes successfully pass `pnpm lint`, `pnpm test`, and `pnpm test:e2e`.

---
*PR created automatically by Jules for task [252523185295385130](https://jules.google.com/task/252523185295385130) started by @szubster*