### PR TITLE
fix: update foundry validation scripts to be archive-aware

### DIFF
--- a/.foundry/epics/epic-112-310-gen2-shiny-breeding-ui.md
+++ b/.foundry/epics/epic-112-310-gen2-shiny-breeding-ui.md
@@ -16,7 +16,7 @@ tags:
   - breeding
   - ui
 research_references:
-  - .foundry/docs/adrs/024-tailwind-v4-utility-consolidation.md
+  - .foundry/archive/docs/adrs/024-tailwind-v4-utility-consolidation.md
   - .foundry/docs/knowledge_base/tailwind_v4_utilities.md
 rejection_count: 0
 rejection_reason: ''

--- a/.foundry/prds/prd-068-037-hidden-items-finder.md
+++ b/.foundry/prds/prd-068-037-hidden-items-finder.md
@@ -53,6 +53,6 @@ As DexHelper already parses the save file, we can read the underlying event flag
 - [ ] E2E tests verify the new view correctly renders based on an initialized save state.
 
 ## 4. Generated Epics
-- [Parse Hidden Item Event Flags](../epics/epic-037-058-hidden-items-save-parsing.md)
-- [Hidden Items Data Structure & Aggregation](../epics/epic-037-059-hidden-items-data-layer.md)
+  - [epic-037-058-hidden-items-save-parsing](../archive/epics/epic-037-058-hidden-items-save-parsing.md)
+  - [epic-037-059-hidden-items-data-layer](../archive/epics/epic-037-059-hidden-items-data-layer.md)
 - [Missing Hidden Items Finder UI](../epics/epic-037-060-hidden-items-ui.md)

--- a/.foundry/tasks/task-277-322-gen3-trick-house-parser-qa.md
+++ b/.foundry/tasks/task-277-322-gen3-trick-house-parser-qa.md
@@ -19,8 +19,8 @@ tags:
   - testing
 research_references:
   - .foundry/docs/knowledge_base/gen3_trick_house_offsets.md
-  - .foundry/docs/adrs/010-gen3-data-parsing.md
-  - .foundry/docs/adrs/adr-061-026-bitwise-state-extraction.md
+  - .foundry/archive/docs/adrs/010-gen3-data-parsing.md
+  - .foundry/archive/docs/adrs/adr-061-026-bitwise-state-extraction.md
 rejection_count: 0
 rejection_reason: ''
 notes: ''

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -19,23 +19,19 @@ function resolveNodeIdToPath(nodeId: string): string {
   const folder = folderMap[type];
   if (!folder) return nodeId;
 
-  const rootPath = `.foundry/${nodeId}.md`;
-  if (fs.existsSync(rootPath)) {
-    return rootPath;
-  }
+  const possiblePaths = [
+    `.foundry/${nodeId}.md`,
+    `.foundry/${folder}/${nodeId}.md`,
+    `.foundry/archive/${folder}/${nodeId}.md`,
+    `.foundry/archive/${nodeId}.md`,
+    `.foundry/docs/adrs/${nodeId}.md`,
+    `.foundry/archive/docs/adrs/${nodeId}.md`
+  ];
 
-  const basePath = `.foundry/${folder}/${nodeId}.md`;
-  if (fs.existsSync(basePath)) {
-    return basePath;
-  }
-  const archivePath = `.foundry/archive/${folder}/${nodeId}.md`;
-  if (fs.existsSync(archivePath)) {
-    return archivePath;
-  }
-
-  const rootArchivePath = `.foundry/archive/${nodeId}.md`;
-  if (fs.existsSync(rootArchivePath)) {
-    return rootArchivePath;
+  for (const p of possiblePaths) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
   }
 
   return nodeId;
@@ -114,7 +110,7 @@ function checkLinks() {
   let hasErrors = false;
 
   for (const file of files) {
-    if (!file.endsWith('.md')) {
+    if (!file.endsWith('.md') || file.includes('/archive/')) {
       continue;
     }
 

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -147,11 +147,20 @@ function validateSchema() {
       }
     }
 
-    // 2.7 Validate paths
+    // 2.7 Validate paths (including archive check)
+    const checkPathExists = (p: string) => {
+      if (fs.existsSync(p)) return true;
+      if (p.startsWith('.foundry/') && !p.includes('/archive/')) {
+        const archivedPath = p.replace('.foundry/', '.foundry/archive/');
+        if (fs.existsSync(archivedPath)) return true;
+      }
+      return false;
+    };
+
     if (data['depends_on'] && Array.isArray(data['depends_on'])) {
       for (const dep of data['depends_on']) {
         if (typeof dep === 'string' && dep.includes('/')) {
-          if (!fs.existsSync(dep)) {
+          if (!checkPathExists(dep)) {
             console.error(`Error: Dependency path does not exist: '${dep}' in file ${file}`);
             hasError = true;
           }
@@ -162,7 +171,7 @@ function validateSchema() {
     if (data['research_references'] && Array.isArray(data['research_references'])) {
       for (const ref of data['research_references']) {
         if (typeof ref === 'string' && ref.includes('/')) {
-          if (!fs.existsSync(ref)) {
+          if (!checkPathExists(ref)) {
             console.error(`Error: Research reference path does not exist: '${ref}' in file ${file}`);
             hasError = true;
           }
@@ -172,7 +181,7 @@ function validateSchema() {
 
     if (data['parent']) {
       if (typeof data['parent'] === 'string' && data['parent'].includes('/')) {
-        if (!fs.existsSync(data['parent'])) {
+        if (!checkPathExists(data['parent'])) {
           console.error(`Error: Parent path does not exist: '${data['parent']}' in file ${file}`);
           hasError = true;
         }


### PR DESCRIPTION
This PR fixes CI failures by making the Foundry schema and link validation scripts aware of the `archive/` directory structure. Documentation files that were recently moved to the archive were causing validation errors in active nodes that referenced them.

Key changes:
- **`scripts/validate-foundry-schema.ts`**: Introduced a fallback check that looks for files in `.foundry/archive/` if the primary path (e.g., in `depends_on` or `research_references`) is not found.
- **`scripts/check-links.ts`**: 
    - Added a filter to skip link validation for any file residing in an `/archive/` directory, as these are historical and expected to have stale links.
    - Enhanced `resolveNodeIdToPath` to search across multiple possible locations including `docs/adrs/` and their archived counterparts.
- **Data Fixes**: Updated several active Foundry nodes (`EPIC`, `TASK`, `PRD`) that had broken internal links or research references due to the recent archiving of ADRs and Epics.

Verification:
- `node --experimental-strip-types scripts/validate-foundry-schema.ts` passes.
- `node --experimental-strip-types scripts/check-links.ts $(find .foundry -name "*.md")` passes.
- Full `pnpm lint`, `pnpm type-check`, and `pnpm test` suite passed successfully.

Fixes #4661

---
*PR created automatically by Jules for task [16797758083387740189](https://jules.google.com/task/16797758083387740189) started by @szubster*