### PR TITLE
Acknowledge pre-existing Gen 2 Pokegear parser implementation

### DIFF
--- a/.foundry/journals/coder/13210301516282490032.md
+++ b/.foundry/journals/coder/13210301516282490032.md
@@ -1,0 +1,5 @@
+# Session 13210301516282490032
+
+The implementation for Gen 2 Pokegear registered numbers parsing was already pre-existing in `src/engine/saveParser/parsers/gen2/phone/parser.ts` and `src/engine/saveParser/parsers/gen2/phone/parser.test.ts`.
+
+I verified the code existed and met all requirements (module-level constants, DataView API, error handling). Therefore, I only updated the task node `task-283-342-parse-registered-numbers-impl.md` to check off the acceptance criteria checkboxes and am submitting an Empty PR as per system policies.

--- a/.foundry/tasks/task-283-342-parse-registered-numbers-impl.md
+++ b/.foundry/tasks/task-283-342-parse-registered-numbers-impl.md
@@ -32,7 +32,7 @@ Implement the parsing logic for Generation 2 Pokegear registered numbers and sta
 - **Error Handling**: You MUST include explicit `try/catch` blocks handling `RangeError` exceptions for out-of-bounds reads, returning an appropriate error message like "The save file is corrupted or incomplete".
 
 ## Acceptance Criteria
-- [ ] Define module-level constants for `wPhoneList` (size 11), `wSwarmFlags`, `wDailyPhoneItemFlags`, `wDailyPhoneTimeOfDayFlags`, and `wSpecialPhoneCallID`.
-- [ ] Implement robust save file parsing logic using the DataView API to extract the Pokegear registered numbers.
-- [ ] Implement explicit `RangeError` handling with `try/catch` block for out-of-bounds reads returning "The save file is corrupted or incomplete".
-- [ ] Ensure all code passes linting, tests, and formatting checks before submission.
+- [x] Define module-level constants for `wPhoneList` (size 11), `wSwarmFlags`, `wDailyPhoneItemFlags`, `wDailyPhoneTimeOfDayFlags`, and `wSpecialPhoneCallID`.
+- [x] Implement robust save file parsing logic using the DataView API to extract the Pokegear registered numbers.
+- [x] Implement explicit `RangeError` handling with `try/catch` block for out-of-bounds reads returning "The save file is corrupted or incomplete".
+- [x] Ensure all code passes linting, tests, and formatting checks before submission.


### PR DESCRIPTION
The implementation for Gen 2 Pokegear registered numbers parsing was already completed and exists in `src/engine/saveParser/parsers/gen2/phone/parser.ts` and `src/engine/saveParser/parsers/gen2/phone/parser.test.ts`. 

I verified that the code meets all architectural constraints:
- Module-level constants are defined for `wPhoneList`, `wSwarmFlags`, etc.
- No inline magic numbers are used.
- Explicit `RangeError` try/catch block is implemented returning "The save file is corrupted or incomplete."
- Tests pass.

Per the Empty PR Policy, I am submitting this empty PR to acknowledge the existing implementation and check off the acceptance criteria on the task node.

---
*PR created automatically by Jules for task [13210301516282490032](https://jules.google.com/task/13210301516282490032) started by @szubster*