### PR TITLE
docs(story_owner): add journal entry for cancelled epic-043-152

### DIFF
--- a/.foundry/journals/story_owner/7330459318399634017.md
+++ b/.foundry/journals/story_owner/7330459318399634017.md
@@ -1,0 +1,3 @@
+# Journal Entry
+
+Epic epic-043-152-gen3-roamer-data-extraction is permanently cancelled because Gen 3 roamer map coordinates are stored in EWRAM and not serialized to the save file. Leaving acceptance criteria unchecked and submitting an empty PR.


### PR DESCRIPTION
Submitting an empty PR as instructed for the permanently cancelled Epic `epic-043-152-gen3-roamer-data-extraction`. The epic is blocked by technical limitations (Gen 3 roamer map coordinates are stored in EWRAM and not serialized to the save file). A session-unique journal entry detailing the cancellation has been created at `.foundry/journals/story_owner/7330459318399634017.md`, and the task's YAML frontmatter and acceptance criteria remain unmodified as per system policies.

---
*PR created automatically by Jules for task [7330459318399634017](https://jules.google.com/task/7330459318399634017) started by @szubster*