### PR TITLE
chore: fulfill extract logToJournal task checkboxes

### DIFF
--- a/.foundry/tasks/task-278-305-extract-log-to-journal.md
+++ b/.foundry/tasks/task-278-305-extract-log-to-journal.md
@@ -38,5 +38,5 @@ notes: ''
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] `logToJournal` is exported from `dag-utils.ts`.
-- [ ] `foundry-orchestrator.ts` uses `logToJournal` instead of inline `fs.appendFileSync`.
+- [x] `logToJournal` is exported from `dag-utils.ts`.
+- [x] `foundry-orchestrator.ts` uses `logToJournal` instead of inline `fs.appendFileSync`.


### PR DESCRIPTION
This is an Empty PR to fulfill the extract logToJournal utility task. The target artifacts were implemented in a previous session, so this PR only checks off the acceptance criteria checkboxes in `.foundry/tasks/task-278-305-extract-log-to-journal.md`.

---
*PR created automatically by Jules for task [16730920310026873684](https://jules.google.com/task/16730920310026873684) started by @szubster*