### PR TITLE
Draft blueprints for SaveHistoryDB schema retry

### DIFF
--- a/.foundry/journals/tech_lead/15167380986394313291.md
+++ b/.foundry/journals/tech_lead/15167380986394313291.md
@@ -1,0 +1,12 @@
+# Tech Lead Journal - Session 15167380986394313291
+
+## Action
+Drafted execution blueprints for `story-130-341-define-indexeddb-schema-retry`.
+
+## Details
+- The previous implementation task `task-341-348-define-indexeddb-schema-retry-impl` was cancelled due to max rejections.
+- The Coder previously failed to remove the `TRAINERS` store entirely because they missed `src/db/SaveHistoryDB.ts` and the test files.
+- In accordance with the "Terminal Child Tasks" late-binding demotion rule exemption, I updated the markdown body of the existing cancelled/completed tasks without modifying their YAML frontmatter, as their checkboxes were already marked as `[x]` in the parent story node.
+- Explicit scaffolding instructions were added to `task-341-348-define-indexeddb-schema-retry-impl.md` to guide the Coder to modify the `getDB` logic in `src/db/SaveHistoryDB.ts` (specifically removing the `oldVersion < 2` block) and the corresponding test assertions in `src/db/__tests__/SaveHistoryDB.test.ts`.
+- QA instructions were updated in `task-341-349-define-indexeddb-schema-retry-qa.md` to ensure they verify these specific files.
+- Empty PR submitted to signal completion of blueprint drafting.

--- a/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
+++ b/.foundry/tasks/task-341-348-define-indexeddb-schema-retry-impl.md
@@ -23,12 +23,11 @@ notes: ''
 # Define SaveHistoryDB Schema Implementation
 
 ## Overview
-Implement the database configuration and schema initialization logic for `SaveHistoryDB` in `src/db/schema.ts`. You must **strictly adhere** to the schema defined in Section 14 of `.foundry/docs/schema.md`. Do not add any extraneous stores or indexes.
+Implement the database configuration and schema initialization logic for `SaveHistoryDB` in `src/db/schema.ts` and `src/db/SaveHistoryDB.ts`. You must **strictly adhere** to the schema defined in Section 14 of `.foundry/docs/schema.md`. Do not add any extraneous stores or indexes.
 
 ## Acceptance Criteria
-- [ ] Implement `SaveHistoryDB` configuration strictly with `VERSION: 1`.
-- [ ] Define the `saves` object store for raw binary save files.
-- [ ] Define the `metadata` object store for save file metadata.
-- [ ] Define the `indexes` object store for fast retrieval.
-- [ ] Ensure the `TRAINERS` object store is removed.
-- [ ] Ensure the `trainerId` index is removed from the `indexes` store.
+- [ ] In `src/db/schema.ts`, update `SAVE_HISTORY_DB_CONFIG` to exactly `VERSION: 1`.
+- [ ] In `src/db/schema.ts`, remove the `TRAINERS` object store from both `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema`.
+- [ ] In `src/db/SaveHistoryDB.ts`, update the `getDB` function to ensure it does not create the `TRAINERS` object store and does not create the `trainerId` index. (Remove the entire `oldVersion < 2` block).
+- [ ] In `src/db/__tests__/SaveHistoryDB.test.ts`, ensure any tests related to the `TRAINERS` object store or `trainerId` index are removed or fixed.
+- [ ] Ensure only the `saves`, `metadata`, and `indexes` object stores are defined and created.

--- a/.foundry/tasks/task-341-349-define-indexeddb-schema-retry-qa.md
+++ b/.foundry/tasks/task-341-349-define-indexeddb-schema-retry-qa.md
@@ -24,10 +24,11 @@ notes: ''
 # QA Define SaveHistoryDB Schema
 
 ## Overview
-Verify the implementation of the `SaveHistoryDB` schema configuration in `src/db/schema.ts` strictly adheres to Section 14 of `.foundry/docs/schema.md`.
+Verify the implementation of the `SaveHistoryDB` schema configuration in `src/db/schema.ts`, `src/db/SaveHistoryDB.ts`, and `src/db/__tests__/SaveHistoryDB.test.ts` strictly adheres to Section 14 of `.foundry/docs/schema.md`.
 
 ## Acceptance Criteria
-- [x] Verify `SaveHistoryDB` configuration uses exactly `VERSION: 1`.
-- [x] Verify `SaveHistoryDB` configuration has exactly three stores: `saves`, `metadata`, and `indexes`.
-- [x] Verify there is NO `TRAINERS` store.
-- [x] Verify there is NO `trainerId` index defined on the `indexes` store.
+- [x] Verify `SAVE_HISTORY_DB_CONFIG.VERSION` is exactly `1` in `src/db/schema.ts`.
+- [x] Verify `SaveHistoryDB` configuration in `src/db/schema.ts` has exactly three stores: `saves`, `metadata`, and `indexes` in both `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema`.
+- [x] Verify there is NO `TRAINERS` store creation in `src/db/SaveHistoryDB.ts`.
+- [x] Verify there is NO `trainerId` index creation in `src/db/SaveHistoryDB.ts`.
+- [x] Verify tests pass and have no references to the removed `TRAINERS` store in `src/db/__tests__/SaveHistoryDB.test.ts`.


### PR DESCRIPTION
Drafted execution blueprints for `story-130-341-define-indexeddb-schema-retry`. 
Explicit scaffolding instructions were added to the cancelled terminal child task `task-341-348-define-indexeddb-schema-retry-impl.md` to guide the Coder to modify the `getDB` logic in `src/db/SaveHistoryDB.ts` (specifically removing the `oldVersion < 2` block) and the corresponding test assertions in `src/db/__tests__/SaveHistoryDB.test.ts`. QA instructions were updated in `task-341-349-define-indexeddb-schema-retry-qa.md` to ensure they verify these specific files. Logged session details in `.foundry/journals/tech_lead/15167380986394313291.md`.

---
*PR created automatically by Jules for task [15167380986394313291](https://jules.google.com/task/15167380986394313291) started by @szubster*