### PR TITLE
QA: Reject Gen 1 TM/HM Parsing Implementation

### DIFF
--- a/.foundry/journals/qa/session_2897712216952814014.md
+++ b/.foundry/journals/qa/session_2897712216952814014.md
@@ -1,0 +1,6 @@
+# QA Journal
+Session ID: 2897712216952814014
+
+## Rejection
+- Rejected implementation of Gen 1 TM/HM save parsing (`task-319-322-gen1-tm-hm-parsing-impl`)
+- **Reason:** Violation of ADR 028. Inline magic numbers (e.g., 0x27e6, 0x25c9) were used for memory offsets in `src/engine/saveParser/parsers/gen1.ts`. The implementation must extract these offsets into module-level constants.

--- a/.foundry/tasks/task-319-322-gen1-tm-hm-parsing-impl.md
+++ b/.foundry/tasks/task-319-322-gen1-tm-hm-parsing-impl.md
@@ -2,7 +2,7 @@
 id: task-319-322-gen1-tm-hm-parsing-impl
 type: TASK
 title: Gen 1 TM/HM Save Parsing Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-14'
 updated_at: '2026-07-24'
@@ -16,8 +16,8 @@ tags:
   - save-parsing
 research_references:
   - .foundry/docs/knowledge_base/moveset-inventory-memory-offsets.md
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Implementation violated ADR 028 by using inline magic numbers for offsets (e.g., 0x27e6, 0x25c9) in parseGen1 instead of module-level constants.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-319-323-gen1-tm-hm-parsing-qa.md
+++ b/.foundry/tasks/task-319-323-gen1-tm-hm-parsing-qa.md
@@ -33,6 +33,10 @@ Verify the implementation of Gen 1 TM/HM save parsing logic. The parsing engine 
 4. **Failure State Handling**: If you experience a transient failure requiring retry or reject the implementation, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`. If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 5. **Empty PR Policy**: If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
+## QA Results
+- Implementation rejected and failed due to violation of ADR 028.
+- Inline magic numbers (e.g., 0x27e6, 0x25c9) are directly used in `src/engine/saveParser/parsers/gen1.ts` for extraction. These need to be converted to module-level constants.
+
 ## Acceptance Criteria
 - [ ] Verify that Gen 1 TM/HM parsing correctly extracts items and quantities.
 - [ ] Verify that TM/HMs are correctly mapped to moves.


### PR DESCRIPTION
- Rejected `task-319-322-gen1-tm-hm-parsing-impl` due to violation of ADR 028.
- The implementer used inline magic numbers (e.g., 0x27e6) for extracting dynamic save blocks in `src/engine/saveParser/parsers/gen1.ts`.
- Updated target task YAML frontmatter `status` to `FAILED`, incremented `rejection_count`, and added `rejection_reason`.
- Added QA results to `.foundry/tasks/task-319-323-gen1-tm-hm-parsing-qa.md`.
- Created QA session journal `.foundry/journals/qa/session_2897712216952814014.md`.

---
*PR created automatically by Jules for task [2897712216952814014](https://jules.google.com/task/2897712216952814014) started by @szubster*