### PR TITLE
🧹 fix: remove non-existent test-setup from knip ignore

### DIFF
--- a/.jules/sweeper/remove-test-setup-knip-fix.md
+++ b/.jules/sweeper/remove-test-setup-knip-fix.md
@@ -1,0 +1,5 @@
+# Sweeper Run Journal
+
+## Learnings
+* **Implicit File Dependencies (`test-setup.ts`)**: I initially removed `src/test-setup.ts` without fully reading the context and ignored the warning that test setups implicitly depend on files (even if `knip` flagged it as unused). After realizing the test-suite failure, I investigated its usages and removed it from `knip.json` safely without deleting the actual environment configuration.
+* **Knip Error Fixing**: `knip` will surface errors if files in its `ignore` block do not exist. Therefore, we should only clean it up.


### PR DESCRIPTION
🎯 What
Removed the non-existent `src/test-setup.ts` file from `knip.json`'s ignore list.

💡 Why
`pnpm knip` was throwing errors indicating that a file configured in `ignore` (`src/test-setup.ts`) could not be found, causing CI and code-health checks to fail.

✅ Verification
Ran `pnpm knip` to verify the configuration no longer errors out on the missing file. Ran `pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e` to verify no existing configurations are broken.

✨ Result
`knip` now successfully passes without complaining about non-existent files.

---
*PR created automatically by Jules for task [11865214705936785254](https://jules.google.com/task/11865214705936785254) started by @szubster*