### PR TITLE
chore: Empty PR for Gen 3 Move Tutor Save File Parsing

### DIFF
--- a/.foundry/epics/epic-055-119-gen3-move-tutor-save-parsing.md
+++ b/.foundry/epics/epic-055-119-gen3-move-tutor-save-parsing.md
@@ -36,9 +36,9 @@ Implement the logic to parse Gen 3 save files and extract the event flags indica
 - The underlying research (`research-055-247-gen3-move-tutor-offsets`) must be completed to provide the necessary memory offsets and event flag mappings.
 
 ## Acceptance Criteria
-- [ ] Move Tutor flags are correctly extracted from Emerald save files using `DataView`.
-- [ ] Move Tutor flags are correctly extracted from FireRed/LeafGreen save files using `DataView`.
-- [ ] The parser correctly distinguishes between "Available" (flag unset) and "Used" (flag set) tutors.
-- [ ] Out-of-bounds reads or malformed saves are handled gracefully without application crashes.
-- [ ] story-119-267-gen3-move-tutor-emerald-parsing
-- [ ] story-119-318-gen3-move-tutor-frlg-parsing
+- [x] Move Tutor flags are correctly extracted from Emerald save files using `DataView`.
+- [x] Move Tutor flags are correctly extracted from FireRed/LeafGreen save files using `DataView`.
+- [x] The parser correctly distinguishes between "Available" (flag unset) and "Used" (flag set) tutors.
+- [x] Out-of-bounds reads or malformed saves are handled gracefully without application crashes.
+- [x] story-119-267-gen3-move-tutor-emerald-parsing
+- [x] story-119-318-gen3-move-tutor-frlg-parsing

--- a/.foundry/journals/story_owner/445421974531024931.md
+++ b/.foundry/journals/story_owner/445421974531024931.md
@@ -1,0 +1,5 @@
+# Session 445421974531024931
+
+The target artifact `epic-055-119-gen3-move-tutor-save-parsing` is already completely implemented via `story-119-267-gen3-move-tutor-emerald-parsing` and `story-119-318-gen3-move-tutor-frlg-parsing`.
+The completion of child stories and their child tasks were pre-existing.
+I'm submitting an empty PR for this epic to allow the orchestrator to advance.


### PR DESCRIPTION
The required child stories (story-119-267-gen3-move-tutor-emerald-parsing and story-119-318-gen3-move-tutor-frlg-parsing) are completely implemented. 
Their completion and their child tasks were pre-existing. 
Checked off the acceptance criteria in the parent epic (`epic-055-119-gen3-move-tutor-save-parsing.md`).
Added a journal entry in `.foundry/journals/story_owner/445421974531024931.md` documenting this.
Submitting an empty PR to allow the orchestrator to advance.

---
*PR created automatically by Jules for task [445421974531024931](https://jules.google.com/task/445421974531024931) started by @szubster*