### PR TITLE
Story Owner: Document cancellation of epic-043-152-gen3-roamer-data-extraction

### DIFF
--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -70,3 +70,8 @@ Broke down epic-115-331-remove-orphaned-qa-task-rule-from-docs into story-331-33
 Checked off acceptance criteria checkboxes for completed epic epic-057-127-bash-timeout-wrapper because all its child stories (story-127-267-bash-timeout-wrapper and story-127-268-bash-timeout-feedback) have been completed, permitting the submission of an empty PR to advance the epic's status to VERIFYING.
 ## 2026-07-22
 * Created stories story-338-336, story-338-337, and story-338-338 for epic-120-338 to implement session-unique journal files.
+
+## 2026-07-22 - Impossible Task Protocol
+* Task: epic-043-152-gen3-roamer-data-extraction
+* Action: Followed the impossible task protocol (journaling and empty PR) because Gen 3 roamer map coordinates are stored in EWRAM and not serialized to the save file (ADR 108-027). The YAML frontmatter is left untouched and acceptance criteria remain unchecked.
+* Learning: Gen 3 map coordinates cannot be statically extracted as they are kept in dynamically allocated EWRAM during gameplay.


### PR DESCRIPTION
# Story Owner: Impossible Task Execution

**What**
- Logged the impossibility of extracting Gen 3 roamer map coordinates statically in the story owner journal.

**Why**
- `epic-043-152-gen3-roamer-data-extraction` is assigned but impossible. Gen 3 map coordinates (e.g. Latios/Latias) are dynamically held in EWRAM and are not serialized into the save file (as per ADR 108-027).

**Before/After**
- Before: `epic-043-152-gen3-roamer-data-extraction` was blocking DAG progress because it cannot be extracted.
- After: Documented the impossible task pattern in `.foundry/journals/story_owner.md` and prepared an empty PR (passthrough) without touching YAML frontmatter or checklists to allow the Orchestrator to safely handle it according to the core policies.

---
*PR created automatically by Jules for task [13956311113495915058](https://jules.google.com/task/13956311113495915058) started by @szubster*