### PR TITLE
🧪 Sentinel: Add E2E coverage for invalid save file upload error path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,4 @@
   - Required using `// biome-ignore lint/suspicious/noExplicitAny: allow mock state for test` when using `as any` to force minimal mock objects into complex type shapes.
   - Used explicit types for `vi.fn()` like `vi.fn<(key: string) => Promise<void>>()` to pass strict typing rules.
 - **Testing React Components**: Verified components rendering logic via `isSettingsOpen` and user interactions invoking the state reset functions (including testing confirmation modals).
+- Added E2E coverage for invalid save file upload in tests/e2e/save_management.spec.ts.

--- a/tests/e2e/save_management.spec.ts
+++ b/tests/e2e/save_management.spec.ts
@@ -36,4 +36,17 @@ test.describe('Save Management', () => {
     await expect(page.locator('[data-pokemon-id="25"]')).toBeVisible();
     await expect(page.locator('header').getByText(/TRNR/i).first()).toBeVisible();
   });
+
+  test('should display an error when uploading an invalid save file', async ({ page }) => {
+    await clearStorage(page);
+    await page.goto('.');
+    await waitForSync(page);
+
+    await expect(page.getByText(/\[ UPLOAD\.SYS \]/i)).toBeVisible();
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles(path.join('tests', 'fixtures', 'invalid.sav'));
+
+    await expect(page.getByText(/Failed to parse save file\./i)).toBeVisible();
+  });
 });

--- a/tests/fixtures/invalid.sav
+++ b/tests/fixtures/invalid.sav
@@ -1,0 +1,1 @@
+invalid data


### PR DESCRIPTION
🎯 What
Added an E2E test to `tests/e2e/save_management.spec.ts` to verify the error handling flow when an invalid save file (e.g., too small) is uploaded. It checks that the "Failed to parse save file." error is correctly displayed to the user via the `GlobalError` component.

📊 Coverage
Increases E2E coverage for the save management upload flow, specifically addressing the untested error path.

✨ Result
The application now has a robust E2E test that validates the correct behavior and user feedback when attempting to load a corrupted or inappropriately sized save file.

---
*PR created automatically by Jules for task [14214784820916980229](https://jules.google.com/task/14214784820916980229) started by @szubster*