### PR TITLE
chore: daily mechanic DAG maintenance

### DIFF
--- a/.foundry/epics/epic-035-048-smart-radar-data-unification.md
+++ b/.foundry/epics/epic-035-048-smart-radar-data-unification.md
@@ -33,5 +33,5 @@ Unify the data structures used by the suggestion engine and the map rendering co
 ## Acceptance Criteria
 - [x] Write stories to implement data unification according to the ADR.
 - [ ] Complete child stories/tasks for data unification.
-- [ ] .foundry/archive/stories/story-048-088-create-route-radar-controller.md
-- [ ] .foundry/stories/story-048-089-route-radar-density-aggregation.md
+- [ ] story-048-088-create-route-radar-controller
+- [ ] story-048-089-route-radar-density-aggregation

--- a/.foundry/epics/epic-036-053-health-scanner-core-engine.md
+++ b/.foundry/epics/epic-036-053-health-scanner-core-engine.md
@@ -41,8 +41,8 @@ None. This is the foundational engine epic.
 
 ## 4. Acceptance Criteria
 - [x] Story Owner: Break this Epic down into actionable Stories.
-- [ ] .foundry/archive/stories/story-053-090-health-scanner-diagnostic-models.md
-- [ ] .foundry/archive/stories/story-053-091-health-scanner-gen1-checksum-validation.md
-- [ ] .foundry/archive/stories/story-053-092-health-scanner-gen2-checksum-validation.md
-- [ ] .foundry/archive/stories/story-053-093-health-scanner-pokemon-bounds-verification.md
-- [ ] .foundry/stories/story-053-094-health-scanner-moveset-inventory-validation.md
+- [ ] story-053-090-health-scanner-diagnostic-models
+- [ ] story-053-091-health-scanner-gen1-checksum-validation
+- [ ] story-053-092-health-scanner-gen2-checksum-validation
+- [ ] story-053-093-health-scanner-pokemon-bounds-verification
+- [ ] story-053-094-health-scanner-moveset-inventory-validation

--- a/.foundry/epics/epic-036-058-feebas-backend-parsing.md
+++ b/.foundry/epics/epic-036-058-feebas-backend-parsing.md
@@ -28,8 +28,8 @@ Create a utility module that reads the parsed save file's data at the identified
 - [x] Create a utility module for Feebas seed extraction.
 - [x] Implement Gen 3 algorithm to calculate the 6 tile coordinates based on the seed.
 - [ ] Ensure fast calculation concurrent with save file hydration.
-- [x] .foundry/archive/stories/story-058-095-feebas-seed-extraction.md
-- [x] .foundry/archive/stories/story-058-096-feebas-tile-calculation.md
-- [x] .foundry/archive/stories/story-058-152-refactor-feebas-magic-numbers.md
+- [x] story-058-095-feebas-seed-extraction
+- [x] story-058-096-feebas-tile-calculation
+- [x] story-058-152-refactor-feebas-magic-numbers
 - [ ] story-058-280-feebas-backend-integration
 

--- a/.foundry/epics/epic-037-055-gen3-berry-tracker-data-extraction.md
+++ b/.foundry/epics/epic-037-055-gen3-berry-tracker-data-extraction.md
@@ -40,5 +40,5 @@ As mandated by ADR 010 (`010-gen3-data-parsing.md`), all data parsing must stric
 - [ ] Serialize the extracted data using `msgpackr` and integrate with the runtime data API.
 
 ### Generated Stories
-- [ ] .foundry/archive/stories/story-055-095-gen3-berry-data-parsing.md
-- [ ] .foundry/stories/story-055-096-gen3-berry-msgpack-integration.md
+- [ ] story-055-095-gen3-berry-data-parsing
+- [ ] story-055-096-gen3-berry-msgpack-integration

--- a/.foundry/epics/epic-037-060-hidden-items-ui.md
+++ b/.foundry/epics/epic-037-060-hidden-items-ui.md
@@ -38,5 +38,5 @@ This Epic corresponds to the third requirement in the Missing Hidden Items Finde
 - [ ] E2E tests verify the new view correctly renders based on an initialized save state.
 
 ## 4. Generated Stories
-- [ ] .foundry/stories/story-060-156-hidden-items-checklist-component.md
-- [ ] .foundry/stories/story-060-157-hidden-items-e2e-tests.md
+- [ ] story-060-156-hidden-items-checklist-component
+- [ ] story-060-157-hidden-items-e2e-tests

--- a/.foundry/epics/epic-038-061-mirage-island-engine.md
+++ b/.foundry/epics/epic-038-061-mirage-island-engine.md
@@ -38,6 +38,6 @@ The parsed application data must include the current Mirage Island value and ide
 - [ ] Write unit tests verifying extraction logic and PID matching.
 
 ### Implementation Stories
-- [ ] .foundry/archive/stories/story-061-098-parse-mirage-island-value.md
-- [ ] .foundry/stories/story-061-099-extract-pokemon-pids.md
-- [ ] .foundry/stories/story-061-100-mirage-island-cross-reference.md
+- [ ] story-061-098-parse-mirage-island-value
+- [ ] story-061-099-extract-pokemon-pids
+- [ ] story-061-100-mirage-island-cross-reference

--- a/.foundry/epics/epic-040-065-gen3-contest-data-integration.md
+++ b/.foundry/epics/epic-040-065-gen3-contest-data-integration.md
@@ -38,6 +38,6 @@ As derived from PRD `prd-070-040-gen3-contest-data-parsing`, this Epic handles i
 - [ ] Confirm all existing Gen 1 and Gen 2 save parsing tests pass without modification.
 - [ ] Write integration tests confirming the parsing engine successfully processes full Gen 3 save files and maps contest data correctly.
 
-- [ ] .foundry/archive/stories/story-065-141-gen3-contest-error-handling.md
-- [ ] .foundry/stories/story-065-142-gen3-contest-data-mapping.md
-- [ ] .foundry/stories/story-065-143-gen3-contest-integration-tests.md
+- [ ] story-065-141-gen3-contest-error-handling
+- [ ] story-065-142-gen3-contest-data-mapping
+- [ ] story-065-143-gen3-contest-integration-tests

--- a/.foundry/epics/epic-041-066-global-ribbon-checklist-dashboard.md
+++ b/.foundry/epics/epic-041-066-global-ribbon-checklist-dashboard.md
@@ -40,7 +40,7 @@ This epic builds the centralized aggregate view (or dashboard) across the entire
 - [ ] Ensure adequate rendering performance for hundreds of Pokémon.
 
 ## 4. Child Nodes
-- [ ] .foundry/archive/stories/story-066-137-global-ribbon-dashboard-scaffold.md
-- [ ] .foundry/stories/story-066-138-master-rank-tracking.md
-- [ ] .foundry/stories/story-066-139-ribbon-filtering-sorting.md
-- [ ] .foundry/stories/story-066-140-ribbon-dashboard-performance.md
+- [ ] story-066-137-global-ribbon-dashboard-scaffold
+- [ ] story-066-138-master-rank-tracking
+- [ ] story-066-139-ribbon-filtering-sorting
+- [ ] story-066-140-ribbon-dashboard-performance

--- a/.foundry/epics/epic-042-065-gen3-contest-advisor-ui.md
+++ b/.foundry/epics/epic-042-065-gen3-contest-advisor-ui.md
@@ -49,6 +49,6 @@ Derived from `prd-070-042-gen3-contest-optimization-advisor`, this epic handles 
 - [ ] Implement and test visual warning states for maxed Sheen scenarios.
 
 ### Stories
-- [ ] .foundry/archive/stories/story-065-149-contest-recommendation-ui-components.md
-- [ ] .foundry/archive/stories/story-065-150-contest-warning-states-ui.md
-- [ ] .foundry/stories/story-065-151-contest-advisor-ui-integration.md
+- [ ] story-065-149-contest-recommendation-ui-components
+- [ ] story-065-150-contest-warning-states-ui
+- [ ] story-065-151-contest-advisor-ui-integration

--- a/.foundry/epics/epic-045-070-implement-dag-context.md
+++ b/.foundry/epics/epic-045-070-implement-dag-context.md
@@ -33,9 +33,9 @@ As per ADR 013 and ADR 017, the core DAG data state must be lifted into a shared
 
 ## Acceptance Criteria
 - [x] Break down into Stories
-- [x] .foundry/archive/stories/story-070-108-create-dag-context-interfaces.md
-- [ ] .foundry/archive/stories/story-070-109-implement-dag-provider.md
-- [ ] .foundry/stories/story-070-245-implement-dag-provider-state-management.md
+- [x] story-070-108-create-dag-context-interfaces
+- [ ] story-070-109-implement-dag-provider
+- [ ] story-070-245-implement-dag-provider-state-management
 
 ### Auditor Rejection
 The generated artifacts do not meet the Acceptance Criteria of the Epic. While DagContext and DagProvider were created, DagProvider does not actually manage the core DAG data state (nodes, edges) by fetching it, nor does it wrap the DAG views. This work was improperly deferred to story-078-120. The Epic cannot be verified until the provider fully manages and provides the state as originally required.

--- a/.foundry/epics/epic-045-071-documentation-macro-node-completion.md
+++ b/.foundry/epics/epic-045-071-documentation-macro-node-completion.md
@@ -39,9 +39,9 @@ Update the core system documentation to detail the new macro node completion rul
 - [x] Verify that there are no conflicting statements across other core documentation.
 
 ### Stories
-- [x] .foundry/archive/stories/story-071-108-update-schema-macro-node-completion.md
-- [x] .foundry/archive/stories/story-071-109-update-adr001-macro-node-completion.md
-- [x] .foundry/archive/stories/story-071-110-verify-core-documentation.md
+- [x] story-071-108-update-schema-macro-node-completion
+- [x] story-071-109-update-adr001-macro-node-completion
+- [x] story-071-110-verify-core-documentation
 
 ### Detached Follow-up Work
 - idea-097-schema-verifying-state-fix

--- a/.foundry/epics/epic-053-103-relative-offsets-adr.md
+++ b/.foundry/epics/epic-053-103-relative-offsets-adr.md
@@ -33,8 +33,8 @@ Currently, save file extraction uses absolute hardcoded offsets for dynamic bloc
 - [x] Create ADR or implement linter rule.
 
 ## Child Stories
-- [x] .foundry/archive/stories/story-103-245-investigate-offset-linter.md
-- [x] .foundry/archive/stories/story-103-246-create-relative-offsets-adr.md
+- [x] story-103-245-investigate-offset-linter
+- [x] story-103-246-create-relative-offsets-adr
 
 ## Auditor Learnings & Follow-ups
 Based on the finding that tooling cannot automatically enforce offset rules, a follow-up node has been spawned to retroactively apply ADR 028 to legacy parsing code:

--- a/.foundry/epics/epic-053-105-daycare-save-parsing.md
+++ b/.foundry/epics/epic-053-105-daycare-save-parsing.md
@@ -35,5 +35,5 @@ Implement offline save parsing to extract real-time Daycare data.
 
 ## Acceptance Criteria
 - [x] Break down into Stories.
-- [ ] .foundry/archive/stories/story-105-240-daycare-gen2-parsing.md
-- [ ] .foundry/stories/story-105-241-daycare-gen3-parsing.md
+- [ ] story-105-240-daycare-gen2-parsing
+- [ ] story-105-241-daycare-gen3-parsing

--- a/.foundry/epics/epic-053-106-egg-hatch-parsing.md
+++ b/.foundry/epics/epic-053-106-egg-hatch-parsing.md
@@ -35,5 +35,5 @@ Implement offline save parsing to calculate exact steps remaining for Eggs.
 
 ## Acceptance Criteria
 - [x] Break down into Stories.
-- [ ] .foundry/archive/stories/story-106-158-gen2-egg-hatch-parsing.md
-- [ ] .foundry/stories/story-106-159-gen3-egg-hatch-parsing.md
+- [ ] story-106-158-gen2-egg-hatch-parsing
+- [ ] story-106-159-gen3-egg-hatch-parsing

--- a/.foundry/epics/epic-054-108-box-analyzer-save-parsing.md
+++ b/.foundry/epics/epic-054-108-box-analyzer-save-parsing.md
@@ -40,5 +40,5 @@ Implement the backend data grouping and aggregation logic to parse PC box data f
 - [ ] Implement Gen 3 PC box parsing and species grouping.
 - [ ] Verify that Party Pokémon are successfully excluded from the extracted data.
 - [ ] Ensure all required stats (DVs/IVs, Natures, Hidden Power, Shininess) are calculated correctly for each Pokémon.
-- [ ] .foundry/archive/stories/story-108-245-gen2-box-parsing.md
-- [ ] .foundry/stories/story-108-246-gen3-box-parsing.md
+- [ ] story-108-245-gen2-box-parsing
+- [ ] story-108-246-gen3-box-parsing

--- a/.foundry/epics/epic-057-128-epic-planner-process-update.md
+++ b/.foundry/epics/epic-057-128-epic-planner-process-update.md
@@ -7,7 +7,7 @@ owner_persona: story_owner
 created_at: '2026-07-03'
 updated_at: '2026-07-03'
 depends_on:
-  - .foundry/epics/epic-057-127-orchestrator-safeguard-investigation.md
+  - epic-057-127-orchestrator-safeguard-investigation
 jules_session_id: null
 pr_number: null
 parent: prd-096-057-macro-node-boundary-enforcement

--- a/.foundry/epics/epic-057-129-schema-documentation-updates.md
+++ b/.foundry/epics/epic-057-129-schema-documentation-updates.md
@@ -7,7 +7,7 @@ owner_persona: story_owner
 created_at: '2026-07-03'
 updated_at: '2026-07-03'
 depends_on:
-  - .foundry/epics/epic-057-128-epic-planner-process-update.md
+  - epic-057-128-epic-planner-process-update
 jules_session_id: null
 pr_number: null
 parent: prd-096-057-macro-node-boundary-enforcement
@@ -28,5 +28,5 @@ As part of enforcing macro node functional boundaries, we need to update templat
 Update `.foundry/docs/schema.md` or other relevant documentation/templates to explicitly require an Integration/E2E Story for all new Epics.
 
 ## Acceptance Criteria
-- [ ] Update `.foundry/docs/schema.md` with the new process requirements.
+- [ ] Update `schema.md` with the new process requirements.
 - [ ] Update any other necessary documentation and schemas.

--- a/.foundry/epics/epic-097-130-schema-verifying-state-update.md
+++ b/.foundry/epics/epic-097-130-schema-verifying-state-update.md
@@ -25,4 +25,4 @@ notes: ""
 This epic implements the required changes from `prd-097-096-schema-verifying-state-fix`. We need to update Invariant 7 in `schema.md` to reflect that `VERIFYING` and `COMPLETED` nodes are read-only for implementing personas, as established by ADR 014.
 
 ## Acceptance Criteria
-- [ ] Story created to update `schema.md` System Invariant 7.
+- [ ] story-xxx created to update schema System Invariant 7.

--- a/.foundry/ideas/idea-058-damage-calculator-integration.md
+++ b/.foundry/ideas/idea-058-damage-calculator-integration.md
@@ -2,7 +2,7 @@
 id: idea-058-damage-calculator-integration
 type: IDEA
 title: Damage Calculator and Showdown Export Integration
-status: ACTIVE
+status: PENDING
 owner_persona: human
 created_at: '2026-05-19'
 updated_at: '2026-05-19'

--- a/.foundry/ideas/idea-066-rom-hack-support.md
+++ b/.foundry/ideas/idea-066-rom-hack-support.md
@@ -2,7 +2,7 @@
 id: idea-066-rom-hack-support
 type: IDEA
 title: ROM Hack Support via Custom Adapters
-status: ACTIVE
+status: PENDING
 owner_persona: human
 created_at: '2026-05-27'
 updated_at: '2026-05-30'

--- a/.foundry/ideas/idea-067-gen3-berry-tracker.md
+++ b/.foundry/ideas/idea-067-gen3-berry-tracker.md
@@ -36,4 +36,4 @@ This automates a tedious real-world time-gated mechanic, acting as an active com
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD detailing the berry patch data structures and UI implementation.
-- [ ] .foundry/prds/prd-067-037-gen3-berry-tracker.md
+- [ ] prd-067-037-gen3-berry-tracker

--- a/.foundry/ideas/idea-068-mirage-island-predictor.md
+++ b/.foundry/ideas/idea-068-mirage-island-predictor.md
@@ -38,5 +38,5 @@ This feature transforms an almost impossible-to-find easter egg into a determini
 - [ ] Product Manager: Convert this idea into a PRD detailing how to extract the daily Mirage Island value and the UI for alerting the player.
 
 ### Generated PRDs
-- [ ] `.foundry/prds/prd-068-038-mirage-island-data-extraction.md`
-- [ ] `.foundry/prds/prd-068-039-mirage-island-ui-alerts.md`
+- [ ] prd-068-038-mirage-island-data-extraction
+- [ ] prd-068-039-mirage-island-ui-alerts

--- a/.foundry/ideas/idea-069-daily-event-tracker.md
+++ b/.foundry/ideas/idea-069-daily-event-tracker.md
@@ -37,4 +37,4 @@ This feature transforms DexHelper from a static data viewer into an active, inte
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to define the specific event flags that need to be parsed and outline the UI checklist component.
-- [ ] [prd-069-038-gen2-daily-events.md](.foundry/prds/prd-069-038-gen2-daily-events.md)
+- [ ] prd-069-038-gen2-daily-events

--- a/.foundry/ideas/idea-070-gen3-contest-tracker.md
+++ b/.foundry/ideas/idea-070-gen3-contest-tracker.md
@@ -36,6 +36,6 @@ This caters directly to the hardcore completionist community, transforming an op
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to define the data structures needed for parsing Contest stats and Ribbons from Gen 3 save formats.
-- [ ] .foundry/prds/prd-070-040-gen3-contest-data-parsing.md
-- [ ] .foundry/prds/prd-070-041-gen3-contest-ui-viewer.md
-- [ ] .foundry/prds/prd-070-042-gen3-contest-optimization-advisor.md
+- [ ] prd-070-040-gen3-contest-data-parsing
+- [ ] prd-070-041-gen3-contest-ui-viewer
+- [ ] prd-070-042-gen3-contest-optimization-advisor

--- a/.foundry/ideas/idea-070-hall-of-fame-exporter.md
+++ b/.foundry/ideas/idea-070-hall-of-fame-exporter.md
@@ -33,4 +33,4 @@ This transforms DexHelper from a personal utility into a social sharing tool. By
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD detailing the required save file offsets for Hall of Fame records and the UI requirements for the certificate generator.
-- [ ] .foundry/prds/prd-070-044-hall-of-fame-exporter.md
+- [ ] prd-070-044-hall-of-fame-exporter

--- a/.foundry/ideas/idea-070-roamer-tracking-dashboard.md
+++ b/.foundry/ideas/idea-070-roamer-tracking-dashboard.md
@@ -39,4 +39,4 @@ This feature eliminates one of the most frustrating and time-consuming mechanics
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to evaluate if the roamer tracking logic currently exists in the codebase and define the required UI implementation details.
-- [ ] .foundry/prds/prd-070-043-roamer-tracking-dashboard.md
+- [ ] prd-070-043-roamer-tracking-dashboard

--- a/.foundry/ideas/idea-071-gen3-roamer-tracker.md
+++ b/.foundry/ideas/idea-071-gen3-roamer-tracker.md
@@ -38,5 +38,5 @@ This feature perfectly aligns with DexHelper's vision as a premium companion app
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to detail the save offsets required for extracting the roamer data structure across different Gen 3 versions.
-- [ ] .foundry/prds/prd-071-044-gen3-roamer-tracker.md
-- [ ] .foundry/archive/research/research-071-138-gen3-roamer-offsets.md
+- [ ] prd-071-044-gen3-roamer-tracker
+- [ ] research-071-138-gen3-roamer-offsets

--- a/.foundry/ideas/idea-071-tailwind-v4-utilities-migration.md
+++ b/.foundry/ideas/idea-071-tailwind-v4-utilities-migration.md
@@ -48,6 +48,6 @@ This significantly improves DX (Developer Experience) and readability. Component
 - [ ] Technical Lead: Based on research findings, draft an ADR outlining the chosen consolidation strategy.
 - [ ] Technical Lead: Outline an incremental migration strategy to update components across `src/components/` without regressions.
 
-- [ ] .foundry/archive/research/research-071-137-tailwind-v4-utilities.md
-- [ ] .foundry/archive/tasks/task-071-150-tailwind-v4-adr.md
-- [ ] .foundry/prds/prd-071-040-tailwind-v4-utilities-migration.md
+- [ ] research-071-137-tailwind-v4-utilities
+- [ ] task-071-150-tailwind-v4-adr
+- [ ] prd-071-040-tailwind-v4-utilities-migration

--- a/.foundry/ideas/idea-072-strict-macro-node-completion.md
+++ b/.foundry/ideas/idea-072-strict-macro-node-completion.md
@@ -29,4 +29,4 @@ We need to strongly enforce the rule that a macro node (IDEA, PRD, EPIC, STORY) 
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD.
-- [ ] .foundry/prds/prd-072-045-strict-macro-node-completion.md
+- [ ] prd-072-045-strict-macro-node-completion

--- a/.foundry/ideas/idea-073-gen3-secret-base-viewer.md
+++ b/.foundry/ideas/idea-073-gen3-secret-base-viewer.md
@@ -36,4 +36,4 @@ This transforms a highly opaque, easily-forgotten social feature into an actiona
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to define the data structures and save file offsets needed for parsing Secret Base and Mixed Record data in Gen 3.
-- [ ] .foundry/prds/prd-073-045-gen3-secret-base-viewer.md
+- [ ] prd-073-045-gen3-secret-base-viewer

--- a/.foundry/ideas/idea-073-refactor-dag-dashboard-context.md
+++ b/.foundry/ideas/idea-073-refactor-dag-dashboard-context.md
@@ -23,4 +23,4 @@ Recent implementation attempts (e.g., `task-085-142`) permanently failed because
 ## Proposal
 Create a dedicated Epic to properly architect and implement the `DagContext` layer before any further UI dashboard features are added. This foundational work will resolve the friction coders are experiencing and allow the Permanent Failure Dashboard to be completed successfully.
 
-- [ ] .foundry/prds/prd-073-045-refactor-dag-dashboard-context.md
+- [ ] prd-073-045-refactor-dag-dashboard-context

--- a/.foundry/ideas/idea-074-refactor-dag-dashboard-context.md
+++ b/.foundry/ideas/idea-074-refactor-dag-dashboard-context.md
@@ -23,4 +23,4 @@ Recent implementation attempts (e.g., `task-085-142`) permanently failed because
 ## Proposal
 Create a dedicated Epic to properly architect and implement the `DagContext` layer before any further UI dashboard features are added. This foundational work will resolve the friction coders are experiencing and allow the Permanent Failure Dashboard to be completed successfully.
 
-- [ ] .foundry/prds/prd-074-046-dag-context-architecture.md
+- [ ] prd-074-046-dag-context-architecture

--- a/.foundry/ideas/idea-075-gen3-tv-swarm-tracker.md
+++ b/.foundry/ideas/idea-075-gen3-tv-swarm-tracker.md
@@ -37,4 +37,4 @@ This feature targets highly obscure, time-gated mechanics in Gen 3 that are incr
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to define the data structures for Gen 3 TV events and outline the UI dashboard.
-- [ ] .foundry/prds/prd-075-047-gen3-tv-swarm-tracker.md
+- [ ] prd-075-047-gen3-tv-swarm-tracker

--- a/.foundry/ideas/idea-077-dynamic-pokeapi-data.md
+++ b/.foundry/ideas/idea-077-dynamic-pokeapi-data.md
@@ -33,4 +33,4 @@ Currently, memory offsets, base move PPs, and authoritative item lists are manua
 ## Benefits
 - Removes large static data tables from the repository.
 - Improves scalability for future generations of Pokémon data.
-- [ ] .foundry/prds/prd-077-049-dynamic-pokedata-parsing.md
+- [ ] prd-077-049-dynamic-pokedata-parsing

--- a/.foundry/ideas/idea-077-gen3-match-call-tracker.md
+++ b/.foundry/ideas/idea-077-gen3-match-call-tracker.md
@@ -37,4 +37,4 @@ This perfectly aligns with DexHelper's vision as an intelligent companion app. I
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to detail the UI requirements and required memory offsets for Emerald Match Call flags.
-- [ ] .foundry/prds/prd-077-048-gen3-match-call-tracker.md
+- [ ] prd-077-048-gen3-match-call-tracker

--- a/.foundry/ideas/idea-079-automated-max-rejection-cancellation.md
+++ b/.foundry/ideas/idea-079-automated-max-rejection-cancellation.md
@@ -36,7 +36,7 @@ Refactor the Foundry Orchestrator (`foundry-orchestrator.ts`) to automatically t
 - [x] Ensure this triggers the proper parent awakening logic.
 
 ## Generated Nodes
-- [ ] .foundry/prds/prd-079-052-automated-max-rejection-cancellation.md
+- [ ] prd-079-052-automated-max-rejection-cancellation
 
 ### Auditor Rejection
 While the nodes are transitioned to CANCELLED, they bypass the parent awakening logic in Phase 3.6 of `foundry-orchestrator.ts`. The condition `node.frontmatter.status === 'FAILED'` must be expanded to include `CANCELLED` nodes with a rejection reason (like max rejection reached).

--- a/.foundry/ideas/idea-079-foundry-zombie-node-cleanup.md
+++ b/.foundry/ideas/idea-079-foundry-zombie-node-cleanup.md
@@ -34,4 +34,4 @@ Implement a garbage collection (GC) mechanism directly within `.github/scripts/f
 This enhancement significantly improves the resilience and self-healing capabilities of the Foundry system, reducing the need for manual TPM intervention to resolve DAG deadlocks caused by transient CI failures.
 
 ## Generated PRDs
-- [ ] .foundry/prds/prd-079-050-foundry-zombie-node-cleanup.md
+- [ ] prd-079-050-foundry-zombie-node-cleanup

--- a/.foundry/ideas/idea-081-friendship-evolution-tracker.md
+++ b/.foundry/ideas/idea-081-friendship-evolution-tracker.md
@@ -33,4 +33,4 @@ Create a dedicated "Friendship Tracker" view or overlay that:
 This perfectly aligns with DexHelper's vision as a premium companion app. It takes an obtuse, high-friction, hidden mechanic and surfaces it into actionable, exact data. This eliminates the guesswork from one of the most common mid-game progression blockers, directly improving the player's experience.
 
 ## Generated PRDs
-- [ ] .foundry/prds/prd-081-051-friendship-evolution-tracker.md
+- [ ] prd-081-051-friendship-evolution-tracker

--- a/.foundry/ideas/idea-083-daycare-egg-tracker.md
+++ b/.foundry/ideas/idea-083-daycare-egg-tracker.md
@@ -36,4 +36,4 @@ Leverage DexHelper's offline-first programmatic save parsing to extract and disp
 ## Value Proposition
 
 By surfacing these highly opaque, heavily utilized mechanics, DexHelper immediately solves a massive pain point for competitive breeders and completionists. Transforming vague in-game hints into exact, actionable data points perfectly aligns with the app's mission to be the ultimate premium companion tool for retro Pokémon.
-- [ ] .foundry/prds/prd-083-053-daycare-egg-tracker.md
+- [ ] prd-083-053-daycare-egg-tracker

--- a/.foundry/ideas/idea-084-standardize-relative-offsets.md
+++ b/.foundry/ideas/idea-084-standardize-relative-offsets.md
@@ -35,6 +35,6 @@ We need an architectural rule (e.g., an ADR) or a linter check to enforce that, 
 
 ## Acceptance Criteria
 - [x] Investigate if a linter rule can be built to flag hardcoded offsets during save parsing.
-- [ ] .foundry/prds/prd-084-053-standardize-relative-offsets.md
+- [ ] prd-084-053-standardize-relative-offsets
 - [ ] If a linter is not feasible, establish a strict architectural ADR mandating relative offset mapping for dynamic save block extraction.
 - [ ] Roll out guidance to Coder and QA personas.

--- a/.foundry/ideas/idea-085-hidden-power-calculator.md
+++ b/.foundry/ideas/idea-085-hidden-power-calculator.md
@@ -2,7 +2,7 @@
 id: idea-085-hidden-power-calculator
 type: IDEA
 title: Hidden Power Type and Base Power Calculator
-status: ACTIVE
+status: PENDING
 owner_persona: human
 created_at: '2026-06-25'
 updated_at: '2026-06-20'

--- a/.foundry/ideas/idea-086-box-duplicate-analyzer.md
+++ b/.foundry/ideas/idea-086-box-duplicate-analyzer.md
@@ -39,4 +39,4 @@ This feature transforms DexHelper from a passive storage viewer into an active b
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD.
-- [ ] .foundry/prds/prd-086-054-box-duplicate-analyzer.md
+- [ ] prd-086-054-box-duplicate-analyzer

--- a/.foundry/ideas/idea-088-trick-house-tracker.md
+++ b/.foundry/ideas/idea-088-trick-house-tracker.md
@@ -35,4 +35,4 @@ This targets a highly localized, easily forgettable side-quest mechanic. By surf
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to investigate the exact save file offsets and bitflags used to track the Trick House puzzle state in Ruby/Sapphire/Emerald.
-- [ ] .foundry/prds/prd-088-054-trick-house-tracker.md
+- [ ] prd-088-054-trick-house-tracker

--- a/.foundry/ideas/idea-089-gen3-ash-gathering-tracker.md
+++ b/.foundry/ideas/idea-089-gen3-ash-gathering-tracker.md
@@ -35,4 +35,4 @@ This targets a highly localized, tedious item-gathering grind. By surfacing the 
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to investigate the exact save file offsets for the Soot Sack step counter in Ruby/Sapphire/Emerald.
-- [ ] .foundry/prds/prd-089-054-gen3-ash-gathering-tracker.md
+- [ ] prd-089-054-gen3-ash-gathering-tracker

--- a/.foundry/ideas/idea-090-pokegear-phone-tracker.md
+++ b/.foundry/ideas/idea-090-pokegear-phone-tracker.md
@@ -36,4 +36,4 @@ This feature targets a core Gen 2 mechanic that is heavily relied upon for progr
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to investigate the exact save file offsets and RNG mechanics governing Pokegear phone calls in Gold/Silver/Crystal.
-- [ ] .foundry/prds/prd-090-055-pokegear-phone-tracker.md
+- [ ] prd-090-055-pokegear-phone-tracker

--- a/.foundry/ideas/idea-091-smart-egg-move-path-finder.md
+++ b/.foundry/ideas/idea-091-smart-egg-move-path-finder.md
@@ -36,4 +36,4 @@ This feature eliminates the need for complex, manual cross-referencing between w
 
 ## Next Steps
 - [x] Product Manager: Convert this idea into a PRD to investigate the graph algorithms needed to calculate breeding chains across Egg Groups.
-- [ ] .foundry/prds/prd-091-055-smart-egg-move-path-finder.md
+- [ ] prd-091-055-smart-egg-move-path-finder

--- a/.foundry/ideas/idea-092-gen3-ev-training-dashboard.md
+++ b/.foundry/ideas/idea-092-gen3-ev-training-dashboard.md
@@ -32,4 +32,4 @@ Features should include:
 
 This directly aligns with DexHelper's vision as a premium companion app that surfaces hidden game state to eliminate tedious manual tracking for hardcore players.
 
-- [ ] .foundry/prds/prd-092-056-gen3-ev-training-dashboard.md
+- [ ] prd-092-056-gen3-ev-training-dashboard

--- a/.foundry/ideas/idea-094-move-tutor-tracker.md
+++ b/.foundry/ideas/idea-094-move-tutor-tracker.md
@@ -31,4 +31,4 @@ Build a "Move Tutor Tracker" dashboard that:
 This turns opaque, hidden game state into actionable strategy for competitive players and Nuzlockers, saving time and removing the need for external resources.
 
 ## Generated PRDs
-- [ ] .foundry/prds/prd-094-055-move-tutor-tracker.md
+- [ ] prd-094-055-move-tutor-tracker

--- a/.foundry/ideas/idea-095-in-game-trade-assistant.md
+++ b/.foundry/ideas/idea-095-in-game-trade-assistant.md
@@ -31,4 +31,4 @@ Build an "In-Game Trade Assistant Dashboard" that:
 This turns opaque, hidden game state into an actionable, highly useful strategy for casual players, completionists, and Nuzlockers alike, removing the need for external resources and tedious PC box checking.
 
 ## Acceptance Criteria
-- [ ] .foundry/prds/prd-095-056-in-game-trade-assistant.md
+- [ ] prd-095-056-in-game-trade-assistant

--- a/.foundry/ideas/idea-095-prevent-blocking-bash-commands.md
+++ b/.foundry/ideas/idea-095-prevent-blocking-bash-commands.md
@@ -35,4 +35,4 @@ To prevent this friction and improve the resilience of the Foundry ecosystem, we
 ## Acceptance Criteria
 - [x] Investigate the feasibility of wrapping bash execution with a timeout mechanism.
 - [x] Implement the timeout logic if feasible, or implement static analysis to reject commands containing known blocking flags (like `-f` on `tail`).
-- [ ] .foundry/prds/prd-095-057-prevent-blocking-bash-commands.md
+- [ ] prd-095-057-prevent-blocking-bash-commands

--- a/.foundry/ideas/idea-096-macro-node-boundary-enforcement.md
+++ b/.foundry/ideas/idea-096-macro-node-boundary-enforcement.md
@@ -27,4 +27,4 @@ Audits reveal that EPICs are being verified before their functional requirements
 Create a mechanism to ensure that an EPIC cannot be marked COMPLETED until its functional requirements are verifiably integrated into the application, not just scaffolded in isolated components.
 
 ## Acceptance Criteria
-- [ ] .foundry/prds/prd-096-057-macro-node-boundary-enforcement.md
+- [ ] prd-096-057-macro-node-boundary-enforcement

--- a/.foundry/ideas/idea-097-schema-verifying-state-fix.md
+++ b/.foundry/ideas/idea-097-schema-verifying-state-fix.md
@@ -25,4 +25,4 @@ notes: ''
 `schema.md` contains a contradiction in its System Invariants. Invariant 7 states: "COMPLETED nodes are read-only. Once a PR is merged, the node must not be edited." However, ADR 014 changed the lifecycle so that when a PR is merged, nodes transition to `VERIFYING`, not `COMPLETED`. The invariant needs to be updated to reflect the `VERIFYING` state accurately.
 
 ## Derived Nodes
-- [ ] .foundry/prds/prd-097-096-schema-verifying-state-fix.md
+- [ ] prd-097-096-schema-verifying-state-fix

--- a/.foundry/journals/mechanic.md
+++ b/.foundry/journals/mechanic.md
@@ -3,3 +3,8 @@
 
 - Found several TPM-blocked nodes related to duplicate/rejected ideas or missing session IDs. Repaired YAML states autonomously.
 - Verified that Orchestrator Phase 3.6 correctly handles Impossible Loops for both FAILED and CANCELLED nodes, as previously requested in `task-154-278`. Completed the task's acceptance criteria to unblock its PR.
+
+# Mechanic Update - 2026-07-16
+
+- Repaired system invariants across the DAG related to relative paths. Updated 95+ DAG nodes to strictly use node IDs in `depends_on`, `parent`, and task checklists instead of relative file paths, bringing them in compliance with ADR 002.
+- Transitioned 3 active IDEA nodes to PENDING status as they were missing a valid `jules_session_id`.

--- a/.foundry/prds/prd-063-034-permanent-failure-dashboard.md
+++ b/.foundry/prds/prd-063-034-permanent-failure-dashboard.md
@@ -34,5 +34,5 @@ Create a dedicated "Permanent Failures" view or filter within the DAG Dashboard.
 - [x] Epic Planner: Create Epics for the permanent failure dashboard feature.
 
 ### Downstream Epics
-- [x] `.foundry/archive/epics/epic-034-046-dag-data-parsing-rejection-count.md`
-- [ ] `.foundry/epics/epic-034-047-permanent-failure-dashboard-ui.md`
+- [x] epic-034-046-dag-data-parsing-rejection-count
+- [ ] epic-034-047-permanent-failure-dashboard-ui

--- a/.foundry/prds/prd-066-036-feebas-tile-predictor.md
+++ b/.foundry/prds/prd-066-036-feebas-tile-predictor.md
@@ -49,7 +49,7 @@ In Pokémon Ruby, Sapphire, and Emerald, Feebas can only be found by fishing on 
 - [x] Epic: Break down into Epics for backend parsing/logic and frontend visualization.
 
 ## Downstream Nodes
-- [ ] .foundry/archive/research/research-036-007-feebas-seed-offset.md
-- [ ] .foundry/archive/tasks/task-036-148-feebas-visualization-adr.md
-- [ ] .foundry/epics/epic-036-058-feebas-backend-parsing.md
-- [ ] .foundry/epics/epic-036-059-feebas-frontend-visualization.md
+- [ ] research-036-007-feebas-seed-offset
+- [ ] task-036-148-feebas-visualization-adr
+- [ ] epic-036-058-feebas-backend-parsing
+- [ ] epic-036-059-feebas-frontend-visualization

--- a/.foundry/prds/prd-066-036-save-file-health-scanner.md
+++ b/.foundry/prds/prd-066-036-save-file-health-scanner.md
@@ -50,5 +50,5 @@ Leverage DexHelper's deep understanding of save file structures (checksums, magi
 - [x] Epic Planner: Break this PRD down into actionable Epics.
 
 ## 6. Generated Epics
-- [ ] .foundry/epics/epic-036-053-health-scanner-core-engine.md
-- [ ] .foundry/epics/epic-036-054-diagnostic-reporting-ui.md
+- [ ] epic-036-053-health-scanner-core-engine
+- [ ] epic-036-054-diagnostic-reporting-ui

--- a/.foundry/prds/prd-067-036-extract-dag-utils.md
+++ b/.foundry/prds/prd-067-036-extract-dag-utils.md
@@ -48,8 +48,8 @@ Create `.github/scripts/dag-utils.ts`.
 
 ## Next Steps
 - [x] Epic Planner: Evaluate this PRD and convert it to Epics to extract the DAG utilities to a shared module.
-- [ ] .foundry/epics/epic-036-053-shared-dag-utilities.md
-- [ ] .foundry/epics/epic-036-054-unify-state-transitions.md
+- [ ] epic-036-053-shared-dag-utilities
+- [ ] epic-036-054-unify-state-transitions
 
 ## Acceptance Criteria
 - [ ] `dag-utils.ts` created with shared functions.

--- a/.foundry/prds/prd-068-038-mirage-island-data-extraction.md
+++ b/.foundry/prds/prd-068-038-mirage-island-data-extraction.md
@@ -38,6 +38,6 @@ As defined in `idea-068-mirage-island-predictor`, we need to implement a predict
 
 ## Acceptance Criteria
 - [x] Epic Planner: Generate child epics that implement the save file parsing updates and the application state hydration.
-- [ ] .foundry/epics/epic-038-061-mirage-island-save-parsing.md
-- [ ] .foundry/archive/epics/epic-038-062-personality-value-extraction.md
-- [ ] .foundry/epics/epic-038-063-mirage-island-data-hydration.md
+- [ ] epic-038-061-mirage-island-save-parsing
+- [ ] epic-038-062-personality-value-extraction
+- [ ] epic-038-063-mirage-island-data-hydration

--- a/.foundry/prds/prd-069-038-gen2-daily-events.md
+++ b/.foundry/prds/prd-069-038-gen2-daily-events.md
@@ -38,6 +38,6 @@ Leverage DexHelper's deep save file parsing to track event flags, combined with 
 - [x] Epic Planner: Break down the "Event Flag Parsing" into Epics.
 - [x] Epic Planner: Break down the "Dynamic Checklist UI" into Epics.
 - [x] Epic Planner: Break down the "Smart Filtering & Forecasting" into Epics.
-- [ ] .foundry/epics/epic-038-061-gen2-event-flag-parsing.md
-- [ ] .foundry/epics/epic-038-062-gen2-dynamic-checklist-ui.md
-- [ ] .foundry/epics/epic-038-063-gen2-smart-filtering-forecasting.md
+- [ ] epic-038-061-gen2-event-flag-parsing
+- [ ] epic-038-062-gen2-dynamic-checklist-ui
+- [ ] epic-038-063-gen2-smart-filtering-forecasting

--- a/.foundry/prds/prd-069-038-mirage-island-predictor.md
+++ b/.foundry/prds/prd-069-038-mirage-island-predictor.md
@@ -45,5 +45,5 @@ To ensure granular execution and minimize complexity, this PRD should be broken 
 - [x] Epic 1 (Engine Updates) node created.
 - [x] Epic 2 (UI Updates) node created.
 
-- [ ] .foundry/epics/epic-038-061-mirage-island-engine.md
-- [ ] .foundry/epics/epic-038-062-mirage-island-ui.md
+- [ ] epic-038-061-mirage-island-engine
+- [ ] epic-038-062-mirage-island-ui

--- a/.foundry/prds/prd-070-041-gen3-contest-ui-viewer.md
+++ b/.foundry/prds/prd-070-041-gen3-contest-ui-viewer.md
@@ -50,7 +50,7 @@ Following the data extraction phase, DexHelper must present the extracted Gen 3 
 - [ ] Pass visual regression and accessibility checks.
 
 ## Generated Epics
-- [ ] .foundry/archive/epics/epic-041-064-contest-ui-shared-components.md
-- [ ] .foundry/archive/epics/epic-041-065-individual-contest-stats-view.md
-- [ ] .foundry/epics/epic-041-066-global-ribbon-checklist-dashboard.md
-- [ ] .foundry/epics/epic-041-091-visual-regression-accessibility.md
+- [ ] epic-041-064-contest-ui-shared-components
+- [ ] epic-041-065-individual-contest-stats-view
+- [ ] epic-041-066-global-ribbon-checklist-dashboard
+- [ ] epic-041-091-visual-regression-accessibility

--- a/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
+++ b/.foundry/prds/prd-070-044-hall-of-fame-exporter.md
@@ -33,10 +33,10 @@ Transform DexHelper into a social sharing utility by parsing Hall of Fame record
 
 ## Acceptance Criteria
 - [x] Break down into ADRs
-- [ ] .foundry/docs/adrs/adr-044-021-hof-data-parsing-architecture.md
-- [ ] .foundry/docs/adrs/adr-044-022-hof-certificate-generation.md
-- [ ] .foundry/docs/adrs/adr-044-023-hof-timeline-ui.md
+- [ ] adr-044-021-hof-data-parsing-architecture
+- [ ] adr-044-022-hof-certificate-generation
+- [ ] adr-044-023-hof-timeline-ui
 - [x] Break down into Epics
-- [ ] .foundry/epics/epic-044-070-hof-data-parsing.md
-- [ ] .foundry/epics/epic-044-071-hof-certificate-rendering.md
-- [ ] .foundry/epics/epic-044-072-hof-timeline-ui.md
+- [ ] epic-044-070-hof-data-parsing
+- [ ] epic-044-071-hof-certificate-rendering
+- [ ] epic-044-072-hof-timeline-ui

--- a/.foundry/prds/prd-072-045-strict-macro-node-completion.md
+++ b/.foundry/prds/prd-072-045-strict-macro-node-completion.md
@@ -36,5 +36,5 @@ Enforce the rule that a macro node (IDEA, PRD, EPIC, STORY) MUST NOT be verified
 
 
 ### Generated Epics
-- [ ] .foundry/epics/epic-045-070-orchestrator-strict-completion.md
-- [ ] .foundry/epics/epic-045-071-documentation-macro-node-completion.md
+- [ ] epic-045-070-orchestrator-strict-completion
+- [ ] epic-045-071-documentation-macro-node-completion

--- a/.foundry/prds/prd-073-045-refactor-dag-dashboard-context.md
+++ b/.foundry/prds/prd-073-045-refactor-dag-dashboard-context.md
@@ -32,6 +32,6 @@ Recent implementation attempts permanently failed because the state was left tig
 ## Acceptance Criteria
 - [x] Break down into Epics
 
-- [ ] .foundry/epics/epic-045-070-implement-dag-context.md
-- [ ] .foundry/epics/epic-045-071-refactor-data-parsing-layer.md
-- [ ] .foundry/epics/epic-045-072-refactor-views.md
+- [ ] epic-045-070-implement-dag-context
+- [ ] epic-045-071-refactor-data-parsing-layer
+- [ ] epic-045-072-refactor-views

--- a/.foundry/prds/prd-077-048-gen3-match-call-tracker.md
+++ b/.foundry/prds/prd-077-048-gen3-match-call-tracker.md
@@ -50,6 +50,6 @@ This PRD outlines the requirements for implementing the "Rematch Dashboard" in D
 
 ## Next Steps
 - [x] Epic Planner: Break this PRD down into Epics (e.g., Save Parsing Engine Updates, Static Data Generation, Dashboard UI).
-- [ ] Epic: [Gen 3 Match Call Save Parsing](.foundry/epics/epic-048-083-gen3-match-call-save-parsing.md)
-- [ ] Epic: [Gen 3 Match Call Static Data Generation](.foundry/epics/epic-048-084-gen3-match-call-static-data.md)
-- [ ] Epic: [Gen 3 Rematch Dashboard UI](.foundry/epics/epic-048-085-gen3-match-call-dashboard-ui.md)
+- [ ] epic-048-083-gen3-match-call-save-parsing
+- [ ] epic-048-084-gen3-match-call-static-data
+- [ ] epic-048-085-gen3-match-call-dashboard-ui

--- a/.foundry/prds/prd-077-049-dynamic-pokedata-parsing.md
+++ b/.foundry/prds/prd-077-049-dynamic-pokedata-parsing.md
@@ -42,7 +42,7 @@ Currently, data such as move PPs and valid item lists are either manually mainta
 - [ ] Write an ADR detailing the architectural approach for integrating this dynamic generation into the existing data pipeline.
 
 ### Epic Breakdown
-- [ ] .foundry/docs/adrs/adr-049-025-dynamic-pokedata-parsing.md
-- [ ] .foundry/epics/epic-049-086-dynamic-move-pp-parsing.md
-- [ ] .foundry/epics/epic-049-087-dynamic-item-list-parsing.md
-- [ ] .foundry/epics/epic-049-088-vite-plugin-jsonl-integration.md
+- [ ] adr-049-025-dynamic-pokedata-parsing
+- [ ] epic-049-086-dynamic-move-pp-parsing
+- [ ] epic-049-087-dynamic-item-list-parsing
+- [ ] epic-049-088-vite-plugin-jsonl-integration

--- a/.foundry/prds/prd-079-052-automated-max-rejection-cancellation.md
+++ b/.foundry/prds/prd-079-052-automated-max-rejection-cancellation.md
@@ -32,4 +32,4 @@ Refactor the Foundry Orchestrator (`foundry-orchestrator.ts`) to automatically t
 
 ## Acceptance Criteria
 - [x] Break down into Epics.
-- [ ] .foundry/epics/epic-052-096-automated-max-rejection-cancellation.md
+- [ ] epic-052-096-automated-max-rejection-cancellation

--- a/.foundry/prds/prd-084-053-standardize-relative-offsets.md
+++ b/.foundry/prds/prd-084-053-standardize-relative-offsets.md
@@ -36,5 +36,5 @@ We need an architectural rule (e.g., an ADR) or a linter check to enforce that, 
 ## Acceptance Criteria
 - [ ] If a linter is not feasible, establish a strict architectural ADR mandating relative offset mapping for dynamic save block extraction.
 - [ ] Roll out guidance to Coder and QA personas.
-- [ ] .foundry/epics/epic-053-103-relative-offsets-adr.md
-- [ ] .foundry/epics/epic-053-104-relative-offsets-guidance.md
+- [ ] epic-053-103-relative-offsets-adr
+- [ ] epic-053-104-relative-offsets-guidance

--- a/.foundry/prds/prd-086-054-box-duplicate-analyzer.md
+++ b/.foundry/prds/prd-086-054-box-duplicate-analyzer.md
@@ -61,6 +61,6 @@ Build a "Duplicate Analyzer" view inside DexHelper's PC Box tracking system. Thi
 
 ## 5. Next Steps
 - [x] Break down this PRD into Epics for backend parsing extensions and frontend UI implementation.
-- [ ] .foundry/epics/epic-054-108-box-analyzer-save-parsing.md
-- [ ] .foundry/epics/epic-054-109-box-analyzer-matrix-ui.md
-- [ ] .foundry/epics/epic-054-110-box-analyzer-release-workflow.md
+- [ ] epic-054-108-box-analyzer-save-parsing
+- [ ] epic-054-109-box-analyzer-matrix-ui
+- [ ] epic-054-110-box-analyzer-release-workflow

--- a/.foundry/prds/prd-088-054-trick-house-tracker.md
+++ b/.foundry/prds/prd-088-054-trick-house-tracker.md
@@ -35,5 +35,5 @@ Extract the Trick House puzzle state using DexHelper's save file parsing capabil
 
 ## 4. Acceptance Criteria
 - [x] Epic Planner: Break down this PRD into Epics for the Tracker Tracker, focusing on the data parsing logic and the frontend presentation logic.
-- [ ] .foundry/epics/epic-054-111-trick-house-save-parsing.md
-- [ ] .foundry/epics/epic-054-112-trick-house-ui.md
+- [ ] epic-054-111-trick-house-save-parsing
+- [ ] epic-054-112-trick-house-ui

--- a/.foundry/prds/prd-089-054-gen3-ash-gathering-tracker.md
+++ b/.foundry/prds/prd-089-054-gen3-ash-gathering-tracker.md
@@ -65,7 +65,7 @@ By extracting the Volcanic Ash count from the Gen 3 save file, DexHelper can pro
 
 ## 5. Acceptance Criteria
 - [x] Epic Planner: Break down this PRD into corresponding EPICs (e.g., Save Parsing, UI Dashboard, Goal Planner Logic).
-- [ ] .foundry/archive/research/research-054-243-gen3-ash-gathering-offsets.md
-- [ ] .foundry/epics/epic-054-113-gen3-ash-save-parsing.md
-- [ ] .foundry/epics/epic-054-114-gen3-ash-dashboard.md
-- [ ] .foundry/epics/epic-054-115-gen3-ash-goal-planner.md
+- [ ] research-054-243-gen3-ash-gathering-offsets
+- [ ] epic-054-113-gen3-ash-save-parsing
+- [ ] epic-054-114-gen3-ash-dashboard
+- [ ] epic-054-115-gen3-ash-goal-planner

--- a/.foundry/prds/prd-090-055-pokegear-phone-tracker.md
+++ b/.foundry/prds/prd-090-055-pokegear-phone-tracker.md
@@ -33,7 +33,7 @@ In Generation 2 (Gold, Silver, Crystal), the Pokégear Phone is a central featur
 
 ## Acceptance Criteria
 - [x] Break down into Epics
-- [ ] .foundry/archive/research/research-055-244-pokegear-mechanics.md
-- [ ] .foundry/epics/epic-055-116-pokegear-active-callers.md
-- [ ] .foundry/epics/epic-055-117-pokegear-predictor.md
-- [ ] .foundry/epics/epic-055-118-pokegear-alerts.md
+- [ ] research-055-244-pokegear-mechanics
+- [ ] epic-055-116-pokegear-active-callers
+- [ ] epic-055-117-pokegear-predictor
+- [ ] epic-055-118-pokegear-alerts

--- a/.foundry/prds/prd-091-055-smart-egg-move-path-finder.md
+++ b/.foundry/prds/prd-091-055-smart-egg-move-path-finder.md
@@ -34,6 +34,6 @@ Breeding for "Egg Moves" is a core mechanic for competitive battling and challen
 
 ## Next Steps
 - [x] Epic Planner: Break this PRD down into actionable EPICs.
-- [ ] .foundry/epics/epic-055-113-egg-move-pathfinding-engine.md
-- [ ] .foundry/epics/epic-055-114-egg-move-inventory-cross-reference.md
-- [ ] .foundry/epics/epic-055-115-egg-move-pathfinder-ui.md
+- [ ] epic-055-113-egg-move-pathfinding-engine
+- [ ] epic-055-114-egg-move-inventory-cross-reference
+- [ ] epic-055-115-egg-move-pathfinder-ui

--- a/.foundry/prds/prd-092-056-gen3-ev-training-dashboard.md
+++ b/.foundry/prds/prd-092-056-gen3-ev-training-dashboard.md
@@ -50,6 +50,6 @@ In Pokémon Generation 3, EVs are completely invisible to the player, making com
 - [ ] The dashboard accurately visualizes the EV distribution and total remaining EVs.
 - [ ] Training recommendations provide actionable route/trainer data for EV farming.
 - [ ] UI components strictly follow the tactical aesthetic guidelines.
-- [ ] .foundry/epics/epic-092-116-gen3-ev-data-extraction.md
-- [ ] .foundry/epics/epic-092-117-gen3-ev-dashboard-ui.md
-- [ ] .foundry/epics/epic-092-118-gen3-ev-training-recommendations.md
+- [ ] epic-092-116-gen3-ev-data-extraction
+- [ ] epic-092-117-gen3-ev-dashboard-ui
+- [ ] epic-092-118-gen3-ev-training-recommendations

--- a/.foundry/prds/prd-103-109-foundry-node-content-consolidation.md
+++ b/.foundry/prds/prd-103-109-foundry-node-content-consolidation.md
@@ -7,7 +7,7 @@ owner_persona: epic_planner
 created_at: '2026-07-06'
 updated_at: '2026-07-06'
 depends_on:
-  - .foundry/tasks/task-103-304-propose-dynamic-policy-injection-adr.md
+  - task-103-304-propose-dynamic-policy-injection-adr
 jules_session_id: null
 pr_number: null
 parent: idea-103-foundry-node-content-consolidation

--- a/.foundry/prds/prd-104-109-missed-trainer-radar.md
+++ b/.foundry/prds/prd-104-109-missed-trainer-radar.md
@@ -44,7 +44,7 @@ Players often accidentally or deliberately skip trainers during their initial ro
 3.  **Aesthetics:** The UI should follow the project's tactical, snooping aesthetic as defined by existing ADRs and the UI style guides.
 
 ## Acceptance Criteria
-- [ ] .foundry/epics/epic-109-306-missed-trainer-data-extraction-gen1-gen2.md
-- [ ] .foundry/epics/epic-109-307-missed-trainer-data-extraction-gen3.md
-- [ ] .foundry/epics/epic-109-308-missed-trainer-radar-ui.md
+- [ ] epic-109-306-missed-trainer-data-extraction-gen1-gen2
+- [ ] epic-109-307-missed-trainer-data-extraction-gen3
+- [ ] epic-109-308-missed-trainer-radar-ui
 - [x] Break down into Epics

--- a/.foundry/stories/story-048-089-route-radar-density-aggregation.md
+++ b/.foundry/stories/story-048-089-route-radar-density-aggregation.md
@@ -37,10 +37,10 @@ Implement the data transformation pipeline inside the `RouteRadarController`. It
 - [ ] Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs.
 
 ## Generated Tasks
-- [ ] .foundry/archive/tasks/task-089-153-implement-radar-heatmap-logic.md
-- [ ] .foundry/archive/tasks/task-089-154-qa-radar-heatmap-logic.md
-- [ ] .foundry/archive/tasks/task-089-165-radar-heatmap-density-logic-impl.md
-- [ ] .foundry/archive/tasks/task-089-166-qa-radar-heatmap-density-logic.md
+- [ ] task-089-153-implement-radar-heatmap-logic
+- [ ] task-089-154-qa-radar-heatmap-logic
+- [ ] task-089-165-radar-heatmap-density-logic-impl
+- [ ] task-089-166-qa-radar-heatmap-density-logic
 - [ ] research-089-167-investigate-heatmap-failure
-- [ ] .foundry/tasks/task-089-177-radar-heatmap-ui-integration-impl.md
-- [ ] .foundry/tasks/task-089-178-qa-radar-heatmap-ui-integration.md
+- [ ] task-089-177-radar-heatmap-ui-integration-impl
+- [ ] task-089-178-qa-radar-heatmap-ui-integration

--- a/.foundry/stories/story-053-094-health-scanner-moveset-inventory-validation.md
+++ b/.foundry/stories/story-053-094-health-scanner-moveset-inventory-validation.md
@@ -37,5 +37,5 @@ Corrupted save files often manifest as impossible movesets or corrupted inventor
 - [x] Tech Lead: Break this Story down into actionable Tasks for the coder.
 
 ### Child Nodes
-- [ ] .foundry/tasks/task-094-157-moveset-inventory-validation-impl.md
-- [ ] .foundry/tasks/task-094-158-moveset-inventory-validation-qa.md
+- [ ] task-094-157-moveset-inventory-validation-impl
+- [ ] task-094-158-moveset-inventory-validation-qa

--- a/.foundry/stories/story-055-096-gen3-berry-msgpack-integration.md
+++ b/.foundry/stories/story-055-096-gen3-berry-msgpack-integration.md
@@ -32,5 +32,5 @@ Serialize the extracted Gen 3 berry patch data using `msgpackr` and integrate wi
 - [ ] Integrate serialized data with PokeData storage generation pipeline.
 - [ ] Expose through runtime API.
 
-- [ ] .foundry/tasks/task-096-194-gen3-berry-msgpack-impl.md
-- [ ] .foundry/tasks/task-096-195-gen3-berry-msgpack-qa.md
+- [ ] task-096-194-gen3-berry-msgpack-impl
+- [ ] task-096-195-gen3-berry-msgpack-qa

--- a/.foundry/stories/story-061-099-extract-pokemon-pids.md
+++ b/.foundry/stories/story-061-099-extract-pokemon-pids.md
@@ -32,5 +32,5 @@ Use the `DataView` API for safe data parsing as per ADR 010.
 - [x] Create/Update TASK nodes to implement parsing the 32-bit PIDs for all party and PC Pokémon in Gen 3 saves.
 
 ### Implementation Tasks
-- [ ] .foundry/tasks/task-099-157-gen3-extract-pokemon-pids-impl.md
-- [ ] .foundry/tasks/task-099-158-gen3-extract-pokemon-pids-qa.md
+- [ ] task-099-157-gen3-extract-pokemon-pids-impl
+- [ ] task-099-158-gen3-extract-pokemon-pids-qa

--- a/.foundry/stories/story-070-150-parse-gen2-hof-records.md
+++ b/.foundry/stories/story-070-150-parse-gen2-hof-records.md
@@ -36,5 +36,5 @@ Implement logic to extract actual Hall of Fame records from Generation 2 (Gold, 
 
 ## Acceptance Criteria
 - [x] Create tasks to implement parsing for Gen 2 Hall of Fame records data.
-- [ ] .foundry/tasks/task-150-212-gen2-hof-records-extraction-impl.md
-- [ ] .foundry/tasks/task-150-213-gen2-hof-records-extraction-qa.md
+- [ ] task-150-212-gen2-hof-records-extraction-impl
+- [ ] task-150-213-gen2-hof-records-extraction-qa

--- a/.foundry/stories/story-070-245-implement-dag-provider-state-management.md
+++ b/.foundry/stories/story-070-245-implement-dag-provider-state-management.md
@@ -27,5 +27,5 @@ The Auditor rejected `epic-045-070-implement-dag-context` because `DagProvider` 
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] .foundry/archive/tasks/task-245-249-implement-dag-provider-logic.md
-- [ ] .foundry/archive/tasks/task-245-250-implement-dag-provider-logic-qa.md
+- [ ] task-245-249-implement-dag-provider-logic
+- [ ] task-245-250-implement-dag-provider-logic-qa

--- a/.foundry/stories/story-106-159-gen3-egg-hatch-parsing.md
+++ b/.foundry/stories/story-106-159-gen3-egg-hatch-parsing.md
@@ -33,5 +33,5 @@ Similar to Gen 2, Gen 3 repurposes the Friendship byte to store remaining "Egg C
 - [ ] Ensure `DataView` API is used.
 - [ ] Write unit tests verifying the calculation.
 
-- [ ] .foundry/archive/tasks/task-159-249-gen3-egg-hatch-parsing-impl.md
-- [ ] .foundry/tasks/task-159-250-gen3-egg-hatch-parsing-qa.md
+- [ ] task-159-249-gen3-egg-hatch-parsing-impl
+- [ ] task-159-250-gen3-egg-hatch-parsing-qa

--- a/.foundry/stories/story-130-316-document-indexeddb-schema.md
+++ b/.foundry/stories/story-130-316-document-indexeddb-schema.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-07-12'
 updated_at: '2026-07-12'
 depends_on:
-  - .foundry/stories/story-130-315-define-indexeddb-schema.md
+  - story-130-315-define-indexeddb-schema
 jules_session_id: null
 pr_number: null
 parent: epic-099-130-indexeddb-schema-design

--- a/.foundry/stories/story-136-295-gen1-checklist-ui.md
+++ b/.foundry/stories/story-136-295-gen1-checklist-ui.md
@@ -7,7 +7,7 @@ owner_persona: "tech_lead"
 created_at: "2026-07-10"
 updated_at: "2026-07-10"
 depends_on:
-  - .foundry/stories/story-136-294-gen1-event-flag-parsing.md
+  - story-136-294-gen1-event-flag-parsing
 jules_session_id: null
 pr_number: null
 parent: epic-106-136-gen1-static-encounters

--- a/.foundry/stories/story-136-295-sorting-standard-strategies.md
+++ b/.foundry/stories/story-136-295-sorting-standard-strategies.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: "2026-07-10"
 updated_at: "2026-07-10"
 depends_on:
-  - .foundry/stories/story-136-294-sorting-interface-base.md
+  - story-136-294-sorting-interface-base
 jules_session_id: null
 pr_number: null
 parent: epic-106-136-pc-box-sorting-algorithms

--- a/.foundry/stories/story-136-296-sorting-cross-gen-considerations.md
+++ b/.foundry/stories/story-136-296-sorting-cross-gen-considerations.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: "2026-07-10"
 updated_at: "2026-07-10"
 depends_on:
-  - .foundry/stories/story-136-295-sorting-standard-strategies.md
+  - story-136-295-sorting-standard-strategies
 jules_session_id: null
 pr_number: null
 parent: epic-106-136-pc-box-sorting-algorithms

--- a/.foundry/stories/story-137-295-gen2-checklist-ui.md
+++ b/.foundry/stories/story-137-295-gen2-checklist-ui.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-07-10'
 updated_at: '2026-07-10'
 depends_on:
-  - .foundry/stories/story-137-294-gen2-event-flag-parsing.md
+  - story-137-294-gen2-event-flag-parsing
 jules_session_id: null
 pr_number: null
 parent: epic-106-137-gen2-static-encounters

--- a/.foundry/stories/story-137-295-move-planner-algorithm.md
+++ b/.foundry/stories/story-137-295-move-planner-algorithm.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-07-10'
 updated_at: '2026-07-10'
 depends_on:
-  - .foundry/stories/story-137-294-diff-engine-logic.md
+  - story-137-294-diff-engine-logic
 jules_session_id: null
 pr_number: null
 parent: epic-106-137-pc-box-diff-engine-move-planner

--- a/.foundry/stories/story-137-296-move-planner-unit-tests.md
+++ b/.foundry/stories/story-137-296-move-planner-unit-tests.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-07-10'
 updated_at: '2026-07-10'
 depends_on:
-  - .foundry/stories/story-137-295-move-planner-algorithm.md
+  - story-137-295-move-planner-algorithm
 jules_session_id: null
 pr_number: null
 parent: epic-106-137-pc-box-diff-engine-move-planner

--- a/.foundry/stories/story-138-295-gen3-static-encounters-ui.md
+++ b/.foundry/stories/story-138-295-gen3-static-encounters-ui.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-07-11'
 updated_at: '2026-07-11'
 depends_on:
-  - .foundry/stories/story-138-294-gen3-static-encounters-parsing.md
+  - story-138-294-gen3-static-encounters-parsing
 jules_session_id: null
 pr_number: null
 parent: epic-106-138-gen3-static-encounters

--- a/.foundry/stories/story-309-003-egg-group-validation.md
+++ b/.foundry/stories/story-309-003-egg-group-validation.md
@@ -7,7 +7,7 @@ owner_persona: "tech_lead"
 created_at: "2026-07-13"
 updated_at: "2026-07-13"
 depends_on:
-  - .foundry/stories/story-309-001-gender-calculation-engine.md
+  - story-309-001-gender-calculation-engine
 jules_session_id: null
 pr_number: null
 parent: epic-112-309-gen2-shiny-breeding-logic

--- a/.foundry/stories/story-309-004-shiny-odds-computation.md
+++ b/.foundry/stories/story-309-004-shiny-odds-computation.md
@@ -7,9 +7,9 @@ owner_persona: "tech_lead"
 created_at: "2026-07-13"
 updated_at: "2026-07-13"
 depends_on:
-  - .foundry/stories/story-309-001-gender-calculation-engine.md
-  - .foundry/stories/story-309-002-dv-overlap-constraint.md
-  - .foundry/stories/story-309-003-egg-group-validation.md
+  - story-309-001-gender-calculation-engine
+  - story-309-002-dv-overlap-constraint
+  - story-309-003-egg-group-validation
 jules_session_id: null
 pr_number: null
 parent: epic-112-309-gen2-shiny-breeding-logic

--- a/.foundry/tasks/task-099-193-mirage-island-parser-qa.md
+++ b/.foundry/tasks/task-099-193-mirage-island-parser-qa.md
@@ -36,4 +36,4 @@ We need to verify that the Gen 3 save parser logic for extracting the Mirage Isl
 ## Acceptance Criteria
 - [ ] Verify unit tests confirm successful parsing using `DataView`.
 - [ ] Verify unit tests confirm graceful error handling for `RangeError`.
-- [ ] Update the parent story `.foundry/stories/story-061-099-implement-mirage-island-parser.md` by checking off this task's checkbox.
+- [ ] Update the parent story by checking off this task's checkbox.

--- a/.foundry/tasks/task-272-305-living-dex-ghost-tracker-qa.md
+++ b/.foundry/tasks/task-272-305-living-dex-ghost-tracker-qa.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-07-11'
 updated_at: '2026-07-13'
 depends_on:
-  - .foundry/tasks/task-272-304-living-dex-ghost-tracker-impl.md
+  - task-272-304-living-dex-ghost-tracker-impl
 jules_session_id: null
 pr_number: null
 parent: story-133-272-living-dex-ghost-tracker

--- a/.foundry/tasks/task-279-305-gen3-ignore-emulator-trailing-bytes-qa.md
+++ b/.foundry/tasks/task-279-305-gen3-ignore-emulator-trailing-bytes-qa.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-07-06'
 updated_at: '2026-07-06'
 depends_on:
-  - .foundry/tasks/task-279-304-gen3-ignore-emulator-trailing-bytes-impl.md
+  - task-279-304-gen3-ignore-emulator-trailing-bytes-impl
 jules_session_id: null
 pr_number: null
 parent: story-081-279-gen3-ignore-emulator-trailing-bytes

--- a/.foundry/tasks/task-283-315-predictor-engine-logic-qa.md
+++ b/.foundry/tasks/task-283-315-predictor-engine-logic-qa.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-07-11'
 updated_at: '2026-07-13'
 depends_on:
-  - .foundry/tasks/task-283-314-predictor-engine-logic-impl.md
+  - task-283-314-predictor-engine-logic-impl
 jules_session_id: null
 pr_number: null
 parent: story-117-283-pokegear-predictor-engine

--- a/.foundry/tasks/task-288-305-gen3-mix-record-inherited-events-qa.md
+++ b/.foundry/tasks/task-288-305-gen3-mix-record-inherited-events-qa.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-07-06'
 updated_at: '2026-07-11'
 depends_on:
-  - .foundry/archive/tasks/task-288-304-gen3-mix-record-inherited-events-impl.md
+  - task-288-304-gen3-mix-record-inherited-events-impl
 jules_session_id: null
 pr_number: null
 parent: story-081-288-gen3-mix-record-inherited-events


### PR DESCRIPTION
This PR completes the Mechanic's daily maintenance session. It addresses structural friction in the Foundry DAG by migrating ~95+ nodes away from relative file paths in their relationships (like `depends_on` and checklists) to strictly use precise Node IDs per ADR 002. It also patches three `IDEA` nodes that were stuck in an invalid `ACTIVE` state.

---
*PR created automatically by Jules for task [15120062734954730316](https://jules.google.com/task/15120062734954730316) started by @szubster*