### PR TITLE
feat: create initial story for Gen 2 DV extraction

### DIFF
--- a/.foundry/epics/epic-112-324-npc-size-record-data-extraction.md
+++ b/.foundry/epics/epic-112-324-npc-size-record-data-extraction.md
@@ -32,3 +32,4 @@ Extract the necessary internal data structures from Gen 2 and Gen 3 save files t
 ## Acceptance Criteria
 - [ ] Implement data extraction for Gen 2 DVs.
 - [ ] Implement data extraction for Gen 3 PV and IVs.
+- [ ] story-324-322-gen2-dv-extraction

--- a/.foundry/stories/story-324-322-gen2-dv-extraction.md
+++ b/.foundry/stories/story-324-322-gen2-dv-extraction.md
@@ -1,0 +1,32 @@
+---
+id: story-324-322-gen2-dv-extraction
+type: STORY
+title: Gen 2 DV Data Extraction for Size Calculation
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-15'
+updated_at: '2026-07-15'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-112-324-npc-size-record-data-extraction
+tags:
+  - dexhelper
+  - generation-2
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 DV Data Extraction for Size Calculation
+
+## 1. Objective
+Design the technical breakdown to extract DVs (Attack, Defense, Speed, Special) for each Pokémon from a Gen 2 save file. This data is required for calculating the size of target Pokémon species.
+
+## 2. Requirements
+- Design extraction mechanisms for Gen 2 Pokémon structures within a save block.
+- Extract the 4 DVs from the raw binary data.
+
+## Acceptance Criteria
+- [ ] Create tasks for the implementation of Gen 2 DV data extraction.


### PR DESCRIPTION
This PR implements the initial step for breaking down EPIC `epic-112-324-npc-size-record-data-extraction`. As the `story_owner`, I have dynamically created the first STORY node (`story-324-322-gen2-dv-extraction`) addressing the Gen 2 DV extraction requirement. 

Following the late-binding principle (ADR 001), I have only created the first story. Subsequent stories (e.g., for Gen 3 PV/IV extraction) will be created after this initial story completes. The parent Epic has been updated to include the new story in its acceptance criteria as an unchecked box, without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [6092087361094101431](https://jules.google.com/task/6092087361094101431) started by @szubster*