### PR TITLE
QA: Re-implement DAG Data Parsing for Rejection Count

### DIFF
--- a/.foundry/journals/qa/10411185586999946812.md
+++ b/.foundry/journals/qa/10411185586999946812.md
@@ -1,0 +1,10 @@
+# Session 10411185586999946812
+
+## Empty PR Submission
+Due to the pre-existing completion of the task node, I have submitted an empty PR to safely complete `task-085-257-qa-extract-rejection-count-retry`. No actual codebase artifacts were created, modified or deleted.
+
+## Actions Taken
+- Explored codebase (`src/components/dashboard/DagContext.tsx`, `src/utils/dag/builder.ts`).
+- Confirmed `rejection_count` is correctly parsed from nodes, exposed by `DagContext` and properly loaded/used.
+- Re-ran the tests to confirm success.
+- Modified `.foundry/tasks/task-085-257-qa-extract-rejection-count-retry.md` to mark the acceptance criteria as completed (via `[x]`).

--- a/.foundry/tasks/task-085-257-qa-extract-rejection-count-retry.md
+++ b/.foundry/tasks/task-085-257-qa-extract-rejection-count-retry.md
@@ -33,7 +33,7 @@ This is a verification task for `task-085-256-impl-extract-rejection-count-retry
 1. Verify context layer broadcasts `rejection_count`.
 
 ## Acceptance Criteria
-- [ ] QA: Verify context layer broadcasts `rejection_count`.
+- [x] QA: Verify context layer broadcasts `rejection_count`.
 
 ## Reminders
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` with a `rejection_reason`.


### PR DESCRIPTION
Verified that the rejection_count property is accurately extracted and broadcasted by the DagContext.

---
*PR created automatically by Jules for task [10411185586999946812](https://jules.google.com/task/10411185586999946812) started by @szubster*