### PR TITLE
🛠️ Infras: Fix Biome CI version drift

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: "2.5.3"
+          version: "2.5.4"
 
       - name: Run Biome
         run: biome ci --error-on-warnings .

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -114,3 +114,6 @@ Critical learnings:
 ## 2026-07-17 - Empty PR Policy for Infrastructure
 **Learning:** Audited the development tooling, found to be highly optimized and matching CI parity. An empty PR will be submitted to respect the bloat policy.
 ## 2026-07-17 - Empty PR Policy for Infrastructure\n**Learning:** Audited the development tooling, found to be highly optimized and matching CI parity. An empty PR will be submitted to respect the bloat policy. Also, ran bundle analysis requiring `pnpm build`.
+
+## 2026-07-20 - Fixed Biome CI Version Drift
+**Learning:** The Biome version was bumped to 2.5.4 in `package.json` and `biome.jsonc`, but the CI workflow (`.github/workflows/biome.yml`) remained at `2.5.3`. It's important to update the GitHub Actions check to ensure the CI environment matches the local environment, avoiding false positive/negative linting results in PRs.


### PR DESCRIPTION
What: Updated the Biome version in `.github/workflows/biome.yml` from `2.5.3` to `2.5.4`.
Why: The Biome version in `package.json` and `biome.jsonc` was bumped to `2.5.4`, but the CI workflow was left at `2.5.3`. This causes CI drift where the GitHub Actions checks use a different linter version than local development.
Impact on DX/CI: Prevents false positive/negative linting results in PRs by ensuring the CI environment matches the local environment.
Setup notes: None.

---
*PR created automatically by Jules for task [723178430274793464](https://jules.google.com/task/723178430274793464) started by @szubster*