### PR TITLE
Update story-149-291-gen3-roamer-core-extraction acceptance criteria

### DIFF
--- a/.foundry/stories/story-149-291-gen3-roamer-core-extraction.md
+++ b/.foundry/stories/story-149-291-gen3-roamer-core-extraction.md
@@ -28,8 +28,8 @@ Implement base DataView parsing for the Gen 3 Roamer structure in SaveBlock1.
 Develop the core parsing logic to extract the Roamer data block (IVs, Species, HP, etc.) from SaveBlock1. This must handle the version-specific offsets for Ruby/Sapphire, Emerald, and FireRed/LeafGreen.
 
 ## Acceptance Criteria
-- [ ] Implement `parseGen3Roamer` function in `src/engine/saveParser/parsers/gen3.ts`.
-- [ ] Support Ruby/Sapphire and Emerald offsets as documented in research.
+- [x] Implement `parseGen3Roamer` function in `src/engine/saveParser/parsers/gen3.ts`.
+- [x] Support Ruby/Sapphire and Emerald offsets as documented in research.
 - [x] Tech Lead: Break down this Story into executable Tasks.
-- [ ] task-291-314-gen3-roamer-core-extraction-impl
-- [ ] task-291-315-gen3-roamer-core-extraction-qa
+- [x] task-291-314-gen3-roamer-core-extraction-impl
+- [x] task-291-315-gen3-roamer-core-extraction-qa


### PR DESCRIPTION
Updates the markdown acceptance criteria in `.foundry/stories/story-149-291-gen3-roamer-core-extraction.md` to reflect that all child tasks are completed. Submitting an empty PR (no code changes) to allow the Orchestrator to transition the story node to `VERIFYING` according to the Empty PR policy and MACRO NODE COMPLETION EXCEPTION rule.

---
*PR created automatically by Jules for task [14368391566023672902](https://jules.google.com/task/14368391566023672902) started by @szubster*