### PR TITLE
Replace failed epic-099-130 with epic-099-340 and research node

### DIFF
--- a/.foundry/epics/epic-099-340-gen3-trainer-data-extraction.md
+++ b/.foundry/epics/epic-099-340-gen3-trainer-data-extraction.md
@@ -1,12 +1,13 @@
 ---
-id: epic-099-130-gen3-trainer-data-extraction
+id: epic-099-340-gen3-trainer-data-extraction
 type: EPIC
 title: Gen 3 Trainer Data Extraction
-status: FAILED
+status: PENDING
 owner_persona: story_owner
-created_at: '2026-07-03'
+created_at: '2026-07-22'
 updated_at: '2026-07-22'
-depends_on: []
+depends_on:
+  - research-099-339-gen3-trainer-data-e2e
 jules_session_id: null
 pr_number: null
 parent: prd-082-099-gen3-trainer-data-extraction
@@ -16,9 +17,7 @@ tags:
   - trainer
 research_references: []
 rejection_count: 0
-rejection_reason: >-
-  [ACKNOWLEDGED] Merged with unfulfilled acceptance criteria: Missing
-  E2E/integration story
+rejection_reason: ''
 notes: ''
 ---
 
@@ -28,9 +27,10 @@ notes: ''
 Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file.
 
 ## Requirements
-- [x] Identify memory offsets for Trainer ID, and Secret ID in a save file.
-- [x] Update the relevant interface to include Secret ID.
-- [x] Implement extraction logic in `src/engine/saveParser/parsers/gen3.ts`.
+- Identify memory offsets for Trainer ID, and Secret ID in a save file.
+- Update the relevant interface to include Secret ID.
+- Implement extraction logic in `src/engine/saveParser/parsers/gen3.ts`.
+- E2E/integration story must be created and completed.
 
 ## Acceptance Criteria
 - [x] Story Owner: Convert this Epic into Stories.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -92,3 +92,6 @@ Broke down PRD prd-116-117-zod-schema-validation-orchestrator into two Epics: ep
 
 ## 2026-07-21
 - Transformed PRD for conflictless journals into an Epic. Ensures we transition from monolithic markdown files to conflict-less storage per session.
+
+## 2026-07-22: Handling permanently failed child epic-099-130-gen3-trainer-data-extraction
+Spawned research-099-339-gen3-trainer-data-e2e to investigate the missing E2E integration story context. Created replacement epic-099-340-gen3-trainer-data-extraction dependent on the research node. Updated PRD and dependent story accordingly.

--- a/.foundry/prds/prd-082-099-gen3-trainer-data-extraction.md
+++ b/.foundry/prds/prd-082-099-gen3-trainer-data-extraction.md
@@ -31,4 +31,6 @@ Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file and disp
 
 ## Acceptance Criteria
 - [x] Epic Planner: Convert this PRD into Epics.
-- [ ] epic-099-130-gen3-trainer-data-extraction
+- [x] epic-099-130-gen3-trainer-data-extraction
+- [ ] research-099-339-gen3-trainer-data-e2e
+- [ ] epic-099-340-gen3-trainer-data-extraction

--- a/.foundry/research/research-099-339-gen3-trainer-data-e2e.md
+++ b/.foundry/research/research-099-339-gen3-trainer-data-e2e.md
@@ -1,0 +1,34 @@
+---
+id: research-099-339-gen3-trainer-data-e2e
+type: RESEARCH
+title: Investigate Gen 3 Trainer Data E2E Story Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-082-099-gen3-trainer-data-extraction
+tags:
+  - gen3
+  - trainer
+  - e2e
+  - failure-analysis
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 3 Trainer Data E2E Story Failure
+
+## Objective
+Investigate the requirements for the missing E2E integration story for the Gen 3 Trainer Data Extraction epic.
+
+## Context
+The epic `epic-099-130-gen3-trainer-data-extraction` failed due to `Missing E2E/integration story`. We need to define the E2E testing requirements before we can successfully implement the extraction logic.
+
+## Acceptance Criteria
+- [ ] Determine the necessary E2E tests for TID/SID extraction.
+- [ ] Document the testing strategy.

--- a/.foundry/stories/story-130-269-extract-gen3-trainer-id-secret-id.md
+++ b/.foundry/stories/story-130-269-extract-gen3-trainer-id-secret-id.md
@@ -9,7 +9,7 @@ updated_at: '2026-07-22'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: epic-099-130-gen3-trainer-data-extraction
+parent: epic-099-340-gen3-trainer-data-extraction
 tags:
   - feature
   - gen3

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,26 +9,16 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as StorageRouteImport } from './routes/storage'
-import { Route as DashboardRouteImport } from './routes/dashboard'
-import { Route as DagRouteImport } from './routes/dag'
-import { Route as AssistantRouteImport } from './routes/assistant'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AssistantRouteImport } from './routes/assistant'
+import { Route as DagRouteImport } from './routes/dag'
+import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as StorageRouteImport } from './routes/storage'
 import { Route as PokemonPokemonIdRouteImport } from './routes/pokemon.$pokemonId'
 
-const StorageRoute = StorageRouteImport.update({
-  id: '/storage',
-  path: '/storage',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DashboardRoute = DashboardRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DagRoute = DagRouteImport.update({
-  id: '/dag',
-  path: '/dag',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AssistantRoute = AssistantRouteImport.update({
@@ -36,9 +26,19 @@ const AssistantRoute = AssistantRouteImport.update({
   path: '/assistant',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const DagRoute = DagRouteImport.update({
+  id: '/dag',
+  path: '/dag',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DashboardRoute = DashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const StorageRoute = StorageRouteImport.update({
+  id: '/storage',
+  path: '/storage',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PokemonPokemonIdRoute = PokemonPokemonIdRouteImport.update({
@@ -110,25 +110,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/storage': {
-      id: '/storage'
-      path: '/storage'
-      fullPath: '/storage'
-      preLoaderRoute: typeof StorageRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dashboard': {
-      id: '/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dag': {
-      id: '/dag'
-      path: '/dag'
-      fullPath: '/dag'
-      preLoaderRoute: typeof DagRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/assistant': {
@@ -138,11 +124,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AssistantRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/dag': {
+      id: '/dag'
+      path: '/dag'
+      fullPath: '/dag'
+      preLoaderRoute: typeof DagRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/storage': {
+      id: '/storage'
+      path: '/storage'
+      fullPath: '/storage'
+      preLoaderRoute: typeof StorageRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/pokemon/$pokemonId': {


### PR DESCRIPTION
Spawns a RESEARCH node to investigate the missing E2E integration story for TID/SID extraction, replaces the failed epic-099-130 with epic-099-340 dependent on the research node, and updates the parent PRD and child story references.

---
*PR created automatically by Jules for task [365735201569879069](https://jules.google.com/task/365735201569879069) started by @szubster*