### PR TITLE
🎨 Palette: Add tooltips and aria-labels to icon-only TacticalButtons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,3 +14,6 @@ Learned about using .cjs for node scripts in ES module projects and the @utility
 - Maintained tactical aesthetics for tooltips by introducing a custom `@utility tactical-tooltip` in `src/index.css`.
 - Modified `TacticalIconButton` to replace native `title` tooltips with a custom CSS tooltip approach (`group-hover:opacity-100`) to address accessibility/UX without native browser styling, while preserving `aria-label` for screen readers.
 - Removed `title` from being spread onto `<button>` props by extracting it and omitting it from `restProps`.
+## 2024-XX-XX
+- **Context**: Added tooltips to `TacticalButton` with `size="icon"`.
+- **Learnings**: Native browser tooltips can be disabled while preserving screen-reader functionality by mapping `props.title` to `aria-label` and stripping it from the rest props using destructuring. We can then conditionally render our own custom `.tactical-tooltip` styling. Also noted that removing `overflow-hidden` dynamically is necessary to prevent tooltips from being clipped by the button container.

--- a/src/components/TacticalButton.tsx
+++ b/src/components/TacticalButton.tsx
@@ -11,12 +11,13 @@ interface TacticalButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEleme
 export const TacticalButton = React.forwardRef<HTMLButtonElement, TacticalButtonProps>(
   ({ className, variant = 'default', size = 'default', hasCrosshairs = false, children, ...props }, ref) => {
     const title = props.title || props['aria-label'];
+    const { title: _title, ...restProps } = props;
     return (
       <button
         ref={ref}
-        title={title}
+        aria-label={title}
         className={cn(
-          'group tactical-text focus-visible:tactical-focus relative inline-flex shrink-0 items-center justify-center gap-3 overflow-hidden rounded-none border border-dashed font-black transition-all disabled:cursor-not-allowed disabled:opacity-50',
+          `group tactical-text focus-visible:tactical-focus relative inline-flex shrink-0 items-center justify-center gap-3 ${size === 'icon' ? '' : 'overflow-hidden'} rounded-none border border-dashed font-black transition-all disabled:cursor-not-allowed disabled:opacity-50`,
           {
             // Variants
             'border-white/20 bg-zinc-900/50 text-zinc-500 hover:border-white/40 hover:bg-zinc-800/80 hover:text-white focus-visible:ring-[var(--theme-primary)]':
@@ -40,7 +41,7 @@ export const TacticalButton = React.forwardRef<HTMLButtonElement, TacticalButton
           },
           className,
         )}
-        {...props}
+        {...restProps}
       >
         {hasCrosshairs === 'corners' ? (
           <CornerCrosshairs
@@ -70,6 +71,12 @@ export const TacticalButton = React.forwardRef<HTMLButtonElement, TacticalButton
         <span className="relative z-10 flex items-center gap-2">{children}</span>
 
         {variant === 'primary' && <div className="absolute top-0 left-0 h-full w-1 bg-[var(--theme-primary)]" />}
+
+        {size === 'icon' && title && (
+          <span className="tactical-tooltip pointer-events-none absolute top-full left-1/2 z-50 mt-2 -translate-x-1/2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+            {title}
+          </span>
+        )}
       </button>
     );
   },

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -163,7 +163,7 @@ describe('AppLayout file upload', () => {
       </QueryClientProvider>,
     );
 
-    const button = page.getByTitle('Import New Save');
+    const button = page.getByRole('button', { name: 'Import New Save', exact: true }).first();
     await expect.element(button).toBeInTheDocument();
 
     const input = document.getElementById('import-save-input') as HTMLInputElement;

--- a/src/components/__tests__/SettingsModal.test.tsx
+++ b/src/components/__tests__/SettingsModal.test.tsx
@@ -47,7 +47,7 @@ describe('SettingsModal', () => {
 
     expect(useStore.getState().isSettingsOpen).toBe(true);
 
-    const closeButton = page.getByTitle('Close settings');
+    const closeButton = page.getByRole('button', { name: 'Close settings', exact: true }).first();
     await closeButton.click();
 
     expect(useStore.getState().isSettingsOpen).toBe(false);


### PR DESCRIPTION
**What:** 
Added custom `.tactical-tooltip` rendering to `TacticalButton` when `size="icon"`. Native browser tooltips are suppressed by intercepting the `title` prop and mapping it to `aria-label`. 

**Why:** 
Previously, icon-only buttons lacked tooltips (or relied on the ugly native browser tooltip which broke the tactical aesthetic). This caused a usability gap. The change introduces clear, styled feedback on hover and focus.

**Before/After:**
*Before:* Icon buttons either had no tooltip or the default gray browser tooltip.
*After:* Icon buttons display a styled, monospace, tactical tooltip perfectly matching the design system.

**Accessibility Notes:**
The `title` prop is intelligently extracted to prevent the native browser tooltip from firing, but it is explicitly passed as `aria-label={title}` to the underlying `<button>`. This ensures screen-readers still announce the button's accessible name properly. Tests were also updated to use `getByRole` for more robust querying.

---
*PR created automatically by Jules for task [7843130593129899583](https://jules.google.com/task/7843130593129899583) started by @szubster*