### PR TITLE
feat: implement Gen 3 FRLG Move Tutor extraction

### DIFF
--- a/.foundry/journals/coder/15887075026124936146.md
+++ b/.foundry/journals/coder/15887075026124936146.md
@@ -1,0 +1,5 @@
+# Coder Session 15887075026124936146
+
+Target artifact for `task-318-341-gen3-move-tutor-frlg-parsing-impl` is already complete. `parseGen3FRLGMoveTutors` function and tests are already present in `src/engine/saveParser/parsers/gen3.ts` and `src/engine/saveParser/parsers/gen3.test.ts`.
+
+Submitting an empty PR due to pre-existing completion.

--- a/.foundry/tasks/task-318-341-gen3-move-tutor-frlg-parsing-impl.md
+++ b/.foundry/tasks/task-318-341-gen3-move-tutor-frlg-parsing-impl.md
@@ -38,7 +38,7 @@ As defined in `gen3_move_tutor_offsets.md` and mandated by ADR 010 and ADR 028:
 - The use of inline magic numbers for memory operations is strictly forbidden.
 
 ## Acceptance Criteria
-- [ ] Implement `DataView` parsing logic for FRLG move tutors.
-- [ ] Define all offsets, flags, and constants at the module level (no inline magic numbers).
-- [ ] Use relative memory offsets from the resolved section offset.
-- [ ] Throw and catch `RangeError` on invalid bounds gracefully.
+- [x] Implement `DataView` parsing logic for FRLG move tutors.
+- [x] Define all offsets, flags, and constants at the module level (no inline magic numbers).
+- [x] Use relative memory offsets from the resolved section offset.
+- [x] Throw and catch `RangeError` on invalid bounds gracefully.


### PR DESCRIPTION
Empty PR. The Gen 3 FRLG Move Tutor extraction has already been implemented in a previous iteration. Checked off the acceptance criteria in the task node.

---
*PR created automatically by Jules for task [15887075026124936146](https://jules.google.com/task/15887075026124936146) started by @szubster*