### PR TITLE
Check off acceptance criteria for QA extend phase 3.6

### DIFF
--- a/.foundry/tasks/task-299-323-extend-phase-3-6-qa.md
+++ b/.foundry/tasks/task-299-323-extend-phase-3-6-qa.md
@@ -32,9 +32,9 @@ Verify the implementation in `.github/scripts/foundry-orchestrator.ts` and the a
 - Run the test suite: `cd .github/scripts && pnpm install && npx vitest`.
 
 ## Acceptance Criteria
-- [ ] Code modifications accurately implement the requirements.
-- [ ] All unit tests pass, explicitly covering the new behaviour.
-- [ ] The change does not break existing test cases.
+- [x] Code modifications accurately implement the requirements.
+- [x] All unit tests pass, explicitly covering the new behaviour.
+- [x] The change does not break existing test cases.
 
 ### REMINDER FOR QA
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
- Checked off the acceptance criteria checkboxes in `.foundry/tasks/task-299-323-extend-phase-3-6-qa.md` after verifying the implementation.
- `foundry-orchestrator.ts` correctly wakes up parent nodes in Phase 3.6 for Impossible Loop conditions.
- Tests in `foundry-orchestrator.test.ts` verify the behavior successfully.
- Tests pass cleanly.

---
*PR created automatically by Jules for task [9928855821412037862](https://jules.google.com/task/9928855821412037862) started by @szubster*