### PR TITLE
🧹 Update knip configuration for serverless functions

### DIFF
--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -7,3 +7,5 @@
 - If `pnpm install` hangs or fails during git hook setup (e.g., `lefthook install`), run `git config --unset-all --global core.hooksPath` before retrying the installation.
 
 * **CRITICAL - WIP PR Rejections:** When tasked with sweeping dead code or unused files via tools like Knip, you MUST double-check if the identified files belong to a feature that is currently Work In Progress (WIP). Do not blindly delete files just because Knip flags them. If you delete WIP files and get rejected, you must apologize, acknowledge the mistake, and submit an empty PR instead of modifying the codebase.
+## 2024-XX-XX: Configuration Maintenance
+When removing files that you suspect are dead code (e.g., ETL scripts or cloud functions), strictly verify if they are explicitly mentioned in configuration files (like `knip.json`) or imported dynamically. Tooling configuration files should be updated to properly ignore external facing code like Cloudflare Pages Functions (`functions/**`), rather than incorrectly deleting the code under the assumption it is unused.

--- a/knip.json
+++ b/knip.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreExportsUsedInFile": true,
-  "ignoreBinaries": [
-    "gh"
-  ],
+  "ignoreBinaries": [],
   "ignoreDependencies": [
     "wrangler",
     "@cloudflare/pages-plugin-cloudflare-access",
@@ -14,8 +12,7 @@
     ".github/scripts/extract-research.ts",
     ".github/scripts/verify-dag-refs.ts",
     "scripts/gen3-fetch-locations.ts",
-    "functions/_middleware.ts",
-    "scripts/data/gen3/match_call/etl.ts"
+    "functions/**"
   ],
   "rules": {
     "files": "warn",


### PR DESCRIPTION
🎯 What
Updated `knip.json` to properly ignore the entire `functions/` directory using the `"functions/**"` glob pattern. Also removed stale entries (`gh` binary and `scripts/data/gen3/match_call/etl.ts`) from the ignore configuration arrays.

💡 Why
The `functions/` directory contains Cloudflare Pages serverless functions. Because they are HTTP entry points and not directly imported by the client-side React application code, `pnpm knip` was throwing false positives about unused exports. The previous configuration was narrowly ignoring a single file (`_middleware.ts`), leaving others (`[id].ts`, `index.ts`) exposed to false positives. Removing `gh` from `ignoreBinaries` and `etl.ts` from `ignore` cleans up stale tooling configuration. 

✅ Verification
Ran `pnpm knip` locally; the previous false positive warnings for `functions/api/saves/index.ts` and `functions/api/saves/[id].ts` are now successfully suppressed. Ran `pnpm lint`, `pnpm test`, and `pnpm test:e2e` to confirm no project regressions.

✨ Result
A cleaner, more accurate `knip` configuration that will prevent CI failures and false alarms regarding unused exports in serverless functions.

---
*PR created automatically by Jules for task [12390379961021847895](https://jules.google.com/task/12390379961021847895) started by @szubster*