### PR TITLE
chore(foundry): break down Pokerus strain detail story into tasks

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -186,3 +186,9 @@ When generating blueprints for Gen 3 dynamic save block extraction (like Volcani
 - Explicitly instructed the Coder and QA personas on error handling, Empty PR requirements, and strict magic number / relative offset rules.
 
 2026-07-16: Created retry 7 for Gen 3 TV parser because retry 6 failed QA due to inline magic numbers and incorrect error message string.
+
+## Pokerus Strain Detail UI Component
+
+- Encountered STORY node for rendering the `pokerus.strain` in the UI detail view.
+- Decided to create both an implementation task (`task-323-331`) and a QA verification task (`task-323-332`) to ensure that visual constraints (tactical hardware aesthetic as defined in ADR 008, 024) and conditional rendering logic (only showing when Infected or Cured) are strictly followed.
+- Set `depends_on` of the QA task to point to the implementation task to avoid DAG deadlocks.

--- a/.foundry/stories/story-322-323-pokerus-strain-detail-ui.md
+++ b/.foundry/stories/story-322-323-pokerus-strain-detail-ui.md
@@ -30,4 +30,6 @@ Implement the UI component for displaying the specific Pokerus strain data in th
 - Ensure the presentation adheres to the "tactical hardware" aesthetic (sharp edges `rounded-none`, dashed borders `border-dashed`, monospaced telemetry fonts) as defined by ADR 008 and ADR 024.
 
 ## 3. Acceptance Criteria
-- [ ] Tech Lead: Break down this Story into actionable Tasks.
+- [x] Tech Lead: Break down this Story into actionable Tasks.
+- [ ] task-323-331-pokerus-strain-detail-ui-impl
+- [ ] task-323-332-pokerus-strain-detail-ui-qa

--- a/.foundry/tasks/task-323-331-pokerus-strain-detail-ui-impl.md
+++ b/.foundry/tasks/task-323-331-pokerus-strain-detail-ui-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-323-331-pokerus-strain-detail-ui-impl
+type: TASK
+title: Implement Pokerus Strain Detail UI
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-322-323-pokerus-strain-detail-ui
+tags:
+  - pokerus
+  - ui
+  - implementation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Pokerus Strain Detail UI
+
+## Objective
+Implement the UI component for displaying the specific Pokerus strain data in the detailed view of a Pokémon.
+
+## Context
+As part of the Pokerus visualization effort, the detail view needs to show the exact strain when a Pokemon is infected or cured. The UI must follow the "tactical hardware" aesthetic (ADR 008, 024).
+
+## Constraints
+- The UI must only display the strain if the Pokémon's Pokerus status is "Infected" or "Cured".
+- Must use Tailwind v4 `@utility` classes for styling where appropriate.
+- Adhere to the "tactical hardware" aesthetic: sharp edges (`rounded-none`), dashed borders (`border-dashed`), monospaced telemetry fonts (`font-mono`).
+
+## Acceptance Criteria
+- [ ] Implement `PokerusStrainDetail` component (or update existing detail component).
+- [ ] Render `pokerus.strain` value conditionally based on `pokerus.status` ("Infected" or "Cured").
+- [ ] Apply "tactical hardware" styling (`rounded-none`, `border-dashed`, `font-mono`, etc.).
+- [ ] Verify functionality with unit/component tests.
+
+## Reminders for Coder
+- **Transient Failures:** Update YAML frontmatter to `status: FAILED` with a `rejection_reason` if retry needed.
+- **Permanent Failures:** Update YAML frontmatter to `status: CANCELLED` with a `rejection_reason` if impossible.
+- **Empty PRs:** Check off all Acceptance Criteria before submitting an empty PR for already complete tasks.

--- a/.foundry/tasks/task-323-332-pokerus-strain-detail-ui-qa.md
+++ b/.foundry/tasks/task-323-332-pokerus-strain-detail-ui-qa.md
@@ -1,0 +1,36 @@
+---
+id: task-323-332-pokerus-strain-detail-ui-qa
+type: TASK
+title: QA - Pokerus Strain Detail UI
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on:
+  - task-323-331-pokerus-strain-detail-ui-impl
+jules_session_id: null
+pr_number: null
+parent: story-322-323-pokerus-strain-detail-ui
+tags:
+  - pokerus
+  - ui
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA - Pokerus Strain Detail UI
+
+## Objective
+Verify the implementation of the Pokerus strain detail UI component.
+
+## Context
+The Coder has implemented the UI to display the Pokerus strain for infected/cured Pokemon. This task verifies the logic, conditional rendering, and aesthetic adherence.
+
+## Acceptance Criteria
+- [ ] Verify the strain is displayed ONLY when status is "Infected" or "Cured".
+- [ ] Verify the strain is NOT displayed when status is "None" or other invalid states.
+- [ ] Verify the UI strictly adheres to the "tactical hardware" aesthetic (`rounded-none`, `border-dashed`, `font-mono`).
+- [ ] Verify there are no visual regressions in the Pokemon detail view.


### PR DESCRIPTION
Broke down the Pokerus strain detail UI story into actionable tasks, defining exact architectural constraints and conditional logic requirements. Includes an implementation task and a dependent QA verification task. Recorded rationale in the tech lead's journal.

---
*PR created automatically by Jules for task [3254397523943306345](https://jules.google.com/task/3254397523943306345) started by @szubster*