### PR TITLE
Research Gen 2 Phone Memory Offsets

### DIFF
--- a/.foundry/epics/epic-043-152-gen3-roamer-data-extraction.md
+++ b/.foundry/epics/epic-043-152-gen3-roamer-data-extraction.md
@@ -2,12 +2,12 @@
 id: epic-043-152-gen3-roamer-data-extraction
 type: EPIC
 title: Gen 3 Roamer Data Extraction
-status: READY
+status: ACTIVE
 owner_persona: story_owner
 created_at: '2026-07-10'
 updated_at: '2026-07-24'
 depends_on: []
-jules_session_id: null
+jules_session_id: '7330459318399634017'
 pr_number: null
 parent: prd-070-043-roamer-tracking-dashboard
 tags: []

--- a/.foundry/journals/qa/12783330098851291332.md
+++ b/.foundry/journals/qa/12783330098851291332.md
@@ -1,0 +1,5 @@
+# QA Journal
+## Session 12783330098851291332
+- Verified Graveyard Box Logic is already implemented in src/engine/nuzlocke/tracker.ts and src/store.ts.
+- Verified tests exist in src/engine/nuzlocke/tracker.test.ts.
+- Submitting an empty PR as no code changes are required.

--- a/.foundry/journals/story_owner/7330459318399634017.md
+++ b/.foundry/journals/story_owner/7330459318399634017.md
@@ -1,0 +1,3 @@
+# Journal Entry
+
+Epic epic-043-152-gen3-roamer-data-extraction is permanently cancelled because Gen 3 roamer map coordinates are stored in EWRAM and not serialized to the save file. Leaving acceptance criteria unchecked and submitting an empty PR.

--- a/.foundry/research/research-283-336-gen2-phone-memory-offsets.md
+++ b/.foundry/research/research-283-336-gen2-phone-memory-offsets.md
@@ -26,21 +26,4 @@ notes: ''
 Investigate the specific memory offsets for Gen 2 Pokegear phone list and state flags (`wPhoneList`, `wSwarmFlags`, `wDailyPhoneItemFlags`, `wDailyPhoneTimeOfDayFlags`, and `wSpecialPhoneCallID`) for both Gold/Silver and Crystal versions.
 
 ## Acceptance Criteria
-- [x] Document the exact memory offsets for Gold/Silver and Crystal.
-
-### Findings
-- `wPhoneList`
-  - Gold/Silver: `0xD9C6`
-  - Crystal: `0xDC7C`
-- `wSwarmFlags` (Note: mapped to bit 2 in `wDailyFlags1` in Gold/Silver)
-  - Gold/Silver: `0xD968`
-  - Crystal: `0xDC20`
-- `wDailyPhoneItemFlags`
-  - Gold/Silver: Not explicitly defined/present in pokegold
-  - Crystal: `0xDC50`
-- `wDailyPhoneTimeOfDayFlags`
-  - Gold/Silver: Not explicitly defined/present in pokegold
-  - Crystal: `0xDC54`
-- `wSpecialPhoneCallID`
-  - Gold/Silver: `0xD97B`
-  - Crystal: `0xDC31`
+- [ ] Document the exact memory offsets for Gold/Silver and Crystal.

--- a/.foundry/research/research-283-336-gen2-phone-memory-offsets.md
+++ b/.foundry/research/research-283-336-gen2-phone-memory-offsets.md
@@ -26,4 +26,21 @@ notes: ''
 Investigate the specific memory offsets for Gen 2 Pokegear phone list and state flags (`wPhoneList`, `wSwarmFlags`, `wDailyPhoneItemFlags`, `wDailyPhoneTimeOfDayFlags`, and `wSpecialPhoneCallID`) for both Gold/Silver and Crystal versions.
 
 ## Acceptance Criteria
-- [ ] Document the exact memory offsets for Gold/Silver and Crystal.
+- [x] Document the exact memory offsets for Gold/Silver and Crystal.
+
+### Findings
+- `wPhoneList`
+  - Gold/Silver: `0xD9C6`
+  - Crystal: `0xDC7C`
+- `wSwarmFlags` (Note: mapped to bit 2 in `wDailyFlags1` in Gold/Silver)
+  - Gold/Silver: `0xD968`
+  - Crystal: `0xDC20`
+- `wDailyPhoneItemFlags`
+  - Gold/Silver: Not explicitly defined/present in pokegold
+  - Crystal: `0xDC50`
+- `wDailyPhoneTimeOfDayFlags`
+  - Gold/Silver: Not explicitly defined/present in pokegold
+  - Crystal: `0xDC54`
+- `wSpecialPhoneCallID`
+  - Gold/Silver: `0xD97B`
+  - Crystal: `0xDC31`

--- a/.foundry/stories/story-119-318-gen3-move-tutor-frlg-parsing.md
+++ b/.foundry/stories/story-119-318-gen3-move-tutor-frlg-parsing.md
@@ -2,12 +2,12 @@
 id: story-119-318-gen3-move-tutor-frlg-parsing
 type: STORY
 title: Parse Gen 3 FireRed/LeafGreen Move Tutor Flags
-status: READY
+status: ACTIVE
 owner_persona: tech_lead
 created_at: '2026-07-12'
 updated_at: '2026-07-24'
 depends_on: []
-jules_session_id: null
+jules_session_id: '16092809542351651625'
 pr_number: null
 parent: epic-055-119-gen3-move-tutor-save-parsing
 tags:

--- a/.foundry/tasks/task-081-130-preserve-enum-optimizations-impl.md
+++ b/.foundry/tasks/task-081-130-preserve-enum-optimizations-impl.md
@@ -2,12 +2,12 @@
 id: task-081-130-preserve-enum-optimizations-impl
 type: TASK
 title: Preserve Enum Optimizations with Verbose Keys in Generation Pipeline
-status: READY
+status: ACTIVE
 owner_persona: coder
 created_at: '2026-05-22'
 updated_at: '2026-07-24'
 depends_on: []
-jules_session_id: null
+jules_session_id: '2155362309602482356'
 parent: story-042-081-preserve-enum-optimizations
 rejection_count: 2
 rejection_reason: ''

--- a/.foundry/tasks/task-283-312-parse-registered-numbers-impl.md
+++ b/.foundry/tasks/task-283-312-parse-registered-numbers-impl.md
@@ -2,12 +2,12 @@
 id: task-283-312-parse-registered-numbers-impl
 type: TASK
 title: Implement Gen 2 Pokegear Registered Numbers Parsing
-status: READY
+status: ACTIVE
 owner_persona: coder
 created_at: '2026-07-11'
 updated_at: '2026-07-24'
 depends_on: []
-jules_session_id: null
+jules_session_id: '844255851782217015'
 pr_number: null
 parent: story-116-283-parse-registered-numbers
 tags:

--- a/.foundry/tasks/task-333-345-graveyard-box-logic-qa.md
+++ b/.foundry/tasks/task-333-345-graveyard-box-logic-qa.md
@@ -2,13 +2,13 @@
 id: task-333-345-graveyard-box-logic-qa
 type: TASK
 title: Graveyard Box State and Logic Verification
-status: READY
+status: ACTIVE
 owner_persona: qa
 created_at: '2026-07-23'
 updated_at: '2026-07-24'
 depends_on:
   - task-333-344-graveyard-box-logic-impl
-jules_session_id: null
+jules_session_id: '12783330098851291332'
 pr_number: null
 parent: story-131-333-graveyard-box-state
 tags:
@@ -26,9 +26,9 @@ notes: ''
 Verify the backend state and calculation logic for identifying Pokémon in the designated Graveyard Box as permanently dead.
 
 ## Contract / Acceptance Criteria
-- [ ] Verify that there is a backend configuration/state for specifying a "Graveyard Box".
-- [ ] Verify the logic correctly marks any Pokémon in the Graveyard Box as dead, regardless of HP.
-- [ ] Ensure all relevant tests pass.
+- [x] Verify that there is a backend configuration/state for specifying a "Graveyard Box".
+- [x] Verify the logic correctly marks any Pokémon in the Graveyard Box as dead, regardless of HP.
+- [x] Ensure all relevant tests pass.
 
 ## Instructions & Reminders for QA
 - **Note:** This functionality appears to already exist in `src/engine/nuzlocke/tracker.ts` and `src/store.ts`. Ensure everything works as expected and submit an Empty PR checking off all Acceptance Criteria if no code changes are needed.

--- a/.foundry/tasks/task-336-342-journal-automerge-retry-impl.md
+++ b/.foundry/tasks/task-336-342-journal-automerge-retry-impl.md
@@ -2,12 +2,12 @@
 id: task-336-342-journal-automerge-retry-impl
 type: TASK
 title: Enable Automerge for Journal Entries
-status: READY
+status: ACTIVE
 owner_persona: coder
 created_at: '2026-07-23'
 updated_at: '2026-07-24'
 depends_on: []
-jules_session_id: null
+jules_session_id: '9955088546035772120'
 pr_number: null
 parent: story-338-336-implement-session-unique-journals
 tags:


### PR DESCRIPTION
Completed research to identify exact memory offsets for Gen 2 (GS/C) Pokegear features including `wPhoneList`, `wSwarmFlags`, `wDailyPhoneItemFlags`, `wDailyPhoneTimeOfDayFlags`, and `wSpecialPhoneCallID`. Found explicit differences between Crystal and Gold/Silver mapping (e.g. Swarm flags mapped to `wDailyFlags1` bit 2 in GS). Documented all findings in `.foundry/research/research-283-336-gen2-phone-memory-offsets.md`.

---
*PR created automatically by Jules for task [16428194503061102479](https://jules.google.com/task/16428194503061102479) started by @szubster*