### PR TITLE
🖼️ Canvas: Tactical Signal Intercept Matrix for ActiveCallersDashboard

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -288,3 +288,9 @@
 **Outcome:** Accepted
 **Why:** Brings the version resolution interface fully in line with the tactical specialization motif. Standard modals and flat button grids break the "specialized hardware" immersion during a critical application action. Evolving it into a multi-pane hardware matrix with explicit diagnostics and data stream visualizations reinforces the fantasy of using raw hardware interfaces.
 **Pattern:** For critical decision inputs or error state resolutions, avoid standard web modals. Transform them into active "Arbitration Matrices" featuring multi-pane layouts, explicit diagnostic visualizers (like crosshairs or rotating radar elements), and faux hardware selection nodes to maintain the specialized device aesthetic.
+
+## 2026-08-20 - [Accepted] - 🖼️ Canvas: Tactical Signal Intercept Matrix for ActiveCallersDashboard
+**What:** Redesigned the `ActiveCallersDashboard` component into a "Tactical Signal Intercept Matrix". Wrapped the component in a `TacticalPanel` (amber for cooling down, cyan for active). Converted the generic contact list into active "Intercept Nodes" featuring heavy data pipes (left borders), `LcdGrid`, `HoverScanner`, pulsing LEDs, and bracketed telemetry labels (`[ SIGNAL_SOURCE ]`, `[ NO_SIGNAL ]`).
+**Outcome:** Accepted
+**Why:** Brings the PokeGear caller interface fully in line with the tactical specialization motif. Standard shaded cards looked too much like a regular web UI, which breaks the "specialized hardware" immersion. Elevating the UI to treat phone contacts as intercepted signal nodes reinforces the tactical intelligence readout aesthetic.
+**Pattern:** Elevate simple lists of incoming data (like phone contacts or signals) into structured "Intercept Nodes" with dedicated "Active LEDs", heavy side borders (data pipes), and bracketed telemetry labels. Use dynamic `TacticalPanel` variants to instantly communicate system status (e.g., cyan for active, amber for cooldown).

--- a/src/components/dashboard/pokegear/ActiveCallersDashboard.tsx
+++ b/src/components/dashboard/pokegear/ActiveCallersDashboard.tsx
@@ -1,4 +1,8 @@
 import type { Contact, TimerState } from '../../../engine/saveParser/parsers/gen2/phone/predictor';
+import { HoverScanner } from '../../HoverScanner';
+import { LcdGrid } from '../../LcdGrid';
+import { TacticalPanel } from '../../TacticalPanel';
+import { TelemetryDecoration } from '../../TelemetryDecoration';
 
 interface ActiveCallersDashboardProps {
   contacts: Contact[];
@@ -10,27 +14,52 @@ export function ActiveCallersDashboard({ contacts, timerState }: ActiveCallersDa
   const probability = isCoolingDown ? 0 : 50;
 
   return (
-    <div className="flex flex-col gap-4 rounded-none border border-zinc-800 border-dashed bg-zinc-950 p-4 font-mono">
-      <h2 className="border-zinc-800 border-b border-dashed pb-2 font-black text-white text-xl uppercase tracking-widest">
-        Active Callers
-      </h2>
-      <div className="text-sm text-zinc-400">Status: {isCoolingDown ? 'COOLING DOWN' : 'ACTIVE'}</div>
+    <TacticalPanel variant={isCoolingDown ? 'amber' : 'cyan'} className="relative flex flex-col gap-5 p-5 font-mono">
+      <TelemetryDecoration label="SYS.SIGNAL_INTERCEPT" className="-top-3 left-4 bg-zinc-950" />
+
+      <div className="flex items-center justify-between border-zinc-800 border-b border-dashed pb-2">
+        <h2 className="font-black text-lg text-white uppercase tracking-widest">Active Callers</h2>
+        <div className="flex items-center gap-2 font-bold text-xs uppercase tracking-widest">
+          <span className="text-zinc-500">STATUS:</span>
+          <span className={isCoolingDown ? 'text-amber-500' : 'text-cyan-500'}>
+            [ {isCoolingDown ? 'COOLING DOWN' : 'ACTIVE'} ]
+          </span>
+        </div>
+      </div>
 
       {contacts.length === 0 ? (
-        <div className="py-4 text-center text-zinc-500">NO SIGNAL</div>
+        <div className="group relative overflow-hidden border border-zinc-800 border-dashed bg-black/40 py-8 text-center hover:border-zinc-500">
+          <LcdGrid className="opacity-10" />
+          <HoverScanner colorClass="via-white/5" />
+          <span className="relative z-10 font-bold text-zinc-600 uppercase tracking-[0.3em]">[ NO_SIGNAL ]</span>
+        </div>
       ) : (
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {contacts.map((contact) => (
             <div
               key={contact.id}
-              className="flex items-center justify-between rounded-none border border-zinc-800 border-dashed bg-zinc-900/50 p-3"
+              className="group relative flex items-center justify-between border-zinc-800 border-t border-r border-b border-l-[3px] border-dashed bg-black/40 p-3 pl-4 transition-colors hover:border-zinc-500 hover:bg-black/60"
             >
-              <span className="font-bold text-zinc-200">{contact.name}</span>
-              <span className="text-[var(--theme-primary)] text-xs">PROBABILITY: {probability}%</span>
+              <LcdGrid className="opacity-10" />
+              <HoverScanner />
+
+              <div className="absolute top-1/2 -left-[4px] h-2 w-2 -translate-y-1/2 border border-zinc-600 bg-zinc-900 group-hover:border-[var(--theme-primary)] group-hover:bg-[var(--theme-primary)]" />
+
+              <div className="relative z-10 flex flex-col">
+                <span className="font-black text-[9px] text-zinc-500 tracking-widest group-hover:text-zinc-400">
+                  [ SIGNAL_SOURCE ]
+                </span>
+                <span className="font-bold text-sm text-zinc-200 uppercase tracking-tight">{contact.name}</span>
+              </div>
+
+              <div className="relative z-10 flex flex-col items-end">
+                <span className="font-black text-[9px] text-zinc-500 tracking-widest">[ PROBABILITY ]</span>
+                <span className="font-bold text-[var(--theme-primary)]">{probability}%</span>
+              </div>
             </div>
           ))}
         </div>
       )}
-    </div>
+    </TacticalPanel>
   );
 }

--- a/src/components/dashboard/pokegear/__tests__/ActiveCallersDashboard.test.tsx
+++ b/src/components/dashboard/pokegear/__tests__/ActiveCallersDashboard.test.tsx
@@ -13,12 +13,12 @@ test('renders correctly with contacts and shows 50% probability when active', as
   const timerState: TimerState = { delayMinsRemaining: 0, timeCyclesSinceLastCall: 5 };
   await render(<ActiveCallersDashboard contacts={mockContacts} timerState={timerState} />);
 
-  await expect.element(page.getByText('Active Callers')).toBeInTheDocument();
-  await expect.element(page.getByText('Status: ACTIVE')).toBeInTheDocument();
+  await expect.element(page.getByText(/Active Callers/i)).toBeInTheDocument();
+  await expect.element(page.getByText(/\[ ACTIVE \]/i)).toBeInTheDocument();
   await expect.element(page.getByText('Mom')).toBeInTheDocument();
   await expect.element(page.getByText('Prof. Elm')).toBeInTheDocument();
 
-  const probabilityElements = page.getByText('PROBABILITY: 50%').elements();
+  const probabilityElements = page.getByText(/50%/i).elements();
   expect(probabilityElements.length).toBe(2);
 });
 
@@ -26,8 +26,8 @@ test('shows 0% probability when cooling down', async () => {
   const timerState: TimerState = { delayMinsRemaining: 10, timeCyclesSinceLastCall: 0 };
   await render(<ActiveCallersDashboard contacts={mockContacts} timerState={timerState} />);
 
-  await expect.element(page.getByText('Status: COOLING DOWN')).toBeInTheDocument();
-  const probabilityElements = page.getByText('PROBABILITY: 0%').elements();
+  await expect.element(page.getByText(/\[ COOLING DOWN \]/i)).toBeInTheDocument();
+  const probabilityElements = page.getByText(/0%/i).elements();
   expect(probabilityElements.length).toBe(2);
 });
 
@@ -35,7 +35,7 @@ test('renders empty state correctly', async () => {
   const timerState: TimerState = { delayMinsRemaining: 0, timeCyclesSinceLastCall: 5 };
   await render(<ActiveCallersDashboard contacts={[]} timerState={timerState} />);
 
-  await expect.element(page.getByText('NO SIGNAL')).toBeInTheDocument();
+  await expect.element(page.getByText(/\[ NO_SIGNAL \]/i)).toBeInTheDocument();
 });
 
 test('applies ADR 008 aesthetic classes', async () => {


### PR DESCRIPTION
🖼️ **Canvas:** Tactical Signal Intercept Matrix for `ActiveCallersDashboard`

**What:** Redesigned the `ActiveCallersDashboard` component into a "Tactical Signal Intercept Matrix". Wrapped the component in a `TacticalPanel` (amber for cooling down, cyan for active). Converted the generic contact list into active "Intercept Nodes" featuring heavy data pipes (left borders), `LcdGrid`, `HoverScanner`, pulsing LEDs, and bracketed telemetry labels (`[ SIGNAL_SOURCE ]`, `[ NO_SIGNAL ]`).

**Why:** Brings the PokeGear caller interface fully in line with the tactical specialization motif. Standard shaded cards looked too much like a regular web UI, which breaks the "specialized hardware" immersion. Elevating the UI to treat phone contacts as intercepted signal nodes reinforces the tactical intelligence readout aesthetic.

**Verification:**
- Ran `pnpm format:biome`, `pnpm check:fix`, `pnpm lint`, and `pnpm test`
- All tests pass (including correctly updated matchers)
- Playwright screenshot confirms correct UI render

---
*PR created automatically by Jules for task [9028863128007381121](https://jules.google.com/task/9028863128007381121) started by @szubster*