### PR TITLE
Fix session-unique journal implementation

### DIFF
--- a/.foundry/tasks/task-338-338-session-unique-journals-impl.md
+++ b/.foundry/tasks/task-338-338-session-unique-journals-impl.md
@@ -34,5 +34,5 @@ Update the system configuration and core agent prompts to enforce the use of ses
 - Specifically, update `.github/scripts/foundry-orchestrator.ts` if it references `.foundry/journals/agile_coach.md` directly.
 
 ## Acceptance Criteria
-- [ ] Agent prompt files in `.github/agents/` are updated to specify session-unique journal paths.
-- [ ] The orchestrator (`.github/scripts/foundry-orchestrator.ts`) is updated to support the new format, if applicable.
+- [x] Agent prompt files in `.github/agents/` are updated to specify session-unique journal paths.
+- [x] The orchestrator (`.github/scripts/foundry-orchestrator.ts`) is updated to support the new format, if applicable.

--- a/.github/agents/agile_coach.md
+++ b/.github/agents/agile_coach.md
@@ -30,7 +30,7 @@ You are the Agile Coach of The Foundry. You run on a daily or weekly schedule as
 
 ## Journal
 
-Your private journal is `.foundry/journals/agile_coach.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/agile_coach/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/agile_coach/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -25,7 +25,7 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 
 ## Journal
 
-Your private journal is `.foundry/journals/architect.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/architect/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/architect/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.

--- a/.github/agents/archivist.md
+++ b/.github/agents/archivist.md
@@ -19,7 +19,7 @@ The following knowledge stores are in scope:
 
 - **Stale entries** — memories referencing completed refactors, merged PRs, or resolved migrations that are no longer relevant
 - **Contradictions** — entries that conflict with current code (e.g., mentioning removed features, old tech stack, deprecated patterns)
-- **Duplicates** — same learning recorded in multiple places (e.g., `.Jules/palette.md` vs `.jules/palette.md`, or a Serena memory duplicating a journal entry)
+- **Duplicates** — same learning recorded in multiple places (e.g., `.Jules/palette/*` vs `.jules/palette/*`, or a Serena memory duplicating a journal entry)
 - **Inaccuracies** — entries that describe the codebase incorrectly (wrong file paths, outdated API patterns, stale architecture descriptions)
 - **Organization** — poorly named or miscategorized memories that should be merged, renamed, or moved to a better topic
 - **Legacy artifacts** — files in `.Jules/` (uppercase) that should be merged into `.jules/` (lowercase) and the uppercase directory cleaned up
@@ -55,10 +55,10 @@ The following knowledge stores are in scope:
 
 ## Journal
 
-Read `.jules/archivist.md` before starting (create if missing).
+Read `.jules/archivist/*.md` (your past journals) before starting.
 Only log **critical** learnings: patterns that cause knowledge rot, memory naming conventions that work well, cross-system duplication patterns.
 
-Your private journal is `.jules/archivist.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/archivist/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/archivist/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ---
 

--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -29,7 +29,7 @@ You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.
 
 ## Journal
 
-Your private journal is `.foundry/journals/auditor.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/auditor/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/auditor/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ## QA Task Verification Pairing Flexibility
 While generally QA tasks verify implementations, the coder is always responsible for writing tests. For simple tasks, it is acceptable for the Tech Lead to decide that the coder's tests and implementation are sufficient without a dedicated, explicit QA task pair. Do not strictly enforce QA task pairing for every single implementation task if the Tech Lead has deemed the complexity low enough to bypass it.

--- a/.github/agents/bolt.md
+++ b/.github/agents/bolt.md
@@ -43,10 +43,10 @@ Identify and implement ONE small performance improvement that makes the applicat
 
 ## Journal
 
-Read `.jules/bolt.md` before starting (create if missing).
+Read `.jules/bolt/*.md` (your past journals) before starting.
 Only log **critical** learnings: surprising failures, rejected changes, codebase-specific patterns.
 
-Your private journal is `.jules/bolt.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/bolt/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/bolt/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ---
 

--- a/.github/agents/canvas.md
+++ b/.github/agents/canvas.md
@@ -4,13 +4,13 @@ Propose and implement ONE ambitious UI/UX change that meaningfully improves a co
 
 ## Session Flow
 
-You have no memory between sessions. Your only persistence is what's committed to the repo: your journal (`.jules/canvas.md`).
+You have no memory between sessions. Your only persistence is what's committed to the repo: your journals (`.jules/canvas/*`).
 
 ### Normal flow (most sessions):
 
-1. **Reflect** — read `.jules/canvas.md` (your journal). Understand your history and design preferences.
+1. **Reflect** — read `.jules/canvas/*.md` (your past journals). Understand your history and design preferences.
 2. **Implement** — open a PR that includes:
-   - A new journal entry in `.jules/canvas.md` for this session's change (labeled as **Accepted**)
+   - A new journal entry in `.jules/canvas/<session_id>.md` for this session's change (labeled as **Accepted**)
    - Your new design change
 3. **Wait** — the maintainer reviews your PR. Two outcomes are possible:
    - **Merge** — session auto-closes. You succeeded. The journal updates you included are now persisted.
@@ -53,9 +53,9 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 ## Journal
 
-File: `.jules/canvas.md` (create if missing).
+File: `.jules/canvas/<session_id>.md` (or timestamp format).
 
-Your private journal is `.jules/canvas.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/canvas/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/canvas/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 Entry format:
 ```

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -41,7 +41,7 @@ When modifying central systems like the DAG Orchestrator (`.github/scripts/found
 
 ## Journal
 
-Your private journal is `.foundry/journals/coder.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/coder/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/coder/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 
 

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -20,7 +20,7 @@ Produce clean, well-structured markdown files for each Epic, ensuring they align
 
 ## Journal
 
-Your private journal is `.foundry/journals/epic_planner.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/epic_planner/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/epic_planner/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 
 ## Core Policies

--- a/.github/agents/infras.md
+++ b/.github/agents/infras.md
@@ -40,10 +40,10 @@ Identify and implement ONE improvement to the development tooling, build pipelin
 
 ## Journal
 
-Read `.jules/infras.md` before starting (create if missing).
+Read `.jules/infras/*.md` (your past journals) before starting.
 Only log **critical** learnings: tool integration gotchas, rejected tooling decisions, CI-specific constraints.
 
-Your private journal is `.jules/infras.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/infras/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/infras/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ---
 

--- a/.github/agents/mason.md
+++ b/.github/agents/mason.md
@@ -39,10 +39,10 @@ Identify and implement ONE React refactoring opportunity by extracting a reusabl
 
 ## Journal
 
-Read `.jules/mason.md` before starting (create if missing).
+Read `.jules/mason/*.md` (your past journals) before starting.
 Log critical learnings: recurring patterns, extraction challenges, or reusable logic wins.
 
-Your private journal is `.jules/mason.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/mason/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/mason/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 
 ## Core Policies

--- a/.github/agents/mechanic.md
+++ b/.github/agents/mechanic.md
@@ -12,7 +12,7 @@ You are the Mechanic of The Foundry. You run on a daily schedule as a meta-agent
 
 ## Journal
 
-Your private journal is `.foundry/journals/mechanic.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/mechanic/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/mechanic/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies.

--- a/.github/agents/nurse.md
+++ b/.github/agents/nurse.md
@@ -42,10 +42,10 @@ Find and fix ONE type-safety issue in the codebase. Tighten types, eliminate uns
 
 ## Journal
 
-Read `.jules/nurse.md` before starting (create if missing).
+Read `.jules/nurse/*.md` (your past journals) before starting.
 Only log **critical** learnings: tricky type narrowing patterns, third-party typing issues, codebase-specific type constraints.
 
-Your private journal is `.jules/nurse.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/nurse/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/nurse/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ---
 

--- a/.github/agents/oak.md
+++ b/.github/agents/oak.md
@@ -49,10 +49,10 @@ All Pokémon data is pre-generated at build time and committed to the repo. The 
 
 ## Journal
 
-Read `.jules/oak.md` before starting (create if missing).
+Read `.jules/oak/*.md` (your past journals) before starting.
 Only log **critical** learnings: ROM parsing quirks, PokeAPI generation-script edge cases, data pipeline gotchas.
 
-Your private journal is `.jules/oak.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/oak/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/oak/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ---
 

--- a/.github/agents/palette.md
+++ b/.github/agents/palette.md
@@ -44,10 +44,10 @@ You are the designated owner of `src/index.css`.
 
 ## Journal
 
-Read `.jules/palette.md` before starting (create if missing).
+Read `.jules/palette/*.md` (your past journals) before starting.
 Only log **critical** learnings: recurring a11y patterns, rejected changes, design-system constraints.
 
-Your private journal is `.jules/palette.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/palette/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/palette/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ---
 

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -14,7 +14,7 @@ You must strictly adhere to the rules in `.foundry/archive/docs/adrs/001-the-fou
 
 ## Journal
 
-Your private journal is `.foundry/journals/product_manager.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/product_manager/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/product_manager/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 
 ## Core Policies

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -34,7 +34,7 @@ When verifying orchestrator logic tasks, ensure you explicitly run the specific 
 
 ## Journal
 
-Your private journal is `.foundry/journals/qa.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/qa/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/qa/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 
 ### Handling Rejections

--- a/.github/agents/researcher.md
+++ b/.github/agents/researcher.md
@@ -20,7 +20,7 @@ Ensure you are fully aware of the rules defined in `.foundry/archive/docs/adrs/0
 
 ## Journal
 
-Your private journal is `.foundry/journals/researcher.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/researcher/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/researcher/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.

--- a/.github/agents/scribe.md
+++ b/.github/agents/scribe.md
@@ -41,10 +41,10 @@ Pick ONE module and improve its documentation — JSDoc on exported APIs, inline
 
 ## Journal
 
-Read `.jules/scribe.md` before starting (create if missing).
+Read `.jules/scribe/*.md` (your past journals) before starting.
 Only log **critical** learnings: misleading code patterns, architectural decisions that need permanent documentation.
 
-Your private journal is `.jules/scribe.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/scribe/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/scribe/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ---
 

--- a/.github/agents/sculptor.md
+++ b/.github/agents/sculptor.md
@@ -41,10 +41,10 @@ Identify and execute ONE refactoring opportunity to make the codebase easier to 
 
 ## Journal
 
-Read `.jules/sculptor.md` before starting (create if missing).
+Read `.jules/sculptor/*.md` (your past journals) before starting.
 Only log **critical** learnings: structural patterns that confuse AI, successful simplification strategies, or unexpected entanglements.
 
-Your private journal is `.jules/sculptor.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/sculptor/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/sculptor/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.

--- a/.github/agents/sentinel.md
+++ b/.github/agents/sentinel.md
@@ -45,10 +45,10 @@ Identify ONE under-tested file or user journey and add focused tests to improve 
 
 ## Journal
 
-Read `.jules/sentinel.md` before starting (create if missing).
+Read `.jules/sentinel/*.md` (your past journals) before starting.
 Only log **critical** learnings: tricky mocking patterns, flaky test causes, codebase-specific test gotchas.
 
-Your private journal is `.jules/sentinel.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/sentinel/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/sentinel/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ---
 

--- a/.github/agents/shield.md
+++ b/.github/agents/shield.md
@@ -41,10 +41,10 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 
 ## Journal
 
-Read `.jules/shield.md` before starting (create if missing).
+Read `.jules/shield/*.md` (your past journals) before starting.
 Only log **critical** learnings: recurring vulnerability patterns or complex security rationales.
 
-Your private journal is `.jules/shield.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/shield/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/shield/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 
 ## Core Policies

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -17,7 +17,7 @@ You must be thoroughly aware of and strictly adhere to the rules outlined in:
 
 ## Journal
 
-Your private journal is `.foundry/journals/story_owner.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/story_owner/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/story_owner/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 
 ## Core Policies

--- a/.github/agents/strategist.md
+++ b/.github/agents/strategist.md
@@ -4,7 +4,7 @@ Review the current Jules agent roster, the quality of existing prompts, and the 
 
 ## Context
 
-The current agent roster lives in `.github/agents/`. Before proposing anything, **read every existing schedule** to understand what's already covered. Also review agent journals (e.g., `.jules/bolt.md`, `.foundry/journals/coder.md`) to assess whether their prompts are producing good results based on their recorded successes and failures.
+The current agent roster lives in `.github/agents/`. Before proposing anything, **read every existing schedule** to understand what's already covered. Also review agent journals (e.g., `.jules/bolt/*`, `.foundry/journals/coder/*`) to assess whether their prompts are producing good results based on their recorded successes and failures.
 
 ## Focus Areas
 
@@ -39,13 +39,13 @@ The current agent roster lives in `.github/agents/`. Before proposing anything, 
 
 ## Session Flow
 
-You have no memory between sessions. Your only persistence is what's committed to the repo: your journal (`.jules/strategist.md`).
+You have no memory between sessions. Your only persistence is what's committed to the repo: your journals (`.jules/strategist/*`).
 
 ### Normal flow (most sessions):
 
-1. **Reflect** — read `.jules/strategist.md` (your journal). Understand your history and proposal preferences.
+1. **Reflect** — read `.jules/strategist/*.md` (your past journals). Understand your history and proposal preferences.
 2. **Assess & Implement** — review agent journals and existing schedules. Identify the single most impactful change (new agent, retirement, or prompt improvement). Open a PR that includes:
-   - A new journal entry in `.jules/strategist.md` for this session's change (labeled as **Accepted**)
+   - A new journal entry in `.jules/strategist/<session_id>.md` for this session's change (labeled as **Accepted**)
    - Your actual changes to the `.github/agents/` files
    - Title the PR: `🧭 Strategist: [proposal type] - [description]`
    - PR body detailing:
@@ -66,9 +66,9 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 ## Journal
 
-File: `.jules/strategist.md` (create if missing).
+File: `.jules/strategist/<session_id>.md` (or timestamp format).
 
-Your private journal is `.jules/strategist.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/strategist/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/strategist/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 Entry format:
 ```

--- a/.github/agents/sweeper.md
+++ b/.github/agents/sweeper.md
@@ -38,10 +38,10 @@ Identify and resolve ONE piece of technical debt, dead code, or messy refactorin
 
 ## Journal
 
-Read `.jules/sweeper.md` before starting (create if missing).
+Read `.jules/sweeper/*.md` (your past journals) before starting.
 Only log **critical** learnings: unexpected entanglements or patterns to watch out for.
 
-Your private journal is `.jules/sweeper.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/sweeper/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/sweeper/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 
 ## Core Policies

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -28,7 +28,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 
 ## Journal
 
-Your private journal is `.foundry/journals/tech_lead.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/tech_lead/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/tech_lead/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 
 ## Core Policies

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -27,7 +27,7 @@ Ensure you are completely aware of the rules defined in:
 
 ## Journal
 
-Your private journal is `.foundry/journals/tpm.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.foundry/journals/tpm/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/tpm/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.

--- a/.github/agents/trainer.md
+++ b/.github/agents/trainer.md
@@ -41,10 +41,10 @@ Identify and implement ONE improvement to the assistant — the core feature tha
 
 ## Journal
 
-Read `.jules/trainer.md` before starting (create if missing).
+Read `.jules/trainer/*.md` (your past journals) before starting.
 Only log **critical** learnings: game-specific edge cases, algorithm failures, data source limitations.
 
-Your private journal is `.jules/trainer.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/trainer/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/trainer/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ---
 

--- a/.github/agents/visionary.md
+++ b/.github/agents/visionary.md
@@ -15,7 +15,7 @@ Generate ONE high-quality, actionable `IDEA` node for either the main project or
 
 **Always:**
 - Review existing `IDEA` nodes in `.foundry/ideas/` to avoid duplicates before proposing a new one.
-- Read `.jules/visionary.md` (your journal) to recall past generated ideas and their outcomes.
+- Read `.jules/visionary/*.md` (your past journals) to recall past generated ideas and their outcomes.
 - Output strictly a well-formatted markdown file in `.foundry/ideas/` adhering to the IDEA schema.
 - Assign the `owner_persona` of the new node to `product_manager`.
 - Clearly articulate the problem and the proposed solution.
@@ -42,10 +42,10 @@ Generate ONE high-quality, actionable `IDEA` node for either the main project or
 
 ## Journal
 
-Read `.jules/visionary.md` before starting (create if missing).
+Read `.jules/visionary/*.md` (your past journals) before starting.
 Only log **critical** learnings: what kinds of ideas get accepted vs rejected, patterns in the project's evolution, feedback from the maintainer.
 
-Your private journal is `.jules/visionary.md`. You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Your private journal is `.jules/visionary/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/visionary/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ---
 

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -1085,7 +1085,11 @@ function main(): void {
         promoteNodeStatus(node, 'PENDING', 'COMPLETED');
 
         const dateStr = todayISO();
-        const logPath = require('node:path').join(repoRoot, '.foundry/journals/agile_coach.md');
+        const logDir = require('node:path').join(repoRoot, '.foundry/journals/agile_coach');
+        if (!DRY_RUN && !require('node:fs').existsSync(logDir)) {
+          require('node:fs').mkdirSync(logDir, { recursive: true });
+        }
+        const logPath = require('node:path').join(logDir, `${Date.now()}.md`);
         const logEntry = `\n## ${dateStr}: Pre-existing Artifacts Anomaly\n\n### Observation\nThe orchestrator detected that target artifacts for \`${node.repoPath}\` already existed and were completely formed before dispatch.\n\n### Action Taken\nBypassed Jules session dispatch via idempotent generation check and auto-fulfilled the node.\n`;
 
         if (!DRY_RUN) {


### PR DESCRIPTION
Replaced hardcoded `.foundry/journals/agent.md` paths with session unique `<session_id>` paths in `.github/agents/` and updated `.github/scripts/foundry-orchestrator.ts`.

---
*PR created automatically by Jules for task [13165369961707733202](https://jules.google.com/task/13165369961707733202) started by @szubster*