### PR TITLE
Create Story: Remove Orphaned QA Rule from Documentation

### DIFF
--- a/.foundry/epics/epic-115-331-remove-orphaned-qa-task-rule-from-docs.md
+++ b/.foundry/epics/epic-115-331-remove-orphaned-qa-task-rule-from-docs.md
@@ -28,4 +28,5 @@ The obsolete "Orphaned QA Task Cancellation Rule" needs to be completely removed
 This epic covers scanning the documentation (specifically `core_policies.md` and related agent docs) and removing any instruction regarding the manual cancellation of orphaned tasks.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Break down this Epic into Stories.
+- [x] Story Owner: Break down this Epic into Stories.
+- [ ] story-331-333-remove-orphaned-qa-rule

--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -28,3 +28,6 @@ When processing roamer tracking, Gen 3 map coordinates cannot be statically extr
 * The child tasks for `epic-044-149-gen3-roamer-core-extraction-v4` were already completed and archived in `.foundry/archive/stories/` (specifically `story-149-291-gen3-roamer-core-extraction.md` and `story-149-292-gen3-roamer-active-flag-parsing.md`). I verified their existence and checked off the acceptance criteria checkboxes in the parent EPIC to allow it to gracefully transition to `VERIFYING` via an empty PR.
 ## 2026-07-17
 * Generated `story-327-331-research-gen3-pokeblock-offsets` and `story-327-332-implement-gen3-pokeblock-parsing` from `epic-114-327-gen3-pokeblock-case-parsing`.
+
+## [2026-07-18] Remove Orphaned QA Task Rule From Docs
+Broke down epic-115-331-remove-orphaned-qa-task-rule-from-docs into story-331-333-remove-orphaned-qa-rule.

--- a/.foundry/stories/story-331-333-remove-orphaned-qa-rule.md
+++ b/.foundry/stories/story-331-333-remove-orphaned-qa-rule.md
@@ -1,0 +1,31 @@
+---
+id: story-331-333-remove-orphaned-qa-rule
+type: STORY
+title: Remove Orphaned QA Rule from Documentation
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-18'
+updated_at: '2026-07-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-115-331-remove-orphaned-qa-task-rule-from-docs
+tags:
+  - docs
+  - agile-coach
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Remove Orphaned QA Rule from Documentation
+
+## Description
+The obsolete "Orphaned QA Task Cancellation Rule" needs to be completely removed from system documentation. Although the orchestrator automatically handles cascaded cancellations (Phase 3.6), there are still instructions within `.foundry/docs/knowledge_base/agents/core_policies.md` telling personas to manually modify the markdown bodies of orphaned tasks. This creates confusion and merge conflicts.
+
+This story tracks identifying and removing those obsolete instructions from `.foundry/docs/knowledge_base/agents/core_policies.md`.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break down into Tasks


### PR DESCRIPTION
This PR breaks down epic-115-331-remove-orphaned-qa-task-rule-from-docs into story-331-333-remove-orphaned-qa-rule to remove the obsolete Orphaned QA Task Cancellation Rule from system documentation.

---
*PR created automatically by Jules for task [18383675543993261458](https://jules.google.com/task/18383675543993261458) started by @szubster*