### PR TITLE
Empty PR to update parent PRD with replacement Epic

### DIFF
--- a/.foundry/epics/epic-108-339-extend-phase-3-6-cancelled-nodes.md
+++ b/.foundry/epics/epic-108-339-extend-phase-3-6-cancelled-nodes.md
@@ -1,0 +1,40 @@
+---
+id: epic-108-339-extend-phase-3-6-cancelled-nodes
+type: EPIC
+title: Extend Phase 3.6 for CANCELLED nodes
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-22'
+updated_at: '2026-07-22'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-086-108-fix-orchestrator-phase-3-6
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extend Phase 3.6 for CANCELLED nodes
+
+## Objective
+Extend Phase 3.6 logic in `foundry-orchestrator.ts` to properly handle nodes transitioning to `CANCELLED` status due to max rejections.
+
+## Context
+In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` status with `rejection_reason === 'Max rejection count reached'` fail to trigger the parent awakening ("Impossible Loop") logic, which previously only applied to `FAILED` nodes. This causes system deadlocks. The parent node needs to be properly awakened (reverted to PENDING/READY) to handle the failure and regenerate nodes.
+
+## Requirements
+- Identify where Phase 3.6 logic is located in `foundry-orchestrator.ts`.
+- Add an explicit check for nodes with `status === 'CANCELLED'` and `rejection_reason === 'Max rejection count reached'`.
+- Ensure the parent node is properly awakened (reverted to PENDING/READY) for these cancelled nodes.
+- Update tests in `foundry-orchestrator.test.ts` to verify this exact behavior.
+- Include an E2E/integration story.
+
+## Acceptance Criteria
+- [ ] Break down into Stories
+- [ ] Create an E2E/integration story for orchestrator Phase 3.6 logic.

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -96,3 +96,7 @@ Broke down PRD prd-116-117-zod-schema-validation-orchestrator into two Epics: ep
 
 ## 2026-07-21
 - Transformed PRD for conflictless journals into an Epic. Ensures we transition from monolithic markdown files to conflict-less storage per session.
+
+## 2026-07-22: Extend Phase 3.6 Epic Replacement
+**Context:** The `epic-108-303-extend-phase-3-6-cancelled-nodes` node failed permanently because it merged with unfulfilled acceptance criteria, specifically missing an E2E/integration story.
+**Action:** Replaced the failed Epic with a new Epic, `epic-108-339-extend-phase-3-6-cancelled-nodes`, which explicitly includes the missing E2E integration story requirement in its scope and acceptance criteria. Updated the parent PRD `prd-086-108-fix-orchestrator-phase-3-6` to check off the failed Epic and appended the new replacement Epic as an unchecked task using its Node ID.

--- a/.foundry/prds/prd-086-108-fix-orchestrator-phase-3-6.md
+++ b/.foundry/prds/prd-086-108-fix-orchestrator-phase-3-6.md
@@ -33,4 +33,5 @@ In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` statu
 - [ ] Phase 3.6 awakening logic supports `CANCELLED` nodes.
 - [ ] Parent nodes correctly awaken when child nodes are cancelled due to hitting max rejections.
 - [ ] Tests verify this exact behavior in `foundry-orchestrator.test.ts`.
-- [ ] epic-108-303-extend-phase-3-6-cancelled-nodes
+- [x] epic-108-303-extend-phase-3-6-cancelled-nodes
+- [ ] epic-108-339-extend-phase-3-6-cancelled-nodes


### PR DESCRIPTION
This is an empty PR to allow the orchestrator to correctly demote the parent node to PENDING since child nodes are incomplete.

The `epic-108-303-extend-phase-3-6-cancelled-nodes` node failed permanently because it merged with unfulfilled acceptance criteria (missing an E2E/integration story). Replaced the failed Epic with a new Epic, `epic-108-339-extend-phase-3-6-cancelled-nodes`, which explicitly includes the missing requirement. Updated the parent PRD `prd-086-108-fix-orchestrator-phase-3-6` to check off the failed Epic and appended the new replacement Epic as an unchecked task using its Node ID.

---
*PR created automatically by Jules for task [13909804115397525680](https://jules.google.com/task/13909804115397525680) started by @szubster*