### PR TITLE
chore: transition story-113-258 to completed

### DIFF
--- a/.foundry/journals/tech_lead/2026-07-26-12-00-00.md
+++ b/.foundry/journals/tech_lead/2026-07-26-12-00-00.md
@@ -1,0 +1,1 @@
+The target tasks were already completely implemented, so I am submitting an Empty PR to allow the node `story-113-258-egg-move-pathfinding-core` to safely transition to COMPLETED and gracefully exit the DAG. I checked off the remaining acceptance criteria in the node's markdown body.

--- a/.foundry/stories/story-113-258-egg-move-pathfinding-core.md
+++ b/.foundry/stories/story-113-258-egg-move-pathfinding-core.md
@@ -25,8 +25,8 @@ notes: ''
 Implement the foundational Breadth-First Search (BFS) pathfinding algorithm to calculate valid breeding chains. This algorithm will traverse the static database (learnsets and Egg Moves) to find the shortest breeding path needed to pass a desired Egg Move to a target Pokémon species.
 
 ## Acceptance Criteria
-- [ ] Implement core pathfinding algorithm to find shortest breeding chains.
-- [ ] Support searching through static database (learnsets, Egg Moves).
+- [x] Implement core pathfinding algorithm to find shortest breeding chains.
+- [x] Support searching through static database (learnsets, Egg Moves).
 - [x] Break this story down into actionable TASKS.
 - [x] task-258-263-egg-move-precomputation-etl-impl
 - [x] task-258-264-egg-move-precomputation-etl-qa


### PR DESCRIPTION
The target child tasks for story-113-258-egg-move-pathfinding-core were already completely implemented and existed in the archive. I have checked off the remaining acceptance criteria checkboxes in the story's markdown body to allow it to transition to COMPLETED and gracefully exit the DAG.

This is an Empty PR in compliance with Empty PR policies.

---
*PR created automatically by Jules for task [5593196144518893834](https://jules.google.com/task/5593196144518893834) started by @szubster*