### PR TITLE
Update idea-067 and Log Anomaly for Pre-existing PRD

### DIFF
--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -63,3 +63,8 @@ When assigned to a macro node (like an IDEA) that has spawned children, DO NOT t
 ## 2026-07-16 - Anomaly Found
 
 When generating the PRD for `idea-117-split-bundles-and-data`, I noticed that the research and ADR references (`research-117-325-bundle-splitting-analysis` and `adr-117-029-bundle-splitting-strategy`) already existed and were marked as completed in the IDEA node's acceptance criteria.
+
+## 2026-07-18
+
+**Anomaly Detected**:
+During the session to transform `idea-067-extract-dag-utils` into a PRD, it was discovered that the target artifact `prd-067-036-extract-dag-utils` already unexpectedly existed prior to the session. The Agile Coach should review this to determine why a target artifact was present before the IDEA was formally processed into a PRD in the current session.


### PR DESCRIPTION
This PR processes the IDEA `idea-067-extract-dag-utils`. It addresses an anomaly where the target artifact already existed prior to the session.

- Checks off the acceptance criteria for the PRD in `idea-067-extract-dag-utils.md`.
- Records the anomaly in `.foundry/journals/product_manager.md` for the Agile Coach.

---
*PR created automatically by Jules for task [12306192269169324192](https://jules.google.com/task/12306192269169324192) started by @szubster*