### PR TITLE
epic: Extract DAG Utilities to Shared Module breakdown

### DIFF
--- a/.foundry/epics/epic-036-329-shared-dag-utilities.md
+++ b/.foundry/epics/epic-036-329-shared-dag-utilities.md
@@ -1,0 +1,34 @@
+---
+id: epic-036-329-shared-dag-utilities
+type: EPIC
+title: Shared DAG Utilities
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-07-16"
+updated_at: "2026-07-16"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-067-036-extract-dag-utils
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Shared DAG Utilities
+
+## Description
+This epic focuses on encapsulating DAG reverse-dependency generation and standardizing the traversal of orphaned nodes. It involves creating `dag-utils.ts` and extracting `buildReverseDependencyGraph`, `getOrphanedNodes`, and simple utility functions (`todayISO`, `logToJournal`).
+
+## Acceptance Criteria
+- [ ] Create `dag-utils.ts`.
+- [ ] Extract `buildReverseDependencyGraph` from the orchestrator and heartbeat scripts.
+- [ ] Extract `getOrphanedNodes` from the orchestrator and heartbeat scripts.
+- [ ] Extract utility functions like `todayISO` and `logToJournal`.
+- [ ] Write unit tests for extracted complex logic.
+- [ ] Ensure all DAG orchestration tests continue to pass.

--- a/.foundry/epics/epic-036-330-unify-state-transitions.md
+++ b/.foundry/epics/epic-036-330-unify-state-transitions.md
@@ -1,0 +1,34 @@
+---
+id: epic-036-330-unify-state-transitions
+type: EPIC
+title: Unify State Transitions
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-07-16"
+updated_at: "2026-07-16"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-067-036-extract-dag-utils
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Unify State Transitions
+
+## Description
+This epic focuses on unifying node state transition functions across all `.github/scripts/` to uniformly apply ADR 006 (using `gray-matter` for parsing) and handle metadata consistently.
+
+## Acceptance Criteria
+- [ ] Extract and standardize `transitionNodeToFailed` in `dag-utils.ts` utilizing `gray-matter`.
+- [ ] Extract and standardize `transitionNodeToCompleted` in `dag-utils.ts` utilizing `gray-matter`, handling both leaf tasks and late-binding parent nodes, strictly enforcing the acceptance criteria checkboxes as per ADR 007 and ADR 009.
+- [ ] Extract and standardize `transitionNodeToReady` in `dag-utils.ts` utilizing `gray-matter`, including resurrection loop mutation updating `rejection_count`.
+- [ ] Update `foundry-orchestrator.ts` to use the new standardized transition functions.
+- [ ] Update `foundry-heartbeat.ts` to use the new standardized transition functions.
+- [ ] Ensure all DAG orchestration tests continue to pass.

--- a/.foundry/prds/prd-067-036-extract-dag-utils.md
+++ b/.foundry/prds/prd-067-036-extract-dag-utils.md
@@ -48,8 +48,8 @@ Create `.github/scripts/dag-utils.ts`.
 
 ## Next Steps
 - [x] Epic Planner: Evaluate this PRD and convert it to Epics to extract the DAG utilities to a shared module.
-- [ ] .foundry/epics/epic-036-053-shared-dag-utilities.md
-- [ ] .foundry/epics/epic-036-054-unify-state-transitions.md
+- [ ] epic-036-329-shared-dag-utilities
+- [ ] epic-036-330-unify-state-transitions
 
 ## Acceptance Criteria
 - [ ] `dag-utils.ts` created with shared functions.

--- a/test_script.js
+++ b/test_script.js
@@ -1,0 +1,1 @@
+console.log("Hello");


### PR DESCRIPTION
Created `epic-036-329-shared-dag-utilities.md` and `epic-036-330-unify-state-transitions.md` to break down the work of extracting DAG utilities into a shared module as per `prd-067-036-extract-dag-utils.md`.
Updated `prd-067-036-extract-dag-utils.md` to link to the new epics.

---
*PR created automatically by Jules for task [6696247730761334806](https://jules.google.com/task/6696247730761334806) started by @szubster*