### PR TITLE
chore: verify pre-existing gen 3 move tutor child tasks

### DIFF
--- a/.foundry/journals/tech_lead/14369504194315571449.md
+++ b/.foundry/journals/tech_lead/14369504194315571449.md
@@ -1,0 +1,3 @@
+# Tech Lead Journal - 14369504194315571449
+
+I am submitting an empty PR due to pre-existing completion of child tasks `task-318-341-gen3-move-tutor-frlg-parsing-impl` and `task-318-342-gen3-move-tutor-frlg-parsing-qa`. The target artifacts are already completely implemented, so I am checking off the acceptance criteria checkboxes without creating new files.

--- a/.foundry/stories/story-119-318-gen3-move-tutor-frlg-parsing.md
+++ b/.foundry/stories/story-119-318-gen3-move-tutor-frlg-parsing.md
@@ -36,5 +36,5 @@ As described in `research-055-247-gen3-move-tutor-offsets` (detailed in `gen3_mo
 ## Acceptance Criteria
 - [x] Create tasks for implementing DataView-based extraction of FRLG Move Tutor bits.
 
-- [ ] task-318-341-gen3-move-tutor-frlg-parsing-impl
-- [ ] task-318-342-gen3-move-tutor-frlg-parsing-qa
+- [x] task-318-341-gen3-move-tutor-frlg-parsing-impl
+- [x] task-318-342-gen3-move-tutor-frlg-parsing-qa


### PR DESCRIPTION
This PR updates the markdown body of `story-119-318-gen3-move-tutor-frlg-parsing` to check off the child implementation and QA tasks, as they were already found to be completed in the codebase. It also adds a corresponding journal entry to document this empty PR transition per the Empty PR Checkbox Policy.

---
*PR created automatically by Jules for task [14369504194315571449](https://jules.google.com/task/14369504194315571449) started by @szubster*