### PR TITLE
docs: add journal entry for task-261-282-gen3-met-location-impl

### DIFF
--- a/.foundry/journals/coder/1750255389450145335.md
+++ b/.foundry/journals/coder/1750255389450145335.md
@@ -1,0 +1,3 @@
+# 1750255389450145335
+
+The implementation for Gen 3 Met Location Extraction (task-261-282-gen3-met-location-impl) was found to be already fully implemented and verified in the codebase prior to execution. As per the Empty PR Policy, I am submitting an empty PR to complete this task, with all acceptance criteria checkboxes checked. The completion of all target artifacts was pre-existing.


### PR DESCRIPTION
This submission adds the coder journal entry for task-261-282-gen3-met-location-impl, recording that the metLocation field in PokemonInstance, MET_LOCATION_OFFSET_IN_M constant, and parseGen3MetLocation helper function were already completely implemented and verified in the codebase.

Fixes #5209

---
*PR created automatically by Jules for task [6002611420691137395](https://jules.google.com/task/6002611420691137395) started by @szubster*