### PR TITLE
feat(foundry): Create Safari Zone Static Data Compilation STORY node

### DIFF
--- a/.foundry/epics/epic-113-324-safari-zone-data-integration.md
+++ b/.foundry/epics/epic-113-324-safari-zone-data-integration.md
@@ -33,4 +33,5 @@ This Epic covers the backend and data extraction logic necessary to power the Sa
 
 ## Acceptance Criteria
 - [ ] Create STORY nodes for Gen 1 and Gen 3 save state integration for Safari Zone encounters.
-- [ ] Create STORY nodes for compiling the static encounter tables for Safari Zones.
+- [x] Create STORY nodes for compiling the static encounter tables for Safari Zones.
+- [ ] story-324-322-safari-zone-static-tables

--- a/.foundry/stories/story-324-322-safari-zone-static-tables.md
+++ b/.foundry/stories/story-324-322-safari-zone-static-tables.md
@@ -1,0 +1,37 @@
+---
+id: story-324-322-safari-zone-static-tables
+type: STORY
+title: Safari Zone Static Data Compilation (Gen 1 & 3)
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-15'
+updated_at: '2026-07-15'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-113-324-safari-zone-data-integration
+tags:
+  - backend
+  - safari-zone
+  - gen1
+  - gen3
+  - static-data
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Safari Zone Static Data Compilation (Gen 1 & 3)
+
+## Overview
+This story covers compiling the static encounter tables for the Safari Zone in Gen 1 (Red/Blue/Yellow) and Gen 3 (Ruby/Sapphire/Emerald, FireRed/LeafGreen). This static data will act as the source of truth for tracking "missing" or "uncaught" Safari Zone encounters when cross-referenced with the user's Pokédex/PC Box state.
+
+## Technical Scope
+- Compile JSON or TypeScript data structures mapping Safari Zone areas to encounter rates and available Pokémon for Gen 1 (Red/Blue/Yellow).
+- Compile JSON or TypeScript data structures mapping Safari Zone areas to encounter rates and available Pokémon for Gen 3 (R/S/E and FR/LG).
+- Implement necessary interfaces/types for this static data.
+- Integrate the static data into the backend's data layer.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
This PR implements the initial breakdown for Epic `epic-113-324-safari-zone-data-integration`. 

Following the late-binding principle defined in ADR 001, only the first STORY node (`story-324-322-safari-zone-static-tables`) has been generated. The Epic's markdown body has been updated to reflect the creation of this static data compilation story as an unchecked dependency in its Acceptance Criteria list.

- Generated `.foundry/stories/story-324-322-safari-zone-static-tables.md`.
- Updated `.foundry/epics/epic-113-324-safari-zone-data-integration.md`.

---
*PR created automatically by Jules for task [4723312568496882233](https://jules.google.com/task/4723312568496882233) started by @szubster*