### PR TITLE
Story Owner: Cancelled epic-043-152-gen3-roamer-data-extraction

### DIFF
--- a/.foundry/journals/story_owner/2026-07-23-23-57-48.md
+++ b/.foundry/journals/story_owner/2026-07-23-23-57-48.md
@@ -1,0 +1,6 @@
+# Journal Entry - 2026-07-23
+
+## Handling Cancelled Epics
+Epic `epic-043-152-gen3-roamer-data-extraction` is permanently cancelled. Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file, making static extraction impossible (as per `research-043-263-roamer-tracking-remediation` and ADR 108-027).
+
+As Story Owner, when encountering a permanently cancelled Epic, I leave the acceptance criteria checkboxes unchecked, document the cancellation in this journal, and submit an empty PR to fail the node gracefully without modifying its YAML frontmatter.


### PR DESCRIPTION
Epic is permanently cancelled as Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file, making static extraction impossible. Submitted an empty PR to gracefully handle the cancellation.

---
*PR created automatically by Jules for task [3393206215441251120](https://jules.google.com/task/3393206215441251120) started by @szubster*