### PR TITLE
⚡ Bolt: Memoize versionEnc to prevent unneeded array allocations

### DIFF
--- a/src/components/pokemon/details/PokemonLocations.tsx
+++ b/src/components/pokemon/details/PokemonLocations.tsx
@@ -10,6 +10,7 @@ import {
   Trees,
   Waves,
 } from 'lucide-react';
+import { useMemo } from 'react';
 import type { CompactEncounter, CompactEncounterDetail } from '../../../db/schema';
 import { POKE_VERSION_MAP, REVERSE_METHOD_MAP } from '../../../db/schema';
 import { isValidStaticGameVersion, staticEncounters } from '../../../engine/data/shared/staticData';
@@ -47,7 +48,8 @@ export function PokemonLocations({
 }: PokemonLocationsProps) {
   const currentVersionId = POKE_VERSION_MAP[gameVersion.toLowerCase()];
   const staticEnc = isValidStaticGameVersion(gameVersion) ? staticEncounters[pokemonId]?.[gameVersion] : undefined;
-  const versionEnc = encounters.filter((e) => e.v === currentVersionId);
+  // ⚡ Bolt: Memoize versionEnc filtering to prevent unneeded array allocations on every render
+  const versionEnc = useMemo(() => encounters.filter((e) => e.v === currentVersionId), [encounters, currentVersionId]);
   const hasEncounters = (staticEnc && staticEnc.length > 0) || versionEnc.length > 0 || evoReq;
 
   return (


### PR DESCRIPTION
💡 What: Memoized the filtering of `encounters` based on `currentVersionId` in `PokemonLocations`.
🎯 Why: Prevents creating a new array on every render, saving unnecessary object allocations and avoiding potential downstream re-renders.
📊 Measured Improvement: Avoids O(N) intermediate array creation every time `PokemonLocations` (or its parent `PokemonDetails`) re-renders without `encounters` or `gameVersion` changing.
How to Verify: Open a Pokemon's details modal, toggle between versions or open catching hints. The application should behave exactly identically, but `versionEnc` will only be recalculated when the underlying data changes.

---
*PR created automatically by Jules for task [3301150046362702509](https://jules.google.com/task/3301150046362702509) started by @szubster*