### PR TITLE
Epic Planner: Demote PRD 057

### DIFF
--- a/.foundry/journals/epic_planner/13025108147948745503.md
+++ b/.foundry/journals/epic_planner/13025108147948745503.md
@@ -1,0 +1,3 @@
+# Session 13025108147948745503
+
+The PRD `prd-095-057-prevent-blocking-bash-commands` already has pending child epics (`epic-057-127-bash-timeout-wrapper` and `epic-057-128-bash-static-analysis-linter`) explicitly drafted in its markdown body from a previous iteration. Following the Late-Binding Orchestrator Demotion Compliance Rule, I am submitting an empty PR without checking off the overarching acceptance criteria. This empty PR is due to pre-existing completion and will allow the orchestrator to correctly demote the parent PRD to PENDING while it waits for its children.


### PR DESCRIPTION
Submitting empty PR to allow the orchestrator to demote PRD 095-057 to PENDING since child Epics already exist.

---
*PR created automatically by Jules for task [13326051968210875270](https://jules.google.com/task/13326051968210875270) started by @szubster*