### PR TITLE
Tech Lead: fix circular dependency blocking split bundles and data PRD

### DIFF
--- a/.foundry/prds/prd-117-116-split-bundles-and-data.md
+++ b/.foundry/prds/prd-117-116-split-bundles-and-data.md
@@ -6,8 +6,7 @@ status: PENDING
 owner_persona: epic_planner
 created_at: '2026-07-16'
 updated_at: '2026-07-16'
-depends_on:
-  - .foundry/ideas/idea-117-split-bundles-and-data.md
+depends_on: []
 jules_session_id: null
 pr_number: null
 parent: idea-117-split-bundles-and-data


### PR DESCRIPTION
This PR removes the redundant and circular depends_on reference from the PRD node to its parent IDEA node, allowing the DAG Orchestrator to correctly pick up and resolve the PRD node.

Fixes #4852

---
*PR created automatically by Jules for task [12839661700288298074](https://jules.google.com/task/12839661700288298074) started by @szubster*