### PR TITLE
Draft technical blueprints for Gen 2 Event Flag Parsing

### DIFF
--- a/.foundry/stories/story-137-294-gen2-event-flag-parsing.md
+++ b/.foundry/stories/story-137-294-gen2-event-flag-parsing.md
@@ -25,5 +25,5 @@ Extract the event flags for Gen 2 static encounters from the save file. This inv
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] task-294-316-gen2-static-encounter-flags-impl
-- [ ] task-294-317-gen2-static-encounter-flags-qa
+- [ ] task-294-329-gen2-static-encounter-flags-impl
+- [ ] task-294-330-gen2-static-encounter-flags-qa

--- a/.foundry/tasks/task-294-329-gen2-static-encounter-flags-impl.md
+++ b/.foundry/tasks/task-294-329-gen2-static-encounter-flags-impl.md
@@ -1,0 +1,47 @@
+---
+id: task-294-329-gen2-static-encounter-flags-impl
+type: TASK
+title: Gen 2 Static Encounter Event Flag Parsing Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-16'
+updated_at: '2026-07-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-137-294-gen2-event-flag-parsing
+tags:
+  - gen2
+  - backend
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Static Encounter Event Flag Parsing Implementation
+
+Implement the parsing logic to extract event flags for Gen 2 static encounters from the save file. This includes specific encounters like Sudowoodo, Snorlax, Red Gyarados, Ho-Oh, and Lugia. The extracted data must be exposed to the state management layer.
+
+## Context and Requirements
+1. **Event Flags Region**: The event flags are located exactly 256 bytes prior to `wCurBox` (`0x2624` for Gold/Silver English, `0x2600` for Crystal English). See `.foundry/docs/knowledge_base/engine/save_parsing/gen2_generic_structure.md`.
+2. **Bitwise Extraction**: Adhere strictly to **ADR 026**. Parsers MUST use explicit bitwise shifting (`>>`) and masking (`&`) to isolate multi-value bitfields or extract single-bit properties into boolean states.
+3. **Module-level Constants**: All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level. Inline magic numbers for memory operations are strictly forbidden.
+
+## Technical Contract
+- **Module:** Target the Gen 2 save parsing module (`src/engine/saveParser/gen2/` or similar).
+- **Constants:** All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level.
+- **No Magic Numbers:** Inline magic numbers are strictly forbidden for memory operations.
+- **Data Exposure:** Ensure the parsed event flags are correctly mapped and exposed to the central state management layer for use by the UI.
+
+## Important Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement event flag extraction for Gen 2 static encounters (Sudowoodo, Snorlax, Red Gyarados, Ho-Oh, Lugia).
+- [ ] Define all memory offsets, lengths, bit locations, and shifts as module-level constants.
+- [ ] Expose the extracted data to the state management layer.
+- [ ] Write or update unit tests to verify parsing logic.

--- a/.foundry/tasks/task-294-330-gen2-static-encounter-flags-qa.md
+++ b/.foundry/tasks/task-294-330-gen2-static-encounter-flags-qa.md
@@ -1,0 +1,49 @@
+---
+id: task-294-330-gen2-static-encounter-flags-qa
+type: TASK
+title: QA - Gen 2 Static Encounter Event Flag Parsing
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-16'
+updated_at: '2026-07-16'
+depends_on:
+  - task-294-329-gen2-static-encounter-flags-impl
+jules_session_id: null
+pr_number: null
+parent: story-137-294-gen2-event-flag-parsing
+tags:
+  - qa
+  - gen2
+  - backend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA - Gen 2 Static Encounter Event Flag Parsing
+
+Verify the implementation of Gen 2 static encounter event flag parsing.
+
+## Verification Requirements
+1. **Constant Enforcement**: Verify that all byte offsets, bit shifts, and masks are defined as module-level constants and NO magic numbers are used in the bitwise logic.
+2. **ADR 026 Compliance**: Verify that explicit bitwise shifting (`>>`) and masking (`&`) are used.
+3. **Test Coverage**: Ensure that the unit tests accurately cover the absolute zero state and the boundary states for each of the relevant flags (Sudowoodo, Snorlax, Red Gyarados, Ho-Oh, Lugia).
+
+## QA Contract
+- Review the implemented code to ensure all memory offsets, lengths, bit locations, and shifts are defined as reusable module-level constants.
+- Reject the implementation if any inline magic numbers are used for memory operations.
+- Verify that the parsed event flags are correctly exposed to the state management layer.
+- Ensure that unit tests are present and pass successfully.
+
+## Important Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify module-level constants for memory operations.
+- [ ] Verify no magic numbers are used inline.
+- [ ] Verify explicit bitwise logic (`&`, `>>`) is used per ADR 026.
+- [ ] Verify data exposure to the state management layer.
+- [ ] Verify unit tests correctly assert the 0 and 1 states of the required static encounter flags.


### PR DESCRIPTION
Creates specific, actionable technical TASK nodes for Gen 2 static encounter event flag parsing. The tasks are set to enforce the use of module-level constants for memory offsets and shifts as requested by the negative constraints. The Story markdown checklist has been accurately updated with the new node IDs without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [2253038913214513075](https://jules.google.com/task/2253038913214513075) started by @szubster*