### PR TITLE
feat(foundry): generate blueprints for RNG TID/SID integration

### DIFF
--- a/.foundry/stories/story-130-270-rng-tid-sid-integration.md
+++ b/.foundry/stories/story-130-270-rng-tid-sid-integration.md
@@ -26,6 +26,8 @@ notes: ''
 Integrate the newly created TID/SID display component into the main Trainer dashboard or relevant save data summary views so users can readily access this information.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Generate actionable Tasks.
+- [x] Tech Lead: Generate actionable Tasks.
 - [ ] The TID/SID component is rendered in the appropriate dashboard view.
 - [ ] Ensure the component receives the correct data from the save state.
+- [ ] task-270-329-rng-tid-sid-integration-impl
+- [ ] task-270-330-rng-tid-sid-integration-qa

--- a/.foundry/tasks/task-270-329-rng-tid-sid-integration-impl.md
+++ b/.foundry/tasks/task-270-329-rng-tid-sid-integration-impl.md
@@ -1,0 +1,41 @@
+---
+id: task-270-329-rng-tid-sid-integration-impl
+type: TASK
+title: Implement RNG TID and SID UI Integration
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-130-270-rng-tid-sid-integration
+tags:
+  - feature
+  - rng
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement RNG TID and SID UI Integration
+
+## Objective
+Integrate the newly created `RngTidSidDisplay` component into the main Trainer dashboard or relevant save data summary views so users can readily access this information.
+
+## Context & Architecture Constraints
+- The component `RngTidSidDisplay` has already been implemented. Integrate it into a dashboard view (such as the trainer info or save summary section).
+- Ensure the component receives the correct Trainer ID (TID) and Secret ID (SID) data from the save state context/store.
+- Maintain the tactical hardware aesthetic guidelines (ADR 024) across the integration layer.
+- **REMINDER FOR CODER:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **REMINDER FOR CODER:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **REMINDER FOR CODER:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+- **REMINDER FOR CODER:** When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
+- **REMINDER FOR CODER:** When drafting blueprints for Gen 3 save file parsing, explicitly require that the Coder uses the resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
+
+## Acceptance Criteria
+- [ ] Integrate the `RngTidSidDisplay` component into the Trainer dashboard view.
+- [ ] Ensure the correct TID and SID are passed to the component from the global store/save state.
+- [ ] Add explicit integration steps and tests for rendering the integrated component to ensure it is properly integrated into the application's view hierarchy.

--- a/.foundry/tasks/task-270-330-rng-tid-sid-integration-qa.md
+++ b/.foundry/tasks/task-270-330-rng-tid-sid-integration-qa.md
@@ -1,0 +1,41 @@
+---
+id: task-270-330-rng-tid-sid-integration-qa
+type: TASK
+title: QA RNG TID and SID UI Integration
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on:
+  - task-270-329-rng-tid-sid-integration-impl
+jules_session_id: null
+pr_number: null
+parent: story-130-270-rng-tid-sid-integration
+tags:
+  - feature
+  - rng
+  - ui
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA RNG TID and SID UI Integration
+
+## Objective
+Verify the integration of the `RngTidSidDisplay` component into the main Trainer dashboard.
+
+## Context & Architecture Constraints
+- Ensure the component is rendered correctly and adheres to tactical hardware aesthetics (ADR 024).
+- Ensure integration tests pass and component is successfully wired to receive data.
+- **REMINDER FOR QA:** If the implementation has errors, you MUST update the target YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- **REMINDER FOR QA:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- **REMINDER FOR QA:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify `RngTidSidDisplay` is visible and placed correctly in the Trainer dashboard view.
+- [ ] Verify the component receives the correct TID and SID from the global store.
+- [ ] Run `pnpm test` to ensure integration tests pass.
+- [ ] Verify component styling aligns with tactical hardware constraints.


### PR DESCRIPTION
Generated actionable TASK nodes for the Coder and QA personas to implement and verify the integration of the `RngTidSidDisplay` component into the Trainer dashboard view, fulfilling `story-130-270-rng-tid-sid-integration`. All architectural constraints and reminders were properly attached to the tasks.

---
*PR created automatically by Jules for task [15154630619081376994](https://jules.google.com/task/15154630619081376994) started by @szubster*