### PR TITLE
chore(foundry): handle epic-108-303 permanent cancellation

### DIFF
--- a/.foundry/epics/epic-108-340-extend-phase-3-6-cancelled-nodes-retry.md
+++ b/.foundry/epics/epic-108-340-extend-phase-3-6-cancelled-nodes-retry.md
@@ -1,0 +1,39 @@
+---
+id: epic-108-340-extend-phase-3-6-cancelled-nodes-retry
+type: EPIC
+title: Extend Phase 3.6 for CANCELLED nodes (Retry)
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-24'
+updated_at: '2026-07-24'
+depends_on: ['research-108-339-investigate-orchestrator-phase-3-6-failure']
+jules_session_id: null
+pr_number: null
+parent: prd-086-108-fix-orchestrator-phase-3-6
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extend Phase 3.6 for CANCELLED nodes (Retry)
+
+## Objective
+Extend Phase 3.6 logic in `foundry-orchestrator.ts` to properly handle nodes transitioning to `CANCELLED` status due to max rejections, taking into account the learnings from the previous research.
+
+## Context
+In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` status with `rejection_reason === 'Max rejection count reached'` fail to trigger the parent awakening ("Impossible Loop") logic. This causes system deadlocks. The parent node needs to be properly awakened (reverted to PENDING/READY) to handle the failure and regenerate nodes.
+
+## Requirements
+- Review the findings in the prerequisite research node.
+- Implement the required changes in `foundry-orchestrator.ts` Phase 3.6.
+- Add an explicit check for nodes with `status === 'CANCELLED'` and `rejection_reason === 'Max rejection count reached'`.
+- Ensure the parent node is properly awakened (reverted to PENDING/READY) for these cancelled nodes.
+- Update tests in `foundry-orchestrator.test.ts` to verify this exact behavior.
+
+## Acceptance Criteria
+- [ ] Break down into Stories

--- a/.foundry/journals/epic_planner/14140594791612700438.md
+++ b/.foundry/journals/epic_planner/14140594791612700438.md
@@ -1,0 +1,4 @@
+# Session 14140594791612700438
+
+## Impossible Loop Handled
+The child epic `epic-108-303-extend-phase-3-6-cancelled-nodes` of PRD `prd-086-108-fix-orchestrator-phase-3-6` was cancelled due to max rejections. I have checked off the cancelled epic in the PRD, created a `RESEARCH` node to investigate the failure, and created a replacement `EPIC` node that depends on the research node.

--- a/.foundry/prds/prd-086-108-fix-orchestrator-phase-3-6.md
+++ b/.foundry/prds/prd-086-108-fix-orchestrator-phase-3-6.md
@@ -33,4 +33,6 @@ In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` statu
 - [ ] Phase 3.6 awakening logic supports `CANCELLED` nodes.
 - [ ] Parent nodes correctly awaken when child nodes are cancelled due to hitting max rejections.
 - [ ] Tests verify this exact behavior in `foundry-orchestrator.test.ts`.
-- [ ] epic-108-303-extend-phase-3-6-cancelled-nodes
+- [x] epic-108-303-extend-phase-3-6-cancelled-nodes
+- [ ] research-108-339-investigate-orchestrator-phase-3-6-failure
+- [ ] epic-108-340-extend-phase-3-6-cancelled-nodes-retry

--- a/.foundry/research/research-108-339-investigate-orchestrator-phase-3-6-failure.md
+++ b/.foundry/research/research-108-339-investigate-orchestrator-phase-3-6-failure.md
@@ -1,0 +1,29 @@
+---
+id: research-108-339-investigate-orchestrator-phase-3-6-failure
+type: RESEARCH
+title: Investigate orchestrator phase 3.6 logic failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-24'
+updated_at: '2026-07-24'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-086-108-fix-orchestrator-phase-3-6
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate orchestrator phase 3.6 logic failure
+
+## Objective
+Investigate why `epic-108-303-extend-phase-3-6-cancelled-nodes` reached the maximum rejection count and permanently failed. Identify the root cause of the QA rejections related to extending the Phase 3.6 logic for `CANCELLED` nodes.
+
+## Context
+The previous epic attempting to fix Phase 3.6 was permanently cancelled due to reaching max rejections. We need to understand what technical requirements or tests the developer failed to implement correctly before generating a new Epic.


### PR DESCRIPTION
Handling the permanent failure of `epic-108-303-extend-phase-3-6-cancelled-nodes` due to max rejections.

I've executed the Impossible Loop recovery procedure:
1.  Checked off the permanently failed epic in `prd-086-108`.
2.  Created `research-108-339` to analyze *why* the previous implementation kept failing QA.
3.  Created `epic-108-340` as the replacement epic, heavily dependent on the research node being completed first.
4.  Appended both new nodes to the PRD.
5.  Logged the session intervention in my Epic Planner journal.

---
*PR created automatically by Jules for task [4669523808454828665](https://jules.google.com/task/4669523808454828665) started by @szubster*