### PR TITLE
🧭 Strategist: Prompt improvement - Enforce RangeError verification in Tech Lead blueprints

### DIFF
--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -10,6 +10,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 4.  **Define Clear Contracts**: Your tasks should serve as a clear contract for the Coder. Include necessary context, constraints, and acceptance criteria.
     - When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
     - When drafting blueprints for Gen 3 save file parsing, explicitly require that the Coder uses the resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
+    - When drafting blueprints for save file parsing, explicitly require that the Coder must catch `RangeError` from out-of-bounds `DataView` reads and throw a new error with the message "The save file is corrupted or incomplete."
 5.  **Intelligent Verification Protocol**: Intelligently decide when a STORY requires a separate QA verification task:
     - If a story involves complex logic or risk, create a matching TASK for the `qa` persona to verify the `coder`'s work.
     - If simple/low-risk, designate the `coder` to self-verify (documented in the task journal).

--- a/.jules/strategist.md
+++ b/.jules/strategist.md
@@ -399,3 +399,9 @@
 **Outcome:** Merged
 **Why:** The memory requires that when running browser-based tests (such as Playwright E2E or Vitest browser) in the headless agent environment, agents must strictly prefix the test command with `xvfb-run` (e.g., `xvfb-run pnpm test:e2e`) to prevent browser launch failures and protocol connection errors. Several agent prompts (bolt, infras, mason, nurse, oak, palette, sculptor, sentinel, shield, sweeper, trainer) and the core policies were just using `pnpm test:e2e` instead of `xvfb-run pnpm test:e2e`.
 **Pattern:** Codify specific, recurring test framework constraints (like xvfb-run prefix for headless browser tests) directly into the agent prompts and core policies to prevent recurring test failures during the QA phase.
+
+## 2026-08-02 - [Accepted] - Prompt improvement - Enforce RangeError verification in Tech Lead blueprints
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `tech_lead.md` journal recorded that when drafting save parser blueprints using `DataView`, they explicitly mandate catching `RangeError` and throwing 'The save file is corrupted or incomplete.' to prevent QA rejections. However, this explicit blueprinting constraint was missing from the Tech Lead agent's prompt, which could lead to missed requirements and QA rejections for the Coder.
+**Pattern:** Codify specific, recurring architectural validation requirements (like checking for `RangeError` handling in save file parsers) directly into the Tech Lead agent's prompt to ensure strict and consistent architectural enforcement when generating tasks.


### PR DESCRIPTION
Proposal: Update the Tech Lead agent's prompt to explicitly mandate catching RangeError when generating save file parsing blueprints.
Justification: The Tech Lead journal states this constraint prevents QA rejections, but it was missing from the agent's actual prompt, leading to missed requirements.
Evidence: The tech_lead.md journal explicitly notes "When drafting save parser blueprints using DataView, explicitly mandate catching RangeError and throwing 'The save file is corrupted or incomplete.' to prevent QA rejections."

---
*PR created automatically by Jules for task [12588582153983905796](https://jules.google.com/task/12588582153983905796) started by @szubster*