### PR TITLE
chore: verify bash timeout feedback story completion

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -199,3 +199,6 @@ During the session for `story-301-314-lift-rejection-count-state`, the target Fo
 Created implementation and QA verification tasks for story-119-261-npc-trade-state-integration. Ensured the QA task explicitly tests the requirements like RangeError handling and constant-defined memory offsets, as state integration changes logic in the core parse pipeline, meaning verification is essential according to the Intelligent Verification Protocol.
 ## 2026-07-17: Empty PR for completed child task
 Assigned to story-130-315-define-indexeddb-schema where its generated child (task-315-322-implement-savehistorydb) has already been completed and archived. Checked off the child checkbox in the story markdown body and submitted an empty PR to transition the Story.
+
+## [Anomaly] Pre-existing completed task
+Assigned to story-127-268-bash-timeout-feedback where its generated child (task-268-322-bash-timeout-feedback-impl) has already been completed. Checked off the child checkbox in the story markdown body and submitted an empty PR to transition the Story.

--- a/.foundry/stories/story-127-268-bash-timeout-feedback.md
+++ b/.foundry/stories/story-127-268-bash-timeout-feedback.md
@@ -28,4 +28,4 @@ Implement feedback mechanism for commands that were interrupted due to timeout.
 
 ## Acceptance Criteria
 - [x] Implement feedback mechanism for interrupted commands.
-- [ ] task-268-322-bash-timeout-feedback-impl
+- [x] task-268-322-bash-timeout-feedback-impl


### PR DESCRIPTION
Empty PR to transition story-127-268-bash-timeout-feedback to VERIFYING as its child task task-268-322-bash-timeout-feedback-impl is already COMPLETED.

---
*PR created automatically by Jules for task [2922555310178579340](https://jules.google.com/task/2922555310178579340) started by @szubster*