### PR TITLE
🧭 Strategist: prompt improvement - Remove duplicate Bash Session Timeout warnings

### DIFF
--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -23,7 +23,6 @@ You are the Auditor persona in the Foundry system. Your role is to assess and ve
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
 
-**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
 
 
 

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -48,7 +48,6 @@ Your private journal is `.foundry/journals/coder.md`. You MUST adhere to the **J
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
 
-**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
 
 
 ## Architectural Compliance & QA Rejections

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -59,7 +59,6 @@ If a cancelled or replaced task node is reawakened (e.g., because its previous i
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
 
-**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
 
 
 ## Architectural Enforcement

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -37,7 +37,6 @@ Your private journal is `.foundry/journals/tech_lead.md`. You MUST adhere to the
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
 
-**WARNING ON BASH SESSIONS:** When using `run_in_bash_session`, do NOT execute blocking commands (e.g., `tail -f`). This will cause the session to hang indefinitely and fail. Use non-blocking alternatives like `cat` or `tail -n`.
 
 ## Architectural Scaffolding
 If a Story involves complex shared state or architectural patterns (such as those mandated by ADR 013 and ADR 017), your blueprints MUST provide explicit scaffolding instructions. For example, explicitly instruct the coder to define the React Context layer first before implementing the UI components, to prevent tight coupling and permanent failures.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -375,3 +375,9 @@
 **Outcome:** Merged
 **Why:** The `qa.md` journal recorded on 2026-07-11 that the `coder` had a task rejected because they failed to handle `RangeError` from the `DataView` API when checking for out-of-bounds reads. The `tech_lead.md` journal also notes explicitly mandating this in blueprints. Adding this instruction to the coder's prompt proactively prevents these QA rejections and aligns the coder with the expected standard.
 **Pattern:** Codify specific, recurring architectural requirements and error handling rules (like catching `RangeError` from `DataView` and throwing a specific error message) directly into the implementer's prompt (`coder.md`) to prevent brittle code and repetitive QA rejections.
+
+## 2026-07-29 - [Accepted] - Prompt Consolidation - Remove duplicate Bash Session Timeout warnings
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The warning about bash sessions (`do NOT execute blocking commands...`) was duplicated across several agent prompts (`coder.md`, `qa.md`, `tech_lead.md`, `auditor.md`), while it is already centralized in `.foundry/docs/knowledge_base/agents/core_policies.md` under `Bash Session Timeout Policy`.
+**Pattern:** Remove duplicated instructions in individual agent prompts if they are already covered by centralized policy files (e.g., `core_policies.md`). This reduces context bloat and ensures a single source of truth for core rules.


### PR DESCRIPTION
**Proposal**: Remove the duplicated bash session timeout warnings (`do NOT execute blocking commands...`) from `auditor.md`, `coder.md`, `qa.md`, and `tech_lead.md`.
**Justification**: This rule is already fully centralized in `.foundry/docs/knowledge_base/agents/core_policies.md` under `Bash Session Timeout Policy`.
**Evidence**: Agent prompts were unnecessarily bloated with a duplicated paragraph already handled by their mandatory read of `core_policies.md`. The journal learning is also included.

---
*PR created automatically by Jules for task [13940547235882625354](https://jules.google.com/task/13940547235882625354) started by @szubster*