### PR TITLE
🧹 Sweeper: clean up knip config

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreExportsUsedInFile": true,
-  "ignoreBinaries": [
-    "gh"
-  ],
   "ignoreDependencies": [
     "wrangler",
     "@cloudflare/pages-plugin-cloudflare-access",
@@ -16,12 +13,11 @@
     "scripts/gen3-fetch-locations.ts",
     "functions/_middleware.ts",
     "functions/api/saves/index.ts",
-    "functions/api/saves/[id].ts",
-    "scripts/data/gen3/match_call/etl.ts"
+    "functions/api/saves/[id].ts"
   ],
   "rules": {
     "files": "warn",
-    "exports": "off",
+    "exports": "warn",
     "types": "warn",
     "dependencies": "error",
     "devDependencies": "error",


### PR DESCRIPTION
🎯 What: Removed obsolete ignore entries in knip.json and enabled exports rule.
💡 Why: Improve code health and prevent dead code accumulation.
✅ Verification: Ran pnpm lint, test, and test:e2e.
✨ Result: Cleaner config, no linting errors.

---
*PR created automatically by Jules for task [11447381594187955597](https://jules.google.com/task/11447381594187955597) started by @szubster*