### PR TITLE
Product Manager: PRD for Circular Dependency Detection

### DIFF
--- a/.foundry/ideas/idea-118-orchestrator-circular-dependency-detection.md
+++ b/.foundry/ideas/idea-118-orchestrator-circular-dependency-detection.md
@@ -35,4 +35,5 @@ Implement a cycle detection mechanism (e.g., using a topological sort or DFS tra
 This significantly improves the robustness of the Foundry system. Instead of nodes silently hanging indefinitely, the orchestrator will proactively detect the deadlock, fail fast, and provide clear feedback to the agents or maintainers, saving time on manual debugging and ensuring the DAG remains healthy.
 
 ## Acceptance Criteria
-- [ ] prd-118-051-circular-dependency-detection
+- [x] prd-118-051-circular-dependency-detection
+- [ ] prd-118-334-circular-dependency-detection

--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -66,3 +66,6 @@ When generating the PRD for `idea-117-split-bundles-and-data`, I noticed that th
 
 ## 2026-07-17
 - Transformed IDEA 116 into PRD 117 to formalize Zod schema validation in the Foundry Orchestrator.
+
+### Observation: Invalid Node Sequence Numbers
+I noticed that `idea-118-orchestrator-circular-dependency-detection.md` contained an invalid child node ID (`prd-118-051...`) in its acceptance criteria, which was completely out of sequence for the current state of the repository. When generating new nodes, it's crucial to properly discover the max sequence number across the repository instead of hallucinating or assuming a sequence number, to preserve the sequential integrity of the node identifiers.

--- a/.foundry/prds/prd-118-334-circular-dependency-detection.md
+++ b/.foundry/prds/prd-118-334-circular-dependency-detection.md
@@ -1,0 +1,37 @@
+---
+id: prd-118-334-circular-dependency-detection
+type: PRD
+title: Circular Dependency Detection in DAG Orchestrator
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-07-20'
+updated_at: '2026-07-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-118-orchestrator-circular-dependency-detection
+tags:
+  - foundry
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# PRD: Circular Dependency Detection in DAG Orchestrator
+
+## Context
+The Foundry DAG Orchestrator currently resolves dependencies linearly to promote nodes from `PENDING` to `READY`. However, there is no inherent protection against circular dependencies (e.g., Node A depends on Node B, which depends on Node A). If agents accidentally introduce a circular dependency (which is explicitly warned against in `core_policies.md`), the affected nodes will become permanently deadlocked in the `PENDING` state, effectively rendering them invisible and preventing progress.
+
+## Requirements
+The orchestrator must be able to detect cycles in the dependency graph during its execution (e.g., in the MAP or RESOLVE phases).
+1. Implement a cycle detection algorithm (such as a topological sort or a depth-first search with a visited/recursion stack) within `.github/scripts/foundry-orchestrator.ts`.
+2. The orchestrator should evaluate all PENDING nodes and their `depends_on` relationships.
+3. If a circular dependency is detected among `PENDING` nodes, the orchestrator should automatically transition the nodes involved in the cycle to `FAILED` status.
+4. The orchestrator must append a standard `rejection_reason` (e.g., "Circular dependency detected") in the frontmatter of the failed nodes so that agents or maintainers can investigate and resolve the deadlock.
+5. In `--dry-run` or `--strict` modes, the orchestrator should also output an explicit error message or log a clear warning regarding the detected cycle.
+
+## Acceptance Criteria
+- [ ] epic-334-335-circular-dependency-detection-epic


### PR DESCRIPTION
Transformed IDEA node into a PRD for implementing circular dependency detection in the DAG Orchestrator. Evaluated the existing IDEA node, corrected an out-of-sequence ID issue, and documented the process in the persona journal.

---
*PR created automatically by Jules for task [17812065996243758029](https://jules.google.com/task/17812065996243758029) started by @szubster*