### PR TITLE
Cancel impossible epic epic-043-152-gen3-roamer-data-extraction

### DIFF
--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -70,3 +70,7 @@ Broke down epic-115-331-remove-orphaned-qa-task-rule-from-docs into story-331-33
 Checked off acceptance criteria checkboxes for completed epic epic-057-127-bash-timeout-wrapper because all its child stories (story-127-267-bash-timeout-wrapper and story-127-268-bash-timeout-feedback) have been completed, permitting the submission of an empty PR to advance the epic's status to VERIFYING.
 ## 2026-07-22
 * Created stories story-338-336, story-338-337, and story-338-338 for epic-120-338 to implement session-unique journal files.
+## 2026-07-23
+* Task: epic-043-152-gen3-roamer-data-extraction
+* Action: Submitted empty PR for impossible task.
+* Learning: As per ADR 108-027, extracting Gen 3 roamer locations is impossible since they are stored dynamically in EWRAM. The epic is permanently CANCELLED. No child nodes generated and YAML frontmatter remains untouched.


### PR DESCRIPTION
Submitted empty PR because extracting Gen 3 roamer locations from the save file is impossible as per ADR 108-027.

---
*PR created automatically by Jules for task [877067983694362462](https://jules.google.com/task/877067983694362462) started by @szubster*