### PR TITLE
Upgrade pnpm to 11.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,9 +90,9 @@
     "vitest-browser-react": "^2.2.0",
     "wrangler": "^4.114.0"
   },
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
   "engines": {
     "node": ">=22.0.0",
-    "pnpm": ">=11.9.0"
+    "pnpm": ">=11.17.0"
   }
 }


### PR DESCRIPTION
Upgraded pnpm version in package.json to the latest 11.17.0 version with Corepack integrity hash and updated engine requirements. Tested, linted, and verified builds pass perfectly.

Fixes #5250

---
*PR created automatically by Jules for task [18070506645442792636](https://jules.google.com/task/18070506645442792636) started by @szubster*