### PR TITLE
🛠️ Infras: resolve archived paths in orchestrator

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -2627,4 +2627,71 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     const epicContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-001.md'), 'utf-8');
     expect(epicContent).toContain('status: COMPLETED');
   });
+
+  test('Archived Dependency: resolves dependency pointing to archived task path', () => {
+    createValidTestNode(tmpDir, '.foundry/archive/tasks/task-completed.md', {
+      id: "task-completed",
+      type: "TASK",
+      title: "Completed Task",
+      status: "COMPLETED",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-dependent.md', {
+      id: "task-dependent",
+      type: "TASK",
+      title: "Dependent Task",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [".foundry/tasks/task-completed.md"],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const dependentContent = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-dependent.md'), 'utf-8');
+    expect(dependentContent).toContain('status: READY');
+  });
+
+  test('Archived Child Path Link: resolves child linked via raw original path when child is archived', () => {
+    createValidTestNode(tmpDir, '.foundry/epics/epic-parent.md', {
+      id: "epic-parent",
+      type: "EPIC",
+      title: "Epic Parent",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    }, `# Epic Parent
+## Acceptance Criteria
+- [ ] Child Story: [.foundry/stories/story-child.md](.foundry/stories/story-child.md)`);
+
+    createValidTestNode(tmpDir, '.foundry/archive/stories/story-child.md', {
+      id: "story-child",
+      type: "STORY",
+      title: "Story Child",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: "epic-parent",
+      tags: ["e2e"],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const parentContent = fs.readFileSync(path.join(tmpDir, '.foundry/epics/epic-parent.md'), 'utf-8');
+    // It should be promoted to READY exactly once (it wakes up because child is complete but it has unchecked tasks)
+    expect(parentContent).toContain('status: READY');
+  });
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -449,7 +449,7 @@ function main(): void {
       .map(id => idToPathMap.get(id))
       .filter((path): path is string => !!path);
 
-    const matches = [...new Set([...linkMatches, ...idMatches])];
+    const matches = [...new Set([...linkMatches, ...idMatches])].map(m => resolveNodePath(m)).filter((m): m is string => !!m);
 
     for (const match of matches) {
       // node.repoPath is the parent, match is the child
@@ -477,7 +477,18 @@ function main(): void {
   function resolveNodePath(ref: string | null | undefined): string | null {
     if (!ref) return null;
     if (idToPathMap.has(ref)) return idToPathMap.get(ref)!;
-    if (ref.startsWith('.foundry/')) return ref;
+    if (ref.startsWith('.foundry/')) {
+      if (nodeMap.has(ref) || fs.existsSync(path.join(repoRoot, ref))) {
+        return ref;
+      }
+      if (!ref.startsWith('.foundry/archive/')) {
+        const archivedRef = ref.replace(/^\.foundry\//, '.foundry/archive/');
+        if (nodeMap.has(archivedRef) || fs.existsSync(path.join(repoRoot, archivedRef))) {
+          return archivedRef;
+        }
+      }
+      return ref;
+    }
 
     // Log a warning if we can't resolve a non-empty reference.
     warn(`Unresolvable node reference: '${ref}'`);
@@ -895,7 +906,8 @@ function main(): void {
 
       const parentPath = resolveNodePath(node.frontmatter.parent);
       const resolvedDeps = node.frontmatter.depends_on.map(d => resolveNodePath(d));
-      const targetArtifacts = matches.filter(m =>
+      const targetArtifacts = matches.map(resolveNodePath).filter((m): m is string =>
+        !!m &&
         m !== node.repoPath &&
         m !== parentPath &&
         !resolvedDeps.includes(m)
@@ -1042,10 +1054,11 @@ function main(): void {
       const links = [...body.matchAll(linkRegex)].map(m => m[1]);
 
       if (links.length > 0) {
-        const allExist = links.every(l => nodeMap.has(l));
-        const hasChild = links.some(l => {
+        const resolvedLinks = links.map(resolveNodePath).filter((l): l is string => !!l);
+        const allExist = resolvedLinks.every(l => nodeMap.has(l));
+        const hasChild = resolvedLinks.some(l => {
           const childNode = nodeMap.get(l);
-          return !!childNode && childNode.frontmatter.parent === node.repoPath;
+          return !!childNode && (childNode.frontmatter.parent === node.repoPath || childNode.frontmatter.parent === node.frontmatter.id);
         });
 
         if (allExist && hasChild) {

--- a/.jules/infras/jules-12956813812122219687-27266662.md
+++ b/.jules/infras/jules-12956813812122219687-27266662.md
@@ -1,0 +1,8 @@
+# Infras Journal - Session jules-12956813812122219687-27266662
+
+## Critical Learnings
+
+- Found a critical bug in the Foundry DAG Orchestrator where completed or cancelled tasks that were moved to `.foundry/archive/` were not correctly resolved by references pointing to their original paths.
+- Fixed `resolveNodePath` in `.github/scripts/foundry-orchestrator.ts` to automatically attempt to resolve paths to their archived counterparts if the original file does not exist.
+- Updated Phase 3 matches, Phase 4 target artifacts, and Phase 4.5 idempotent links to resolve using the updated helper.
+- Added extensive regression tests to prevent similar issues in the future.


### PR DESCRIPTION
What:
Resolve archived paths in orchestrator to prevent repeating work.

Why:
When children are completed and archived, the orchestrator fails to resolve original paths, blocking dependents or causing re-promotions.

Impact on DX/CI:
Prevents redundant scheduling in CI.

Setup notes:
None.

Fixes #5019

---
*PR created automatically by Jules for task [12956813812122219687](https://jules.google.com/task/12956813812122219687) started by @szubster*