### PR TITLE
Implement feedback mechanism for interrupted commands

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -113,3 +113,4 @@ If you lack critical context or specifications (e.g., exact memory offsets) nece
 * Never execute blocking commands (e.g., `tail -f`, long-running loops) in `run_in_bash_session` as they will cause the session to hang indefinitely.
 * Use non-blocking alternatives like `cat` or `tail -n`.
 * If a long-running process must be executed, it must be backgrounded (`&`) or wrapped using the standard GNU `timeout` command (e.g., `timeout 30s command`).
+* **Timeout Interruption Feedback:** When the `timeout` command successfully interrupts a process that exceeds the specified duration, it returns **exit code 124**. Agents MUST recognize exit code 124 as an explicit timeout indicator, rather than a generic command failure, and MUST switch to using non-blocking alternatives (like `cat` or `tail -n`) instead of retrying the blocking command.

--- a/.foundry/tasks/task-268-322-bash-timeout-feedback-impl.md
+++ b/.foundry/tasks/task-268-322-bash-timeout-feedback-impl.md
@@ -36,4 +36,4 @@ Implement a feedback mechanism for bash commands that were interrupted due to ti
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Update `core_policies.md` with the exit code 124 feedback mechanism.
+- [x] Update `core_policies.md` with the exit code 124 feedback mechanism.


### PR DESCRIPTION
Update `.foundry/docs/knowledge_base/agents/core_policies.md` to explicitly state that when the `timeout` command interrupts a process, it returns exit code 124, and guide agents to recognize this exit code as a timeout and use non-blocking alternatives like `cat` or `tail -n`. Marked task 268-322 as completed.

---
*PR created automatically by Jules for task [9736254150260241551](https://jules.google.com/task/9736254150260241551) started by @szubster*