### PR TITLE
🧭 Strategist: Prompt improvement - Consolidate Save Parsing Rules

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -114,3 +114,11 @@ If you lack critical context or specifications (e.g., exact memory offsets) nece
 * Use non-blocking alternatives like `cat` or `tail -n`.
 * If a long-running process must be executed, it must be backgrounded (`&`) or wrapped using the standard GNU `timeout` command (e.g., `timeout 30s command`).
 * **Timeout Interruption Feedback:** When the `timeout` command successfully interrupts a process that exceeds the specified duration, it returns **exit code 124**. Agents MUST recognize exit code 124 as an explicit timeout indicator, rather than a generic command failure, and MUST switch to using non-blocking alternatives (like `cat` or `tail -n`) instead of retrying the blocking command.
+
+## Save File Parsing & Magic Numbers
+When working with save file parsing or data definitions across any persona (Tech Lead drafting tasks, Coder implementing, QA validating):
+- **Reusable Constants**: You MUST explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Strictly avoid using inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions.
+- **Bounds Checking**: When using the `DataView` API for array bounds checking or extraction limits, you MUST NOT use inline magic numbers; these bounds must also be defined as reusable constants at the module level.
+- **Gen 3 Relative Offsets**: When writing Gen 3 save block extraction functions, you must pass and utilize the resolved section offset (e.g., `section1Offset` or `section2Offset`) to calculate relative memory offsets, rather than using absolute hardcoded offsets, to properly support the Gen 3 A/B bank flash memory architecture.
+- **Bitwise Blocks**: When parsing bitwise blocks (like event flag arrays) using the `DataView` API, you must explicitly map the specific bit offsets corresponding to target events. Just extracting the array is insufficient; explicitly identifying the individual bit offsets is required for downstream consumption.
+- **Error Handling**: When using the `DataView` API to parse save files, you MUST catch `RangeError` for out-of-bounds reads and throw a new error with the message "The save file is corrupted or incomplete." to prevent crashes and QA rejections. QA MUST explicitly reject tasks that fail to handle these rules.

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -16,15 +16,6 @@ When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.t
 
 
 
-## Save File Parsing & Magic Numbers
-When implementing save file parsing or data definitions, you MUST explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Strictly avoid using inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions. This ensures robustness against version-specific shifts and prevents brittle code. Furthermore, when using the `DataView` API for array bounds checking or extraction limits (e.g., max record counts), you MUST NOT use inline magic numbers; these bounds must also be defined as reusable constants at the module level.
-
-When writing Gen 3 save block extraction functions, you must pass and utilize the resolved section offset (e.g., `section1Offset` or `section2Offset`) to calculate relative memory offsets, rather than using absolute hardcoded offsets, to properly support the Gen 3 A/B bank flash memory architecture.
-
-When parsing bitwise blocks (like event flag arrays) using the `DataView` API, you must explicitly map the specific bit offsets corresponding to target events. Just extracting the array is insufficient; explicitly identifying the individual bit offsets is required for downstream consumption.
-
-When using the `DataView` API to parse save files, you MUST catch `RangeError` for out-of-bounds reads and throw a new error with the message "The save file is corrupted or incomplete." to prevent crashes and QA rejections.
-
 ## UI Aesthetic Constraints (ADR 008)
 When implementing UI components, you MUST adhere strictly to the "tactical hardware/snooping" aesthetic outlined in ADR 008.
 - Explicitly use sharp edges (`rounded-none`).

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -17,7 +17,7 @@ Ensure you are fully aware of the rules defined in `.foundry/archive/docs/adrs/0
 
 ## Responsibilities
 
-1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria. You MUST explicitly reject tasks that use inline magic numbers (e.g., `0x2dd6`, `>> 4`) for save file data extraction instead of defined reusable constants at the module level. You MUST also explicitly reject tasks that use absolute memory offsets (e.g., `0x2dd6`) for Gen 3 dynamic save block extraction instead of calculating relative offsets from the resolved section offset (e.g., `section1Offset`). You MUST ensure that any tasks involving parsers for save files properly catch `RangeError` from the `DataView` API when checking for out-of-bounds reads.
+1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria. You MUST rigorously enforce the Save File Parsing rules defined in `core_policies.md`, explicitly rejecting tasks that use magic numbers, absolute Gen 3 offsets, or fail to catch `RangeError` from `DataView` reads.
 2. **Review**: Ensure implemented code follows architectural constraints (especially ADR 001).
 3. **Approval/Rejection**: If the implementation is valid, approve it. If not, detail what is missing or incorrect according to the contract and architecture.
 4. **Specify Results**: Explicitly specify the results of your validation work. Depending on the scope and need for further analysis, this output can include new tests, documentation updates, or the creation of new tasks, stories, PRDs, or ideas.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -8,9 +8,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 2.  **Adhere to Architecture Decisions**: You must be intimately familiar with and strictly follow the rules defined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`. Ensure that your blueprints align with this core architecture.
 3.  **Draft Technical Blueprints**: Take the requirements defined in a STORY and break them down into specific, actionable technical TASK nodes. If multiple tasks are created and one depends on the implementation details of another, you MUST explicitly set the `depends_on` field of the dependent task to point to the prerequisite task to prevent DAG deadlocks.
 4.  **Define Clear Contracts**: Your tasks should serve as a clear contract for the Coder. Include necessary context, constraints, and acceptance criteria.
-    - When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
-    - When drafting blueprints for Gen 3 save file parsing, explicitly require that the Coder uses the resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
-    - When drafting blueprints for save file parsing, explicitly require that the Coder must catch `RangeError` from out-of-bounds `DataView` reads and throw a new error with the message "The save file is corrupted or incomplete."
+    - When drafting blueprints for save file parsing, explicitly enforce the Save File Parsing rules defined in `core_policies.md`.
 5.  **Intelligent Verification Protocol**: Intelligently decide when a STORY requires a separate QA verification task:
     - If a story involves complex logic or risk, create a matching TASK for the `qa` persona to verify the `coder`'s work.
     - If simple/low-risk, designate the `coder` to self-verify (documented in the task journal).

--- a/.jules/strategist/2026-08-09-prompt-consolidation-save-parsing.md
+++ b/.jules/strategist/2026-08-09-prompt-consolidation-save-parsing.md
@@ -1,0 +1,5 @@
+## 2026-08-09 - [Accepted] - Prompt improvement - Consolidate Save Parsing Rules
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The prompt files for `coder`, `qa`, and `tech_lead` all contained duplicated and verbose instructions regarding save file parsing (magic numbers, `RangeError` bounds checking, relative Gen 3 offsets, bitwise mapping). This duplicated context consumes token windows and makes it harder to update rules consistently.
+**Pattern:** Centralize widely-shared, verbose rules (like save parsing and DataView constraints) into `core_policies.md` and instruct personas to reference them there, rather than repeating the full paragraphs in every individual agent prompt.


### PR DESCRIPTION
**Proposal:** Consolidate duplicated save file parsing rules into `core_policies.md`.
**Justification:** The `coder`, `qa`, and `tech_lead` prompts all contained lengthy, duplicated instructions for parsing save files (e.g., catching `RangeError`, using relative offsets for Gen 3, defining magic numbers as module-level constants). This bloats the prompts and makes updating the rules error-prone.
**Evidence:** The duplicated paragraphs were present in `.github/agents/coder.md`, `.github/agents/qa.md`, and `.github/agents/tech_lead.md`. By centralizing them in `.foundry/docs/knowledge_base/agents/core_policies.md`, we ensure all agents operate from a single source of truth.

---
*PR created automatically by Jules for task [11916631329081872099](https://jules.google.com/task/11916631329081872099) started by @szubster*