### PR TITLE
Story Owner: Break down Epic 120-338 into Stories

### DIFF
--- a/.foundry/epics/epic-120-338-implement-conflictless-journals.md
+++ b/.foundry/epics/epic-120-338-implement-conflictless-journals.md
@@ -29,3 +29,6 @@ To resolve frequent git merge conflicts on `.foundry/journals/*.md` files, this 
 - [ ] Ensure storage is in persona-specific subdirectories (e.g. `.foundry/journals/coder/`).
 - [ ] Update the TPM persona responsibilities to aggregate and archive these individual files appropriately.
 - [ ] Update downstream nodes and scripts that reference journals to correctly reference these fragmented journal files or rely on aggregation mechanisms.
+- [ ] story-338-336-implement-session-unique-journals
+- [ ] story-338-337-update-tpm-aggregation
+- [ ] story-338-338-update-downstream-references

--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -58,3 +58,5 @@ Broke down epic-115-331-remove-orphaned-qa-task-rule-from-docs into story-331-33
 - Spawned research-137-330 to investigate failure of story-137-294.
 - Created replacement nodes story-137-333 and story-137-334.
 - Checked off permanently failed child nodes in epic markdown.
+## 2026-07-22
+* Created stories story-338-336, story-338-337, and story-338-338 for epic-120-338 to implement session-unique journal files.

--- a/.foundry/stories/story-338-336-implement-session-unique-journals.md
+++ b/.foundry/stories/story-338-336-implement-session-unique-journals.md
@@ -1,0 +1,34 @@
+---
+id: story-338-336-implement-session-unique-journals
+type: STORY
+title: Implement Session-Unique Journal Files
+status: READY
+owner_persona: tech_lead
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-120-338-implement-conflictless-journals
+tags:
+  - foundry
+  - journals
+  - workflow
+  - DX
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Implement Session-Unique Journal Files
+
+## Context
+Currently, agent personas write to monolithic journal files (e.g., `.foundry/journals/coder.md`), leading to frequent merge conflicts when multiple agents run concurrently. We need to transition to session-unique files per persona.
+
+## Objectives
+- Update the system configuration or core agent prompt infrastructure to point agents towards session-unique files within persona-specific subdirectories (e.g., `.foundry/journals/coder/<session_id>.md` or timestamped).
+- Ensure existing infrastructure (like the orchestrator or prompts) supports this new location format.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break this Story down into actionable Tasks.

--- a/.foundry/stories/story-338-337-update-tpm-aggregation.md
+++ b/.foundry/stories/story-338-337-update-tpm-aggregation.md
@@ -1,0 +1,35 @@
+---
+id: story-338-337-update-tpm-aggregation
+type: STORY
+title: Update TPM Persona to Aggregate Session Journals
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on:
+  - story-338-336-implement-session-unique-journals
+jules_session_id: null
+pr_number: null
+parent: epic-120-338-implement-conflictless-journals
+tags:
+  - foundry
+  - journals
+  - workflow
+  - DX
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Update TPM Persona to Aggregate Session Journals
+
+## Context
+With agents writing to session-unique journal files, the TPM persona must be updated to aggregate or archive these files instead of managing monolithic files.
+
+## Objectives
+- Update the TPM persona's instructions and responsibilities to read all session-unique files in persona-specific subdirectories.
+- Define a process for the TPM to aggregate these files into a master log or archive them to prevent directory bloat.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break this Story down into actionable Tasks.

--- a/.foundry/stories/story-338-338-update-downstream-references.md
+++ b/.foundry/stories/story-338-338-update-downstream-references.md
@@ -1,0 +1,35 @@
+---
+id: story-338-338-update-downstream-references
+type: STORY
+title: Update Downstream References for Fragmented Journals
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on:
+  - story-338-337-update-tpm-aggregation
+jules_session_id: null
+pr_number: null
+parent: epic-120-338-implement-conflictless-journals
+tags:
+  - foundry
+  - journals
+  - workflow
+  - DX
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: Update Downstream References for Fragmented Journals
+
+## Context
+Various nodes, scripts, and personas (like the Agile Coach or resurrected FAILED nodes) currently reference monolithic journal files (e.g., `.foundry/journals/coder.md`). With the transition to session-unique and TPM-aggregated journals, these references must be updated.
+
+## Objectives
+- Identify all scripts, documents, and agent prompts that reference old journal paths.
+- Update them to either reference the new directory structure, the TPM's aggregated master logs, or instruct them to read fragmented files dynamically.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break this Story down into actionable Tasks.


### PR DESCRIPTION
- Created `story-338-336-implement-session-unique-journals`
- Created `story-338-337-update-tpm-aggregation`
- Created `story-338-338-update-downstream-references`
- Updated parent `epic-120-338-implement-conflictless-journals` to include references to the new stories
- Added a new daily entry to the `story_owner.md` journal

---
*PR created automatically by Jules for task [12022632914776563562](https://jules.google.com/task/12022632914776563562) started by @szubster*