### PR TITLE
feat: implement R2 push sync logic

### DIFF
--- a/.foundry/journals/coder/4633870046994094550.md
+++ b/.foundry/journals/coder/4633870046994094550.md
@@ -1,0 +1,1 @@
+Updated logic in useFileSyncController.ts and AppLayout.tsx to push local save data to R2 upon file upload and live file change. Handled auth checks correctly using AUTH_LOGGED_IN_INDICATOR.

--- a/.foundry/tasks/task-264-346-r2-push-sync-logic-impl.md
+++ b/.foundry/tasks/task-264-346-r2-push-sync-logic-impl.md
@@ -32,5 +32,5 @@ As the user makes progress or uploads new saves locally, these changes must be s
 - Use try/catch so R2 failures do not crash the app or block local IndexedDB persistence.
 
 ## Acceptance Criteria
-- [ ] Logic implemented to push local save data to R2 upon file upload and live file change in `useFileSyncController.ts`.
-- [ ] Implementation handles auth checks correctly.
+- [x] Logic implemented to push local save data to R2 upon file upload and live file change in `useFileSyncController.ts`.
+- [x] Implementation handles auth checks correctly.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,10 +1,12 @@
 import type React from 'react';
 import { useEffect } from 'react';
+import { AUTH_LOGGED_IN_INDICATOR } from '../contexts/AuthContext';
 import { saveDB } from '../db/SaveDB';
 import { parseSaveFile } from '../engine/saveParser/index';
 import { useStore } from '../store';
 import { cn } from '../utils/cn';
 import { VERSION_THEMES } from '../utils/generationConfig';
+import { r2Client } from '../utils/r2/client';
 import { reloadPage } from '../utils/window';
 import { AppHeader } from './AppHeader';
 import { BottomNav } from './BottomNav';
@@ -39,7 +41,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
     if (!file) return;
 
     const reader = new FileReader();
-    reader.onload = (e) => {
+    reader.onload = async (e) => {
       try {
         if (!(e.target?.result instanceof ArrayBuffer)) {
           throw new Error('Failed to read file as ArrayBuffer');
@@ -55,7 +57,19 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           setManualVersion(null);
         }
 
-        saveDB.putSave('last_save_file', new Uint8Array(buffer)).catch(() => console.error('System: sync failed'));
+        await saveDB
+          .putSave('last_save_file', new Uint8Array(buffer))
+          .catch(() => console.error('System: sync failed'));
+
+        if (localStorage.getItem(AUTH_LOGGED_IN_INDICATOR) === 'true') {
+          try {
+            const saves = await r2Client.listSaves();
+            const saveId = saves.length > 0 && saves[0] ? saves[0] : 'save-1';
+            await r2Client.putSave(saveId, new Uint8Array(buffer));
+          } catch {
+            console.error('System: push to cloud failed');
+          }
+        }
       } catch {
         setError('Failed to parse save file.');
         setSaveData(null);

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -319,13 +319,20 @@ describe('AppLayout file upload', () => {
     const file = new File(['mock save content'], 'save.sav', { type: 'application/octet-stream' });
     await expect.element(page.getByText('[ UPLOAD.SYS ]')).toBeInTheDocument();
 
+    // biome-ignore lint/suspicious/noExplicitAny: Required for mock overriding context
     const readAsArrayBufferMock = vi.fn<(_f: File) => void>(function (this: any, _f: File) {
       const buffer = new ArrayBuffer(10);
       if (this.onload) {
+        // biome-ignore lint/suspicious/noExplicitAny: internal mock state
         this.onload({ target: { result: buffer } } as any);
       }
     });
-    vi.stubGlobal('FileReader', class { readAsArrayBuffer = readAsArrayBufferMock; });
+    vi.stubGlobal(
+      'FileReader',
+      class {
+        readAsArrayBuffer = readAsArrayBufferMock;
+      },
+    );
 
     const element = document.querySelector('input[type="file"]') as HTMLInputElement;
     const dataTransfer = new DataTransfer();
@@ -366,13 +373,20 @@ describe('AppLayout file upload', () => {
     const file = new File(['mock save content'], 'save.sav', { type: 'application/octet-stream' });
     await expect.element(page.getByText('[ UPLOAD.SYS ]')).toBeInTheDocument();
 
+    // biome-ignore lint/suspicious/noExplicitAny: Required for mock overriding context
     const readAsArrayBufferMock = vi.fn<(_f: File) => void>(function (this: any, _f: File) {
       const buffer = new ArrayBuffer(10);
       if (this.onload) {
+        // biome-ignore lint/suspicious/noExplicitAny: internal mock state
         this.onload({ target: { result: buffer } } as any);
       }
     });
-    vi.stubGlobal('FileReader', class { readAsArrayBuffer = readAsArrayBufferMock; });
+    vi.stubGlobal(
+      'FileReader',
+      class {
+        readAsArrayBuffer = readAsArrayBufferMock;
+      },
+    );
 
     const element = document.querySelector('input[type="file"]') as HTMLInputElement;
     const dataTransfer = new DataTransfer();

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -18,6 +18,13 @@ vi.mock('../../engine/saveParser/index', () => ({
   parseSaveFile: vi.fn<typeof parseSaveFile>(),
 }));
 
+vi.mock('../../utils/r2/client', () => ({
+  r2Client: {
+    listSaves: vi.fn(),
+    putSave: vi.fn(),
+  },
+}));
+
 describe('AppLayout chunk error handling', () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -229,5 +236,68 @@ describe('AppLayout file upload', () => {
     );
 
     vi.unstubAllGlobals();
+  });
+
+  it('should push save to R2 when logged in', async () => {
+    const { AUTH_LOGGED_IN_INDICATOR } = await import('../../contexts/AuthContext');
+    const { r2Client } = await import('../../utils/r2/client');
+
+    localStorage.setItem(AUTH_LOGGED_IN_INDICATOR, 'true');
+    vi.mocked(r2Client.listSaves).mockResolvedValue(['existing-save']);
+    vi.mocked(r2Client.putSave).mockResolvedValue();
+
+    const putSaveSpy = vi.spyOn(saveDB, 'putSave').mockResolvedValue(undefined);
+
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    );
+
+    const file = new File(['mock save content'], 'save.sav', { type: 'application/octet-stream' });
+
+    await expect.element(page.getByText('[ UPLOAD.SYS ]')).toBeInTheDocument();
+
+    // biome-ignore lint/suspicious/noExplicitAny: Required for mock overriding context
+    const readAsArrayBufferMock = vi.fn<(_f: File) => void>(function (this: any, _f: File) {
+      const buffer = new ArrayBuffer(10);
+      if (this.onload) {
+        // biome-ignore lint/suspicious/noExplicitAny: internal mock state
+        this.onload({ target: { result: buffer } } as any);
+      }
+    });
+    vi.stubGlobal(
+      'FileReader',
+      class {
+        readAsArrayBuffer = readAsArrayBufferMock;
+      },
+    );
+
+    const element = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+
+    Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files')?.set?.call(element, dataTransfer.files);
+    Object.defineProperty(element, 'files', {
+      value: dataTransfer.files,
+      configurable: true,
+      writable: true,
+    });
+
+    const changeEvent = new Event('change', { bubbles: true, cancelable: true });
+    element.dispatchEvent(changeEvent);
+
+    await vi.waitFor(
+      () => {
+        expect(parseSaveFile).toHaveBeenCalled();
+        expect(putSaveSpy).toHaveBeenCalled();
+        expect(r2Client.listSaves).toHaveBeenCalled();
+        expect(r2Client.putSave).toHaveBeenCalledWith('existing-save', expect.any(Uint8Array));
+      },
+      { timeout: 3000 },
+    );
+
+    vi.unstubAllGlobals();
+    localStorage.clear();
   });
 });

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -301,4 +301,98 @@ describe('AppLayout file upload', () => {
     vi.unstubAllGlobals();
     localStorage.clear();
   });
+
+  it('should fallback to save-1 if no R2 saves exist on upload', async () => {
+    const { AUTH_LOGGED_IN_INDICATOR } = await import('../../contexts/AuthContext');
+    const { r2Client } = await import('../../utils/r2/client');
+
+    localStorage.setItem(AUTH_LOGGED_IN_INDICATOR, 'true');
+    vi.mocked(r2Client.listSaves).mockResolvedValue([]);
+    vi.mocked(r2Client.putSave).mockResolvedValue();
+
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    );
+
+    const file = new File(['mock save content'], 'save.sav', { type: 'application/octet-stream' });
+    await expect.element(page.getByText('[ UPLOAD.SYS ]')).toBeInTheDocument();
+
+    const readAsArrayBufferMock = vi.fn<(_f: File) => void>(function (this: any, _f: File) {
+      const buffer = new ArrayBuffer(10);
+      if (this.onload) {
+        this.onload({ target: { result: buffer } } as any);
+      }
+    });
+    vi.stubGlobal('FileReader', class { readAsArrayBuffer = readAsArrayBufferMock; });
+
+    const element = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+
+    Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files')?.set?.call(element, dataTransfer.files);
+    Object.defineProperty(element, 'files', { value: dataTransfer.files, configurable: true, writable: true });
+
+    const changeEvent = new Event('change', { bubbles: true, cancelable: true });
+    element.dispatchEvent(changeEvent);
+
+    await vi.waitFor(
+      () => {
+        expect(r2Client.putSave).toHaveBeenCalledWith('save-1', expect.any(Uint8Array));
+      },
+      { timeout: 3000 },
+    );
+
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('should gracefully handle R2 failure on upload', async () => {
+    const { AUTH_LOGGED_IN_INDICATOR } = await import('../../contexts/AuthContext');
+    const { r2Client } = await import('../../utils/r2/client');
+
+    localStorage.setItem(AUTH_LOGGED_IN_INDICATOR, 'true');
+    vi.mocked(r2Client.listSaves).mockRejectedValue(new Error('Network error'));
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    );
+
+    const file = new File(['mock save content'], 'save.sav', { type: 'application/octet-stream' });
+    await expect.element(page.getByText('[ UPLOAD.SYS ]')).toBeInTheDocument();
+
+    const readAsArrayBufferMock = vi.fn<(_f: File) => void>(function (this: any, _f: File) {
+      const buffer = new ArrayBuffer(10);
+      if (this.onload) {
+        this.onload({ target: { result: buffer } } as any);
+      }
+    });
+    vi.stubGlobal('FileReader', class { readAsArrayBuffer = readAsArrayBufferMock; });
+
+    const element = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+
+    Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files')?.set?.call(element, dataTransfer.files);
+    Object.defineProperty(element, 'files', { value: dataTransfer.files, configurable: true, writable: true });
+
+    const changeEvent = new Event('change', { bubbles: true, cancelable: true });
+    element.dispatchEvent(changeEvent);
+
+    await vi.waitFor(
+      () => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith('System: push to cloud failed');
+      },
+      { timeout: 3000 },
+    );
+
+    vi.unstubAllGlobals();
+    localStorage.clear();
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createMemoryHistory, createRootRoute, createRouter, RouterProvider } from '@tanstack/react-router';
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
@@ -20,8 +21,8 @@ vi.mock('../../engine/saveParser/index', () => ({
 
 vi.mock('../../utils/r2/client', () => ({
   r2Client: {
-    listSaves: vi.fn(),
-    putSave: vi.fn(),
+    listSaves: vi.fn<() => Promise<string[]>>(),
+    putSave: vi.fn<(id: string, data: Uint8Array) => Promise<void>>(),
   },
 }));
 

--- a/src/hooks/useFileSyncController.test.tsx
+++ b/src/hooks/useFileSyncController.test.tsx
@@ -216,7 +216,9 @@ describe('useFileSyncController', () => {
     // Setup file mock
     const mockFile = {
       arrayBuffer: vi.fn<() => Promise<ArrayBuffer>>().mockResolvedValue(new ArrayBuffer(8)),
-      get lastModified() { return 1000; },
+      get lastModified() {
+        return 1000;
+      },
     };
 
     const mockHandle = {

--- a/src/hooks/useFileSyncController.test.tsx
+++ b/src/hooks/useFileSyncController.test.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+/* eslint-disable @typescript-eslint/unbound-method */
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
@@ -10,8 +11,8 @@ import { useFileSyncController } from './useFileSyncController';
 // Mock dependencies
 vi.mock('../utils/r2/client', () => ({
   r2Client: {
-    listSaves: vi.fn(),
-    putSave: vi.fn(),
+    listSaves: vi.fn<() => Promise<string[]>>(),
+    putSave: vi.fn<(id: string, data: Uint8Array) => Promise<void>>(),
   },
 }));
 

--- a/src/hooks/useFileSyncController.test.tsx
+++ b/src/hooks/useFileSyncController.test.tsx
@@ -206,6 +206,41 @@ describe('useFileSyncController', () => {
     expect(r2Client.putSave).toHaveBeenCalledWith('existing-save-id', expect.any(Uint8Array));
   });
 
+  it('should fallback to save-1 if no R2 saves exist', async () => {
+    const { AUTH_LOGGED_IN_INDICATOR } = await import('../contexts/AuthContext');
+    const { r2Client } = await import('../utils/r2/client');
+
+    localStorage.setItem(AUTH_LOGGED_IN_INDICATOR, 'true');
+    vi.mocked(r2Client.listSaves).mockResolvedValue([]);
+
+    // Setup file mock
+    const mockFile = {
+      arrayBuffer: vi.fn<() => Promise<ArrayBuffer>>().mockResolvedValue(new ArrayBuffer(8)),
+      get lastModified() { return 1000; },
+    };
+
+    const mockHandle = {
+      getFile: vi.fn<() => Promise<unknown>>().mockImplementation(() => Promise.resolve(mockFile)),
+    };
+
+    Object.defineProperty(window, 'showOpenFilePicker', {
+      value: vi.fn<() => Promise<unknown[]>>().mockResolvedValue([mockHandle]),
+      writable: true,
+      configurable: true,
+    });
+
+    vi.mocked(saveParser.parseSaveFile).mockReturnValue({
+      gameVersion: 'red',
+      // biome-ignore lint/suspicious/noExplicitAny: Mock value typing
+    } as any);
+
+    void render(<TestComponent />);
+    await page.getByTestId('request-btn').click();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(r2Client.putSave).toHaveBeenCalledWith('save-1', expect.any(Uint8Array));
+  });
+
   it('should gracefully handle R2 failure', async () => {
     const { AUTH_LOGGED_IN_INDICATOR } = await import('../contexts/AuthContext');
     const { r2Client } = await import('../utils/r2/client');

--- a/src/hooks/useFileSyncController.test.tsx
+++ b/src/hooks/useFileSyncController.test.tsx
@@ -8,6 +8,13 @@ import { useStore } from '../store';
 import { useFileSyncController } from './useFileSyncController';
 
 // Mock dependencies
+vi.mock('../utils/r2/client', () => ({
+  r2Client: {
+    listSaves: vi.fn(),
+    putSave: vi.fn(),
+  },
+}));
+
 vi.mock('../db/SaveDB', () => ({
   saveDB: {
     putSave: vi.fn<() => void>(),
@@ -57,6 +64,7 @@ describe('useFileSyncController', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'setTimeout'] });
 
     // Setup store mocks
@@ -155,6 +163,91 @@ describe('useFileSyncController', () => {
 
     expect(mockHandle.getFile).toHaveBeenCalledTimes(14); // 4 + 10 polls
     expect(mockSetSaveData).toHaveBeenCalledTimes(2); // File didn't change again
+  });
+
+  it('should push to R2 when logged in', async () => {
+    const { AUTH_LOGGED_IN_INDICATOR } = await import('../contexts/AuthContext');
+    const { r2Client } = await import('../utils/r2/client');
+
+    localStorage.setItem(AUTH_LOGGED_IN_INDICATOR, 'true');
+    vi.mocked(r2Client.listSaves).mockResolvedValue(['existing-save-id']);
+
+    // Setup file mock
+    const mockFile = {
+      arrayBuffer: vi.fn<() => Promise<ArrayBuffer>>().mockResolvedValue(new ArrayBuffer(8)),
+      get lastModified() {
+        return 1000;
+      },
+    };
+
+    const mockHandle = {
+      getFile: vi.fn<() => Promise<unknown>>().mockImplementation(() => {
+        return Promise.resolve(mockFile);
+      }),
+    };
+
+    Object.defineProperty(window, 'showOpenFilePicker', {
+      value: vi.fn<() => Promise<unknown[]>>().mockResolvedValue([mockHandle]),
+      writable: true,
+      configurable: true,
+    });
+
+    vi.mocked(saveParser.parseSaveFile).mockReturnValue({
+      gameVersion: 'red',
+      // biome-ignore lint/suspicious/noExplicitAny: Mock value typing
+    } as any);
+
+    void render(<TestComponent />);
+    await page.getByTestId('request-btn').click();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(r2Client.listSaves).toHaveBeenCalled();
+    expect(r2Client.putSave).toHaveBeenCalledWith('existing-save-id', expect.any(Uint8Array));
+  });
+
+  it('should gracefully handle R2 failure', async () => {
+    const { AUTH_LOGGED_IN_INDICATOR } = await import('../contexts/AuthContext');
+    const { r2Client } = await import('../utils/r2/client');
+
+    localStorage.setItem(AUTH_LOGGED_IN_INDICATOR, 'true');
+    vi.mocked(r2Client.listSaves).mockRejectedValue(new Error('Network error'));
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Setup file mock
+    const mockFile = {
+      arrayBuffer: vi.fn<() => Promise<ArrayBuffer>>().mockResolvedValue(new ArrayBuffer(8)),
+      get lastModified() {
+        return 1000;
+      },
+    };
+
+    const mockHandle = {
+      getFile: vi.fn<() => Promise<unknown>>().mockImplementation(() => {
+        return Promise.resolve(mockFile);
+      }),
+    };
+
+    Object.defineProperty(window, 'showOpenFilePicker', {
+      value: vi.fn<() => Promise<unknown[]>>().mockResolvedValue([mockHandle]),
+      writable: true,
+      configurable: true,
+    });
+
+    vi.mocked(saveParser.parseSaveFile).mockReturnValue({
+      gameVersion: 'red',
+      // biome-ignore lint/suspicious/noExplicitAny: Mock value typing
+    } as any);
+
+    void render(<TestComponent />);
+    await page.getByTestId('request-btn').click();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('System: push to cloud failed');
+    // Ensure state still transitioned to live despite the R2 error
+    await expect.element(page.getByTestId('status')).toHaveTextContent('live');
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('should clean up interval on unmount', async () => {

--- a/src/hooks/useFileSyncController.ts
+++ b/src/hooks/useFileSyncController.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { AUTH_LOGGED_IN_INDICATOR } from '../contexts/AuthContext';
 import { saveDB } from '../db/SaveDB';
 import { parseSaveFile } from '../engine/saveParser/index';
 import { useStore } from '../store';
+import { r2Client } from '../utils/r2/client';
 
 /**
  * Represents the current state of the File System Access API synchronization.
@@ -75,6 +77,17 @@ export function useFileSyncController() {
         }
 
         await saveDB.putSave('last_save_file', new Uint8Array(buffer));
+
+        if (localStorage.getItem(AUTH_LOGGED_IN_INDICATOR) === 'true') {
+          try {
+            const saves = await r2Client.listSaves();
+            const saveId = saves.length > 0 && saves[0] ? saves[0] : 'save-1';
+            await r2Client.putSave(saveId, new Uint8Array(buffer));
+          } catch {
+            console.error('System: push to cloud failed');
+          }
+        }
+
         setStatus('live');
         setErrorMsg(null);
       } catch {


### PR DESCRIPTION
Implemented logic to push local save data to Cloudflare R2 upon file upload and live file change. Handled authentication checks using `AUTH_LOGGED_IN_INDICATOR` and added `try/catch` to prevent network failures from interrupting local IndexedDB persistence.

---
*PR created automatically by Jules for task [4633870046994094550](https://jules.google.com/task/4633870046994094550) started by @szubster*