### PR TITLE
chore: complete task-341-348-define-indexeddb-schema-retry-impl

### DIFF
--- a/.foundry/journals/coder/13844134766059607560.md
+++ b/.foundry/journals/coder/13844134766059607560.md
@@ -1,0 +1,7 @@
+# Session 13844134766059607560
+
+I reviewed `task-341-348-define-indexeddb-schema-retry-impl`. The requirement was to implement `SaveHistoryDB` configuration and schema initialization logic, including the `saves`, `metadata`, and `indexes` object stores.
+
+Upon inspecting `src/db/schema.ts`, I observed that `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema` are already implemented completely and meet all the acceptance criteria. The configuration and object stores are fully defined.
+
+Because the target artifact already exists and is complete, I am submitting an Empty PR to unblock the DAG. I checked off the acceptance criteria in the parent node's markdown body. The completion was pre-existing.

--- a/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
+++ b/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
@@ -26,7 +26,7 @@ notes: ''
 Implement the database configuration and schema initialization logic for `SaveHistoryDB`. This may already be implemented in `src/db/schema.ts` from a previous iteration. If the target artifact already exists and is complete, submit an empty PR.
 
 ## Acceptance Criteria
-- [ ] Implement `SaveHistoryDB` configuration (version, name, object stores).
-- [ ] Define the `saves` object store.
-- [ ] Define the `metadata` object store.
-- [ ] Define the `indexes` object store.
+- [x] Implement `SaveHistoryDB` configuration (version, name, object stores).
+- [x] Define the `saves` object store.
+- [x] Define the `metadata` object store.
+- [x] Define the `indexes` object store.


### PR DESCRIPTION
This PR marks `task-341-348-define-indexeddb-schema-retry-impl` as complete. The requirement was to implement `SaveHistoryDB` configuration and schema initialization logic. 

Upon inspection, `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema` are already implemented completely in `src/db/schema.ts`. Therefore, this is an empty PR to unblock the DAG.

- Checked off acceptance criteria in the task file.
- Documented findings in the coder journal.
- Verified test suite passes without regressions.

---
*PR created automatically by Jules for task [13844134766059607560](https://jules.google.com/task/13844134766059607560) started by @szubster*