### PR TITLE
Empty PR: Cancel epic-043-152-gen3-roamer-data-extraction

### DIFF
--- a/.foundry/journals/story_owner.md
+++ b/.foundry/journals/story_owner.md
@@ -70,3 +70,5 @@ Broke down epic-115-331-remove-orphaned-qa-task-rule-from-docs into story-331-33
 Checked off acceptance criteria checkboxes for completed epic epic-057-127-bash-timeout-wrapper because all its child stories (story-127-267-bash-timeout-wrapper and story-127-268-bash-timeout-feedback) have been completed, permitting the submission of an empty PR to advance the epic's status to VERIFYING.
 ## 2026-07-22
 * Created stories story-338-336, story-338-337, and story-338-338 for epic-120-338 to implement session-unique journal files.
+## 2026-07-23
+* Cancelled epic-043-152-gen3-roamer-data-extraction via the impossible task protocol. Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file (ADR 108-027), making static extraction impossible. Left YAML frontmatter completely untouched and submitted an empty PR without checking acceptance criteria.


### PR DESCRIPTION
This PR follows the impossible task protocol for epic-043-152-gen3-roamer-data-extraction. Gen 3 roamer map coordinates are stored in EWRAM and cannot be extracted from the save file. YAML frontmatter and acceptance criteria remain unmodified.

---
*PR created automatically by Jules for task [2520435504506704120](https://jules.google.com/task/2520435504506704120) started by @szubster*