### PR TITLE
feat(ui): integrate rng tid/sid display into telemetry matrix

### DIFF
--- a/.foundry/journals/coder/12455144608732302771.md
+++ b/.foundry/journals/coder/12455144608732302771.md
@@ -1,0 +1,17 @@
+# Coder Session Journal
+- **Task ID**: task-333-346-rng-tid-sid-integration-impl
+- **Session ID**: 12455144608732302771
+- **Focus**: Integrating the RngTidSidDisplay component into the main TelemetryMatrix in the header.
+
+## Findings & Actions Taken
+1. Added RngTidSidDisplay into `src/components/header/TelemetryMatrix.tsx`.
+2. Passed `saveData.trainerId` to `tid` and `saveData.secretId` to `sid` when rendering RngTidSidDisplay.
+3. Included the condition `saveData.secretId !== undefined` to only show the TID/SID display if the save actually holds a secret ID (as per requirements & types where `secretId` is optional).
+4. Ran all `pnpm type-check` and unit/e2e tests, successfully.
+5. Handled Playwright browser installation to fix local missing executable issues.
+6. Verified frontend by taking a full screenshot with a Gen 3 (Emerald) save fixture to ensure it seamlessly integrates without breaking layout bounds. The verification confirmed the display looks tactically cohesive with the rest of the UI.
+7. Updated the markdown checkboxes for `task-333-346-rng-tid-sid-integration-impl.md` and `story-130-333-rng-tid-sid-integration-retry.md` appropriately.
+
+## Verification
+- Pre-commit verification (Intelligent Verification Protocol): I self-verified this task visually via a Playwright UI screenshot with `emerald_postgame.sav`, confirming the tid/sid component aligns beautifully in the top-right of the telemetry matrix when populated.
+- Tests (both Vitest and E2E) run and pass flawlessly.

--- a/.foundry/stories/story-130-333-rng-tid-sid-integration-retry.md
+++ b/.foundry/stories/story-130-333-rng-tid-sid-integration-retry.md
@@ -34,7 +34,7 @@ This is a retry of the cancelled `story-130-270-rng-tid-sid-integration`. The im
 - [x] Ensure the component receives the correct data from the save state.
 - [x] Render the TID/SID component in the appropriate dashboard view.
 - [x] Tech Lead: Generate actionable Tasks.
-- [ ] task-333-346-rng-tid-sid-integration-impl
+- [x] task-333-346-rng-tid-sid-integration-impl
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/tasks/task-333-346-rng-tid-sid-integration-impl.md
+++ b/.foundry/tasks/task-333-346-rng-tid-sid-integration-impl.md
@@ -35,5 +35,5 @@ This is a retry of the cancelled `story-130-270-rng-tid-sid-integration`. The im
 - Ensure the component is correctly imported in `TelemetryMatrix.tsx`.
 
 ## Acceptance Criteria
-- [ ] Import `RngTidSidDisplay` in `src/components/header/TelemetryMatrix.tsx`.
-- [ ] Render `RngTidSidDisplay` in `TelemetryMatrix.tsx` and pass `saveData.trainerId` as `tid` and `saveData.secretId` as `sid`.
+- [x] Import `RngTidSidDisplay` in `src/components/header/TelemetryMatrix.tsx`.
+- [x] Render `RngTidSidDisplay` in `TelemetryMatrix.tsx` and pass `saveData.trainerId` as `tid` and `saveData.secretId` as `sid`.

--- a/src/components/header/TelemetryMatrix.tsx
+++ b/src/components/header/TelemetryMatrix.tsx
@@ -1,9 +1,8 @@
 import type { SaveData } from '../../engine/saveParser';
 import { CornerCrosshairs } from '../CornerCrosshairs';
 import { InlineDataPoint } from '../InlineDataPoint';
-import { VerticalDivider } from '../VerticalDivider';
 import { RngTidSidDisplay } from '../RngTidSidDisplay';
-
+import { VerticalDivider } from '../VerticalDivider';
 
 interface TelemetryMatrixProps {
   saveData: SaveData;
@@ -45,7 +44,11 @@ export function TelemetryMatrix({ saveData, progressPercentage }: TelemetryMatri
         <>
           <VerticalDivider className="h-8" />
           <div className="flex h-full items-center justify-center pl-4">
-            <RngTidSidDisplay tid={saveData.trainerId} sid={saveData.secretId} className="h-full border-none !p-0 bg-transparent" />
+            <RngTidSidDisplay
+              tid={saveData.trainerId}
+              sid={saveData.secretId}
+              className="!p-0 h-full border-none bg-transparent"
+            />
           </div>
         </>
       )}

--- a/src/components/header/TelemetryMatrix.tsx
+++ b/src/components/header/TelemetryMatrix.tsx
@@ -2,6 +2,8 @@ import type { SaveData } from '../../engine/saveParser';
 import { CornerCrosshairs } from '../CornerCrosshairs';
 import { InlineDataPoint } from '../InlineDataPoint';
 import { VerticalDivider } from '../VerticalDivider';
+import { RngTidSidDisplay } from '../RngTidSidDisplay';
+
 
 interface TelemetryMatrixProps {
   saveData: SaveData;
@@ -39,6 +41,14 @@ export function TelemetryMatrix({ saveData, progressPercentage }: TelemetryMatri
           />
         </div>
       </div>
+      {saveData.secretId !== undefined && (
+        <>
+          <VerticalDivider className="h-8" />
+          <div className="flex h-full items-center justify-center pl-4">
+            <RngTidSidDisplay tid={saveData.trainerId} sid={saveData.secretId} className="h-full border-none !p-0 bg-transparent" />
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Integrated the newly built `RngTidSidDisplay` component into the `TelemetryMatrix` UI header.

- Conditionally renders when `saveData.secretId` is available.
- Formatted gracefully matching the tactical hardware aesthetic.
- Checked off task and story markdown criteria for PR.
- Added session journal noting self-verification via playwright screenshots.

---
*PR created automatically by Jules for task [12455144608732302771](https://jules.google.com/task/12455144608732302771) started by @szubster*