### PR TITLE
chore(foundry): Handle impossible loop for Gen 2 Static Encounters epic

### DIFF
--- a/.foundry/epics/epic-106-137-gen2-static-encounters.md
+++ b/.foundry/epics/epic-106-137-gen2-static-encounters.md
@@ -26,8 +26,12 @@ Break down the Gen 2 static encounter checklist into stories.
 ## Acceptance Criteria
 - [x] Create story for Gen 2 event flag parsing
 - [x] Create story for Gen 2 checklist UI
-- [ ] story-137-294-gen2-event-flag-parsing
-- [ ] story-137-295-gen2-checklist-ui
+- [x] story-137-294-gen2-event-flag-parsing
+- [x] story-137-295-gen2-checklist-ui
+
+- [ ] research-137-330-investigate-gen2-event-flag-failure
+- [ ] story-137-333-gen2-event-flag-parsing-retry
+- [ ] story-137-334-gen2-checklist-ui-retry
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -28,3 +28,8 @@ When processing roamer tracking, Gen 3 map coordinates cannot be statically extr
 * The child tasks for `epic-044-149-gen3-roamer-core-extraction-v4` were already completed and archived in `.foundry/archive/stories/` (specifically `story-149-291-gen3-roamer-core-extraction.md` and `story-149-292-gen3-roamer-active-flag-parsing.md`). I verified their existence and checked off the acceptance criteria checkboxes in the parent EPIC to allow it to gracefully transition to `VERIFYING` via an empty PR.
 ## 2026-07-17
 * Generated `story-327-331-research-gen3-pokeblock-offsets` and `story-327-332-implement-gen3-pokeblock-parsing` from `epic-114-327-gen3-pokeblock-case-parsing`.
+
+## [2026-07-18] Handled Impossible Loop for epic-106-137-gen2-static-encounters
+- Spawned research-137-330 to investigate failure of story-137-294.
+- Created replacement nodes story-137-333 and story-137-334.
+- Checked off permanently failed child nodes in epic markdown.

--- a/.foundry/research/research-137-330-investigate-gen2-event-flag-failure.md
+++ b/.foundry/research/research-137-330-investigate-gen2-event-flag-failure.md
@@ -1,0 +1,27 @@
+---
+id: research-137-330-investigate-gen2-event-flag-failure
+type: RESEARCH
+title: Investigate Gen 2 Event Flag Parsing Failure
+status: READY
+owner_persona: researcher
+created_at: '2026-07-18'
+updated_at: '2026-07-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-106-137-gen2-static-encounters
+tags:
+  - gen2
+  - backend
+  - failure-investigation
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 2 Event Flag Parsing Failure
+
+Investigate the root cause of the permanent failure in `story-137-294-gen2-event-flag-parsing`.
+
+## Acceptance Criteria
+- [ ] Root cause identified and documented.

--- a/.foundry/stories/story-137-333-gen2-event-flag-parsing-retry.md
+++ b/.foundry/stories/story-137-333-gen2-event-flag-parsing-retry.md
@@ -1,0 +1,28 @@
+---
+id: story-137-333-gen2-event-flag-parsing-retry
+type: STORY
+title: Gen 2 Event Flag Parsing (Retry)
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-18'
+updated_at: '2026-07-18'
+depends_on:
+  - research-137-330-investigate-gen2-event-flag-failure
+jules_session_id: null
+pr_number: null
+parent: epic-106-137-gen2-static-encounters
+tags:
+  - gen2
+  - backend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Event Flag Parsing (Retry)
+
+Extract the event flags for Gen 2 static encounters from the save file. This involves finding the offsets and bit positions for encounters like Sudowoodo, Snorlax, Red Gyarados, and Ho-Oh/Lugia, and exposing this data to the state management layer.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks

--- a/.foundry/stories/story-137-334-gen2-checklist-ui-retry.md
+++ b/.foundry/stories/story-137-334-gen2-checklist-ui-retry.md
@@ -1,0 +1,28 @@
+---
+id: story-137-334-gen2-checklist-ui-retry
+type: STORY
+title: Gen 2 Checklist UI (Retry)
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-18'
+updated_at: '2026-07-18'
+depends_on:
+  - story-137-333-gen2-event-flag-parsing-retry
+jules_session_id: null
+pr_number: null
+parent: epic-106-137-gen2-static-encounters
+tags:
+  - gen2
+  - frontend
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 2 Checklist UI (Retry)
+
+Create the UI component to display the checklist of Gen 2 static encounters (Sudowoodo, Snorlax, Red Gyarados, and Ho-Oh/Lugia) based on the event flags parsed from the backend. The design must adhere strictly to the project's 'tactical hardware/snooping' aesthetic (sharp edges, dashed borders, monospaced telemetry fonts).
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
Handled the impossible loop condition for `epic-106-137-gen2-static-encounters` where `story-137-294` hit the max rejection count and failed. Followed the impossible loop protocol:
- Created a research node (`research-137-330`) to investigate the failure.
- Generated replacement nodes (`story-137-333` and `story-137-334`) dependent on the research node.
- Checked off permanently failed child nodes and linked new nodes in the parent EPIC markdown.
- Documented actions in the story_owner journal.

---
*PR created automatically by Jules for task [80578693855257164](https://jules.google.com/task/80578693855257164) started by @szubster*