### PR TITLE
📜 Scribe: Documented saveParser/parsers/common.ts module

### DIFF
--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -1,3 +1,17 @@
+/**
+ * @module common
+ *
+ * Shared utilities and definitions for the save file parser engine.
+ *
+ * This module serves two critical roles:
+ * 1. **Unified Schema (`SaveData`)**: It defines the singular, cross-generation interface
+ *    that normalizes wildly different binary architectures (e.g. Gen 1's sequential block
+ *    vs Gen 3's A/B encrypted flash banks) into a consistent JSON payload for the UI.
+ * 2. **Shared Utilities**: It provides decoding and evaluation functions that are common
+ *    across multiple generations, such as character decoding (`decodeGen12String`), stat
+ *    DV parsing, and Shininess evaluation (`checkShiny`).
+ */
+
 export type GameVersion =
   | 'red'
   | 'blue'


### PR DESCRIPTION
What: Added module-level JSDoc documentation to src/engine/saveParser/parsers/common.ts.

Why: The common.ts file is the backbone of the saveParser module, defining the SaveData interface that normalizes player state across all generations, but it lacked a module overview explaining its purpose and architecture.

Summary of additions:
- Added @module JSDoc block to common.ts explaining its role in the save parser architecture and the significance of the unified SaveData schema.

---
*PR created automatically by Jules for task [11484996863057216888](https://jules.google.com/task/11484996863057216888) started by @szubster*