### PR TITLE
Generate Epics for DAG Utilities Module

### DIFF
--- a/.foundry/epics/epic-036-329-shared-dag-utilities.md
+++ b/.foundry/epics/epic-036-329-shared-dag-utilities.md
@@ -1,10 +1,10 @@
 ---
-id: epic-036-053-shared-dag-utilities
+id: epic-036-329-shared-dag-utilities
 type: EPIC
 title: Shared DAG Utilities Module
-status: FAILED
+status: PENDING
 owner_persona: story_owner
-created_at: '2026-05-31'
+created_at: '2026-07-16'
 updated_at: '2026-07-16'
 depends_on: []
 jules_session_id: null
@@ -15,10 +15,8 @@ tags:
   - orchestrator
 research_references: []
 rejection_count: 0
-rejection_reason: >-
-  [ACKNOWLEDGED] Merged with unfulfilled acceptance criteria: Missing
-  E2E/integration story
-notes: Spawned from prd-067-036-extract-dag-utils.
+rejection_reason: ''
+notes: Spawned from prd-067-036-extract-dag-utils. Replaces failed epic-036-053-shared-dag-utilities.
 ---
 
 # Extract Shared DAG Utilities
@@ -34,19 +32,16 @@ This epic extracts pure functions from `.github/scripts/foundry-orchestrator.ts`
   - `getOrphanedNodes(startNodePath, reverseGraph)`
 - Create unit tests for complex logic within `dag-utils.ts`.
 - Update the DAG orchestration tests to use the new module.
+- Provide End-to-End/Integration stories to fully satisfy previously failed acceptance criteria.
 
 ## Next Steps
-- [x] story-053-278-extract-log-to-journal
-- [x] Story Owner: Write Story to create the `dag-utils.ts` module with pure functions and basic utilities.
-  - Spawned: `.foundry/archive/stories/story-053-090-extract-dag-utilities.md`
-
-
-- [x] Story Owner: Write Story to create unit tests for `dag-utils.ts`.
-  - Spawned: `.foundry/archive/stories/story-053-106-dag-utils-unit-tests.md`
-- [x] Story Owner: Write Story to update DAG orchestration tests.
-  - Spawned: `.foundry/archive/stories/story-053-107-update-dag-orchestration-tests.md`
+- [ ] .foundry/stories/story-329-331-extract-dag-utilities.md
+- [ ] .foundry/stories/story-329-332-dag-utils-unit-tests.md
+- [ ] .foundry/stories/story-329-333-update-dag-orchestration-tests.md
+- [ ] .foundry/stories/story-329-334-e2e-integration-test.md
 
 ## Acceptance Criteria
-- [x] `dag-utils.ts` is created and contains the extracted pure functions and utilities.
-- [x] New unit tests are written for `dag-utils.ts`.
-- [x] Existing tests still pass.
+- [ ] `dag-utils.ts` is created and contains the extracted pure functions and utilities.
+- [ ] New unit tests are written for `dag-utils.ts`.
+- [ ] Existing tests still pass.
+- [ ] E2E integration test confirms behavior is unaffected across orchestrator functions.

--- a/.foundry/epics/epic-036-330-unify-state-transitions.md
+++ b/.foundry/epics/epic-036-330-unify-state-transitions.md
@@ -1,13 +1,13 @@
 ---
-id: epic-036-054-unify-state-transitions
+id: epic-036-330-unify-state-transitions
 type: EPIC
 title: Unify DAG Node State Transitions
 status: PENDING
 owner_persona: story_owner
-created_at: '2026-05-31'
-updated_at: '2026-05-31'
+created_at: '2026-07-16'
+updated_at: '2026-07-16'
 depends_on:
-  - epic-036-053-shared-dag-utilities
+  - epic-036-329-shared-dag-utilities
 jules_session_id: null
 parent: prd-067-036-extract-dag-utils
 tags:
@@ -17,7 +17,7 @@ tags:
 research_references: []
 rejection_count: 0
 rejection_reason: ''
-notes: Spawned from prd-067-036-extract-dag-utils.
+notes: Spawned from prd-067-036-extract-dag-utils. Replaces epic-036-054-unify-state-transitions.
 ---
 
 # Unify DAG Node State Transitions
@@ -34,7 +34,7 @@ This epic extracts state transition functions into the new shared module `.githu
 - Ensure the state transitions apply ADR 006 and handle metadata consistently.
 
 ## Next Steps
-- [ ] Story Owner: Write Story to extract and use transition functions.
+- [ ] .foundry/stories/story-330-335-extract-transition-functions.md
 
 ## Acceptance Criteria
 - [ ] State transition functions are centralized in `dag-utils.ts`.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -58,3 +58,6 @@ Successfully broke down the "Missed Trainer Radar" PRD (`prd-104-109-missed-trai
 **Important Reminders:**
 - Temporary processing files (like `batch_*` logs from bash commands) must be manually deleted before committing to avoid polluting the workspace.
 - The `depends_on` array in the YAML frontmatter MUST use the bare node ID (e.g., `epic-109-306-missed-trainer-data-extraction-gen1-gen2`), not the relative file path.
+
+## 2026-07-16: Replacement of FAILED and CANCELLED Epics
+When spawning new epics to replace previously FAILED or CANCELLED epics, it is important to include explicit research into the rejection reason provided in the failed node's frontmatter. In this case, `epic-036-053-shared-dag-utilities.md` was FAILED due to `[ACKNOWLEDGED] Merged with unfulfilled acceptance criteria: Missing E2E/integration story`. The replacement epic, `epic-036-329-shared-dag-utilities.md`, was created with a specific scope item and acceptance criteria added for the missing E2E integration story. Old nodes were removed and references in the parent PRD were replaced with the new ones.

--- a/.foundry/prds/prd-067-036-extract-dag-utils.md
+++ b/.foundry/prds/prd-067-036-extract-dag-utils.md
@@ -48,8 +48,8 @@ Create `.github/scripts/dag-utils.ts`.
 
 ## Next Steps
 - [x] Epic Planner: Evaluate this PRD and convert it to Epics to extract the DAG utilities to a shared module.
-- [ ] .foundry/epics/epic-036-053-shared-dag-utilities.md
-- [ ] .foundry/epics/epic-036-054-unify-state-transitions.md
+- [ ] .foundry/epics/epic-036-329-shared-dag-utilities.md
+- [ ] .foundry/epics/epic-036-330-unify-state-transitions.md
 
 ## Acceptance Criteria
 - [ ] `dag-utils.ts` created with shared functions.


### PR DESCRIPTION
This PR transitions `prd-067-036-extract-dag-utils` into detailed Epic blueprints as required by the Epic Planner persona.

The previously failed Epics were removed and successfully replaced with robust Epics that explicitly capture the orchestrator E2E integration testing constraints, properly linked to the parent PRD.

---
*PR created automatically by Jules for task [4296716186946512330](https://jules.google.com/task/4296716186946512330) started by @szubster*