### PR TITLE
chore(orchestrator): check off e2e safeguard task criteria

### DIFF
--- a/.foundry/journals/coder/2026-07-27.md
+++ b/.foundry/journals/coder/2026-07-27.md
@@ -1,0 +1,9 @@
+# 2026-07-27 Session Log
+
+## Observation
+I was assigned to implement E2E safeguards on Epic nodes. Upon exploring `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-heartbeat.ts`, I found that the logic to enforce an `e2e` or `integration` tagged child `STORY` before marking an `EPIC` as `COMPLETED` was already fully implemented.
+
+The tests in `.github/scripts/foundry-orchestrator.test.ts` and `.github/scripts/foundry-heartbeat.test.ts` also already exist and pass perfectly.
+
+## Action Taken
+Since the target artifacts were already completely implemented, I checked off the remaining acceptance criteria in the task markdown body (`task-269-346-e2e-safeguard-impl.md`) and submitted an Empty PR to allow the DAG to progress, per the EMPTY PR POLICY.

--- a/.foundry/tasks/task-269-346-e2e-safeguard-impl.md
+++ b/.foundry/tasks/task-269-346-e2e-safeguard-impl.md
@@ -48,10 +48,10 @@ Implement logic in `.github/scripts/foundry-orchestrator.ts` and `.github/script
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement E2E enforcement logic in `foundry-orchestrator.ts` (Phase 4.1 / 4.5).
-- [ ] Implement E2E enforcement logic in `foundry-heartbeat.ts` (`transitionNodeToCompleted`).
-- [ ] Add unit tests in `foundry-orchestrator.test.ts` covering the new rules for EPICs.
-- [ ] Add unit tests in `foundry-heartbeat.test.ts` covering the new rules for EPICs.
+- [x] Implement E2E enforcement logic in `foundry-orchestrator.ts` (Phase 4.1 / 4.5).
+- [x] Implement E2E enforcement logic in `foundry-heartbeat.ts` (`transitionNodeToCompleted`).
+- [x] Add unit tests in `foundry-orchestrator.test.ts` covering the new rules for EPICs.
+- [x] Add unit tests in `foundry-heartbeat.test.ts` covering the new rules for EPICs.
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
The required E2E safeguard logic was already implemented in both foundry-orchestrator.ts and foundry-heartbeat.ts in a previous PR, and tests were also present and passing. Checking off the acceptance criteria and submitting an Empty PR to allow the DAG to progress, per the EMPTY PR POLICY.

---
*PR created automatically by Jules for task [4592769062627020176](https://jules.google.com/task/4592769062627020176) started by @szubster*