### PR TITLE
docs(qa): verify graveyard box logic implementation

### DIFF
--- a/.foundry/tasks/task-333-345-graveyard-box-logic-qa.md
+++ b/.foundry/tasks/task-333-345-graveyard-box-logic-qa.md
@@ -26,9 +26,9 @@ notes: ''
 Verify the backend state and calculation logic for identifying Pokémon in the designated Graveyard Box as permanently dead.
 
 ## Contract / Acceptance Criteria
-- [ ] Verify that there is a backend configuration/state for specifying a "Graveyard Box".
-- [ ] Verify the logic correctly marks any Pokémon in the Graveyard Box as dead, regardless of HP.
-- [ ] Ensure all relevant tests pass.
+- [x] Verify that there is a backend configuration/state for specifying a "Graveyard Box".
+- [x] Verify the logic correctly marks any Pokémon in the Graveyard Box as dead, regardless of HP.
+- [x] Ensure all relevant tests pass.
 
 ## Instructions & Reminders for QA
 - **Note:** This functionality appears to already exist in `src/engine/nuzlocke/tracker.ts` and `src/store.ts`. Ensure everything works as expected and submit an Empty PR checking off all Acceptance Criteria if no code changes are needed.


### PR DESCRIPTION
Verified that the core logic for checking designated Graveyard boxes already exists in `src/engine/nuzlocke/tracker.ts` (`getGraveyardPokemon`) and frontend state in `src/store.ts`. 

All acceptance criteria checkboxes for `task-333-345-graveyard-box-logic-qa` have been checked off. Submitting this as an Empty PR to complete the QA node according to ADR 007 and ADR 009.

---
*PR created automatically by Jules for task [17406397350687005318](https://jules.google.com/task/17406397350687005318) started by @szubster*