### PR TITLE
🧹 Clean up unused exports found by knip

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -7,3 +7,10 @@
 - If `pnpm install` hangs or fails during git hook setup (e.g., `lefthook install`), run `git config --unset-all --global core.hooksPath` before retrying the installation.
 
 * **CRITICAL - WIP PR Rejections:** When tasked with sweeping dead code or unused files via tools like Knip, you MUST double-check if the identified files belong to a feature that is currently Work In Progress (WIP). Do not blindly delete files just because Knip flags them. If you delete WIP files and get rejected, you must apologize, acknowledge the mistake, and submit an empty PR instead of modifying the codebase.
+
+### Date: $(date +%Y-%m-%d)
+**Critical Learning: Knip False Positives on Cloudflare Functions**
+When running `pnpm knip` to identify unused exports or dead code, it is critical to be extremely careful with files in the `functions/` directory. Cloudflare Pages uses this directory for file-based routing. The exports in these files (like `onRequestGet` or `onRequestPut`) are never explicitly imported elsewhere in the codebase; they are invoked dynamically by the framework. `knip` will often falsely flag these files (e.g., `functions/api/saves/[id].ts`, `functions/api/saves/index.ts`) as unused. Deleting them will completely break backend API endpoints and introduce major regressions. Always verify implicit or framework-level usage before deleting files or exports flagged by static analysis tools.
+
+**Critical Learning: Avoid Truncated Output for Plan Groundedness**
+When exploring code for refactoring or deletion, do not rely on `cat` or `grep` for multi-line structures or complex file modifications, as the output is often truncated. Always use the `read_file` tool to inspect the full, untruncated contents of a file before formulating an execution plan to ensure edits are accurate and strictly grounded in the codebase's actual state.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -118,10 +118,6 @@ export const EGG_GROUP_MAP: Record<string, number> = {
   'no-eggs': 15,
 };
 
-export const REVERSE_EGG_GROUP_MAP: Record<number, string> = Object.fromEntries(
-  Object.entries(EGG_GROUP_MAP).map(([k, v]) => [v, k]),
-);
-
 export const MOVE_DAMAGE_CLASS = {
   PHYSICAL: 1,
   SPECIAL: 2,

--- a/src/engine/gen3/lottery/lottery.ts
+++ b/src/engine/gen3/lottery/lottery.ts
@@ -2,11 +2,6 @@ export interface LotteryPokemon {
   otId: number;
 }
 
-export const TIER_1_MATCHES = 5;
-export const TIER_2_MATCHES = 4;
-export const TIER_3_MATCHES = 3;
-export const TIER_4_MATCHES = 2;
-
 export interface LotteryResult {
   tier: 0 | 1 | 2 | 3 | 4;
   winningPokemon: LotteryPokemon | null; // Replace any with appropriate Pokemon type

--- a/src/engine/gen3/secretBase/parser.ts
+++ b/src/engine/gen3/secretBase/parser.ts
@@ -3,7 +3,6 @@ import { decodeGen12String, type GameVersion, type Gen3SecretBasePartyMember } f
 export const SECRET_BASE_SIZE = 160;
 export const FLAGS_OFFSET = 0x01;
 export const BATTLED_OWNER_TODAY_MASK = 1 << 5;
-export const SECRET_BASES_COUNT = 20;
 
 export const TRAINER_NAME_OFFSET = 0x02;
 export const TRAINER_NAME_LENGTH_RS = 7;
@@ -11,10 +10,8 @@ export const TRAINER_NAME_LENGTH_EMERALD = 8;
 
 export const TRAINER_ID_OFFSET_RS = 0x09;
 export const TRAINER_ID_OFFSET_EMERALD = 0x0a;
-export const TRAINER_ID_LENGTH = 4;
 
 export const PARTY_OFFSET = 0x34;
-export const PARTY_SIZE = 108;
 export const PARTY_COUNT = 6;
 
 export const POKEMON_PERSONALITY_OFFSET = 0x00;

--- a/src/engine/saveParser/gen3/lottery/parser.ts
+++ b/src/engine/saveParser/gen3/lottery/parser.ts
@@ -1,7 +1,5 @@
-export const EMERALD_LOTTERY_HIGH_OFFSET = 0x1432;
 export const EMERALD_LOTTERY_LOW_OFFSET = 0x1434;
 export const RS_LOTTERY_LOW_OFFSET = 0x13d6;
-export const RS_LOTTERY_HIGH_OFFSET = 0x13d8;
 
 /**
  * Parses the daily lottery number from a Gen 3 save file.


### PR DESCRIPTION
🎯 What
Cleaned up dead code by removing unused exports and abandoned functions found by knip.
Removed `REVERSE_EGG_GROUP_MAP`, `TIER_1_MATCHES`, `TIER_2_MATCHES`, `TIER_3_MATCHES`, `TIER_4_MATCHES`, `SECRET_BASES_COUNT`, `TRAINER_ID_LENGTH`, `PARTY_SIZE`, `EMERALD_LOTTERY_HIGH_OFFSET`, and `RS_LOTTERY_HIGH_OFFSET`.

💡 Why
To improve the codebase's health and maintainability by resolving technical debt and dead code.

✅ Verification
Ran `pnpm knip`, `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to ensure no functionality is broken and all unused exports are cleared.

✨ Result
A cleaner codebase with less dead code, making it easier to maintain and develop further.

---
*PR created automatically by Jules for task [14796128906966467861](https://jules.google.com/task/14796128906966467861) started by @szubster*