### PR TITLE
🖼️ Canvas: Tactical Version Arbitration Matrix

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -282,3 +282,9 @@
 **Outcome:** Merged
 **Why:** Enhances the specialized hardware illusion by converting generic ribbon lists into segmented diagnostic outputs.
 **Pattern:** Repeat: Wrapping arrays/lists of badges in a `LcdGrid` and using `HoverScanner` for interactive data points. Avoid: Relying on exact text matches in global tests without updating strict `getByText` locator queries, as tactical bracket formatting (`[ $Label_SYS ]`) breaks basic matchers.
+
+## 2026-08-15 - [Accepted] - 🖼️ Canvas: Tactical Version Arbitration Matrix
+**What:** Redesigned the `VersionModal` component into a "Tactical Version Arbitration Matrix". Replaced the simple modal layout with a full dual-pane hardware dashboard (`[ DIAGNOSTIC_READOUT ]` and `[ ARBITRATION_MATRIX ]`) utilizing `TacticalPanel`. Transformed the basic warning icon into an animated `ServerCrash` crosshair. Evolved the version selection buttons from basic grid squares to detailed active hardware nodes featuring data pipes (`SYS.VER`), active scanning radar sweeps, and strict uppercase monospace typography.
+**Outcome:** Accepted
+**Why:** Brings the version resolution interface fully in line with the tactical specialization motif. Standard modals and flat button grids break the "specialized hardware" immersion during a critical application action. Evolving it into a multi-pane hardware matrix with explicit diagnostics and data stream visualizations reinforces the fantasy of using raw hardware interfaces.
+**Pattern:** For critical decision inputs or error state resolutions, avoid standard web modals. Transform them into active "Arbitration Matrices" featuring multi-pane layouts, explicit diagnostic visualizers (like crosshairs or rotating radar elements), and faux hardware selection nodes to maintain the specialized device aesthetic.

--- a/src/components/VersionModal.tsx
+++ b/src/components/VersionModal.tsx
@@ -1,10 +1,12 @@
-import { AlertTriangle } from 'lucide-react';
+import { ServerCrash } from 'lucide-react';
 
 import { useStore } from '../store';
 import { getGenerationConfig } from '../utils/generationConfig';
 import { CornerCrosshairs } from './CornerCrosshairs';
+import { EdgeLabel } from './EdgeLabel';
 import { HoverScanner } from './HoverScanner';
 import { TacticalModal } from './TacticalModal';
+import { TacticalPanel } from './TacticalPanel';
 import { TelemetryDecoration } from './TelemetryDecoration';
 
 export function VersionModal() {
@@ -22,56 +24,89 @@ export function VersionModal() {
     <TacticalModal
       isOpen={isVersionModalOpen}
       ariaLabel="Version Conflict Resolution"
-      containerClassName="z-[70]"
+      containerClassName="z-[70] items-center justify-center p-4"
       backdropClassName="bg-black/90 backdrop-blur-md"
-      dialogClassName="max-w-lg border border-zinc-800 border-dashed bg-zinc-900"
+      dialogClassName="w-full max-w-4xl border-none bg-transparent"
     >
-      <CornerCrosshairs className="h-2 w-2 border-zinc-600" />
+      <TacticalPanel variant="amber" className="flex flex-col overflow-hidden border-2 sm:flex-row">
+        <TelemetryDecoration
+          label="SYS.ARBITRATION_MATRIX"
+          className="top-0 right-4 bg-zinc-950 text-amber-500"
+          dotClassName="text-amber-500 animate-pulse"
+        />
 
-      {/* Telemetry decoration */}
-      <TelemetryDecoration
-        label="SYS.VERSION_CONFLICT"
-        className="top-0 left-4 bg-zinc-950 text-amber-600"
-        dotClassName="text-amber-500"
-      />
+        {/* Left Pane: Diagnostic Readout */}
+        <div className="relative flex w-full flex-col border-amber-500/30 border-b border-dashed bg-black/60 p-6 sm:w-1/3 sm:border-r sm:border-b-0 sm:p-8">
+          <EdgeLabel className="-top-2 left-4 bg-amber-950 px-2 text-amber-500">[ DIAGNOSTIC_READOUT ]</EdgeLabel>
 
-      <div className="flex flex-col items-center border-zinc-800 border-b border-dashed p-8 pt-10 text-center">
-        <div className="mb-4 inline-flex border border-amber-500/20 border-dashed bg-amber-500/10 p-3">
-          <CornerCrosshairs className="h-1 w-1 border-amber-500/40" />
-          <AlertTriangle className="text-amber-500" size={24} />
-        </div>
-        <h2 className="font-black font-mono text-2xl text-white uppercase tracking-tighter">SYS.VERSION_CONFLICT</h2>
-        <p className="tactical-text mt-1 font-bold text-[10px] text-zinc-500 uppercase leading-relaxed">
-          Game version detection failed. Manual override required.
-        </p>
-      </div>
-
-      <div className="grid grid-cols-1 gap-4 p-8 sm:grid-cols-3">
-        {versions.map((v) => (
-          <button
-            type="button"
-            key={v.id}
-            aria-label={`Select ${v.label} version`}
-            onClick={() => {
-              setManualVersion(v.id);
-              setIsVersionModalOpen(false);
-            }}
-            className="group focus-visible:tactical-focus relative border border-zinc-800 border-dashed bg-zinc-950 p-6 text-center transition-all hover:border-[var(--theme-primary)]/50"
-          >
-            <CornerCrosshairs className="h-1 w-1 border-zinc-700 transition-colors group-hover:border-[var(--theme-primary)]" />
-
-            {/* Radar hover effect */}
-            <HoverScanner colorClass="via-[var(--theme-primary)]/10" />
-
-            <div className="relative z-10 flex flex-col items-center gap-3">
-              <div className={`h-3 w-3 shadow-lg ${v.dotColor}`} />
-              <span className="font-black font-mono text-xs text-zinc-100 uppercase tracking-[0.2em] transition-colors group-hover:text-[var(--theme-primary)]">
-                {v.label}
-              </span>
+          <div className="flex flex-1 flex-col items-center justify-center text-center">
+            <div className="relative mb-6 flex h-20 w-20 items-center justify-center border border-amber-500/50 border-dashed bg-amber-500/10 shadow-[0_0_15px_rgba(245,158,11,0.2)]">
+              <CornerCrosshairs className="h-2 w-2 border-amber-500" />
+              <div className="absolute inset-0 scale-75 animate-[spin_3s_linear_infinite] rounded-full border border-amber-500/20 opacity-50" />
+              <div className="absolute inset-0 scale-50 animate-[ping_2s_ease-out_infinite] rounded-full border border-amber-500/40" />
+              <ServerCrash className="relative z-10 text-amber-500" size={32} />
             </div>
-          </button>
-        ))}
-      </div>
+
+            <div className="flex flex-col gap-2">
+              <h2 className="font-black font-mono text-amber-500 text-xl uppercase tracking-tighter shadow-amber-500/20 drop-shadow-md">
+                SYS.CONFLICT
+              </h2>
+              <div className="mt-2 border-amber-500/50 border-l-2 pl-3 text-left">
+                <p className="tactical-text font-bold text-[9px] text-zinc-400 uppercase leading-relaxed">
+                  [ ANOMALY ] Game version signature indistinguishable.
+                </p>
+                <p className="tactical-text mt-1 font-bold text-[9px] text-amber-500 uppercase leading-relaxed">
+                  [ ACTION ] Manual user arbitration required to resume uplink.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Right Pane: Arbitration Matrix */}
+        <div className="relative flex w-full flex-col bg-black/40 p-6 sm:w-2/3 sm:p-8">
+          <EdgeLabel className="-top-2 left-4 bg-zinc-950 px-2 text-zinc-500">[ ARBITRATION_MATRIX ]</EdgeLabel>
+
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {versions.map((v) => (
+              <button
+                type="button"
+                key={v.id}
+                aria-label={`Select ${v.label} version`}
+                onClick={() => {
+                  setManualVersion(v.id);
+                  setIsVersionModalOpen(false);
+                }}
+                className="group focus-visible:tactical-focus relative flex flex-col border border-zinc-800 border-dashed bg-zinc-950 p-4 transition-all hover:scale-[1.02] hover:border-amber-500/50 hover:bg-amber-950/20 active:scale-95"
+              >
+                <CornerCrosshairs className="h-1.5 w-1.5 border-zinc-700 transition-colors group-hover:border-amber-500" />
+                <HoverScanner colorClass="via-amber-500/20" />
+
+                {/* Hardware node layout */}
+                <div className="relative z-10 flex w-full flex-row items-center justify-between border-zinc-800 border-b border-dashed pb-3 group-hover:border-amber-500/30">
+                  <div className="flex items-center gap-2">
+                    <div
+                      className={`h-2.5 w-2.5 border border-black shadow-lg ${v.dotColor} group-hover:animate-pulse`}
+                    />
+                    <span className="font-black font-mono text-[10px] text-zinc-400 uppercase tracking-[0.2em] transition-colors group-hover:text-amber-500">
+                      SYS.VER
+                    </span>
+                  </div>
+                  <span className="font-black font-mono text-[9px] text-zinc-600 uppercase transition-colors group-hover:text-amber-400">
+                    [ SELECT ]
+                  </span>
+                </div>
+
+                <div className="relative z-10 mt-3 flex items-center justify-center py-2">
+                  <span className="font-black font-mono text-lg text-white uppercase tracking-widest drop-shadow-sm transition-colors group-hover:text-amber-400">
+                    {v.label}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      </TacticalPanel>
     </TacticalModal>
   );
 }

--- a/src/components/__tests__/VersionModal.test.tsx
+++ b/src/components/__tests__/VersionModal.test.tsx
@@ -21,7 +21,7 @@ describe('VersionModal', () => {
   it('should not render anything when isVersionModalOpen is false', async () => {
     await render(<VersionModal />);
 
-    await expect.element(page.getByText('SYS.VERSION_CONFLICT')).not.toBeInTheDocument();
+    await expect.element(page.getByText('SYS.CONFLICT')).not.toBeInTheDocument();
   });
 
   it('should render fallback versions when saveData is null', async () => {
@@ -29,7 +29,7 @@ describe('VersionModal', () => {
     await render(<VersionModal />);
 
     // Modal title should exist
-    const elements = page.getByText('SYS.VERSION_CONFLICT');
+    const elements = page.getByText('SYS.CONFLICT');
     await expect.element(elements.first()).toBeInTheDocument();
 
     // Should have Gen 1 and Gen 2 labels
@@ -50,7 +50,7 @@ describe('VersionModal', () => {
 
     await render(<VersionModal />);
 
-    const elements = page.getByText('SYS.VERSION_CONFLICT');
+    const elements = page.getByText('SYS.CONFLICT');
     await expect.element(elements.first()).toBeInTheDocument();
 
     // Should only have Gen 1 labels


### PR DESCRIPTION
Replaced the simple grid and modal layout of `VersionModal` with a dual-pane TacticalPanel ('Version Arbitration Matrix'). The left pane acts as a diagnostic readout featuring an animated `ServerCrash` crosshair icon and segmented warning text. The right pane replaces flat buttons with active hardware selection nodes utilizing data pipes (`SYS.VER`), radar sweeps (`HoverScanner`), and fully uppercase monospace typography, deeply reinforcing the specialized tactical hardware illusion. Tests were updated to reflect the new `SYS.CONFLICT` copy. Included a Canvas journal entry documenting the pattern for future modals.

---
*PR created automatically by Jules for task [7108372253879113636](https://jules.google.com/task/7108372253879113636) started by @szubster*