### PR TITLE
Handle Gen 1 Checklist UI Failure

### DIFF
--- a/.foundry/epics/epic-106-136-gen1-static-encounters.md
+++ b/.foundry/epics/epic-106-136-gen1-static-encounters.md
@@ -27,7 +27,7 @@ Break down the Gen 1 static encounter checklist into stories.
 - [x] Create story for Gen 1 event flag parsing
 - [x] Create story for Gen 1 checklist UI
 - [ ] story-136-294-gen1-event-flag-parsing
-- [ ] story-136-295-gen1-checklist-ui
+- [x] story-136-295-gen1-checklist-ui
 
-### SCHEMA
-https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md
+- [ ] research-136-329-gen1-checklist-ui-failure
+- [ ] story-136-330-gen1-checklist-ui-retry

--- a/.foundry/research/research-136-329-gen1-checklist-ui-failure.md
+++ b/.foundry/research/research-136-329-gen1-checklist-ui-failure.md
@@ -1,0 +1,30 @@
+---
+id: research-136-329-gen1-checklist-ui-failure
+type: RESEARCH
+title: Investigate Gen 1 Checklist UI Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-106-136-gen1-static-encounters
+tags:
+  - gen1
+  - feature
+  - ui
+research_references:
+  - story-136-295-gen1-checklist-ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 1 Checklist UI Failure
+
+Investigate the root cause for the `story-136-295-gen1-checklist-ui` task failing with `Max rejection count reached`. This task failed permanently and we need to understand why before attempting to reimplement it.
+
+## Acceptance Criteria
+- [ ] Investigate the rejection reasons for `story-136-295-gen1-checklist-ui` by reading the relevant QA or Auditor journals.
+- [ ] Write a summary of the failure causes and proposed technical solutions in this file.

--- a/.foundry/stories/story-136-330-gen1-checklist-ui-retry.md
+++ b/.foundry/stories/story-136-330-gen1-checklist-ui-retry.md
@@ -1,0 +1,29 @@
+---
+id: story-136-330-gen1-checklist-ui-retry
+type: STORY
+title: Gen 1 Checklist UI (Retry)
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on:
+  - research-136-329-gen1-checklist-ui-failure
+jules_session_id: null
+pr_number: null
+parent: epic-106-136-gen1-static-encounters
+tags:
+  - gen1
+  - feature
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 1 Checklist UI (Retry)
+
+Create the UI component for the Gen 1 static encounter checklist, mapping the parsed event flags to visual states. This is a retry of the permanently failed `story-136-295-gen1-checklist-ui` task.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
Handled the permanent failure (due to max rejections) of `story-136-295-gen1-checklist-ui` by:
1. Spawning a new `RESEARCH` node (`research-136-329-gen1-checklist-ui-failure.md`) to investigate the failure.
2. Spawning a new `STORY` node (`story-136-330-gen1-checklist-ui-retry.md`) that depends on the research node.
3. Marking the permanently failed child node as complete (`[x]`) in the parent epic `epic-106-136-gen1-static-encounters.md`.
4. Appending the newly spawned nodes to the parent epic's Acceptance Criteria.

---
*PR created automatically by Jules for task [7338557801985656937](https://jules.google.com/task/7338557801985656937) started by @szubster*