### PR TITLE
💡 Visionary: Gen 2 Unown Dex Progress Tracker

### DIFF
--- a/.foundry/ideas/idea-119-gen2-unown-dex-tracker.md
+++ b/.foundry/ideas/idea-119-gen2-unown-dex-tracker.md
@@ -20,7 +20,7 @@ rejection_reason: ""
 ## Context
 In Generation 2 (Gold, Silver, Crystal), catching all 26 Unown forms is a significant endgame side quest tied to the Ruins of Alph puzzles. The in-game Unown Dex tracks which forms have been caught, but unlocking more Unown forms requires completing specific sliding puzzles in the Ruins of Alph chambers.
 
-Currently, DexHelper provides excellent utility for the standard Pokédex, but it lacks support for this unique, fragmented sub-quest. Hardcore completionists would benefit greatly from a unified view that connects their caught Unown forms with the hidden puzzle completion flags.
+Currently, DexHelper provides an UnownDexPanel that highlights caught forms, but it lacks the contextual link to the requisite Ruins of Alph sliding puzzle event flags. Hardcore completionists would benefit greatly from a unified view that connects their caught Unown forms with the hidden puzzle completion flags.
 
 ## Proposal
 Create a dedicated `Gen 2 Unown Dex Progress Tracker` dashboard. This feature will:

--- a/.foundry/ideas/idea-119-gen2-unown-dex-tracker.md
+++ b/.foundry/ideas/idea-119-gen2-unown-dex-tracker.md
@@ -1,0 +1,32 @@
+---
+id: idea-119-gen2-unown-dex-tracker
+type: IDEA
+title: Gen 2 Unown Dex Progress Tracker
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-07-18'
+updated_at: '2026-07-18'
+depends_on: []
+jules_session_id: null
+tags:
+  - feature
+  - gen2
+  - unown
+rejection_reason: ""
+---
+
+# Gen 2 Unown Dex Progress Tracker
+
+## Context
+In Generation 2 (Gold, Silver, Crystal), catching all 26 Unown forms is a significant endgame side quest tied to the Ruins of Alph puzzles. The in-game Unown Dex tracks which forms have been caught, but unlocking more Unown forms requires completing specific sliding puzzles in the Ruins of Alph chambers.
+
+Currently, DexHelper provides excellent utility for the standard Pokédex, but it lacks support for this unique, fragmented sub-quest. Hardcore completionists would benefit greatly from a unified view that connects their caught Unown forms with the hidden puzzle completion flags.
+
+## Proposal
+Create a dedicated `Gen 2 Unown Dex Progress Tracker` dashboard. This feature will:
+1. Extract the caught Unown forms from the save file (utilizing the Gen 2 Unown Dex save block data).
+2. Extract the event flags related to the four Ruins of Alph sliding puzzles (Kabuto, Aerodactyl, Ho-Oh, Omanyte).
+3. Display a visual grid of the 26 Unown letters, highlighting which ones have been caught.
+4. Provide actionable warnings if the player is missing Unown forms because they have not completed the requisite puzzle. For example, if they are missing forms unlocked by the Ho-Oh puzzle, the dashboard should explicitly state: "You must complete the Ho-Oh puzzle in the Ruins of Alph to encounter more Unown forms."
+
+This aligns perfectly with DexHelper's vision as a premium companion app by surfacing hidden save state data and transforming a tedious, trial-and-error collection quest into a clear, actionable checklist.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -229,3 +229,7 @@
 ## 2026-07-17
 **Idea:** Implement Circular Dependency Detection in DAG Orchestrator
 **Learning:** As the Foundry Orchestrator resolves dependencies linearly, circular dependencies can cause silent failures (deadlocking nodes in PENDING). Proactively implementing cycle detection in the orchestrator aligns with the "Technical Evolution" focus area by significantly improving the robustness of the system and preventing infinite hanging states caused by agent mistakes.
+
+## 2026-07-18
+**Idea:** Gen 2 Unown Dex Progress Tracker
+**Learning:** Expanding on collection capabilities, extracting and tracking Unown forms along with the Ruins of Alph puzzle flags transforms a tedious, multi-step sub-quest into an actionable dashboard. This caters to hardcore completionists and leverages the save file's deep state to offer premium utility, perfectly aligning with DexHelper's vision.


### PR DESCRIPTION
This PR proposes a new feature for DexHelper: a "Gen 2 Unown Dex Progress Tracker".

By extracting the caught Unown forms and the event flags for the four Ruins of Alph sliding puzzles from the save file, we can provide a unified dashboard. This feature transforms a fragmented sub-quest into an actionable checklist with explicit warnings if requisite puzzles have not been completed, perfectly aligning with the app's premium utility vision.

The corresponding idea node has been generated under `.foundry/ideas/idea-119-gen2-unown-dex-tracker.md`, and the learnings have been logged to the visionary journal.

---
*PR created automatically by Jules for task [3245826062187253088](https://jules.google.com/task/3245826062187253088) started by @szubster*