### PR TITLE
Story Owner: Complete Gen 3 Trainer Data Extraction Epic

### DIFF
--- a/.foundry/epics/epic-099-130-gen3-trainer-data-extraction.md
+++ b/.foundry/epics/epic-099-130-gen3-trainer-data-extraction.md
@@ -26,10 +26,10 @@ notes: ''
 Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file.
 
 ## Requirements
-- [ ] Identify memory offsets for Trainer ID, and Secret ID in a save file.
-- [ ] Update the relevant interface to include Secret ID.
-- [ ] Implement extraction logic in `src/engine/saveParser/parsers/gen3.ts`.
+- [x] Identify memory offsets for Trainer ID, and Secret ID in a save file.
+- [x] Update the relevant interface to include Secret ID.
+- [x] Implement extraction logic in `src/engine/saveParser/parsers/gen3.ts`.
 
 ## Acceptance Criteria
 - [x] Story Owner: Convert this Epic into Stories.
-- [ ] story-130-269-extract-gen3-trainer-id-secret-id
+- [x] story-130-269-extract-gen3-trainer-id-secret-id


### PR DESCRIPTION
Checked off the acceptance criteria for `epic-099-130-gen3-trainer-data-extraction.md` since its child stories have already been completed, allowing it to transition to VERIFYING.

---
*PR created automatically by Jules for task [6800304169251158758](https://jules.google.com/task/6800304169251158758) started by @szubster*