### PR TITLE
Verify Session-Unique Journal Files Implementation

### DIFF
--- a/.foundry/journals/qa/11644115072242309867.md
+++ b/.foundry/journals/qa/11644115072242309867.md
@@ -1,0 +1,3 @@
+# Session 11644115072242309867
+
+Verified the implementation of session-unique journal files. All agents prompt files correctly instruct agents to use session-unique journal paths, and the orchestrator is updated to support the directory-based structure. Task is approved.

--- a/.foundry/tasks/task-338-339-session-unique-journals-qa.md
+++ b/.foundry/tasks/task-338-339-session-unique-journals-qa.md
@@ -28,5 +28,5 @@ notes: ''
 Verify that the system configuration and agent prompts have been successfully updated to enforce the use of session-unique journal files.
 
 ## Acceptance Criteria
-- [ ] Verify that agent prompt files in `.github/agents/` instruct the use of session-unique journal paths.
-- [ ] Verify that the orchestrator (`.github/scripts/foundry-orchestrator.ts`) supports the new directory-based or timestamp format for journals, if modified.
+- [x] Verify that agent prompt files in `.github/agents/` instruct the use of session-unique journal paths.
+- [x] Verify that the orchestrator (`.github/scripts/foundry-orchestrator.ts`) supports the new directory-based or timestamp format for journals, if modified.


### PR DESCRIPTION
QA validated the session unique journal implementation. Tests passed, and all agent prompt files instruct the use of session-unique journal paths. Orchestrator properly uses a timestamp-based format for agile_coach anomaly journals.

---
*PR created automatically by Jules for task [11644115072242309867](https://jules.google.com/task/11644115072242309867) started by @szubster*