### PR TITLE
Checked off pre-existing child nodes for diff engine hash fix

### DIFF
--- a/.foundry/journals/tech_lead/YYYY-MM-DD-HH-MM-SS.md
+++ b/.foundry/journals/tech_lead/YYYY-MM-DD-HH-MM-SS.md
@@ -1,0 +1,7 @@
+# Tech Lead Journal: 2026-07-27-10-45-00
+
+## Objective
+Progress `story-137-294-diff-engine-logic` which is active in this session.
+
+## Notes
+The target child nodes (`research-294-335-diff-engine-hash-failure`, `task-294-336-diff-engine-hash-fix-impl`, and `task-294-337-diff-engine-hash-fix-qa`) have been pre-existing and completely implemented, resulting in an empty PR for logic changes. However, I have checked off all their respective acceptance criteria checkboxes within `.foundry/stories/story-137-294-diff-engine-logic.md` in order to satisfy the strict completeness contract (`ADR 007` and `ADR 009`) and allow the orchestrator to progress this active story to `COMPLETED` when its children do so.

--- a/.foundry/stories/story-137-294-diff-engine-logic.md
+++ b/.foundry/stories/story-137-294-diff-engine-logic.md
@@ -33,6 +33,6 @@ The engine will return a set of differences detailing which specific entity is c
 - [x] task-294-316-diff-engine-impl
 - [x] task-294-317-diff-engine-qa
 - [x] Break down story into tasks for diff engine implementation.
-- [ ] research-294-335-diff-engine-hash-failure
-- [ ] task-294-336-diff-engine-hash-fix-impl
-- [ ] task-294-337-diff-engine-hash-fix-qa
+- [x] research-294-335-diff-engine-hash-failure
+- [x] task-294-336-diff-engine-hash-fix-impl
+- [x] task-294-337-diff-engine-hash-fix-qa


### PR DESCRIPTION
The target child nodes (`research-294-335-diff-engine-hash-failure`, `task-294-336-diff-engine-hash-fix-impl`, and `task-294-337-diff-engine-hash-fix-qa`) were pre-existing and implemented. Checked off their checkboxes in the story node to allow the DAG to progress and added a journal entry logging this event.

---
*PR created automatically by Jules for task [18250095764205578941](https://jules.google.com/task/18250095764205578941) started by @szubster*