### PR TITLE
📝 Tech Lead: Break down Update Runtime Interfaces to Verbose Keys story

### DIFF
--- a/.foundry/journals/tech_lead/5926053002464511574.md
+++ b/.foundry/journals/tech_lead/5926053002464511574.md
@@ -1,0 +1,5 @@
+# Tech Lead Journal Entry - Session 5926053002464511574
+
+Reviewed ADR 015 regarding reverting data optimizations for PokeData.
+Drafted implementation and QA tasks for Story 043-336 to update the runtime interfaces and consumers to expect the new verbose keys (e.g., `n` -> `name`, `cr` -> `captureRate`).
+Utilized the intelligent verification protocol to separate the implementation (coder) and the verification (QA) into separate sequential tasks due to the high risk of widespread changes across application interfaces.

--- a/.foundry/stories/story-043-336-update-runtime-interfaces-keys.md
+++ b/.foundry/stories/story-043-336-update-runtime-interfaces-keys.md
@@ -30,4 +30,6 @@ Implement changes required by ADR 015. Update the runtime interfaces and compone
 
 ## Acceptance Criteria
 - [ ] Implement required application changes.
-- [ ] Break down story into tasks for technical blueprinting and implementation.
+- [x] Break down story into tasks for technical blueprinting and implementation.
+- [ ] task-336-346-update-runtime-interfaces-keys-impl
+- [ ] task-336-347-update-runtime-interfaces-keys-qa

--- a/.foundry/tasks/task-336-346-update-runtime-interfaces-keys-impl.md
+++ b/.foundry/tasks/task-336-346-update-runtime-interfaces-keys-impl.md
@@ -1,0 +1,36 @@
+---
+id: task-336-346-update-runtime-interfaces-keys-impl
+type: TASK
+title: Update Runtime Interfaces to Verbose Keys Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-26'
+updated_at: '2026-07-26'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-043-336-update-runtime-interfaces-keys
+tags:
+  - feature
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Update Runtime Interfaces to Verbose Keys Implementation
+
+## Objective
+Implement changes required by ADR 015. Update the runtime interfaces and components that load the generated PokeData to expect the new verbose property names, replacing the old minified accessors.
+
+## Scope
+- Update `src/db/schema.ts`, `src/db/PokeDB.ts` and associated application interfaces to map correctly to properties like `name`, `captureRate`, `genderRate`, `chance` and others defined in PokeData Property Naming Schema.
+- Update data-consuming components to accurately retrieve the data via the extended, readable keys.
+- Ensure that memory offsets, lengths, bit locations, and shifts for dynamic block extraction (if any) are defined as reusable constants at the module level.
+- Ensure `RangeError` from out-of-bounds `DataView` reads throws a new error with the message "The save file is corrupted or incomplete."
+
+## Acceptance Criteria
+- [ ] Implement verbose property names according to the schema.
+- [ ] Web app renders properly.
+- [ ] Build and tests pass.

--- a/.foundry/tasks/task-336-347-update-runtime-interfaces-keys-qa.md
+++ b/.foundry/tasks/task-336-347-update-runtime-interfaces-keys-qa.md
@@ -1,0 +1,32 @@
+---
+id: task-336-347-update-runtime-interfaces-keys-qa
+type: TASK
+title: Update Runtime Interfaces to Verbose Keys QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-26'
+updated_at: '2026-07-26'
+depends_on:
+  - task-336-346-update-runtime-interfaces-keys-impl
+jules_session_id: null
+pr_number: null
+parent: story-043-336-update-runtime-interfaces-keys
+tags:
+  - qa
+  - feature
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Update Runtime Interfaces to Verbose Keys QA
+
+## Objective
+Verify the implementation of ADR 015, ensuring the application runtime uses verbose keys correctly and all type safety/tests pass.
+
+## Acceptance Criteria
+- [ ] Application compiles without type errors.
+- [ ] Tests and linter pass.
+- [ ] Manual or E2E tests confirm that poke data is successfully loaded from DB and properly hydrated.


### PR DESCRIPTION
This PR breaks down the STORY node `story-043-336-update-runtime-interfaces-keys` into actionable technical tasks.

**Changes:**
- **Implementation Task:** Drafted `task-336-346-update-runtime-interfaces-keys-impl.md` assigning the technical work to the `coder` persona, instructing them to implement the new verbose property names in the application runtime interfaces per ADR 015.
- **QA Task:** Drafted `task-336-347-update-runtime-interfaces-keys-qa.md` assigning verification to the `qa` persona, utilizing the Intelligent Verification Protocol due to the widespread impact of changing core interface keys.
- **Story Update:** Checked off the blueprinting acceptance criteria in the parent STORY node and appended the new unchecked tasks to the list.
- **Journal:** Logged the architectural decisions and verification strategy to the Tech Lead journal.

---
*PR created automatically by Jules for task [5926053002464511574](https://jules.google.com/task/5926053002464511574) started by @szubster*