### PR TITLE
feat(saveParser): Update Gen 2 event flag offsets

### DIFF
--- a/.foundry/journals/coder/14037663772721128626.md
+++ b/.foundry/journals/coder/14037663772721128626.md
@@ -1,0 +1,14 @@
+# Coder Journal - Session 14037663772721128626
+
+## Pattern Observed: Gen 2 Event Flag Parsing
+
+When extracting event flag constants from the Pokécrystal source code (`constants/event_flags.asm`), we MUST NOT use line numbers as bit indices, because the assembly uses macros (like `const_skip`, `const_def`) to dynamically advance the constant counter. Instead, we must use the true parsed bit values explicitly.
+
+For the static encounters:
+- `EVENT_FOUGHT_SUDOWOODO` = 42
+- `EVENT_FOUGHT_HO_OH` = 791
+- `EVENT_FOUGHT_LUGIA` = 792
+- `EVENT_FOUGHT_SNORLAX` = 1872
+- `EVENT_LAKE_OF_RAGE_RED_GYARADOS` = 1873
+
+Also, under ADR 028, we must strictly define all offsets, lengths (such as `EVENT_FLAGS_LENGTH = 0x100`), and bit locations as reusable constants at the module level. Inline magic numbers are not allowed.

--- a/.foundry/tasks/task-137-338-gen2-event-flag-parsing-retry-impl.md
+++ b/.foundry/tasks/task-137-338-gen2-event-flag-parsing-retry-impl.md
@@ -36,6 +36,6 @@ Implement the extraction of Gen 2 event flags from the save file.
 - Ensure appropriate RangeError handling for DataView operations.
 
 ## Acceptance Criteria
-- [ ] Implement Gen 2 event flag extraction using the specified bit offsets.
-- [ ] Define all memory offsets and bit locations as reusable constants at the module level (no magic numbers).
-- [ ] Expose the extracted flags to the state management layer.
+- [x] Implement Gen 2 event flag extraction using the specified bit offsets.
+- [x] Define all memory offsets and bit locations as reusable constants at the module level (no magic numbers).
+- [x] Expose the extracted flags to the state management layer.

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -34,16 +34,18 @@ const EVENT_FLAGS_OFFSET_GS = 0x2624;
 const DAYCARE_EGG_FLAG_OFFSET_CRYSTAL = 0x282b;
 const DAYCARE_EGG_FLAG_MASK = 0x01;
 
-const EVENT_FLAG_SUDOWOODO_BYTE = Math.floor(51 / 8);
-const EVENT_FLAG_SUDOWOODO_BIT = 51 % 8;
-const EVENT_FLAG_HO_OH_BYTE = Math.floor(470 / 8);
-const EVENT_FLAG_HO_OH_BIT = 470 % 8;
-const EVENT_FLAG_LUGIA_BYTE = Math.floor(471 / 8);
-const EVENT_FLAG_LUGIA_BIT = 471 % 8;
-const EVENT_FLAG_SNORLAX_BYTE = Math.floor(1326 / 8);
-const EVENT_FLAG_SNORLAX_BIT = 1326 % 8;
-const EVENT_FLAG_RED_GYARADOS_BYTE = Math.floor(1327 / 8);
-const EVENT_FLAG_RED_GYARADOS_BIT = 1327 % 8;
+const EVENT_FLAG_SUDOWOODO_BYTE = Math.floor(42 / 8);
+const EVENT_FLAG_SUDOWOODO_BIT = 42 % 8;
+const EVENT_FLAG_HO_OH_BYTE = Math.floor(791 / 8);
+const EVENT_FLAG_HO_OH_BIT = 791 % 8;
+const EVENT_FLAG_LUGIA_BYTE = Math.floor(792 / 8);
+const EVENT_FLAG_LUGIA_BIT = 792 % 8;
+const EVENT_FLAG_SNORLAX_BYTE = Math.floor(1872 / 8);
+const EVENT_FLAG_SNORLAX_BIT = 1872 % 8;
+const EVENT_FLAG_RED_GYARADOS_BYTE = Math.floor(1873 / 8);
+const EVENT_FLAG_RED_GYARADOS_BIT = 1873 % 8;
+
+const EVENT_FLAGS_LENGTH = 0x100;
 
 const CAUGHT_TIME_MASK = 0xc0;
 const CAUGHT_TIME_SHIFT = 6;
@@ -689,9 +691,9 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
   const roamingLegendaries = parseRoamingLegendaries(view, isCrystal);
 
   const eventFlagsOffset = isCrystal ? EVENT_FLAGS_OFFSET_CRYSTAL : EVENT_FLAGS_OFFSET_GS;
-  const eventFlags = new Uint8Array(0x100);
+  const eventFlags = new Uint8Array(EVENT_FLAGS_LENGTH);
   try {
-    for (let i = 0; i < 0x100; i++) {
+    for (let i = 0; i < EVENT_FLAGS_LENGTH; i++) {
       eventFlags[i] = view.getUint8(eventFlagsOffset + i);
     }
   } catch (error) {

--- a/src/engine/saveParser/parsers/gen2_encounter_flags.test.ts
+++ b/src/engine/saveParser/parsers/gen2_encounter_flags.test.ts
@@ -14,10 +14,10 @@ describe('Gen 2 Static Encounter Flags', () => {
     // Offset for Event Flags in GS is 0x2624
     const offset = 0x2624;
 
-    const EVENT_FLAG_SUDOWOODO_BYTE = Math.floor(51 / 8);
-    const EVENT_FLAG_SUDOWOODO_BIT = 51 % 8;
-    const EVENT_FLAG_HO_OH_BYTE = Math.floor(470 / 8);
-    const EVENT_FLAG_HO_OH_BIT = 470 % 8;
+    const EVENT_FLAG_SUDOWOODO_BYTE = Math.floor(42 / 8);
+    const EVENT_FLAG_SUDOWOODO_BIT = 42 % 8;
+    const EVENT_FLAG_HO_OH_BYTE = Math.floor(791 / 8);
+    const EVENT_FLAG_HO_OH_BIT = 791 % 8;
 
     // Set Sudowoodo (byte 6, bit 3)
     view.setUint8(offset + EVENT_FLAG_SUDOWOODO_BYTE, 1 << EVENT_FLAG_SUDOWOODO_BIT);


### PR DESCRIPTION
Implement the extraction of Gen 2 event flags using correct bit offsets per research-137-330. 

Adheres to ADR 028 by using explicitly defined module-level constants for all memory offsets, lengths, and bit locations instead of inline magic numbers. RangeError handling remains intact. Tests are updated to pass with the new offsets. Checked off acceptance criteria in task node markdown.

---
*PR created automatically by Jules for task [14037663772721128626](https://jules.google.com/task/14037663772721128626) started by @szubster*