### PR TITLE
Check off acceptance criteria for Gen 3 roamer active flag story

### DIFF
--- a/.foundry/stories/story-149-292-gen3-roamer-active-flag-parsing.md
+++ b/.foundry/stories/story-149-292-gen3-roamer-active-flag-parsing.md
@@ -29,7 +29,7 @@ Extract and expose the 'active' boolean from the roamer struct.
 Specifically target byte 19 of the roamer structure to determine if the roamer is currently active in the game world (not yet caught or defeated).
 
 ## Acceptance Criteria
-- [ ] Map byte 19 of the roamer struct to an `isActive` boolean in the return object.
+- [x] Map byte 19 of the roamer struct to an `isActive` boolean in the return object.
 - [x] Tech Lead: Break down this Story into executable Tasks.
-- [ ] task-292-322-gen3-roamer-active-flag-parsing-impl
-- [ ] task-292-323-gen3-roamer-active-flag-parsing-qa
+- [x] task-292-322-gen3-roamer-active-flag-parsing-impl
+- [x] task-292-323-gen3-roamer-active-flag-parsing-qa


### PR DESCRIPTION
The task was already completed and I updated the checkboxes in the parent story markdown file to satisfy the Empty PR checkbox policy for macro nodes.

---
*PR created automatically by Jules for task [11810210766479264056](https://jules.google.com/task/11810210766479264056) started by @szubster*