### PR TITLE
chore: complete qa for npc trade data mapping

### DIFF
--- a/.foundry/tasks/task-260-319-npc-trade-data-mapping-qa.md
+++ b/.foundry/tasks/task-260-319-npc-trade-data-mapping-qa.md
@@ -34,7 +34,7 @@ Verify the standard mapping connecting raw bitflags to specific NPC trade encoun
 - **CRITICAL:** Ensure that all memory offsets, lengths, bit locations, and shifts are defined as reusable constants at the module level. Inline magic numbers are strictly forbidden. If any are found, reject the implementation task.
 
 ## Acceptance Criteria
-- [ ] Verify that Gen 2 NPC trade flag mapping is correctly implemented.
-- [ ] Verify that Gen 3 NPC trade flag mapping (RSE/FRLG) is correctly implemented.
-- [ ] Verify that there are no inline magic numbers used for offsets or data lengths.
-- [ ] Verify that the `SaveData` correctly maps the extracted flags to the encounters.
+- [x] Verify that Gen 2 NPC trade flag mapping is correctly implemented.
+- [x] Verify that Gen 3 NPC trade flag mapping (RSE/FRLG) is correctly implemented.
+- [x] Verify that there are no inline magic numbers used for offsets or data lengths.
+- [x] Verify that the `SaveData` correctly maps the extracted flags to the encounters.


### PR DESCRIPTION
This PR completes task `task-260-319-npc-trade-data-mapping-qa` as the QA persona.

I have verified the implementations merged previously:
- The parser accurately extracts Gen 2 and Gen 3 (RSE/FRLG) trade flags and exposes them via `npcTradeFlags` and `gen3NPCTrades`.
- The assistant properly consumes these flags (`saveData.npcTradeFlags`, `saveData.gen3NPCTrades`) in `tradeGenerator.ts` to hide trades that have already been executed by the player.
- No inline magic numbers are used (relies on explicitly defined module-level constants like `FLAG_RUSTBORO_NPC_TRADE_COMPLETED`).

I've marked the checklist criteria off in the task file. Submitting an empty PR to allow the orchestrator to advance the task out of the DAG.

---
*PR created automatically by Jules for task [8271528523374954513](https://jules.google.com/task/8271528523374954513) started by @szubster*