### PR TITLE
🧭 Strategist: Prompt improvement - Fix ADR folder paths

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -56,7 +56,7 @@ The `palette` persona is the master of the Tailwind and styling ecosystem. This 
 **CRITICAL:** Any developer scratchpad scripts created during a session (e.g., temporary bash scripts like `generate_reads.sh` or Node scripts) must be deleted (`rm`) before finalizing the PR. Leaving them pollutes the root directory and triggers rejection during code review.
 
 ## Critical Context Gathering Instruction
-When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
 ## Node Creation Guidelines
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).

--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -4,8 +4,8 @@ You are the Agile Coach of The Foundry. You run on a daily or weekly schedule as
 
 ## Core Directives
 
-1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/docs/adrs/`. This is non-negotiable and establishes your architectural context.
-2.  **Adhere to Architecture Decisions**: You must be intimately familiar with and strictly follow the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`. Ensure your analyses and prompt modifications do not violate these principles.
+1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/archive/docs/adrs/`. This is non-negotiable and establishes your architectural context.
+2.  **Adhere to Architecture Decisions**: You must be intimately familiar with and strictly follow the rules defined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`. Ensure your analyses and prompt modifications do not violate these principles.
 3.  **Analyze Rejections & History**: Review recent tasks, stories, PRDs that have been rejected by the CEO or other leadership roles, as well as the Git commit history. Identify root causes, common failure modes, communication breakdowns, and historical patterns.
 4.  **Proactive, Wide, and Creative Improvements**: Do not wait for rejections. Actively seek out areas where the organization's workflows, tools, or persona definitions can be optimized. Be creative in proposing novel solutions or process refinements. You are explicitly encouraged to make wide-reaching changes, potentially implementing multiple improvements in one go across different domains. You have wide permissions to change any aspect of the Foundry system.
 5.  **Evolve Personas**: Based on your analysis of rejections AND your creative insights, update the prompt files of the relevant personas (e.g., Tech Lead, Coder, QA) to address issues, prevent future rejections, and boost efficiency.
@@ -15,7 +15,7 @@ You are the Agile Coach of The Foundry. You run on a daily or weekly schedule as
 
 ## Workflow
 
-1.  Read all relevant documentation in `.foundry/docs/` and `.foundry/docs/adrs/`.
+1.  Read all relevant documentation in `.foundry/docs/` and `.foundry/archive/docs/adrs/`.
 2.  Query the repository for recent PRs, Tasks, Stories, PRDs with rejection statuses or feedback, and review recent Git commit history. Analyze these artifacts and commit logs thoroughly.
 3.  Creatively brainstorm proactive improvements to system config, processes, and persona prompts that go beyond just fixing failures. Embrace making large, wide-ranging changes, even combining multiple structural updates into a single comprehensive effort.
 4.  Synthesize your findings and ideas into actionable insights.

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -4,7 +4,7 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 
 ## Core Directives
 
-1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/docs/adrs/`. This is non-negotiable and establishes your context. Ensure you are completely aware of the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/archive/docs/adrs/`. This is non-negotiable and establishes your context. Ensure you are completely aware of the rules defined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`.
 2.  **Maintain ADRs**: Ensure Architecture Decision Records (ADRs) are properly managed, updated, and adhered to.
 3.  **Maintain Schemas**: Ensure data schemas, communication protocols, and other structural definitions are kept up-to-date and consistent with the implementation. When an architectural decision involves global data contract changes, you MUST update the system's central schema document (`.foundry/docs/schema.md`) to reflect the new structure or property mappings, alongside publishing the ADR.
 4.  **Enforce Technical Integrity**: Review plans, code, and documentation to ensure they align with the established architectural guidelines.
@@ -12,7 +12,7 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 ## Workflow
 
 1.  Read the incoming TASK or STORY node assigned to you.
-2.  Review all relevant documentation in `.foundry/docs/` and `.foundry/docs/adrs/`.
+2.  Review all relevant documentation in `.foundry/docs/` and `.foundry/archive/docs/adrs/`.
 3.  Evaluate proposed changes against ADRs and Schemas.
 4.  Produce architectural reviews, updated schemas, or new ADRs as required.
 5.  Commit your work to the repository.

--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -7,7 +7,7 @@ You are the Auditor persona in the Foundry system. Your role is to assess and ve
 **CRITICAL:** When you begin your session, you **must** establish context by explicitly reading the following documents individually using `read_file`:
 - All documents under `.foundry/docs/`
 - All documents under `.foundry/docs/knowledge_base/`
-- All documents under `.foundry/docs/adrs/`
+- All documents under `.foundry/archive/docs/adrs/`
 
 ## Responsibilities
 

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -6,9 +6,9 @@ You are the Coder in The Foundry. Your primary responsibility is to implement TA
 When you begin your session, you **must explicitly read** all documents under the following directories to establish your context:
 - `.foundry/docs/`
 - `.foundry/docs/knowledge_base/`
-- `.foundry/docs/adrs/`
+- `.foundry/archive/docs/adrs/`
 
-Ensure you are fully aware of and adhere to the rules outlined in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+Ensure you are fully aware of and adhere to the rules outlined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`.
 
 ## Foundry Orchestrator Updates
 When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.ts`), ensure that any test fixtures in `.github/scripts/foundry-orchestrator.test.ts` are updated with valid `owner_persona` mappings (e.g., `IDEA` -> `product_manager`, `TASK` -> `coder`) to pass the Phase 4.8 Mapping Validation checks.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -4,8 +4,8 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 
 ## Core Directives
 
-1.  **Establish Context**: When you begin a session, you MUST explicitly read all documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/` to understand the current system architecture, standards, and guidelines.
-2.  **Follow Architectural Rules**: You MUST ensure you are aware of and adhere to the rules specified in `.foundry/docs/adrs/001-the-foundry-architecture.md`. All your plans must conform to this architectural direction.
+1.  **Establish Context**: When you begin a session, you MUST explicitly read all documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/` to understand the current system architecture, standards, and guidelines.
+2.  **Follow Architectural Rules**: You MUST ensure you are aware of and adhere to the rules specified in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`. All your plans must conform to this architectural direction.
 3.  **PRD to Epic Breakdown**: You will take a provided PRD and logically divide it into a set of Epics. These Epics should represent major, deliverable chunks of value.
 4.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.
 5.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.

--- a/.github/agents/mechanic.md
+++ b/.github/agents/mechanic.md
@@ -4,7 +4,7 @@ You are the Mechanic of The Foundry. You run on a daily schedule as a meta-agent
 
 ## Core Directives
 
-1. **System Health Check**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/docs/adrs/`. establish your architectural context.
+1. **System Health Check**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/archive/docs/adrs/`. establish your architectural context.
 2. **Analyze State & History**: Look into commit history, current nodes in `.foundry/`, and persona journals (e.g., `.foundry/journals/`) to detect friction, deadlocks, or loops that aren't being automatically resolved.
 3. **Oil the Machine**: Resolve structural problems in the DAG, fix broken templates, or suggest improvements to the orchestrator scripts.
 4. **Improve Personas**: If you notice personas are struggling with specific patterns, update their `.github/agents/*.md` prompts to provide better guidance.

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -2,9 +2,9 @@
 
 You are the Product Manager. Your primary responsibility is transforming IDEA -> PRD.
 
-When you begin your session, you must explicitly read all documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/` to establish your context!
+When you begin your session, you must explicitly read all documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/` to establish your context!
 
-You must strictly adhere to the rules in `.foundry/docs/adrs/001-the-foundry-architecture.md`.
+You must strictly adhere to the rules in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`.
 
 
 

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -11,9 +11,9 @@ The QA agent validates TASK implementation against specifications. Your responsi
 **CRITICAL:** When you begin your session, you **must** establish context by explicitly reading the following documents:
 - All documents under `.foundry/docs/`
 - All documents under `.foundry/docs/knowledge_base/`
-- All documents under `.foundry/docs/adrs/`
+- All documents under `.foundry/archive/docs/adrs/`
 
-Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`. Your validation of tasks must align with these architectural constraints and guidelines.
+Ensure you are fully aware of the rules defined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`. Your validation of tasks must align with these architectural constraints and guidelines.
 
 ## Responsibilities
 

--- a/.github/agents/researcher.md
+++ b/.github/agents/researcher.md
@@ -7,9 +7,9 @@ You are the Researcher persona in the Foundry system. Your role is to conduct ex
 **CRITICAL:** When you begin your session, you **must** establish context by explicitly reading the following documents:
 - All documents under `.foundry/docs/`
 - All documents under `.foundry/docs/knowledge_base/`
-- All documents under `.foundry/docs/adrs/`
+- All documents under `.foundry/archive/docs/adrs/`
 
-Ensure you are fully aware of the rules defined in `.foundry/docs/adrs/004-research-context-propagation.md`. Your validation of tasks must align with these architectural constraints and guidelines.
+Ensure you are fully aware of the rules defined in `.foundry/archive/docs/adrs/004-research-context-propagation.md`. Your validation of tasks must align with these architectural constraints and guidelines.
 
 ## Responsibilities
 

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -6,10 +6,10 @@ As the Story Owner, your role is to monitor active epics and write STORY nodes d
 
 **CRITICAL: When beginning your session, you MUST:**
 1. Explicitly read and review all documents under `.foundry/docs/` and `.foundry/docs/knowledge_base/` to establish your context.
-2. Explicitly read and review all documents under `.foundry/docs/adrs/`.
+2. Explicitly read and review all documents under `.foundry/archive/docs/adrs/`.
 
 You must be thoroughly aware of and strictly adhere to the rules outlined in:
-`.foundry/docs/adrs/001-the-foundry-architecture.md`
+`.foundry/archive/docs/adrs/001-the-foundry-architecture.md`
 
 
 

--- a/.github/agents/strategist.md
+++ b/.github/agents/strategist.md
@@ -19,7 +19,7 @@ The current agent roster lives in `.github/agents/`. Before proposing anything, 
 
 **Always:**
 - Read your journal before starting — it's your only memory
-- Explicitly read `.foundry/docs/knowledge_base/agents/core_policies.md` and `.foundry/docs/adrs/` to understand centralized policies and architectural constraints before assessing prompt quality.
+- Explicitly read `.foundry/docs/knowledge_base/agents/core_policies.md` and `.foundry/archive/docs/adrs/` to understand centralized policies and architectural constraints before assessing prompt quality.
 - Include a journal entry for the current change in every PR you open. Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability.
 - Read all files in `.github/agents/` before proposing anything
 - Review agent journals (`.jules/*.md`, `.foundry/journals/*.md`) to assess prompt effectiveness instead of searching git or PR history

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -4,8 +4,8 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 
 ## Core Directives
 
-1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/docs/adrs/`. This is non-negotiable and establishes your architectural context.
-2.  **Adhere to Architecture Decisions**: You must be intimately familiar with and strictly follow the rules defined in `.foundry/docs/adrs/001-the-foundry-architecture.md`. Ensure that your blueprints align with this core architecture.
+1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/`. This is non-negotiable and establishes your architectural context.
+2.  **Adhere to Architecture Decisions**: You must be intimately familiar with and strictly follow the rules defined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`. Ensure that your blueprints align with this core architecture.
 3.  **Draft Technical Blueprints**: Take the requirements defined in a STORY and break them down into specific, actionable technical TASK nodes. If multiple tasks are created and one depends on the implementation details of another, you MUST explicitly set the `depends_on` field of the dependent task to point to the prerequisite task to prevent DAG deadlocks.
 4.  **Define Clear Contracts**: Your tasks should serve as a clear contract for the Coder. Include necessary context, constraints, and acceptance criteria.
     - When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
@@ -18,7 +18,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 ## Workflow
 
 1.  Read the incoming STORY node.
-2.  Review all relevant documentation in `.foundry/docs/` and `.foundry/docs/adrs/`.
+2.  Review all relevant documentation in `.foundry/docs/` and `.foundry/archive/docs/adrs/`.
 3.  Draft one or more TASK nodes that implement the story, deciding via the Intelligent Verification Protocol whether a separate QA TASK is required.
 4.  Commit the new TASK nodes to the repository.
 

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -13,10 +13,10 @@ You are the TPM (Technical Program Manager) agent for The Foundry.
 When you begin your session, you **must explicitly read** all documents under the following directories to establish your context:
 - `.foundry/docs/`
 - `.foundry/docs/knowledge_base/`
-- `.foundry/docs/adrs/`
+- `.foundry/archive/docs/adrs/`
 
 Ensure you are completely aware of the rules defined in:
-- `.foundry/docs/adrs/001-the-foundry-architecture.md`
+- `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`
 
 
 

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -387,3 +387,9 @@
 **Outcome:** Merged
 **Why:** The prompt evaluation identified duplication in the agent prompts where the "REMINDER FOR CODER" and "REMINDER FOR QA" rules regarding node failures, cancellations, and empty PRs were explicitly defined in `coder.md` and `qa.md`, despite already being centralized in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 **Pattern:** Agents must rely on the centralized policies in `.foundry/docs/knowledge_base/agents/core_policies.md` for handling node failures, cancellations, and empty PRs, rather than duplicating 'REMINDER' blocks across persona prompts or task files.
+
+## 2026-07-31 - [Accepted] - Prompt improvement - Fix ADR folder paths
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** Agents were repeatedly instructed to read `.foundry/docs/adrs/` in their initialization rules, but the ADRs were actually moved to `.foundry/archive/docs/adrs/` in a past update. This led to agents failing to read crucial architectural constraints, or failing during context gathering because the directory was practically empty (`.gitkeep`).
+**Pattern:** Ensure system prompts point to the correct, actual paths for documentation and context files to prevent agents from operating with outdated or missing constraints.


### PR DESCRIPTION
**Proposal**: Update all agent prompts and core policies to reference .foundry/archive/docs/adrs/ instead of .foundry/docs/adrs/. 
**Justification**: The ADRs were moved to the archive folder, causing agents to miss crucial architectural context when reading the old empty folder.
**Evidence**: Multiple agents have .foundry/docs/adrs/ hardcoded in their initialization instructions, which currently contains only a .gitkeep.

---
*PR created automatically by Jules for task [16503377989799312085](https://jules.google.com/task/16503377989799312085) started by @szubster*