### PR TITLE
🗿 Sculptor: Refactor magic numbers in Gen 3 save parser

### DIFF
--- a/.jules/sculptor/refactor-gen3-magic-numbers-2024-06.md
+++ b/.jules/sculptor/refactor-gen3-magic-numbers-2024-06.md
@@ -1,0 +1,4 @@
+# Sculptor Journal - Gen 3 Refactoring
+## Learnings
+* When refactoring large TS files, using a Node script with `.cjs` extension works far better than `sed` and `grep` over bash, preventing truncation and missing substitutions.
+* Identifying inline magic numbers in heavily structured binaries (like Pokemon save files) significantly boosts AI parsing predictability since the offsets are strictly bounded to constants.

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -41,6 +41,15 @@ import type {
 } from './common';
 
 const SIGNATURE = 0x08012025;
+const SIGNATURE_OFFSET = 4088;
+const SECTION_ID_OFFSET = 4084;
+const SAVE_INDEX_OFFSET = 4092;
+const BERRY_STAGE_OFFSET = 1;
+const BERRY_MINUTES_OFFSET = 2;
+const BERRY_YIELD_OFFSET = 4;
+const BERRY_WATERED_OFFSET = 5;
+const HIDDEN_ITEM_FLAGS_OFFSET = 62;
+
 const SECTION_SIZE = 4096;
 const GEN3_TRAINER_ID_OFFSET = 0x000a;
 const SECRET_ID_SHIFT = 16;
@@ -227,10 +236,10 @@ function getLatestSectionOffset(view: DataView, targetSectionId: number): number
   for (let i = 0; i < NUM_SECTIONS; i++) {
     const offset = SAVE_BLOCK_A + i * SECTION_SIZE;
     try {
-      const signature = view.getUint32(offset + 4088, true);
+      const signature = view.getUint32(offset + SIGNATURE_OFFSET, true);
       if (signature === SIGNATURE) {
-        const sectionId = view.getUint16(offset + 4084, true);
-        const saveIndex = view.getUint32(offset + 4092, true);
+        const sectionId = view.getUint16(offset + SECTION_ID_OFFSET, true);
+        const saveIndex = view.getUint32(offset + SAVE_INDEX_OFFSET, true);
         if (saveIndexA === -1) saveIndexA = saveIndex;
         if (sectionId === targetSectionId) sectionOffsetA = offset;
       }
@@ -242,10 +251,10 @@ function getLatestSectionOffset(view: DataView, targetSectionId: number): number
   for (let i = 0; i < NUM_SECTIONS; i++) {
     const offset = SAVE_BLOCK_B + i * SECTION_SIZE;
     try {
-      const signature = view.getUint32(offset + 4088, true);
+      const signature = view.getUint32(offset + SIGNATURE_OFFSET, true);
       if (signature === SIGNATURE) {
-        const sectionId = view.getUint16(offset + 4084, true);
-        const saveIndex = view.getUint32(offset + 4092, true);
+        const sectionId = view.getUint16(offset + SECTION_ID_OFFSET, true);
+        const saveIndex = view.getUint32(offset + SAVE_INDEX_OFFSET, true);
         if (saveIndexB === -1) saveIndexB = saveIndex;
         if (sectionId === targetSectionId) sectionOffsetB = offset;
       }
@@ -299,14 +308,14 @@ function extractBerryPatches(view: DataView, saveBlock1Offset: number) {
     const offset = baseOffset + i * 8;
     try {
       const berryId = view.getUint8(offset);
-      const stageByte = view.getUint8(offset + 1);
+      const stageByte = view.getUint8(offset + BERRY_STAGE_OFFSET);
       const stage = stageByte & 0x7f;
       const stopGrowth = (stageByte & 0x80) !== 0;
 
-      const minutesUntilNextStage = view.getUint16(offset + 2, true);
-      const berryYield = view.getUint8(offset + 4);
+      const minutesUntilNextStage = view.getUint16(offset + BERRY_MINUTES_OFFSET, true);
+      const berryYield = view.getUint8(offset + BERRY_YIELD_OFFSET);
 
-      const wateredByte = view.getUint8(offset + 5);
+      const wateredByte = view.getUint8(offset + BERRY_WATERED_OFFSET);
       const regrowthCount = wateredByte & 0x0f;
       const watered1 = (wateredByte & 0x10) !== 0;
       const watered2 = (wateredByte & 0x20) !== 0;
@@ -851,8 +860,8 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     const hiddenItemFlags = new Uint8Array(14);
 
     for (let i = 0; i < 14; i++) {
-      const currentByte = view.getUint8(flagsOffset + 62 + i);
-      const nextByte = view.getUint8(flagsOffset + 62 + i + 1);
+      const currentByte = view.getUint8(flagsOffset + HIDDEN_ITEM_FLAGS_OFFSET + i);
+      const nextByte = view.getUint8(flagsOffset + HIDDEN_ITEM_FLAGS_OFFSET + i + 1);
       hiddenItemFlags[i] = ((currentByte >> 4) | ((nextByte & 0x0f) << 4)) & 0xff;
     }
 


### PR DESCRIPTION
🎯 What: Replaced inline magic numbers for memory offsets in gen3.ts with module-level constants. 💡 Why (AI Readability Impact): Improves predictability for LLMs and prevents accidental errors by clearly naming structure bounds and limits. ✅ Verification: Ran pnpm lint, test, and E2E tests to ensure no regressions. ✨ Result: The Gen 3 save parser now uses descriptive constant names, making the parsing logic self-documenting and strictly bounded.

---
*PR created automatically by Jules for task [11212870391196212470](https://jules.google.com/task/11212870391196212470) started by @szubster*