### PR TITLE
chore(foundry): document cancellation of epic-043-152

### DIFF
--- a/.foundry/journals/story_owner/4888067131241406297.md
+++ b/.foundry/journals/story_owner/4888067131241406297.md
@@ -1,0 +1,1 @@
+Cancellation of Epic 043-152 due to ADR 108-027 making static map extraction impossible


### PR DESCRIPTION
This PR acts as an empty PR for the permanently cancelled `epic-043-152-gen3-roamer-data-extraction`. The Epic was aborted because Gen 3 roamer map coordinates are not serialized to the save file, making static extraction impossible per `ADR 108-027`. No nodes were modified to adhere to strict cancellation policies (YAML frontmatter and checkboxes remain untouched), but a session-unique journal entry has been created to log the learning and fail the node gracefully.

---
*PR created automatically by Jules for task [4888067131241406297](https://jules.google.com/task/4888067131241406297) started by @szubster*