### PR TITLE
🧱 Mason: DataLabel component extraction

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -162,3 +162,9 @@
   - Using a `variant` prop (`primary`, `red`, `purple`, `blue`, `pink`) was necessary because the CSS classes used across these borders and shadow effects rely heavily on arbitrary values (e.g., `shadow-[0_0_8px_rgba(239,68,68,0.5)]`). Attempting to control complex multi-color opacity hover states with pure standard Tailwind classes across such an intricate DOM structure is brittle; centralizing the exact strings in a switch statement ensures rendering stability.
   - When visually verifying UI components via Playwright that are deeply nested or require specific complex state, temporarily create a dedicated test route/page (e.g., `src/routes/test.tsx`) to render the component directly, capture the screenshot, and carefully remove the temporary files (`git reset HEAD ... && rm ...`) before committing.
 When reusing standard React components, use getByRole for finding interactive elements in tests
+## DataLabel Extraction
+- **What**: Extracted the repeating `<span>` pattern (`className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest"`) into a generic `<DataLabel>` component.
+- **Why**: Consolidated standard styling for basic data labels, which was widely duplicated across multiple components like `PokemonEvolutions`, `PokemonLocations`, `PokemonCaughtDetails`, and `ContestRibbonBadge`.
+- **Key Learnings**:
+  - Always implement `React.forwardRef` and extend standard interfaces like `React.HTMLAttributes<HTMLSpanElement>` to ensure that utility components drop into layouts effortlessly without breaking standard HTML behaviors.
+  - Utilize a custom node script utilizing `regex` for reliable and safe batch replacement of specific and lengthy multi-line inline JSX structures across the codebase before using tools like `biome` to clean up the formatting.

--- a/src/components/DataLabel.tsx
+++ b/src/components/DataLabel.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { cn } from '../utils/cn';
+
+interface DataLabelProps extends React.HTMLAttributes<HTMLSpanElement> {
+  children: React.ReactNode;
+}
+
+export const DataLabel = React.forwardRef<HTMLSpanElement, DataLabelProps>(({ className, children, ...props }, ref) => {
+  return (
+    <span
+      ref={ref}
+      className={cn('font-mono text-[9px] text-zinc-500 uppercase tracking-widest', className)}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+});
+
+DataLabel.displayName = 'DataLabel';

--- a/src/components/pokemon/details/ContestRibbonBadge.tsx
+++ b/src/components/pokemon/details/ContestRibbonBadge.tsx
@@ -2,6 +2,7 @@ import { Award, ShieldAlert } from 'lucide-react';
 import React from 'react';
 import { cn } from '../../../utils/cn';
 import { CornerCrosshairs } from '../../CornerCrosshairs';
+import { DataLabel } from '../../DataLabel';
 import { HoverScanner } from '../../HoverScanner';
 import { LcdGrid } from '../../LcdGrid';
 
@@ -62,7 +63,7 @@ export const ContestRibbonBadge = React.forwardRef<HTMLDivElement, ContestRibbon
 
         <div className="relative z-10 mb-4 flex items-start justify-between">
           <div className="flex flex-col">
-            <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ ${type}_SYS ]</span>
+            <DataLabel>[ ${type}_SYS ]</DataLabel>
             <span
               className={cn('mt-0.5 font-black font-display text-xl uppercase tracking-tight', typeTextColorMap[type])}
             >

--- a/src/components/pokemon/details/PokemonCaughtDetails.tsx
+++ b/src/components/pokemon/details/PokemonCaughtDetails.tsx
@@ -4,6 +4,7 @@ import type { PokemonInstance } from '../../../engine/saveParser/index';
 import { useStore } from '../../../store';
 import { getTimeCapsuleValidation } from '../../../utils/timeCapsule';
 import { ContestConditionStats } from '../../ContestConditionStats';
+import { DataLabel } from '../../DataLabel';
 import { HoverScanner } from '../../HoverScanner';
 import { LcdGrid } from '../../LcdGrid';
 import { SectionHeader } from '../../SectionHeader';
@@ -78,19 +79,19 @@ export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps)
             <div className="relative z-10 flex flex-1 flex-col justify-center gap-0 border-white/10 border-l-2 border-dashed bg-zinc-950/40 p-4">
               {p.otName && (
                 <div className="relative flex items-center gap-3 border-zinc-700 border-l-2 border-dashed pb-3 pl-3 before:absolute before:top-2 before:-left-[2px] before:h-1 before:w-1 before:bg-zinc-500">
-                  <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ OT_ID ]</span>
+                  <DataLabel>[ OT_ID ]</DataLabel>
                   <span className="truncate font-mono text-[11px] text-zinc-300">{p.otName}</span>
                 </div>
               )}
               {p.item !== undefined && p.item > 0 && (
                 <div className="relative flex items-center gap-3 border-zinc-700 border-l-2 border-dashed py-3 pl-3 before:absolute before:top-4 before:-left-[2px] before:h-1 before:w-1 before:bg-zinc-500">
-                  <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ HELD_ITEM ]</span>
+                  <DataLabel>[ HELD_ITEM ]</DataLabel>
                   <span className="truncate font-mono text-[11px] text-zinc-300">{gen2Items[p.item]}</span>
                 </div>
               )}
               {p.friendship !== undefined && (
                 <div className="relative flex items-center gap-3 border-zinc-700 border-l-2 border-dashed pt-3 pl-3 before:absolute before:top-4 before:-left-[2px] before:h-1 before:w-1 before:bg-zinc-500">
-                  <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ SYNC_RATE ]</span>
+                  <DataLabel>[ SYNC_RATE ]</DataLabel>
                   <span className="font-mono text-[11px] text-rose-400">{p.friendship} PT</span>
                 </div>
               )}

--- a/src/components/pokemon/details/PokemonEvolutions.tsx
+++ b/src/components/pokemon/details/PokemonEvolutions.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { stadiumRewardsData } from '../../../engine/data/shared/staticData';
 import type { SaveData } from '../../../engine/saveParser/index';
 import { cn } from '../../../utils/cn';
+import { DataLabel } from '../../DataLabel';
 import { InlineLink } from '../../InlineLink';
 import { TacticalBadge } from '../../TacticalBadge';
 import { TacticalNode } from '../../TacticalNode';
@@ -82,7 +83,7 @@ function ProcurementStrategy({
         </div>
 
         <div className="relative z-10 flex flex-col gap-2">
-          <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ STATUS REPORT ]</span>
+          <DataLabel>[ STATUS REPORT ]</DataLabel>
           <div className="border border-red-500/30 border-dashed bg-zinc-950/80 p-3">
             <div className="font-bold text-sm text-zinc-300 leading-relaxed">
               Species missing from Living Dex. Priority retrieval recommended via
@@ -105,9 +106,7 @@ function ProcurementStrategy({
           </div>
           {stadiumRewards && (
             <div className="mt-2 flex flex-col gap-2">
-              <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">
-                [ ALTERNATE_EXTRACTION ]
-              </span>
+              <DataLabel>[ ALTERNATE_EXTRACTION ]</DataLabel>
               <div className="flex flex-wrap gap-2">
                 {stadiumRewards.rewards.map((r) => (
                   <TacticalBadge
@@ -156,7 +155,7 @@ function EvolutionFrom({
         </div>
 
         <div className="relative z-10 flex flex-1 flex-col gap-2">
-          <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ PRE_EVOLUTION_LINK ]</span>
+          <DataLabel>[ PRE_EVOLUTION_LINK ]</DataLabel>
           <div className="flex flex-1 flex-col justify-center border border-purple-500/30 border-dashed bg-zinc-950/80 p-3">
             <div className="mb-2 font-bold text-sm text-zinc-300 leading-relaxed">
               <InlineLink
@@ -170,7 +169,7 @@ function EvolutionFrom({
             </div>
             <div className="font-black text-[10px] text-purple-400/60 uppercase">METHOD: {evoReq.method}</div>
             <div className="mt-4 flex items-center justify-between border-zinc-800 border-t border-dashed pt-2">
-              <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ ASSET_STATUS ]</span>
+              <DataLabel>[ ASSET_STATUS ]</DataLabel>
               <div
                 className={cn(
                   'relative z-10 inline-flex items-center gap-2 rounded-none border border-dashed px-2 py-1 font-black text-[9px] uppercase tracking-widest',
@@ -217,7 +216,7 @@ function EvolutionTo({
         </div>
 
         <div className="relative z-10 flex flex-1 flex-col gap-2">
-          <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ EVOLUTION_TRAJECTORY ]</span>
+          <DataLabel>[ EVOLUTION_TRAJECTORY ]</DataLabel>
           <div className="flex flex-col gap-2">
             {evolvesTo.map((evo) => (
               <div
@@ -277,7 +276,7 @@ function BreedingProtocol({
 
         <div className="relative z-10 grid grid-cols-1 gap-4 md:grid-cols-2">
           <div className="flex flex-col gap-2">
-            <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ CROSS_REFERENCE ]</span>
+            <DataLabel>[ CROSS_REFERENCE ]</DataLabel>
             <div className="flex flex-wrap gap-2 border border-pink-500/30 border-dashed bg-zinc-950/80 p-3">
               {breedingInfo.parentNames.map((name: string, i: number) => (
                 <React.Fragment key={name}>
@@ -297,7 +296,7 @@ function BreedingProtocol({
             </div>
           </div>
           <div className="flex flex-col gap-2">
-            <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ METHODOLOGY ]</span>
+            <DataLabel>[ METHODOLOGY ]</DataLabel>
             <div className="relative z-10 rounded-none border border-pink-500/30 border-dashed bg-pink-500/10 p-3 font-black text-[10px] text-pink-400 uppercase leading-relaxed tracking-widest">
               {breedingInfo.method}
             </div>

--- a/src/components/pokemon/details/PokemonLocations.tsx
+++ b/src/components/pokemon/details/PokemonLocations.tsx
@@ -14,6 +14,7 @@ import type { CompactEncounter, CompactEncounterDetail } from '../../../db/schem
 import { POKE_VERSION_MAP, REVERSE_METHOD_MAP } from '../../../db/schema';
 import { isValidStaticGameVersion, staticEncounters } from '../../../engine/data/shared/staticData';
 import { cn } from '../../../utils/cn';
+import { DataLabel } from '../../DataLabel';
 import { SectionHeader } from '../../SectionHeader';
 import { TacticalBadge } from '../../TacticalBadge';
 import { TacticalNode } from '../../TacticalNode';
@@ -142,7 +143,7 @@ function GeospatialNode({ encounter: e, areaName }: { encounter: CompactEncounte
 
         {/* Vectors */}
         <div className="flex flex-col gap-2">
-          <span className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest">[ DETECTION VECTORS ]</span>
+          <DataLabel>[ DETECTION VECTORS ]</DataLabel>
           <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
             {e.d.map((d: CompactEncounterDetail, di: number) => {
               const methodStr = REVERSE_METHOD_MAP[d.m]?.toLowerCase() || 'unknown';


### PR DESCRIPTION
🎯 What
Extracted the widely repeated boilerplate span `className="font-mono text-[9px] text-zinc-500 uppercase tracking-widest"` into a typed, reusable `<DataLabel>` component.
Replaced instances of this span in `ContestRibbonBadge.tsx`, `PokemonCaughtDetails.tsx`, `PokemonEvolutions.tsx`, and `PokemonLocations.tsx`.

💡 Why
Centralizes basic data label styling logic and reduces heavy markup duplication across UI panels while ensuring accessibility standards remain intact through `forwardRef`.

✅ Verification
- Run `pnpm lint`, `pnpm test`, and `pnpm test:e2e` and confirmed complete pass on all checks.
- Code review was successfully processed.

✨ Result
Eliminated visual bloat in files containing many small metadata segments, replacing repeated `span` elements spanning dozens of lines with clear, expressive `<DataLabel>` usage.

---
*PR created automatically by Jules for task [6703624588661490334](https://jules.google.com/task/6703624588661490334) started by @szubster*