### PR TITLE
📜 Epic Planner: Add Gen 3 Trainer Data Extraction Epic

### DIFF
--- a/.foundry/epics/epic-099-346-gen3-trainer-data-extraction.md
+++ b/.foundry/epics/epic-099-346-gen3-trainer-data-extraction.md
@@ -1,15 +1,15 @@
 ---
-id: prd-082-099-gen3-trainer-data-extraction
-type: PRD
+id: epic-099-346-gen3-trainer-data-extraction
+type: EPIC
 title: Gen 3 Trainer Data Extraction
-status: ACTIVE
-owner_persona: epic_planner
-created_at: '2026-07-01'
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-25'
 updated_at: '2026-07-25'
 depends_on: []
-jules_session_id: '1822128316479176715'
+jules_session_id: null
 pr_number: null
-parent: idea-082-gen3-secret-id-shiny-rng
+parent: prd-082-099-gen3-trainer-data-extraction
 tags:
   - feature
   - gen3
@@ -19,17 +19,17 @@ rejection_count: 0
 rejection_reason: ''
 notes: ''
 ---
+
 # Gen 3 Trainer Data Extraction
 
 ## Objective
-Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file and display it in the application.
+Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file.
 
 ## Requirements
 - Identify memory offsets for Trainer ID, and Secret ID in a save file.
 - Update the relevant interface to include Secret ID.
 - Implement extraction logic in `src/engine/saveParser/parsers/gen3.ts`.
+- Include E2E/integration testing to ensure reliability and correct rendering.
 
 ## Acceptance Criteria
-- [x] Epic Planner: Convert this PRD into Epics.
-- [ ] epic-099-130-gen3-trainer-data-extraction
-- [ ] epic-099-346-gen3-trainer-data-extraction
+- [ ] Story Owner: Convert this Epic into Stories.

--- a/.foundry/journals/epic_planner/1822128316479176715.md
+++ b/.foundry/journals/epic_planner/1822128316479176715.md
@@ -1,0 +1,17 @@
+# 1822128316479176715 - Epic Planner Journal
+- I am reviewing the PRD `prd-082-099-gen3-trainer-data-extraction.md`.
+- It seems there was already an epic `epic-099-130-gen3-trainer-data-extraction.md` created for this PRD.
+- However, the epic is marked as `FAILED` with a `rejection_reason`: "[ACKNOWLEDGED] Merged with unfulfilled acceptance criteria: Missing E2E/integration story".
+- My task is to fix this by creating a new Epic or modifying the PRD to create an Epic that includes an E2E/integration story, or to create another epic specifically for E2E testing to fulfill the PRD requirements.
+- The PRD acceptance criteria has `- [ ] epic-099-130-gen3-trainer-data-extraction`, but I should create a new epic that satisfies the missing E2E story requirement. Let's create `epic-099-339-gen3-trainer-data-extraction-e2e.md` (338 is the highest in my `ls -1 .foundry/epics/ | tail -n 10` but `epic-120-338-implement-conflictless-journals.md` exists).
+Wait, looking at `epic-099-130-gen3-trainer-data-extraction.md`, the AC has:
+`- [x] story-130-269-extract-gen3-trainer-id-secret-id`
+I'll create a new Epic to represent the missing E2E integration, or recreate/supersede the failed epic. Actually, the prompt says "Your core responsibility is transforming a Product Requirements Document (PRD) into detailed EPIC breakdowns." Since the existing epic failed due to "Missing E2E/integration story", I should create a new epic specifically for the E2E story (or update the PRD to point to a new comprehensive epic). Wait, the PRD acceptance criteria is:
+`- [ ] epic-099-130-gen3-trainer-data-extraction`
+I must check off `- [ ] epic-099-130-gen3-trainer-data-extraction` in the PRD, but the prompt says: "When applying the Empty PR policy for completed macro nodes (e.g., Epics with already archived children), ensure your journal entry explicitly states that you are submitting an empty PR due to pre-existing completion. Do not claim to have created new files, as automated reviewers will fail the PR for missing artifacts."
+
+Ah, the PRD's AC has `- [ ] epic-099-130-gen3-trainer-data-extraction`. The epic exists but failed.
+If I need to fix the failure, I should create a new EPIC for the E2E testing.
+Let's see what the rejection reason in `epic-099-130-gen3-trainer-data-extraction.md` says: `[ACKNOWLEDGED] Merged with unfulfilled acceptance criteria: Missing E2E/integration story`
+
+Let's write a new epic `epic-099-339-gen3-trainer-data-extraction-e2e.md`.


### PR DESCRIPTION
Creates a new `epic-099-346-gen3-trainer-data-extraction.md` for Gen 3 Trainer Data Extraction that includes requirements for E2E testing, replacing the previous failed epic.
Appends this new epic to the original PRD (`prd-082-099-gen3-trainer-data-extraction.md`) acceptance criteria without modifying the YAML frontmatter.

---
*PR created automatically by Jules for task [1822128316479176715](https://jules.google.com/task/1822128316479176715) started by @szubster*