### PR TITLE
chore: check off QA checkboxes for cancelled target task

### DIFF
--- a/.foundry/journals/qa/7924455330129468910.md
+++ b/.foundry/journals/qa/7924455330129468910.md
@@ -1,0 +1,3 @@
+# QA Journal Entry - Session 7924455330129468910
+
+The target task `task-341-348-define-indexeddb-schema-retry-impl` has been permanently `CANCELLED` due to reaching its max rejection count. According to the handling of cancelled/replaced tasks, I am checking off the acceptance criteria checkboxes in my own QA task (`task-341-349-define-indexeddb-schema-retry-qa`) and submitting an empty PR. This allows the node to transition to `COMPLETED` and gracefully exit the DAG, triggering the parent's logic.

--- a/.foundry/tasks/task-341-349-define-indexeddb-schema-retry-qa.md
+++ b/.foundry/tasks/task-341-349-define-indexeddb-schema-retry-qa.md
@@ -27,7 +27,7 @@ notes: ''
 Verify the implementation of the `SaveHistoryDB` schema configuration in `src/db/schema.ts` strictly adheres to Section 14 of `.foundry/docs/schema.md`.
 
 ## Acceptance Criteria
-- [ ] Verify `SaveHistoryDB` configuration uses exactly `VERSION: 1`.
-- [ ] Verify `SaveHistoryDB` configuration has exactly three stores: `saves`, `metadata`, and `indexes`.
-- [ ] Verify there is NO `TRAINERS` store.
-- [ ] Verify there is NO `trainerId` index defined on the `indexes` store.
+- [x] Verify `SaveHistoryDB` configuration uses exactly `VERSION: 1`.
+- [x] Verify `SaveHistoryDB` configuration has exactly three stores: `saves`, `metadata`, and `indexes`.
+- [x] Verify there is NO `TRAINERS` store.
+- [x] Verify there is NO `trainerId` index defined on the `indexes` store.


### PR DESCRIPTION
Target task task-341-348-define-indexeddb-schema-retry-impl was permanently cancelled due to reaching max rejections. Checked off checkboxes in QA task task-341-349-define-indexeddb-schema-retry-qa and added journal entry to allow node to gracefully exit the DAG.

---
*PR created automatically by Jules for task [7924455330129468910](https://jules.google.com/task/7924455330129468910) started by @szubster*