### PR TITLE
Cancel Gen 3 roamer data extraction epic

### DIFF
--- a/.foundry/journals/story_owner/10929901102298299333.md
+++ b/.foundry/journals/story_owner/10929901102298299333.md
@@ -1,0 +1,2 @@
+# Session 10929901102298299333
+Epic epic-043-152-gen3-roamer-data-extraction is permanently cancelled due to ADR 108-027, as Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file.


### PR DESCRIPTION
Permanently cancelled epic-043-152-gen3-roamer-data-extraction due to the impossibility of statically extracting Gen 3 roamer location from the save file (as documented in ADR 108-027). Submitted an empty PR to fail the node gracefully without modifying its YAML frontmatter, complying with Empty PR policies. Created a session-unique journal entry.

---
*PR created automatically by Jules for task [10929901102298299333](https://jules.google.com/task/10929901102298299333) started by @szubster*