### PR TITLE
QA Validation: Gen 2 Pokegear Registered Numbers Parsing

### DIFF
--- a/.foundry/journals/qa/14711255524066460026.md
+++ b/.foundry/journals/qa/14711255524066460026.md
@@ -1,0 +1,16 @@
+# QA Validation Journal: Gen 2 Pokegear Registered Numbers Parsing
+Session ID: 14711255524066460026
+
+## Task Information
+- **ID:** task-283-343-parse-registered-numbers-qa
+- **Title:** QA Gen 2 Pokegear Registered Numbers Parsing
+- **Target Task:** task-283-342-parse-registered-numbers-impl
+
+## Validation Results
+- The parsing logic correctly extracts `wPhoneList` from the Gen 2 save data. The implementation maps `GS_WPHONE_LIST_INDEX` and `GS_WPHONE_LIST` for Gold/Silver saves and `CRYSTAL_WPHONE_LIST_INDEX` and `CRYSTAL_WPHONE_LIST` for Crystal saves, adhering to the offsets documented in `.foundry/docs/knowledge_base/gen2_phone_offsets.md`.
+- RangeError handling is correctly implemented inside `parseGen2PokegearData` inside `src/engine/saveParser/parsers/gen2/phone/parser.ts`, wrapping the DataView reads in a `try/catch` and returning "The save file is corrupted or incomplete" on out-of-bounds reads, per Section 13 in `.foundry/docs/schema.md`.
+- Comprehensive unit tests exist in `src/engine/saveParser/parsers/gen2/phone/parser.test.ts` for Gold/Silver, Crystal, and out-of-bounds save cases, with high test coverage.
+- Module-level constants are used rather than hardcoding memory offsets inline. No magic numbers were found. ADR 028 is satisfied.
+
+## Outcome
+Validation is successful. No code changes are required. Acceptance criteria have been checked off. Submitted an empty PR.

--- a/.foundry/tasks/task-283-343-parse-registered-numbers-qa.md
+++ b/.foundry/tasks/task-283-343-parse-registered-numbers-qa.md
@@ -27,6 +27,6 @@ notes: ''
 Verify the parsing logic for Generation 2 Pokegear registered numbers and state flags.
 
 ## Acceptance Criteria
-- [ ] Verify the parsing logic extracts `wPhoneList` correctly.
-- [ ] Verify error handling correctly throws "The save file is corrupted or incomplete" on out-of-bounds reads.
-- [ ] Ensure full test coverage is provided.
+- [x] Verify the parsing logic extracts `wPhoneList` correctly.
+- [x] Verify error handling correctly throws "The save file is corrupted or incomplete" on out-of-bounds reads.
+- [x] Ensure full test coverage is provided.


### PR DESCRIPTION
This PR documents the successful QA validation for `task-283-343-parse-registered-numbers-qa`. The implementation (`task-283-342-parse-registered-numbers-impl`) successfully handles `wPhoneList` extraction for Gold/Silver and Crystal according to `.foundry/docs/knowledge_base/gen2_phone_offsets.md`. It properly includes `RangeError` bounds checking per Section 13 of `.foundry/docs/schema.md`. Test coverage is verified, and the Acceptance Criteria in the QA task have been marked complete. A journal entry was added detailing the validation.

---
*PR created automatically by Jules for task [14711255524066460026](https://jules.google.com/task/14711255524066460026) started by @szubster*