### PR TITLE
fix(foundry): add missing child node to epic-055-119 acceptance criteria

### DIFF
--- a/.foundry/epics/epic-055-119-gen3-move-tutor-save-parsing.md
+++ b/.foundry/epics/epic-055-119-gen3-move-tutor-save-parsing.md
@@ -42,3 +42,4 @@ Implement the logic to parse Gen 3 save files and extract the event flags indica
 - [x] Out-of-bounds reads or malformed saves are handled gracefully without application crashes.
 - [x] story-119-267-gen3-move-tutor-emerald-parsing
 - [x] story-119-318-gen3-move-tutor-frlg-parsing
+- [x] story-119-268-gen3-move-tutor-frlg-parsing

--- a/.foundry/journals/story_owner/6579414286306081301.md
+++ b/.foundry/journals/story_owner/6579414286306081301.md
@@ -1,0 +1,3 @@
+# Session 6579414286306081301
+
+The `epic-055-119-gen3-move-tutor-save-parsing` was incorrectly advancing and potentially failing because a completed child node `story-119-268-gen3-move-tutor-frlg-parsing` was entirely missing from its acceptance criteria checkboxes. I have appended `- [x] story-119-268-gen3-move-tutor-frlg-parsing` to the markdown body of the parent to ensure the strict parent-child verification checks in the DAG Orchestrator are satisfied.


### PR DESCRIPTION
The target artifact `epic-055-119-gen3-move-tutor-save-parsing` was failing to pass validation (Macro Node Completion Exception) because one of its completed child stories, `story-119-268-gen3-move-tutor-frlg-parsing`, was missing from the `## Acceptance Criteria` checkboxes in the markdown body.

I have updated the epic to explicitly append `- [x] story-119-268-gen3-move-tutor-frlg-parsing` to the markdown body, which allows the orchestrator's strict parent-child checks to succeed. I also created a journal entry at `.foundry/journals/story_owner/6579414286306081301.md` documenting this finding as required. All relevant tests (`pnpm test` and `xvfb-run pnpm test:e2e`) pass.

---
*PR created automatically by Jules for task [6579414286306081301](https://jules.google.com/task/6579414286306081301) started by @szubster*