### PR TITLE
🎨 Palette: Tooltips for TacticalIconButton

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@ When dynamically creating new downstream nodes (IDEA, TASK, RESEARCH, or ADR) in
 
 - **Aria-Label Fallbacks for UI Primitives**: When building or refactoring composite UI primitives such as `TacticalMultiSelectControl` or `TacticalSegmentedControl` where labels can be React nodes (like icons), always ensure there is an explicit `ariaLabel` property on the items. Use this to automatically apply an accessible fallback for both `aria-label` and `title` attributes on the rendered buttons, ensuring tooltip and screen reader support isn't lost.
 Learned about using .cjs for node scripts in ES module projects and the @utility directive in tailwind v4.
+- Maintained tactical aesthetics for tooltips by introducing a custom `@utility tactical-tooltip` in `src/index.css`.
+- Modified `TacticalIconButton` to replace native `title` tooltips with a custom CSS tooltip approach (`group-hover:opacity-100`) to address accessibility/UX without native browser styling, while preserving `aria-label` for screen readers.
+- Removed `title` from being spread onto `<button>` props by extracting it and omitting it from `restProps`.

--- a/src/components/TacticalIconButton.tsx
+++ b/src/components/TacticalIconButton.tsx
@@ -8,9 +8,24 @@ interface TacticalIconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonE
 export const TacticalIconButton = React.forwardRef<HTMLButtonElement, TacticalIconButtonProps>(
   ({ className, children, type = 'button', ...props }, ref) => {
     const title = props.title || props['aria-label'];
+
+    // Omit title from props passed to button to avoid native browser tooltip
+    const { title: _title, ...restProps } = props;
+
     return (
-      <button ref={ref} type={type} title={title} className={cn('tactical-icon-button', className)} {...props}>
+      <button
+        ref={ref}
+        type={type}
+        aria-label={title}
+        className={cn('tactical-icon-button group relative', className)}
+        {...restProps}
+      >
         {children}
+        {title && (
+          <span className="tactical-tooltip pointer-events-none absolute top-full left-1/2 z-50 mt-2 -translate-x-1/2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+            {title}
+          </span>
+        )}
       </button>
     );
   },

--- a/src/index.css
+++ b/src/index.css
@@ -142,6 +142,10 @@ body {
   }
 }
 
+@utility tactical-tooltip {
+  @apply rounded-none border border-dashed border-[var(--theme-border)] bg-zinc-950 px-2 py-1 font-mono text-[9px] text-zinc-300 uppercase tracking-widest whitespace-nowrap shadow-md;
+}
+
 @utility tactical-icon-button {
   @apply rounded-none border border-dashed border-[var(--theme-border)] bg-[var(--theme-surface)] p-2 text-white font-mono transition-all focus-visible:tactical-focus disabled:cursor-not-allowed disabled:opacity-50;
 


### PR DESCRIPTION
What: Added custom CSS tooltips to TacticalIconButton. 
Why: Missing tooltips for icon-only buttons. 
Before/After: Replaced native browser tooltips with custom design system tooltips. 
Accessibility notes: Ensures aria-label is applied and tooltips reveal on hover and focus-visible.

---
*PR created automatically by Jules for task [9688627685496270806](https://jules.google.com/task/9688627685496270806) started by @szubster*