### PR TITLE
QA: Reject Gen 3 secret base locations impl

### DIFF
--- a/.foundry/journals/qa/13362131402450864056.md
+++ b/.foundry/journals/qa/13362131402450864056.md
@@ -1,0 +1,13 @@
+# QA Validation Log - Gen 3 Secret Base Locations Parser
+## Session: 13362131402450864056
+
+### Target Task
+`task-333-334-gen3-secret-base-locations-impl`
+
+### Result
+REJECTED
+
+### Reason
+The Coder failed to adhere to the correct memory offsets for Gen 3 games. The implementation assumed that Emerald uses 8 bytes for `trainerName` and `0x0A` for the `trainerId` offset. However, as documented in `.foundry/docs/knowledge_base/gen3_secret_base_offsets.md`, `TRAINER_NAME_LENGTH` is exactly 7 bytes and `TRAINER_ID_OFFSET` is `0x09` consistently across all Gen 3 games (Ruby/Sapphire and Emerald).
+
+Because of this, I have updated the Coder's task to `FAILED` with a `rejection_count` of 2 and added a clear `rejection_reason`. This will trigger the resurrection loop. I have updated my own task (`task-333-335-gen3-secret-base-locations-qa`) with notes about this failure.

--- a/.foundry/tasks/task-333-334-gen3-secret-base-locations-impl.md
+++ b/.foundry/tasks/task-333-334-gen3-secret-base-locations-impl.md
@@ -2,7 +2,7 @@
 id: task-333-334-gen3-secret-base-locations-impl
 type: TASK
 title: Implement Gen 3 Secret Base Locations Parser
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-19'
 updated_at: '2026-07-28'
@@ -16,8 +16,8 @@ tags:
   - secret-base
   - save-parsing
 research_references: []
-rejection_count: 1
-rejection_reason: ''
+rejection_count: 2
+rejection_reason: 'The implementation uses incorrect constants for trainer name and trainer id. Per gen3_secret_base_offsets.md, TRAINER_NAME_LENGTH is exactly 7 bytes and TRAINER_ID_OFFSET is 0x09 identically across all Gen 3 games (Ruby/Sapphire and Emerald). The implementation incorrectly used 8 bytes and 0x0a for Emerald.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-333-335-gen3-secret-base-locations-qa.md
+++ b/.foundry/tasks/task-333-335-gen3-secret-base-locations-qa.md
@@ -36,3 +36,6 @@ QA verification for the Gen 3 Secret Base Locations parser.
 ## Acceptance Criteria
 - [ ] Code review passes, ensuring no magic numbers exist and all ADRs are followed.
 - [ ] Unit tests cover out-of-bounds reads and correct extraction/mapping.
+
+## Notes
+- 2026-07-28: Validation failed. The Coder incorrectly assumed Emerald uses 8 bytes for `trainerName` and `0x0A` for the `trainerId` offset. As per `gen3_secret_base_offsets.md`, `TRAINER_NAME_LENGTH` is exactly 7 bytes and `TRAINER_ID_OFFSET` is `0x09` identically across all Gen 3 games. Task has been marked as FAILED to trigger resurrection loop.


### PR DESCRIPTION
QA rejection of Gen 3 secret base parser

The Coder implementation used incorrect memory offsets for the Emerald trainer name length and trainer id. Following QA rules, I have rejected the target task, updated the rejection reason, appended my notes, and recorded this in my journal.

---
*PR created automatically by Jules for task [13362131402450864056](https://jules.google.com/task/13362131402450864056) started by @szubster*