### PR TITLE
Fix Gen 3 Feebas Seed Extraction Offset

### DIFF
--- a/.foundry/tasks/task-280-325-feebas-backend-integration-retry-impl.md
+++ b/.foundry/tasks/task-280-325-feebas-backend-integration-retry-impl.md
@@ -26,13 +26,13 @@ notes: ''
 Update the `SaveData` interface and the parsing logic to extract and calculate Feebas tile locations for RSE saves, ensuring correct usage of relative offsets based on `section1Offset`.
 
 ## Acceptance Criteria
-- [ ] Add `gen3FeebasTiles?: number[]` to the `SaveData` interface.
-- [ ] Modify the parsing logic to safely extract the seed and calculate the tiles for 'ruby', 'sapphire', or 'emerald' versions. Wrap this in a try-catch to prevent a malformed seed from failing the entire save parse.
-- [ ] Ensure the extraction function receives the `section1Offset` from the parsing engine to correctly calculate the seed position relative to the active save block, resolving the A/B bank issue.
-- [ ] Return the calculated tiles as `gen3FeebasTiles` in the returned `SaveData` object.
-- [ ] Update the corresponding tests to verify `gen3FeebasTiles` populates correctly when valid versions are passed.
-- [ ] Explicitly define all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level, forbidding inline magic numbers.
-- [ ] Explicitly use the resolved section offset (`section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
+- [x] Add `gen3FeebasTiles?: number[]` to the `SaveData` interface.
+- [x] Modify the parsing logic to safely extract the seed and calculate the tiles for 'ruby', 'sapphire', or 'emerald' versions. Wrap this in a try-catch to prevent a malformed seed from failing the entire save parse.
+- [x] Ensure the extraction function receives the `section1Offset` from the parsing engine to correctly calculate the seed position relative to the active save block, resolving the A/B bank issue.
+- [x] Return the calculated tiles as `gen3FeebasTiles` in the returned `SaveData` object.
+- [x] Update the corresponding tests to verify `gen3FeebasTiles` populates correctly when valid versions are passed.
+- [x] Explicitly define all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level, forbidding inline magic numbers.
+- [x] Explicitly use the resolved section offset (`section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
 
 ## Failure Rules & Instructions
 - If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/engine/gen3/feebas.test.ts
+++ b/src/engine/gen3/feebas.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   calculateFeebasTiles,
   extractFeebasSeed,
-  FEEBAS_SEED_OFFSET_EMERALD,
-  FEEBAS_SEED_OFFSET_RS,
+  FEEBAS_SEED_RELATIVE_OFFSET_EMERALD,
+  FEEBAS_SEED_RELATIVE_OFFSET_RS,
   mapSpotIdsToCoordinates,
 } from './feebas';
 
@@ -12,7 +12,7 @@ describe('extractFeebasSeed', () => {
     // 0x2dd6 + 2 bytes = 11736 bytes
     const buffer = new ArrayBuffer(12000);
     const view = new DataView(buffer);
-    view.setUint16(0x1f00 + FEEBAS_SEED_OFFSET_RS, 0x1234, true);
+    view.setUint16(0x1f00 + FEEBAS_SEED_RELATIVE_OFFSET_RS, 0x1234, true);
 
     const seedRuby = extractFeebasSeed(view, 'ruby', 0x1f00);
     expect(seedRuby).toBe(0x1234);
@@ -25,7 +25,7 @@ describe('extractFeebasSeed', () => {
     // 0x2e66 + 2 bytes = 11880 bytes
     const buffer = new ArrayBuffer(12000);
     const view = new DataView(buffer);
-    view.setUint16(0x1f00 + FEEBAS_SEED_OFFSET_EMERALD, 0x5678, true);
+    view.setUint16(0x1f00 + FEEBAS_SEED_RELATIVE_OFFSET_EMERALD, 0x5678, true);
 
     const seedEmerald = extractFeebasSeed(view, 'emerald', 0x1f00);
     expect(seedEmerald).toBe(0x5678);

--- a/src/engine/gen3/feebas.ts
+++ b/src/engine/gen3/feebas.ts
@@ -1,7 +1,7 @@
 import type { GameVersion } from '../saveParser/parsers/common';
 
-export const FEEBAS_SEED_OFFSET_RS = 0x0ed6;
-export const FEEBAS_SEED_OFFSET_EMERALD = 0x0f66;
+export const FEEBAS_SEED_RELATIVE_OFFSET_RS = 0x0ed6;
+export const FEEBAS_SEED_RELATIVE_OFFSET_EMERALD = 0x0f66;
 
 export const LCG_MULTIPLIER = 1103515245;
 export const LCG_ADDEND = 12345;
@@ -18,14 +18,14 @@ export const FEEBAS_BOUNDARY = 4;
  * @returns The 16-bit Feebas seed.
  * @throws Error if the save file is corrupted or incomplete.
  */
-export function extractFeebasSeed(saveData: DataView, gameVersion: GameVersion, section2Offset: number): number {
+export function extractFeebasSeed(saveData: DataView, gameVersion: GameVersion, section1Offset: number): number {
   try {
     let offset = 0;
 
     if (gameVersion === 'ruby' || gameVersion === 'sapphire') {
-      offset = section2Offset + FEEBAS_SEED_OFFSET_RS;
+      offset = section1Offset + FEEBAS_SEED_RELATIVE_OFFSET_RS;
     } else if (gameVersion === 'emerald') {
-      offset = section2Offset + FEEBAS_SEED_OFFSET_EMERALD;
+      offset = section1Offset + FEEBAS_SEED_RELATIVE_OFFSET_EMERALD;
     } else {
       throw new Error(`Unsupported game version for Feebas seed extraction: ${gameVersion}`);
     }

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { FEEBAS_SEED_OFFSET_RS } from '../../gen3/feebas';
+import { FEEBAS_SEED_RELATIVE_OFFSET_RS } from '../../gen3/feebas';
 import {
   EMERALD_MOVE_TUTOR_BYTE_1_OFFSET,
   EMERALD_MOVE_TUTOR_BYTE_2_OFFSET,
@@ -50,7 +50,7 @@ describe('gen3 parser scaffolding', () => {
     }
 
     // Mock a seed at the expected offset for Ruby/Sapphire
-    view.setUint16(0x2000 + FEEBAS_SEED_OFFSET_RS, 12345, true);
+    view.setUint16(0x1000 + FEEBAS_SEED_RELATIVE_OFFSET_RS, 12345, true);
 
     try {
       const resultRS = parseGen3(view, 'ruby');

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -897,7 +897,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     let gen3FeebasTiles: number[] | undefined;
     if (_forcedVersion === 'ruby' || _forcedVersion === 'sapphire' || _forcedVersion === 'emerald') {
       try {
-        const seed = extractFeebasSeed(view, _forcedVersion, section2Offset);
+        const seed = extractFeebasSeed(view, _forcedVersion, section1Offset);
         gen3FeebasTiles = calculateFeebasTiles(seed);
       } catch {
         // Ignored


### PR DESCRIPTION
This PR correctly modifies the Gen 3 Feebas seed extraction logic to use the `section1Offset` as the base for calculating the relative offset, instead of relying on `section2Offset` or hardcoded absolute offsets. This fixes the parsing failure caused by A/B bank shifts. It also updates constants to explicitly reflect that they are relative to the block offset.

---
*PR created automatically by Jules for task [15725494186370917773](https://jules.google.com/task/15725494186370917773) started by @szubster*