### PR TITLE
chore(foundry): process story-039-263-r2-pull-sync-logic

### DIFF
--- a/.foundry/journals/tech_lead/12144804470286496581.md
+++ b/.foundry/journals/tech_lead/12144804470286496581.md
@@ -1,0 +1,7 @@
+# Tech Lead Journal
+
+Session ID: 12144804470286496581
+
+Encountered story `story-039-263-r2-pull-sync-logic` where the acceptance criteria were already checked off, and child tasks (`task-263-285-r2-pull-sync-logic-impl` and `task-263-286-r2-pull-sync-logic-qa`) were already drafted and checked off.
+
+Proceeding with an Empty PR to allow the orchestrator to correctly demote the parent node to PENDING while it waits for its children or to transition it to VERIFYING if its children are completed. No task drafting was required.


### PR DESCRIPTION
Empty PR to allow the orchestrator to transition the story node `story-039-263-r2-pull-sync-logic` to `VERIFYING` because all child tasks and acceptance criteria are already completed.

---
*PR created automatically by Jules for task [12144804470286496581](https://jules.google.com/task/12144804470286496581) started by @szubster*