### PR TITLE
Tech Lead: Blueprint E2E Safeguard Tasks

### DIFF
--- a/.foundry/journals/tech_lead/14162838589507285272.md
+++ b/.foundry/journals/tech_lead/14162838589507285272.md
@@ -1,0 +1,4 @@
+# Tech Lead Journal
+Session: 14162838589507285272
+
+Drafted technical blueprints (`task-269-346-e2e-safeguard-impl` and `task-269-347-e2e-safeguard-qa`) to fulfill the requirements of `story-127-269-epic-e2e-safeguard`. Appended these new tasks as unchecked checkboxes in the parent story node. I noticed there are older task iterations in the list (`task-269-334` etc.), so I simply appended the new ones to the end of the Acceptance Criteria list without checking off any logic myself.

--- a/.foundry/stories/story-127-269-epic-e2e-safeguard.md
+++ b/.foundry/stories/story-127-269-epic-e2e-safeguard.md
@@ -33,6 +33,8 @@ Implement logic in `.github/scripts/foundry-orchestrator.ts` (or `foundry-heartb
 - [ ] task-269-334-e2e-safeguard-impl
 - [x] task-269-270-e2e-safeguard-qa
 - [ ] task-269-335-e2e-safeguard-qa
+- [ ] task-269-346-e2e-safeguard-impl
+- [ ] task-269-347-e2e-safeguard-qa
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/tasks/task-269-346-e2e-safeguard-impl.md
+++ b/.foundry/tasks/task-269-346-e2e-safeguard-impl.md
@@ -1,0 +1,57 @@
+---
+id: task-269-346-e2e-safeguard-impl
+type: TASK
+title: Implement E2E Safeguards on Epics
+status: READY
+owner_persona: coder
+created_at: '2026-07-25'
+updated_at: '2026-07-25'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-127-269-epic-e2e-safeguard
+tags:
+  - process
+  - orchestrator
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement E2E Safeguards on Epics
+
+## Context
+As part of enforcing macro node functional boundaries, we need to ensure that an EPIC cannot be marked `COMPLETED` until its functional requirements are verifiably integrated and tested.
+
+## Goal
+Implement logic in `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts` to ensure that an EPIC node cannot be promoted to `VERIFYING` or `COMPLETED` unless it contains at least one child STORY that explicitly represents integration or E2E testing (e.g., tags contain `e2e` or `integration`).
+
+## Technical Blueprint
+
+1. **Modify `foundry-orchestrator.ts`:**
+   - In **Phase 4.1: Late-Binding Completion**, before transitioning a late-binding parent to `COMPLETED` when all children are completed, check if the node `type` is `EPIC`.
+   - If it is an `EPIC`, iterate over its children and ensure at least one child node has `type` equal to `STORY` and its `tags` array contains either `'e2e'` or `'integration'` (case-insensitive).
+   - If the E2E requirement is not met, do NOT transition the EPIC to `COMPLETED`. Instead, transition it to `FAILED` with a `rejection_reason` indicating that an E2E/integration story is missing (e.g., `'Merged with unfulfilled acceptance criteria: Missing E2E/integration story'`).
+   - In **Phase 4.5: Idempotent Generation Check**, ensure similar logic applies if an EPIC is being bypassed to `COMPLETED`. However, if the EPIC does not generate children, the check might fail it. Make sure the logic appropriately flags EPICs that lack E2E stories.
+
+2. **Modify `foundry-heartbeat.ts`:**
+   - In the `transitionNodeToCompleted` function, before transitioning an `EPIC` to `VERIFYING`, perform the same check.
+   - Fetch the child nodes for the `EPIC`. If none of its children are a `STORY` with an `e2e` or `integration` tag, transition the node to `FAILED` with a similar `rejection_reason`.
+
+3. **Add Unit Tests:**
+   - In `foundry-orchestrator.test.ts`, add test cases demonstrating that an `EPIC` fails Late-Binding Completion if it lacks an E2E/integration child story, and succeeds when it has one.
+   - In `foundry-heartbeat.test.ts`, add test cases demonstrating that `transitionNodeToCompleted` transitions an `EPIC` to `FAILED` instead of `VERIFYING` if it lacks an E2E/integration child story, and succeeds when it has one.
+
+## Workflow Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Implement E2E enforcement logic in `foundry-orchestrator.ts` (Phase 4.1 / 4.5).
+- [ ] Implement E2E enforcement logic in `foundry-heartbeat.ts` (`transitionNodeToCompleted`).
+- [ ] Add unit tests in `foundry-orchestrator.test.ts` covering the new rules for EPICs.
+- [ ] Add unit tests in `foundry-heartbeat.test.ts` covering the new rules for EPICs.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/tasks/task-269-347-e2e-safeguard-qa.md
+++ b/.foundry/tasks/task-269-347-e2e-safeguard-qa.md
@@ -1,0 +1,56 @@
+---
+id: task-269-347-e2e-safeguard-qa
+type: TASK
+title: QA - Implement E2E Safeguards on Epics
+status: READY
+owner_persona: qa
+created_at: '2026-07-25'
+updated_at: '2026-07-25'
+depends_on:
+  - task-269-346-e2e-safeguard-impl
+jules_session_id: null
+pr_number: null
+parent: story-127-269-epic-e2e-safeguard
+tags:
+  - process
+  - orchestrator
+  - qa
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA - Implement E2E Safeguards on Epics
+
+## Context
+As part of enforcing macro node functional boundaries, we need to ensure that an EPIC cannot be marked `COMPLETED` until its functional requirements are verifiably integrated and tested. The implementation task (`task-269-346-e2e-safeguard-impl`) is responsible for adding this logic to `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts`.
+
+## Goal
+Verify the implementation of E2E safeguards on Epic nodes.
+
+## Technical Blueprint
+
+1. **Verify Implementation:**
+   - Check that `foundry-orchestrator.ts` has been modified to enforce the E2E story rule for `EPIC` nodes during Phase 4.1 and Phase 4.5.
+   - Check that `foundry-heartbeat.ts` has been modified to enforce the E2E story rule for `EPIC` nodes during `transitionNodeToCompleted`.
+   - Ensure the rejection reason is clear and descriptive (e.g., `'Merged with unfulfilled acceptance criteria: Missing E2E/integration story'`).
+
+2. **Verify Tests:**
+   - Review `foundry-orchestrator.test.ts` to confirm there are new test cases for an `EPIC` with and without an E2E child story.
+   - Review `foundry-heartbeat.test.ts` to confirm there are new test cases for an `EPIC` with and without an E2E child story.
+   - Run the tests locally to ensure they pass: `cd .github/scripts && pnpm install && npx vitest run`.
+
+## Workflow Reminders
+- If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## Acceptance Criteria
+- [ ] Verify E2E enforcement logic in `foundry-orchestrator.ts`.
+- [ ] Verify E2E enforcement logic in `foundry-heartbeat.ts`.
+- [ ] Verify unit tests in `foundry-orchestrator.test.ts`.
+- [ ] Verify unit tests in `foundry-heartbeat.test.ts`.
+- [ ] Ensure all unit tests pass successfully.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Drafted technical blueprints (task-269-346 and task-269-347) for enforcing E2E safeguards on Epic nodes. Appended references to the new task nodes as unchecked checkboxes in the parent story node.

---
*PR created automatically by Jules for task [8216856509574027356](https://jules.google.com/task/8216856509574027356) started by @szubster*