### PR TITLE
feat(dashboard): expose rejection_count in DagContext

### DIFF
--- a/.foundry/tasks/task-085-256-impl-extract-rejection-count-retry.md
+++ b/.foundry/tasks/task-085-256-impl-extract-rejection-count-retry.md
@@ -33,7 +33,7 @@ This is a retry of the previously permanently failed `task-085-142`. In order to
 2. The core requirement is to verify that the React context layer (`DagContext.tsx`) correctly exposes the property to connected UI views. Ensure that the initial state in `DagContext.tsx` sets the `rejection_count` properly from the parsed nodes.
 
 ## Acceptance Criteria
-- [ ] Coder: Ensure React context layer correctly exposes the property.
+- [x] Coder: Ensure React context layer correctly exposes the property.
 
 ## Reminders
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.

--- a/src/components/dashboard/DagContext.tsx
+++ b/src/components/dashboard/DagContext.tsx
@@ -126,6 +126,7 @@ export function DagProvider({ children }: { children: ReactNode }) {
             ...node.data,
             label: node.id,
             id: node.id,
+            rejection_count: node.data.rejection_count ?? 0,
             depends_on:
               typeof node.data.depends_on === 'object' && Array.isArray(node.data.depends_on)
                 ? node.data.depends_on

--- a/src/components/dashboard/__tests__/DagContext.test.tsx
+++ b/src/components/dashboard/__tests__/DagContext.test.tsx
@@ -5,10 +5,12 @@ import { render } from 'vitest-browser-react';
 import { DagProvider, useDagContext } from '../DagContext';
 
 const TestComponent = () => {
-  const { maxRejectionThreshold, setActiveView } = useDagContext();
+  const { maxRejectionThreshold, setActiveView, nodes } = useDagContext();
   return (
     <div>
       <div data-testid="threshold">{maxRejectionThreshold}</div>
+      <div data-testid="node-count">{nodes.length}</div>
+      {nodes.length > 0 && <div data-testid="node-rejection">{nodes[0]?.data.rejection_count}</div>}
       <button type="button" data-testid="btn" onClick={() => setActiveView('board')}>
         Set View
       </button>
@@ -29,7 +31,7 @@ test('DagProvider provides maxRejectionThreshold and handles data loading correc
           owner_persona: 'human',
           label: 'node',
           title: 'Node 1',
-          rejection_count: 0,
+          rejection_count: 3,
           depends_on: [],
         },
       },
@@ -43,6 +45,7 @@ test('DagProvider provides maxRejectionThreshold and handles data loading correc
   );
 
   await expect.element(page.getByTestId('threshold')).toHaveTextContent('3');
+  await expect.element(page.getByTestId('node-rejection')).toHaveTextContent('3');
   await page.getByTestId('btn').click();
 });
 


### PR DESCRIPTION
Exposes the previously parsed `rejection_count` property onto the generated `initialNodes` in `DagContext.tsx` to support the permanent failure views in the DAG Dashboard (ADR 017). Updates related tests.

---
*PR created automatically by Jules for task [11313847774056704544](https://jules.google.com/task/11313847774056704544) started by @szubster*