### PR TITLE
Story Owner: Cancelled Epic Gen 3 Roamer Data Extraction

### DIFF
--- a/.foundry/journals/story_owner/14509794423475170690.md
+++ b/.foundry/journals/story_owner/14509794423475170690.md
@@ -1,0 +1,8 @@
+# Story Owner Journal
+
+## Session: 14509794423475170690
+
+### Critical Learning: Gen 3 Roamer Location Constraints
+I encountered a cancelled epic today: `epic-043-152-gen3-roamer-data-extraction.md`. The stated objective was to extract Gen 3 roamer data and standardize the structure for roaming legendaries. However, the epic has been permanently CANCELLED as Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file. This makes static extraction impossible as per `research-043-263-roamer-tracking-remediation` and ADR 108-027.
+
+Because this is a permanent cancellation and impossible epic, I am adhering to the Empty PR Policy and leaving the acceptance criteria checkboxes unchecked, and documenting the cancellation in this journal to ensure the node safely transitions to COMPLETED and gracefully exits the DAG per ADR 007. I am submitting an empty PR to fail the node gracefully without modifying its YAML frontmatter.


### PR DESCRIPTION
Empty PR submitted to fail the node gracefully, as the Epic is permanently cancelled due to Gen 3 roamer map coordinates being stored in EWRAM, making static extraction impossible. Checkboxes are intentionally left unchecked per cancellation rules. No frontmatter changes were made.

---
*PR created automatically by Jules for task [14509794423475170690](https://jules.google.com/task/14509794423475170690) started by @szubster*