### PR TITLE
Transform idea-067 to PRD and handle failure anomaly

### DIFF
--- a/.foundry/ideas/idea-067-extract-dag-utils.md
+++ b/.foundry/ideas/idea-067-extract-dag-utils.md
@@ -35,4 +35,6 @@ Operations to extract include:
 - [x] Product Manager: Evaluate this proposal and convert it to a PRD detailing the specific functions to be extracted and the testing strategy.
 
 ## References
-- [prd-067-036-extract-dag-utils.md](./.foundry/prds/prd-067-036-extract-dag-utils.md)
+- [x] [prd-067-036-extract-dag-utils.md](./.foundry/prds/prd-067-036-extract-dag-utils.md)
+- [ ] .foundry/research/research-067-329-investigate-dag-utils-failure.md
+- [ ] .foundry/prds/prd-067-330-extract-dag-utils-revised.md

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -63,3 +63,10 @@ When assigned to a macro node (like an IDEA) that has spawned children, DO NOT t
 ## 2026-07-16 - Anomaly Found
 
 When generating the PRD for `idea-117-split-bundles-and-data`, I noticed that the research and ADR references (`research-117-325-bundle-splitting-analysis` and `adr-117-029-bundle-splitting-strategy`) already existed and were marked as completed in the IDEA node's acceptance criteria.
+
+## Anomaly: Target Foundry Artifact Already Exists (2026-07-17)
+**Observation:**
+During the task to transform `idea-067-extract-dag-utils` into a PRD, it was discovered that the target Foundry artifact (`prd-067-036-extract-dag-utils.md`) already unexpectedly existed in the system and had a CANCELLED status.
+
+**Impact:**
+The Orchestrator assigned a PRD transformation task for an IDEA whose child nodes have already been generated and processed (and permanently failed). The Agile Coach should review this anomaly to investigate why the IDEA was reawakened or scheduled when its generated artifact was already present, potentially indicating a bug in the Orchestrator's late-binding state transition logic or the Resurrection Loop.

--- a/.foundry/prds/prd-067-330-extract-dag-utils-revised.md
+++ b/.foundry/prds/prd-067-330-extract-dag-utils-revised.md
@@ -1,0 +1,60 @@
+---
+id: prd-067-330-extract-dag-utils-revised
+type: PRD
+title: Extract DAG Utilities to Shared Module (Revised)
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on:
+  - research-067-329-investigate-dag-utils-failure
+jules_session_id: null
+parent: idea-067-extract-dag-utils
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+research_references:
+  - .foundry/research/research-067-329-investigate-dag-utils-failure.md
+rejection_count: 0
+rejection_reason: ''
+notes: Revised PRD spawned after the failure of prd-067-036-extract-dag-utils
+---
+
+# Extract DAG Utilities to Shared Module (Revised)
+
+## 1. Introduction
+The Foundry orchestrator and heartbeat scripts currently duplicate complex DAG management logic. This duplication increases the risk of bugs and divergent behavior, as evidenced by recent discrepancies in the Impossible Loop handling. This PRD details the revised extraction of these core utilities into a shared module, incorporating findings from the prior failed attempt.
+
+## 2. Goals & Objectives
+- Address and resolve the specific technical blockers identified in `research-067-329-investigate-dag-utils-failure` that caused the original extraction attempt to fail.
+- Encapsulate DAG reverse-dependency generation.
+- Standardize the traversal of orphaned nodes.
+- Unify node state transition functions (e.g., `transitionNodeToFailed`, `transitionNodeToCompleted`, and `transitionNodeToReady`) across all `.github/scripts/` to uniformly apply ADR 006 (using `gray-matter` for parsing) and handle metadata consistently.
+
+## 3. Scope of Extraction
+
+### 3.1 `dag-utils.ts` Creation
+Create `.github/scripts/dag-utils.ts` utilizing the revised approach defined in the associated research node.
+
+### 3.2 Key Functions to Extract/Implement
+*(To be refined based on research node findings, but initially targeting the original scope)*
+- **`buildReverseDependencyGraph(nodes, resolveNodePath)`**: A pure function that returns a `Map<string, string[]>` where keys are node paths and values are arrays of dependent node paths.
+- **`getOrphanedNodes(startNodePath, reverseGraph)`**: A function that traverses the reverse dependency graph and returns a `Set<string>` of all paths that depend (directly or indirectly) on the `startNodePath`.
+- **`transitionNodeToFailed(node, repoRoot, rejectionReason, dryRun)`**: Surgical mutation applying ADR 006. Updates status, `jules_session_id`, `updated_at`, and appends the `rejection_reason` using `matter.stringify`.
+- **`transitionNodeToCompleted(node, repoRoot, prNumber, dryRun, hasChildrenCheck)`**: Surgical mutation handling both leaf tasks and late-binding parent nodes, strictly enforcing the acceptance criteria checkboxes as per ADR 007 and ADR 009.
+- **`transitionNodeToReady(node, repoRoot, reason, dryRun)`**: Resurrection loop mutation updating `rejection_count`. If count reaches 3, transitions to `FAILED`.
+
+## 4. Testing Strategy
+- The current test suite in `.github/scripts/foundry-orchestrator.test.ts` and `.github/scripts/foundry-heartbeat.test.ts` must pass without modifications to ensure external behavior remains intact.
+- Extract any helper functions that are purely utility (like `todayISO`, `logToJournal`) to `dag-utils.ts` and write new unit tests if they contain complex logic, though simple file operations might not require it.
+- Ensure the test suite correctly executes `pnpm install && npx vitest run` in `.github/scripts/` to validate changes across both files.
+
+## Next Steps
+- [ ] Epic Planner: Evaluate this PRD and the associated research node, then convert it to Epics to extract the DAG utilities to a shared module.
+
+## Acceptance Criteria
+- [ ] Incorporate insights from `research-067-329-investigate-dag-utils-failure`.
+- [ ] `dag-utils.ts` created with shared functions.
+- [ ] `foundry-orchestrator.ts` and `foundry-heartbeat.ts` refactored to use `dag-utils.ts`.
+- [ ] All DAG orchestration tests pass.

--- a/.foundry/research/research-067-329-investigate-dag-utils-failure.md
+++ b/.foundry/research/research-067-329-investigate-dag-utils-failure.md
@@ -1,0 +1,37 @@
+---
+id: research-067-329-investigate-dag-utils-failure
+type: RESEARCH
+title: Investigate Extract DAG Utils Failure
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on: []
+jules_session_id: null
+parent: null
+tags:
+  - refactor
+  - foundry
+  - orchestrator
+  - investigation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: Spawned to investigate the permanent failure of prd-067-036-extract-dag-utils
+---
+
+# Investigate Extract DAG Utils Failure
+
+## Context
+The PRD node `prd-067-036-extract-dag-utils` was cancelled due to reaching the maximum rejection count (3 rejections). The objective was to extract DAG utilities (like reverse dependency generation, orphaned node identification, and state transition mutations) into a shared `.github/scripts/dag-utils.ts` file to reduce duplication between `foundry-orchestrator.ts` and `foundry-heartbeat.ts`.
+
+## Objective
+Investigate the specific reasons why the extraction of these utilities failed during implementation or verification.
+- Review PR review comments or journals related to the rejections of `prd-067-036-extract-dag-utils` or its descendant nodes (if any were spawned).
+- Identify any hidden complexities, missing dependencies, or architectural conflicts (such as issues with `gray-matter` standardization) that prevented successful extraction.
+- Provide a clear report on the roadblocks and suggest a revised, lower-risk approach for standardizing the DAG utilities.
+
+## Acceptance Criteria
+- [ ] Determine the exact technical reasons for the previous rejections.
+- [ ] Document findings in this markdown file.
+- [ ] Transition status to COMPLETED once findings are documented and a clear path forward is established for the revised PRD.

--- a/.foundry/research/research-067-329-investigate-dag-utils-failure.md
+++ b/.foundry/research/research-067-329-investigate-dag-utils-failure.md
@@ -3,7 +3,7 @@ id: research-067-329-investigate-dag-utils-failure
 type: RESEARCH
 title: Investigate Extract DAG Utils Failure
 status: PENDING
-owner_persona: tech_lead
+owner_persona: researcher
 created_at: '2026-07-17'
 updated_at: '2026-07-17'
 depends_on: []


### PR DESCRIPTION
Transforms idea-067 into a PRD. As the target PRD already existed and had failed, followed the Impossible Loop policy to generate a research node to investigate and a revised PRD. Appended the journal entry per instructions.

---
*PR created automatically by Jules for task [9837866238546685315](https://jules.google.com/task/9837866238546685315) started by @szubster*