### PR TITLE
🛠️ Infras: Fix Biome CI version drift

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: "2.5.3"
+          version: "2.5.4"
 
       - name: Run Biome
         run: biome ci --error-on-warnings .

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -114,3 +114,6 @@ Critical learnings:
 ## 2026-07-17 - Empty PR Policy for Infrastructure
 **Learning:** Audited the development tooling, found to be highly optimized and matching CI parity. An empty PR will be submitted to respect the bloat policy.
 ## 2026-07-17 - Empty PR Policy for Infrastructure\n**Learning:** Audited the development tooling, found to be highly optimized and matching CI parity. An empty PR will be submitted to respect the bloat policy. Also, ran bundle analysis requiring `pnpm build`.
+
+## 2026-07-20 - Fixed Biome CI Version Drift
+**Learning:** The project's Biome version was bumped to `2.5.4` locally (`package.json`, `biome.jsonc`), but the CI workflow (`.github/workflows/biome.yml`) remained at `2.5.3`. This causes CI drift where the GitHub Actions checks use a different linter version than local development. Updated `.github/workflows/biome.yml` to `2.5.4`.


### PR DESCRIPTION
What: Update biome version in CI to 2.5.4.
Why: Fixes version drift.
Impact on DX/CI: Ensures CI runs the same Biome version as local development.
Setup notes: None.

---
*PR created automatically by Jules for task [13106474877790053229](https://jules.google.com/task/13106474877790053229) started by @szubster*