### PR TITLE
feat: implement SaveHistoryDB IndexedDB wrapper

### DIFF
--- a/.foundry/tasks/task-315-322-implement-savehistorydb.md
+++ b/.foundry/tasks/task-315-322-implement-savehistorydb.md
@@ -42,10 +42,10 @@ The application uses IndexedDB to store save file history. The configuration and
 5. Implement fallback mechanisms (like in `src/db/SaveDB.ts`) using a Map if IndexedDB is unavailable.
 
 ## Acceptance Criteria
-- [ ] The `SaveHistoryDB` database is correctly initialized using `openDB` from `idb`.
-- [ ] The `saves` object store is created during the upgrade process.
-- [ ] The `metadata` object store is created during the upgrade process.
-- [ ] The `indexes` object store is created during the upgrade process.
+- [x] The `SaveHistoryDB` database is correctly initialized using `openDB` from `idb`.
+- [x] The `saves` object store is created during the upgrade process.
+- [x] The `metadata` object store is created during the upgrade process.
+- [x] The `indexes` object store is created during the upgrade process.
 
 ## Instructions for Coder
 

--- a/src/db/SaveHistoryDB.ts
+++ b/src/db/SaveHistoryDB.ts
@@ -1,0 +1,116 @@
+import { type IDBPDatabase, openDB } from 'idb';
+import { SAVE_HISTORY_DB_CONFIG, type SaveHistoryDBSchema } from './schema';
+
+// Fallback mechanisms for environments where IndexedDB is unavailable
+const fallbackStorageSaves = new Map<string, Uint8Array>();
+const fallbackStorageMetadata = new Map<string, Record<string, unknown>>();
+const fallbackStorageIndexes = new Map<string, Record<string, unknown>>();
+
+let dbPromise: Promise<IDBPDatabase<SaveHistoryDBSchema>> | null = null;
+
+const getDB = async (): Promise<IDBPDatabase<SaveHistoryDBSchema>> => {
+  if (!dbPromise) {
+    dbPromise = openDB<SaveHistoryDBSchema>(SAVE_HISTORY_DB_CONFIG.NAME, SAVE_HISTORY_DB_CONFIG.VERSION, {
+      upgrade(db, oldVersion) {
+        if (oldVersion < 1) {
+          db.createObjectStore(SAVE_HISTORY_DB_CONFIG.STORES.SAVES);
+          db.createObjectStore(SAVE_HISTORY_DB_CONFIG.STORES.METADATA);
+          db.createObjectStore(SAVE_HISTORY_DB_CONFIG.STORES.INDEXES);
+        }
+      },
+    });
+  }
+  return dbPromise;
+};
+
+export const saveHistoryDB = {
+  async getSave(id: string): Promise<Uint8Array | undefined> {
+    try {
+      const db = await getDB();
+      return await db.get(SAVE_HISTORY_DB_CONFIG.STORES.SAVES, id);
+    } catch {
+      console.error('System: sync failed');
+      return fallbackStorageSaves.get(id);
+    }
+  },
+
+  async putSave(id: string, data: Uint8Array): Promise<void> {
+    try {
+      const db = await getDB();
+      await db.put(SAVE_HISTORY_DB_CONFIG.STORES.SAVES, data, id);
+    } catch {
+      console.error('System: sync failed');
+      fallbackStorageSaves.set(id, data);
+    }
+  },
+
+  async deleteSave(id: string): Promise<void> {
+    try {
+      const db = await getDB();
+      await db.delete(SAVE_HISTORY_DB_CONFIG.STORES.SAVES, id);
+    } catch {
+      console.error('System: sync failed');
+      fallbackStorageSaves.delete(id);
+    }
+  },
+
+  async getMetadata(id: string): Promise<Record<string, unknown> | undefined> {
+    try {
+      const db = await getDB();
+      return await db.get(SAVE_HISTORY_DB_CONFIG.STORES.METADATA, id);
+    } catch {
+      console.error('System: sync failed');
+      return fallbackStorageMetadata.get(id);
+    }
+  },
+
+  async putMetadata(id: string, data: Record<string, unknown>): Promise<void> {
+    try {
+      const db = await getDB();
+      await db.put(SAVE_HISTORY_DB_CONFIG.STORES.METADATA, data, id);
+    } catch {
+      console.error('System: sync failed');
+      fallbackStorageMetadata.set(id, data);
+    }
+  },
+
+  async deleteMetadata(id: string): Promise<void> {
+    try {
+      const db = await getDB();
+      await db.delete(SAVE_HISTORY_DB_CONFIG.STORES.METADATA, id);
+    } catch {
+      console.error('System: sync failed');
+      fallbackStorageMetadata.delete(id);
+    }
+  },
+
+  async getIndex(id: string): Promise<Record<string, unknown> | undefined> {
+    try {
+      const db = await getDB();
+      return await db.get(SAVE_HISTORY_DB_CONFIG.STORES.INDEXES, id);
+    } catch {
+      console.error('System: sync failed');
+      return fallbackStorageIndexes.get(id);
+    }
+  },
+
+  async putIndex(id: string, data: Record<string, unknown>): Promise<void> {
+    try {
+      const db = await getDB();
+      await db.put(SAVE_HISTORY_DB_CONFIG.STORES.INDEXES, data, id);
+    } catch {
+      console.error('System: sync failed');
+      fallbackStorageIndexes.set(id, data);
+    }
+  },
+
+  async deleteIndex(id: string): Promise<void> {
+    try {
+      const db = await getDB();
+      await db.delete(SAVE_HISTORY_DB_CONFIG.STORES.INDEXES, id);
+    } catch {
+      console.error('System: sync failed');
+      fallbackStorageIndexes.delete(id);
+    }
+  },
+};

--- a/src/db/__tests__/SaveHistoryDB.test.ts
+++ b/src/db/__tests__/SaveHistoryDB.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { deleteDB } from 'idb';
+
+describe('SaveHistoryDB normal operation', () => {
+  let saveHistoryDB: typeof import('../SaveHistoryDB').saveHistoryDB;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import('../SaveHistoryDB');
+    saveHistoryDB = mod.saveHistoryDB;
+    await deleteDB('SaveHistoryDB');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should store, retrieve and delete saves, metadata, and indexes', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    await saveHistoryDB.putSave('save1', data);
+
+    const retrieved = await saveHistoryDB.getSave('save1');
+    expect(retrieved).toEqual(data);
+
+    await saveHistoryDB.deleteSave('save1');
+    const retrievedAfterDelete = await saveHistoryDB.getSave('save1');
+    expect(retrievedAfterDelete).toBeUndefined();
+
+    const meta = { test: 123 };
+    await saveHistoryDB.putMetadata('meta1', meta);
+
+    const retrievedMeta = await saveHistoryDB.getMetadata('meta1');
+    expect(retrievedMeta).toEqual(meta);
+
+    await saveHistoryDB.deleteMetadata('meta1');
+    const retrievedMetaAfterDelete = await saveHistoryDB.getMetadata('meta1');
+    expect(retrievedMetaAfterDelete).toBeUndefined();
+
+    const indexData = { someId: 'a' };
+    await saveHistoryDB.putIndex('index1', indexData);
+
+    const retrievedIndex = await saveHistoryDB.getIndex('index1');
+    expect(retrievedIndex).toEqual(indexData);
+
+    await saveHistoryDB.deleteIndex('index1');
+    const retrievedIndexAfterDelete = await saveHistoryDB.getIndex('index1');
+    expect(retrievedIndexAfterDelete).toBeUndefined();
+  });
+});
+
+describe('SaveHistoryDB fallback operation', () => {
+  let saveHistoryDB: typeof import('../SaveHistoryDB').saveHistoryDB;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock('idb', () => ({
+      openDB: vi.fn<() => Promise<never>>().mockRejectedValue(new Error('IndexedDB not available')),
+    }));
+    const mod = await import('../SaveHistoryDB');
+    saveHistoryDB = mod.saveHistoryDB;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.doUnmock('idb');
+    vi.restoreAllMocks();
+  });
+
+  it('should use fallback storage when indexedDB fails for saves, metadata, and indexes', async () => {
+    const data = new Uint8Array([4, 5, 6]);
+    await saveHistoryDB.putSave('fallback1', data);
+
+    const retrieved = await saveHistoryDB.getSave('fallback1');
+    expect(retrieved).toEqual(data);
+
+    await saveHistoryDB.deleteSave('fallback1');
+    const retrievedAfterDelete = await saveHistoryDB.getSave('fallback1');
+    expect(retrievedAfterDelete).toBeUndefined();
+
+    const metaData = { a: 1 };
+    await saveHistoryDB.putMetadata('fallbackMeta', metaData);
+
+    const retrievedMeta = await saveHistoryDB.getMetadata('fallbackMeta');
+    expect(retrievedMeta).toEqual(metaData);
+
+    await saveHistoryDB.deleteMetadata('fallbackMeta');
+    const retrievedMetaAfterDelete = await saveHistoryDB.getMetadata('fallbackMeta');
+    expect(retrievedMetaAfterDelete).toBeUndefined();
+
+    const indexData = { b: 2 };
+    await saveHistoryDB.putIndex('fallbackIndex', indexData);
+
+    const retrievedIndex = await saveHistoryDB.getIndex('fallbackIndex');
+    expect(retrievedIndex).toEqual(indexData);
+
+    await saveHistoryDB.deleteIndex('fallbackIndex');
+    const retrievedIndexAfterDelete = await saveHistoryDB.getIndex('fallbackIndex');
+    expect(retrievedIndexAfterDelete).toBeUndefined();
+
+    expect(console.error).toHaveBeenCalledWith('System: sync failed');
+  });
+});


### PR DESCRIPTION
Implements `SaveHistoryDB` to persist save file history, wrapping the IndexedDB `openDB` initialization as described in `schema.ts`. Fallbacks to maps in memory are also implemented in case of IndexedDB failure.

Resolves #task-315-322-implement-savehistorydb

---
*PR created automatically by Jules for task [539190474458586177](https://jules.google.com/task/539190474458586177) started by @szubster*