### PR TITLE
🧭 Strategist: Prompt improvement - Plan Review Citation Rule

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -50,6 +50,7 @@ The `palette` persona is the master of the Tailwind and styling ecosystem. This 
 **Execution Plan Groundedness Rule:** Execution plans must not propose actions that have already been successfully completed in the bash session. Your plan must reflect the current state of the workspace. Furthermore, you must not read files or use file paths that have not been explicitly discovered and printed in the current session's trace. Do not propose creating files with assumed, guessed, or placeholder names (e.g., `<NNN>`). Determine exact filenames before plan creation.
 **Execution Plan Specificity Rule:** Execution plans must consist solely of single, actionable, un-nested instructions. Conversational monologue, mental actions, scratchpad notes, placeholders, and nested bullet points are strictly forbidden.
 **Execution Plan Tense Rule:** Execution plans must consist solely of forward-looking, actionable steps required to complete the task. Do not include past-tense descriptions or summaries of actions already completed during the exploratory phase.
+**Plan Review Citation Rule:** When using the `request_plan_review` tool, you must explicitly cite the exact file path of the documentation or source code (e.g., `.foundry/docs/knowledge_base/...`) that provides the business logic, formulas, or constants referenced in your plan steps. Failure to do so may cause the reviewer to incorrectly reject the plan for 'hallucinations'.
 
 
 ## Scratchpad Cleanup

--- a/.jules/strategist/2026-08-03-plan-review-citation.md
+++ b/.jules/strategist/2026-08-03-plan-review-citation.md
@@ -1,0 +1,5 @@
+## 2026-08-03 - [Accepted] - Prompt improvement - Plan Review Citation Rule
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** Agents were using `request_plan_review` with business logic, formulas, or constants in their plans, but were not citing where those requirements came from (e.g., `.foundry/docs/...`). Reviewers, without context of the project documents, were incorrectly rejecting these correct plans as AI "hallucinations".
+**Pattern:** Codify system memory constraints into `core_policies.md` to prevent plan reviewers from incorrectly rejecting valid execution plans, by mandating explicit file path citations for business logic to prove groundedness.


### PR DESCRIPTION
**Proposal:**
Added the `Plan Review Citation Rule` to the `core_policies.md` document under `Execution Plan Rules`.

**Justification:**
Agents often need to formulate execution plans that contain specific business logic, constants, or formulas (e.g. for extracting save file data). Reviewers often reject valid plans because they perceive these specific details as AI "hallucinations" since they lack full project context. This prompt improvement solves that by mandating that agents explicitly cite the exact file paths of the documentation/code that provide those requirements when requesting a plan review. This allows the reviewer to verify the groundedness of the plan.

**Evidence:**
This failure pattern is well documented in previous tasks. We codified this rule in the central `core_policies.md` so that all personas are aware when generating execution plans. A new journal entry was recorded in `.jules/strategist/2026-08-03-plan-review-citation.md`.

---
*PR created automatically by Jules for task [4182169657556545478](https://jules.google.com/task/4182169657556545478) started by @szubster*