### PR TITLE
Convert IDEA 115 into PRD: Remove Obsolete Orphaned Node Manual Cancellation Rule

### DIFF
--- a/.foundry/prds/prd-115-115-remove-obsolete-orphaned-node-manual-cancellation.md
+++ b/.foundry/prds/prd-115-115-remove-obsolete-orphaned-node-manual-cancellation.md
@@ -1,19 +1,23 @@
 ---
-id: idea-115-remove-obsolete-orphaned-node-manual-cancellation
-type: IDEA
+id: prd-115-115-remove-obsolete-orphaned-node-manual-cancellation
+type: PRD
 title: Remove Obsolete Orphaned Node Manual Cancellation Rule
-status: ACTIVE
-owner_persona: product_manager
-created_at: '2026-07-12'
-updated_at: '2026-07-15'
+status: PENDING
+owner_persona: epic_planner
+created_at: "2026-07-15"
+updated_at: "2026-07-15"
 depends_on: []
-jules_session_id: '543639033010388496'
-parent: null
+jules_session_id: null
+pr_number: null
+parent: idea-115-remove-obsolete-orphaned-node-manual-cancellation
 tags:
   - foundry
   - orchestrator
   - agile-coach
-rejection_reason: ''
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
 ---
 
 # Remove Obsolete Orphaned Node Manual Cancellation Rule
@@ -22,5 +26,4 @@ rejection_reason: ''
 The Agile Coach identified friction caused by the obsolete "Orphaned QA Task Cancellation Rule" in `core_policies.md`. The orchestrator's Phase 3.6 cascade cancellation logic now automatically cancels PENDING nodes that depend on permanently failed nodes, making the manual markdown body updates redundant and conflict-prone. This rule has been removed from `core_policies.md` to streamline the agent workflow and align with the Orchestrator's automated capabilities.
 
 ## Acceptance Criteria
-- [x] Product Manager: Convert this idea into a PRD to formalize the removal of manual orphaned node cancellation rules across the documentation.
-- [ ] prd-115-115-remove-obsolete-orphaned-node-manual-cancellation
+- [ ] Epic Planner: Break down this PRD into Epics.


### PR DESCRIPTION
This PR transforms `idea-115` into a formal PRD.

Changes:
- Created new PRD node `.foundry/prds/prd-115-115-remove-obsolete-orphaned-node-manual-cancellation.md` and assigned ownership to the `epic_planner`.
- Updated `.foundry/ideas/idea-115-remove-obsolete-orphaned-node-manual-cancellation.md` to check off the conversion criteria and append the new PRD node ID.

---
*PR created automatically by Jules for task [543639033010388496](https://jules.google.com/task/543639033010388496) started by @szubster*