### PR TITLE
Story Owner: Gracefully fail cancelled epic-043-152-gen3-roamer-data-extraction

### DIFF
--- a/.foundry/journals/story_owner/3122477383916726742.md
+++ b/.foundry/journals/story_owner/3122477383916726742.md
@@ -1,0 +1,4 @@
+# Session 3122477383916726742
+
+## Cancellation of epic-043-152-gen3-roamer-data-extraction
+The Epic `epic-043-152-gen3-roamer-data-extraction` is permanently CANCELLED and aborted. As detailed in ADR 108-027 and `research-043-263-roamer-tracking-remediation`, Gen 3 roamer map coordinates are stored in dynamically allocated EWRAM during gameplay and are not serialized to the save file, making static extraction mathematically impossible.


### PR DESCRIPTION
This PR contains no modifications to the target Epic node in order to gracefully fail the permanently cancelled epic-043-152-gen3-roamer-data-extraction. Gen 3 roamer map coordinates are stored in EWRAM and are impossible to extract statically (ADR 108-027).

---
*PR created automatically by Jules for task [7684408797279668300](https://jules.google.com/task/7684408797279668300) started by @szubster*