### PR TITLE
🛡️ Nurse: [type improvement]

### DIFF
--- a/.jules/nurse.md
+++ b/.jules/nurse.md
@@ -1,2 +1,3 @@
 # Nurse type improvements
 Found and removed an unnecessary `as` cast in `src/components/TacticalSegmentedControl.tsx` that was bypassing the compiler checks for `document.activeElement`. Replaced with proper type narrowing.
+- Replaced unsafe 'as' casts in ShinyCarrierBreedingDashboard.tsx for breeding pair parents with generic types in BreedingPair and calculateBreedingPairs to allow TypeScript to automatically infer the types.

--- a/src/components/dashboard/breeding/ShinyCarrierBreedingDashboard.tsx
+++ b/src/components/dashboard/breeding/ShinyCarrierBreedingDashboard.tsx
@@ -119,8 +119,8 @@ export const ShinyCarrierBreedingDashboard: React.FC = () => {
         ) : (
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             {breedingPairs.map((pair) => {
-              const pA = pair.parentA as PokemonWithMetadata & { _source: string; _speciesName: string };
-              const pB = pair.parentB as PokemonWithMetadata & { _source: string; _speciesName: string };
+              const pA = pair.parentA;
+              const pB = pair.parentB;
 
               return (
                 <div

--- a/src/engine/breeding/pair_algorithm.ts
+++ b/src/engine/breeding/pair_algorithm.ts
@@ -27,9 +27,9 @@ export interface PokemonWithMetadata {
 /**
  * Represents a valid pairing of two Pokémon capable of producing an egg, scored by the likelihood of generating a shiny offspring.
  */
-export interface BreedingPair {
-  parentA: PokemonWithMetadata;
-  parentB: PokemonWithMetadata;
+export interface BreedingPair<T extends PokemonWithMetadata = PokemonWithMetadata> {
+  parentA: T;
+  parentB: T;
   score: number; // Prioritize by Shiny Carrier status
 }
 
@@ -49,8 +49,8 @@ export interface BreedingPair {
  * const pairs = calculateBreedingPairs([pikachu, ditto]);
  * // Returns [{ parentA: pikachu, parentB: ditto, score: 0 }]
  */
-export function calculateBreedingPairs(pokemonList: PokemonWithMetadata[]): BreedingPair[] {
-  const pairs: BreedingPair[] = [];
+export function calculateBreedingPairs<T extends PokemonWithMetadata>(pokemonList: T[]): BreedingPair<T>[] {
+  const pairs: BreedingPair<T>[] = [];
 
   for (let i = 0; i < pokemonList.length; i++) {
     for (let j = i + 1; j < pokemonList.length; j++) {


### PR DESCRIPTION
Replaced unsafe `as` casts for breeding pair parents with generic types in `BreedingPair` and `calculateBreedingPairs`.

---
*PR created automatically by Jules for task [10819236970613565934](https://jules.google.com/task/10819236970613565934) started by @szubster*