### PR TITLE
task-338-338-session-unique-journals-impl

### DIFF
--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -242,3 +242,6 @@ Appended tech lead journal for breaking down Gen 3 Volcanic Ash extraction story
 ## 2026-07-22: Break down session unique journals story
 - **Node**: story-338-336-implement-session-unique-journals
 - **Actions**: Broke down the story into an implementation task to update agent prompts and orchestrator for session-unique journals, and a QA verification task to ensure the instructions and parsing logic are correct.
+## 2026-07-22: Automerge Journal Updates
+- **Node**: story-338-336-implement-session-unique-journals
+- **Actions**: Added additional tasks to update the automerge GitHub action to allow PRs containing only journal file changes to be automatically merged.

--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -238,3 +238,7 @@ Appended tech lead journal for breaking down Gen 3 Volcanic Ash extraction story
 - **Node**: `story-137-294-diff-engine-logic`
 - **Actions**: Investigated the permanent failure of `task-294-316-diff-engine-impl`. Discovered that the `hash` property was missing from the `PokemonInstance` interface, leading to the Coder attempting to use a fallback generator and failing the QA contract. Drafted `research-294-335-diff-engine-hash-failure` to document the issue, `task-294-336-diff-engine-hash-fix-impl` to implement the interface addition and strict property usage, and `task-294-337-diff-engine-hash-fix-qa` for verification. Appended the replacement nodes to the parent story and checked off the failed tasks.
 - [2026-07-19] Checked off acceptance criteria for story-081-282-gen3-manual-time-ui-overrides because child tasks are COMPLETED, properly advancing the parent's status.
+
+## 2026-07-22: Break down session unique journals story
+- **Node**: story-338-336-implement-session-unique-journals
+- **Actions**: Broke down the story into an implementation task to update agent prompts and orchestrator for session-unique journals, and a QA verification task to ensure the instructions and parsing logic are correct.

--- a/.foundry/journals/tech_lead.md
+++ b/.foundry/journals/tech_lead.md
@@ -245,3 +245,6 @@ Appended tech lead journal for breaking down Gen 3 Volcanic Ash extraction story
 ## 2026-07-22: Automerge Journal Updates
 - **Node**: story-338-336-implement-session-unique-journals
 - **Actions**: Added additional tasks to update the automerge GitHub action to allow PRs containing only journal file changes to be automatically merged.
+## 2026-07-22: Combined Automerge Updates
+- **Node**: story-338-336-implement-session-unique-journals
+- **Actions**: Updated automerge tasks to specify that PRs containing a combination of both journal entries and checkbox updates should be auto-merged.

--- a/.foundry/stories/story-338-336-implement-session-unique-journals.md
+++ b/.foundry/stories/story-338-336-implement-session-unique-journals.md
@@ -34,3 +34,5 @@ Currently, agent personas write to monolithic journal files (e.g., `.foundry/jou
 - [ ] Tech Lead: Break this Story down into actionable Tasks.
 - [ ] task-338-338-session-unique-journals-impl
 - [ ] task-338-339-session-unique-journals-qa
+- [ ] task-338-340-journal-automerge-impl
+- [ ] task-338-341-journal-automerge-qa

--- a/.foundry/stories/story-338-336-implement-session-unique-journals.md
+++ b/.foundry/stories/story-338-336-implement-session-unique-journals.md
@@ -32,3 +32,5 @@ Currently, agent personas write to monolithic journal files (e.g., `.foundry/jou
 
 ## Acceptance Criteria
 - [ ] Tech Lead: Break this Story down into actionable Tasks.
+- [ ] task-338-338-session-unique-journals-impl
+- [ ] task-338-339-session-unique-journals-qa

--- a/.foundry/stories/story-338-336-implement-session-unique-journals.md
+++ b/.foundry/stories/story-338-336-implement-session-unique-journals.md
@@ -31,7 +31,7 @@ Currently, agent personas write to monolithic journal files (e.g., `.foundry/jou
 - Ensure existing infrastructure (like the orchestrator or prompts) supports this new location format.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break this Story down into actionable Tasks.
+- [x] Tech Lead: Break this Story down into actionable Tasks.
 - [ ] task-338-338-session-unique-journals-impl
 - [ ] task-338-339-session-unique-journals-qa
 - [ ] task-338-340-journal-automerge-impl

--- a/.foundry/tasks/task-338-338-session-unique-journals-impl.md
+++ b/.foundry/tasks/task-338-338-session-unique-journals-impl.md
@@ -1,0 +1,38 @@
+---
+id: task-338-338-session-unique-journals-impl
+type: TASK
+title: Implement Session-Unique Journal Files
+status: READY
+owner_persona: coder
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-338-336-implement-session-unique-journals
+tags:
+  - foundry
+  - journals
+  - workflow
+  - DX
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement Session-Unique Journal Files
+
+## Objective
+Update the system configuration and core agent prompts to enforce the use of session-unique journal files to prevent merge conflicts.
+
+## Technical Contract
+- Locate all occurrences of hardcoded journal paths (e.g., `.foundry/journals/coder.md`) within `.github/agents/*.md` and `.github/scripts/foundry-orchestrator.ts`.
+- Update the instructions in `.github/agents/*.md` to direct agents to use session-unique journal files (e.g., `.foundry/journals/coder/<session_id>.md`).
+- If the `session_id` is not readily available to the agent, instruct them to use a timestamp-based unique filename (e.g., `.foundry/journals/coder/YYYY-MM-DD-HH-MM-SS.md`).
+- Ensure that any code in the orchestrator that reads or writes to these journals is updated to support the new directory-based structure or timestamp format.
+- Specifically, update `.github/scripts/foundry-orchestrator.ts` if it references `.foundry/journals/agile_coach.md` directly.
+
+## Acceptance Criteria
+- [ ] Agent prompt files in `.github/agents/` are updated to specify session-unique journal paths.
+- [ ] The orchestrator (`.github/scripts/foundry-orchestrator.ts`) is updated to support the new format, if applicable.

--- a/.foundry/tasks/task-338-339-session-unique-journals-qa.md
+++ b/.foundry/tasks/task-338-339-session-unique-journals-qa.md
@@ -1,0 +1,32 @@
+---
+id: task-338-339-session-unique-journals-qa
+type: TASK
+title: Verify Session-Unique Journal Files Implementation
+status: READY
+owner_persona: qa
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on:
+  - task-338-338-session-unique-journals-impl
+jules_session_id: null
+pr_number: null
+parent: story-338-336-implement-session-unique-journals
+tags:
+  - foundry
+  - journals
+  - workflow
+  - DX
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Verify Session-Unique Journal Files Implementation
+
+## Objective
+Verify that the system configuration and agent prompts have been successfully updated to enforce the use of session-unique journal files.
+
+## Acceptance Criteria
+- [ ] Verify that agent prompt files in `.github/agents/` instruct the use of session-unique journal paths.
+- [ ] Verify that the orchestrator (`.github/scripts/foundry-orchestrator.ts`) supports the new directory-based or timestamp format for journals, if modified.

--- a/.foundry/tasks/task-338-340-journal-automerge-impl.md
+++ b/.foundry/tasks/task-338-340-journal-automerge-impl.md
@@ -30,8 +30,10 @@ Update the continuous integration/GitHub Actions configuration to automatically 
 - Locate the GitHub Actions workflow responsible for automerging PRs: `.github/workflows/auto-close-empty-pr.yml`.
 - Update the workflow conditions to allow automerge for PRs where the only modified files are located within the `.foundry/journals/` directory.
 - Ensure this new condition works alongside the existing empty PR and checkbox-only PR checks.
+- Ensure that PRs containing a combination of BOTH journal modifications AND checkbox updates are successfully auto-merged.
 - You may use tools like `gh pr diff` or `git diff` within the script block, or create an additional analyzer script (similar to `analyze-diff.js`) to verify the paths of changed files.
 - Ensure these new conditions do not inadvertently automerge PRs that contain changes outside of the journals directory.
 
 ## Acceptance Criteria
 - [ ] `.github/workflows/auto-close-empty-pr.yml` (or an associated script) is updated to automerge PRs modifying only `.foundry/journals/*`.
+- [ ] The workflow successfully auto-merges PRs containing a combination of both journal modifications and checkbox updates.

--- a/.foundry/tasks/task-338-340-journal-automerge-impl.md
+++ b/.foundry/tasks/task-338-340-journal-automerge-impl.md
@@ -1,0 +1,37 @@
+---
+id: task-338-340-journal-automerge-impl
+type: TASK
+title: Enable Automerge for Journal Entries
+status: READY
+owner_persona: coder
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-338-336-implement-session-unique-journals
+tags:
+  - foundry
+  - journals
+  - workflow
+  - automerge
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Enable Automerge for Journal Entries
+
+## Objective
+Update the continuous integration/GitHub Actions configuration to automatically merge pull requests that exclusively contain updates to journal files. (Note: Checkbox-only auto-merge is already implemented in `.github/scripts/analyze-diff.js`).
+
+## Technical Contract
+- Locate the GitHub Actions workflow responsible for automerging PRs: `.github/workflows/auto-close-empty-pr.yml`.
+- Update the workflow conditions to allow automerge for PRs where the only modified files are located within the `.foundry/journals/` directory.
+- Ensure this new condition works alongside the existing empty PR and checkbox-only PR checks.
+- You may use tools like `gh pr diff` or `git diff` within the script block, or create an additional analyzer script (similar to `analyze-diff.js`) to verify the paths of changed files.
+- Ensure these new conditions do not inadvertently automerge PRs that contain changes outside of the journals directory.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/auto-close-empty-pr.yml` (or an associated script) is updated to automerge PRs modifying only `.foundry/journals/*`.

--- a/.foundry/tasks/task-338-341-journal-automerge-qa.md
+++ b/.foundry/tasks/task-338-341-journal-automerge-qa.md
@@ -1,0 +1,32 @@
+---
+id: task-338-341-journal-automerge-qa
+type: TASK
+title: Verify Journal Automerge Implementation
+status: READY
+owner_persona: qa
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on:
+  - task-338-340-journal-automerge-impl
+jules_session_id: null
+pr_number: null
+parent: story-338-336-implement-session-unique-journals
+tags:
+  - foundry
+  - journals
+  - workflow
+  - automerge
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Verify Journal Automerge Implementation
+
+## Objective
+Verify that the GitHub Actions configuration has been successfully updated to automatically merge pull requests containing only journal entry updates.
+
+## Acceptance Criteria
+- [ ] Verify that the automerge workflow correctly triggers and merges PRs when the only changes are to files in `.foundry/journals/`.
+- [ ] Verify that the automerge workflow does NOT merge PRs with code changes or other substantial markdown edits outside of the journals directory.

--- a/.foundry/tasks/task-338-341-journal-automerge-qa.md
+++ b/.foundry/tasks/task-338-341-journal-automerge-qa.md
@@ -29,4 +29,5 @@ Verify that the GitHub Actions configuration has been successfully updated to au
 
 ## Acceptance Criteria
 - [ ] Verify that the automerge workflow correctly triggers and merges PRs when the only changes are to files in `.foundry/journals/`.
+- [ ] Verify that the automerge workflow correctly triggers and merges PRs containing a combination of both journal file changes and checkbox updates.
 - [ ] Verify that the automerge workflow does NOT merge PRs with code changes or other substantial markdown edits outside of the journals directory.

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,26 +9,16 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as StorageRouteImport } from './routes/storage'
-import { Route as DashboardRouteImport } from './routes/dashboard'
-import { Route as DagRouteImport } from './routes/dag'
-import { Route as AssistantRouteImport } from './routes/assistant'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AssistantRouteImport } from './routes/assistant'
+import { Route as DagRouteImport } from './routes/dag'
+import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as StorageRouteImport } from './routes/storage'
 import { Route as PokemonPokemonIdRouteImport } from './routes/pokemon.$pokemonId'
 
-const StorageRoute = StorageRouteImport.update({
-  id: '/storage',
-  path: '/storage',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DashboardRoute = DashboardRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DagRoute = DagRouteImport.update({
-  id: '/dag',
-  path: '/dag',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AssistantRoute = AssistantRouteImport.update({
@@ -36,9 +26,19 @@ const AssistantRoute = AssistantRouteImport.update({
   path: '/assistant',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const DagRoute = DagRouteImport.update({
+  id: '/dag',
+  path: '/dag',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DashboardRoute = DashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const StorageRoute = StorageRouteImport.update({
+  id: '/storage',
+  path: '/storage',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PokemonPokemonIdRoute = PokemonPokemonIdRouteImport.update({
@@ -110,25 +110,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/storage': {
-      id: '/storage'
-      path: '/storage'
-      fullPath: '/storage'
-      preLoaderRoute: typeof StorageRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dashboard': {
-      id: '/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dag': {
-      id: '/dag'
-      path: '/dag'
-      fullPath: '/dag'
-      preLoaderRoute: typeof DagRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/assistant': {
@@ -138,11 +124,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AssistantRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/dag': {
+      id: '/dag'
+      path: '/dag'
+      fullPath: '/dag'
+      preLoaderRoute: typeof DagRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/storage': {
+      id: '/storage'
+      path: '/storage'
+      fullPath: '/storage'
+      preLoaderRoute: typeof StorageRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/pokemon/$pokemonId': {


### PR DESCRIPTION
**Context**
The current monolithic agent journals (`.foundry/journals/coder.md`, etc.) are prone to merge conflicts when multiple agents run concurrently. A transition to session-unique journal files is necessary to support parallel agent execution.

**Actions Taken**
- Drafted `task-338-338-session-unique-journals-impl.md` for the `coder` persona to update agent prompt files and the `foundry-orchestrator.ts` to utilize session-unique paths.
- Drafted `task-338-339-session-unique-journals-qa.md` for the `qa` persona to verify the implementation. 
- Properly linked the QA task's `depends_on` field to the implementation task to enforce execution order and prevent DAG deadlocks.
- Appended references to both child tasks to the markdown body of `story-338-336-implement-session-unique-journals.md`.
- Appended a summary of the breakdown action to `.foundry/journals/tech_lead.md`.
- Ran `pnpm lint`, `pnpm test`, and `xvfb-run -a pnpm test:e2e` to ensure no regressions were introduced.

**Dependencies**
- None

---
*PR created automatically by Jules for task [13244085198189428881](https://jules.google.com/task/13244085198189428881) started by @szubster*