### PR TITLE
Protect Terminal Status Nodes in Heartbeat Transitions

### DIFF
--- a/.github/scripts/foundry-heartbeat.test.ts
+++ b/.github/scripts/foundry-heartbeat.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { main, identifyBranchesForCleanup, cleanupRemoteBranches, transitionNodeToCompleted } from './foundry-heartbeat.ts';
+import { main, identifyBranchesForCleanup, cleanupRemoteBranches, transitionNodeToCompleted, transitionNodeToReady, transitionNodeToReadyWithoutPenalty, transitionNodeToFailed } from './foundry-heartbeat.ts';
 import * as orchestrator from './foundry-orchestrator.ts';
 
 vi.mock('node:fs');
@@ -1647,5 +1647,87 @@ status: ACTIVE
 
       const result = await identifyBranchesForCleanup('/mock', ['origin/branch-session-fail'], ['branch-session-fail']);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('Terminal Status Protection', () => {
+    it('should preserve CANCELLED or COMPLETED status in transitionNodeToCompleted', async () => {
+      vi.mocked(fs.writeFileSync).mockClear();
+      const mockCancelledNode = {
+        filePath: '/mock/repo/.foundry/epics/epic-1.md',
+        repoPath: '.foundry/epics/epic-1.md',
+        rawContent: '---\ntype: EPIC\nstatus: CANCELLED\njules_session_id: "session-1"\n---\nBody'
+      };
+      await transitionNodeToCompleted(mockCancelledNode, '/mock/repo', 123);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+      vi.mocked(fs.writeFileSync).mockClear();
+      const mockCompletedNode = {
+        filePath: '/mock/repo/.foundry/epics/epic-1.md',
+        repoPath: '.foundry/epics/epic-1.md',
+        rawContent: '---\ntype: EPIC\nstatus: COMPLETED\njules_session_id: "session-1"\n---\nBody'
+      };
+      await transitionNodeToCompleted(mockCompletedNode, '/mock/repo', 123);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should preserve CANCELLED or COMPLETED status in transitionNodeToReady', async () => {
+      vi.mocked(fs.writeFileSync).mockClear();
+      const mockCancelledNode = {
+        filePath: '/mock/repo/.foundry/epics/epic-1.md',
+        repoPath: '.foundry/epics/epic-1.md',
+        rawContent: '---\ntype: EPIC\nstatus: CANCELLED\njules_session_id: "session-1"\n---\nBody'
+      };
+      await transitionNodeToReady(mockCancelledNode, '/mock/repo', 'reason');
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+      vi.mocked(fs.writeFileSync).mockClear();
+      const mockCompletedNode = {
+        filePath: '/mock/repo/.foundry/epics/epic-1.md',
+        repoPath: '.foundry/epics/epic-1.md',
+        rawContent: '---\ntype: EPIC\nstatus: COMPLETED\njules_session_id: "session-1"\n---\nBody'
+      };
+      await transitionNodeToReady(mockCompletedNode, '/mock/repo', 'reason');
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should preserve CANCELLED or COMPLETED status in transitionNodeToReadyWithoutPenalty', async () => {
+      vi.mocked(fs.writeFileSync).mockClear();
+      const mockCancelledNode = {
+        filePath: '/mock/repo/.foundry/epics/epic-1.md',
+        repoPath: '.foundry/epics/epic-1.md',
+        rawContent: '---\ntype: EPIC\nstatus: CANCELLED\njules_session_id: "session-1"\n---\nBody'
+      };
+      await transitionNodeToReadyWithoutPenalty(mockCancelledNode, '/mock/repo', 'reason');
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+      vi.mocked(fs.writeFileSync).mockClear();
+      const mockCompletedNode = {
+        filePath: '/mock/repo/.foundry/epics/epic-1.md',
+        repoPath: '.foundry/epics/epic-1.md',
+        rawContent: '---\ntype: EPIC\nstatus: COMPLETED\njules_session_id: "session-1"\n---\nBody'
+      };
+      await transitionNodeToReadyWithoutPenalty(mockCompletedNode, '/mock/repo', 'reason');
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should preserve CANCELLED or COMPLETED status in transitionNodeToFailed', async () => {
+      vi.mocked(fs.writeFileSync).mockClear();
+      const mockCancelledNode = {
+        filePath: '/mock/repo/.foundry/epics/epic-1.md',
+        repoPath: '.foundry/epics/epic-1.md',
+        rawContent: '---\ntype: EPIC\nstatus: CANCELLED\njules_session_id: "session-1"\n---\nBody'
+      };
+      await transitionNodeToFailed(mockCancelledNode, '/mock/repo', 'reason');
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+      vi.mocked(fs.writeFileSync).mockClear();
+      const mockCompletedNode = {
+        filePath: '/mock/repo/.foundry/epics/epic-1.md',
+        repoPath: '.foundry/epics/epic-1.md',
+        rawContent: '---\ntype: EPIC\nstatus: COMPLETED\njules_session_id: "session-1"\n---\nBody'
+      };
+      await transitionNodeToFailed(mockCompletedNode, '/mock/repo', 'reason');
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
   });

--- a/.github/scripts/foundry-heartbeat.ts
+++ b/.github/scripts/foundry-heartbeat.ts
@@ -49,6 +49,10 @@ export async function transitionNodeToFailed(node: any, repoRoot: string, reject
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
   const parsed = matter(node.rawContent);
+  if (parsed.data.status === 'CANCELLED' || parsed.data.status === 'COMPLETED') {
+    info(`${dryTag}Preserving terminal status '${parsed.data.status}' for node: ${node.repoPath}`);
+    return;
+  }
   parsed.data.status = 'FAILED';
   parsed.data.jules_session_id = null;
   parsed.data.updated_at = dateStr;
@@ -71,6 +75,10 @@ export async function transitionNodeToCompleted(node: any, repoRoot: string, prN
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
   const parsed = matter(node.rawContent);
+  if (parsed.data.status === 'CANCELLED' || parsed.data.status === 'COMPLETED') {
+    info(`${dryTag}Preserving terminal status '${parsed.data.status}' for node: ${node.repoPath}`);
+    return;
+  }
 
   // Late-Binding Support: If unchecked tasks exist, check if node is a parent.
   const acceptanceCriteriaMatch = parsed.content.match(/## Acceptance Criteria\s*([\s\S]*?)(?:\n## |$)/);
@@ -200,6 +208,10 @@ export async function transitionNodeToReady(node: any, repoRoot: string, reason:
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
   const parsed = matter(node.rawContent);
+  if (parsed.data.status === 'CANCELLED' || parsed.data.status === 'COMPLETED') {
+    info(`${dryTag}Preserving terminal status '${parsed.data.status}' for node: ${node.repoPath}`);
+    return;
+  }
   const newRejectionCount = (parsed.data.rejection_count || 0) + 1;
   parsed.data.rejection_count = newRejectionCount;
   parsed.data.updated_at = dateStr;
@@ -245,6 +257,10 @@ export async function transitionNodeToReadyWithoutPenalty(node: any, repoRoot: s
   const dryTag = DRY_RUN ? '[DRY-RUN] ' : '';
 
   const parsed = matter(node.rawContent);
+  if (parsed.data.status === 'CANCELLED' || parsed.data.status === 'COMPLETED') {
+    info(`${dryTag}Preserving terminal status '${parsed.data.status}' for node: ${node.repoPath}`);
+    return;
+  }
 
   const currentStatus = parsed.data.status || node.frontmatter.status;
   if (currentStatus === "VERIFYING") {


### PR DESCRIPTION
This submission adds terminal status protection to the Foundry heartbeat transition functions to preserve `CANCELLED` and `COMPLETED` states, bypassing any automated transitions, checks, or validation (such as E2E story enforcement on merged epics). Extensive tests have been added and run successfully.

Fixes #5065

---
*PR created automatically by Jules for task [7453759957278763742](https://jules.google.com/task/7453759957278763742) started by @szubster*