### PR TITLE
🔍 Auditor: Reject idea-067-extract-dag-utils

### DIFF
--- a/.foundry/ideas/idea-067-extract-dag-utils.md
+++ b/.foundry/ideas/idea-067-extract-dag-utils.md
@@ -32,7 +32,12 @@ Operations to extract include:
 - Standardizing the `transitionNodeToFailed`, `transitionNodeToCompleted`, and `transitionNodeToReady` functions to ensure they uniformly apply ADR 006 (`gray-matter`) and appropriately append metadata like `rejection_reason`.
 
 ## Next Steps
-- [x] Product Manager: Evaluate this proposal and convert it to a PRD detailing the specific functions to be extracted and the testing strategy.
+- [ ] Product Manager: Evaluate this proposal and convert it to a PRD detailing the specific functions to be extracted and the testing strategy.
 
 ## References
 - [prd-067-036-extract-dag-utils.md](./.foundry/prds/prd-067-036-extract-dag-utils.md)
+
+### Auditor Rejection
+The child PRD (`prd-067-036-extract-dag-utils`) was permanently CANCELLED because one of its child epics (`epic-036-053-shared-dag-utilities`) reached the max rejection count and permanently failed. Therefore, the functional requirements of this IDEA node were not fully implemented.
+
+The Product Manager must apply the Impossible Loop Policy to handle the permanent failure of the child node.

--- a/.foundry/journals/auditor.md
+++ b/.foundry/journals/auditor.md
@@ -132,3 +132,11 @@ Successfully verified that the Automated Max Rejection Cancellation epic was cor
 ## 2026-07-12
 **Architectural Constraint (State Machine UI Consistency):**
 When changing node state transitions (e.g., from FAILED to CANCELLED for max rejections), we must explicitly audit downstream UI consumers (like the DAG Dashboard) that may be relying on the previous status to render information correctly.
+
+## 2026-07-19: Enforcing the Impossible Loop Policy on Macro Nodes
+
+**Pattern / Constraint:**
+When verifying `idea-067-extract-dag-utils`, it was discovered that one of its spawned descendant macro nodes (`prd-067-036-extract-dag-utils`) was permanently CANCELLED due to a max rejection count, yet the IDEA node itself had its acceptance criteria erroneously checked.
+
+**Why this matters:**
+The Auditor MUST reject any macro node whose descendant nodes have been permanently cancelled. This enforces the Impossible Loop Policy, ensuring the node owner takes responsibility for handling the permanent failure (e.g., by spawning a `RESEARCH` node and defining a new path forward) instead of allowing an incomplete feature to bypass verification.


### PR DESCRIPTION
Rejecting the IDEA node because its spawned child PRD (prd-067-036-extract-dag-utils) was permanently CANCELLED and its functional requirements were not fully implemented. The node owner must apply the Impossible Loop Policy.

---
*PR created automatically by Jules for task [7863210176275723016](https://jules.google.com/task/7863210176275723016) started by @szubster*