### PR TITLE
Story Breakdown: epic-032-043-runtime-interfaces-keys

### DIFF
--- a/.foundry/epics/epic-032-043-runtime-interfaces-keys.md
+++ b/.foundry/epics/epic-032-043-runtime-interfaces-keys.md
@@ -27,3 +27,4 @@ Update the runtime interfaces and components that load the generated PokeData to
 ## Acceptance Criteria
 - [ ] The application compiles without type errors in `src/db/schema.ts`.
 - [ ] Components load Pokémon data without issues utilizing the expanded keys.
+- [ ] story-043-336-update-runtime-interfaces-keys

--- a/.foundry/stories/story-043-336-update-runtime-interfaces-keys.md
+++ b/.foundry/stories/story-043-336-update-runtime-interfaces-keys.md
@@ -1,0 +1,33 @@
+---
+id: story-043-336-update-runtime-interfaces-keys
+type: STORY
+title: Update Runtime Interfaces to Verbose Keys
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-21'
+updated_at: '2026-07-21'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-032-043-runtime-interfaces-keys
+tags:
+  - feature
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Update Runtime Interfaces to Verbose Keys
+
+## Objective
+Implement changes required by ADR 015. Update the runtime interfaces and components that load the generated PokeData to expect the new verbose property names, replacing the old minified accessors.
+
+## Scope
+- Update `src/db/schema.ts`, `src/db/PokeDB.ts` and associated application interfaces to map correctly to properties like `name`, `captureRate`, `genderRate`, `chance` and others defined in PokeData Property Naming Schema.
+- Verify components accurately retrieve the data via the extended, readable keys.
+
+## Acceptance Criteria
+- [ ] Implement required application changes.
+- [ ] Break down story into tasks for technical blueprinting and implementation.


### PR DESCRIPTION
Generated `story-043-336-update-runtime-interfaces-keys` to implement the runtime interfaces updates to verbose keys, and updated the parent epic with the new child node checkbox.

---
*PR created automatically by Jules for task [15119671586332056850](https://jules.google.com/task/15119671586332056850) started by @szubster*