### PR TITLE
chore: update Epic acceptance criteria for E2E safeguards

### DIFF
--- a/.foundry/epics/epic-057-127-orchestrator-safeguard-investigation.md
+++ b/.foundry/epics/epic-057-127-orchestrator-safeguard-investigation.md
@@ -29,4 +29,4 @@ Investigate `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/found
 ## Acceptance Criteria
 - [x] Analyze orchestrator scripts for programmatic safeguards.
 - [x] Create necessary STORY nodes for investigation and implementation if viable.
-- [ ] story-127-269-epic-e2e-safeguard
+- [x] story-127-269-epic-e2e-safeguard


### PR DESCRIPTION
The E2E safeguard story (`story-127-269-epic-e2e-safeguard`) is already marked as `COMPLETED`. This PR checks off the corresponding acceptance criteria in the parent Epic (`epic-057-127-orchestrator-safeguard-investigation`) to allow the orchestrator to promote it.

---
*PR created automatically by Jules for task [14235836430779637836](https://jules.google.com/task/14235836430779637836) started by @szubster*