### PR TITLE
feat: create blueprints for living dex pc mapping

### DIFF
--- a/.foundry/stories/story-133-273-living-dex-pc-mapping.md
+++ b/.foundry/stories/story-133-273-living-dex-pc-mapping.md
@@ -26,6 +26,9 @@ notes: ''
 This story involves creating the mapping layer to identify which Pokémon the player currently owns, and exactly which PC Box and Slot they reside in. This allows the Living Dex Tracker to display owned Pokémon in their current positions.
 
 ## Acceptance Criteria
+- [ ] task-273-327-living-dex-pc-mapping-impl
+- [ ] task-273-328-living-dex-pc-mapping-qa
+
 - [ ] Implement data mapping to identify existing Pokémon and their PC Box/Slot locations.
 
 ### SCHEMA

--- a/.foundry/tasks/task-273-327-living-dex-pc-mapping-impl.md
+++ b/.foundry/tasks/task-273-327-living-dex-pc-mapping-impl.md
@@ -1,0 +1,49 @@
+---
+id: task-273-327-living-dex-pc-mapping-impl
+type: TASK
+title: Living Dex PC Mapping Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-16'
+updated_at: '2026-07-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-133-273-living-dex-pc-mapping
+tags:
+  - living-dex
+  - data-mapping
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Living Dex PC Mapping Implementation
+
+## Context
+This task implements the mapping layer to identify which Pokémon the player currently owns and their exact PC Box and Slot locations. This data mapping allows the Living Dex Tracker to properly render and track owned Pokémon in their current positions.
+
+## Acceptance Criteria
+- [ ] Implement data mapping functions to extract PC Box and Slot locations for owned Pokémon.
+- [ ] Parse PC Box data correctly according to Gen 3 architecture specifications.
+
+## Technical Blueprint
+
+1. **Mapping Functions**:
+   - Write the data mapping layer that queries or parses the user's PC Box state to extract the ownership status and location (Box, Slot) of Pokémon.
+   - Utilize existing `PokeData` application data structure (with fully expanded property names as per ADR 015) when building the payload.
+
+2. **Gen 3 Save Parsing Constraints**:
+   - When extracting data from Gen 3 save files, you **MUST** use the dynamically resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
+   - **NO INLINE MAGIC NUMBERS**: All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level.
+
+3. **Architectural Scaffolding**:
+   - If this implementation requires complex shared state (like UI toggles or global states), you must define the React Context layer first before implementing dependent UI components to prevent tight coupling.
+   - Follow the tactical hardware aesthetic rules (ADR 008): `rounded-none`, `border-dashed`, and `font-mono`.
+
+## Important Reminders for the Coder
+
+- **Transient Failures**: If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures**: If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Submission**: If you submit an empty PR for a completed task (e.g., if the code already exists), you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-273-328-living-dex-pc-mapping-qa.md
+++ b/.foundry/tasks/task-273-328-living-dex-pc-mapping-qa.md
@@ -1,0 +1,50 @@
+---
+id: task-273-328-living-dex-pc-mapping-qa
+type: TASK
+title: Living Dex PC Mapping Verification
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-16'
+updated_at: '2026-07-16'
+depends_on:
+  - task-273-327-living-dex-pc-mapping-impl
+jules_session_id: null
+pr_number: null
+parent: story-133-273-living-dex-pc-mapping
+tags:
+  - living-dex
+  - qa
+  - data-mapping
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Living Dex PC Mapping Verification
+
+## Context
+This QA task verifies the implementation of the Living Dex PC Mapping layer. Because parsing save file memory and dynamically resolving A/B bank flash memory sections carries significant technical risk, the Intelligent Verification Protocol requires a dedicated QA pass to ensure strict adherence to Gen 3 architecture constraints.
+
+## Acceptance Criteria
+- [ ] Verify that data mapping functions correctly extract PC Box and Slot locations for owned Pokémon.
+- [ ] Verify that the Coder strictly utilized dynamically resolved section offsets for relative memory offset calculations instead of hardcoded absolute values for Gen 3 parsing.
+- [ ] Verify that there are absolutely NO inline magic numbers used for memory offsets, lengths, bit locations, or shifts, and that they are all defined as reusable module-level constants.
+
+## QA Verification Protocol
+
+1. **Review Gen 3 Memory Safety**:
+   - Inspect the DataView parsing code. Ensure that `section1Offset` (or similar resolved offsets) is used as the base for calculating the absolute positions in memory.
+   - Look for any arbitrary integers like `0x1000` or `1234` passed to DataView getters. If found, reject the implementation immediately.
+   - Verify that `RangeError` is properly caught when using the DataView API and thrown as 'The save file is corrupted or incomplete.'
+
+2. **Verify Architecture Constraints**:
+   - If React Context layers were scaffolded, verify they correctly decouple shared state from the UI components.
+   - If UI components were implemented, verify adherence to the tactical hardware aesthetic (ADR 008): `rounded-none`, `border-dashed`, and `font-mono`.
+
+## Important Reminders for the QA Persona
+
+- **Transient Failures**: If you experience a transient failure requiring retry during your testing, you MUST update the YAML frontmatter of your QA task to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failures**: If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Target Rejections**: If you reject the Coder's implementation, you MUST update the **TARGET task's** YAML frontmatter (`status: FAILED`, increment `rejection_count`, add `rejection_reason`) and do not check its Acceptance Criteria. You MUST NOT modify your own QA task's YAML frontmatter; instead, note the failure in your markdown body and submit an Empty PR.
+- **Empty PR Submission**: If you submit an empty PR for a successfully completed QA task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Created technical blueprints (TASKs) for the Living Dex PC Mapping story.

- Added `.foundry/tasks/task-273-327-living-dex-pc-mapping-impl.md` for the Coder persona.
- Added `.foundry/tasks/task-273-328-living-dex-pc-mapping-qa.md` for the QA persona.
- Appended the new tasks as unchecked checkboxes in the Acceptance Criteria of `.foundry/stories/story-133-273-living-dex-pc-mapping.md`.
- Adhered strictly to architectural constraints, Gen 3 save parsing instructions (no magic numbers, resolved section offsets), and empty PR checklist rules.

---
*PR created automatically by Jules for task [1958304095104093980](https://jules.google.com/task/1958304095104093980) started by @szubster*