### PR TITLE
fix(gen3): Enforce strict error message matching for TV block parsing

### DIFF
--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -481,9 +481,7 @@ describe('parseGen3MixRecords', () => {
     const buffer = new ArrayBuffer(800); // Not enough space for 25 items (900 bytes)
     const view = new DataView(buffer);
 
-    expect(() => parseGen3MixRecords(view, 0)).toThrowError(
-      'The save file is corrupted or incomplete.',
-    );
+    expect(() => parseGen3MixRecords(view, 0)).toThrowError('The save file is corrupted or incomplete.');
   });
 });
 
@@ -1108,9 +1106,7 @@ describe('parseGen3ActiveSwarm', () => {
     const view = new DataView(buffer);
     const offset = 0;
 
-    expect(() => parseGen3ActiveSwarm(view, offset)).toThrow(
-      'The save file is corrupted or incomplete.',
-    );
+    expect(() => parseGen3ActiveSwarm(view, offset)).toThrow('The save file is corrupted or incomplete.');
   });
 
   it('parseGen3TotalBattlePoints should correctly extract the total BP balance', () => {

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -482,7 +482,7 @@ describe('parseGen3MixRecords', () => {
     const view = new DataView(buffer);
 
     expect(() => parseGen3MixRecords(view, 0)).toThrowError(
-      'The save file is corrupted or incomplete: Invalid TV block struct.',
+      'The save file is corrupted or incomplete.',
     );
   });
 });
@@ -1109,7 +1109,7 @@ describe('parseGen3ActiveSwarm', () => {
     const offset = 0;
 
     expect(() => parseGen3ActiveSwarm(view, offset)).toThrow(
-      'The save file is corrupted or incomplete: Invalid TV block struct.',
+      'The save file is corrupted or incomplete.',
     );
   });
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -501,7 +501,7 @@ export function parseGen3Roamer(view: DataView, saveBlock1Offset: number, gameVe
  * @param view - The raw save file DataView.
  * @param offset - The offset within the buffer to read the TV Shows array from.
  * @returns An array of parsed Gen3TVShow metadata.
- * @throws Error - "The save file is corrupted or incomplete: Invalid TV block struct." on out-of-bounds reads.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
  */
 export function parseGen3TVBlock(view: DataView, offset: number): Gen3TVShow[] {
   try {
@@ -516,7 +516,7 @@ export function parseGen3TVBlock(view: DataView, offset: number): Gen3TVShow[] {
     return shows;
   } catch (error) {
     if (error instanceof RangeError) {
-      throw new Error('The save file is corrupted or incomplete: Invalid TV block struct.');
+      throw new Error('The save file is corrupted or incomplete.');
     }
     throw error;
   }
@@ -571,7 +571,7 @@ export function parseGen3MixRecords(view: DataView, offset: number) {
  * @param view - The raw save file DataView.
  * @param offset - The offset within the buffer to read the TV Shows array from.
  * @returns An object containing the extracted Gen3ActiveSwarm data or undefined if none found.
- * @throws Error - "The save file is corrupted or incomplete: Invalid TV block struct." on out-of-bounds reads.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
  */
 /**
  * Extracts the Volcanic Ash gather count from a Gen 3 save file.


### PR DESCRIPTION
The previous retry of the Gen 3 TV Block Parser implementation successfully utilized `DataView` for bounds checking but incorrectly appended `: Invalid TV block struct.` to the `RangeError` messages. This PR enforces strict adherence to the mandated error message (`"The save file is corrupted or incomplete."`) to pass the QA validation, and updates the tests to assert this exact output. This fulfills the requirements of `task-121-309-gen3-tv-block-parser-retry6-impl`.

---
*PR created automatically by Jules for task [16645026755795621807](https://jules.google.com/task/16645026755795621807) started by @szubster*