### PR TITLE
🛡️ Nurse: Replace unsafe as any in r2Client.putSave

### DIFF
--- a/.jules/nurse/2026-07-24-01-37-29.md
+++ b/.jules/nurse/2026-07-24-01-37-29.md
@@ -1,0 +1,1 @@
+# Learnings\n\nWhen resolving TypeScript type errors assigning `Uint8Array` to a `fetch` `body` (`BodyInit`), avoid using `as any` by explicitly typing the variable as `Uint8Array<ArrayBuffer>` instead of the wider default `Uint8Array<ArrayBufferLike>`, as `SharedArrayBuffer` is incompatible.

--- a/src/utils/r2/client.ts
+++ b/src/utils/r2/client.ts
@@ -11,12 +11,10 @@ export const r2Client = {
     const buffer = await res.arrayBuffer();
     return new Uint8Array(buffer);
   },
-  async putSave(id: string, data: Uint8Array): Promise<void> {
+  async putSave(id: string, data: Uint8Array<ArrayBuffer>): Promise<void> {
     const res = await fetch(`/api/saves/${id}`, {
       method: 'PUT',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      // biome-ignore lint/suspicious/noExplicitAny: Blob buffer mismatch
-      body: data as any,
+      body: data,
       headers: { 'Content-Type': 'application/octet-stream' },
     });
     if (!res.ok) throw new Error('Failed to put save');


### PR DESCRIPTION
What was unsafe: The `putSave` method used `as any` because TypeScript threw an error when attempting to assign a `Uint8Array` to `BodyInit` due to an issue with ArrayBuffer variants.
How it was fixed: Explicitly typed the `data` argument as `Uint8Array<ArrayBuffer>` which satisfies the `BodyInit` signature.
What the compiler now catches: The TypeScript compiler now properly enforces that only a valid `Uint8Array` backed by a standard `ArrayBuffer` is passed to the fetch body.

---
*PR created automatically by Jules for task [14303294578928970554](https://jules.google.com/task/14303294578928970554) started by @szubster*