### PR TITLE
Transform idea-117-split-bundles-and-data into PRD

### DIFF
--- a/.foundry/ideas/idea-117-split-bundles-and-data.md
+++ b/.foundry/ideas/idea-117-split-bundles-and-data.md
@@ -39,6 +39,7 @@ Implement generation-based splitting for JavaScript engine logic, UI components,
 - **Better Resource Management**: Only load the data, code, and UI the user actually needs.
 
 ## Acceptance Criteria
+- [ ] prd-117-116-split-bundles-and-data
 - [x] Research conducted on bundle size distribution and potential gains (`research-117-325-bundle-splitting-analysis`).
 - [x] Architectural strategy documented in an ADR (`adr-117-029-bundle-splitting-strategy`).
 - [ ] Save parsers refactored to use dynamic imports in `src/engine/saveParser/index.ts`.

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -59,3 +59,7 @@ During the resurrection loop for `idea-066-save-file-health-scanner` (Attempt 5)
 **Action & Constraint:**
 When assigned to a macro node (like an IDEA) that has spawned children, DO NOT transition it to VERIFYING (by submitting an Empty PR with all boxes checked) until ALL descendant nodes have transitioned to COMPLETED. If the downstream nodes are still PENDING, you MUST keep the macro node in a PENDING state. To do this, uncheck the Acceptance Criteria checkbox corresponding to the uncompleted downstream dependency and submit the PR. This breaks the premature verification loop and allows the system to wait for downstream implementation.
 
+
+## 2026-07-16 - Anomaly Found
+
+When generating the PRD for `idea-117-split-bundles-and-data`, I noticed that the research and ADR references (`research-117-325-bundle-splitting-analysis` and `adr-117-029-bundle-splitting-strategy`) already existed and were marked as completed in the IDEA node's acceptance criteria.

--- a/.foundry/prds/prd-117-116-split-bundles-and-data.md
+++ b/.foundry/prds/prd-117-116-split-bundles-and-data.md
@@ -1,0 +1,53 @@
+---
+id: prd-117-116-split-bundles-and-data
+type: PRD
+title: Split bundles and data by game generation
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-16'
+updated_at: '2026-07-16'
+depends_on:
+  - .foundry/ideas/idea-117-split-bundles-and-data.md
+jules_session_id: null
+pr_number: null
+parent: idea-117-split-bundles-and-data
+tags:
+  - performance
+  - architecture
+  - bundles
+research_references:
+  - research-117-325-bundle-splitting-analysis
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Split bundles and data by game generation
+
+## 1. Problem Statement
+As DexHelper supports more Pokémon generations, the amount of code (parsers, strategies) and data (encounters, locations) is increasing. Currently, everything is loaded upfront, which affects initial load performance and memory usage.
+
+## 2. Goals & Objectives
+*   **Performance:** Reduce initial load time (~30-50%).
+*   **Efficiency:** Improve runtime memory efficiency by not loading irrelevant generation logic/UI.
+*   **Scalability:** Create a future-proof architecture for Gen 4+.
+
+## 3. Scope
+*   **Engine Code Splitting:** Generation-specific logic will be moved behind dynamic imports (`import()`).
+    *   Save Parsers: Refactor `parseSaveFile` to lazily load generation-specific parsers.
+    *   Assistant Strategies: Refactor `getStrategy` to be asynchronous and dynamically import the requested strategy.
+*   **UI Component Splitting:** UI components exclusively used for specific generations will be loaded via `React.lazy`.
+*   **Data Splitting:** The monolithic `pokedata.msgpack` will be split into a "core" bundle and generation-specific "extension" bundles.
+
+## 4. Dependencies
+*   Research conducted on bundle size distribution (`research-117-325-bundle-splitting-analysis`).
+*   Architectural strategy documented in an ADR (`adr-117-029-bundle-splitting-strategy`).
+
+## 5. Acceptance Criteria
+- [ ] Save parsers refactored to use dynamic imports.
+- [ ] Assistant strategies refactored to use dynamic imports.
+- [ ] Generation-specific UI components refactored to use `React.lazy`.
+- [ ] `pokedataPlugin` updated to emit multiple msgpack bundles.
+- [ ] `PokeDB.ts` updated to support multi-part data synchronization.
+- [ ] Performance verification complete.
+- [ ] Assigned a scheduled agent to monitor bundle sizes.


### PR DESCRIPTION
This PR transforms the `idea-117-split-bundles-and-data` into a PRD. 

- The `idea-117-split-bundles-and-data.md` file was updated to include the generated PRD in its Acceptance Criteria list.
- A new PRD `prd-117-116-split-bundles-and-data.md` was generated based on the idea file.
- Documented in the journal that the idea node already had research/adr marked as complete before the session began.

---
*PR created automatically by Jules for task [9171823765110906856](https://jules.google.com/task/9171823765110906856) started by @szubster*