### PR TITLE
QA: Reject NPC Trade State Integration

### DIFF
--- a/.foundry/journals/qa/682146954706425586.md
+++ b/.foundry/journals/qa/682146954706425586.md
@@ -1,0 +1,9 @@
+
+## 2026-07-27 - Session 682146954706425586
+**Rejection of task-261-331-npc-trade-state-integration-impl**
+
+The implementation was rejected because it failed to address the core requirements. Specifically:
+1. The developer failed to update `parseGen3` to correctly use `section1Offset` for `parseGen3RSENPCTrades` (Emerald) and `parseGen3FRLGNPCTrades` (FRLG). They were still using `section2Offset`. This violates the strict architectural requirements for Gen 3 data structures.
+2. The developer failed to add tests in `gen3.test.ts` to actually verify that the NPC trade flags are properly integrated into the unified `SaveData` object. This violates the testing requirements and Acceptance Criteria.
+
+This is a recurring issue where the implementer ignores previous feedback regarding offset corrections and test coverage integration. The task has been bumped to a FAILED status and returned to the Resurrection Loop.

--- a/.foundry/tasks/task-261-331-npc-trade-state-integration-impl.md
+++ b/.foundry/tasks/task-261-331-npc-trade-state-integration-impl.md
@@ -2,7 +2,7 @@
 id: task-261-331-npc-trade-state-integration-impl
 type: TASK
 title: NPC Trade State Integration Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-17'
 updated_at: '2026-07-26'
@@ -14,8 +14,8 @@ tags:
   - backend
   - state-integration
 research_references: []
-rejection_count: 2
-rejection_reason: ''
+rejection_count: 3
+rejection_reason: 'The tests in gen3.test.ts do not verify the integration into the SaveData object, and the parseGen3 function incorrectly uses section2Offset instead of section1Offset for Emerald and FRLG.'
 notes: ''
 ---
 
@@ -35,8 +35,8 @@ Implement the logic to integrate the extracted NPC trade flags into the unified 
 - **CRITICAL:** You must catch `RangeError` for out-of-bounds reads and explicitly throw a new error with the message "The save file is corrupted or incomplete."
 
 ## Acceptance Criteria
-- [x] Integrate Gen 2 and Gen 3 extracted NPC trade flags into the unified `SaveData` object.
-- [x] Ensure `SaveData` interface properties are correctly typed and updated if necessary.
-- [x] Explicitly define and use reusable constants for memory offsets, lengths, and bit locations.
-- [x] Use `section1Offset` for relative Gen 3 calculations.
-- [x] Properly catch `RangeError` and throw the exact error message: "The save file is corrupted or incomplete."
+- [ ] Integrate Gen 2 and Gen 3 extracted NPC trade flags into the unified `SaveData` object.
+- [ ] Ensure `SaveData` interface properties are correctly typed and updated if necessary.
+- [ ] Explicitly define and use reusable constants for memory offsets, lengths, and bit locations.
+- [ ] Use `section1Offset` for relative Gen 3 calculations.
+- [ ] Properly catch `RangeError` and throw the exact error message: "The save file is corrupted or incomplete."

--- a/.foundry/tasks/task-261-332-npc-trade-state-integration-qa.md
+++ b/.foundry/tasks/task-261-332-npc-trade-state-integration-qa.md
@@ -28,6 +28,7 @@ Verify the implementation of NPC Trade State Integration into the `SaveData` obj
 
 ### QA Notes
 - 2026-07-25: Rejected `task-261-331-npc-trade-state-integration-impl`. The tests in `gen3.test.ts` do not verify the integration into the `SaveData` object, and the `parseGen3` function incorrectly uses `section2Offset` instead of `section1Offset` for Emerald and FRLG.
+- 2026-07-27: Rejected `task-261-331-npc-trade-state-integration-impl` again. The previous feedback was not addressed. The tests in `gen3.test.ts` still do not verify the integration into the `SaveData` object, and the `parseGen3` function still incorrectly uses `section2Offset` instead of `section1Offset` for Emerald and FRLG.
 
 ## Context and Constraints
 - The `qa` persona MUST verify that the `coder` correctly implemented the state integration logic for NPC Trade flags.


### PR DESCRIPTION
QA: Reject NPC Trade State Integration

Updates task-261-331-npc-trade-state-integration-impl.md to FAILED state and provides feedback regarding missing tests and incorrect section offset used in parseGen3. Unchecked completion checkboxes. Updated QA task markdown notes and logged the rejection in the QA journal.

---
*PR created automatically by Jules for task [682146954706425586](https://jules.google.com/task/682146954706425586) started by @szubster*