### PR TITLE
Update acceptance criteria for epic-044-149-gen3-roamer-core-extraction-v4

### DIFF
--- a/.foundry/epics/epic-044-149-gen3-roamer-core-extraction-v4.md
+++ b/.foundry/epics/epic-044-149-gen3-roamer-core-extraction-v4.md
@@ -30,8 +30,8 @@ Parse the `Roamer` struct from the save file (SaveBlock1) to extract the IVs, Pe
 ## Acceptance Criteria
 - [x] Implement robust `DataView` parsing for the Gen 3 `Roamer` struct across all Gen 3 game versions.
 - [x] Extract and expose the `active` boolean to determine if the roamer is currently available in the game world.
-- [ ] Write unit tests verifying extraction against known good save fixtures for each game version.
+- [x] Write unit tests verifying extraction against known good save fixtures for each game version.
 - [x] story-149-291-gen3-roamer-core-extraction
 - [x] story-149-292-gen3-roamer-active-flag-parsing
-- [ ] story-149-333-gen3-roamer-unit-tests
+- [x] story-149-333-gen3-roamer-unit-tests
 - [x] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/journals/story_owner/12066916843217249989.md
+++ b/.foundry/journals/story_owner/12066916843217249989.md
@@ -1,0 +1,3 @@
+# Journal Update
+
+Pre-existing completed tasks / stories were identified correctly (in this case `story-149-333-gen3-roamer-unit-tests.md` existed and was `COMPLETED` along with its child task nodes). The epic's acceptance criteria checkboxes were updated accordingly. No new story needed to be created.


### PR DESCRIPTION
Checking off completed story story-149-333-gen3-roamer-unit-tests in epic-044-149-gen3-roamer-core-extraction-v4 markdown body. The story was already implemented.

---
*PR created automatically by Jules for task [12066916843217249989](https://jules.google.com/task/12066916843217249989) started by @szubster*