### PR TITLE
feat: implement precise breeding mechanics for egg move pathfinding

### DIFF
--- a/.foundry/journals/coder/2026-07-26-22-10-55.md
+++ b/.foundry/journals/coder/2026-07-26-22-10-55.md
@@ -1,0 +1,4 @@
+# Session Log: Egg Move Breeding Rules
+- Modified `scripts/generate-pokedata.ts` to enforce accurate gender rates and egg groups for the father (male, explicit egg groups) and mother (female, effective egg groups from evolutions).
+- Addressed 'No Eggs' (group 15) edge cases by explicitly filtering them out.
+- Handled tests and Playwright binary dependency setup.

--- a/.foundry/tasks/task-259-348-egg-move-breeding-rules-impl.md
+++ b/.foundry/tasks/task-259-348-egg-move-breeding-rules-impl.md
@@ -26,7 +26,7 @@ notes: ''
 Implement the breeding rules for the core pathfinding algorithm that calculates valid egg moves in `scripts/generate-pokedata.ts`. The algorithm should respect Gen 2 and Gen 3 breeding mechanics, specifically around Egg Groups and Gender Rates. Note that the Breadth-First Search (BFS) is already implemented in `scripts/generate-pokedata.ts`, you just need to refine the constraints of what constitutes a valid breeding edge.
 
 ## Acceptance Criteria
-- [ ] Update `scripts/generate-pokedata.ts` to ensure the BFS algorithm respects Egg Group matching. If two Pokemon share an egg group (and neither is in the "No Eggs" group), they can breed.
-- [ ] Update `scripts/generate-pokedata.ts` to ensure the algorithm respects gender requirements (opposite genders). One parent must be able to be male (gender_rate < 8 and !== -1) and the other female (gender_rate > 0 and !== -1), unless breeding with Ditto.
-- [ ] Update `scripts/generate-pokedata.ts` to ensure invalid breeding pairs (e.g., both parents in the "No Eggs" group) are excluded.
-- [ ] Verify `getEffectiveEggGroups` works as expected for this logic.
+- [x] Update `scripts/generate-pokedata.ts` to ensure the BFS algorithm respects Egg Group matching. If two Pokemon share an egg group (and neither is in the "No Eggs" group), they can breed.
+- [x] Update `scripts/generate-pokedata.ts` to ensure the algorithm respects gender requirements (opposite genders). One parent must be able to be male (gender_rate < 8 and !== -1) and the other female (gender_rate > 0 and !== -1), unless breeding with Ditto.
+- [x] Update `scripts/generate-pokedata.ts` to ensure invalid breeding pairs (e.g., both parents in the "No Eggs" group) are excluded.
+- [x] Verify `getEffectiveEggGroups` works as expected for this logic.

--- a/scripts/generate-pokedata.ts
+++ b/scripts/generate-pokedata.ts
@@ -947,10 +947,14 @@ for (const moveId of eggMovesIds) {
     if (!uData) continue;
 
     // Check if u can be male (gender_rate < 8 and !== -1)
+      // The father (u) passes the egg move. It must be male.
     const uGr = uData.gr !== undefined ? uData.gr : 4;
-    if (uGr === -1 || uGr === 8) continue; // Genderless or 100% Female cannot pass egg moves
+      if (uGr === -1 || uGr === 8) continue; // Genderless (-1) or 100% Female (8) cannot pass egg moves
 
-    const uEg = getEffectiveEggGroups(u);
+      // For the father, we strictly use its *own* egg groups, not effective ones from evolutions,
+      // because baby forms (which don't have egg groups) cannot be fathers.
+      const uEg = uData.eg || [];
+      if (uEg.length === 0 || uEg.includes(15)) continue; // 15 is "No Eggs" (e.g., babies, legendaries)
 
     for (const vData of pokemon) {
       const v = vData.id;
@@ -960,11 +964,16 @@ for (const moveId of eggMovesIds) {
       if (!targets.has(v) && !sources.has(v)) continue;
 
       const vGr = vData.gr !== undefined ? vData.gr : 4;
+        // The mother (v) determines the species. If it's a baby, it can't breed, but its evolved form can.
+        // So we use getEffectiveEggGroups to see if the species line can produce eggs.
       const vEg = getEffectiveEggGroups(v);
+
+        // If the mother's effective egg group is empty or is "No Eggs", it cannot breed.
+        if (vEg.length === 0 || vEg.includes(15)) continue;
 
       let canProduce = false;
 
-      // 1. Normal breeding: v has females, and u and v share an egg group
+        // 1. Normal breeding: v can be female (not genderless, not 100% male), and u and v share an egg group.
       if (vGr !== -1 && vGr !== 0 && uEg.some((g: number) => vEg.includes(g))) {
         canProduce = true;
       }


### PR DESCRIPTION
Implement the breeding rules for the core pathfinding algorithm that calculates valid egg moves in `scripts/generate-pokedata.ts`. The algorithm now correctly respects Gen 2 and Gen 3 breeding mechanics, specifically around Egg Groups and Gender Rates for fathers and mothers, including filtering out the "No Eggs" group.

---
*PR created automatically by Jules for task [9439737012059559338](https://jules.google.com/task/9439737012059559338) started by @szubster*