### PR TITLE
chore(qa): mark gen3 contest and frontier extraction as complete

### DIFF
--- a/.foundry/tasks/task-320-323-gen3-contest-frontier-qa.md
+++ b/.foundry/tasks/task-320-323-gen3-contest-frontier-qa.md
@@ -35,7 +35,7 @@ Verify the implementation of extraction logic for Master Rank Contest condition 
 - Verify that for Gen 3 save file parsing, the Coder used the resolved section offset (e.g., `section1Offset` or `section2Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets.
 
 ## Acceptance Criteria
-- [ ] Verify Contest extraction logic using `DataView`.
-- [ ] Verify Battle Frontier extraction logic using `DataView`.
-- [ ] Verify no magic numbers are used inline for memory operations.
-- [ ] Verify appropriate A/B bank relative offset resolution is used.
+- [x] Verify Contest extraction logic using `DataView`.
+- [x] Verify Battle Frontier extraction logic using `DataView`.
+- [x] Verify no magic numbers are used inline for memory operations.
+- [x] Verify appropriate A/B bank relative offset resolution is used.


### PR DESCRIPTION
Checked off acceptance criteria in task-320-323-gen3-contest-frontier-qa.md after verifying the correct implementation of DataView parsing for gen 3 contest ribbons and battle frontier symbols/win streaks.

---
*PR created automatically by Jules for task [16146267929111479059](https://jules.google.com/task/16146267929111479059) started by @szubster*