### PR TITLE
🧬 Oak: [data correction] Remove Lotad line from Emerald unobtainable list

### DIFF
--- a/.jules/oak/session-correction.md
+++ b/.jules/oak/session-correction.md
@@ -1,0 +1,3 @@
+# Oak Learnings
+
+* **Data Pipeline Gotchas:** The Gen 3 version exclusives list for Emerald in `src/engine/exclusives/gen3Exclusives.ts` incorrectly included the Lotad evolutionary line (270, 271, 272). Lotad is actually available natively in Emerald (e.g. Route 102), making it a Ruby exclusive (missing in Ruby) but NOT an Emerald exclusive (missing in Emerald). Only Surskit, Masquerain, Meditite, Medicham, Roselia, Zangoose, and Lunatone are truly missing from Emerald. Always cross-reference the exact PokeAPI encounter data for version `emerald` before trusting arrays labeled "missing".

--- a/data/db/metadata.json
+++ b/data/db/metadata.json
@@ -1,4 +1,4 @@
 {
   "sourceSha": "",
-  "generatedAt": "2026-07-27T10:42:54.584Z"
+  "generatedAt": "2026-07-28T01:51:40.100Z"
 }

--- a/src/engine/exclusives/__tests__/gen3Exclusives.test.ts
+++ b/src/engine/exclusives/__tests__/gen3Exclusives.test.ts
@@ -30,6 +30,11 @@ describe('gen3Exclusives', () => {
       expect(getGen3UnobtainableReason(273, 'emerald', 0, ownedSet)).toBeNull();
     });
 
+    it('should return null for Lotad in Emerald (available natively)', () => {
+      const ownedSet = new Set<number>();
+      expect(getGen3UnobtainableReason(270, 'emerald', 0, ownedSet)).toBeNull();
+    });
+
     it('should return reason for FireRed exclusive missing (LeafGreen exclusives)', () => {
       const ownedSet = new Set<number>();
       const reason = getGen3UnobtainableReason(27, 'firered', 0, ownedSet); // Sandshrew

--- a/src/engine/exclusives/gen3Exclusives.ts
+++ b/src/engine/exclusives/gen3Exclusives.ts
@@ -5,7 +5,7 @@ export const GEN3_VERSION_EXCLUSIVES: Record<string, number[]> = {
   // Sapphire missing (Ruby exclusives)
   sapphire: [273, 274, 275, 303, 335, 338, 381, 383],
   // Emerald missing
-  emerald: [270, 271, 272, 283, 284, 307, 308, 315, 335, 337],
+  emerald: [283, 284, 307, 308, 315, 335, 337],
   // FireRed missing (LeafGreen exclusives)
   firered: [27, 28, 37, 38, 69, 70, 71, 79, 80, 120, 121, 126, 127, 183, 184, 199, 200, 215, 223, 224, 226, 240, 298],
   // LeafGreen missing (FireRed exclusives)


### PR DESCRIPTION
**What was wrong:** The Lotad evolutionary line (270, 271, 272) was incorrectly marked as unobtainable in Pokémon Emerald within `src/engine/exclusives/gen3Exclusives.ts`. Lotad is actually available natively (e.g. Route 102).

**Canonical source used:** Cross-referenced with PokeAPI `/api/v2/pokemon/270/encounters` which explicitly confirms `emerald` in `version_details`.

**Impact on users:** Users playing Emerald version will no longer be falsely told that they must trade to obtain Lotad, Lombre, or Ludicolo.

Includes an updated unit test to prevent regression. Data regeneration was run and no JSONL files were modified because the generation script does not use this hardcoded logic for output—it is strictly used at runtime.

---
*PR created automatically by Jules for task [6044724458137686372](https://jules.google.com/task/6044724458137686372) started by @szubster*