### PR TITLE
Implement task-341-348-define-indexeddb-schema-retry-impl

### DIFF
--- a/.foundry/journals/coder/14217363794546868270.md
+++ b/.foundry/journals/coder/14217363794546868270.md
@@ -1,0 +1,3 @@
+Session: 14217363794546868270
+Node: task-341-348-define-indexeddb-schema-retry-impl
+Outcome: Target artifact (SAVE_HISTORY_DB_CONFIG in src/db/schema.ts) already existed and was verified complete via grep. Submitted empty PR by checking off Acceptance Criteria checkboxes while preserving the YAML frontmatter entirely.

--- a/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
+++ b/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
@@ -26,7 +26,7 @@ notes: ''
 Implement the database configuration and schema initialization logic for `SaveHistoryDB`. This may already be implemented in `src/db/schema.ts` from a previous iteration. If the target artifact already exists and is complete, submit an empty PR.
 
 ## Acceptance Criteria
-- [ ] Implement `SaveHistoryDB` configuration (version, name, object stores).
-- [ ] Define the `saves` object store.
-- [ ] Define the `metadata` object store.
-- [ ] Define the `indexes` object store.
+- [x] Implement `SaveHistoryDB` configuration (version, name, object stores).
+- [x] Define the `saves` object store.
+- [x] Define the `metadata` object store.
+- [x] Define the `indexes` object store.


### PR DESCRIPTION
- Verified that the `SAVE_HISTORY_DB_CONFIG` is fully implemented and correct in `src/db/schema.ts`
- Updated the checkboxes in `.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md` to indicate task completion.
- No code logic changes required. Empty PR submission per `ADR-009`.

---
*PR created automatically by Jules for task [14217363794546868270](https://jules.google.com/task/14217363794546868270) started by @szubster*