### PR TITLE
Enforce tactical aesthetic in Shiny Carrier Breeding Dashboard

### DIFF
--- a/src/components/dashboard/breeding/ShinyCarrierBreedingDashboard.tsx
+++ b/src/components/dashboard/breeding/ShinyCarrierBreedingDashboard.tsx
@@ -113,7 +113,7 @@ export const ShinyCarrierBreedingDashboard: React.FC = () => {
         </div>
 
         {breedingPairs.length === 0 ? (
-          <div className="border-2 border-zinc-800 border-dashed bg-black/40 p-8 text-center">
+          <div className="rounded-none border-2 border-zinc-800 border-dashed bg-black/40 p-8 text-center">
             <span className="tactical-text text-zinc-500">NO SHINY CARRIER BREEDING PAIRS AVAILABLE</span>
           </div>
         ) : (
@@ -125,9 +125,9 @@ export const ShinyCarrierBreedingDashboard: React.FC = () => {
               return (
                 <div
                   key={`pair-${pA.id}-${pB.id}`}
-                  className="relative flex flex-col gap-2 border-2 border-zinc-700 border-dashed bg-black/60 p-3 font-mono text-xs transition-colors hover:border-zinc-500"
+                  className="relative flex flex-col gap-2 rounded-none border-2 border-zinc-700 border-dashed bg-black/60 p-3 font-mono text-xs transition-colors hover:border-zinc-500"
                 >
-                  <div className="absolute top-0 right-0 border-zinc-700 border-b-2 border-l-2 border-dashed bg-zinc-900/80 px-2 py-1 text-[10px] text-zinc-400">
+                  <div className="absolute top-0 right-0 rounded-none border-zinc-700 border-b-2 border-l-2 border-dashed bg-zinc-900/80 px-2 py-1 text-[10px] text-zinc-400">
                     SCORE: {pair.score}
                   </div>
 


### PR DESCRIPTION
This commit adds the missing `rounded-none` utility classes to the container elements within the `ShinyCarrierBreedingDashboard` component. This ensures the component correctly adheres to the "tactical hardware" aesthetic outlined in ADR 008, addressing the previous rejection. No behavioral changes were made.

---
*PR created automatically by Jules for task [1387029238596306939](https://jules.google.com/task/1387029238596306939) started by @szubster*