### PR TITLE
qa: Verify RNG TID and SID Display Component

### DIFF
--- a/.foundry/tasks/task-269-263-rng-tid-sid-component-qa.md
+++ b/.foundry/tasks/task-269-263-rng-tid-sid-component-qa.md
@@ -32,10 +32,10 @@ Verify the newly implemented RNG TID and SID Display component meets all require
 - Verify that the component is actually integrated and renderable in the application.
 
 ## Acceptance Criteria
-- [ ] Verified TID and SID display.
-- [ ] Verified "Copy to Clipboard" functionality.
-- [ ] Verified tactical hardware aesthetic styling.
-- [ ] Verified integration and rendering.
+- [x] Verified TID and SID display.
+- [x] Verified "Copy to Clipboard" functionality.
+- [x] Verified tactical hardware aesthetic styling.
+- [x] Verified integration and rendering.
 
 ## Constraints & Reminders
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Checked off acceptance criteria in the QA task node after verifying the implementation meets all requirements (display, copy functionality, tactical hardware styling, and rendering). Tests are passing.

---
*PR created automatically by Jules for task [11578555142251076998](https://jules.google.com/task/11578555142251076998) started by @szubster*