### PR TITLE
🧪 Sentinel: Improve test coverage for SettingsModal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,2 +1,11 @@
 - When writing Vitest tests, always provide explicit type parameters to `vi.fn()` (e.g., `vi.fn<() => void>()`) to satisfy strict Biome type-checking and avoid `any` usage.
 - In Playwright E2E tests, always call `await waitForSync(page)` after navigation to ensure IndexedDB sync completes.
+## 2024-05-27
+
+- **Test Target Identification**: Used test coverage reporting to identify missing test coverage for `src/components/SettingsModal.tsx`.
+- **Vitest**:
+  - Mocked `saveDB` properly to ensure tests isolate component behavior.
+  - Required using `// eslint-disable-next-line @typescript-eslint/unbound-method` when passing an unbound mock function like `saveDB.deleteSave` into `expect(...).toHaveBeenCalledWith(...)`.
+  - Required using `// biome-ignore lint/suspicious/noExplicitAny: allow mock state for test` when using `as any` to force minimal mock objects into complex type shapes.
+  - Used explicit types for `vi.fn()` like `vi.fn<(key: string) => Promise<void>>()` to pass strict typing rules.
+- **Testing React Components**: Verified components rendering logic via `isSettingsOpen` and user interactions invoking the state reset functions (including testing confirmation modals).

--- a/src/components/__tests__/SettingsModal.test.tsx
+++ b/src/components/__tests__/SettingsModal.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { saveDB } from '../../db/SaveDB';
+import { useStore } from '../../store';
+import { SettingsModal } from '../SettingsModal';
+
+vi.mock('../../db/SaveDB', () => ({
+  saveDB: {
+    deleteSave: vi.fn<(key: string) => Promise<void>>(),
+  },
+}));
+
+describe('SettingsModal', () => {
+  beforeEach(() => {
+    useStore.setState({
+      isSettingsOpen: false,
+      saveData: null,
+      manualVersion: null,
+      isLivingDex: false,
+      globalPokeball: 'poke',
+      nuzlockeGraveyardBox: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should not render when isSettingsOpen is false', async () => {
+    useStore.setState({ isSettingsOpen: false });
+    const { baseElement } = await render(<SettingsModal />);
+    expect(baseElement.innerHTML).not.toContain('SYS.CONFIG');
+  });
+
+  it('should render when isSettingsOpen is true', async () => {
+    useStore.setState({ isSettingsOpen: true });
+    await render(<SettingsModal />);
+
+    await expect.element(page.getByRole('heading', { name: 'SYS.CONFIG' })).toBeInTheDocument();
+    await expect.element(page.getByText('Configure your experience')).toBeInTheDocument();
+  });
+
+  it('should close when the close button is clicked', async () => {
+    useStore.setState({ isSettingsOpen: true });
+    await render(<SettingsModal />);
+
+    expect(useStore.getState().isSettingsOpen).toBe(true);
+
+    const closeButton = page.getByTitle('Close settings');
+    await closeButton.click();
+
+    expect(useStore.getState().isSettingsOpen).toBe(false);
+  });
+
+  it('should call deleteSave and reset state when Clear Storage is confirmed', async () => {
+    useStore.setState({
+      isSettingsOpen: true,
+      manualVersion: 'red', // use gen 1 to prevent unknown generation error
+      // biome-ignore lint/suspicious/noExplicitAny: allow mock state for test
+      saveData: { generation: 1, gameVersion: 'red', owned: new Set(), seen: new Set(), party: [], pc: [] } as any,
+    });
+    await render(<SettingsModal />);
+
+    // Click SYS.PURGE to open confirmation
+    const purgeButton = page.getByText(/SYS\.PURGE/);
+    await purgeButton.click();
+
+    // Click CONFIRM.PURGE
+    const confirmButton = page.getByText(/CONFIRM\.PURGE/);
+    await confirmButton.click();
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(saveDB.deleteSave).toHaveBeenCalledWith('last_save_file');
+    expect(useStore.getState().saveData).toBeNull();
+    expect(useStore.getState().manualVersion).toBeNull();
+    expect(useStore.getState().isSettingsOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
🎯 What:
Added comprehensive tests for `src/components/SettingsModal.tsx` using `vitest-browser-react`.

📊 Coverage:
Before this PR, `SettingsModal.tsx` lacked a dedicated test file and had gaps in its interaction flows. The new tests verify:
- It correctly remains hidden when `isSettingsOpen` is false.
- It renders when `isSettingsOpen` is true.
- Clicking the close button calls `setIsSettingsOpen(false)`.
- Clicking the purge data confirm buttons calls the underlying `saveDB.deleteSave` and resets global Zustand state properly.

✨ Result:
Test coverage for `src/components/SettingsModal.tsx` should now be highly robust against regression. All linting and tests (unit + E2E) passed successfully.

---
*PR created automatically by Jules for task [8326004689452642499](https://jules.google.com/task/8326004689452642499) started by @szubster*