### PR TITLE
📜 Scribe: Document store.ts types

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -16,9 +16,23 @@ import { r2Client } from './utils/r2/client';
  */
 
 // ─── Types ───────────────────────────────────────────────────────────
+/**
+ * Represents the supported game versions (e.g., 'red', 'gold', 'emerald')
+ * used throughout the application to determine version-specific logic.
+ */
 export type GameVersion = GameVersionType;
+/**
+ * The array of valid UI filter strings used to restrict which Pokémon
+ * are currently visible in the Dex grids.
+ */
 export const FILTER_TYPES = ['secured', 'missing', 'dex-only'] as const;
+
+/** Union type representing an active UI filter mode. */
 export type FilterType = (typeof FILTER_TYPES)[number];
+/**
+ * Represents the visual style of Pokéball used as a global theme override
+ * across the application UI (e.g., in headers and list items).
+ */
 export type PokeballType =
   | 'poke'
   | 'great'


### PR DESCRIPTION
**What**
Added missing JSDoc comments to `src/store.ts` for the `GameVersion`, `FILTER_TYPES`, `FilterType`, and `PokeballType` exported symbols.

**Why**
These core types are exported and used heavily throughout the application (e.g. by components, filters, and suggestion strategies), but lacked proper API documentation explaining their purpose and invariants.

**Summary of Additions**
- JSDoc for `GameVersion` explaining its usage in version-specific logic.
- JSDoc for `FILTER_TYPES` explaining its role in UI visibility restriction.
- JSDoc for `FilterType` (union type).
- JSDoc for `PokeballType` explaining its role as a global theme override.

---
*PR created automatically by Jules for task [3797436037676212406](https://jules.google.com/task/3797436037676212406) started by @szubster*