### PR TITLE
feat(foundry): implement feedback mechanism for interrupted commands blueprint

### DIFF
--- a/.foundry/stories/story-127-268-bash-timeout-feedback.md
+++ b/.foundry/stories/story-127-268-bash-timeout-feedback.md
@@ -27,4 +27,5 @@ notes: ''
 Implement feedback mechanism for commands that were interrupted due to timeout.
 
 ## Acceptance Criteria
-- [ ] Implement feedback mechanism for interrupted commands.
+- [x] Implement feedback mechanism for interrupted commands.
+- [ ] task-268-322-bash-timeout-feedback-impl

--- a/.foundry/tasks/task-268-322-bash-timeout-feedback-impl.md
+++ b/.foundry/tasks/task-268-322-bash-timeout-feedback-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-268-322-bash-timeout-feedback-impl
+type: TASK
+title: Implement feedback mechanism for interrupted commands
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-15'
+updated_at: '2026-07-15'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-127-268-bash-timeout-feedback
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement feedback mechanism for interrupted commands
+
+## Overview
+Implement a feedback mechanism for bash commands that were interrupted due to timeout, based on the findings from `research-267-296-bash-timeout-wrapper-alternatives` and the existing core policies.
+
+## Constraints & Requirements
+- Update the `.foundry/docs/knowledge_base/agents/core_policies.md` file to explicitly state that when the `timeout` command interrupts a process, it returns exit code 124.
+- Guide agents to recognize this exit code as a timeout and to use non-blocking alternatives like `cat` or `tail -n`.
+- Since this is a simple documentation/policy change with low risk, the Coder is designated to self-verify.
+
+## Instructions for Coder
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Update `core_policies.md` with the exit code 124 feedback mechanism.


### PR DESCRIPTION
This PR introduces the technical blueprint (Task) for the "Implement feedback mechanism for interrupted commands" story.

It creates `task-268-322-bash-timeout-feedback-impl` which instructs the Coder to update `core_policies.md` to explicitly state that the `timeout` command returns exit code 124 when it interrupts a process. This will serve as a mechanism to guide agents to recognize timeouts and use non-blocking alternatives.

The parent story `story-127-268-bash-timeout-feedback` has been updated to check off the acceptance criteria and append the new task.

---
*PR created automatically by Jules for task [18442134624650825073](https://jules.google.com/task/18442134624650825073) started by @szubster*