### PR TITLE
tech-lead: Draft tasks for Pokerus Strain Badge UI Component

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -186,3 +186,8 @@ When generating blueprints for Gen 3 dynamic save block extraction (like Volcani
 - Explicitly instructed the Coder and QA personas on error handling, Empty PR requirements, and strict magic number / relative offset rules.
 
 2026-07-16: Created retry 7 for Gen 3 TV parser because retry 6 failed QA due to inline magic numbers and incorrect error message string.
+## 2026-07-17: Pokerus Strain Badge Component
+
+- Evaluated the Product Story for the Pokerus Strain Badge UI Component (`story-323-322-pokerus-strain-badge-component`).
+- Drafted the implementation task for the `PokerusBadge` React component, ensuring it adheres to the tactical hardware aesthetic guidelines (ADR 024) and uses Tailwind v4 `@utility` classes.
+- Initially assigned a separate QA task, but this UI component is simple and low-risk. In the future, I will instruct the Coder to self-verify for such simple components to streamline the pipeline and adhere to the Intelligent Verification Protocol.

--- a/.foundry/stories/story-323-322-pokerus-strain-badge-component.md
+++ b/.foundry/stories/story-323-322-pokerus-strain-badge-component.md
@@ -30,4 +30,6 @@ Develop a reusable UI component that visually displays the Pokerus strain (e.g.,
 - Ensure the badge clearly distinguishes between different strains visually (colors or labels).
 
 ## 3. Acceptance Criteria
-- [ ] Tech Lead: Break down into Tasks.
+- [x] Tech Lead: Break down into Tasks.
+- [ ] task-322-331-pokerus-strain-badge-component-impl
+- [ ] task-322-332-pokerus-strain-badge-component-qa

--- a/.foundry/tasks/task-322-331-pokerus-strain-badge-component-impl.md
+++ b/.foundry/tasks/task-322-331-pokerus-strain-badge-component-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-322-331-pokerus-strain-badge-component-impl
+type: TASK
+title: Pokerus Strain Badge UI Component Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-323-322-pokerus-strain-badge-component
+tags:
+  - pokerus
+  - ui
+  - react
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Pokerus Strain Badge UI Component Implementation
+
+## 1. Objective
+Implement the `PokerusBadge` React component that visually displays the Pokerus strain following the "tactical hardware" aesthetic.
+
+## 2. Context & Requirements
+- Based on `story-323-322-pokerus-strain-badge-component`.
+- The component must display the strain visually (e.g., Strain 1, Strain 2, etc.) using distinctive labels or colors.
+- Styling must adhere strictly to ADR 008 and ADR 024. Use the tactical styling guidelines such as `rounded-none`, `border-dashed`, and monospaced fonts (`font-mono`).
+- As per the `tailwind_v4_utilities.md` guidelines, utilize the existing `@utility` classes if applicable (e.g., `tactical-panel`, `tactical-button`) or direct utility classes like `border border-dashed rounded-none` instead of deprecated `@layer components` combinations.
+- The component must accept props to distinguish the strain data.
+
+## 3. Acceptance Criteria
+- [ ] Create the `PokerusBadge` component in the appropriate UI component directory.
+- [ ] Apply the tactical hardware aesthetic rules as specified.
+- [ ] Add explicit integration steps or Storybook/test rendering if applicable to ensure it is renderable and not a dead file (Component Integration Policy).
+- [ ] Update the `PokerusBadge` component to correctly map distinct visual properties (color/text) to different strains.

--- a/.foundry/tasks/task-322-332-pokerus-strain-badge-component-qa.md
+++ b/.foundry/tasks/task-322-332-pokerus-strain-badge-component-qa.md
@@ -1,0 +1,39 @@
+---
+id: task-322-332-pokerus-strain-badge-component-qa
+type: TASK
+title: Pokerus Strain Badge UI Component QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-17'
+updated_at: '2026-07-17'
+depends_on:
+  - task-322-331-pokerus-strain-badge-component-impl
+jules_session_id: null
+pr_number: null
+parent: story-323-322-pokerus-strain-badge-component
+tags:
+  - pokerus
+  - ui
+  - react
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Pokerus Strain Badge UI Component QA
+
+## 1. Objective
+Verify the implementation of the `PokerusBadge` React component visually and functionally.
+
+## 2. Context & Requirements
+- Verify that the new component correctly adheres to the "tactical hardware" design (ADR 024) utilizing proper `rounded-none`, `border-dashed`, and `font-mono` styles.
+- Verify that the component properly utilizes Tailwind v4 `@utility` classes if applicable.
+- Ensure the component handles different Pokerus strains gracefully and visually distinguishes between them.
+- If rendering fails or aesthetic does not align with requirements, reject the dependency task.
+
+## 3. Acceptance Criteria
+- [ ] Verify the component renders correctly in tests or storybook.
+- [ ] Verify distinct visual representation of different Pokerus strains.
+- [ ] Verify aesthetic adherence to ADR 008 and ADR 024.


### PR DESCRIPTION
Created task nodes for the `story-323-322-pokerus-strain-badge-component` story and updated the Tech Lead journal.

---
*PR created automatically by Jules for task [13368304363640602748](https://jules.google.com/task/13368304363640602748) started by @szubster*