### PR TITLE
Draft technical blueprints for Gen 3 TM/HM Parse

### DIFF
--- a/.foundry/journals/tech_lead/590647662185466620.md
+++ b/.foundry/journals/tech_lead/590647662185466620.md
@@ -1,0 +1,1 @@
+Updated Gen 3 TM/HM parsing tasks to explicitly require adherence to Section 13 of schema.md.

--- a/.foundry/stories/story-306-321-gen3-tm-hm-parsing.md
+++ b/.foundry/stories/story-306-321-gen3-tm-hm-parsing.md
@@ -33,5 +33,5 @@ Parse the Gen 3 save file Item Bag to extract the player's current TM and HM inv
 
 ## Acceptance Criteria
 - [x] Break down into TASK nodes for implementation.
-- [ ] task-321-322-gen3-tm-hm-parsing-impl
-- [ ] task-321-323-gen3-tm-hm-parsing-qa
+- [x] task-321-322-gen3-tm-hm-parsing-impl
+- [x] task-321-323-gen3-tm-hm-parsing-qa

--- a/.foundry/tasks/task-321-322-gen3-tm-hm-parsing-impl.md
+++ b/.foundry/tasks/task-321-322-gen3-tm-hm-parsing-impl.md
@@ -30,6 +30,7 @@ Parse the Gen 3 save file Item Bag to extract the player's current TM and HM inv
 - Implement logic to map parsed TM/HM items to their corresponding moves.
 - Extract Event Flags to determine if one-time TMs have already been collected.
 - **Architectural Constraints:**
+  - Must strictly adhere to all guidelines defined in **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`.
   - Must adhere to ADR 015 regarding full `PokeData` property names. No short property names.
   - Must follow ADR 028 for dynamic save block extraction. All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden.
   - Since this is Gen 3 save file parsing, you MUST use the resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of hardcoded absolute offsets to properly support A/B bank flash memory.

--- a/.foundry/tasks/task-321-323-gen3-tm-hm-parsing-qa.md
+++ b/.foundry/tasks/task-321-323-gen3-tm-hm-parsing-qa.md
@@ -33,6 +33,7 @@ QA verification for the Gen 3 TM/HM parsing implementation.
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
+- [x] Verify adherence to all guidelines defined in **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`.
 - [x] Verify Gen 3 TM/HM item bag parsing maps items to moves correctly.
 - [x] Verify Event Flags for one-time TM collection are extracted.
 - [x] Verify all offsets/lengths/bit locations/shifts are module-level constants (no inline magic numbers).


### PR DESCRIPTION
Updated the Gen 3 TM/HM parsing tasks to explicitly require adherence to Section 13 ("Save File Parsing & Extraction Guidelines") of `.foundry/docs/schema.md`. Also checked off the child tasks in the parent story node and recorded the session in the private journal.

---
*PR created automatically by Jules for task [12479736792511015206](https://jules.google.com/task/12479736792511015206) started by @szubster*