### PR TITLE
💡 Visionary: Pokémon-Themed Foundry Persona Skins and Gamified Workflow

### DIFF
--- a/.foundry/ideas/idea-122-pokemon-themed-foundry-personas.md
+++ b/.foundry/ideas/idea-122-pokemon-themed-foundry-personas.md
@@ -1,0 +1,102 @@
+---
+id: idea-122-pokemon-themed-foundry-personas
+type: IDEA
+title: Pokémon-Themed Foundry Persona Skins and Gamified Workflow
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-07-25'
+updated_at: '2026-07-25'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - ux
+  - gamification
+  - personas
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Pokémon-Themed Foundry Persona Skins and Gamified Workflow
+
+## Description
+To bring character, engagement, and a distinct retro-gaming identity to the Foundry, this idea proposes a cohesive Pokémon-themed visual and narrative reskin for both the **Foundry Owner Personas** (which govern system nodes) and the **Jules Agent Personas** (which execute sessions). Additionally, it translates the system's strict directed acyclic graph (DAG) status transitions into gamified Pokémon concepts like **Egg Incubation, Evolution, Elite Four Verification, and Pokémon Center Restoration**.
+
+This provides a delightful narrative layer over the codebase, making autonomous agent interactions, log files, pull requests, and automated dashboards significantly more fun and readable for developers and maintainers.
+
+---
+
+## The Master Theme Spec
+
+### 🌟 Foundry Owner Personas (The Gym Leaders & Professors)
+Each of the 13 system roles in `.foundry/docs/schema.md` is mapped to an iconic Pokémon entity:
+1. **`product_manager` ➔ Dragonite (The Delivery Messenger)**
+   - *Lore:* Spans the distance between raw ideas and structured PRDs, soaring through specifications at Mach 3 to deliver clear blueprints.
+2. **`epic_planner` ➔ Metagross (The Supercomputer Analyst)**
+   - *Lore:* With four brains linked together, Metagross calculates the optimal layout of macro-epics, ensuring seamless topological dependency graphs.
+3. **`story_owner` ➔ Xatu (The Future Sight Planner)**
+   - *Lore:* Stares into future timelines. Governs late-binding requirements and writes Story N+1 only when Story N has fully materialized in reality.
+4. **`architect` ➔ Mewtwo (The Master Mind of the Blueprint)**
+   - *Lore:* Focuses on absolute structural consistency, master schemas, and ADR correctness. Intolerant of disorganized architectures.
+5. **`tech_lead` ➔ Alakazam (The 5,000 IQ Taskmaster)**
+   - *Lore:* Translates high-level stories into detailed, byte-level technical tasks, organizing plans with telekinetic precision.
+6. **`coder` ➔ Pikachu (The Spark of Implementation)**
+   - *Lore:* Charges the codebase with electric energy, turning static markdown requirements into fully functional code.
+7. **`qa` ➔ Ditto (The Contract Matcher)**
+   - *Lore:* Instantly transforms itself into the exact shape of the PRD/Story acceptance criteria to verify the implementation matches perfectly.
+8. **`human` ➔ Legendary Pokémon Trainer (Red/Blue/Gold)**
+   - *Lore:* The master coordinator. Bypasses standard automated heartbeat constraints and dictates global strategy.
+9. **`tpm` ➔ Delibird (The Postman & Hall of Famer)**
+   - *Lore:* Glides around hourly to archive completed nodes, manage learning logs, and bundle PRs for the grand Hall of Fame.
+10. **`agile_coach` ➔ Professor Oak (The Process Pioneer)**
+    - *Lore:* Mentors the factory's development, refines agent prompts, and optimizes overall system workflows.
+11. **`mechanic` ➔ Rotom-Wash (The Deadlock Cleaner)**
+    - *Lore:* Infiltrates the plumbing of the system to flush out loops, clear blocked paths, and resolve pipeline deadlocks.
+12. **`researcher` ➔ Unown (The Exploratory Glyph)**
+    - *Lore:* Formulates late-bound research blocks, decoding hidden variables and exploring mystery areas of the save parser.
+13. **`auditor` ➔ Arceus (The Creator and Arbiter)**
+    - *Lore:* Verifies PR artifacts against the original grand design, extracts critical lessons, and spawns follow-up nodes.
+
+---
+
+### 🎨 Jules Agent Personas (The Companion Pokémon)
+The developer-facing personas defined under `.jules/` receive matched narrative skins:
+1. **🧬 Oak (Data Integrity)** ➔ Keep as **Professor Oak**, standardizing exclusives lists and encounter maps.
+2. **🛡️ Nurse (Type Safety)** ➔ **Nurse Joy (Chansey/Blissey)**, caring for unstable code bases and sterilizing dangerous TypeScript compilation errors.
+3. **🧪 Sentinel (Testing & Coverage)** ➔ **Noctowl**, keeping a keen eye on test suite coverage gaps and guarding code quality through the night.
+4. **🧹 Sweeper (Cleanup & Refactor)** ➔ **Cinccino**, sweeping away dead code, unused exports, and redundant configurations with its clean-obsessed tail.
+5. **🎨 Palette (Design & Styling)** ➔ **Smeargle**, painting custom utility styles and Tailwind classes to build a beautiful visual interface.
+6. **📜 Scribe (Documentation & Lore)** ➔ **Slowking**, translating complex architectural decisions into rich, ancient-feeling markdown histories.
+7. **🧠 Trainer (Quality & Improvement)** ➔ **Lucario**, using its Aura sensing to refine and guide recommendation algorithms and statistical weights.
+8. **💡 Visionary (Creative Ideation)** ➔ **Celebi**, traveling between timelines to draft high-quality product ideas while keeping the orchestrator robust.
+9. **🗿 Sculptor (AI Readability)** ➔ **Claydol**, reshaping complex code into simple, clean paths designed to be easily read by other AI minds.
+10. **🛠️ Infras (CI/CD Powerhouse)** ➔ **Machamp**, utilizing four arms to lift heavy build environments and power the continuous integration pipelines.
+
+---
+
+### 🎮 The Gamified Status Lifecycle
+Node transitions in our DAG are reimagined as progression mechanics:
+- **`PENDING` ➔ 🥚 Pokémon Egg:** The node exists but is still incubating, blocked by prerequisites.
+- **`READY` ➔ 🐣 Hatched:** All prerequisite nodes have hatched (completed), and the node is ready for dispatch.
+- **`ACTIVE` ➔ ⚔️ In Battle:** A Jules agent is actively battling the implementation of the task.
+- **`VERIFYING` ➔ 🏆 Elite Four Challenge:** The QA/Auditor evaluates the work to ensure it meets Champion standards.
+- **`COMPLETED` ➔ 🌟 Fully Evolved / Hall of Fame:** The task has successfully evolved and is archived permanently.
+- **`FAILED` or `BLOCKED` ➔ 🏥 Pokémon Center:** The node fainted due to an error and is sent to the recovery queue for the Mechanic/TPM to heal.
+
+---
+
+## Rationale & Benefits
+- **Identity & Fun:** Infuses the repo with a unique charm that perfectly matches DexHelper's primary goal: being a high-quality Pokémon companion tool.
+- **Clarity in PRs:** Streamlines PR titles (e.g. `⚡ Pikachu (Coder): Implement breeding parser` or `🛡️ Nurse Joy (Type Safety): Resolve undefined bounds`).
+- **Clean Diagnostics:** A dashboard showing "3 Eggs incubating, 2 in Battle, and 1 in the Pokémon Center" is instantly intuitive and visually striking.
+
+---
+
+## Acceptance Criteria
+- [ ] Product Manager: Convert this idea into a PRD specifying the theme integration and updating the Foundry schema.
+- [ ] Designer: Create custom visual icons/badges representing the mapped Pokémon roles on the DAG dashboard.
+- [ ] Coder: Update the DAG UI dashboard and log-viewing panels to show the themed names, statuses, and icons.
+- [ ] TPM: Update `.github/scripts/foundry-orchestrator.ts` to output themed messages and emoji badges to GitHub Action summaries.

--- a/.foundry/ideas/idea-122-pokemon-themed-foundry-personas.md
+++ b/.foundry/ideas/idea-122-pokemon-themed-foundry-personas.md
@@ -23,62 +23,72 @@ notes: ''
 # Pokémon-Themed Foundry Persona Skins and Gamified Workflow
 
 ## Description
-To bring character, engagement, and a distinct retro-gaming identity to the Foundry, this idea proposes a cohesive Pokémon-themed visual and narrative reskin for both the **Foundry Owner Personas** (which govern system nodes) and the **Jules Agent Personas** (which execute sessions). Additionally, it translates the system's strict directed acyclic graph (DAG) status transitions into gamified Pokémon concepts like **Egg Incubation, Evolution, Elite Four Verification, and Pokémon Center Restoration**.
+To bring character, engagement, and a distinct retro-gaming identity to the Foundry, this idea proposes a cohesive Pokémon-themed visual and narrative reskin for both the **Foundry Owner Personas** (which govern system nodes) and the **Jules Agent Personas** (which execute sessions). Based on core user feedback, this theme strictly utilizes highly iconic **Generation 1 Pokémon and characters**—the very foundation of the series and the absolute sweet spot for retro-gaming nostalgia.
 
-This provides a delightful narrative layer over the codebase, making autonomous agent interactions, log files, pull requests, and automated dashboards significantly more fun and readable for developers and maintainers.
+Additionally, it translates the system's strict directed acyclic graph (DAG) status transitions into gamified Pokémon concepts like **Egg Incubation, Evolution, Elite Four Verification, and Pokémon Center Recovery**.
 
 ---
 
-## The Master Theme Spec
+## The Master Theme Spec (Strictly Gen 1)
 
 ### 🌟 Foundry Owner Personas (The Gym Leaders & Professors)
-Each of the 13 system roles in `.foundry/docs/schema.md` is mapped to an iconic Pokémon entity:
-1. **`product_manager` ➔ Dragonite (The Delivery Messenger)**
-   - *Lore:* Spans the distance between raw ideas and structured PRDs, soaring through specifications at Mach 3 to deliver clear blueprints.
-2. **`epic_planner` ➔ Metagross (The Supercomputer Analyst)**
-   - *Lore:* With four brains linked together, Metagross calculates the optimal layout of macro-epics, ensuring seamless topological dependency graphs.
-3. **`story_owner` ➔ Xatu (The Future Sight Planner)**
-   - *Lore:* Stares into future timelines. Governs late-binding requirements and writes Story N+1 only when Story N has fully materialized in reality.
-4. **`architect` ➔ Mewtwo (The Master Mind of the Blueprint)**
-   - *Lore:* Focuses on absolute structural consistency, master schemas, and ADR correctness. Intolerant of disorganized architectures.
-5. **`tech_lead` ➔ Alakazam (The 5,000 IQ Taskmaster)**
-   - *Lore:* Translates high-level stories into detailed, byte-level technical tasks, organizing plans with telekinetic precision.
-6. **`coder` ➔ Pikachu (The Spark of Implementation)**
-   - *Lore:* Charges the codebase with electric energy, turning static markdown requirements into fully functional code.
-7. **`qa` ➔ Ditto (The Contract Matcher)**
-   - *Lore:* Instantly transforms itself into the exact shape of the PRD/Story acceptance criteria to verify the implementation matches perfectly.
-8. **`human` ➔ Legendary Pokémon Trainer (Red/Blue/Gold)**
-   - *Lore:* The master coordinator. Bypasses standard automated heartbeat constraints and dictates global strategy.
-9. **`tpm` ➔ Delibird (The Postman & Hall of Famer)**
-   - *Lore:* Glides around hourly to archive completed nodes, manage learning logs, and bundle PRs for the grand Hall of Fame.
+Each of the 13 system roles in `.foundry/docs/schema.md` is mapped to an iconic Gen 1 entity:
+1. **`product_manager` ➔ Dragonite (#149 - The Delivery Messenger)**
+   - *Lore:* Soars across the ocean to deliver raw ideas as perfectly structured PRD blueprints.
+2. **`epic_planner` ➔ Alakazam (#065 - The 5,000 IQ Strategist)**
+   - *Lore:* Using its immense psychic brainpower, Alakazam organizes macroscopic epics and maps out structural dependencies in its head.
+3. **`story_owner` ➔ Bill (The Prominent Gen 1 Scientist & Inventor)**
+   - *Lore:* The master of the PC Storage System, Bill dynamically writes individual stories and sets up next steps based on real-time collection progress.
+4. **`architect` ➔ Mewtwo (#150 - The Master Mind of the Blueprint)**
+   - *Lore:* Demands absolute logical structural perfection. Governs the schemas, master invariants, and ADR documents with psychic intolerance for messiness.
+5. **`tech_lead` ➔ Porygon (#137 - The Digital Blueprint Optimizer)**
+   - *Lore:* A Pokémon constructed entirely of programming code. Translates stories into clean, byte-level structural engineering tasks.
+6. **`coder` ➔ Pikachu (#025 - The Spark of Implementation)**
+   - *Lore:* Charges the codebase with electrical energy, turning static markdown requirements into fully functional code.
+7. **`qa` ➔ Ditto (#132 - The Contract Matcher)**
+   - *Lore:* Transforms itself into the exact specification of the PRD/Story to verify that the implementation is a flawless match.
+8. **`human` ➔ Legendary Pokémon Trainer (Red)**
+   - *Lore:* The ultimate Champion. Bypasses standard automated heartbeat constraints and commands the grand pipeline strategies.
+9. **`tpm` ➔ Meowth (#052 - The Coin Finder & Archivist)**
+   - *Lore:* Uses Pay Day to secure and archive completed nodes into the vault, meticulously maintaining learning logs.
 10. **`agile_coach` ➔ Professor Oak (The Process Pioneer)**
-    - *Lore:* Mentors the factory's development, refines agent prompts, and optimizes overall system workflows.
-11. **`mechanic` ➔ Rotom-Wash (The Deadlock Cleaner)**
-    - *Lore:* Infiltrates the plumbing of the system to flush out loops, clear blocked paths, and resolve pipeline deadlocks.
-12. **`researcher` ➔ Unown (The Exploratory Glyph)**
-    - *Lore:* Formulates late-bound research blocks, decoding hidden variables and exploring mystery areas of the save parser.
-13. **`auditor` ➔ Arceus (The Creator and Arbiter)**
-    - *Lore:* Verifies PR artifacts against the original grand design, extracts critical lessons, and spawns follow-up nodes.
+    - *Lore:* The father of the Pokédex, mentoring the factory, evolving agent prompts, and guiding overall workflows.
+11. **`mechanic` ➔ Blastoise (#009 - The Torrential Pipeline Cleanser)**
+    - *Lore:* Blasts through clogged pipelines with Hydro Pump, flushing out loops, resolving deadlocks, and clearing broken file paths.
+12. **`researcher` ➔ Mew (#151 - The Exploratory Genesis)**
+    - *Lore:* Capable of learning any move. Spawns late-bound research nodes to explore and decode the deepest secrets of the ROM save formats.
+13. **`auditor` ➔ Lapras (#131 - The Gentle Final Guide)**
+    - *Lore:* Navigates the PR artifacts safely to shore, verifying and distilling crucial lessons learned before final completion.
 
 ---
 
 ### 🎨 Jules Agent Personas (The Companion Pokémon)
-The developer-facing personas defined under `.jules/` receive matched narrative skins:
-1. **🧬 Oak (Data Integrity)** ➔ Keep as **Professor Oak**, standardizing exclusives lists and encounter maps.
-2. **🛡️ Nurse (Type Safety)** ➔ **Nurse Joy (Chansey/Blissey)**, caring for unstable code bases and sterilizing dangerous TypeScript compilation errors.
-3. **🧪 Sentinel (Testing & Coverage)** ➔ **Noctowl**, keeping a keen eye on test suite coverage gaps and guarding code quality through the night.
-4. **🧹 Sweeper (Cleanup & Refactor)** ➔ **Cinccino**, sweeping away dead code, unused exports, and redundant configurations with its clean-obsessed tail.
-5. **🎨 Palette (Design & Styling)** ➔ **Smeargle**, painting custom utility styles and Tailwind classes to build a beautiful visual interface.
-6. **📜 Scribe (Documentation & Lore)** ➔ **Slowking**, translating complex architectural decisions into rich, ancient-feeling markdown histories.
-7. **🧠 Trainer (Quality & Improvement)** ➔ **Lucario**, using its Aura sensing to refine and guide recommendation algorithms and statistical weights.
-8. **💡 Visionary (Creative Ideation)** ➔ **Celebi**, traveling between timelines to draft high-quality product ideas while keeping the orchestrator robust.
-9. **🗿 Sculptor (AI Readability)** ➔ **Claydol**, reshaping complex code into simple, clean paths designed to be easily read by other AI minds.
-10. **🛠️ Infras (CI/CD Powerhouse)** ➔ **Machamp**, utilizing four arms to lift heavy build environments and power the continuous integration pipelines.
+The developer-facing personas defined under `.jules/` receive matched narrative Gen 1 skins:
+1. **🧬 Oak (Data Integrity)** ➔ **Professor Oak**
+   - *Lore:* Standardizes version-exclusive lists and encounter tables with absolute factual authority.
+2. **🛡️ Nurse (Type Safety)** ➔ **Nurse Joy (Chansey - #113)**
+   - *Lore:* Heals unstable code bases by curing unsafe typings and ensuring compilation warnings are completely sterilized.
+3. **🧪 Sentinel (Testing & Coverage)** ➔ **Gengar (#094 - The Shadow Checker)**
+   - *Lore:* Infiltrates the dark corners of the codebase, ensuring that no testing gap is left hidden from the light.
+4. **🧹 Sweeper (Cleanup & Refactor)** ➔ **Scyther (#123 - The Code Pruner)**
+   - *Lore:* Uses Fury Cutter to cleanly slice away dead code, unused exports, and redundant configurations.
+5. **🎨 Palette (Design & Styling)** ➔ **Pidgeot (#018 - The Tailwind Master)**
+   - *Lore:* Uses Tailwind to sweep up custom utilities and style elements beautifully, creating a gorgeous visual interface.
+6. **📜 Scribe (Documentation & Lore)** ➔ **Slowbro (#080 - The Deep Chronicler)**
+   - *Lore:* Contemplates architectural decisions for hours before writing them down as detailed, simple markdown lore.
+7. **🧠 Trainer (Quality & Improvement)** ➔ **Machamp (#068 - The Model Optimizer)**
+   - *Lore:* Exercises statistical weights and recommendation algorithms to build powerful, high-performance dashboards.
+8. **💡 Visionary (Creative Ideation)** ➔ **Eevee (#133 - The Evolution of Ideas)**
+   - *Lore:* Full of infinite potential and multiple evolutionary paths, Eevee envisions balanced product ideas.
+9. **🗿 Sculptor (AI Readability)** ➔ **Sandslash (#028 - The Code Refiner)**
+   - *Lore:* Uses its sharp claws to simplify and carve messy, complex code paths into beautifully organized, readable segments.
+10. **🛠️ Infras (CI/CD Powerhouse)** ➔ **Golem (#076 - The Pipeline Foundation)**
+    - *Lore:* A rock-solid anchor for the build environments, rolling through the muscles of continuous integration.
 
 ---
 
 ### 🎮 The Gamified Status Lifecycle
-Node transitions in our DAG are reimagined as progression mechanics:
+Node transitions in our DAG are reimagined as classic Gen 1 progression mechanics:
 - **`PENDING` ➔ 🥚 Pokémon Egg:** The node exists but is still incubating, blocked by prerequisites.
 - **`READY` ➔ 🐣 Hatched:** All prerequisite nodes have hatched (completed), and the node is ready for dispatch.
 - **`ACTIVE` ➔ ⚔️ In Battle:** A Jules agent is actively battling the implementation of the task.
@@ -90,7 +100,7 @@ Node transitions in our DAG are reimagined as progression mechanics:
 
 ## Rationale & Benefits
 - **Identity & Fun:** Infuses the repo with a unique charm that perfectly matches DexHelper's primary goal: being a high-quality Pokémon companion tool.
-- **Clarity in PRs:** Streamlines PR titles (e.g. `⚡ Pikachu (Coder): Implement breeding parser` or `🛡️ Nurse Joy (Type Safety): Resolve undefined bounds`).
+- **Clarity in PRs:** Streamlines PR titles (e.g. `⚡ Pikachu (Coder): Implement breeding parser` or `🛡️ Chansey (Type Safety): Resolve undefined bounds`).
 - **Clean Diagnostics:** A dashboard showing "3 Eggs incubating, 2 in Battle, and 1 in the Pokémon Center" is instantly intuitive and visually striking.
 
 ---

--- a/.jules/visionary/13048993490522208946.md
+++ b/.jules/visionary/13048993490522208946.md
@@ -1,0 +1,12 @@
+# Visionary Journal
+
+- **Active Session ID:** 13048993490522208946
+- **Domain:** Foundry (Internal Factory Gamification)
+- **Proposed Idea:** Pokémon-Themed Foundry Persona Skins and Gamified Workflow
+- **Rationale & Concept:**
+  The user requested to make the Foundry more fun, characterful, and Pokémon-themed. By mapping each Foundry role and Jules persona to custom Pokémon lore/entities and renaming DAG statuses to match mechanics (Eggs, Evolution, Pokémon Center, and Elite Four Challenges), we create a high-quality, memorable interface that transforms structural pipeline concepts into retro-gaming flavor.
+
+- **How this idea maintains the 50/50 balance between DexHelper and Foundry:**
+  In the last session, we created `idea-121-gen3-mystery-gift-viewer.md`, which is a **DexHelper (Main Product)** feature designed to improve Gen 3 save file collection parsing.
+  In this session, we are proposing `idea-122-pokemon-themed-foundry-personas.md`, which is a **Foundry (Internal Orchestration)** optimization and identity feature.
+  This maintains a strict and healthy **50/50 split** between developer-facing product features and system/orchestrator improvements, as outlined in the *Strategic Balance Learning* section of our journal. It ensures both spheres receive equal focus and creative energy.

--- a/.jules/visionary/13048993490522208946.md
+++ b/.jules/visionary/13048993490522208946.md
@@ -2,9 +2,11 @@
 
 - **Active Session ID:** 13048993490522208946
 - **Domain:** Foundry (Internal Factory Gamification)
-- **Proposed Idea:** Pokémon-Themed Foundry Persona Skins and Gamified Workflow
+- **Proposed Idea:** Pokémon-Themed Foundry Persona Skins and Gamified Workflow (Generation 1 Edition)
 - **Rationale & Concept:**
-  The user requested to make the Foundry more fun, characterful, and Pokémon-themed. By mapping each Foundry role and Jules persona to custom Pokémon lore/entities and renaming DAG statuses to match mechanics (Eggs, Evolution, Pokémon Center, and Elite Four Challenges), we create a high-quality, memorable interface that transforms structural pipeline concepts into retro-gaming flavor.
+  The user requested to make the Foundry more fun, characterful, and Pokémon-themed, with a strict focus on **Generation 1**. Gen 1 contains the most iconic, widely recognized, and nostalgic Pokémon and characters (like Red, Bill, Oak, Pikachu, Alakazam, Ditto, and Mewtwo).
+
+  By mapping the 13 Foundry Owner roles and 10 Jules Agent personas exclusively to highly recognizable Gen 1 entities, and renaming DAG statuses to classic Gen 1 concepts (Eggs, Battles, Elite Four Challenges, and Pokémon Center Restoration), we create a high-quality, unforgettable interface. For instance, mapping the `palette` styling persona to **Pidgeot (the Tailwind CSS Master)** is a witty, highly effective Gen 1 pun that developers will instantly love.
 
 - **How this idea maintains the 50/50 balance between DexHelper and Foundry:**
   In the last session, we created `idea-121-gen3-mystery-gift-viewer.md`, which is a **DexHelper (Main Product)** feature designed to improve Gen 3 save file collection parsing.


### PR DESCRIPTION
## 🎯 What & Why
This PR creates a new high-quality, actionable `IDEA` node (`idea-122-pokemon-themed-foundry-personas.md`) that gamifies the Foundry! 
It proposes a narrative and visual skin for both the 13 Foundry Owner Personas and 10 Jules Agent Personas mapping them to iconic Pokémon and Gym Leader/Professor roles. Furthermore, it reimagines our strict directed acyclic graph (DAG) status lifecycle transitions as retro-gaming mechanics (`Egg Incubation`, `In Battle`, `Elite Four Challenge`, `Evolution`, and `Pokémon Center Recovery`).

## ✨ Impact
This brings delightful retro-gaming character and narrative styling directly to the developer experience of our team, matching the spirit of DexHelper (being the ultimate premium Pokémon companion tool). 
It makes status dashboards, action summaries, and journal logs vastly more engaging and fun to read while maintaining our robust underlying DAG orchestrator logic.

Fixes #5145

---
*PR created automatically by Jules for task [13048993490522208946](https://jules.google.com/task/13048993490522208946) started by @szubster*