### PR TITLE
💡 Visionary: Gen 3 Spinda Pattern Viewer

### DIFF
--- a/.foundry/ideas/idea-119-gen3-spinda-pattern-viewer.md
+++ b/.foundry/ideas/idea-119-gen3-spinda-pattern-viewer.md
@@ -1,0 +1,37 @@
+---
+id: idea-119-gen3-spinda-pattern-viewer
+type: IDEA
+title: Gen 3 Spinda Pattern Viewer
+status: PENDING
+owner_persona: "product_manager"
+created_at: "2026-07-19"
+updated_at: "2026-07-19"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - gen3
+  - spinda
+  - collection
+  - premium-feature
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen 3 Spinda Pattern Viewer
+
+## Description
+In Generation 3, the Pokémon Spinda has a unique mechanic where its spot pattern is procedurally generated based on its 32-bit Personality Value (PID), resulting in over 4 billion possible variations. Currently, players have no way of easily organizing or visualizing their unique Spinda collection outside of manually viewing them one by one in the game.
+
+By extracting the PID of caught Spinda from the party and PC Box data within an uploaded Gen 3 `.sav` file, DexHelper can accurately render a visual gallery of the exact Spinda patterns the player owns. This leverages our save parsing capabilities to create a highly visual, premium collector utility that transforms raw save data into an engaging visual dashboard.
+
+## Problem Statement
+Spinda collectors have no external tools to visualize and catalog their unique Spinda spot patterns from their save files, forcing them to rely on slow, manual in-game box checking.
+
+## Solution
+Create a Spinda Pattern Viewer dashboard that parses Spinda PIDs from the uploaded Gen 3 save file and uses a 2D canvas (or layered SVG) approach to render the exact spot patterns for each owned Spinda, displaying them in a unified gallery.
+
+## Acceptance Criteria
+- [ ] Product Manager: Convert this idea into a PRD to formalize the rendering approach and assign it to an epic for tracking.

--- a/.jules/visionary.md
+++ b/.jules/visionary.md
@@ -229,3 +229,7 @@
 ## 2026-07-17
 **Idea:** Implement Circular Dependency Detection in DAG Orchestrator
 **Learning:** As the Foundry Orchestrator resolves dependencies linearly, circular dependencies can cause silent failures (deadlocking nodes in PENDING). Proactively implementing cycle detection in the orchestrator aligns with the "Technical Evolution" focus area by significantly improving the robustness of the system and preventing infinite hanging states caused by agent mistakes.
+
+## 2026-07-19
+**Idea:** Gen 3 Spinda Pattern Viewer
+**Learning:** Targeting deeply obscure, math-driven visual mechanics (like Spinda's PID-based spots) leverages our save parsing to offer a visual wow-factor that is completely unavailable in the base game. It strongly emphasizes the "premium companion app" ethos by turning hidden binary data into a unique gallery experience for collectors.


### PR DESCRIPTION
🎯 What
Proposing a new IDEA node for a Gen 3 Spinda Pattern Viewer. This feature will extract Spinda PIDs from Gen 3 save files to visually render the exact spot patterns a player has caught.

⚠️ Risk
Low. This is purely an idea generation PR (IDEA node). No implementation or system modifications are made.

🛡️ Solution
Added `.foundry/ideas/idea-119-gen3-spinda-pattern-viewer.md` assigning it to the Product Manager for PRD conversion. Also recorded findings in `.jules/visionary.md`.

---
*PR created automatically by Jules for task [4602899598823021259](https://jules.google.com/task/4602899598823021259) started by @szubster*