### PR TITLE
Cancel Gen 3 Roamer Data Extraction Epic

### DIFF
--- a/.foundry/journals/story_owner/7684408797279668300.md
+++ b/.foundry/journals/story_owner/7684408797279668300.md
@@ -1,0 +1,9 @@
+# Journal Session 7684408797279668300
+
+## Epic Cancellation
+
+Epic `epic-043-152-gen3-roamer-data-extraction` is permanently cancelled. As stated in the Epic's Task Cancellation block:
+
+> This Epic is permanently CANCELLED as Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file, making static extraction impossible as per research-043-263-roamer-tracking-remediation and ADR 108-027.
+
+The checkboxes in the markdown body of the node have been deliberately left unchecked, and no YAML frontmatter has been modified, in accordance with the memory: "When handling a permanently cancelled or impossible Epic as the Story Owner, leave the acceptance criteria checkboxes unchecked, document the cancellation in a session-unique journal, and submit an empty PR to fail the node gracefully without modifying its YAML frontmatter."


### PR DESCRIPTION
Empty PR to cancel epic-043-152-gen3-roamer-data-extraction due to technical impossibility.

---
*PR created automatically by Jules for task [14189807071227932321](https://jules.google.com/task/14189807071227932321) started by @szubster*