### PR TITLE
Agile Coach: Centralize Reminders & Implement Cycle Detection

### DIFF
--- a/.foundry/journals/agile_coach.md
+++ b/.foundry/journals/agile_coach.md
@@ -14,3 +14,7 @@ I have extracted these common directives and appended them directly to `.foundry
 ## 2026-07-17: Consolidated Task Reminders
 Identified redundancy where the Tech Lead was instructed to copy-paste failure handling and Empty PR checkbox reminders into every single TASK node's markdown body. This causes unnecessary bloat.
 I have removed this directive from `tech_lead.md` and created an IDEA node (`idea-118-centralize-prompt-reminders`) to track this process improvement. The core policies (`core_policies.md`) already cover these rules comprehensively.
+
+## 2026-07-18: Centralized Reminders and Cycle Detection
+- Removed redundant `### REMINDER FOR QA` and `### REMINDER FOR CODER` blocks from the `qa` and `coder` persona prompts, as well as an existing task (`task-299-323-extend-phase-3-6-qa`), satisfying `idea-118-centralize-prompt-reminders`. These rules should rely on core_policies.md instead to reduce duplication and token usage.
+- Implemented circular dependency detection in the Foundry Orchestrator (`foundry-orchestrator.ts`) during Phase 3.9 using a DFS-based cycle detection algorithm. `PENDING` nodes involved in a cycle will now be safely transitioned to `FAILED` with `rejection_reason = "Circular dependency detected"`, satisfying `idea-118-orchestrator-circular-dependency-detection` and preventing DAG deadlocks.

--- a/.foundry/tasks/task-299-323-extend-phase-3-6-qa.md
+++ b/.foundry/tasks/task-299-323-extend-phase-3-6-qa.md
@@ -36,10 +36,5 @@ Verify the implementation in `.github/scripts/foundry-orchestrator.ts` and the a
 - [x] All unit tests pass, explicitly covering the new behaviour.
 - [x] The change does not break existing test cases.
 
-### REMINDER FOR QA
-- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
-
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -54,7 +54,3 @@ You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.
 When a QA agent rejects your task for missing architectural requirements (e.g., failing to implement a shared React Context mandated by an ADR), you MUST comprehensively implement the missing architectural layer. Do not simply fake a fix or ignore the architectural constraint. Repeatedly failing to adhere to ADRs will result in permanent failure and system penalties.
 
 
-### REMINDER FOR CODER
-- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -65,7 +65,3 @@ You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.
 When validating tasks, you MUST strictly enforce architectural patterns mandated by ADRs (e.g., ADR 013 and ADR 017 requiring shared React Contexts). If a coder repeatedly ignores these requirements and fakes fixes, explicitly document this persistent failure in your journal and escalate by suggesting the creation of a specialized `RESEARCH` or `TASK` node to address the developer friction.
 
 
-### REMINDER FOR QA
-- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -2552,8 +2552,11 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     const bContent = fs.readFileSync(path.join(tmpDir, ".foundry/tasks/task-b.md"), "utf-8");
     const cContent = fs.readFileSync(path.join(tmpDir, ".foundry/tasks/task-c.md"), "utf-8");
 
-    expect(aContent).toContain("status: PENDING");
-    expect(bContent).toContain("status: PENDING");
-    expect(cContent).toContain("status: PENDING");
+    expect(aContent).toContain("status: FAILED");
+    expect(aContent).toContain("rejection_reason: Circular dependency detected");
+    expect(bContent).toContain("status: FAILED");
+    expect(bContent).toContain("rejection_reason: Circular dependency detected");
+    expect(cContent).toContain("status: FAILED");
+    expect(cContent).toContain("rejection_reason: Circular dependency detected");
   });
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -712,6 +712,69 @@ function main(): void {
     }
   }
 
+  // ── Phase 3.9: CIRCULAR DEPENDENCY DETECTION ───────────────────────────────
+  info('Phase 3.9: Detecting circular dependencies among PENDING nodes...');
+
+  const pendingNodesForCycleDetection = nodes.filter(n => n.frontmatter.status === 'PENDING');
+  const dependencyGraph = new Map<string, string[]>();
+
+  for (const n of pendingNodesForCycleDetection) {
+    const deps = (n.frontmatter.depends_on || []).map(resolveNodePath).filter(Boolean) as string[];
+    // Also include implicit parent dependencies
+    const parentPath = resolveNodePath(n.frontmatter.parent);
+    if (parentPath) {
+      deps.push(parentPath);
+    }
+    dependencyGraph.set(n.repoPath, deps);
+  }
+
+  const visitedForCycle = new Set<string>();
+  const recursionStack = new Set<string>();
+  const nodesInCycle = new Set<string>();
+
+  function dfsCycle(nodePath: string): boolean {
+    visitedForCycle.add(nodePath);
+    recursionStack.add(nodePath);
+
+    const deps = dependencyGraph.get(nodePath) || [];
+    let hasCycle = false;
+    for (const dep of deps) {
+      if (!dependencyGraph.has(dep)) continue; // Only care about PENDING dependencies
+
+      if (!visitedForCycle.has(dep)) {
+        if (dfsCycle(dep)) {
+          nodesInCycle.add(dep);
+          hasCycle = true;
+        }
+      } else if (recursionStack.has(dep)) {
+        nodesInCycle.add(dep);
+        hasCycle = true;
+      }
+    }
+
+    recursionStack.delete(nodePath);
+    if (hasCycle) {
+       nodesInCycle.add(nodePath);
+    }
+    return hasCycle;
+  }
+
+  for (const n of pendingNodesForCycleDetection) {
+    if (!visitedForCycle.has(n.repoPath)) {
+      dfsCycle(n.repoPath);
+    }
+  }
+
+  if (nodesInCycle.size > 0) {
+    warn(`Detected circular dependency involving ${nodesInCycle.size} nodes.`);
+    for (const nodePath of nodesInCycle) {
+      const cycleNode = nodes.find(n => n.repoPath === nodePath);
+      if (cycleNode) {
+        promoteNodeToFailedWithReason(cycleNode, 'Circular dependency detected');
+      }
+    }
+  }
+
   // ── Phase 4: RESOLVE ───────────────────────────────────────────────────────
   info('Phase 4: Resolving DAG — finding eligible PENDING nodes...');
   const eligible: ParsedNode[] = [];


### PR DESCRIPTION
This PR implements the ideas generated by the Agile Coach (idea-118-centralize-prompt-reminders and idea-118-orchestrator-circular-dependency-detection). It removes redundant REMINDER blocks from persona prompts and task files to reduce prompt rot and rely on `core_policies.md`. Furthermore, it implements DFS-based circular dependency detection in the Foundry Orchestrator (`foundry-orchestrator.ts`) to prevent infinite hangs by failing cyclic nodes. Tests have been updated.

---
*PR created automatically by Jules for task [2686330818287595682](https://jules.google.com/task/2686330818287595682) started by @szubster*