### PR TITLE
🧩 Tech Lead: Blueprints for Gen 3 Static Encounters Parsing

### DIFF
--- a/.foundry/journals/tech_lead/13196900096244356753.md
+++ b/.foundry/journals/tech_lead/13196900096244356753.md
@@ -1,0 +1,2 @@
+
+## 2026-07-25 - Drafted technical blueprints for Gen 3 static encounters parsing (tasks 346 and 347) and appended them to story 138-294.

--- a/.foundry/stories/story-138-294-gen3-static-encounters-parsing.md
+++ b/.foundry/stories/story-138-294-gen3-static-encounters-parsing.md
@@ -31,3 +31,5 @@ Implement the save block extraction logic for Gen 3 event flags related to stati
 - [ ] Follow dynamic save block extraction guidelines (ADR 028).
 - [ ] task-294-331-gen3-static-encounter-flags-impl
 - [ ] task-294-332-gen3-static-encounter-flags-qa
+- [ ] task-294-346-gen3-static-encounter-flags-impl
+- [ ] task-294-347-gen3-static-encounter-flags-qa

--- a/.foundry/tasks/task-294-346-gen3-static-encounter-flags-impl.md
+++ b/.foundry/tasks/task-294-346-gen3-static-encounter-flags-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-294-346-gen3-static-encounter-flags-impl
+type: TASK
+title: Implement Gen 3 Static Encounter Flags Parsing
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-25'
+updated_at: '2026-07-25'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-106-138-gen3-static-encounters
+tags:
+  - gen3
+  - feature
+  - parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Gen 3 Static Encounter Flags Parsing
+
+Implement `extractGen3StaticEncounterFlags` function using DataView API to extract event flags starting at `0x1270` within `SaveBlock1`.
+
+## Context
+
+According to ADR 028 and the knowledge base, Gen 3 save extraction must use relative offsets using the parsed `section1Offset`. All offsets and bit masks must be explicitly defined as reusable constants at the module level. Inline magic numbers are forbidden.
+Furthermore, the `RangeError` from the DataView API must be gracefully handled to throw exactly "The save file is corrupted or incomplete."
+Implement parsing for Emerald, FireRed/LeafGreen, and Ruby/Sapphire based on `.foundry/docs/knowledge_base/gen3_static_encounters/gen3_static_encounter_offsets.md`.
+
+## Acceptance Criteria
+- [ ] Ensure `src/engine/gen3/staticEncounters.ts` meets the criteria.
+- [ ] Define module-level constants for all event flags and bit positions.
+- [ ] Implement `extractGen3StaticEncounterFlags` mapping DataView to flags boolean state.
+- [ ] Follow ADR 028: No magic numbers. Use relative offsets `section1Offset + EVENT_FLAGS_START + BYTE_OFFSET`.
+- [ ] Handle `RangeError` and re-throw with "The save file is corrupted or incomplete."
+- [ ] Write tests ensuring offsets are parsed correctly and RangeError is handled.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/tasks/task-294-347-gen3-static-encounter-flags-qa.md
+++ b/.foundry/tasks/task-294-347-gen3-static-encounter-flags-qa.md
@@ -1,0 +1,32 @@
+---
+id: task-294-347-gen3-static-encounter-flags-qa
+type: TASK
+title: QA Gen 3 Static Encounter Flags Parsing
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-25'
+updated_at: '2026-07-25'
+depends_on:
+  - task-294-346-gen3-static-encounter-flags-impl
+jules_session_id: null
+pr_number: null
+parent: epic-106-138-gen3-static-encounters
+tags:
+  - gen3
+  - feature
+  - parsing
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Gen 3 Static Encounter Flags Parsing
+
+Verify the implementation of `extractGen3StaticEncounterFlags`.
+
+## Acceptance Criteria
+- [ ] Verify that all offsets and bit masks are module-level constants. No inline magic numbers.
+- [ ] Verify that DataView API `RangeError` is handled properly and throws "The save file is corrupted or incomplete."
+- [ ] Verify that relative offset calculations (`section1Offset + EVENT_FLAGS_START + offset`) are correctly applied.


### PR DESCRIPTION
Created technical blueprints (tasks 346 and 347) for parsing Gen 3 static encounter event flags, enforcing relative offsets (ADR 028) and RangeError handling. Updated story 138-294.

---
*PR created automatically by Jules for task [13196900096244356753](https://jules.google.com/task/13196900096244356753) started by @szubster*