### PR TITLE
fix(schema): support the 'auditor' persona in schema validation

### DIFF
--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -61,7 +61,7 @@ function validateSchema() {
   const validStatuses = ['PENDING', 'READY', 'ACTIVE', 'VERIFYING', 'COMPLETED', 'FAILED', 'BLOCKED', 'CANCELLED'];
   const validPersonas = [
     'product_manager', 'epic_planner', 'story_owner', 'architect',
-    'tech_lead', 'coder', 'qa', 'human', 'tpm', 'agile_coach', 'researcher'
+    'tech_lead', 'coder', 'qa', 'human', 'tpm', 'agile_coach', 'researcher', 'auditor'
   ];
 
   const validMappings: Record<string, string[]> = {
@@ -125,7 +125,7 @@ function validateSchema() {
     }
 
     // 2.5 Validate persona mapping
-    if (type && owner_persona && owner_persona !== 'human' && owner_persona !== 'tpm' && owner_persona !== 'agile_coach') {
+    if (type && owner_persona && owner_persona !== 'human' && owner_persona !== 'tpm' && owner_persona !== 'agile_coach' && owner_persona !== 'auditor') {
       const allowedPersonas = validMappings[type as string] || [];
       if (!allowedPersonas.includes(owner_persona)) {
         console.error(`Error: Invalid mapping: ${type} node '${file}' cannot be owned by '${owner_persona}'`);


### PR DESCRIPTION
The 'auditor' persona is responsible for verifying macro nodes (IDEA, PRD, EPIC). When these nodes are transitioned to the 'VERIFYING' status, their owner_persona is dynamically updated to 'auditor'. The schema validation script previously did not allow 'auditor' as a valid owner_persona, causing pre-commit hook failures on remote orchestration runs. This patch adds 'auditor' to the validPersonas list and bypasses type mapping validation for 'auditor' (similar to 'human', 'tpm', and 'agile_coach'), enabling proper validation and unblocking the orchestration pipeline.

Fixes #4769

---
*PR created automatically by Jules for task [16540965962331514110](https://jules.google.com/task/16540965962331514110) started by @szubster*