### PR TITLE
🛠️ Infras: Add CI reporters to Playwright and Vitest

### DIFF
--- a/.jules/infras/jules-session-infras.md
+++ b/.jules/infras/jules-session-infras.md
@@ -1,5 +1,6 @@
-# Infras Journal - Session jules-infras-lefthook
+# Infras Journal - Session jules-infras
 
 ## Critical Learnings
 - **Tooling configuration context:** `lefthook.yml` parallel execution can safely be enabled for this repo without hitting race conditions on pre-commit since the tasks (lint, check, types) do not mutually overlap file writes in a way that breaks.
 - **Git hooks and Node engine issue:** Using `lefthook` along with `pnpm` can sometimes get into a broken state (`[ERROR] Command failed with exit code 1: pnpm install`) if hooks aren't set up correctly initially. Running `git config --unset-all --global core.hooksPath` allows `pnpm install` and the subsequent `lefthook install` to run properly.
+- **CI Annotations with Built-in Reporters:** Tools like Playwright and Vitest support native Github Actions reporters that generate inline PR annotations. They can easily be activated in CI environments using `process.env['CI']` and `process.env['GITHUB_ACTIONS']` without needing dedicated Github Actions marketplace extensions.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,9 +14,9 @@ export default defineConfig({
   forbidOnly: !!process.env['CI'],
   retries: process.env['CI'] ? 2 : 0,
   workers: process.env['CI'] ? 2 : '50%',
-  reporter: [
-    ['html', { open: 'never' }],
-  ],
+  reporter: process.env['CI']
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['html', { open: 'never' }]],
   use: {
     actionTimeout: 15000,
     navigationTimeout: 30000,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,9 @@ export default defineConfig(async (configEnv) => {
         include: ['src/**/*.ts', 'src/**/*.tsx'],
         exclude: ['**/*.json', '**/*.test.ts', '**/*.test.tsx', 'src/hooks/useFileSyncController.ts', 'src/db/SaveDB.ts', 'src/components/AppHeader.tsx', 'src/components/header/OfflineControls.tsx', 'src/components/header/SystemControls.tsx', 'src/components/header/TelemetryMatrix.tsx', 'src/components/dashboard/battle-frontier/BattleFrontierDashboard.tsx'],
       },
-      reporters: ['default', ['junit', { outputFile: './test-report.junit.xml' }]],
+      reporters: process.env['GITHUB_ACTIONS']
+        ? ['github-actions', 'default', ['junit', { outputFile: './test-report.junit.xml' }]]
+        : ['default', ['junit', { outputFile: './test-report.junit.xml' }]],
       // Vitest 4 uses 'projects' instead of 'workspace'
       projects: [
         {


### PR DESCRIPTION
This patch dynamically adds the 'github' reporter to Playwright and the 'github-actions' reporter to Vitest when running in a CI environment. This improves developer experience by showing test failures as inline code annotations in GitHub pull requests, rather than requiring developers to comb through raw CI logs.

The changes are entirely non-disruptive to local development environments, as the reporters are conditionally applied using `process.env['CI']` and `process.env['GITHUB_ACTIONS']`.

---
*PR created automatically by Jules for task [7394556495899181996](https://jules.google.com/task/7394556495899181996) started by @szubster*