### PR TITLE
Draft technical blueprints for SaveHistoryDB schema

### DIFF
--- a/.foundry/journals/tech_lead/1509983911165701547.md
+++ b/.foundry/journals/tech_lead/1509983911165701547.md
@@ -1,0 +1,6 @@
+# Session 1509983911165701547
+Broke down story-130-341-define-indexeddb-schema-retry into technical blueprints:
+- task-341-348-define-indexeddb-schema-retry-impl
+- task-341-349-define-indexeddb-schema-retry-qa
+
+Noted that the implementation artifacts may already be pre-existing in `src/db/schema.ts`.

--- a/.foundry/stories/story-130-341-define-indexeddb-schema-retry.md
+++ b/.foundry/stories/story-130-341-define-indexeddb-schema-retry.md
@@ -31,3 +31,5 @@ Define the `SaveHistoryDB` IndexedDB schema within the application codebase. Thi
 - [ ] Define the `saves` object store for raw binary save files (`Uint8Array`).
 - [ ] Define the `metadata` object store for save file metadata.
 - [ ] Define the `indexes` object store for fast retrieval of save data without parsing raw saves.
+- [ ] task-341-348-define-indexeddb-schema-retry-impl
+- [ ] task-341-349-define-indexeddb-schema-retry-qa

--- a/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
+++ b/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
@@ -1,0 +1,32 @@
+---
+id: task-341-348-define-indexeddb-schema-retry-impl
+type: TASK
+title: Define SaveHistoryDB Schema Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-26'
+updated_at: '2026-07-26'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-130-341-define-indexeddb-schema-retry
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Define SaveHistoryDB Schema Implementation
+
+## Overview
+Implement the database configuration and schema initialization logic for `SaveHistoryDB`. This may already be implemented in `src/db/schema.ts` from a previous iteration. If the target artifact already exists and is complete, submit an empty PR.
+
+## Acceptance Criteria
+- [ ] Implement `SaveHistoryDB` configuration (version, name, object stores).
+- [ ] Define the `saves` object store.
+- [ ] Define the `metadata` object store.
+- [ ] Define the `indexes` object store.

--- a/.foundry/tasks/task-341-349-define-indexeddb-schema-retry-qa.md
+++ b/.foundry/tasks/task-341-349-define-indexeddb-schema-retry-qa.md
@@ -1,0 +1,30 @@
+---
+id: task-341-349-define-indexeddb-schema-retry-qa
+type: TASK
+title: QA Define SaveHistoryDB Schema
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-26'
+updated_at: '2026-07-26'
+depends_on:
+  - task-341-348-define-indexeddb-schema-retry-impl
+jules_session_id: null
+pr_number: null
+parent: story-130-341-define-indexeddb-schema-retry
+tags:
+  - storage
+  - indexeddb
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Define SaveHistoryDB Schema
+
+## Overview
+Verify the implementation of the `SaveHistoryDB` schema configuration in `src/db/schema.ts` against the defined requirements.
+
+## Acceptance Criteria
+- [ ] Verify `SaveHistoryDB` configuration exists with the correct stores (`saves`, `metadata`, `indexes`).


### PR DESCRIPTION
Broke down the `story-130-341-define-indexeddb-schema-retry` into actionable technical tasks for implementation and verification, satisfying the requirements for the `SaveHistoryDB` IndexedDB schema setup.

---
*PR created automatically by Jules for task [1509983911165701547](https://jules.google.com/task/1509983911165701547) started by @szubster*