### PR TITLE
Fix Impossible Loop parent awakening for CANCELLED nodes

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1571,6 +1571,8 @@ vi.doMock('node:url', async (importOriginal) => {
 
     const task2Content = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-002.md'), 'utf-8');
     expect(task2Content).toContain('status: CANCELLED');
+    const storyContent = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-001.md'), 'utf-8');
+    expect(storyContent).toContain('status: READY');
     expect(task2Content).toContain('rejection_reason: \'Cancelled due to permanent failure of dependency: task-001\'');
   });
 

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -679,8 +679,7 @@ function main(): void {
       node.frontmatter.rejection_reason &&
       !node.frontmatter.rejection_reason.startsWith('[ACKNOWLEDGED]') &&
       node.frontmatter.rejection_reason !== 'Cancelled due to cascading cancellation from parent' &&
-      !node.frontmatter.rejection_reason.startsWith('Cancelled due to permanent failure of dependency:')) ||
-      (node.frontmatter.status === 'CANCELLED' && node.frontmatter.rejection_reason === 'Max rejection count reached')
+      !node.frontmatter.rejection_reason.startsWith('Cancelled due to permanent failure of dependency:'))
     ) {
       // Skip waking up parent if the child is merely suspended (waiting for dependencies/children).
       // We ignore the parent node itself during this check because it's exactly what we want to find out


### PR DESCRIPTION
Fix a bug where the orchestrator fails to awaken parent node for CANCELLED nodes because it fails to consider the ACKNOWLEDGED status prefix, causing it to fall into an infinite loop.

---
*PR created automatically by Jules for task [8927631362033752800](https://jules.google.com/task/8927631362033752800) started by @szubster*