### PR TITLE
Fix multi-step breeding chains for egg moves

### DIFF
--- a/.foundry/journals/coder/2523728584342463970.md
+++ b/.foundry/journals/coder/2523728584342463970.md
@@ -1,0 +1,2 @@
+# Journal
+Verified and corrected backwards traversal in egg move breeding generator to support multi-step chains efficiently and correctly evaluated intermediate ancestors that lack the required move.

--- a/.foundry/tasks/task-260-352-egg-move-multi-step-chains-impl.md
+++ b/.foundry/tasks/task-260-352-egg-move-multi-step-chains-impl.md
@@ -33,6 +33,6 @@ When a Pokémon requires an egg move, the static data (`p.em[moveId]`) provides 
 - The suggestion should encourage breeding the owned ancestor to produce the next step in the chain.
 
 ## Acceptance Criteria
-- [ ] Multi-step chains are fully traversed to find an owned ancestor.
-- [ ] Suggestions indicate which owned Pokémon to breed and what the resulting intermediate offspring will be.
-- [ ] Ensure O(1) in-place array mutation is maintained for performance as per Architecture Notes.
+- [x] Multi-step chains are fully traversed to find an owned ancestor.
+- [x] Suggestions indicate which owned Pokémon to breed and what the resulting intermediate offspring will be.
+- [x] Ensure O(1) in-place array mutation is maintained for performance as per Architecture Notes.

--- a/src/engine/assistant/generators/breedGenerator.ts
+++ b/src/engine/assistant/generators/breedGenerator.ts
@@ -120,6 +120,9 @@ export function generateBreedingSuggestions(
               const instances = instancesBySpecies.get(stepSpeciesId) || [];
               const hasMove = instances.some((inst) => inst.moves?.includes(moveId));
 
+              // If it doesn't have the move, and it's not the base of the chain, keep traversing
+              if (!hasMove && k > 0) continue;
+
               let description = `Breed your #${stepSpeciesId} to get a #${nextStepSpeciesId} with the Egg Move!`;
               const title = `Breed: #${nextStepSpeciesId}`;
               if (hasMove) {


### PR DESCRIPTION
Implemented backwards traversal for complex multi-step breeding chains in Gen 2 Daycare suggestions. The previous implementation broke the loop as soon as an owned ancestor was found, even if it lacked the required egg move, rendering the suggestion useless. The updated logic will skip intermediate steps without the move until it finds an ancestor that possesses it or reaches the base level-up learner. Tests confirmed the expected behaviour and all checks have passed.

Acceptance criteria in `.foundry/tasks/task-260-352-egg-move-multi-step-chains-impl.md` have been updated.

---
*PR created automatically by Jules for task [2523728584342463970](https://jules.google.com/task/2523728584342463970) started by @szubster*