### PR TITLE
🖼️ Canvas: Tactical Telemetry DataLabel Redesign

### DIFF
--- a/.jules/canvas.md
+++ b/.jules/canvas.md
@@ -294,3 +294,9 @@
 **Outcome:** Accepted
 **Why:** The previous search bar and filter section looked like a standard web form, which broke the "specialized hardware" immersion during regular interaction. Transforming it into an active intelligence dashboard with radar crosshairs and membrane switch filters reinforces the fantasy of using a physical tactical device.
 **Pattern:** Always elevate search and filter controls from standard inputs to active "Acquisition Matrices" by incorporating hardware analogies (e.g. radar scans, membrane toggles, status LEDs) and structural paneling (`[ TARGET_ACQUISITION ]`) to maintain the specialized device simulation.
+
+## 2026-08-20 - [Accepted] - 🖼️ Canvas: Tactical Telemetry DataLabel Redesign
+**What:** Redesigned the `DataLabel` component into a "Tactical Telemetry Data Node". Replaced the simple span with a `w-fit` rigid segmented block (`group relative flex items-center border-l-[2px] border-dashed`) featuring an active status LED indicator (an absolutely positioned node that glows on hover) and strict uppercase monospace typography.
+**Outcome:** Accepted
+**Why:** Brings the granular data display labels in line with the established specialized hardware motif. The previous `DataLabel` was a simple styled text span, which broke the terminal simulation. Treating individual labels as active telemetry endpoints reinforces the physical device fantasy.
+**Pattern:** Apply tactical aesthetics (dashed borders acting as connecting lines, absolute positioning LEDs, tight monospace typography) even to the smallest, most granular data labeling elements to maintain absolute visual coherence deep within complex data views.

--- a/src/components/DataLabel.tsx
+++ b/src/components/DataLabel.tsx
@@ -9,9 +9,13 @@ export const DataLabel = React.forwardRef<HTMLSpanElement, DataLabelProps>(({ cl
   return (
     <span
       ref={ref}
-      className={cn('font-mono text-[9px] text-zinc-500 uppercase tracking-widest', className)}
+      className={cn(
+        'group relative inline-flex w-fit items-center gap-2 border-zinc-800 border-l-[2px] border-dashed bg-zinc-950/80 px-1.5 py-0.5 font-black font-mono text-[9px] text-zinc-400 uppercase tracking-widest transition-colors hover:border-[var(--theme-primary)]/50 hover:bg-black',
+        className,
+      )}
       {...props}
     >
+      <span className="absolute top-1/2 left-[-3px] h-1.5 w-1.5 -translate-y-1/2 bg-zinc-700 transition-colors group-hover:bg-[var(--theme-primary)]" />
       {children}
     </span>
   );


### PR DESCRIPTION
Proposes and implements an ambitious UI/UX redesign of the `DataLabel` component, transforming it from a standard text span into a tactical hardware endpoint. This change aligns with the "snooping" aesthetic, employing dashed lines, rigid structural aesthetics, and absolute-positioned scanning indicators to elevate the presentation of granular telemetry readouts across the app.

---
*PR created automatically by Jules for task [3382074644569885742](https://jules.google.com/task/3382074644569885742) started by @szubster*