### PR TITLE
Empty PR: Demote PRD 085 to PENDING with new child epics

### DIFF
--- a/.foundry/epics/epic-107-339-lift-rejection-count-state-v2.md
+++ b/.foundry/epics/epic-107-339-lift-rejection-count-state-v2.md
@@ -1,0 +1,37 @@
+---
+id: epic-107-339-lift-rejection-count-state-v2
+type: EPIC
+title: Lift Constant and Update Context V2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on:
+  - research-107-336-investigate-epic-301-failure
+jules_session_id: null
+pr_number: null
+parent: prd-085-107-lift-rejection-count-state
+tags:
+  - refactor
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Lift Constant and Update Context V2
+
+## Objective
+Extract the `MAX_REJECTION_THRESHOLD` constant (value: 3) from local file scopes into `DagContext.tsx` or a dedicated shared constants utility, and expose it through the React context layer.
+
+## Context
+Currently, the threshold for determining if a node has permanently failed (`rejection_count >= 3`) is hardcoded in several components (e.g., `DagDashboard.tsx` and `DagNode.tsx`). This tight coupling makes maintaining and modifying the threshold difficult. Lifting this state is required by ADR 017 to display permanent failures correctly on the dashboard.
+
+## Requirements
+1. Define `MAX_REJECTION_THRESHOLD = 3` in `DagContext.tsx` (or a shared constants file).
+2. Expose this value through the `DagContextState` interface.
+3. Provide the value in the `DagProvider`.
+4. Include an explicit requirement for E2E and integration tests.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/epics/epic-107-340-update-dashboard-rejection-count-v2.md
+++ b/.foundry/epics/epic-107-340-update-dashboard-rejection-count-v2.md
@@ -1,0 +1,36 @@
+---
+id: epic-107-340-update-dashboard-rejection-count-v2
+type: EPIC
+title: Update UI Views with Lifted Constant V2
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on:
+  - epic-107-339-lift-rejection-count-state-v2
+jules_session_id: null
+pr_number: null
+parent: prd-085-107-lift-rejection-count-state
+tags:
+  - refactor
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Update UI Views with Lifted Constant V2
+
+## Objective
+Update UI components and related tests to use the `MAX_REJECTION_THRESHOLD` constant exposed by `DagContext` instead of a hardcoded value.
+
+## Context
+With the threshold for permanent failures extracted to the React Context, the UI components need to be refactored to consume this value. This ensures consistency and fulfills the requirements of PRD 107 and ADR 017.
+
+## Requirements
+1. Update `DagDashboard.tsx` to use the exposed threshold when filtering nodes for the "Permanent Failures" view.
+2. Update `DagNode.tsx` to use the exposed threshold when applying permanent failure styles.
+3. Update `DagNode.test.tsx` and any other related test files to use the shared constant.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -92,3 +92,6 @@ Broke down PRD prd-116-117-zod-schema-validation-orchestrator into two Epics: ep
 
 ## 2026-07-21
 - Transformed PRD for conflictless journals into an Epic. Ensures we transition from monolithic markdown files to conflict-less storage per session.
+
+## 2026-07-22: Handling Rejection of epic-107-301
+Encountered permanently failed epic-107-301 due to missing E2E integration story. Spawning research node research-107-336 and replacement epics epic-107-339 and epic-107-340. Demoted parent prd-085-107-lift-rejection-count-state to PENDING by appending new nodes as unchecked criteria and checking off the pending epics 301 and 302.

--- a/.foundry/prds/prd-085-107-lift-rejection-count-state.md
+++ b/.foundry/prds/prd-085-107-lift-rejection-count-state.md
@@ -34,5 +34,8 @@ When reviewing the DAG Dashboard code, it was observed that the permanent failur
 - [ ] Break down into Epics
 
 ## Generated Epics
-- [ ] epic-107-301-lift-rejection-count-state
-- [ ] epic-107-302-update-dashboard-rejection-count
+- [x] epic-107-301-lift-rejection-count-state
+- [x] epic-107-302-update-dashboard-rejection-count
+- [ ] research-107-336-investigate-epic-301-failure
+- [ ] epic-107-339-lift-rejection-count-state-v2
+- [ ] epic-107-340-update-dashboard-rejection-count-v2

--- a/.foundry/research/research-107-336-investigate-epic-301-failure.md
+++ b/.foundry/research/research-107-336-investigate-epic-301-failure.md
@@ -1,0 +1,27 @@
+---
+id: research-107-336-investigate-epic-301-failure
+type: RESEARCH
+title: Investigate Lift Rejection Count Epic Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-085-107-lift-rejection-count-state
+tags:
+  - research
+  - orchestration
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Investigate Lift Rejection Count Epic Failure
+
+## 1. Objective
+Investigate why `epic-107-301-lift-rejection-count-state` was permanently cancelled (Missing E2E/integration story).
+
+## 2. Acceptance Criteria
+- [ ] Root cause identified and documented.
+- [ ] Proposed fix architecture defined for the replacement Epic.

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,26 +9,16 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as StorageRouteImport } from './routes/storage'
-import { Route as DashboardRouteImport } from './routes/dashboard'
-import { Route as DagRouteImport } from './routes/dag'
-import { Route as AssistantRouteImport } from './routes/assistant'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AssistantRouteImport } from './routes/assistant'
+import { Route as DagRouteImport } from './routes/dag'
+import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as StorageRouteImport } from './routes/storage'
 import { Route as PokemonPokemonIdRouteImport } from './routes/pokemon.$pokemonId'
 
-const StorageRoute = StorageRouteImport.update({
-  id: '/storage',
-  path: '/storage',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DashboardRoute = DashboardRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DagRoute = DagRouteImport.update({
-  id: '/dag',
-  path: '/dag',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AssistantRoute = AssistantRouteImport.update({
@@ -36,9 +26,19 @@ const AssistantRoute = AssistantRouteImport.update({
   path: '/assistant',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const DagRoute = DagRouteImport.update({
+  id: '/dag',
+  path: '/dag',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DashboardRoute = DashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const StorageRoute = StorageRouteImport.update({
+  id: '/storage',
+  path: '/storage',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PokemonPokemonIdRoute = PokemonPokemonIdRouteImport.update({
@@ -110,25 +110,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/storage': {
-      id: '/storage'
-      path: '/storage'
-      fullPath: '/storage'
-      preLoaderRoute: typeof StorageRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dashboard': {
-      id: '/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dag': {
-      id: '/dag'
-      path: '/dag'
-      fullPath: '/dag'
-      preLoaderRoute: typeof DagRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/assistant': {
@@ -138,11 +124,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AssistantRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/dag': {
+      id: '/dag'
+      path: '/dag'
+      fullPath: '/dag'
+      preLoaderRoute: typeof DagRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/storage': {
+      id: '/storage'
+      path: '/storage'
+      fullPath: '/storage'
+      preLoaderRoute: typeof StorageRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/pokemon/$pokemonId': {


### PR DESCRIPTION
This empty PR fulfills the orchestration rules to allow the parent node to step down to PENDING after generating new dependent files.

- **What:** Demoted prd-085-107-lift-rejection-count-state to PENDING, created research node 336, replacement epic 339, and replacement epic 340. Checked off failed epic 301 and dependent epic 302.
- **Why:** The previous Epic `epic-107-301` was permanently cancelled due to a missing E2E requirement. We had to create a new research node to investigate this and properly replace the failed nodes as per the "Handling Permanent Child Failures" orchestration rule.
- **Impact on DX/CI:** N/A (Foundry internal process).
- **Setup notes:** No setup needed.

---
*PR created automatically by Jules for task [1797941619447229784](https://jules.google.com/task/1797941619447229784) started by @szubster*