### PR TITLE
feat(save): implement move planner algorithm

### DIFF
--- a/.foundry/journals/coder/6146293549486245581.md
+++ b/.foundry/journals/coder/6146293549486245581.md
@@ -1,0 +1,4 @@
+# Session 6146293549486245581
+
+* Learned that when resolving relocation cycles in save parsing diffs, identifying nodes with an in-degree > 0 but an out-degree of 0 provides acyclic paths that must be processed backwards to prevent data overwrites.
+* Discovered that resolving 3+ size cycles efficiently requires a temporary holding space (`-1, -1` box/slot), as swapping sequentially overwrites the next member of the cycle before it can be moved.

--- a/.foundry/tasks/task-295-352-move-planner-impl.md
+++ b/.foundry/tasks/task-295-352-move-planner-impl.md
@@ -41,8 +41,8 @@ The output should be a structured list of operations, such as:
 3. The output operations should be minimal.
 
 ## Acceptance Criteria
-- [ ] Implement `calculateMovePlan` (or similar) function.
-- [ ] Define the output operation structure (e.g., `MoveOperation` type).
-- [ ] Write unit tests for basic linear moves.
-- [ ] Write unit tests for swap scenarios (two Pokémon trading spots).
-- [ ] Write unit tests for cycle resolutions (3+ Pokémon forming a relocation cycle).
+- [x] Implement `calculateMovePlan` (or similar) function.
+- [x] Define the output operation structure (e.g., `MoveOperation` type).
+- [x] Write unit tests for basic linear moves.
+- [x] Write unit tests for swap scenarios (two Pokémon trading spots).
+- [x] Write unit tests for cycle resolutions (3+ Pokémon forming a relocation cycle).

--- a/src/engine/saveParser/utils/movePlanner.test.ts
+++ b/src/engine/saveParser/utils/movePlanner.test.ts
@@ -1,22 +1,23 @@
-import { describe, it, expect } from 'vitest';
-import { calculateMovePlan } from './movePlanner';
-import type { BoxDiffResult } from './boxDiff';
+import { describe, expect, it } from 'vitest';
 import type { PokemonInstance } from '../parsers/common';
+import type { BoxDiffResult } from './boxDiff';
+import { calculateMovePlan } from './movePlanner';
 
 describe('movePlanner', () => {
-  const createMockPokemon = (hash: string, box: number, slot: number): PokemonInstance => ({
-    hash,
-    storageLocation: `Box ${box}`,
-    slot,
-    speciesName: 'Bulbasaur',
-    speciesId: 1,
-    level: 5,
-    nickname: '',
-    exp: 0,
-    isShiny: false,
-    moves: [],
-    dvs: { hp: 0, atk: 0, def: 0, spc: 0, spe: 0 },
-  } as unknown as PokemonInstance);
+  const createMockPokemon = (hash: string, box: number, slot: number): PokemonInstance =>
+    ({
+      hash,
+      storageLocation: `Box ${box}`,
+      slot,
+      speciesName: 'Bulbasaur',
+      speciesId: 1,
+      level: 5,
+      nickname: '',
+      exp: 0,
+      isShiny: false,
+      moves: [],
+      dvs: { hp: 0, atk: 0, def: 0, spc: 0, spe: 0 },
+    }) as unknown as PokemonInstance;
 
   it('handles basic linear moves', () => {
     const diff: BoxDiffResult = {

--- a/src/engine/saveParser/utils/movePlanner.test.ts
+++ b/src/engine/saveParser/utils/movePlanner.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { calculateMovePlan } from './movePlanner';
+import type { BoxDiffResult } from './boxDiff';
+import type { PokemonInstance } from '../parsers/common';
+
+describe('movePlanner', () => {
+  const createMockPokemon = (hash: string, box: number, slot: number): PokemonInstance => ({
+    hash,
+    storageLocation: `Box ${box}`,
+    slot,
+    speciesName: 'Bulbasaur',
+    speciesId: 1,
+    level: 5,
+    nickname: '',
+    exp: 0,
+    isShiny: false,
+    moves: [],
+    dvs: { hp: 0, atk: 0, def: 0, spc: 0, spe: 0 },
+  } as unknown as PokemonInstance);
+
+  it('handles basic linear moves', () => {
+    const diff: BoxDiffResult = {
+      additions: [],
+      removals: [],
+      relocations: [
+        {
+          pokemon: createMockPokemon('A', 1, 2),
+          sourceBox: 1,
+          sourceSlot: 1,
+          targetBox: 1,
+          targetSlot: 2,
+        },
+      ],
+    };
+
+    const plan = calculateMovePlan(diff);
+    expect(plan).toEqual([
+      {
+        type: 'MOVE',
+        sourceBox: 1,
+        sourceSlot: 1,
+        targetBox: 1,
+        targetSlot: 2,
+      },
+    ]);
+  });
+
+  it('handles basic SWAP (2-cycle) scenarios', () => {
+    const diff: BoxDiffResult = {
+      additions: [],
+      removals: [],
+      relocations: [
+        {
+          pokemon: createMockPokemon('A', 1, 2),
+          sourceBox: 1,
+          sourceSlot: 1,
+          targetBox: 1,
+          targetSlot: 2,
+        },
+        {
+          pokemon: createMockPokemon('B', 1, 1),
+          sourceBox: 1,
+          sourceSlot: 2,
+          targetBox: 1,
+          targetSlot: 1,
+        },
+      ],
+    };
+
+    const plan = calculateMovePlan(diff);
+    expect(plan).toEqual([
+      {
+        type: 'SWAP',
+        sourceBox: 1,
+        sourceSlot: 1,
+        targetBox: 1,
+        targetSlot: 2,
+      },
+    ]);
+  });
+
+  it('handles cycle resolutions (3+ Pokémon)', () => {
+    const diff: BoxDiffResult = {
+      additions: [],
+      removals: [],
+      relocations: [
+        {
+          pokemon: createMockPokemon('A', 1, 2),
+          sourceBox: 1,
+          sourceSlot: 1,
+          targetBox: 1,
+          targetSlot: 2,
+        },
+        {
+          pokemon: createMockPokemon('B', 1, 3),
+          sourceBox: 1,
+          sourceSlot: 2,
+          targetBox: 1,
+          targetSlot: 3,
+        },
+        {
+          pokemon: createMockPokemon('C', 1, 1),
+          sourceBox: 1,
+          sourceSlot: 3,
+          targetBox: 1,
+          targetSlot: 1,
+        },
+      ],
+    };
+
+    const plan = calculateMovePlan(diff);
+    // Move A to Temp
+    // Move C to A's spot
+    // Move B to C's spot
+    // Move Temp(A) to B's spot (target of A)
+    expect(plan).toEqual([
+      { type: 'MOVE', sourceBox: 1, sourceSlot: 1, targetBox: -1, targetSlot: -1 },
+      { type: 'MOVE', sourceBox: 1, sourceSlot: 3, targetBox: 1, targetSlot: 1 },
+      { type: 'MOVE', sourceBox: 1, sourceSlot: 2, targetBox: 1, targetSlot: 3 },
+      { type: 'MOVE', sourceBox: -1, sourceSlot: -1, targetBox: 1, targetSlot: 2 },
+    ]);
+  });
+});

--- a/src/engine/saveParser/utils/movePlanner.ts
+++ b/src/engine/saveParser/utils/movePlanner.ts
@@ -108,6 +108,7 @@ export function calculateMovePlan(diff: BoxDiffResult): MoveOperation[] {
     if (cycle.length === 2) {
       // 2-cycle can be resolved with a single SWAP
       const r0 = cycle[0];
+      if (!r0) continue;
       operations.push({
         type: 'SWAP',
         sourceBox: r0.sourceBox,
@@ -122,6 +123,7 @@ export function calculateMovePlan(diff: BoxDiffResult): MoveOperation[] {
       const tempSlot = -1;
 
       const firstReloc = cycle[0];
+      if (!firstReloc) continue;
 
       // MOVE first pokemon to Temp
       operations.push({
@@ -135,6 +137,7 @@ export function calculateMovePlan(diff: BoxDiffResult): MoveOperation[] {
       // Move remaining pokemon in the cycle backwards
       for (let i = cycle.length - 1; i > 0; i--) {
         const r = cycle[i];
+        if (!r) continue;
         operations.push({
           type: 'MOVE',
           sourceBox: r.sourceBox,

--- a/src/engine/saveParser/utils/movePlanner.ts
+++ b/src/engine/saveParser/utils/movePlanner.ts
@@ -1,5 +1,5 @@
-import type { BoxDiffResult } from './boxDiff';
 import type { PokemonInstance } from '../parsers/common';
+import type { BoxDiffResult } from './boxDiff';
 
 export type MoveOperationType = 'MOVE' | 'SWAP' | 'DEPOSIT' | 'WITHDRAW';
 
@@ -60,7 +60,8 @@ export function calculateMovePlan(diff: BoxDiffResult): MoveOperation[] {
 
   // Resolve paths backwards to avoid overwriting
   while (queue.length > 0) {
-    const curr = queue.shift()!;
+    const curr = queue.shift();
+    if (!curr) continue;
     const reloc = inEdge.get(curr);
     if (reloc) {
       operations.push({

--- a/src/engine/saveParser/utils/movePlanner.ts
+++ b/src/engine/saveParser/utils/movePlanner.ts
@@ -1,0 +1,170 @@
+import type { BoxDiffResult } from './boxDiff';
+import type { PokemonInstance } from '../parsers/common';
+
+export type MoveOperationType = 'MOVE' | 'SWAP' | 'DEPOSIT' | 'WITHDRAW';
+
+export interface MoveOperation {
+  type: MoveOperationType;
+  sourceBox: number;
+  sourceSlot: number;
+  targetBox: number;
+  targetSlot: number;
+}
+
+function extractBoxSlot(p: PokemonInstance): { box: number; slot: number } {
+  const boxMatch = p.storageLocation.match(/Box (\d+)/);
+  const box = boxMatch?.[1] ? parseInt(boxMatch[1], 10) : -1;
+  const slot = p.slot ?? -1;
+  return { box, slot };
+}
+
+/**
+ * Translates a BoxDiffResult into a sequential list of minimal, actionable manual user
+ * operations required to transition the PC layout from the current state to the target state.
+ */
+export function calculateMovePlan(diff: BoxDiffResult): MoveOperation[] {
+  const operations: MoveOperation[] = [];
+
+  // 1. Process all WITHDRAWs (Removals) to free up slots
+  for (const removal of diff.removals) {
+    const { box, slot } = extractBoxSlot(removal);
+    operations.push({
+      type: 'WITHDRAW',
+      sourceBox: box,
+      sourceSlot: slot,
+      targetBox: -1,
+      targetSlot: -1,
+    });
+  }
+
+  // 2. Process relocations
+  const outEdge = new Map<string, BoxDiffResult['relocations'][number]>();
+  const inEdge = new Map<string, BoxDiffResult['relocations'][number]>();
+
+  const formatSlot = (box: number, slot: number) => `${box}:${slot}`;
+
+  for (const reloc of diff.relocations) {
+    const u = formatSlot(reloc.sourceBox, reloc.sourceSlot);
+    const v = formatSlot(reloc.targetBox, reloc.targetSlot);
+    outEdge.set(u, reloc);
+    inEdge.set(v, reloc);
+  }
+
+  // Find all paths (nodes that have incoming edges but NO outgoing edges)
+  const queue: string[] = [];
+  for (const v of inEdge.keys()) {
+    if (!outEdge.has(v)) {
+      queue.push(v);
+    }
+  }
+
+  // Resolve paths backwards to avoid overwriting
+  while (queue.length > 0) {
+    const curr = queue.shift()!;
+    const reloc = inEdge.get(curr);
+    if (reloc) {
+      operations.push({
+        type: 'MOVE',
+        sourceBox: reloc.sourceBox,
+        sourceSlot: reloc.sourceSlot,
+        targetBox: reloc.targetBox,
+        targetSlot: reloc.targetSlot,
+      });
+
+      const u = formatSlot(reloc.sourceBox, reloc.sourceSlot);
+      outEdge.delete(u);
+      inEdge.delete(curr);
+
+      // If the source of this move now has no outgoing edges, it becomes the end of a path
+      if (inEdge.has(u) && !outEdge.has(u)) {
+        queue.push(u);
+      }
+    }
+  }
+
+  // Resolve remaining cycles
+  while (outEdge.size > 0) {
+    // Pick an arbitrary starting point
+    const start = outEdge.keys().next().value;
+    if (!start) break;
+
+    const cycle: BoxDiffResult['relocations'][number][] = [];
+    let curr = start;
+
+    // Trace the cycle
+    while (true) {
+      const reloc = outEdge.get(curr);
+      if (!reloc) break;
+
+      cycle.push(reloc);
+      outEdge.delete(curr);
+      inEdge.delete(formatSlot(reloc.targetBox, reloc.targetSlot));
+
+      curr = formatSlot(reloc.targetBox, reloc.targetSlot);
+      if (curr === start) break;
+    }
+
+    if (cycle.length === 2) {
+      // 2-cycle can be resolved with a single SWAP
+      const r0 = cycle[0];
+      operations.push({
+        type: 'SWAP',
+        sourceBox: r0.sourceBox,
+        sourceSlot: r0.sourceSlot,
+        targetBox: r0.targetBox,
+        targetSlot: r0.targetSlot,
+      });
+    } else if (cycle.length > 2) {
+      // 3+ cycle needs a temporary holding space (Party / empty slot)
+      // We will use -1, -1 to denote temporary holding space
+      const tempBox = -1;
+      const tempSlot = -1;
+
+      const firstReloc = cycle[0];
+
+      // MOVE first pokemon to Temp
+      operations.push({
+        type: 'MOVE',
+        sourceBox: firstReloc.sourceBox,
+        sourceSlot: firstReloc.sourceSlot,
+        targetBox: tempBox,
+        targetSlot: tempSlot,
+      });
+
+      // Move remaining pokemon in the cycle backwards
+      for (let i = cycle.length - 1; i > 0; i--) {
+        const r = cycle[i];
+        operations.push({
+          type: 'MOVE',
+          sourceBox: r.sourceBox,
+          sourceSlot: r.sourceSlot,
+          targetBox: r.targetBox,
+          targetSlot: r.targetSlot,
+        });
+      }
+
+      // Finally move from Temp to the target of the first relocation
+      operations.push({
+        type: 'MOVE',
+        sourceBox: tempBox,
+        sourceSlot: tempSlot,
+        targetBox: firstReloc.targetBox,
+        targetSlot: firstReloc.targetSlot,
+      });
+    }
+  }
+
+  // 3. Process all DEPOSITs (Additions)
+  for (const addition of diff.additions) {
+    const { box, slot } = extractBoxSlot(addition);
+    operations.push({
+      type: 'DEPOSIT',
+      sourceBox: -1,
+      sourceSlot: -1,
+      targetBox: box,
+      targetSlot: slot,
+    });
+  }
+
+  return operations;
+}


### PR DESCRIPTION
This PR implements the move planner algorithm specified in `task-295-352-move-planner-impl`. 

It translates `BoxDiffResult` relocations, additions, and removals into a sequential list of minimal actionable operations. The algorithm carefully resolves acyclic paths by working backward and correctly disentangles 2-cycles and larger cycles using swaps and a temporary holding slot.

---
*PR created automatically by Jules for task [6146293549486245581](https://jules.google.com/task/6146293549486245581) started by @szubster*