### PR TITLE
Empty PR to transition epic-057-127-bash-timeout-wrapper

### DIFF
--- a/.foundry/journals/story_owner/8656734789421139177.md
+++ b/.foundry/journals/story_owner/8656734789421139177.md
@@ -1,0 +1,4 @@
+
+## 2026-07-25
+* Task: epic-057-127-bash-timeout-wrapper
+* Action: Submitted empty PR to transition the epic since all child stories are already completed and their acceptance criteria were checked.


### PR DESCRIPTION
Submitting an empty PR as Story Owner for `epic-057-127-bash-timeout-wrapper` because all of its child stories (`story-127-267-bash-timeout-wrapper` and `story-127-268-bash-timeout-feedback`) are already completed and the acceptance criteria in the markdown body have been checked. This will allow the orchestrator to advance the epic to `VERIFYING` state.

---
*PR created automatically by Jules for task [8656734789421139177](https://jules.google.com/task/8656734789421139177) started by @szubster*