### PR TITLE
Story Owner: Abort epic-043-152-gen3-roamer-data-extraction

### DIFF
--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -66,3 +66,8 @@ Broke down epic-115-331-remove-orphaned-qa-task-rule-from-docs into story-331-33
 Checked off acceptance criteria checkboxes for completed epic epic-057-127-bash-timeout-wrapper because all its child stories (story-127-267-bash-timeout-wrapper and story-127-268-bash-timeout-feedback) have been completed, permitting the submission of an empty PR to advance the epic's status to VERIFYING.
 ## 2026-07-22
 * Created stories story-338-336, story-338-337, and story-338-338 for epic-120-338 to implement session-unique journal files.
+
+## 2026-07-22
+* Task: epic-043-152-gen3-roamer-data-extraction
+* Action: Handled impossible task by following the impossible task protocol. The YAML frontmatter was left completely untouched and no acceptance criteria were checked. Submitted empty PR.
+* Learning: Gen 3 roamer map coordinates are stored in dynamically allocated EWRAM during gameplay and are not serialized to the save file. This makes static extraction impossible per research-043-263-roamer-tracking-remediation and ADR 108-027.


### PR DESCRIPTION
epic-043-152-gen3-roamer-data-extraction is permanently cancelled because Gen 3 roamer map coordinates are stored in EWRAM and are not serialized. Leaving frontmatter untouched and criteria unchecked per policies.

---
*PR created automatically by Jules for task [12219933142997194731](https://jules.google.com/task/12219933142997194731) started by @szubster*