### PR TITLE
Story Owner: Create circular dependency detection story

### DIFF
--- a/.foundry/journals/story_owner/2610669616610393911.md
+++ b/.foundry/journals/story_owner/2610669616610393911.md
@@ -1,0 +1,5 @@
+# Journal - Story Owner
+Session: 2610669616610393911
+
+- Created new STORY node `.foundry/stories/story-338-336-implement-orchestrator-cycle-detection.md` to implement circular dependency detection for the DAG Orchestrator.
+- Did not modify the parent epic's YAML frontmatter. Left acceptance criteria checkbox for this story UNCHECKED in the Epic body because the child node is still PENDING.

--- a/.foundry/stories/story-338-336-implement-orchestrator-cycle-detection.md
+++ b/.foundry/stories/story-338-336-implement-orchestrator-cycle-detection.md
@@ -1,0 +1,30 @@
+---
+id: story-338-336-implement-orchestrator-cycle-detection
+type: STORY
+title: 'Story: Implement Orchestrator Cycle Detection'
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-26'
+updated_at: '2026-07-26'
+depends_on: []
+jules_session_id: null
+parent: epic-334-338-circular-dependency-detection
+tags:
+  - foundry
+  - orchestrator
+rejection_count: 0
+rejection_reason: ''
+---
+
+# Story: Implement Orchestrator Cycle Detection
+
+## Overview
+Implement robust circular dependency detection during the MAP or RESOLVE phases of the DAG orchestrator execution in `.github/scripts/foundry-orchestrator.ts`. The orchestrator must properly evaluate all `PENDING` nodes and their `depends_on` relationships to detect cycles (e.g., using a topological sort or DFS with a recursion stack).
+
+## Acceptance Criteria
+- [ ] Orchestrator detects circular dependencies and transitions involved nodes to `FAILED`.
+- [ ] Descriptive `rejection_reason` (e.g., "Circular dependency detected") is appended in the frontmatter of failed nodes.
+- [ ] Running orchestrator in `--dry-run` or `--strict` modes outputs explicit warnings/error logs detailing the detected cycle.
+
+### Generated Tasks
+<!-- Tech lead will append tasks here -->


### PR DESCRIPTION
I've created the STORY node `story-338-336-implement-orchestrator-cycle-detection.md` to map out the implementation for the circular dependency detection feature. I also logged my actions to the `story_owner` journal and left the parent epic's checkbox unchecked, since this child node is still `PENDING`.

---
*PR created automatically by Jules for task [2610669616610393911](https://jules.google.com/task/2610669616610393911) started by @szubster*