### PR TITLE
fix: resolve redundant scheduling of completed/archived tasks in foundry

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -2694,4 +2694,40 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     // It should be promoted to READY exactly once (it wakes up because child is complete but it has unchecked tasks)
     expect(parentContent).toContain('status: READY');
   });
+
+  test('Regression: Idempotent generation check bypasses dispatch of archived parent with archived children', () => {
+    createValidTestNode(tmpDir, '.foundry/archive/epics/epic-parent.md', {
+      id: "epic-parent",
+      type: "EPIC",
+      title: "Epic Parent",
+      status: "PENDING",
+      owner_persona: "story_owner",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    }, `# Epic Parent
+## Acceptance Criteria
+- [x] Child Story: [.foundry/stories/story-child.md](.foundry/stories/story-child.md)`);
+
+    createValidTestNode(tmpDir, '.foundry/archive/stories/story-child.md', {
+      id: "story-child",
+      type: "STORY",
+      title: "Story Child",
+      status: "COMPLETED",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      parent: ".foundry/epics/epic-parent.md",
+      tags: ["e2e"],
+      jules_session_id: null,
+    });
+
+    main();
+
+    const parentContent = fs.readFileSync(path.join(tmpDir, '.foundry/archive/epics/epic-parent.md'), 'utf-8');
+    // It should be promoted to COMPLETED directly, bypassing READY/ACTIVE dispatch!
+    expect(parentContent).toContain('status: COMPLETED');
+  });
 });

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -414,15 +414,40 @@ function main(): void {
 
   const childToParents = new Map<string, Set<string>>();
 
+  /**
+   * Helper to resolve a node reference (either ID or path) to a repo-relative path.
+   */
+  function resolveNodePath(ref: string | null | undefined): string | null {
+    if (!ref) return null;
+    if (idToPathMap.has(ref)) return idToPathMap.get(ref)!;
+    if (ref.startsWith('.foundry/')) {
+      if (nodeMap.has(ref) || fs.existsSync(path.join(repoRoot, ref))) {
+        return ref;
+      }
+      if (!ref.startsWith('.foundry/archive/')) {
+        const archivedRef = ref.replace(/^\.foundry\//, '.foundry/archive/');
+        if (nodeMap.has(archivedRef) || fs.existsSync(path.join(repoRoot, archivedRef))) {
+          return archivedRef;
+        }
+      }
+      return ref;
+    }
+
+    // Log a warning if we can't resolve a non-empty reference.
+    warn(`Unresolvable node reference: '${ref}'`);
+    return null;
+  }
+
   // 1. First pass: strictly populate nodeMap and idToPathMap (Already done above)
 
   // 2. Second pass: evaluate explicit parents and markdown links
   for (const node of nodes) {
     let parentPath = node.frontmatter.parent;
     if (parentPath) {
-      // Resolve parent path if it's an ID
-      if (idToPathMap.has(parentPath)) {
-        parentPath = idToPathMap.get(parentPath)!;
+      // Resolve parent path fully (handles IDs and archived/non-archived paths)
+      const resolvedParent = resolveNodePath(parentPath);
+      if (resolvedParent) {
+        parentPath = resolvedParent;
       }
 
       if (!parentToChildren.has(parentPath)) {
@@ -469,30 +494,6 @@ function main(): void {
         }
       }
     }
-  }
-
-  /**
-   * Helper to resolve a node reference (either ID or path) to a repo-relative path.
-   */
-  function resolveNodePath(ref: string | null | undefined): string | null {
-    if (!ref) return null;
-    if (idToPathMap.has(ref)) return idToPathMap.get(ref)!;
-    if (ref.startsWith('.foundry/')) {
-      if (nodeMap.has(ref) || fs.existsSync(path.join(repoRoot, ref))) {
-        return ref;
-      }
-      if (!ref.startsWith('.foundry/archive/')) {
-        const archivedRef = ref.replace(/^\.foundry\//, '.foundry/archive/');
-        if (nodeMap.has(archivedRef) || fs.existsSync(path.join(repoRoot, archivedRef))) {
-          return archivedRef;
-        }
-      }
-      return ref;
-    }
-
-    // Log a warning if we can't resolve a non-empty reference.
-    warn(`Unresolvable node reference: '${ref}'`);
-    return null;
   }
 
   // ── Phase 3.0: MAX REJECTION THRESHOLD CHECK ───────────────────────────────
@@ -1058,7 +1059,10 @@ function main(): void {
         const allExist = resolvedLinks.every(l => nodeMap.has(l));
         const hasChild = resolvedLinks.some(l => {
           const childNode = nodeMap.get(l);
-          return !!childNode && (childNode.frontmatter.parent === node.repoPath || childNode.frontmatter.parent === node.frontmatter.id);
+          if (!childNode) return false;
+          const resolvedParentOfChild = resolveNodePath(childNode.frontmatter.parent);
+          const resolvedNodePathValue = resolveNodePath(node.repoPath);
+          return resolvedParentOfChild === resolvedNodePathValue || childNode.frontmatter.parent === node.frontmatter.id;
         });
 
         if (allExist && hasChild) {


### PR DESCRIPTION
This PR fixes the bug where foundry schedules the same work repeatedly by ensuring parent references are resolved using resolveNodePath and correcting the idempotent child check in Phase 4.5.

Fixes #5019

---
*PR created automatically by Jules for task [2246445417413805417](https://jules.google.com/task/2246445417413805417) started by @szubster*