### PR TITLE
Empty PR: Target PRD-117-116 artifact already exists

### DIFF
--- a/.foundry/journals/product_manager.md
+++ b/.foundry/journals/product_manager.md
@@ -81,3 +81,6 @@ I noticed that `idea-118-orchestrator-circular-dependency-detection.md` containe
 ## 2026-07-20 - Anomaly Found
 When handling idea-117-split-bundles-and-data, I found that the target PRD artifact prd-117-116-split-bundles-and-data already existed with status COMPLETED. The PRD was successfully generated beforehand.
 - 2026-07-20: Formalized idea-120 into prd-120-335 to transition from monolithic agent journals to session-unique markdown files, eliminating persistent GitHub merge conflicts.
+
+## 2026-07-22 - Idea Transformation to PRD Anomaly
+When beginning the session to transform `idea-117-split-bundles-and-data` into a PRD, I discovered that the target artifact `prd-117-116-split-bundles-and-data` already existed and its acceptance criteria was checked on the idea node. This is an anomaly that the Agile Coach should review. Submitting an empty PR to allow the DAG to progress since the target artifact exists.


### PR DESCRIPTION
Submitting an empty PR as the target PRD artifact (`prd-117-116-split-bundles-and-data`) already unexpectedly existed prior to the session, and its acceptance criteria was already checked off on the `idea-117` node. As per the Product Manager persona instructions, this anomaly has been logged to the journal for the Agile Coach to review, and an empty PR is submitted to allow the DAG to progress.

---
*PR created automatically by Jules for task [4495334202403632906](https://jules.google.com/task/4495334202403632906) started by @szubster*