### PR TITLE
✅ QA: Approved Gen 3 FRLG Move Tutor implementation

### DIFF
--- a/.foundry/journals/qa/5216732828107445733.md
+++ b/.foundry/journals/qa/5216732828107445733.md
@@ -1,0 +1,8 @@
+# QA Session 5216732828107445733
+
+- Validated task-318-341-gen3-move-tutor-frlg-parsing-impl
+- Confirmed FRLG move tutor extraction exclusively uses DataView.
+- Confirmed no inline magic numbers (all constants mapped correctly at module level).
+- Confirmed relative offsets are used (calculated from section2Offset + GEN3_EVENT_FLAGS_OFFSET).
+- Confirmed RangeError bounds checking handles corrupted files appropriately.
+- Approved task.

--- a/.foundry/tasks/task-318-342-gen3-move-tutor-frlg-parsing-qa.md
+++ b/.foundry/tasks/task-318-342-gen3-move-tutor-frlg-parsing-qa.md
@@ -36,6 +36,6 @@ You must verify the implementation from `task-318-341-gen3-move-tutor-frlg-parsi
 - Relative offsets calculated from the resolved section offset are used (ADR 028).
 
 ## Acceptance Criteria
-- [ ] Verify `DataView` is used exclusively for FRLG move tutor extraction.
-- [ ] Verify there are NO inline magic numbers for memory offsets.
-- [ ] Verify the parser relies on `DataView` bounds checking to fail gracefully on corrupted files.
+- [x] Verify `DataView` is used exclusively for FRLG move tutor extraction.
+- [x] Verify there are NO inline magic numbers for memory offsets.
+- [x] Verify the parser relies on `DataView` bounds checking to fail gracefully on corrupted files.


### PR DESCRIPTION
The implementation strictly adhered to all ADRs, used relative offsets, defined constants, exclusively used DataView, and caught RangeError appropriately.

---
*PR created automatically by Jules for task [5216732828107445733](https://jules.google.com/task/5216732828107445733) started by @szubster*