### PR TITLE
Investigate Gen 3 Secret Base Parsing Permanent Failure

### DIFF
--- a/.foundry/docs/knowledge_base/gen3_secret_base_parsing_failure.md
+++ b/.foundry/docs/knowledge_base/gen3_secret_base_parsing_failure.md
@@ -1,0 +1,19 @@
+# Gen 3 Secret Base Parsing Failure Analysis
+
+## Context
+The epic `epic-045-070-gen3-secret-base-parsing` was permanently cancelled after reaching its Max Rejection Count. This cancellation subsequently caused the dependent epics `epic-045-071-gen3-secret-base-radar-integration` and `epic-045-072-gen3-secret-base-dashboard` to also be automatically cancelled by the Orchestrator. This document investigates the root cause of the initial failure and the current state of the Gen 3 Secret Base parsing architecture.
+
+## Root Cause of Failure
+The permanent failure of `epic-045-070-gen3-secret-base-parsing` was triggered specifically by its child task `task-108-163-gen3-secret-base-parser`. This task reached its maximum rejection count because the implemented parser failed to adhere to the architectural constraint defined in **ADR 010: Gen3 Data Parsing Strategy**. Specifically, the implementation did not explicitly catch `RangeError` exceptions originating from out-of-bounds `DataView` reads.
+
+When `DataView` attempts to read beyond the boundaries of an `ArrayBuffer` (which frequently happens with malformed or truncated save files), it natively throws a `RangeError`. ADR 010 strictly mandates that these errors must be caught and gracefully re-thrown with the standardized message `'The save file is corrupted or incomplete.'` to prevent unhandled application crashes.
+
+## Current State and Resolution
+Although the original task failed and the epic was cancelled, the DAG Orchestrator correctly spawned follow-up tasks via the resilience loop. The retry implementation task, `task-108-222-gen3-secret-base-parser-retry-impl`, and its associated QA verification, `task-108-223-gen3-secret-base-parser-retry-qa`, successfully addressed the issue.
+
+The parser located in `src/engine/gen3/secretBase/parser.ts` and the global hook in `src/engine/saveParser/parsers/gen3.ts` both now correctly wrap the `DataView` operations in `try/catch` blocks that explicitly trap `RangeError` and map it to the required error string. Furthermore, they utilize proper relative module-level constants (complying with ADR 028).
+
+## Conclusion
+The underlying parsing logic for Gen 3 Secret Bases is currently **fully implemented, correct, and architecturally compliant**. The failure was a transient process error in the DAG graph where the parent Epic was permanently aborted before the retry logic could successfully reintegrate.
+
+Because the technical implementation is already sound, any replacement epics for `epic-045-071-gen3-secret-base-radar-integration` and `epic-045-072-gen3-secret-base-dashboard` can proceed immediately. No further structural changes or offset recalculations to the Gen 3 parser are required.

--- a/.foundry/research/research-045-321-investigate-secret-base-failure.md
+++ b/.foundry/research/research-045-321-investigate-secret-base-failure.md
@@ -32,4 +32,4 @@ The epic `epic-045-070-gen3-secret-base-parsing` reached its Max Rejection Count
 - Propose a revised approach or updated offsets to ensure the replacement tasks succeed.
 
 ## Acceptance Criteria
-- [ ] Researcher: Produce a research document detailing the root cause of the failure and providing correct offsets/logic.
+- [x] Researcher: Produce a research document detailing the root cause of the failure and providing correct offsets/logic.


### PR DESCRIPTION
Produced research document `.foundry/docs/knowledge_base/gen3_secret_base_parsing_failure.md` explaining the root cause of `epic-045-070-gen3-secret-base-parsing` cancellation (failure to explicitly catch `RangeError`). Confirmed the current parsing logic is correct and ADR 010-compliant via retry tasks. Checked off acceptance criteria in the research node.

---
*PR created automatically by Jules for task [3161144391888883375](https://jules.google.com/task/3161144391888883375) started by @szubster*