### PR TITLE
chore: verify db schema for multiple saves QA

### DIFF
--- a/.foundry/journals/qa/14373879936299843698.md
+++ b/.foundry/journals/qa/14373879936299843698.md
@@ -1,0 +1,6 @@
+# Session 14373879936299843698
+
+## Observations
+Verified task-255-339-db-schema-saves-qa (SaveHistoryDB schema update to version 2, adding trainers store and trainerId index).
+
+The database schema modifications met the requirements laid out in the target task, providing a serializable structure necessary for Cloudflare synchronization while establishing the one-to-many relationship via the new index.

--- a/.foundry/tasks/task-255-339-db-schema-saves-qa.md
+++ b/.foundry/tasks/task-255-339-db-schema-saves-qa.md
@@ -33,6 +33,6 @@ Verify the implementation of the new database schema updates for managing multip
 3. **Sync Readiness**: Review the schema design to ensure it is structured appropriately for syncing with the Cloudflare backend.
 
 ## Acceptance Criteria
-- [ ] Verify the schema correctly stores multiple save files per playthrough.
-- [ ] Verify the relationships between Trainer profiles and their respective save history.
-- [ ] Verify the schema supports syncing with the Cloudflare backend.
+- [x] Verify the schema correctly stores multiple save files per playthrough.
+- [x] Verify the relationships between Trainer profiles and their respective save history.
+- [x] Verify the schema supports syncing with the Cloudflare backend.


### PR DESCRIPTION
Verified the SaveHistoryDB schema modifications (version 2, trainers store, trainerId index) against the task requirements. Checked off acceptance criteria and recorded observations in the QA journal per the journaling policies.

---
*PR created automatically by Jules for task [14373879936299843698](https://jules.google.com/task/14373879936299843698) started by @szubster*