### PR TITLE
chore(dag): check off completed task in parent story

### DIFF
--- a/.foundry/stories/story-053-278-extract-log-to-journal.md
+++ b/.foundry/stories/story-053-278-extract-log-to-journal.md
@@ -33,5 +33,5 @@ The `logToJournal` function was missed in the initial extraction of DAG utilitie
 - [x] `foundry-orchestrator.ts` uses `logToJournal` instead of inline `fs.appendFileSync`.
 
 ### Child Tasks
-- [ ] task-278-305-extract-log-to-journal
+- [x] task-278-305-extract-log-to-journal
 - [x] task-278-304-extract-log-to-journal


### PR DESCRIPTION
Checked off the child task `task-278-305-extract-log-to-journal` in `.foundry/stories/story-053-278-extract-log-to-journal.md` since the file already exists and its implementation was completed in a previous session, but the checkbox was left unchecked preventing the parent node from transitioning.

---
*PR created automatically by Jules for task [6584717038830962090](https://jules.google.com/task/6584717038830962090) started by @szubster*