### PR TITLE
Cancel Epic: Gen 3 Roamer Data Extraction

### DIFF
--- a/.foundry/journals/story_owner/15926776242114287155.md
+++ b/.foundry/journals/story_owner/15926776242114287155.md
@@ -1,0 +1,3 @@
+# Session 15926776242114287155
+
+Epic epic-043-152-gen3-roamer-data-extraction is permanently cancelled because Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file, making static extraction impossible as per research-043-263-roamer-tracking-remediation and ADR 108-027.


### PR DESCRIPTION
This PR formally documents the permanent cancellation of Epic epic-043-152-gen3-roamer-data-extraction in the Story Owner journal. The Epic is cancelled because Gen 3 roamer map coordinates are stored in EWRAM and are not serialized to the save file, making static extraction impossible as per research-043-263-roamer-tracking-remediation and ADR 108-027.

The Epic YAML frontmatter is unmodified and acceptance criteria are left unchecked in compliance with system policies for handling cancelled Epics.

---
*PR created automatically by Jules for task [15926776242114287155](https://jules.google.com/task/15926776242114287155) started by @szubster*