### PR TITLE
Epic Planner: Replace failed Epic with missing E2E story

### DIFF
--- a/.foundry/epics/epic-107-302-update-dashboard-rejection-count.md
+++ b/.foundry/epics/epic-107-302-update-dashboard-rejection-count.md
@@ -7,7 +7,7 @@ owner_persona: story_owner
 created_at: '2026-07-10'
 updated_at: '2026-07-10'
 depends_on:
-  - epic-107-301-lift-rejection-count-state
+  - epic-107-339-lift-rejection-count-state
 jules_session_id: null
 pr_number: null
 parent: prd-085-107-lift-rejection-count-state
@@ -32,6 +32,8 @@ With the threshold for permanent failures extracted to the React Context (in Epi
 1. Update `DagDashboard.tsx` to use the exposed threshold when filtering nodes for the "Permanent Failures" view.
 2. Update `DagNode.tsx` to use the exposed threshold when applying permanent failure styles.
 3. Update `DagNode.test.tsx` and any other related test files to use the shared constant.
+4. Ensure a final STORY dedicated to Integration and E2E Verification is created.
 
 ## Acceptance Criteria
 - [ ] Break down into Stories
+- [ ] Create E2E/integration story

--- a/.foundry/epics/epic-107-339-lift-rejection-count-state.md
+++ b/.foundry/epics/epic-107-339-lift-rejection-count-state.md
@@ -1,0 +1,38 @@
+---
+id: epic-107-339-lift-rejection-count-state
+type: EPIC
+title: Lift Constant and Update Context
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-085-107-lift-rejection-count-state
+tags:
+  - refactor
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Lift Constant and Update Context
+
+## Objective
+Extract the `MAX_REJECTION_THRESHOLD` constant (value: 3) from local file scopes into `DagContext.tsx` or a dedicated shared constants utility, and expose it through the React context layer.
+
+## Context
+Currently, the threshold for determining if a node has permanently failed (`rejection_count >= 3`) is hardcoded in several components (e.g., `DagDashboard.tsx` and `DagNode.tsx`). This tight coupling makes maintaining and modifying the threshold difficult. Lifting this state is required by ADR 017 to display permanent failures correctly on the dashboard.
+
+## Requirements
+1. Define `MAX_REJECTION_THRESHOLD = 3` in `DagContext.tsx` (or a shared constants file).
+2. Expose this value through the `DagContextState` interface.
+3. Provide the value in the `DagProvider`.
+4. Ensure a final STORY dedicated to Integration and E2E Verification is created.
+
+## Acceptance Criteria
+- [x] Break down into Stories
+- [ ] Create E2E/integration story

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -92,3 +92,8 @@ Broke down PRD prd-116-117-zod-schema-validation-orchestrator into two Epics: ep
 
 ## 2026-07-21
 - Transformed PRD for conflictless journals into an Epic. Ensures we transition from monolithic markdown files to conflict-less storage per session.
+
+## Session 2026-07-22: Handling Acknowledged Missing E2E Criterion
+**Context:** Processing PRD `prd-085-107-lift-rejection-count-state`.
+**Observation:** `epic-107-301-lift-rejection-count-state` was explicitly failed due to an acknowledged missing criterion ("Missing E2E/integration story"). Also `epic-107-302-update-dashboard-rejection-count` was missing the mandatory E2E story requirement.
+**Action:** Created a replacement node `epic-107-339-lift-rejection-count-state` that includes the missing E2E integration story criteria. The old failed node was left intact in the file system to avoid dangling references and broken links. Updated the parent PRD's checkboxes by checking off the failed node and adding the new replacement node. Updated dependent node (`epic-107-302-update-dashboard-rejection-count`) to depend on the new ID and added the E2E verification requirement to it.

--- a/.foundry/prds/prd-085-107-lift-rejection-count-state.md
+++ b/.foundry/prds/prd-085-107-lift-rejection-count-state.md
@@ -34,5 +34,6 @@ When reviewing the DAG Dashboard code, it was observed that the permanent failur
 - [ ] Break down into Epics
 
 ## Generated Epics
-- [ ] epic-107-301-lift-rejection-count-state
+- [x] epic-107-301-lift-rejection-count-state
+- [ ] epic-107-339-lift-rejection-count-state
 - [ ] epic-107-302-update-dashboard-rejection-count


### PR DESCRIPTION
Created replacement `epic-107-339-lift-rejection-count-state` for the failed `epic-107-301-lift-rejection-count-state` to include the missing E2E integration story criteria. The old node was kept intact to preserve historical state. Updated parent PRD and dependent epic to reflect the new ID.

---
*PR created automatically by Jules for task [8082975142364024643](https://jules.google.com/task/8082975142364024643) started by @szubster*