### PR TITLE
feat: create technical blueprints for Gen 3 Trainer Defeat Flags extraction

### DIFF
--- a/.foundry/stories/story-307-319-gen3-trainer-flags-extraction.md
+++ b/.foundry/stories/story-307-319-gen3-trainer-flags-extraction.md
@@ -32,4 +32,7 @@ Extract standard and rematch trainer defeat flags from Gen 3 save files to be us
 5.  **Relative Offsets & Constants (ADR 028):** All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
 
 ## Acceptance Criteria
-- [ ] Create Tech Lead Task Blueprints
+- [x] Create Tech Lead Task Blueprints
+
+- [ ] task-319-322-gen3-trainer-flags-extraction-impl
+- [ ] task-319-323-gen3-trainer-flags-extraction-qa

--- a/.foundry/tasks/task-319-322-gen3-trainer-flags-extraction-impl.md
+++ b/.foundry/tasks/task-319-322-gen3-trainer-flags-extraction-impl.md
@@ -1,0 +1,44 @@
+---
+id: task-319-322-gen3-trainer-flags-extraction-impl
+type: TASK
+title: Implement Gen 3 Trainer Defeat Flags Extraction
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-307-319-gen3-trainer-flags-extraction
+tags:
+  - data-extraction
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Trainer Defeat Flags Extraction
+
+## Objective
+Implement the logic to extract standard and rematch trainer defeat flags from Gen 3 save files to be used by the Missed Trainer Radar.
+
+## Contract & Constraints
+1. **Gen 3 Data Parsing (ADR 010):** All new Gen3 save parsing logic MUST exclusively use the native `DataView` API rather than raw `Uint8Array` manipulations. You must catch `RangeError` for out-of-bounds reads and throw a new error with the exact message 'The save file is corrupted or incomplete.'
+2. **Cured Boundaries (ADR 026):** All flag extractions must utilize explicit bitwise masking and shifting.
+3. **Relative Offsets (ADR 028):** All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
+4. **Resolved Section Offsets:** You MUST use the resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
+5. **Data Structure:** The extracted flags must be structured correctly for use in the UI.
+
+## Acceptance Criteria
+- [ ] Implement `DataView` parsing for standard trainer defeat flags.
+- [ ] Implement `DataView` parsing for rematch trainer defeat flags.
+- [ ] Ensure all offsets and bit shifts are module-level constants.
+- [ ] Ensure A/B bank relative offset logic is used.
+- [ ] Add unit tests covering extraction logic (including absolute zero and boundary states per ADR 026).
+
+## Node Handling Policies
+- **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Submission:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not manually update the status.

--- a/.foundry/tasks/task-319-323-gen3-trainer-flags-extraction-qa.md
+++ b/.foundry/tasks/task-319-323-gen3-trainer-flags-extraction-qa.md
@@ -1,0 +1,43 @@
+---
+id: task-319-323-gen3-trainer-flags-extraction-qa
+type: TASK
+title: QA Gen 3 Trainer Defeat Flags Extraction
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-14'
+updated_at: '2026-07-14'
+depends_on:
+  - .foundry/tasks/task-319-322-gen3-trainer-flags-extraction-impl.md
+jules_session_id: null
+pr_number: null
+parent: story-307-319-gen3-trainer-flags-extraction
+tags:
+  - data-extraction
+  - gen3
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 Trainer Defeat Flags Extraction
+
+## Objective
+Verify the correctness of the Gen 3 Trainer Defeat Flags Extraction implementation according to the architectural constraints.
+
+## Contract & Constraints
+1. **Gen 3 Data Parsing (ADR 010):** Verify that all new Gen3 save parsing logic exclusively uses the native `DataView` API and properly catches `RangeError` for out-of-bounds reads.
+2. **Cured Boundaries (ADR 026):** Verify that all flag extractions utilize explicit bitwise masking and shifting, and are tested for absolute zero and boundary states.
+3. **Relative Offsets (ADR 028):** Verify that all memory offsets, lengths, bit locations, and shifts are explicitly defined as reusable constants at the module level without inline magic numbers.
+4. **Resolved Section Offsets:** Verify the use of resolved section offsets (e.g., `section1Offset`) to calculate relative memory offsets.
+
+## Acceptance Criteria
+- [ ] Review code to verify compliance with ADR 010, 026, and 028.
+- [ ] Review code to verify correct A/B bank flash memory support via section offset calculations.
+- [ ] Ensure all required unit tests pass and cover the edge cases.
+
+## Node Handling Policies
+- **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Submission:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not manually update the status.


### PR DESCRIPTION
This PR implements the Technical Lead task of creating technical blueprints for extracting Gen 3 Trainer Defeat flags.

- Created an implementation TASK blueprint (`task-319-322-gen3-trainer-flags-extraction-impl.md`) for the Coder, enforcing constraints around `DataView` parsing (ADR 010), bitwise explicit boundaries (ADR 026), and strict module-level constants for relative offsets (ADR 028) that use Section resolved offsets to support Gen 3 A/B bank flash memory.
- Created a QA TASK blueprint (`task-319-323-gen3-trainer-flags-extraction-qa.md`) to verify these changes due to the complexity and risk associated with binary save parsing.
- Included necessary failure policy reminders in both nodes.
- Updated the parent STORY node (`story-307-319-gen3-trainer-flags-extraction.md`) acceptance criteria with the new task checkboxes without altering its existing YAML frontmatter.

---
*PR created automatically by Jules for task [5968959432566922383](https://jules.google.com/task/5968959432566922383) started by @szubster*