### PR TITLE
Allow 'auditor' persona on 'VERIFYING' nodes in schema validation

### DIFF
--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -61,7 +61,8 @@ function validateSchema() {
   const validStatuses = ['PENDING', 'READY', 'ACTIVE', 'VERIFYING', 'COMPLETED', 'FAILED', 'BLOCKED', 'CANCELLED'];
   const validPersonas = [
     'product_manager', 'epic_planner', 'story_owner', 'architect',
-    'tech_lead', 'coder', 'qa', 'human', 'tpm', 'agile_coach', 'researcher'
+    'tech_lead', 'coder', 'qa', 'human', 'tpm', 'agile_coach', 'researcher',
+    'auditor'
   ];
 
   const validMappings: Record<string, string[]> = {
@@ -125,7 +126,7 @@ function validateSchema() {
     }
 
     // 2.5 Validate persona mapping
-    if (type && owner_persona && owner_persona !== 'human' && owner_persona !== 'tpm' && owner_persona !== 'agile_coach') {
+    if (type && owner_persona && owner_persona !== 'human' && owner_persona !== 'tpm' && owner_persona !== 'agile_coach' && !(owner_persona === 'auditor' && status === 'VERIFYING')) {
       const allowedPersonas = validMappings[type as string] || [];
       if (!allowedPersonas.includes(owner_persona)) {
         console.error(`Error: Invalid mapping: ${type} node '${file}' cannot be owned by '${owner_persona}'`);


### PR DESCRIPTION
This PR fixes the Foundry Engine orchestration failure caused by schema validation errors. It adds 'auditor' to the list of valid owner personas, and bypasses the standard node-to-persona mapping validations if the owner is 'auditor' and the node's status is 'VERIFYING'.

Fixes #4778

---
*PR created automatically by Jules for task [6824898669000166859](https://jules.google.com/task/6824898669000166859) started by @szubster*