### PR TITLE
Epic Planner: Handle permanent failure of bash timeout wrapper

### DIFF
--- a/.foundry/epics/epic-057-347-bash-timeout-wrapper-retry.md
+++ b/.foundry/epics/epic-057-347-bash-timeout-wrapper-retry.md
@@ -1,0 +1,31 @@
+---
+id: epic-057-347-bash-timeout-wrapper-retry
+type: EPIC
+title: Timeout Wrapper for Bash Sessions (Retry)
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-26'
+updated_at: '2026-07-26'
+depends_on:
+  - research-057-346-investigate-bash-timeout-failure
+jules_session_id: null
+pr_number: null
+parent: prd-095-057-prevent-blocking-bash-commands
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references:
+  - research-057-346-investigate-bash-timeout-failure
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Timeout Wrapper for Bash Sessions (Retry)
+
+## Overview
+Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that run over a specific threshold (e.g., 30 seconds), based on findings from the research phase.
+
+## Acceptance Criteria
+- [ ] Break down this epic into stories.

--- a/.foundry/epics/epic-057-348-bash-static-analysis-linter-retry.md
+++ b/.foundry/epics/epic-057-348-bash-static-analysis-linter-retry.md
@@ -1,0 +1,30 @@
+---
+id: epic-057-348-bash-static-analysis-linter-retry
+type: EPIC
+title: Static Analysis Linter for Bash Sessions (Retry)
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-07-26'
+updated_at: '2026-07-26'
+depends_on:
+  - epic-057-347-bash-timeout-wrapper-retry
+jules_session_id: null
+pr_number: null
+parent: prd-095-057-prevent-blocking-bash-commands
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Static Analysis Linter for Bash Sessions (Retry)
+
+## Overview
+Implement a static analysis linter to proactively block known infinite-blocking commands like `tail -f` before execution.
+
+## Acceptance Criteria
+- [ ] Break down this epic into stories.

--- a/.foundry/journals/epic_planner/3721592406195149594.md
+++ b/.foundry/journals/epic_planner/3721592406195149594.md
@@ -1,0 +1,4 @@
+# Session 3721592406195149594
+
+## Learning
+When processing a parent node (e.g., a PRD) whose generated child nodes (e.g., Epics) have permanently failed and reached their max rejection count, I must spawn a `RESEARCH` node to investigate the root cause of the failure. I must then create replacement nodes that explicitly depend on the new research node, append them to the parent's markdown body as unchecked tasks, and check off the permanently failed child nodes. This process resolves the impossible loop and ensures the DAG orchestrator can progress successfully.

--- a/.foundry/prds/prd-095-057-prevent-blocking-bash-commands.md
+++ b/.foundry/prds/prd-095-057-prevent-blocking-bash-commands.md
@@ -41,5 +41,8 @@ Agent sessions executing long-running or blocking bash commands (like `tail -f`)
 
 ## Acceptance Criteria
 - [x] Break down this PRD into Epics mapping out the implementation strategy (e.g., exploring wrapper feasibility, updating bash tool infrastructure).
-- [ ] epic-057-127-bash-timeout-wrapper
-- [ ] epic-057-128-bash-static-analysis-linter
+- [x] epic-057-127-bash-timeout-wrapper
+- [x] epic-057-128-bash-static-analysis-linter
+- [ ] research-057-346-investigate-bash-timeout-failure
+- [ ] epic-057-347-bash-timeout-wrapper-retry
+- [ ] epic-057-348-bash-static-analysis-linter-retry

--- a/.foundry/research/research-057-346-investigate-bash-timeout-failure.md
+++ b/.foundry/research/research-057-346-investigate-bash-timeout-failure.md
@@ -1,0 +1,30 @@
+---
+id: research-057-346-investigate-bash-timeout-failure
+type: RESEARCH
+title: Investigate Bash Timeout Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-26'
+updated_at: '2026-07-26'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-095-057-prevent-blocking-bash-commands
+tags:
+  - foundry
+  - resilience
+  - failure-analysis
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Bash Timeout Failure
+
+## Overview
+The epic `epic-057-127-bash-timeout-wrapper` reached the maximum rejection count and was cancelled. We need to research the root cause of this failure to successfully implement the bash session timeout wrapper without encountering the same issues.
+
+## Acceptance Criteria
+- [ ] Research root cause of `epic-057-127-bash-timeout-wrapper` failure.
+- [ ] Document findings and propose an alternative implementation strategy.


### PR DESCRIPTION
Addresses the permanent failure of the bash timeout wrapper epics by spawning a research node to investigate the failure, creating retry epics that depend on the research, and checking off the failed epics in the PRD. This ensures the DAG orchestrator can properly progress and resolves the impossible loop.

---
*PR created automatically by Jules for task [3721592406195149594](https://jules.google.com/task/3721592406195149594) started by @szubster*