### PR TITLE
chore: acknowledge completed tasks in story-036-255-progression-save-model

### DIFF
--- a/.foundry/journals/tech_lead/12774191174114317974.md
+++ b/.foundry/journals/tech_lead/12774191174114317974.md
@@ -1,0 +1,3 @@
+# Session 12774191174114317974
+
+The target artifacts for the story `story-036-255-progression-save-model` were already completed in the codebase prior to this session (by child nodes `task-255-338-db-schema-saves-impl` and `task-255-339-db-schema-saves-qa`), but the parent story's markdown checkboxes were not checked. I have checked off the acceptance criteria for these child nodes and am submitting an Empty PR to transition the parent node to VERIFYING as per the Empty PR Checkbox Policy.

--- a/.foundry/stories/story-036-255-progression-save-model.md
+++ b/.foundry/stories/story-036-255-progression-save-model.md
@@ -31,5 +31,5 @@ To support progression tracking and multiple save files per playthrough, we need
 
 ## Acceptance Criteria
 - [x] Tech Lead: Break this Story down into Tasks to define the specific database tables and indexes needed for managing multiple save files.
-- [ ] task-255-338-db-schema-saves-impl
-- [ ] task-255-339-db-schema-saves-qa
+- [x] task-255-338-db-schema-saves-impl
+- [x] task-255-339-db-schema-saves-qa


### PR DESCRIPTION
Updates the acceptance criteria checkboxes in `story-036-255-progression-save-model.md` as the underlying implementation and QA tasks were already completed in the codebase in a prior session. Submitting as an Empty PR to unblock the orchestrator and transition the story to VERIFYING.

---
*PR created automatically by Jules for task [12774191174114317974](https://jules.google.com/task/12774191174114317974) started by @szubster*