### PR TITLE
🧭 Strategist: Prompt improvement - Consolidate Node Failure Rules

### DIFF
--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -54,7 +54,3 @@ You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.
 When a QA agent rejects your task for missing architectural requirements (e.g., failing to implement a shared React Context mandated by an ADR), you MUST comprehensively implement the missing architectural layer. Do not simply fake a fix or ignore the architectural constraint. Repeatedly failing to adhere to ADRs will result in permanent failure and system penalties.
 
 
-### REMINDER FOR CODER
-- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -65,7 +65,3 @@ You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.
 When validating tasks, you MUST strictly enforce architectural patterns mandated by ADRs (e.g., ADR 013 and ADR 017 requiring shared React Contexts). If a coder repeatedly ignores these requirements and fakes fixes, explicitly document this persistent failure in your journal and escalate by suggesting the creation of a specialized `RESEARCH` or `TASK` node to address the developer friction.
 
 
-### REMINDER FOR QA
-- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
-- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
-- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -381,3 +381,9 @@
 **Outcome:** Merged
 **Why:** The prompt evaluation identified duplication in the agent prompts where the "WARNING ON BASH SESSIONS" rule was explicitly defined in `auditor.md`, `coder.md`, `qa.md`, and `tech_lead.md`, despite already being present in the centralized `.foundry/docs/knowledge_base/agents/core_policies.md` under "Bash Session Timeout Policy".
 **Pattern:** Consolidate duplicated core prompt instructions into `.foundry/docs/knowledge_base/agents/core_policies.md` and instruct the agents to read it. This drastically reduces prompt size, creates a single source of truth, and allows global policy updates without touching multiple individual schedule files.
+
+## 2026-07-30 - [Accepted] - Prompt improvement - Consolidate Node Failure Rules
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The prompt evaluation identified duplication in the agent prompts where the "REMINDER FOR CODER" and "REMINDER FOR QA" rules regarding node failures, cancellations, and empty PRs were explicitly defined in `coder.md` and `qa.md`, despite already being centralized in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+**Pattern:** Agents must rely on the centralized policies in `.foundry/docs/knowledge_base/agents/core_policies.md` for handling node failures, cancellations, and empty PRs, rather than duplicating 'REMINDER' blocks across persona prompts or task files.


### PR DESCRIPTION
This PR consolidates node failure and Empty PR policies across the Foundry system. The `REMINDER FOR CODER` and `REMINDER FOR QA` blocks from `.github/agents/coder.md` and `.github/agents/qa.md` have been removed, as these identical rules already exist in `.foundry/docs/knowledge_base/agents/core_policies.md`.

This prompt improvement simplifies the agent schedules and enforces reliance on a single, centralized source of truth for architectural guidelines. It includes the required Strategist journal log for the accepted improvement.

---
*PR created automatically by Jules for task [8684432661830582462](https://jules.google.com/task/8684432661830582462) started by @szubster*