### PR TITLE
Cancel epic-043-152-gen3-roamer-data-extraction (Impossible)

### DIFF
--- a/.foundry/journals/story_owner/692935771812904034.md
+++ b/.foundry/journals/story_owner/692935771812904034.md
@@ -1,0 +1,4 @@
+# Story Owner Journal
+
+## Gen 3 Roamer Tracking Limitations
+When processing roamer tracking, Gen 3 map coordinates cannot be statically extracted as they are kept in dynamically allocated EWRAM during gameplay and are never serialized into the save file (as per research-043-263-roamer-tracking-remediation and ADR 108-027). Any epic attempting to extract Gen 3 roamer map coordinates must be cancelled with status CANCELLED and no acceptance criteria checked. This ensures we avoid the Impossible Loop.


### PR DESCRIPTION
Empty PR to gracefully fail cancelled epic per rules. Gen 3 roamer map coordinates cannot be statically extracted as they are kept in dynamically allocated EWRAM during gameplay, per ADR 108-027.

---
*PR created automatically by Jules for task [692935771812904034](https://jules.google.com/task/692935771812904034) started by @szubster*