### PR TITLE
🧹 Clean up unused exports and fix Knip false positives

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -7,3 +7,5 @@
 - If `pnpm install` hangs or fails during git hook setup (e.g., `lefthook install`), run `git config --unset-all --global core.hooksPath` before retrying the installation.
 
 * **CRITICAL - WIP PR Rejections:** When tasked with sweeping dead code or unused files via tools like Knip, you MUST double-check if the identified files belong to a feature that is currently Work In Progress (WIP). Do not blindly delete files just because Knip flags them. If you delete WIP files and get rejected, you must apologize, acknowledge the mistake, and submit an empty PR instead of modifying the codebase.
+
+* When using tools like `knip` to identify unused code or dead exports, always explicitly verify candidates using global search (`grep`) before deletion to prevent unintentionally removing dynamically loaded dependencies (such as Cloudflare Pages API functions in `functions/` or implicitly required test files). If such dynamically loaded files are identified by Knip, do not delete them; instead, add them to the `ignore` array in `knip.json`.

--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,8 @@
     ".github/scripts/verify-dag-refs.ts",
     "scripts/gen3-fetch-locations.ts",
     "functions/_middleware.ts",
+    "functions/api/saves/index.ts",
+    "functions/api/saves/[id].ts",
     "scripts/data/gen3/match_call/etl.ts"
   ],
   "rules": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -118,10 +118,6 @@ export const EGG_GROUP_MAP: Record<string, number> = {
   'no-eggs': 15,
 };
 
-export const REVERSE_EGG_GROUP_MAP: Record<number, string> = Object.fromEntries(
-  Object.entries(EGG_GROUP_MAP).map(([k, v]) => [v, k]),
-);
-
 export const MOVE_DAMAGE_CLASS = {
   PHYSICAL: 1,
   SPECIAL: 2,

--- a/src/engine/gen3/lottery/lottery.ts
+++ b/src/engine/gen3/lottery/lottery.ts
@@ -2,11 +2,6 @@ export interface LotteryPokemon {
   otId: number;
 }
 
-export const TIER_1_MATCHES = 5;
-export const TIER_2_MATCHES = 4;
-export const TIER_3_MATCHES = 3;
-export const TIER_4_MATCHES = 2;
-
 export interface LotteryResult {
   tier: 0 | 1 | 2 | 3 | 4;
   winningPokemon: LotteryPokemon | null; // Replace any with appropriate Pokemon type

--- a/src/engine/gen3/secretBase/parser.ts
+++ b/src/engine/gen3/secretBase/parser.ts
@@ -3,7 +3,6 @@ import { decodeGen12String, type GameVersion, type Gen3SecretBasePartyMember } f
 export const SECRET_BASE_SIZE = 160;
 export const FLAGS_OFFSET = 0x01;
 export const BATTLED_OWNER_TODAY_MASK = 1 << 5;
-export const SECRET_BASES_COUNT = 20;
 
 export const TRAINER_NAME_OFFSET = 0x02;
 export const TRAINER_NAME_LENGTH_RS = 7;
@@ -11,10 +10,8 @@ export const TRAINER_NAME_LENGTH_EMERALD = 8;
 
 export const TRAINER_ID_OFFSET_RS = 0x09;
 export const TRAINER_ID_OFFSET_EMERALD = 0x0a;
-export const TRAINER_ID_LENGTH = 4;
 
 export const PARTY_OFFSET = 0x34;
-export const PARTY_SIZE = 108;
 export const PARTY_COUNT = 6;
 
 export const POKEMON_PERSONALITY_OFFSET = 0x00;

--- a/src/engine/saveParser/gen3/lottery/parser.ts
+++ b/src/engine/saveParser/gen3/lottery/parser.ts
@@ -1,7 +1,5 @@
-export const EMERALD_LOTTERY_HIGH_OFFSET = 0x1432;
 export const EMERALD_LOTTERY_LOW_OFFSET = 0x1434;
 export const RS_LOTTERY_LOW_OFFSET = 0x13d6;
-export const RS_LOTTERY_HIGH_OFFSET = 0x13d8;
 
 /**
  * Parses the daily lottery number from a Gen 3 save file.


### PR DESCRIPTION
`🎯 What`
Clean up unused exports identified by Knip and add false positives (`functions/api/saves`) to Knip ignore list.
`💡 Why`
Reduce technical debt and improve code health by removing dead code.
`✅ Verification`
Ran `pnpm lint`, `pnpm test`, and `pnpm knip` to verify all tests pass and there are no unused exports.
`✨ Result`
Cleaner codebase with less dead code and a properly configured Knip.

---
*PR created automatically by Jules for task [15472818686219570113](https://jules.google.com/task/15472818686219570113) started by @szubster*