### PR TITLE
QA: Reject SaveHistoryDB schema implementation

### DIFF
--- a/.foundry/journals/qa/4699122810863772733.md
+++ b/.foundry/journals/qa/4699122810863772733.md
@@ -1,0 +1,12 @@
+# QA Session 4699122810863772733
+
+**Target Task**: `task-341-348-define-indexeddb-schema-retry-impl`
+**Outcome**: REJECTED
+
+## Details
+The implementation of the `SaveHistoryDB` schema in `src/db/schema.ts` violated the requirements outlined in `.foundry/docs/schema.md` (Section 14). Specifically:
+1. `SAVE_HISTORY_DB_CONFIG.VERSION` was set to `2` instead of the expected `1`.
+2. A `TRAINERS` store was added to `SAVE_HISTORY_DB_CONFIG.STORES` and `SaveHistoryDBSchema`, which is not part of the schema definition.
+3. The `INDEXES` store incorrectly included a `trainerId` index.
+
+The target task has been transitioned to `FAILED`, with `rejection_count` incremented and a `rejection_reason` provided. My own QA task remains `ACTIVE` with notes appended to the markdown body.

--- a/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
+++ b/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
@@ -2,7 +2,7 @@
 id: task-341-348-define-indexeddb-schema-retry-impl
 type: TASK
 title: Define SaveHistoryDB Schema Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-26'
 updated_at: '2026-07-26'
@@ -15,8 +15,8 @@ tags:
   - indexeddb
   - history
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Implementation does not match schema requirements in .foundry/docs/schema.md (Section 14). Specifically, VERSION is 2 instead of 1, and there is an extra TRAINERS store and trainerId index.'
 notes: ''
 ---
 
@@ -26,7 +26,7 @@ notes: ''
 Implement the database configuration and schema initialization logic for `SaveHistoryDB`. This may already be implemented in `src/db/schema.ts` from a previous iteration. If the target artifact already exists and is complete, submit an empty PR.
 
 ## Acceptance Criteria
-- [x] Implement `SaveHistoryDB` configuration (version, name, object stores).
-- [x] Define the `saves` object store.
-- [x] Define the `metadata` object store.
-- [x] Define the `indexes` object store.
+- [ ] Implement `SaveHistoryDB` configuration (version, name, object stores).
+- [ ] Define the `saves` object store.
+- [ ] Define the `metadata` object store.
+- [ ] Define the `indexes` object store.

--- a/.foundry/tasks/task-341-349-define-indexeddb-schema-retry-qa.md
+++ b/.foundry/tasks/task-341-349-define-indexeddb-schema-retry-qa.md
@@ -28,3 +28,6 @@ Verify the implementation of the `SaveHistoryDB` schema configuration in `src/db
 
 ## Acceptance Criteria
 - [ ] Verify `SaveHistoryDB` configuration exists with the correct stores (`saves`, `metadata`, `indexes`).
+
+## QA Notes
+- Validation FAILED. The implementation in `src/db/schema.ts` sets `SAVE_HISTORY_DB_CONFIG.VERSION` to 2 instead of 1. It also incorrectly adds a `TRAINERS` store and a `trainerId` index, which are not part of the schema defined in `.foundry/docs/schema.md` (Section 14).


### PR DESCRIPTION
The implementation in `src/db/schema.ts` sets `SAVE_HISTORY_DB_CONFIG.VERSION` to 2 instead of 1, adds a `TRAINERS` store, and adds a `trainerId` index to `INDEXES`. This violates the schema defined in `.foundry/docs/schema.md` (Section 14).

The target task (`task-341-348-define-indexeddb-schema-retry-impl`) has been transitioned to `FAILED`, with `rejection_count` incremented, a `rejection_reason` provided, and acceptance criteria unchecked.

Notes have been appended to the QA task (`task-341-349-define-indexeddb-schema-retry-qa`) and a session journal entry has been created detailing the rejection.

---
*PR created automatically by Jules for task [4699122810863772733](https://jules.google.com/task/4699122810863772733) started by @szubster*