### PR TITLE
🧪 Sentinel: Add test coverage for catchGenerator.ts

### DIFF
--- a/.jules/sentinel/coverage-journal.md
+++ b/.jules/sentinel/coverage-journal.md
@@ -1,0 +1,5 @@
+# Sentinel Learnings: catchGenerator.ts
+
+- **Tricky Types:** Be extremely careful about `any` casting in tests. Biome enforces strict rules against `any` (`lint/suspicious/noExplicitAny`). Always mock out explicit object interfaces (e.g., `{ encounterInfo?: Record<number, EncounterDetail[]> }` rather than `any`) or cast back to original types instead of raw `any`.
+- **Iterative Refinements:** When creating mock files from bash using regex on TS files, be sure to use a Node script (`.cjs` extension) so ESM restrictions on `require` are bypassed.
+- **Coverage Impact:** Adding complete logic branches to `catchGenerator.ts` (a heavily nested and complex graph traversal engine module) substantially helps safeguard core engine refactors in the future.

--- a/plan.md
+++ b/plan.md
@@ -1,34 +1,4 @@
-I have identified a repeating JSX pattern in `src/components/pokemon/details/PokemonEvolutions.tsx` and `src/components/pokemon/details/PokemonLocations.tsx`.
-
-The pattern is a "Tactical Block Header" that consists of a tracking label with an icon, a large bold title, and an optional trailing icon in a squared box with tactical styling (shadow, border, etc.).
-
-It takes the form:
-```tsx
-<div className="flex items-start justify-between border-red-500/20 border-b border-dashed pb-3">
-  <div className="flex flex-col gap-1">
-    <span className="flex items-center gap-1.5 font-mono text-[9px] text-red-500 uppercase tracking-widest">
-      <Target size={10} /> [ OBJECTIVE_LINK ]
-    </span>
-    <span className="font-black font-display text-white text-xl uppercase tracking-tight drop-shadow-[0_0_5px_rgba(255,255,255,0.1)] transition-colors group-hover:text-red-400">
-      PROCUREMENT STRATEGY
-    </span>
-  </div>
-  <div className="flex h-8 w-8 items-center justify-center rounded-none border border-red-500/20 bg-red-500/5 shadow-[inset_0_0_10px_rgba(239,68,68,0.1)]">
-    <AlertTriangle size={14} className="text-red-500/60 transition-colors group-hover:text-red-500" />
-  </div>
-</div>
-```
-
-The differences between instances are:
-1. `variant`: Controls the color (e.g., red, purple, blue, pink, var(--theme-primary)).
-2. `icon`: The React node for the leading icon (e.g., `<Target size={10} />`).
-3. `trackingLabel`: The text for the tracking label (e.g., `[ OBJECTIVE_LINK ]`).
-4. `title`: The main title text (e.g., `PROCUREMENT STRATEGY`).
-5. `trailingIcon`: The optional React node for the trailing icon (e.g., `<AlertTriangle size={14} />`).
-6. `className`: For any custom classes like `border-zinc-800/50` for the default primary one in `PokemonLocations.tsx`.
-
-I will create a new component `TacticalBlockHeader` in `src/components/TacticalBlockHeader.tsx` to encapsulate this.
-
-Then, I will replace the instances in `PokemonEvolutions.tsx` and `PokemonLocations.tsx` with this new component.
-
-Finally, I will run the tests and linter, add a journal entry, and submit the changes.
+1. **Focus Area:** Enhance test coverage in `src/engine/assistant/generators/catchGenerator.ts` by checking in `src/engine/assistant/generators/__tests__/catchGenerator.test.ts`. This module drives the core logic for recommending local and nearby catches and is a critical path for the suggestion engine.
+2. **Implementation:** I have written the test suite which covers various scenarios (local catches, nearby logic, checking distances, static gift exclusions, malformed data edge cases). The coverage for this file was increased successfully in my manual test.
+3. **Pre-commit:** I will complete the pre-commit steps to ensure proper testing, verification, review, and reflection are done (pnpm lint, pnpm test).
+4. **Submission:** I will submit a PR with an appropriate title and description.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Focus Area:** Enhance test coverage in `src/engine/assistant/generators/catchGenerator.ts` by checking in `src/engine/assistant/generators/__tests__/catchGenerator.test.ts`. This module drives the core logic for recommending local and nearby catches and is a critical path for the suggestion engine.
-2. **Implementation:** I have written the test suite which covers various scenarios (local catches, nearby logic, checking distances, static gift exclusions, malformed data edge cases). The coverage for this file was increased successfully in my manual test.
-3. **Pre-commit:** I will complete the pre-commit steps to ensure proper testing, verification, review, and reflection are done (pnpm lint, pnpm test).
-4. **Submission:** I will submit a PR with an appropriate title and description.

--- a/src/engine/assistant/generators/__tests__/catchGenerator.test.ts
+++ b/src/engine/assistant/generators/__tests__/catchGenerator.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from 'vitest';
+import type { SaveData } from '../../../saveParser/index';
+import { gen1Strategy } from '../../strategies/gen1Strategy';
+import type { AssistantStrategy, Suggestion } from '../../strategies/types';
+import type { AssistantApiData } from '../../suggestionEngineTypes';
+import { generateCatchSuggestions } from '../catchGenerator';
+
+describe('catchGenerator', () => {
+  it('should skip processing if apiData.localEncounters is empty or localAid is missing', () => {
+    const apiData = {
+      localEncounters: [],
+      localAid: undefined,
+      missingEncounters: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const myOtIds = new Set<number>();
+    const missingIds = new Set<number>([1]);
+    const queryTargets = [1];
+    const saveData = { generation: 1, currentMapId: 1 } as SaveData;
+    const suggestions: Suggestion[] = [];
+    const localPids = new Set<number>();
+
+    generateCatchSuggestions(
+      apiData,
+      1, // displayVersionId
+      myOtIds,
+      missingIds,
+      queryTargets,
+      saveData,
+      gen1Strategy,
+      suggestions,
+      localPids,
+    );
+
+    expect(suggestions).toHaveLength(0);
+    expect(localPids.size).toBe(0);
+  });
+
+  it('should skip pokemon if they are static gifts and already owned (myOtIds)', () => {
+    const apiData = {
+      localEncounters: [
+        { pid: 133, enc: [{ aid: 1, v: 1, d: [{ c: 100, m: 1, min: 25, max: 25 }] }] }, // Eevee (static gift Gen 1)
+      ],
+      localAid: 1,
+      missingEncounters: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const myOtIds = new Set<number>([133]);
+    const missingIds = new Set<number>([133]);
+    const queryTargets = [133];
+    const saveData = { generation: 1, currentMapId: 1 } as SaveData;
+    const suggestions: Suggestion[] = [];
+    const localPids = new Set<number>();
+
+    generateCatchSuggestions(
+      apiData,
+      1,
+      myOtIds,
+      missingIds,
+      queryTargets,
+      saveData,
+      gen1Strategy,
+      suggestions,
+      localPids,
+    );
+
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it('should add local encounter suggestion with details and time', () => {
+    const apiData = {
+      localEncounters: [{ pid: 1, enc: [{ aid: 1, v: 1, d: [{ c: 10, m: 1, min: 2, max: 5, t: 1 }] }] }],
+      localAid: 1,
+      missingEncounters: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const myOtIds = new Set<number>();
+    const missingIds = new Set<number>([1]);
+    const queryTargets = [1];
+    const saveData = { generation: 1, currentMapId: 1, currentMapName: 'Pallet Town' } as SaveData;
+    const suggestions: Suggestion[] = [];
+    const localPids = new Set<number>();
+
+    generateCatchSuggestions(
+      apiData,
+      1,
+      myOtIds,
+      missingIds,
+      queryTargets,
+      saveData,
+      gen1Strategy,
+      suggestions,
+      localPids,
+    );
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]?.category).toBe('Catch');
+    expect(suggestions[0]?.pokemonIds).toEqual([1]);
+    expect(
+      (
+        suggestions[0] as unknown as {
+          encounterInfo?: Record<number, import('../../strategies/types').EncounterDetail[]>;
+        }
+      )?.encounterInfo?.[1]?.[0]?.time,
+    ).toBe(1);
+  });
+
+  it('should ignore encounters not matching displayVersionId or localAid', () => {
+    const apiData = {
+      localEncounters: [
+        {
+          pid: 1,
+          enc: [
+            { aid: 2, v: 1, d: [{ c: 10, m: 1, min: 2, max: 5 }] }, // Wrong aid
+            { aid: 1, v: 2, d: [{ c: 10, m: 1, min: 2, max: 5 }] }, // Wrong version
+          ],
+        },
+      ],
+      localAid: 1,
+      missingEncounters: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const myOtIds = new Set<number>();
+    const missingIds = new Set<number>([1]);
+    const queryTargets = [1];
+    const saveData = { generation: 1, currentMapId: 1 } as SaveData;
+    const suggestions: Suggestion[] = [];
+    const localPids = new Set<number>();
+
+    generateCatchSuggestions(
+      apiData,
+      1,
+      myOtIds,
+      missingIds,
+      queryTargets,
+      saveData,
+      gen1Strategy,
+      suggestions,
+      localPids,
+    );
+
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it('should ignore missing encounters with missing details or no enc data', () => {
+    const apiData = {
+      localEncounters: [],
+      localAid: undefined,
+      missingEncounters: {
+        1: { enc: null } as unknown,
+        2: { enc: [{ aid: 2, v: 1, d: [undefined] }] } as unknown, // Missing detail object
+      },
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const myOtIds = new Set<number>();
+    const missingIds = new Set<number>([1, 2]);
+    const queryTargets = [1, 2];
+    const saveData = { generation: 1, currentMapId: 1 } as SaveData;
+    const suggestions: Suggestion[] = [];
+    const localPids = new Set<number>();
+
+    const mockStrategy = {
+      ...gen1Strategy,
+      getMapDistance: () => ({ distance: 2, name: 'Route 1' }),
+    } as unknown as AssistantStrategy;
+
+    generateCatchSuggestions(
+      apiData,
+      1,
+      myOtIds,
+      missingIds,
+      queryTargets,
+      saveData,
+      mockStrategy,
+      suggestions,
+      localPids,
+    );
+
+    // Pid 1 has no enc data. Pid 2 has enc data, but its detail object is undefined.
+    // So both will either not trigger nearby suggestion, or will trigger it with empty bestDetails.
+    // Since bestE is set for pid 2, it WILL add pid 2 to group but with empty details.
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    expect(
+      (
+        suggestions[0] as unknown as {
+          encounterInfo?: Record<number, import('../../strategies/types').EncounterDetail[]>;
+        }
+      )?.encounterInfo?.[2],
+    ).toEqual([]);
+  });
+
+  it('should suggest nearby encounters grouped by area and distance', () => {
+    const apiData = {
+      localEncounters: [],
+      localAid: undefined,
+      missingEncounters: {
+        1: { enc: [{ aid: 2, v: 1, d: [{ c: 10, m: 1, min: 2, max: 5 }] }] },
+        2: { enc: [{ aid: 2, v: 1, d: [{ c: 10, m: 1, min: 2, max: 5 }] }] },
+        3: { enc: [{ aid: 3, v: 1, d: [{ c: 10, m: 1, min: 2, max: 5 }] }] },
+      },
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const myOtIds = new Set<number>();
+    const missingIds = new Set<number>([1, 2, 3]);
+    const queryTargets = [1, 2, 3];
+    const saveData = { generation: 1, currentMapId: 1 } as SaveData;
+    const suggestions: Suggestion[] = [];
+    const localPids = new Set<number>();
+
+    const mockStrategy = {
+      ...gen1Strategy,
+      getMapDistance: (_curr: number, target: number) => {
+        if (target === 2) return { distance: 2, name: 'Route 1' };
+        if (target === 3) return { distance: 4, name: 'Route 2' };
+        return null;
+      },
+    } as unknown as AssistantStrategy;
+
+    generateCatchSuggestions(
+      apiData,
+      1,
+      myOtIds,
+      missingIds,
+      queryTargets,
+      saveData,
+      mockStrategy,
+      suggestions,
+      localPids,
+    );
+
+    expect(suggestions).toHaveLength(2); // One for Route 1 (pids 1,2), one for Route 2 (pid 3)
+    const sugg1 = suggestions.find((s) => s.id === 'catch-nearby-2-2');
+    expect(sugg1).toBeDefined();
+    expect(sugg1?.pokemonIds).toEqual([1, 2]);
+
+    const sugg2 = suggestions.find((s) => s.id === 'catch-nearby-3-4');
+    expect(sugg2).toBeDefined();
+    expect(sugg2?.pokemonIds).toEqual([3]);
+  });
+
+  it('should ignore nearby encounters that are too far (> 7 distance) or wrong version', () => {
+    const apiData = {
+      localEncounters: [],
+      localAid: undefined,
+      missingEncounters: {
+        1: { enc: [{ aid: 2, v: 1, d: [{ c: 10, m: 1, min: 2, max: 5 }] }] },
+        2: { enc: [{ aid: 3, v: 2, d: [{ c: 10, m: 1, min: 2, max: 5 }] }] }, // wrong version
+      },
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const myOtIds = new Set<number>();
+    const missingIds = new Set<number>([1, 2]);
+    const queryTargets = [1, 2];
+    const saveData = { generation: 1, currentMapId: 1 } as SaveData;
+    const suggestions: Suggestion[] = [];
+    const localPids = new Set<number>();
+
+    const mockStrategy = {
+      ...gen1Strategy,
+      getMapDistance: (_curr: number, target: number) => {
+        if (target === 2) return { distance: 8, name: 'Far Away' };
+        return null;
+      },
+    } as unknown as AssistantStrategy;
+
+    generateCatchSuggestions(
+      apiData,
+      1,
+      myOtIds,
+      missingIds,
+      queryTargets,
+      saveData,
+      mockStrategy,
+      suggestions,
+      localPids,
+    );
+
+    expect(suggestions).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
🎯 What: Added unit tests for generateCatchSuggestions in catchGenerator.ts to improve coverage of core engine logic.
📊 Coverage: Increased coverage for catchGenerator.ts significantly, testing local encounters, static gifts, distance exclusions, and grouping logic.
✨ Result: Enhanced confidence in the suggestion engine's local and nearby catch logic without modifying application source code.

---
*PR created automatically by Jules for task [15264696899111228156](https://jules.google.com/task/15264696899111228156) started by @szubster*