### PR TITLE
Extend Phase 3.6 for CANCELLED nodes

### DIFF
--- a/.foundry/tasks/task-299-322-extend-phase-3-6-impl.md
+++ b/.foundry/tasks/task-299-322-extend-phase-3-6-impl.md
@@ -32,9 +32,9 @@ Update `.github/scripts/foundry-orchestrator.ts` Phase 3.6 logic to correctly aw
 - Update tests in `.github/scripts/foundry-orchestrator.test.ts` to assert that parent nodes are awakened when child nodes are cancelled due to max rejections.
 
 ## Acceptance Criteria
-- [ ] Phase 3.6 condition in `foundry-orchestrator.ts` checks for `CANCELLED` status and `Max rejection count reached` reason.
-- [ ] Parent nodes of such cancelled nodes are correctly awakened.
-- [ ] Tests in `foundry-orchestrator.test.ts` are updated to cover this new case.
+- [x] Phase 3.6 condition in `foundry-orchestrator.ts` checks for `CANCELLED` status and `Max rejection count reached` reason.
+- [x] Parent nodes of such cancelled nodes are correctly awakened.
+- [x] Tests in `foundry-orchestrator.test.ts` are updated to cover this new case.
 
 ### REMINDER FOR CODER
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1499,6 +1499,39 @@ vi.doMock('node:url', async (importOriginal) => {
     expect(completedResult).not.toContain('status: CANCELLED');
   });
 
+  test('Impossible Loop: Wakes up parent if child is CANCELLED due to max rejections', () => {
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-impossible.md', {
+      id: "task-impossible",
+      type: "TASK",
+      title: "Impossible Task",
+      status: "CANCELLED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      parent: ".foundry/stories/story-001.md",
+      depends_on: [".foundry/stories/story-001.md"],
+      jules_session_id: null,
+      rejection_reason: "Max rejection count reached",
+    });
+
+    main();
+
+    const result = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-001.md'), 'utf-8');
+    expect(result).toContain('status: READY');
+  });
+
   test('Impossible Loop: Auto-cancels node when max rejection count is reached', async () => {
     createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
       id: "story-001",

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -675,11 +675,12 @@ function main(): void {
     }
 
     if (
-      (node.frontmatter.status === 'FAILED' || node.frontmatter.status === 'CANCELLED') &&
+      ((node.frontmatter.status === 'FAILED' || node.frontmatter.status === 'CANCELLED') &&
       node.frontmatter.rejection_reason &&
       !node.frontmatter.rejection_reason.startsWith('[ACKNOWLEDGED]') &&
       node.frontmatter.rejection_reason !== 'Cancelled due to cascading cancellation from parent' &&
-      !node.frontmatter.rejection_reason.startsWith('Cancelled due to permanent failure of dependency:')
+      !node.frontmatter.rejection_reason.startsWith('Cancelled due to permanent failure of dependency:')) ||
+      (node.frontmatter.status === 'CANCELLED' && node.frontmatter.rejection_reason === 'Max rejection count reached')
     ) {
       // Skip waking up parent if the child is merely suspended (waiting for dependencies/children).
       // We ignore the parent node itself during this check because it's exactly what we want to find out


### PR DESCRIPTION
Updated `.github/scripts/foundry-orchestrator.ts` Phase 3.6 Impossible Loop condition to include `CANCELLED` status combined with the `Max rejection count reached` rejection reason, allowing parent nodes to be properly awakened when child nodes permanently fail. Added a corresponding unit test in `foundry-orchestrator.test.ts`. All test suites pass.

---
*PR created automatically by Jules for task [2296249863922076582](https://jules.google.com/task/2296249863922076582) started by @szubster*