### PR TITLE
🧭 Strategist: Prompt Consolidation - Centralize Save File Parsing Rules

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -307,11 +307,14 @@ Enum-to-number optimizations (e.g., mapping encounter methods or string triggers
 
 ---
 
-## 13. Dynamic Save Block Extraction Guidelines
+## 13. Save File Parsing & Extraction Guidelines
 
-As defined in ADR 028, to ensure maintainability and readability within the save parsing engine, the following rules apply when extracting dynamic save blocks:
-*   **Module-Level Constants:** All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level.
-*   **No Magic Numbers:** The use of inline magic numbers for memory operations during dynamic save block extraction is strictly forbidden. This constraint must be enforced during code reviews.
+To ensure maintainability and readability within the save parsing engine, the following rules apply when parsing or extracting save file blocks:
+*   **Module-Level Constants:** All memory offsets, lengths, bit locations, shifts, and array bounds checking limits must be explicitly defined as reusable constants at the module level.
+*   **No Magic Numbers:** The use of inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions is strictly forbidden.
+*   **Relative Offsets (Gen 3):** When extracting Gen 3 save blocks, you must pass and utilize the resolved section offset (e.g., `section1Offset` or `section2Offset`) to calculate relative memory offsets rather than absolute hardcoded offsets, supporting the A/B bank flash memory architecture.
+*   **Bitwise Mapping:** When parsing bitwise blocks (e.g., event flags) using the `DataView` API, you must explicitly map the specific bit offsets corresponding to target events. Just extracting the raw array is insufficient.
+*   **RangeError Handling:** When using the `DataView` API, you MUST catch `RangeError` for out-of-bounds reads and throw a new error with the message "The save file is corrupted or incomplete." to prevent application crashes.
 
 ---
 

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -16,14 +16,8 @@ When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.t
 
 
 
-## Save File Parsing & Magic Numbers
-When implementing save file parsing or data definitions, you MUST explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Strictly avoid using inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions. This ensures robustness against version-specific shifts and prevents brittle code. Furthermore, when using the `DataView` API for array bounds checking or extraction limits (e.g., max record counts), you MUST NOT use inline magic numbers; these bounds must also be defined as reusable constants at the module level.
-
-When writing Gen 3 save block extraction functions, you must pass and utilize the resolved section offset (e.g., `section1Offset` or `section2Offset`) to calculate relative memory offsets, rather than using absolute hardcoded offsets, to properly support the Gen 3 A/B bank flash memory architecture.
-
-When parsing bitwise blocks (like event flag arrays) using the `DataView` API, you must explicitly map the specific bit offsets corresponding to target events. Just extracting the array is insufficient; explicitly identifying the individual bit offsets is required for downstream consumption.
-
-When using the `DataView` API to parse save files, you MUST catch `RangeError` for out-of-bounds reads and throw a new error with the message "The save file is corrupted or incomplete." to prevent crashes and QA rejections.
+## Save File Parsing
+When implementing save file parsing, extraction functions, or mapping bitwise blocks, you MUST strictly adhere to the guidelines defined in **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`. This includes rules regarding module-level constants, avoiding magic numbers, using relative offsets for Gen 3, and catching `RangeError`.
 
 ## UI Aesthetic Constraints (ADR 008)
 When implementing UI components, you MUST adhere strictly to the "tactical hardware/snooping" aesthetic outlined in ADR 008.

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -17,7 +17,7 @@ Ensure you are fully aware of the rules defined in `.foundry/archive/docs/adrs/0
 
 ## Responsibilities
 
-1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria. You MUST explicitly reject tasks that use inline magic numbers (e.g., `0x2dd6`, `>> 4`) for save file data extraction instead of defined reusable constants at the module level. You MUST also explicitly reject tasks that use absolute memory offsets (e.g., `0x2dd6`) for Gen 3 dynamic save block extraction instead of calculating relative offsets from the resolved section offset (e.g., `section1Offset`). You MUST ensure that any tasks involving parsers for save files properly catch `RangeError` from the `DataView` API when checking for out-of-bounds reads.
+1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria. For tasks involving save file parsing, you MUST explicitly reject implementations that violate any of the rules defined in **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`.
 2. **Review**: Ensure implemented code follows architectural constraints (especially ADR 001).
 3. **Approval/Rejection**: If the implementation is valid, approve it. If not, detail what is missing or incorrect according to the contract and architecture.
 4. **Specify Results**: Explicitly specify the results of your validation work. Depending on the scope and need for further analysis, this output can include new tests, documentation updates, or the creation of new tasks, stories, PRDs, or ideas.

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -8,9 +8,7 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 2.  **Adhere to Architecture Decisions**: You must be intimately familiar with and strictly follow the rules defined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`. Ensure that your blueprints align with this core architecture.
 3.  **Draft Technical Blueprints**: Take the requirements defined in a STORY and break them down into specific, actionable technical TASK nodes. If multiple tasks are created and one depends on the implementation details of another, you MUST explicitly set the `depends_on` field of the dependent task to point to the prerequisite task to prevent DAG deadlocks.
 4.  **Define Clear Contracts**: Your tasks should serve as a clear contract for the Coder. Include necessary context, constraints, and acceptance criteria.
-    - When drafting blueprints for save file parsing, explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level, forbidding inline magic numbers.
-    - When drafting blueprints for Gen 3 save file parsing, explicitly require that the Coder uses the resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.
-    - When drafting blueprints for save file parsing, explicitly require that the Coder must catch `RangeError` from out-of-bounds `DataView` reads and throw a new error with the message "The save file is corrupted or incomplete."
+    - When drafting blueprints for save file parsing, you MUST explicitly require the Coder to strictly adhere to all guidelines defined in **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`.
 5.  **Intelligent Verification Protocol**: Intelligently decide when a STORY requires a separate QA verification task:
     - If a story involves complex logic or risk, create a matching TASK for the `qa` persona to verify the `coder`'s work.
     - If simple/low-risk, designate the `coder` to self-verify (documented in the task journal).

--- a/.jules/strategist/2026-08-15-consolidate-save-parsing-rules.md
+++ b/.jules/strategist/2026-08-15-consolidate-save-parsing-rules.md
@@ -1,0 +1,5 @@
+## 2026-08-15 - [Accepted] - Prompt Consolidation: Centralize Save File Parsing Rules
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The rules for save file parsing (avoiding magic numbers, using relative offsets for Gen 3, catching RangeError, and mapping bitwise offsets) were duplicated across `coder.md`, `tech_lead.md`, and `qa.md`. This verbosity wastes context window tokens and creates a maintenance burden if the rules change.
+**Pattern:** Consolidate redundant architectural or implementation rules from agent prompts into centralized sections in `.foundry/docs/schema.md` (or other core docs) and have the agent prompts reference them. This enforces a single source of truth and reduces token usage.


### PR DESCRIPTION
This PR centralizes the "Save File Parsing & Extraction Guidelines" to enforce a single source of truth and reduce duplicated text across agent prompts.

### Changes:
- **`schema.md`:** Expanded Section 13 to include all save parsing rules (magic numbers, `RangeError` constraints, Gen 3 relative offsets, and bitwise mapping).
- **`coder.md`, `qa.md`, `tech_lead.md`:** Replaced verbose inline rules with a reference to Section 13 of `schema.md`.
- **`.jules/strategist/2026-08-15-consolidate-save-parsing-rules.md`:** Added a journal entry explaining the rationale for this prompt consolidation.

---
*PR created automatically by Jules for task [14641202388436388838](https://jules.google.com/task/14641202388436388838) started by @szubster*