### PR TITLE
🧹 Sweeper: Remove zod from knip.json ignoreDependencies

### DIFF
--- a/.jules/sweeper/remove-unused-zod-config.md
+++ b/.jules/sweeper/remove-unused-zod-config.md
@@ -1,0 +1,5 @@
+# Sweeper Run Journal
+
+## Learnings
+* **Leftover knip config**: `zod` was still listed in `ignoreDependencies` in `knip.json` even though it was not in `package.json`. Knip flagged this as a configuration issue (`Module load error` or similar warning, although it actually just showed `zod` next to `Remove from ignoreDependencies`). Removing it from `knip.json` safely resolves the warning.
+* **Implicit File Dependencies (`test-setup.ts`)**: I recalled that previously removing `src/test-setup.ts` without full context caused test-suite failures, so checking implicit usages is always important, even for seemingly simple config changes.

--- a/knip.json
+++ b/knip.json
@@ -4,8 +4,7 @@
   "ignoreDependencies": [
     "wrangler",
     "@cloudflare/pages-plugin-cloudflare-access",
-    "@cloudflare/workers-types",
-    "zod"
+    "@cloudflare/workers-types"
   ],
   "ignore": [
     "src/test-setup.ts",


### PR DESCRIPTION
🎯 What: Removed `zod` from `ignoreDependencies` in `knip.json`.
💡 Why: `zod` is not in the root `package.json`, so Knip was emitting a warning about an unused configuration directive.
✅ Verification: Ran `pnpm knip`, `pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e` to ensure no regressions and that the knip warning is gone.
✨ Result: Clean knip run.

---
*PR created automatically by Jules for task [11743014610831876686](https://jules.google.com/task/11743014610831876686) started by @szubster*