### PR TITLE
QA: Fix Gen 3 Met Location QA task

### DIFF
--- a/.foundry/stories/story-097-261-extract-pokemon-met-locations.md
+++ b/.foundry/stories/story-097-261-extract-pokemon-met-locations.md
@@ -30,5 +30,5 @@ Parse save files to extract the `met_location` for all Pokémon in the Party and
 
 ## Acceptance Criteria
 - [x] Tasks are generated
-- [ ] task-261-282-gen3-met-location-impl
-- [ ] task-261-283-gen3-met-location-qa
+- [x] task-261-282-gen3-met-location-impl
+- [x] task-261-283-gen3-met-location-qa

--- a/.foundry/tasks/task-261-283-gen3-met-location-qa.md
+++ b/.foundry/tasks/task-261-283-gen3-met-location-qa.md
@@ -38,8 +38,8 @@ Verify that the `metLocation` parsing logic for Gen 3 Pokémon is correctly impl
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Code correctly parses `metLocation` using constants and `DataView`.
-- [ ] Tests verify the parsing logic.
+- [x] Code correctly parses `metLocation` using constants and `DataView`.
+- [x] Tests verify the parsing logic.
 
 ### QA Rejection
 - Implementation uses MISC_MET_LOCATION_OFFSET instead of required MET_LOCATION_OFFSET_IN_M.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -1374,7 +1374,7 @@ describe('parseGen3MetLocation', () => {
     const view = new DataView(buffer);
     const miscSubstructureOffset = 4;
 
-    // MISC_MET_LOCATION_OFFSET is 1
+    // MET_LOCATION_OFFSET_IN_M is 1
     // 4 + 1 = 5
     view.setUint8(5, 42); // 42 is the met location
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -122,7 +122,7 @@ const POKE_NEWS_STATE_OFFSET = 1;
 const POKE_NEWS_COUNTDOWN_OFFSET = 2;
 
 const MISC_IV_EGG_ABILITY_OFFSET = 4;
-const MISC_MET_LOCATION_OFFSET = 1;
+export const MET_LOCATION_OFFSET_IN_M = 1;
 const IS_EGG_BIT_SHIFT = 30;
 const GROWTH_FRIENDSHIP_OFFSET = 4;
 const EGG_CYCLE_STEPS = 256;
@@ -1253,7 +1253,7 @@ export {
  */
 export function parseGen3MetLocation(view: DataView, miscSubstructureOffset: number): number {
   try {
-    return view.getUint8(miscSubstructureOffset + MISC_MET_LOCATION_OFFSET);
+    return view.getUint8(miscSubstructureOffset + MET_LOCATION_OFFSET_IN_M);
   } catch (error) {
     if (error instanceof RangeError) {
       throw new Error('The save file is corrupted or incomplete.');


### PR DESCRIPTION
Fixes the Gen 3 Met Location QA task by properly using MET_LOCATION_OFFSET_IN_M and resolving the node rejection.

---
*PR created automatically by Jules for task [14649701129480848192](https://jules.google.com/task/14649701129480848192) started by @szubster*