### PR TITLE
feat: break down fame checker prd into epics

### DIFF
--- a/.foundry/epics/epic-115-331-gen3-fame-checker-research.md
+++ b/.foundry/epics/epic-115-331-gen3-fame-checker-research.md
@@ -1,0 +1,38 @@
+---
+id: epic-115-331-gen3-fame-checker-research
+type: EPIC
+title: Gen 3 Fame Checker Event Flag Research
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-115-115-gen3-fame-checker-assistant
+tags:
+  - gen3
+  - firered
+  - leafgreen
+  - fame-checker
+  - research
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Fame Checker Event Flag Research
+
+## Context
+As defined in `prd-115-115-gen3-fame-checker-assistant`, tracking missing Fame Checker entries in Pokémon FireRed and LeafGreen is tedious because the game only shows acquired entries. We need to leverage DexHelper's save parsing to read hidden event flags for Fame Checker progress.
+
+Before we can extract this data, we need to know exactly which bits or event flags correspond to which Fame Checker entries in the FireRed/LeafGreen save file structure.
+
+## Objectives
+- Research and document the exact memory offsets, event flags, or bitmasks used to track Fame Checker progress in FireRed and LeafGreen.
+- Create a comprehensive mapping between in-game Fame Checker entries (e.g., Oak, Daisy, Bill) and their underlying save file data points.
+
+## Scope
+- Focus exclusively on Pokémon FireRed and LeafGreen save files.
+- Produce documentation detailing the findings.

--- a/.foundry/epics/epic-115-332-gen3-fame-checker-save-parsing.md
+++ b/.foundry/epics/epic-115-332-gen3-fame-checker-save-parsing.md
@@ -1,0 +1,40 @@
+---
+id: epic-115-332-gen3-fame-checker-save-parsing
+type: EPIC
+title: Gen 3 Fame Checker Save Parsing
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on:
+  - epic-115-331-gen3-fame-checker-research
+jules_session_id: null
+pr_number: null
+parent: prd-115-115-gen3-fame-checker-assistant
+tags:
+  - gen3
+  - firered
+  - leafgreen
+  - fame-checker
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Fame Checker Save Parsing
+
+## Context
+Following the research into Fame Checker event flags (`epic-115-331-gen3-fame-checker-research`), we need to implement the save parser to extract this data from FireRed and LeafGreen save files.
+
+## Objectives
+- Integrate the event flag offsets discovered during the research phase into the Gen 3 save parser.
+- Implement robust parsing logic to read the specific bits/flags representing each Fame Checker entry.
+- Expose the parsed Fame Checker data in the normalized application state.
+
+## Scope
+- Modify the save parsing layer (e.g., using `DataView` API).
+- Ensure explicit handling for FireRed/LeafGreen specific structures compared to Ruby/Sapphire/Emerald where applicable.
+- Adhere strictly to the "Dynamic Save Block Extraction Guidelines" (ADR 028), using module-level constants for offsets and avoiding inline magic numbers.
+- Ensure the data structure conforms to the `PokeData` application naming schema where necessary.

--- a/.foundry/epics/epic-115-333-gen3-fame-checker-dashboard-ui.md
+++ b/.foundry/epics/epic-115-333-gen3-fame-checker-dashboard-ui.md
@@ -1,0 +1,39 @@
+---
+id: epic-115-333-gen3-fame-checker-dashboard-ui
+type: EPIC
+title: Gen 3 Fame Checker Dashboard UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on:
+  - epic-115-332-gen3-fame-checker-save-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-115-115-gen3-fame-checker-assistant
+tags:
+  - gen3
+  - firered
+  - leafgreen
+  - fame-checker
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Fame Checker Dashboard UI
+
+## Context
+With the Fame Checker progress data successfully extracted from the save file (`epic-115-332-gen3-fame-checker-save-parsing`), we must build a UI dashboard to present this data. Tracking missing entries is tedious because the in-game UI only shows acquired entries. Players have to guess missing entries and use external wikis.
+
+## Objectives
+- Create a dashboard that explicitly shows players what Fame Checker entries they have unlocked and which ones are missing.
+- The UI should group entries by NPC (e.g., Prof. Oak, Daisy Oak, Bill, etc.).
+- For missing entries, provide actionable hints (exact location and condition) so the player knows how to acquire them.
+
+## Scope
+- Develop a set of React components for the Fame Checker dashboard.
+- Ensure the UI aligns with the application's overall design system (Tailwind v4 primitives).
+- Follow the "tactical hardware/snooping" aesthetic guidelines where appropriate.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -63,3 +63,10 @@ Successfully broke down the "Missed Trainer Radar" PRD (`prd-104-109-missed-trai
 
 ## 2026-07-16: Replacement of FAILED and CANCELLED Epics
 When spawning new epics to replace previously FAILED or CANCELLED epics, it is important to include explicit research into the rejection reason provided in the failed node's frontmatter. In this case, `epic-036-053-shared-dag-utilities.md` was FAILED due to `[ACKNOWLEDGED] Merged with unfulfilled acceptance criteria: Missing E2E/integration story`. The replacement epic, `epic-036-329-shared-dag-utilities.md`, was created with a specific scope item and acceptance criteria added for the missing E2E integration story. Old nodes were removed and references in the parent PRD were replaced with the new ones.
+
+## 2026-07-17: Fame Checker PRD Breakdown
+Successfully broke down `prd-115-115-gen3-fame-checker-assistant` into three distinct epics to handle the full lifecycle from research to UI:
+1. `epic-115-331-gen3-fame-checker-research`: A research node specifically assigned to find the exact event flags in FireRed/LeafGreen.
+2. `epic-115-332-gen3-fame-checker-save-parsing`: The implementation phase for integrating those discovered offsets.
+3. `epic-115-333-gen3-fame-checker-dashboard-ui`: Building out the final dashboard for players.
+I ensured the correct DAG order by using `depends_on` between them and appended them to the PRD's Acceptance Criteria.

--- a/.foundry/prds/prd-115-115-gen3-fame-checker-assistant.md
+++ b/.foundry/prds/prd-115-115-gen3-fame-checker-assistant.md
@@ -33,3 +33,8 @@ Leverage DexHelper's save parsing to read hidden event flags for Fame Checker pr
 - Parse event flags related to the Fame Checker in FireRed/LeafGreen.
 - Create UI dashboard to display unlocked and missing Fame Checker entries for each NPC.
 - Provide actionable location/action hints for missing entries.
+
+## Acceptance Criteria
+- [ ] epic-115-331-gen3-fame-checker-research
+- [ ] epic-115-332-gen3-fame-checker-save-parsing
+- [ ] epic-115-333-gen3-fame-checker-dashboard-ui


### PR DESCRIPTION
This PR completes the `epic_planner` task of breaking down `prd-115-115-gen3-fame-checker-assistant`.

It generates three new epics:
1. `epic-115-331-gen3-fame-checker-research`
2. `epic-115-332-gen3-fame-checker-save-parsing` (depends on research)
3. `epic-115-333-gen3-fame-checker-dashboard-ui` (depends on save parsing)

The new epics are assigned to the `story_owner` persona and appended to the PRD's acceptance criteria without modifying its YAML frontmatter. The planner's journal has also been updated.

---
*PR created automatically by Jules for task [16718105700076690052](https://jules.google.com/task/16718105700076690052) started by @szubster*