### PR TITLE
chore: close out already implemented Gen 1 TM HM parsing task

### DIFF
--- a/.foundry/journals/coder/2026-07-24-22-13-27.md
+++ b/.foundry/journals/coder/2026-07-24-22-13-27.md
@@ -1,0 +1,4 @@
+## 2026-07-24 - Gen 1 TM/HM Save Parsing Implementation
+The task `task-319-322-gen1-tm-hm-parsing-impl` was to extract TM and HM inventory, map them to moves, and extract event flags.
+Upon investigation, this has already been completed in a previous session. `parseGen1TMFlags` extracts event flags and is used in `parseGen1`. The `tms` object is created and correctly uses `GEN1_TM_HM_TO_MOVE_ID`, `inventory`, `pcItems`, and `GEN1_TM_EVENT_FLAGS`. Tests also exist for these implementations.
+Submitting an empty PR to close this node out.


### PR DESCRIPTION
The required functionality (TM/HM item extraction, mapping to moves, and one-time TM event flags) has already been implemented and tested in previous sessions via `parseGen1` and `GEN1_TM_EVENT_FLAGS` in the Gen 1 save parser. 

I've added a coder journal entry reflecting this investigation and am submitting an empty PR as per the Empty PR policy to close this task out. The acceptance criteria checkboxes are already checked in the task node.

---
*PR created automatically by Jules for task [3288900589414075789](https://jules.google.com/task/3288900589414075789) started by @szubster*