### PR TITLE
Create retry 7 tasks for Gen 3 TV parser

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -184,3 +184,5 @@ When generating blueprints for Gen 3 dynamic save block extraction (like Volcani
 - Created implementation task `task-320-322-gen3-contest-frontier-impl`.
 - Created QA task `task-320-323-gen3-contest-frontier-qa` following the Intelligent Verification Protocol due to memory parsing complexity and A/B bank relative offset resolution requirements.
 - Explicitly instructed the Coder and QA personas on error handling, Empty PR requirements, and strict magic number / relative offset rules.
+
+2026-07-16: Created retry 7 for Gen 3 TV parser because retry 6 failed QA due to inline magic numbers and incorrect error message string.

--- a/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
+++ b/.foundry/stories/story-081-121-gen3-tv-block-dataview-parser.md
@@ -50,5 +50,7 @@ Implement the foundational logic to locate and read the TV broadcast data block 
 - [x] task-121-281-gen3-tv-block-parser-retry4-qa
 - [x] task-121-304-gen3-tv-block-parser-retry5-impl
 - [x] task-121-305-gen3-tv-block-parser-retry5-qa
-- [ ] task-121-309-gen3-tv-block-parser-retry6-impl
-- [ ] task-121-310-gen3-tv-block-parser-retry6-qa
+- [x] task-121-309-gen3-tv-block-parser-retry6-impl
+- [x] task-121-310-gen3-tv-block-parser-retry6-qa
+- [ ] task-121-327-gen3-tv-block-parser-retry7-impl
+- [ ] task-121-328-gen3-tv-block-parser-retry7-qa

--- a/.foundry/tasks/task-121-327-gen3-tv-block-parser-retry7-impl.md
+++ b/.foundry/tasks/task-121-327-gen3-tv-block-parser-retry7-impl.md
@@ -1,0 +1,63 @@
+---
+id: task-121-327-gen3-tv-block-parser-retry7-impl
+type: TASK
+title: Implement Gen 3 TV Block DataView Parser (Retry 7)
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-16'
+updated_at: '2026-07-16'
+depends_on:
+  - .foundry/tasks/task-121-310-gen3-tv-block-parser-retry6-qa.md
+jules_session_id: null
+pr_number: null
+parent: story-081-121-gen3-tv-block-dataview-parser
+tags:
+  - feature
+  - gen3
+  - data-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Gen 3 TV Block DataView Parser (Retry 7)
+
+## Description
+This task requires you to implement the foundational logic to locate and read the TV broadcast data block from the Gen 3 save file structure, addressing the QA failure from Retry 6.
+
+As mandated by **ADR 010**, you MUST strictly utilize the `DataView` API for all new Gen 3 data parsing logic to ensure robustness and safety. You must avoid legacy `Uint8Array` manual read methods and instead use `DataView` methods such as `getUint8`, `getUint16`, etc., to enforce native bounds checking.
+
+Any out-of-bounds reads or structurally corrupt states within the TV block MUST trigger a gracefully caught `RangeError`.
+**CRITICAL:** When throwing or handling this `RangeError`, the error message text MUST be exactly `"The save file is corrupted or incomplete."` with no additional text.
+
+**CRITICAL CONSTRAINT:** All memory offsets, lengths, bit locations, and shifts MUST be defined as reusable constants at the module level. Inline magic numbers (e.g., `+ 2`, `+ 4`, `+ 6`) are strictly forbidden. You MUST explicitly use the following module-level constants (or similar semantic names) based on the research findings:
+- `TVGROUP_RECORD_MIX_START = 21`
+- `TVGROUP_RECORD_MIX_END = 40`
+- `TVSHOW_STRUCT_SIZE = 36`
+- `TV_SHOWS_COUNT = 25`
+- `TVSHOW_MASS_OUTBREAK = 41`
+- `OUTBREAK_MOVES_OFFSET = 0x04`
+- `OUTBREAK_SPECIES_OFFSET = 0x0C`
+- `OUTBREAK_MAP_NUM_OFFSET = 0x10`
+- `OUTBREAK_MAP_GROUP_OFFSET = 0x11`
+- `OUTBREAK_PROBABILITY_OFFSET = 0x13`
+- `OUTBREAK_LEVEL_OFFSET = 0x14`
+- `OUTBREAK_DAYS_BEFORE_OFFSET = 0x16`
+- `OUTBREAK_LANGUAGE_OFFSET = 0x18`
+
+Any size, ID, or increment constants must NOT be hardcoded inline inside parsing functions.
+
+When parsing Gen 3 save files, memory offsets must be calculated as relative offsets from the resolved section offset (e.g., `section1Offset + 0x90`) rather than using absolute memory offsets (e.g., `0x142c`).
+
+## Acceptance Criteria
+- [ ] The TV block extraction logic is built entirely using `DataView`.
+- [ ] All memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level (no inline magic numbers).
+- [ ] Memory offsets are calculated as relative offsets from the resolved section offset.
+- [ ] Explicit error handling catches `RangeError` exceptions natively thrown by `DataView`, translating it to an Error with message exactly `"The save file is corrupted or incomplete."`.
+- [ ] New parsing functions conform to the existing Gen 1 and Gen 2 backward-compatible parsing interfaces without breaking them.
+
+## Important Protocols (For Coder)
+- **Transient Failure:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **Permanent Failure:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Protocol:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.foundry/tasks/task-121-328-gen3-tv-block-parser-retry7-qa.md
+++ b/.foundry/tasks/task-121-328-gen3-tv-block-parser-retry7-qa.md
@@ -1,0 +1,61 @@
+---
+id: task-121-328-gen3-tv-block-parser-retry7-qa
+type: TASK
+title: QA - Implement Gen 3 TV Block DataView Parser (Retry 7)
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-16'
+updated_at: '2026-07-16'
+depends_on:
+  - .foundry/tasks/task-121-327-gen3-tv-block-parser-retry7-impl.md
+jules_session_id: null
+pr_number: null
+parent: story-081-121-gen3-tv-block-dataview-parser
+tags:
+  - feature
+  - gen3
+  - data-parsing
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Task: Verify Gen 3 TV Block DataView Parser (Retry 7)
+
+## Description
+This task requires you to verify the implementation of the Gen 3 TV Block DataView parser performed in `task-121-327-gen3-tv-block-parser-retry7-impl`.
+
+You must strictly verify that the coder has adhered to **ADR 010** and used the `DataView` API exclusively. You must also verify that **ALL** memory offsets, lengths, bit locations, and shifts have been defined as module-level constants and that no inline magic numbers (e.g. `+ 2`, `+ 4`, `+ 6`) were used in the parsing logic.
+
+Specifically, check for the presence and usage of the following constants based on research:
+- `TVGROUP_RECORD_MIX_START = 21`
+- `TVGROUP_RECORD_MIX_END = 40`
+- `TVSHOW_STRUCT_SIZE = 36`
+- `TV_SHOWS_COUNT = 25`
+- `TVSHOW_MASS_OUTBREAK = 41`
+- `OUTBREAK_MOVES_OFFSET = 0x04`
+- `OUTBREAK_SPECIES_OFFSET = 0x0C`
+- `OUTBREAK_MAP_NUM_OFFSET = 0x10`
+- `OUTBREAK_MAP_GROUP_OFFSET = 0x11`
+- `OUTBREAK_PROBABILITY_OFFSET = 0x13`
+- `OUTBREAK_LEVEL_OFFSET = 0x14`
+- `OUTBREAK_DAYS_BEFORE_OFFSET = 0x16`
+- `OUTBREAK_LANGUAGE_OFFSET = 0x18`
+
+Ensure that the coder uses the resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets.
+
+Finally, verify that the `RangeError` caught includes the exact text `"The save file is corrupted or incomplete."`.
+
+## Acceptance Criteria
+- [ ] Verified that the TV block extraction logic strictly utilizes `DataView`.
+- [ ] Verified that no inline magic numbers were used, and all offsets/lengths are reusable constants at the module level.
+- [ ] Verified that relative offsets from the resolved section offset are used, instead of absolute offsets.
+- [ ] Verified that out-of-bounds reads gracefully throw a caught `RangeError` with the exact message text `"The save file is corrupted or incomplete."`.
+- [ ] Verified that existing interfaces were not broken.
+
+## Important Protocols (For QA)
+- **Transient Failure:** If you experience a transient failure requiring retry or if the Coder's implementation is incorrect, you MUST update the YAML frontmatter to `status: FAILED` with a detailed `rejection_reason`.
+- **Permanent Failure:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **Empty PR Protocol:** If you submit an empty PR for a completed QA task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
This PR creates the Retry 7 implementation and QA tasks for parsing the Gen 3 TV block using DataView. It also updates the parent story node by checking off the failed tasks and appending the new ones, and adds a journal entry to document this action.

---
*PR created automatically by Jules for task [4634479930571772443](https://jules.google.com/task/4634479930571772443) started by @szubster*