### PR TITLE
Foundry Zombie Node Garbage Collection Epics Replacement

### DIFF
--- a/.foundry/epics/epic-050-330-zombie-node-remediation-logic.md
+++ b/.foundry/epics/epic-050-330-zombie-node-remediation-logic.md
@@ -1,0 +1,39 @@
+---
+id: epic-050-330-zombie-node-remediation-logic
+type: EPIC
+title: Zombie Node Remediation Logic V2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on:
+  - .foundry/research/research-050-329-investigate-zombie-gc-failure.md
+jules_session_id: null
+pr_number: null
+parent: prd-079-050-foundry-zombie-node-cleanup
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Zombie Node Remediation Logic V2
+
+## Context
+Following the detection of "zombie" nodes (nodes incorrectly stuck in the `ACTIVE` state), the system must auto-remediate them to prevent DAG deadlocks. This involves transitioning their state to `FAILED`.
+This is a replacement epic following the failure of `epic-050-090-zombie-node-remediation-and-gc`. The implementation must incorporate findings from the prerequisite research node.
+
+## Scope
+This Epic handles the remediation logic (state transitions) specifically updating the YAML frontmatter of identified zombie nodes to change `status: ACTIVE` to `status: FAILED`.
+
+## Acceptance Criteria
+- [ ] Review research findings from `research-050-329-investigate-zombie-gc-failure`.
+- [ ] Implement state transition logic to modify `status` to `FAILED` in the markdown files safely.
+- [ ] Ensure robust unit test coverage for the remediation functionality.
+
+## Next Steps
+- [ ] Break down into Stories.

--- a/.foundry/epics/epic-050-331-zombie-node-gc-integration.md
+++ b/.foundry/epics/epic-050-331-zombie-node-gc-integration.md
@@ -1,0 +1,39 @@
+---
+id: epic-050-331-zombie-node-gc-integration
+type: EPIC
+title: Zombie Node GC Integration V2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on:
+  - .foundry/research/research-050-329-investigate-zombie-gc-failure.md
+jules_session_id: null
+pr_number: null
+parent: prd-079-050-foundry-zombie-node-cleanup
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Zombie Node GC Integration V2
+
+## Context
+Once zombie nodes are detected and the state transition logic is in place, the GC process must be integrated to run reliably. This is a replacement epic for the integration aspect of the failed `epic-050-090-zombie-node-remediation-and-gc`.
+
+## Scope
+This Epic handles the decision and implementation of whether this GC process runs synchronously within the main orchestrator script or as an independent scheduled script. The implementation must incorporate findings from the prerequisite research node.
+
+## Acceptance Criteria
+- [ ] Review research findings from `research-050-329-investigate-zombie-gc-failure`.
+- [ ] Determine the integration approach (standalone script vs. direct orchestrator integration).
+- [ ] Implement the integration pattern accurately utilizing the detection engine and remediation logic.
+- [ ] Ensure that remediated nodes (`FAILED` state) are correctly processed by the existing resurrection loop on the subsequent cycle.
+
+## Next Steps
+- [ ] Break down into Stories.

--- a/.foundry/prds/prd-079-050-foundry-zombie-node-cleanup.md
+++ b/.foundry/prds/prd-079-050-foundry-zombie-node-cleanup.md
@@ -53,4 +53,7 @@ The mechanism will:
 ## 5. Next Steps
 - [x] Break down into Epics.
   - [ ] epic-050-089-zombie-node-detection-engine
-  - [ ] epic-050-090-zombie-node-remediation-and-gc
+  - [x] epic-050-090-zombie-node-remediation-and-gc
+  - [ ] research-050-329-investigate-zombie-gc-failure
+  - [ ] epic-050-330-zombie-node-remediation-logic
+  - [ ] epic-050-331-zombie-node-gc-integration

--- a/.foundry/research/research-050-329-investigate-zombie-gc-failure.md
+++ b/.foundry/research/research-050-329-investigate-zombie-gc-failure.md
@@ -1,0 +1,34 @@
+---
+id: research-050-329-investigate-zombie-gc-failure
+type: RESEARCH
+title: Investigate Zombie GC Remediation Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-079-050-foundry-zombie-node-cleanup
+tags:
+  - foundry
+  - orchestrator
+  - maintenance
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Zombie GC Remediation Failure
+
+## Objective
+Investigate the root cause behind the max rejection count and cancellation of `epic-050-090-zombie-node-remediation-and-gc` and its associated stories.
+
+## Context
+The zombie node remediation epic reached max rejections. To properly unblock this DAG and resolve the infinite loops, we need to understand what specifically failed during its implementation or verification.
+
+## Acceptance Criteria
+- [ ] Read the auditor and qa persona journals to understand why `epic-050-090-zombie-node-remediation-and-gc` failed.
+- [ ] Produce a summary of findings.
+- [ ] Determine the path forward for the replacement Epics.


### PR DESCRIPTION
This PR addresses the cancelled `epic-050-090-zombie-node-remediation-and-gc` by investigating the failure through a newly created `RESEARCH` node, and breaking the work down into two new epics: `epic-050-330-zombie-node-remediation-logic` and `epic-050-331-zombie-node-gc-integration`, per the Impossible Loop policy. The parent `PRD` has been updated appropriately.

---
*PR created automatically by Jules for task [3950568151983724188](https://jules.google.com/task/3950568151983724188) started by @szubster*