### PR TITLE
🖼️ Canvas: Tactical Reconnaissance Matrix Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -288,3 +288,9 @@
 **Outcome:** Accepted
 **Why:** Brings the version resolution interface fully in line with the tactical specialization motif. Standard modals and flat button grids break the "specialized hardware" immersion during a critical application action. Evolving it into a multi-pane hardware matrix with explicit diagnostics and data stream visualizations reinforces the fantasy of using raw hardware interfaces.
 **Pattern:** For critical decision inputs or error state resolutions, avoid standard web modals. Transform them into active "Arbitration Matrices" featuring multi-pane layouts, explicit diagnostic visualizers (like crosshairs or rotating radar elements), and faux hardware selection nodes to maintain the specialized device aesthetic.
+
+## 2026-08-16 - [Accepted] - 🖼️ Canvas: Tactical Reconnaissance Matrix Redesign
+**What:** Redesigned the `SearchAndFilters` component into a "Tactical Reconnaissance Matrix". Replaced the default variant of `TacticalPanel` with the cyan variant, added `<LcdGrid>` and `<HoverScanner>` to the container, and restyled the search input area to resemble a "Target Acquisition" radar node featuring an animated crosshair. Modified the filter buttons to resemble physical membrane switches with dedicated status LED indicators.
+**Outcome:** Accepted
+**Why:** The previous search bar and filter section looked like a standard web form, which broke the "specialized hardware" immersion during regular interaction. Transforming it into an active intelligence dashboard with radar crosshairs and membrane switch filters reinforces the fantasy of using a physical tactical device.
+**Pattern:** Always elevate search and filter controls from standard inputs to active "Acquisition Matrices" by incorporating hardware analogies (e.g. radar scans, membrane toggles, status LEDs) and structural paneling (`[ TARGET_ACQUISITION ]`) to maintain the specialized device simulation.

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -1,9 +1,11 @@
-import { Search } from 'lucide-react';
+import { Crosshair } from 'lucide-react';
 import { useMemo, useRef } from 'react';
 import { FILTER_TYPES, type FilterType, useStore } from '../store';
 import { ClearFiltersBadge } from './ClearFiltersBadge';
 import { EdgeLabel } from './EdgeLabel';
 import { FilterBadge } from './FilterBadge';
+import { HoverScanner } from './HoverScanner';
+import { LcdGrid } from './LcdGrid';
 import { LocationSuggestions } from './LocationSuggestions';
 import { TacticalInput } from './TacticalInput';
 import { TacticalMultiSelectControl } from './TacticalMultiSelectControl';
@@ -36,33 +38,47 @@ export function SearchAndFilters() {
   };
 
   return (
-    <div className="sticky top-0 z-30 -mt-6 mb-6 border-[var(--theme-primary)]/30 border-b border-dashed bg-zinc-950/90 px-4 pt-6 pb-2 shadow-[0_10px_30px_rgba(0,0,0,0.8)] backdrop-blur-md">
-      <TacticalPanel className="p-4 sm:p-5" variant="default">
-        <TelemetryDecoration label="SYS.QUERY_TERMINAL" className="top-0 right-4 bg-zinc-950" />
+    <div className="sticky top-0 z-30 -mt-6 mb-6 border-[var(--theme-primary)]/30 border-b-2 border-dashed bg-zinc-950/95 px-4 pt-6 pb-4 shadow-[0_20px_50px_rgba(0,0,0,0.8)] backdrop-blur-xl">
+      <TacticalPanel className="p-4 sm:p-6" variant="cyan">
+        <TelemetryDecoration
+          label="SYS.RECON_MATRIX"
+          className="top-0 right-4 bg-zinc-950"
+          textClassName="text-cyan-500"
+          dotClassName="text-cyan-500"
+        />
+        <LcdGrid className="opacity-[0.03]" />
+        <HoverScanner />
 
-        <div className="flex flex-col gap-6 pt-3 xl:flex-row">
-          {/* Left Pane: Query Uplink */}
-          <div className="relative flex-1 border border-zinc-800 border-dashed bg-black/40 p-3">
-            <EdgeLabel className="-top-2 left-2">[ QUERY_UPLINK ]</EdgeLabel>
-            <div className="flex items-center gap-3">
-              <div className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden border border-[var(--theme-primary)]/30 bg-[var(--theme-primary)]/5">
-                <Search size={16} className="relative z-10 text-[var(--theme-primary)]" />
-                <div className="absolute inset-0 animate-[spin_4s_linear_infinite] border-[1px] border-[var(--theme-primary)]/20 bg-[radial-gradient(circle_at_center,transparent_0,var(--theme-primary)_100%)] opacity-20" />
-                <div className="absolute top-1/2 left-0 h-[1px] w-full bg-[var(--theme-primary)]/40 shadow-[0_0_8px_var(--theme-primary)]" />
+        <div className="relative z-10 flex flex-col gap-8 pt-4 xl:flex-row xl:items-stretch">
+          {/* Left Pane: Target Acquisition */}
+          <div className="relative flex-1 border border-cyan-500/20 border-dashed bg-cyan-950/20 p-4 shadow-[inset_0_0_20px_rgba(6,182,212,0.05)]">
+            <div className="absolute top-0 left-0 h-2 w-2 border-cyan-500/50 border-t border-l" />
+            <div className="absolute top-0 right-0 h-2 w-2 border-cyan-500/50 border-t border-r" />
+            <div className="absolute bottom-0 left-0 h-2 w-2 border-cyan-500/50 border-b border-l" />
+            <div className="absolute right-0 bottom-0 h-2 w-2 border-cyan-500/50 border-r border-b" />
+
+            <EdgeLabel className="-top-2 left-4 bg-zinc-950 text-cyan-500">[ TARGET_ACQUISITION ]</EdgeLabel>
+
+            <div className="mt-2 flex items-center gap-4">
+              <div className="relative flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden border border-cyan-500/40 bg-cyan-500/10">
+                <Crosshair size={20} className="relative z-10 text-cyan-400" />
+                <div className="absolute inset-0 animate-[spin_3s_linear_infinite] border-[1px] border-cyan-500/30 bg-[radial-gradient(circle_at_center,transparent_0,var(--theme-primary)_100%)] opacity-30" />
+                <div className="absolute top-1/2 left-0 h-[1px] w-full bg-cyan-400/50 shadow-[0_0_10px_rgba(34,211,238,0.8)]" />
+                <div className="absolute top-0 left-1/2 h-full w-[1px] bg-cyan-400/50 shadow-[0_0_10px_rgba(34,211,238,0.8)]" />
               </div>
               <div className="flex-1">
                 <TacticalInput
                   ref={inputRef}
                   type="text"
                   data-testid="search-input"
-                  placeholder="[ ENTER QUERY_ ]"
+                  placeholder="[ ENTER COORDINATES OR ID ]"
                   aria-label="Search Pokedex by name, ID, or location"
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   onKeyDown={handleKeyDown}
                   onClear={handleClearSearch}
                   containerClassName="w-full"
-                  className="!border-none !bg-transparent !py-2 !pl-2 focus:!bg-white/5"
+                  className="!border-b !border-cyan-500/30 !bg-transparent !py-3 !pl-2 focus:!border-cyan-400 focus:!bg-cyan-950/30 font-mono text-cyan-100 placeholder:text-cyan-700/50"
                 >
                   <LocationSuggestions />
                 </TacticalInput>
@@ -70,27 +86,32 @@ export function SearchAndFilters() {
             </div>
           </div>
 
-          {/* Right Pane: Parameter Matrix */}
-          <div className="relative flex-1 border border-zinc-800 border-dashed bg-black/40 p-3 xl:max-w-2xl">
-            <EdgeLabel className="-top-2 left-2">[ PARAMETER_MATRIX ]</EdgeLabel>
+          {/* Right Pane: Filter Parameters */}
+          <div className="relative flex-1 border border-zinc-800 border-dashed bg-black/60 p-4 xl:max-w-2xl">
+            <EdgeLabel className="-top-2 left-4">[ PARAMETER_MATRIX ]</EdgeLabel>
             <TacticalMultiSelectControl<FilterType>
               ariaLabel="Filter Pokémon"
-              containerClassName="h-full justify-center"
-              buttonBaseClassName="relative group min-w-[80px] xl:min-w-[100px] h-10 flex flex-col items-center justify-center !border !border-dashed gap-1"
+              containerClassName="h-full justify-center pt-2"
+              buttonBaseClassName="relative group min-w-[80px] xl:min-w-[100px] h-12 flex flex-col items-center justify-center !border !border-dashed gap-1 transition-all"
               selectedValues={filtersSet}
               onValueToggle={(f) => toggleFilter(f)}
-              defaultActiveClassName="!border-[var(--theme-primary)] bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_15px_rgba(var(--theme-primary-rgb),0.2)]"
-              defaultInactiveClassName="!border-zinc-800 bg-zinc-950/80 text-zinc-600 hover:!border-zinc-600 hover:bg-zinc-900 hover:text-zinc-400"
+              defaultActiveClassName="!border-cyan-500 bg-cyan-500/20 text-cyan-400 shadow-[inset_0_0_20px_rgba(6,182,212,0.2)] scale-[0.98]"
+              defaultInactiveClassName="!border-zinc-800 bg-zinc-950 text-zinc-500 hover:!border-zinc-600 hover:bg-zinc-900 hover:text-zinc-400 hover:-translate-y-0.5"
               renderPrefixItem={() => (
                 <ClearFiltersBadge isActive={filtersSet.size === 0} onClick={() => setFilters([])} />
               )}
               items={FILTER_TYPES.map((f) => ({
                 id: f,
                 label: (
-                  <FilterBadge
-                    isActive={filtersSet.has(f)}
-                    label={f === 'secured' ? 'SECURED' : f === 'missing' ? 'MISSING' : 'DEX ONLY'}
-                  />
+                  <div className="flex flex-col items-center gap-1">
+                    <div
+                      className={`h-1 w-4 rounded-full ${filtersSet.has(f) ? 'bg-cyan-400 shadow-[0_0_8px_rgba(34,211,238,0.8)]' : 'bg-zinc-800'}`}
+                    />
+                    <FilterBadge
+                      isActive={filtersSet.has(f)}
+                      label={f === 'secured' ? 'SECURED' : f === 'missing' ? 'MISSING' : 'DEX ONLY'}
+                    />
+                  </div>
                 ),
                 ariaLabel: f === 'secured' ? 'Secured filter' : f === 'missing' ? 'Missing filter' : 'Dex Only filter',
                 testId: `filter-${f}`,

--- a/src/components/__tests__/SearchAndFilters.test.tsx
+++ b/src/components/__tests__/SearchAndFilters.test.tsx
@@ -68,7 +68,7 @@ describe('SearchAndFilters', () => {
       </QueryClientProvider>,
     );
 
-    const input = page.getByPlaceholder('[ ENTER QUERY_ ]');
+    const input = page.getByPlaceholder('[ ENTER COORDINATES OR ID ]');
     await input.fill('pikachu');
     await expect.element(input).toHaveValue('pikachu');
     expect(useStore.getState().searchTerm).toBe('pikachu');
@@ -83,7 +83,7 @@ describe('SearchAndFilters', () => {
       </QueryClientProvider>,
     );
 
-    const input = page.getByPlaceholder('[ ENTER QUERY_ ]');
+    const input = page.getByPlaceholder('[ ENTER COORDINATES OR ID ]');
     await input.click();
     await input.fill('test');
 


### PR DESCRIPTION
Redesigned the `SearchAndFilters` component into a "Tactical Reconnaissance Matrix". Replaced the default variant of `TacticalPanel` with the cyan variant, added `<LcdGrid>` and `<HoverScanner>` to the container, and restyled the search input area to resemble a "Target Acquisition" radar node featuring an animated crosshair. Modified the filter buttons to resemble physical membrane switches with dedicated status LED indicators.

**Outcome:** Accepted
**Why:** The previous search bar and filter section looked like a standard web form, which broke the "specialized hardware" immersion during regular interaction. Transforming it into an active intelligence dashboard with radar crosshairs and membrane switch filters reinforces the fantasy of using a physical tactical device.

---
*PR created automatically by Jules for task [5140890187337203816](https://jules.google.com/task/5140890187337203816) started by @szubster*