### PR TITLE
feat: implement unit tests for Zod schema definition

### DIFF
--- a/.foundry/tasks/task-336-342-zod-schema-definition-impl.md
+++ b/.foundry/tasks/task-336-342-zod-schema-definition-impl.md
@@ -22,5 +22,5 @@ notes: ''
 Define the core Zod schema based on the rules and structure defined in `.foundry/docs/schema.md`.
 
 ## Acceptance Criteria
-- [ ] Implement the Zod schema
-- [ ] Write unit tests for schema validation
+- [x] Implement the Zod schema
+- [x] Write unit tests for schema validation

--- a/.github/scripts/schema.test.ts
+++ b/.github/scripts/schema.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { NodeFrontmatterSchema } from './schema.ts';
+
+describe('NodeFrontmatterSchema', () => {
+  it('validates a correct full node', () => {
+    const node = {
+      id: "task-001-002-test",
+      type: "TASK",
+      title: "Test Task",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-07-26",
+      updated_at: "2026-07-26",
+      depends_on: [],
+      jules_session_id: null,
+      pr_number: null,
+      parent: "story-001",
+      tags: [],
+      research_references: [],
+      rejection_count: 0,
+      rejection_reason: "",
+      notes: ""
+    };
+    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow();
+  });
+
+  it('validates a minimal node', () => {
+    const node = {
+      id: "idea-001",
+      type: "IDEA",
+      title: "New Idea",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: "2026-07-26",
+      updated_at: "2026-07-26",
+      depends_on: [],
+      jules_session_id: null
+    };
+    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow();
+  });
+
+  it('fails if required field is missing', () => {
+    const node = {
+      id: "idea-001",
+      type: "IDEA",
+      title: "New Idea",
+      status: "PENDING",
+      // owner_persona is missing
+      created_at: "2026-07-26",
+      updated_at: "2026-07-26",
+      depends_on: [],
+      jules_session_id: null
+    };
+    expect(() => NodeFrontmatterSchema.parse(node)).toThrow();
+  });
+
+  it('fails if type is invalid', () => {
+    const node = {
+      id: "idea-001",
+      type: "INVALID_TYPE",
+      title: "New Idea",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: "2026-07-26",
+      updated_at: "2026-07-26",
+      depends_on: [],
+      jules_session_id: null
+    };
+    expect(() => NodeFrontmatterSchema.parse(node)).toThrow();
+  });
+
+  it('fails if status is invalid', () => {
+    const node = {
+      id: "idea-001",
+      type: "IDEA",
+      title: "New Idea",
+      status: "INVALID_STATUS",
+      owner_persona: "product_manager",
+      created_at: "2026-07-26",
+      updated_at: "2026-07-26",
+      depends_on: [],
+      jules_session_id: null
+    };
+    expect(() => NodeFrontmatterSchema.parse(node)).toThrow();
+  });
+
+  it('fails if owner_persona is invalid', () => {
+    const node = {
+      id: "idea-001",
+      type: "IDEA",
+      title: "New Idea",
+      status: "PENDING",
+      owner_persona: "INVALID_PERSONA",
+      created_at: "2026-07-26",
+      updated_at: "2026-07-26",
+      depends_on: [],
+      jules_session_id: null
+    };
+    expect(() => NodeFrontmatterSchema.parse(node)).toThrow();
+  });
+
+  it('validates handling optional tags', () => {
+    const node = {
+      id: "idea-001",
+      type: "IDEA",
+      title: "New Idea",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: "2026-07-26",
+      updated_at: "2026-07-26",
+      depends_on: [],
+      jules_session_id: null,
+      tags: ["one", "two"]
+    };
+    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow();
+  });
+});

--- a/.github/scripts/schema.test.ts
+++ b/.github/scripts/schema.test.ts
@@ -21,7 +21,7 @@ describe('NodeFrontmatterSchema', () => {
       rejection_reason: "",
       notes: ""
     };
-    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow();
+    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow(Error);
   });
 
   it('validates a minimal node', () => {
@@ -36,7 +36,7 @@ describe('NodeFrontmatterSchema', () => {
       depends_on: [],
       jules_session_id: null
     };
-    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow();
+    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow(Error);
   });
 
   it('fails if required field is missing', () => {
@@ -51,7 +51,7 @@ describe('NodeFrontmatterSchema', () => {
       depends_on: [],
       jules_session_id: null
     };
-    expect(() => NodeFrontmatterSchema.parse(node)).toThrow();
+    expect(() => NodeFrontmatterSchema.parse(node)).toThrow(Error);
   });
 
   it('fails if type is invalid', () => {
@@ -66,7 +66,7 @@ describe('NodeFrontmatterSchema', () => {
       depends_on: [],
       jules_session_id: null
     };
-    expect(() => NodeFrontmatterSchema.parse(node)).toThrow();
+    expect(() => NodeFrontmatterSchema.parse(node)).toThrow(Error);
   });
 
   it('fails if status is invalid', () => {
@@ -81,7 +81,7 @@ describe('NodeFrontmatterSchema', () => {
       depends_on: [],
       jules_session_id: null
     };
-    expect(() => NodeFrontmatterSchema.parse(node)).toThrow();
+    expect(() => NodeFrontmatterSchema.parse(node)).toThrow(Error);
   });
 
   it('fails if owner_persona is invalid', () => {
@@ -96,7 +96,7 @@ describe('NodeFrontmatterSchema', () => {
       depends_on: [],
       jules_session_id: null
     };
-    expect(() => NodeFrontmatterSchema.parse(node)).toThrow();
+    expect(() => NodeFrontmatterSchema.parse(node)).toThrow(Error);
   });
 
   it('validates handling optional tags', () => {
@@ -112,6 +112,6 @@ describe('NodeFrontmatterSchema', () => {
       jules_session_id: null,
       tags: ["one", "two"]
     };
-    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow();
+    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow(Error);
   });
 });


### PR DESCRIPTION
This pull request addresses the active TASK `task-336-342-zod-schema-definition-impl` by:
1. Adding comprehensive unit tests to `.github/scripts/schema.test.ts` to validate the `NodeFrontmatterSchema` defined in `schema.ts`.
2. Validating minimum requirements, complete nodes, optional properties, and missing required variables, as defined in the Foundry architecture.
3. Updating the markdown acceptance criteria body in the active TASK.

Note that `schema.ts` itself was already pre-implemented, and this submission focuses strictly on test completion as required.

---
*PR created automatically by Jules for task [17072693815667279676](https://jules.google.com/task/17072693815667279676) started by @szubster*