### PR TITLE
🎨 Palette: Add custom tactical tooltip to TacticalButton

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,3 +14,4 @@ Learned about using .cjs for node scripts in ES module projects and the @utility
 - Maintained tactical aesthetics for tooltips by introducing a custom `@utility tactical-tooltip` in `src/index.css`.
 - Modified `TacticalIconButton` to replace native `title` tooltips with a custom CSS tooltip approach (`group-hover:opacity-100`) to address accessibility/UX without native browser styling, while preserving `aria-label` for screen readers.
 - Removed `title` from being spread onto `<button>` props by extracting it and omitting it from `restProps`.
+- Added custom custom tactical-tooltip to TacticalButton to replace standard browser tooltips and align styling with the rest of the app's tactical aesthetic.

--- a/src/components/TacticalButton.tsx
+++ b/src/components/TacticalButton.tsx
@@ -14,7 +14,6 @@ export const TacticalButton = React.forwardRef<HTMLButtonElement, TacticalButton
     return (
       <button
         ref={ref}
-        title={title}
         className={cn(
           'group tactical-text focus-visible:tactical-focus relative inline-flex shrink-0 items-center justify-center gap-3 overflow-hidden rounded-none border border-dashed font-black transition-all disabled:cursor-not-allowed disabled:opacity-50',
           {
@@ -70,6 +69,11 @@ export const TacticalButton = React.forwardRef<HTMLButtonElement, TacticalButton
         <span className="relative z-10 flex items-center gap-2">{children}</span>
 
         {variant === 'primary' && <div className="absolute top-0 left-0 h-full w-1 bg-[var(--theme-primary)]" />}
+        {title && (
+          <span className="tactical-tooltip pointer-events-none absolute top-full left-1/2 z-50 mt-2 -translate-x-1/2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+            {title}
+          </span>
+        )}
       </button>
     );
   },


### PR DESCRIPTION
Replaced the native browser tooltip (`title` attribute) on `TacticalButton` with a custom CSS-driven `.tactical-tooltip` to maintain consistent styling with the app's tactical aesthetic, similar to the existing implementation in `TacticalIconButton`. Accessibility is preserved by maintaining `aria-label`.

---
*PR created automatically by Jules for task [4247624696293394655](https://jules.google.com/task/4247624696293394655) started by @szubster*