### PR TITLE
Blueprint tasks for Gen 3 Hall of Fame & Pokédex Data Extraction

### DIFF
--- a/.foundry/stories/story-304-319-gen3-hof-pokedex-extraction.md
+++ b/.foundry/stories/story-304-319-gen3-hof-pokedex-extraction.md
@@ -33,3 +33,6 @@ Extract the `GAME_STAT_ENTERED_HOF` (ID 10) to determine Hall of Fame entry and 
 ## Acceptance Criteria
 - [ ] Implement Hall of Fame extraction logic.
 - [ ] Implement Pokédex extraction logic.
+
+- [ ] task-319-323-gen3-hof-pokedex-extraction-impl
+- [ ] task-319-324-gen3-hof-pokedex-extraction-qa

--- a/.foundry/tasks/task-319-323-gen3-hof-pokedex-extraction-impl.md
+++ b/.foundry/tasks/task-319-323-gen3-hof-pokedex-extraction-impl.md
@@ -1,0 +1,51 @@
+---
+id: task-319-323-gen3-hof-pokedex-extraction-impl
+type: TASK
+title: 'Implement Gen 3 Hall of Fame & Pokédex Data Extraction'
+status: READY
+owner_persona: coder
+created_at: '2026-07-15'
+updated_at: '2026-07-15'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-304-319-gen3-hof-pokedex-extraction
+tags:
+  - data-extraction
+  - gen3
+research_references:
+  - .foundry/docs/knowledge_base/engine/save_parsing/gen3_hall_of_fame.md
+  - .foundry/docs/knowledge_base/gen3_pokemon_data_structure.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Hall of Fame & Pokédex Data Extraction
+
+## Objective
+Implement the logic to extract the Hall of Fame entry flag (`GAME_STAT_ENTERED_HOF`, ID 10) and Pokédex data (number of caught Pokémon in Hoenn and National Dex) from Gen 3 save files.
+
+## Technical Contract
+- **Architecture Constraint (ADR 010):** You MUST exclusively use the native `DataView` API (e.g., `getUint8`, `getUint16`, `getUint32`) for all new parsing logic.
+- **Architecture Constraint (ADR 028):** You MUST define all memory offsets, limits, bit locations, and shifts as reusable module-level constants. Inline magic numbers are strictly forbidden.
+- **Relative Offsets:** When parsing data from `SaveBlock1`, you MUST use the dynamically resolved `section1Offset` passed to the function to calculate relative memory offsets, properly supporting the Gen 3 A/B bank flash memory architecture.
+- **Bounds Checking:** You MUST wrap your `DataView` reads in a `try...catch` block. If a `RangeError` is caught, you MUST throw a new `Error` with the precise message `"The save file is corrupted or incomplete."` to prevent silent failures.
+- **Implementation Scope:**
+  - Locate and extract the `GAME_STAT_ENTERED_HOF` (ID 10) from the `gameStats` array in `SaveBlock1` or use an equivalent methodology per the research references to determine Hall of Fame entry.
+  - Extract the number of caught Pokémon in both the Hoenn and National Dex. (The exact offsets and structure should be determined during implementation based on Gen 3 save structure knowledge).
+- **Testing:** You MUST write corresponding Vitest unit tests to cover the new extraction logic.
+
+## Acceptance Criteria
+- [ ] `DataView` API is used for parsing.
+- [ ] All offsets and constants are defined at the module level.
+- [ ] Relative offsets from `section1Offset` are used for `SaveBlock1` data.
+- [ ] `RangeError` is caught and translated to `"The save file is corrupted or incomplete."`.
+- [ ] `GAME_STAT_ENTERED_HOF` or equivalent Hall of Fame entry flag is extracted.
+- [ ] Number of caught Pokémon in Hoenn and National Dex is extracted.
+- [ ] Tests are written and pass.
+
+## Persona Instructions
+- **Coder & QA:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Coder & QA:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Coder & QA:** If you submit an empty PR for a completed task (e.g., if the work is already done), you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-319-324-gen3-hof-pokedex-extraction-qa.md
+++ b/.foundry/tasks/task-319-324-gen3-hof-pokedex-extraction-qa.md
@@ -1,0 +1,50 @@
+---
+id: task-319-324-gen3-hof-pokedex-extraction-qa
+type: TASK
+title: 'QA: Gen 3 Hall of Fame & Pokédex Data Extraction'
+status: READY
+owner_persona: qa
+created_at: '2026-07-15'
+updated_at: '2026-07-15'
+depends_on:
+  - task-319-323-gen3-hof-pokedex-extraction-impl
+jules_session_id: null
+pr_number: null
+parent: story-304-319-gen3-hof-pokedex-extraction
+tags:
+  - data-extraction
+  - gen3
+research_references:
+  - .foundry/docs/knowledge_base/engine/save_parsing/gen3_hall_of_fame.md
+  - .foundry/docs/knowledge_base/gen3_pokemon_data_structure.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA: Gen 3 Hall of Fame & Pokédex Data Extraction
+
+## Objective
+Verify the implementation of the Gen 3 Hall of Fame entry and Pokédex data extraction logic against the architectural requirements.
+
+## Verification Tasks
+1.  **Architecture Verification (ADR 010):** Verify that the `coder` exclusively used the `DataView` API. If they used raw `Uint8Array` manipulations, reject the PR.
+2.  **Architecture Verification (ADR 028):** Verify that all memory offsets, limits, bit locations, and shifts are defined as reusable module-level constants. Inline magic numbers are forbidden.
+3.  **Relative Offsets Verification:** Verify that the `coder` used the dynamically resolved `section1Offset` passed to the function to calculate relative memory offsets for `SaveBlock1` data. If they used hardcoded absolute offsets, reject the PR.
+4.  **Bounds Checking Verification:** Verify that `DataView` reads are wrapped in a `try...catch` block and that `RangeError` is caught and re-thrown as exactly `"The save file is corrupted or incomplete."`.
+5.  **Implementation Verification:** Verify that `GAME_STAT_ENTERED_HOF` (or an equivalent Hall of Fame entry flag) and the Hoenn/National Dex caught Pokémon counts are correctly extracted.
+6.  **Test Verification:** Verify that the Vitest test suite is updated and all tests pass.
+
+## Acceptance Criteria
+- [ ] Code uses only `DataView` API.
+- [ ] No inline magic numbers exist for offsets/limits/shifts.
+- [ ] Relative offsets based on `section1Offset` are used.
+- [ ] `RangeError` handling is strictly implemented as specified.
+- [ ] Logic correctly extracts Hall of Fame entry flag and Pokédex caught counts.
+- [ ] Tests exist, are comprehensive, and pass.
+
+## Persona Instructions
+- **Coder & QA:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Coder & QA:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Coder & QA:** If you submit an empty PR for a completed task (e.g., if the work is already done), you MUST check off all Acceptance Criteria checkboxes before submitting.
+- **QA:** If rejecting the implementation, you MUST update the TARGET task's YAML frontmatter (`status: FAILED`, increment `rejection_count`, add `rejection_reason`) while keeping your own QA task's frontmatter unchanged.


### PR DESCRIPTION
This PR implements the blueprint tasks for `story-304-319-gen3-hof-pokedex-extraction`.

It creates the implementation task (`task-319-323-gen3-hof-pokedex-extraction-impl.md`) for the coder and the verification task (`task-319-324-gen3-hof-pokedex-extraction-qa.md`) for the QA persona. Both tasks enforce the `DataView` architecture constraints (ADR 010), the module-level constant definitions (ADR 028), and the usage of relative offsets mapped to `section1Offset`. 

The story markdown node has been updated to track these two new descendant nodes via markdown checkboxes. The story node's YAML frontmatter was not modified, preserving DAG invariants.

---
*PR created automatically by Jules for task [16676321156850284457](https://jules.google.com/task/16676321156850284457) started by @szubster*