### PR TITLE
QA: Reject task-341-348-define-indexeddb-schema-retry-impl

### DIFF
--- a/.foundry/journals/qa/1101468998112411997.md
+++ b/.foundry/journals/qa/1101468998112411997.md
@@ -1,0 +1,7 @@
+# QA Journal - 1101468998112411997
+
+## Session Notes
+- Validated task-341-348-define-indexeddb-schema-retry-impl.
+- **Result:** FAILED.
+- **Reasoning:** The implementation in `src/db/schema.ts` sets `SAVE_HISTORY_DB_CONFIG.VERSION` to 2 instead of 1, and incorrectly adds a `TRAINERS` store and a `trainerId` index. This violates Section 14 of `.foundry/docs/schema.md`.
+- **Action Taken:** Updated the target task's YAML frontmatter (status: FAILED, rejection_count: 3, rejection_reason added) and unchecked its acceptance criteria checkboxes. Left QA task YAML frontmatter unmodified and updated the QA task's markdown body with the rejection details.

--- a/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
+++ b/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
@@ -2,7 +2,7 @@
 id: task-341-348-define-indexeddb-schema-retry-impl
 type: TASK
 title: Define SaveHistoryDB Schema Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-26'
 updated_at: '2026-07-27'
@@ -15,8 +15,8 @@ tags:
   - indexeddb
   - history
 research_references: []
-rejection_count: 2
-rejection_reason: ''
+rejection_count: 3
+rejection_reason: 'Implementation violated schema requirements (Section 14). SAVE_HISTORY_DB_CONFIG.VERSION was set to 2 instead of 1, and it incorrectly included TRAINERS store and trainerId index.'
 notes: ''
 ---
 
@@ -26,7 +26,7 @@ notes: ''
 Implement the database configuration and schema initialization logic for `SaveHistoryDB`. This may already be implemented in `src/db/schema.ts` from a previous iteration. If the target artifact already exists and is complete, submit an empty PR.
 
 ## Acceptance Criteria
-- [x] Implement `SaveHistoryDB` configuration (version, name, object stores).
-- [x] Define the `saves` object store.
-- [x] Define the `metadata` object store.
-- [x] Define the `indexes` object store.
+- [ ] Implement `SaveHistoryDB` configuration (version, name, object stores).
+- [ ] Define the `saves` object store.
+- [ ] Define the `metadata` object store.
+- [ ] Define the `indexes` object store.

--- a/.foundry/tasks/task-341-349-define-indexeddb-schema-retry-qa.md
+++ b/.foundry/tasks/task-341-349-define-indexeddb-schema-retry-qa.md
@@ -31,3 +31,4 @@ Verify the implementation of the `SaveHistoryDB` schema configuration in `src/db
 
 ## QA Notes
 - Validation FAILED. The implementation in `src/db/schema.ts` sets `SAVE_HISTORY_DB_CONFIG.VERSION` to 2 instead of 1. It also incorrectly adds a `TRAINERS` store and a `trainerId` index, which are not part of the schema defined in `.foundry/docs/schema.md` (Section 14).
+- Target task `task-341-348-define-indexeddb-schema-retry-impl` has been updated to `FAILED` with rejection feedback to prompt a retry.


### PR DESCRIPTION
This PR represents the QA agent explicitly rejecting the implementation of `SaveHistoryDB` due to a strict violation of Section 14 of the schema.

The schema expects `SAVE_HISTORY_DB_CONFIG.VERSION` to be 1, but the implemented code has 2. It also adds a `TRAINERS` store and a `trainerId` index which are not in the spec.

- Modifies the target task's YAML frontmatter (status: FAILED, rejection_count: 3).
- Appends failure details to the QA task's markdown body.
- Adds an entry to the QA journal.

---
*PR created automatically by Jules for task [1101468998112411997](https://jules.google.com/task/1101468998112411997) started by @szubster*