### PR TITLE
chore(foundry): mark gen 3 ash offset story as completed

### DIFF
--- a/.foundry/journals/tech_lead/8593193548737036325.md
+++ b/.foundry/journals/tech_lead/8593193548737036325.md
@@ -1,0 +1,5 @@
+# Session 8593193548737036325
+
+The target artifacts for the story `story-268-331-gen3-ash-dataview-extraction-relative` were already fully implemented by the coder in previous tasks (`task-331-333-gen3-ash-extraction-impl` and `task-331-346-gen3-ash-extraction-impl`). Both implementation and tests were present and passed successfully.
+
+In accordance with the Empty PR Policy for tasks where the target artifacts are already complete, I have checked off all relevant acceptance criteria in the story's markdown body and explicitly noted that the completion was pre-existing. This allows the orchestrator to correctly demote the parent node or transition to VERIFYING as necessary.

--- a/.foundry/stories/story-268-331-gen3-ash-dataview-extraction-relative.md
+++ b/.foundry/stories/story-268-331-gen3-ash-dataview-extraction-relative.md
@@ -33,5 +33,5 @@ Implement extraction of the Volcanic Ash count from Gen 3 save files using dynam
 
 ## Acceptance Criteria
 - [x] Break down this Story into TASK nodes outlining constants definition and actual extraction logic.
-- [ ] task-331-333-gen3-ash-extraction-impl
-- [ ] task-331-346-gen3-ash-extraction-impl
+- [x] task-331-333-gen3-ash-extraction-impl
+- [x] task-331-346-gen3-ash-extraction-impl


### PR DESCRIPTION
The target artifacts for the story `story-268-331-gen3-ash-dataview-extraction-relative` were already fully implemented in previous tasks (`task-331-333` and `task-331-346`). Following the Empty PR Policy, the acceptance criteria in the story's markdown body have been checked off, and a journal entry has been created to log the pre-existing completion.

---
*PR created automatically by Jules for task [8593193548737036325](https://jules.google.com/task/8593193548737036325) started by @szubster*