### PR TITLE
chore(foundry): draft tasks for Gen 2 trainer data extraction

### DIFF
--- a/.foundry/stories/story-306-320-gen2-trainer-data-extraction.md
+++ b/.foundry/stories/story-306-320-gen2-trainer-data-extraction.md
@@ -31,4 +31,8 @@ Extract and parse the trainer defeat flags for Generation 2 games from Bank 1.
 3. Use relative offsets and constants (ADR 028) strictly. No inline magic numbers.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks
+- [x] Break down into Tasks
+
+
+- [ ] task-320-322-gen2-trainer-flags-impl
+- [ ] task-320-323-gen2-trainer-flags-qa

--- a/.foundry/tasks/task-320-322-gen2-trainer-flags-impl.md
+++ b/.foundry/tasks/task-320-322-gen2-trainer-flags-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-320-322-gen2-trainer-flags-impl
+type: TASK
+title: Gen 2 Trainer Data Extraction Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-15'
+updated_at: '2026-07-15'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-306-320-gen2-trainer-data-extraction
+tags:
+  - gen2
+  - save-engine
+  - extraction
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Trainer Data Extraction Implementation
+
+## Objective
+Implement the logic to extract and parse the trainer defeat flags for Generation 2 games (Gold/Silver/Crystal) from Bank 1.
+
+## Requirements
+1. **Extraction Target**: Extract the trainer defeat event flags from Bank 1.
+    - Note from `gen2_generic_structure.md`: The Event Flags block is 256 bytes in length and is consistently located exactly `0x100` (256) bytes prior to `wCurBox`.
+2. **Explicit Bitwise Logic (ADR 026)**: You MUST use explicit bitwise shifting (`>>`) and masking (`&`) to isolate the specific trainer defeat flags rather than evaluating the entire byte. Include appropriate boundary tests as required by ADR 026.
+3. **Relative Offsets & Constants (ADR 028)**: All memory offsets, lengths, bit locations, and shifts MUST be defined as reusable constants at the module level. You are strictly forbidden from using inline magic numbers for memory reads.
+
+## Instructions
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement Gen 2 trainer flags extraction logic.
+- [ ] Ensure ADR 026 compliance (explicit bitwise logic).
+- [ ] Ensure ADR 028 compliance (module-level constants, no magic numbers).

--- a/.foundry/tasks/task-320-323-gen2-trainer-flags-qa.md
+++ b/.foundry/tasks/task-320-323-gen2-trainer-flags-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-320-323-gen2-trainer-flags-qa
+type: TASK
+title: Gen 2 Trainer Data Extraction QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-15'
+updated_at: '2026-07-15'
+depends_on:
+  - task-320-322-gen2-trainer-flags-impl
+jules_session_id: null
+pr_number: null
+parent: story-306-320-gen2-trainer-data-extraction
+tags:
+  - gen2
+  - save-engine
+  - extraction
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Trainer Data Extraction QA
+
+## Objective
+Verify the implementation of the Gen 2 trainer defeat flags extraction logic.
+
+## Requirements
+1. Verify that the Coder correctly implemented the extraction of trainer defeat event flags from Bank 1 for Gen 2 (GS/Crystal).
+2. **ADR 026 Verification**: Confirm that explicit bitwise logic (shifting and masking) was used with appropriate boundary testing.
+3. **ADR 028 Verification**: Confirm that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. Ensure there are no inline magic numbers.
+
+## Instructions
+- If the Coder's implementation is incomplete or violates the architecture rules, reject the task.
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify Gen 2 trainer flags extraction logic works as intended.
+- [ ] Confirm ADR 026 compliance.
+- [ ] Confirm ADR 028 compliance.


### PR DESCRIPTION
This empty PR fulfills the Tech Lead's task to break down `story-306-320-gen2-trainer-data-extraction` into Technical TASK nodes, adhering to the architecture schemas and journaling rules, without touching the parent node's YAML frontmatter.

---
*PR created automatically by Jules for task [10582392032178616751](https://jules.google.com/task/10582392032178616751) started by @szubster*