### PR TITLE
🗃️ Archivist: Cleanup operational execution traces and duplicate journals

### DIFF
--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -129,10 +129,6 @@ When verifying `epic-104-133-gen3-lottery-offsets-research`, I learned that the 
 ## 2026-07-11: Automated Max Rejection Cancellation
 Successfully verified that the Automated Max Rejection Cancellation epic was correctly broken down into two child stories (`story-096-153-max-rejection-cancellation` and `story-096-154-parent-awakening-logic`) and that both stories were successfully completed.
 
-### epic-052-096-automated-max-rejection-cancellation
-- **Node**: `epic-052-096-automated-max-rejection-cancellation`
-- **Result**: Verification Passed.
-- **Notes**: The Epic was successfully broken down into stories `story-096-153-max-rejection-cancellation` and `story-096-154-parent-awakening-logic`. Both stories and their descendant task nodes were implemented, merged, and moved to COMPLETED status. The `foundry-orchestrator.ts` Phase 3.0 and Phase 3.6 correctly implemented the logic to handle max rejections and CANCELLED nodes, as verified by reading the scripts and running the test suite. All child nodes and their tasks are completely marked as `[x]`. I am submitting an empty PR to transition this node to COMPLETED.
 
 ## 2026-07-12
 **Architectural Constraint (State Machine UI Consistency):**

--- a/.foundry/journals/coder.md
+++ b/.foundry/journals/coder.md
@@ -89,7 +89,6 @@ Biome and Oxlint do not currently support custom JS linting rules. The built-in 
 Task task-267-262-bash-timeout-wrapper-impl was cancelled because `run_in_bash_session` is a built-in platform tool provided to agents, not a script or function defined within this repository's codebase. It is therefore impossible to implement a wrapper or linter for it from within the repo.
 
 ## 2026-07-10: Self-Verification of Party Zero HP Detection
-In task `task-269-263-detect-party-zero-hp-impl`, I verified the existing implementation of `getDeadPokemon` in `src/engine/nuzlocke/tracker.ts`. The function correctly extracts party Pokémon that have fainted (HP is 0). I ran `pnpm test` and confirmed that the tests in `src/engine/nuzlocke/tracker.test.ts` cover this functionality and pass successfully. Per the Intelligent Verification Protocol, I have self-verified this simple, low-risk task and am submitting an empty PR with the checked acceptance criteria.
 
 ## Session: task-267-287-gen3-move-tutor-emerald-impl
 

--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -42,4 +42,3 @@ To enforce the architecture correctly, all dynamic save block extraction functio
 - **Reason**: The developer reached max rejections by faking the relative offset calculation fix. They kept the absolute memory offsets and performed math manipulation, violating ADR 028.
 
 ## 2026-07-13 - Feebas Extraction Permanent Failure (Task: task-280-305-feebas-backend-integration-qa)
-The coder failed to properly implement relative memory offsets using `section1Offset` for Feebas seed extraction after multiple rejections. They used `section2Offset` instead of `section1Offset`, violating the architecture requirements of the Gen 3 A/B bank flash memory system. As they have reached the maximum rejection count, I have permanently failed the `task-280-304-feebas-backend-integration` by setting its status to `CANCELLED`.

--- a/.jules/trainer.md
+++ b/.jules/trainer.md
@@ -38,12 +38,6 @@
 **Action:** When evaluating `EVO_TRIGGER.BREED` (or general breeding recommendations), check `isInDaycare`. If true and `length === 1`, suggest "Need Partner" and advise leaving a compatible partner (like Ditto). If false, explicitly advise leaving the target AND a compatible partner.
 ## 2024-05-20 - Multi-stage Evolution Deduplication
 **Learning:** The suggestion engine previously generated redundant suggestions for multi-stage evolutions if multiple subsequent stages were missing (e.g., both Charmeleon and Charizard missing from Pokedex would generate two "Evolve Charmander" suggestions).
-**Action:** When iterating over , skip generation if  AND the intermediate  is also present in . This allows the engine to naturally generate a single "Path to" suggestion for the intermediate stage without flooding the UI.
-## 2024-05-20 - Intermediate Evolution Suggestion Clarity
-**Learning:** For multi-stage evolutions where an intermediate stage is required (e.g. "Path to #Charizard" needing a Charmeleon), the previous title ("Level Up Evolution") and description were misleading, implying the immediate evolution would yield the final target.
-**Action:** Dynamically rewrite the title (e.g., `Path to #${targetId}`) and description (e.g., `into #${immediateEvoTargetId} to progress towards #${targetId}`) when  to clarify the intermediate progression step.
-## 2024-05-20 - Multi-stage Evolution Deduplication
-**Learning:** The suggestion engine previously generated redundant suggestions for multi-stage evolutions if multiple subsequent stages were missing (e.g., both Charmeleon and Charizard missing from Pokedex would generate two "Evolve Charmander" suggestions).
 **Action:** When iterating over `immediateEvoTarget.det`, skip generation if `immediateEvoTargetId !== targetId` AND the intermediate `immediateEvoTargetId` is also present in `missingIds`. This allows the engine to naturally generate a single "Path to" suggestion for the intermediate stage without flooding the UI.
 ## 2024-05-20 - Intermediate Evolution Suggestion Clarity
 **Learning:** For multi-stage evolutions where an intermediate stage is required (e.g. "Path to #Charizard" needing a Charmeleon), the previous title ("Level Up Evolution") and description were misleading, implying the immediate evolution would yield the final target.


### PR DESCRIPTION
Removed duplicate learnings from auditor and trainer journals, and removed operational execution trace lines from qa and coder journals.

🎯 What
Cleaned up journal and memory files by removing duplicates and noise.

💡 Why
To improve context size and adhere to the guidelines which explicitly instruct agents not to use their journals as logbooks for routine execution traces. Duplicates bloat the prompt without adding value.

✅ Verification
Ran `pnpm lint` and `pnpm test`.

✨ Result
Journals are cleaner, contain fewer duplicates and focus more on architectural guidelines and critical learnings.

---
*PR created automatically by Jules for task [12957264672762274391](https://jules.google.com/task/12957264672762274391) started by @szubster*