### PR TITLE
story-127-267-bash-timeout-wrapper: Empty PR Completion

### DIFF
--- a/.foundry/stories/story-127-267-bash-timeout-wrapper.md
+++ b/.foundry/stories/story-127-267-bash-timeout-wrapper.md
@@ -26,9 +26,9 @@ notes: ''
 Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that run over a specific threshold (e.g., 30 seconds).
 
 ## Acceptance Criteria
-- [ ] Implement timeout wrapper.
+- [x] Implement timeout wrapper.
 - [x] task-267-262-bash-timeout-wrapper-impl
 - [x] task-267-263-bash-timeout-wrapper-qa
-- [ ] research-267-296-bash-timeout-wrapper-alternatives
-- [ ] task-267-297-bash-timeout-wrapper-impl-v2
-- [ ] task-267-298-bash-timeout-wrapper-qa-v2
+- [x] research-267-296-bash-timeout-wrapper-alternatives
+- [x] task-267-297-bash-timeout-wrapper-impl-v2
+- [x] task-267-298-bash-timeout-wrapper-qa-v2


### PR DESCRIPTION
Completed story-127-267-bash-timeout-wrapper by checking off its acceptance criteria. All child tasks and research nodes have reached terminal states (COMPLETED or CANCELLED) and there are no active dependencies left. Submitted as an empty PR to transition the STORY to COMPLETED state.

---
*PR created automatically by Jules for task [14451521963020126576](https://jules.google.com/task/14451521963020126576) started by @szubster*