### PR TITLE
Verify story-130-269-rng-tid-sid-component

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -184,3 +184,7 @@ When generating blueprints for Gen 3 dynamic save block extraction (like Volcani
 - Created implementation task `task-320-322-gen3-contest-frontier-impl`.
 - Created QA task `task-320-323-gen3-contest-frontier-qa` following the Intelligent Verification Protocol due to memory parsing complexity and A/B bank relative offset resolution requirements.
 - Explicitly instructed the Coder and QA personas on error handling, Empty PR requirements, and strict magic number / relative offset rules.
+## 2026-07-16: RNG TID and SID Display Component
+- **Observation**: Tasked with story-130-269-rng-tid-sid-component where all its generated children have completed successfully.
+- **Action**: Checked off the child checkboxes and acceptance criteria in the story markdown body and submitted an empty PR.
+- **Lesson**: Handing back control to the orchestrator properly.

--- a/.foundry/stories/story-130-269-rng-tid-sid-component.md
+++ b/.foundry/stories/story-130-269-rng-tid-sid-component.md
@@ -26,10 +26,10 @@ Design and implement a reusable UI component that clearly displays both the Trai
 
 ## Acceptance Criteria
 - [x] Tech Lead: Generate actionable Tasks.
-- [ ] Component displays TID and SID.
-- [ ] Component includes a "Copy to Clipboard" feature that formats them appropriately for RNG tools.
-- [ ] task-269-262-rng-tid-sid-component-impl
-- [ ] task-269-263-rng-tid-sid-component-qa
+- [x] Component includes a "Copy to Clipboard" feature that formats them appropriately for RNG tools.
+- [x] Component displays TID and SID.
+- [x] task-269-262-rng-tid-sid-component-impl
+- [x] task-269-263-rng-tid-sid-component-qa
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Checked off completed child tasks and acceptance criteria for `story-130-269-rng-tid-sid-component`. Modified `.foundry/journals/tech_lead.md` to append a journal entry.

---
*PR created automatically by Jules for task [6428404085085240292](https://jules.google.com/task/6428404085085240292) started by @szubster*