### PR TITLE
docs: complete story-149-333-gen3-roamer-unit-tests acceptance criteria

### DIFF
--- a/.foundry/journals/tech_lead/800926013637352944.md
+++ b/.foundry/journals/tech_lead/800926013637352944.md
@@ -1,0 +1,9 @@
+# Tech Lead Session Journal
+
+## Session ID: 800926013637352944
+
+## Observations & Actions
+- Assigned to `story-149-333-gen3-roamer-unit-tests`.
+- The child task `task-333-346-gen3-roamer-extraction-tests-impl` has already been `COMPLETED`.
+- Checked off the completed child task in the story's acceptance criteria.
+- Submitting an empty PR as the required implementation is already done.

--- a/.foundry/stories/story-149-333-gen3-roamer-unit-tests.md
+++ b/.foundry/stories/story-149-333-gen3-roamer-unit-tests.md
@@ -30,4 +30,4 @@ Develop unit tests to verify that the core parsing logic for the Gen 3 Roamer st
 ## Acceptance Criteria
 - [x] Tech Lead: Break down this Story into executable Tasks.
 - [x] task-333-333-gen3-roamer-extraction-tests-impl
-- [ ] task-333-346-gen3-roamer-extraction-tests-impl
+- [x] task-333-346-gen3-roamer-extraction-tests-impl


### PR DESCRIPTION
Submitting an empty PR for `story-149-333-gen3-roamer-unit-tests`.

The required child task `task-333-346-gen3-roamer-extraction-tests-impl` has already been implemented and transitioned to `COMPLETED`. 

I have updated the Story's markdown body to check off this acceptance criterion and created a journal entry documenting the pre-existing completion as per the Empty PR Policy for parent node demotion/completion.

---
*PR created automatically by Jules for task [800926013637352944](https://jules.google.com/task/800926013637352944) started by @szubster*