### PR TITLE
Story Owner: Acknowledge Cancellation of Gen 3 Roamer Extraction Epic

### DIFF
--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -58,3 +58,7 @@ Broke down epic-115-331-remove-orphaned-qa-task-rule-from-docs into story-331-33
 - Spawned research-137-330 to investigate failure of story-137-294.
 - Created replacement nodes story-137-333 and story-137-334.
 - Checked off permanently failed child nodes in epic markdown.
+
+## 2026-07-22
+*   Task: epic-043-152-gen3-roamer-data-extraction
+*   Action: Submitted an Empty PR because the epic is permanently impossible due to Gen 3 roamer coordinates being stored in EWRAM and not serialized to the save file (ADR 108-027).


### PR DESCRIPTION
Epic 043-152 (Gen 3 Roamer Data Extraction) is marked as permanently CANCELLED as Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file, making static extraction impossible (ADR 108-027).

As Story Owner, I am bypassing generating child nodes and explicitly submitting an empty PR to allow the node to gracefully exit out of the active flow. I have documented this case in the `story_owner` journal. Acceptance Criteria checkboxes in the epic markdown body remain strictly unchecked.

---
*PR created automatically by Jules for task [3067252283141016182](https://jules.google.com/task/3067252283141016182) started by @szubster*