### PR TITLE
Skip auto-remediation for terminated sessions in garbage collector

### DIFF
--- a/.github/scripts/garbage-collector.test.ts
+++ b/.github/scripts/garbage-collector.test.ts
@@ -94,7 +94,7 @@ owner_persona: human
     expect(remediateZombieModule.remediateZombieNode).not.toHaveBeenCalled();
   });
 
-  it('remediates nodes if session is TERMINATED', async () => {
+  it('does not remediate nodes if session is TERMINATED', async () => {
     const tmpNodePath = createTestNode(`---
 id: task-terminated
 status: ACTIVE
@@ -108,11 +108,8 @@ jules_session_id: sess-terminated
     await main();
 
     expect(sessionApiModule.checkSessionLiveliness).toHaveBeenCalledWith('sess-terminated', 'test-key');
-    expect(remediateZombieModule.remediateZombieNode).toHaveBeenCalledWith(
-      expect.any(String),
-      tmpNodePath,
-      'Zombie node detected: Session sess-terminated is TERMINATED without resolving the node'
-    );
+    expect(remediateZombieModule.remediateZombieNode).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledWith(`[GC] Skipping node ${tmpNodePath}: Session sess-terminated is TERMINATED (heartbeat will resolve)`);
   });
 
   it('does not remediate nodes if session is ACTIVE', async () => {

--- a/.github/scripts/garbage-collector.ts
+++ b/.github/scripts/garbage-collector.ts
@@ -53,8 +53,7 @@ export async function main() {
       const liveliness = await checkSessionLiveliness(sessionId, julesKey);
 
       if (liveliness === 'TERMINATED') {
-        console.info(`[GC] Remediating node ${relativePath}: Session ${sessionId} is TERMINATED`);
-        remediateZombieNode(repoRoot, relativePath, `Zombie node detected: Session ${sessionId} is TERMINATED without resolving the node`);
+        console.info(`[GC] Skipping node ${relativePath}: Session ${sessionId} is TERMINATED (heartbeat will resolve)`);
       }
     } catch (err) {
       console.error(`[GC] Error processing node ${relativePath}:`, err);


### PR DESCRIPTION
Modified the garbage collector script to skip auto-remediation/retrying for nodes with terminated sessions in Jules (COMPLETED/FAILED), since they are perfectly normal and are designed to be processed gracefully by the heartbeat orchestrator instead. Corresponding tests were updated.

Fixes #4765

---
*PR created automatically by Jules for task [16876888483219180385](https://jules.google.com/task/16876888483219180385) started by @szubster*