### PR TITLE
Epic Planner: Centralize Coder and QA Task Prompt Reminders Epics

### DIFF
--- a/.foundry/epics/epic-117-334-centralize-prompt-rules.md
+++ b/.foundry/epics/epic-117-334-centralize-prompt-rules.md
@@ -1,0 +1,35 @@
+---
+id: epic-117-334-centralize-prompt-rules
+type: EPIC
+title: Centralize Coder and QA Prompt Rules
+status: READY
+owner_persona: story_owner
+created_at: '2026-07-19'
+updated_at: '2026-07-19'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-118-117-centralize-prompt-reminders
+tags:
+  - foundry
+  - agents
+  - prompts
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Centralize Coder and QA Prompt Rules
+
+## 1. Context & Objectives
+This epic fulfills the primary objective of `prd-118-117-centralize-prompt-reminders` by ensuring that instructions regarding transient failures, permanent failures, and Empty PR Checkbox policy are centralized and reinforced in the agent prompt files (`coder.md`, `qa.md`) or the core policy document (`core_policies.md`), rather than being appended to every single TASK node by the Tech Lead.
+
+## 2. Requirements
+- The `tech_lead.md` persona prompt must be updated to remove the directive forcing the Tech Lead to append `### REMINDER FOR CODER` and `### REMINDER FOR QA` blocks to task nodes.
+- Ensure that the agent prompts (`coder.md`, `qa.md`) or `core_policies.md` have explicit, centralized documentation on task failure management and PR submission rules, so the system does not lose this critical knowledge.
+- Review existing documentation to verify no duplicate or contradictory reminders exist across the agent guidelines.
+
+## 3. High-Level Acceptance Criteria
+- [ ] `tech_lead.md` is updated to remove the requirement to append reminder blocks to tasks.
+- [ ] Centralized instructions for failure handling and Empty PR submission are verified/added to `core_policies.md`, `coder.md`, and `qa.md`.

--- a/.foundry/epics/epic-117-335-migrate-task-reminders.md
+++ b/.foundry/epics/epic-117-335-migrate-task-reminders.md
@@ -1,0 +1,37 @@
+---
+id: epic-117-335-migrate-task-reminders
+type: EPIC
+title: Migrate and Clean Existing Task Reminders
+status: READY
+owner_persona: story_owner
+created_at: '2026-07-19'
+updated_at: '2026-07-19'
+depends_on:
+  - epic-117-334-centralize-prompt-rules
+jules_session_id: null
+pr_number: null
+parent: prd-118-117-centralize-prompt-reminders
+tags:
+  - foundry
+  - script
+  - migration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Migrate and Clean Existing Task Reminders
+
+## 1. Context & Objectives
+This epic fulfills the optional cleanup objective of `prd-118-117-centralize-prompt-reminders`. Since the rules for Coder and QA are now centralized and the Tech Lead will no longer append reminders to new tasks, we must run a one-time migration to strip existing `### REMINDER FOR CODER` and `### REMINDER FOR QA` blocks from currently active, pending, or ready TASK nodes to clean up the workspace and reduce token usage.
+
+## 2. Requirements
+- Develop a script or use standard bash utilities to locate all active, pending, or ready TASK nodes in `.foundry/tasks/`.
+- Strip out any `### REMINDER FOR CODER` and `### REMINDER FOR QA` sections (including their content) from the markdown bodies of these tasks.
+- Ensure the migration script does not accidentally alter the YAML frontmatter or other valid acceptance criteria.
+- Execute the migration and commit the cleaned files.
+
+## 3. High-Level Acceptance Criteria
+- [ ] A migration script or command is written and executed to remove `### REMINDER FOR CODER` and `### REMINDER FOR QA` blocks from existing `.foundry/tasks/`.
+- [ ] Active and pending TASK files are clean and no longer contain the redundant prompt rules.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -72,3 +72,9 @@ Successfully broke down `prd-115-115-gen3-fame-checker-assistant` into three dis
 2. `epic-115-332-gen3-fame-checker-save-parsing`: The implementation phase for integrating those discovered offsets.
 3. `epic-115-333-gen3-fame-checker-dashboard-ui`: Building out the final dashboard for players.
 I ensured the correct DAG order by using `depends_on` between them and appended them to the PRD's Acceptance Criteria.
+
+## 2026-07-19: Centralize Prompt Rules Epic Generation
+Broke down PRD `prd-118-117-centralize-prompt-reminders` into two separate Epics:
+1. `epic-117-334-centralize-prompt-rules` to handle the prompt updates and documentation.
+2. `epic-117-335-migrate-task-reminders` to handle the cleanup script for existing nodes.
+Updated the PRD by appending the Epics to the Acceptance Criteria. Corrected a minor flaw where `epic-117-335` depended on a file path instead of a Node ID, adhering to the DAG dependency constraint that `depends_on` within macro nodes must use Node IDs.

--- a/.foundry/prds/prd-118-117-centralize-prompt-reminders.md
+++ b/.foundry/prds/prd-118-117-centralize-prompt-reminders.md
@@ -39,3 +39,8 @@ Currently, the Tech Lead persona has explicit instructions to append a "REMINDER
 - The Tech Lead prompt (`tech_lead.md`) no longer dictates appending these reminders to TASK nodes.
 - `coder.md` and `qa.md` (or `core_policies.md`) have clear, centralized instructions on task failure management and PR submission rules.
 - Existing tasks are cleaned up (if the migration script is run), or new tasks generated after this change do not contain the reminder blocks.
+
+## Acceptance Criteria
+- [x] Break down into Epics
+- [ ] epic-117-334-centralize-prompt-rules
+- [ ] epic-117-335-migrate-task-reminders


### PR DESCRIPTION
Creates epics epic-117-334-centralize-prompt-rules and epic-117-335-migrate-task-reminders from PRD prd-118-117-centralize-prompt-reminders to consolidate prompt rules and migrate existing tasks.

---
*PR created automatically by Jules for task [120116510880636003](https://jules.google.com/task/120116510880636003) started by @szubster*