### PR TITLE
Create task blueprints for RNG TID/SID integration

### DIFF
--- a/.foundry/stories/story-130-270-rng-tid-sid-integration.md
+++ b/.foundry/stories/story-130-270-rng-tid-sid-integration.md
@@ -26,6 +26,8 @@ notes: ''
 Integrate the newly created TID/SID display component into the main Trainer dashboard or relevant save data summary views so users can readily access this information.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Generate actionable Tasks.
 - [ ] The TID/SID component is rendered in the appropriate dashboard view.
 - [ ] Ensure the component receives the correct data from the save state.
+- [x] Tech Lead: Generate actionable Tasks.
+- [ ] task-270-329-rng-tid-sid-integration-impl
+- [ ] task-270-330-rng-tid-sid-integration-qa

--- a/.foundry/tasks/task-270-329-rng-tid-sid-integration-impl.md
+++ b/.foundry/tasks/task-270-329-rng-tid-sid-integration-impl.md
@@ -1,0 +1,43 @@
+---
+id: task-270-329-rng-tid-sid-integration-impl
+type: TASK
+title: Implement RNG TID and SID UI Integration
+status: ACTIVE
+owner_persona: coder
+created_at: '2026-07-17T00:07:41Z'
+updated_at: '2026-07-17T00:07:41Z'
+depends_on:
+  - story-130-269-rng-tid-sid-component
+jules_session_id: null
+pr_number: null
+parent: story-130-270-rng-tid-sid-integration
+tags:
+  - feature
+  - rng
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Implement RNG TID and SID UI Integration
+
+## Context
+Integrate the newly created TID/SID display component into the main Trainer dashboard or relevant save data summary views.
+
+## Constraints & Requirements
+- Comply with tactical hardware/snooping aesthetic (ADR 008): sharp edges (`rounded-none`), no rounded corners, dashed borders (`border-dashed`), and monospaced telemetry fonts (`font-mono`).
+- Ensure the component correctly consumes save data state context (ADR 013/017 architecture if applicable, or generic Context API).
+
+## Acceptance Criteria
+- [ ] Integrate the TID/SID component into the Trainer dashboard or relevant view.
+- [ ] Ensure the component receives the correct save state data.
+- [ ] Render the component and confirm it matches the tactical hardware aesthetic.
+- [ ] Include explicit integration steps and tests for rendering the component in the application's view hierarchy.
+
+## Coder/QA Instructions
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level (no inline magic numbers).
+- For Gen 3 save file parsing, you must use the resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.

--- a/.foundry/tasks/task-270-330-rng-tid-sid-integration-qa.md
+++ b/.foundry/tasks/task-270-330-rng-tid-sid-integration-qa.md
@@ -1,0 +1,42 @@
+---
+id: task-270-330-rng-tid-sid-integration-qa
+type: TASK
+title: QA RNG TID and SID UI Integration
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-17T00:07:41Z'
+updated_at: '2026-07-17T00:07:41Z'
+depends_on:
+  - task-270-329-rng-tid-sid-integration-impl
+jules_session_id: null
+pr_number: null
+parent: story-130-270-rng-tid-sid-integration
+tags:
+  - feature
+  - rng
+  - ui
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# QA RNG TID and SID UI Integration
+
+## Context
+Verify the integration of the TID/SID display component into the main Trainer dashboard.
+
+## Verification Requirements
+- Verify the component adheres to the tactical hardware aesthetic (ADR 008).
+- Verify the component renders correctly and receives the correct save state data.
+- Verify tests were written for the component rendering in the view hierarchy.
+
+## Acceptance Criteria
+- [ ] Review implementation PR.
+- [ ] Confirm tests pass and coverage is adequate.
+- [ ] Verify aesthetic compliance.
+
+## Coder/QA Instructions
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.


### PR DESCRIPTION
Generates actionable Task nodes (impl and QA) for the `story-130-270-rng-tid-sid-integration` story and updates the parent story's markdown checkboxes without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [15399854346624155568](https://jules.google.com/task/15399854346624155568) started by @szubster*