### PR TITLE
Fix infinite verification spawning of auditor sessions

### DIFF
--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -112,6 +112,63 @@ describe('Foundry Heartbeat', () => {
     expect(writeCall[1]).toContain('status: VERIFYING');
   });
 
+  it('should transition an active PRD node with owner_persona product_manager to VERIFYING and update owner_persona to auditor', async () => {
+    const mockPrd = {
+      filePath: '/mock/repo/.foundry/prds/prd-1.md',
+      repoPath: '.foundry/prds/prd-1.md',
+      frontmatter: {
+        id: 'prd-1',
+        type: 'PRD',
+        status: 'ACTIVE',
+        owner_persona: 'product_manager',
+        jules_session_id: 'session-1'
+      },
+      rawContent: '---\ntype: PRD\nstatus: ACTIVE\nowner_persona: "product_manager"\njules_session_id: "session-1"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/prds/prd-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockImplementation((fp) => {
+      if (fp === '/mock/repo/.foundry/prds/prd-1.md') return mockPrd as any;
+      return null;
+    });
+
+    await transitionNodeToCompleted(mockPrd, mockRepoRoot, 123);
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(writeCall[0]).toBe(mockPrd.filePath);
+    expect(writeCall[1]).toContain('status: VERIFYING');
+    expect(writeCall[1]).toContain('owner_persona: auditor');
+  });
+
+  it('should transition an active PRD node with owner_persona auditor to COMPLETED directly', async () => {
+    const mockPrd = {
+      filePath: '/mock/repo/.foundry/prds/prd-1.md',
+      repoPath: '.foundry/prds/prd-1.md',
+      frontmatter: {
+        id: 'prd-1',
+        type: 'PRD',
+        status: 'ACTIVE',
+        owner_persona: 'auditor',
+        jules_session_id: 'session-1'
+      },
+      rawContent: '---\ntype: PRD\nstatus: ACTIVE\nowner_persona: "auditor"\njules_session_id: "session-1"\n---\nBody'
+    };
+
+    vi.mocked(orchestrator.discoverNodeFiles).mockReturnValue(['/mock/repo/.foundry/prds/prd-1.md']);
+    vi.mocked(orchestrator.parseNodeFile).mockImplementation((fp) => {
+      if (fp === '/mock/repo/.foundry/prds/prd-1.md') return mockPrd as any;
+      return null;
+    });
+
+    await transitionNodeToCompleted(mockPrd, mockRepoRoot, 123);
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(writeCall[0]).toBe(mockPrd.filePath);
+    expect(writeCall[1]).toContain('status: COMPLETED');
+  });
+
   it('should transition a node to READY without penalty if its Jules session is in a terminal state without a PR', async () => {
     const mockNode = {
       filePath: '/mock/repo/.foundry/tasks/task-1.md',

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -114,6 +114,7 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
   }
 
   const nodeType = parsed.data.type || node.frontmatter.type;
+  const ownerPersona = parsed.data.owner_persona || node.frontmatter.owner_persona;
 
   if (nodeType === 'EPIC') {
     const filePaths = discoverNodeFiles(path.join(repoRoot, '.foundry'));
@@ -148,8 +149,9 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
     }
   }
 
-  if (["IDEA", "PRD", "EPIC"].includes(nodeType)) {
+  if (["IDEA", "PRD", "EPIC"].includes(nodeType) && ownerPersona !== 'auditor') {
     parsed.data.status = "VERIFYING";
+    parsed.data.owner_persona = "auditor";
     parsed.data.jules_session_id = null;
     parsed.data.updated_at = dateStr;
     parsed.data.rejection_reason = '';

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -1052,7 +1052,8 @@ function main(): void {
       node.frontmatter.owner_persona === 'human' ||
       node.frontmatter.owner_persona === 'tpm' ||
       node.frontmatter.owner_persona === 'agile_coach' ||
-      node.frontmatter.owner_persona === 'mechanic'
+      node.frontmatter.owner_persona === 'mechanic' ||
+      node.frontmatter.owner_persona === 'auditor'
     ) {
       validatedEligible.push(node);
       continue;


### PR DESCRIPTION
Resolves the bug where multiple auditor sessions are spawned infinitely for completed IDEA, PRD, or EPIC nodes before they can transition to COMPLETED.

Fixes #4722

---
*PR created automatically by Jules for task [1934181322407448376](https://jules.google.com/task/1934181322407448376) started by @szubster*