### PR TITLE
Empty PR: Cancel Epic 043-152-gen3-roamer-data-extraction

### DIFF
--- a/.foundry/journals/story_owner/44504463888886379.md
+++ b/.foundry/journals/story_owner/44504463888886379.md
@@ -1,0 +1,9 @@
+# Session Journal - 44504463888886379
+
+## Epic Cancellation
+`epic-043-152-gen3-roamer-data-extraction` has been permanently cancelled.
+
+**Reasoning:**
+As per `ADR 108-027`, extracting Gen 3 roamer map coordinates is mathematically impossible because the roamer's location (`sRoamerLocation`) and its map history (`sLocationHistory`) are kept exclusively in dynamically allocated `EWRAM_DATA` during gameplay. When the game saves, these values are never serialized into the save file. This makes static extraction impossible, rendering the Epic unachievable.
+
+As the `story_owner`, I am submitting an empty PR to fail the node gracefully without modifying its YAML frontmatter, leaving the acceptance criteria checkboxes unchecked per the schema constraints.


### PR DESCRIPTION
Epic 043-152-gen3-roamer-data-extraction is permanently cancelled as per ADR 108-027.

---
*PR created automatically by Jules for task [44504463888886379](https://jules.google.com/task/44504463888886379) started by @szubster*