### PR TITLE
📜 Story Owner: Cancelled epic-043-152-gen3-roamer-data-extraction

### DIFF
--- a/.foundry/epics/epic-043-152-gen3-roamer-data-extraction.md
+++ b/.foundry/epics/epic-043-152-gen3-roamer-data-extraction.md
@@ -2,7 +2,7 @@
 id: epic-043-152-gen3-roamer-data-extraction
 type: EPIC
 title: Gen 3 Roamer Data Extraction
-status: ACTIVE
+status: CANCELLED
 owner_persona: story_owner
 created_at: '2026-07-10'
 updated_at: '2026-07-22'
@@ -13,7 +13,7 @@ parent: prd-070-043-roamer-tracking-dashboard
 tags: []
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file, making static extraction impossible as per research-043-263-roamer-tracking-remediation and ADR 108-027.'
 notes: ''
 ---
 # Gen 3 Roamer Data Extraction
@@ -36,3 +36,6 @@ Extract Gen 3 roamer data and standardize the structure for roaming legendaries.
 
 ### Task Cancellation
 This Epic is permanently CANCELLED as Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file, making static extraction impossible as per `research-043-263-roamer-tracking-remediation` and ADR 108-027.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -70,3 +70,5 @@ Broke down epic-115-331-remove-orphaned-qa-task-rule-from-docs into story-331-33
 Checked off acceptance criteria checkboxes for completed epic epic-057-127-bash-timeout-wrapper because all its child stories (story-127-267-bash-timeout-wrapper and story-127-268-bash-timeout-feedback) have been completed, permitting the submission of an empty PR to advance the epic's status to VERIFYING.
 ## 2026-07-22
 * Created stories story-338-336, story-338-337, and story-338-338 for epic-120-338 to implement session-unique journal files.
+## 2026-07-22
+* Cancelled epic-043-152-gen3-roamer-data-extraction because Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file, making static extraction impossible as per research-043-263-roamer-tracking-remediation and ADR 108-027.


### PR DESCRIPTION
Cancelled `epic-043-152-gen3-roamer-data-extraction` because Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file, making static extraction impossible as per `research-043-263-roamer-tracking-remediation` and ADR 108-027. Also updated the journal to record this context.

---
*PR created automatically by Jules for task [17880154622601339866](https://jules.google.com/task/17880154622601339866) started by @szubster*