### PR TITLE
Epic Breakdown: Extend Phase 3.6 for CANCELLED nodes

### DIFF
--- a/.foundry/epics/epic-108-339-extend-phase-3-6-cancelled-nodes.md
+++ b/.foundry/epics/epic-108-339-extend-phase-3-6-cancelled-nodes.md
@@ -1,0 +1,40 @@
+---
+id: epic-108-339-extend-phase-3-6-cancelled-nodes
+type: EPIC
+title: Extend Phase 3.6 for CANCELLED nodes
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-23'
+updated_at: '2026-07-23'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-086-108-fix-orchestrator-phase-3-6
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extend Phase 3.6 for CANCELLED nodes
+
+## Objective
+Extend Phase 3.6 logic in `foundry-orchestrator.ts` to properly handle nodes transitioning to `CANCELLED` status due to max rejections.
+
+## Context
+In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` status with `rejection_reason === 'Max rejection count reached'` fail to trigger the parent awakening ("Impossible Loop") logic, which previously only applied to `FAILED` nodes. This causes system deadlocks. The parent node needs to be properly awakened (reverted to PENDING/READY) to handle the failure and regenerate nodes.
+
+## Requirements
+- Identify where Phase 3.6 logic is located in `foundry-orchestrator.ts`.
+- Add an explicit check for nodes with `status === 'CANCELLED'` and `rejection_reason === 'Max rejection count reached'`.
+- Ensure the parent node is properly awakened (reverted to PENDING/READY) for these cancelled nodes.
+- Update tests in `foundry-orchestrator.test.ts` to verify this exact behavior.
+- Ensure the epic includes a final STORY dedicated to Integration and E2E Verification.
+
+## Acceptance Criteria
+- [ ] Break down into Stories
+- [ ] Create a final STORY dedicated to Integration and E2E Verification

--- a/.foundry/journals/epic_planner.md
+++ b/.foundry/journals/epic_planner.md
@@ -96,3 +96,8 @@ Broke down PRD prd-116-117-zod-schema-validation-orchestrator into two Epics: ep
 
 ## 2026-07-21
 - Transformed PRD for conflictless journals into an Epic. Ensures we transition from monolithic markdown files to conflict-less storage per session.
+
+## Session 2026-07-23: Replacement of Epic missing E2E story
+**Context:** Processing PRD `prd-086-108-fix-orchestrator-phase-3-6`.
+**Observation:** The child Epic `epic-108-303-extend-phase-3-6-cancelled-nodes` was failed with the acknowledged missing criteria of an E2E/integration story.
+**Action:** Created a replacement Epic `epic-108-339-extend-phase-3-6-cancelled-nodes` that explicitly includes the missing E2E integration story requirement in its scope and acceptance criteria. Updated the parent PRD to check off the failed Epic and appended the new replacement Epic as an unchecked task using its Node ID. Submitted a PR to allow the orchestrator to correctly demote the node to PENDING.

--- a/.foundry/prds/prd-086-108-fix-orchestrator-phase-3-6.md
+++ b/.foundry/prds/prd-086-108-fix-orchestrator-phase-3-6.md
@@ -33,4 +33,5 @@ In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` statu
 - [ ] Phase 3.6 awakening logic supports `CANCELLED` nodes.
 - [ ] Parent nodes correctly awaken when child nodes are cancelled due to hitting max rejections.
 - [ ] Tests verify this exact behavior in `foundry-orchestrator.test.ts`.
-- [ ] epic-108-303-extend-phase-3-6-cancelled-nodes
+- [x] epic-108-303-extend-phase-3-6-cancelled-nodes
+- [ ] epic-108-339-extend-phase-3-6-cancelled-nodes


### PR DESCRIPTION
Generated replacement epic for prd-086-108-fix-orchestrator-phase-3-6 to include the missing E2E integration story, checked off the failed epic, and logged the anomaly in the epic planner journal.

---
*PR created automatically by Jules for task [14140594791612700438](https://jules.google.com/task/14140594791612700438) started by @szubster*