### PR TITLE
fix: resolve DAG circular dependencies and deadlocks

### DIFF
--- a/.foundry/epics/epic-009-atomic-handoff-testing.md
+++ b/.foundry/epics/epic-009-atomic-handoff-testing.md
@@ -2,22 +2,18 @@
 id: epic-009-atomic-handoff-testing
 type: EPIC
 title: 'Epic: Atomic Handoff Testing Expansion'
-status: FAILED
+status: PENDING
 owner_persona: story_owner
 created_at: '2026-04-22'
 updated_at: '2026-07-19'
-depends_on:
-  - epic-008-atomic-handoff-orchestrator
-  - story-009-032-lifecycle-integration-tests
-  - story-009-031-deadlock-prevention-tests
-  - story-009-030-single-persona-dag-tests
+depends_on: []
 jules_session_id: null
 parent: prd-001-v2-lifecycle
 tags:
   - v2-architecture
   - lifecycle
   - atomic-handoffs
-rejection_reason: Circular dependency detected
+rejection_reason: ''
 rejection_count: 1
 ---
 

--- a/.foundry/epics/epic-054-108-box-analyzer-save-parsing.md
+++ b/.foundry/epics/epic-054-108-box-analyzer-save-parsing.md
@@ -40,5 +40,5 @@ Implement the backend data grouping and aggregation logic to parse PC box data f
 - [ ] Implement Gen 3 PC box parsing and species grouping.
 - [ ] Verify that Party Pokémon are successfully excluded from the extracted data.
 - [ ] Ensure all required stats (DVs/IVs, Natures, Hidden Power, Shininess) are calculated correctly for each Pokémon.
-- [ ] .foundry/archive/stories/story-108-245-gen2-box-parsing.md
+- [x] .foundry/archive/stories/story-108-245-gen2-box-parsing.md
 - [ ] .foundry/stories/story-108-246-gen3-box-parsing.md

--- a/.foundry/journals/mechanic.md
+++ b/.foundry/journals/mechanic.md
@@ -11,3 +11,12 @@
 - Checked off the completed dependency (`task-280-304`) in its parent story (`story-087-280`).
 - Fixed invalid path formatting for dependencies in `task-280-306` and `task-294-317`.
 - Resolved an Impossible Loop deadlock by correctly propagating QA rejection to the target implementation task (`task-294-316` set to `FAILED`, incremented rejection count to 3, with detailed QA failure reason). Reset the corresponding QA task (`task-294-317`) back to `PENDING` to await retry.
+
+# Mechanic Update - 2026-07-21
+
+- Resolved DAG deadlock/circular dependencies involving 4 nodes: `epic-009-atomic-handoff-testing`, `story-009-031-deadlock-prevention-tests`, `research-246-244-gen3-box-parsing`, and `story-108-246-gen3-box-parsing`.
+- Removed self-referencing, archived, and child dependencies from `epic-009-atomic-handoff-testing`'s `depends_on` array.
+- Removed child task dependency from `story-009-031-deadlock-prevention-tests`'s `depends_on` array.
+- Reset the status of `epic-009-atomic-handoff-testing`, `story-009-031-deadlock-prevention-tests`, `research-246-244-gen3-box-parsing`, and `story-108-246-gen3-box-parsing` to `PENDING` and cleared their `rejection_reason` in frontmatter.
+- Removed child research dependency from `story-108-246-gen3-box-parsing`'s `depends_on` array.
+- Checked off the completed and archived `story-108-245-gen2-box-parsing` checkbox in `epic-054-108-box-analyzer-save-parsing` markdown body without modifying any frontmatter.

--- a/.foundry/research/research-246-244-gen3-box-parsing.md
+++ b/.foundry/research/research-246-244-gen3-box-parsing.md
@@ -2,7 +2,7 @@
 id: research-246-244-gen3-box-parsing
 type: RESEARCH
 title: Research PC Box Memory Offsets for Generation 3
-status: FAILED
+status: PENDING
 owner_persona: researcher
 created_at: '2026-07-02'
 updated_at: '2026-07-19'
@@ -16,7 +16,7 @@ tags:
   - gen3
 research_references: []
 rejection_count: 1
-rejection_reason: Circular dependency detected
+rejection_reason: ''
 notes: ''
 ---
 

--- a/.foundry/stories/story-009-031-deadlock-prevention-tests.md
+++ b/.foundry/stories/story-009-031-deadlock-prevention-tests.md
@@ -2,19 +2,18 @@
 id: story-009-031-deadlock-prevention-tests
 type: STORY
 title: 'Story: Deadlock Prevention Mechanism Unit Tests'
-status: FAILED
+status: PENDING
 owner_persona: tech_lead
 created_at: '2026-04-27'
 updated_at: '2026-07-19'
-depends_on:
-  - task-031-048-implement-deadlock-tests
+depends_on: []
 jules_session_id: null
 parent: epic-009-atomic-handoff-testing
 tags:
   - v2-architecture
   - lifecycle
   - atomic-handoffs
-rejection_reason: Circular dependency detected
+rejection_reason: ''
 rejection_count: 1
 ---
 

--- a/.foundry/stories/story-108-246-gen3-box-parsing.md
+++ b/.foundry/stories/story-108-246-gen3-box-parsing.md
@@ -2,12 +2,11 @@
 id: story-108-246-gen3-box-parsing
 type: STORY
 title: Gen 3 Box Parsing and Grouping
-status: FAILED
+status: PENDING
 owner_persona: tech_lead
 created_at: '2026-06-29'
 updated_at: '2026-07-19'
-depends_on:
-  - research-246-244-gen3-box-parsing
+depends_on: []
 jules_session_id: null
 pr_number: null
 parent: epic-054-108-box-analyzer-save-parsing
@@ -18,7 +17,7 @@ tags:
   - gen3
 research_references: []
 rejection_count: 2
-rejection_reason: Circular dependency detected
+rejection_reason: ''
 notes: ''
 ---
 


### PR DESCRIPTION
This PR resolves the circular dependency warning in Phase 3.9 and deadlock conditions flagged by the Foundry DAG orchestrator by breaking explicit loops and setting the affected nodes back to PENDING.

Fixes #4832

---
*PR created automatically by Jules for task [7952043555084628977](https://jules.google.com/task/7952043555084628977) started by @szubster*