### PR TITLE
Tech Lead: Handle Secret Base Parse Failure

### DIFF
--- a/.foundry/journals/tech_lead/17846287558025326046.md
+++ b/.foundry/journals/tech_lead/17846287558025326046.md
@@ -1,0 +1,13 @@
+# Tech Lead Journal: 17846287558025326046
+
+**Date:** 2026-07-28
+**Story:** `story-324-333-parse-secret-base-locations`
+
+## Failure Analysis & Recovery
+- The child task `task-333-334-gen3-secret-base-locations-impl` permanently failed its QA process (`task-333-335-gen3-secret-base-locations-qa`).
+- **Root Cause:** The parser implementation incorrectly assumed that `trainerName` uses 8 bytes and `trainerId` begins at offset `0x0A` for Emerald. As documented in `.foundry/docs/knowledge_base/gen3_secret_base_offsets.md`, these sizes/offsets are identical across all Gen 3 games (`PLAYER_NAME_LENGTH` is 7 bytes, and `TRAINER_ID` is at offset `0x09`).
+- **Action Taken:** According to the "The Impossible Loop" protocol for permanent child failures, I verified the correct offsets from the documentation and spawned a new RESEARCH node (`research-333-348-investigate-secret-base-offsets`). I then created replacement implementation and QA tasks (`task-333-349` and `task-333-350`) that explicitly reference the research node and mandate the correct offsets. I appended these new nodes to the STORY markdown body and checked off the failed nodes to allow the DAG to progress once the new tasks complete.
+
+## Architectural Enforcement
+- Enforced ADR 028: Reminded the Coder to explicitly define module-level constants for memory offsets instead of using inline magic numbers.
+- Enforced ADR 010: Restated the requirement to catch `RangeError` from the `DataView` API and map it to `'The save file is corrupted or incomplete.'`.

--- a/.foundry/research/research-333-348-investigate-secret-base-offsets.md
+++ b/.foundry/research/research-333-348-investigate-secret-base-offsets.md
@@ -1,0 +1,58 @@
+---
+id: research-333-348-investigate-secret-base-offsets
+type: RESEARCH
+title: Investigate Gen 3 Secret Base Offsets
+status: COMPLETED
+owner_persona: researcher
+created_at: '2026-07-28'
+updated_at: '2026-07-28'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-324-333-parse-secret-base-locations
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - save-parsing
+  - research
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# RESEARCH: Investigate Gen 3 Secret Base Offsets
+
+## Investigation Goal
+The previous implementation `task-333-334-gen3-secret-base-locations-impl` failed because it incorrectly assumed Emerald uses 8 bytes for `trainerName` and `0x0A` for the `trainerId` offset. This research node documents the correct offsets.
+
+## Findings
+According to `.foundry/docs/knowledge_base/gen3_secret_base_offsets.md`, the correct offsets for Gen 3 Secret Bases are as follows:
+
+*   **PLAYER_NAME_LENGTH and OT_NAME_LENGTH** are exactly **7 bytes**.
+*   **TRAINER_ID_LENGTH** is **4 bytes**.
+
+Therefore, the `trainerName` is 7 bytes (offset `0x02` to `0x08`) and `trainerId` is 4 bytes (offset `0x09` to `0x0C`). This applies identically across all Gen 3 games (Ruby, Sapphire, Emerald).
+
+In Emerald:
+*   `0x00`: `secretBaseId` (1 byte)
+*   `0x01`: `flags` (1 byte)
+*   `0x02`: `trainerName` (7 bytes)
+*   `0x09`: `trainerId` (4 bytes)
+*   `0x0D`: `language` (1 byte)
+*   `0x0E`: `numSecretBasesReceived` (2 bytes)
+
+In Ruby/Sapphire:
+*   `0x00`: `secretBaseId` (1 byte)
+*   `0x01`: `flags` (1 byte)
+*   `0x02`: `playerName` (7 bytes)
+*   `0x09`: `trainerId` (4 bytes)
+*   `0x0D`: (implicit padding)
+*   `0x0E`: `numSecretBasesReceived` (2 bytes)
+
+This information MUST be used by the implementation tasks to correctly parse the save files and avoid `RangeError` or incorrect data extraction.
+
+## Acceptance Criteria
+- [x] Document the correct sizes and offsets for trainerName and trainerId.
+- [x] Verify that the offsets are identical across all Gen 3 games.

--- a/.foundry/stories/story-324-333-parse-secret-base-locations.md
+++ b/.foundry/stories/story-324-333-parse-secret-base-locations.md
@@ -32,5 +32,8 @@ As part of the Gen 3 Secret Base and Mixed Record Viewer, we need to extract the
 
 ## Acceptance Criteria
 - [x] Tech Lead: Break this Story down into actionable Tasks.
-- [ ] task-333-334-gen3-secret-base-locations-impl
-- [ ] task-333-335-gen3-secret-base-locations-qa
+- [x] task-333-334-gen3-secret-base-locations-impl
+- [x] task-333-335-gen3-secret-base-locations-qa
+- [ ] research-333-348-investigate-secret-base-offsets
+- [ ] task-333-349-gen3-secret-base-locations-retry-impl
+- [ ] task-333-350-gen3-secret-base-locations-retry-qa

--- a/.foundry/tasks/task-333-349-gen3-secret-base-locations-retry-impl.md
+++ b/.foundry/tasks/task-333-349-gen3-secret-base-locations-retry-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-333-349-gen3-secret-base-locations-retry-impl
+type: TASK
+title: Implement Gen 3 Secret Base Locations Parser (Retry)
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-28'
+updated_at: '2026-07-28'
+depends_on:
+  - research-333-348-investigate-secret-base-offsets
+jules_session_id: null
+pr_number: null
+parent: story-324-333-parse-secret-base-locations
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement Gen 3 Secret Base Locations Parser (Retry)
+
+## Context
+As part of the Gen 3 Secret Base and Mixed Record Viewer, we need to extract the locations of all active Secret Bases from the save file. This involves finding where the Secret Bases are built and who owns them.
+The previous implementation failed due to incorrect offsets. It incorrectly assumed Emerald uses 8 bytes for `trainerName` and `0x0A` for the `trainerId` offset.
+
+## Requirements
+- Use the `DataView` API (per ADR 010) to parse the Gen 3 save file and identify all active Secret Base locations.
+- **CRITICAL:** You must strictly adhere to all guidelines defined in **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`.
+- **CRITICAL (Research Node):** As per `research-333-348-investigate-secret-base-offsets`, `trainerName` is 7 bytes (offset `0x02`) and `trainerId` is 4 bytes (offset `0x09`). These offsets are identical across all Gen 3 games.
+- Ensure that you properly catch `RangeError` exceptions originating from out-of-bounds `DataView` reads, and rethrow them with the message: `'The save file is corrupted or incomplete.'` (per ADR 010).
+- **CRITICAL (ADR 028):** All memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level. Inline magic numbers for memory operations are strictly forbidden.
+- **CRITICAL:** Use the resolved section offset (e.g., `section1Offset`) to calculate relative memory offsets instead of using absolute hardcoded offsets.
+- Map the internal location IDs to the unified Gen 3 map graph.
+
+## Acceptance Criteria
+- [ ] Parser correctly extracts the internal location IDs and active state of the secret bases, using the correct trainer name length (7) and trainer ID offset (0x09).
+- [ ] `RangeError` is caught and rethrown with the exact message.
+- [ ] No inline magic numbers; all memory offsets and sizes are module-level constants.
+- [ ] Parsing correctly uses the relative `section1Offset` rather than absolute offsets.
+- [ ] Location IDs are mapped to the correct Gen 3 map graph locations.

--- a/.foundry/tasks/task-333-350-gen3-secret-base-locations-retry-qa.md
+++ b/.foundry/tasks/task-333-350-gen3-secret-base-locations-retry-qa.md
@@ -1,0 +1,39 @@
+---
+id: task-333-350-gen3-secret-base-locations-retry-qa
+type: TASK
+title: QA Gen 3 Secret Base Locations Parser (Retry)
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-28'
+updated_at: '2026-07-28'
+depends_on:
+  - task-333-349-gen3-secret-base-locations-retry-impl
+jules_session_id: null
+pr_number: null
+parent: story-324-333-parse-secret-base-locations
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Gen 3 Secret Base Locations Parser (Retry)
+
+## Context
+QA verification for the Gen 3 Secret Base Locations parser (retry task). The previous attempt failed due to incorrect `trainerName` length and `trainerId` offsets.
+
+## Verification Requirements
+- Verify that `trainerName` uses length 7 (offset `0x02`) and `trainerId` uses offset `0x09` as documented in `research-333-348-investigate-secret-base-offsets`.
+- Verify that `DataView` API is used and `RangeError` exceptions are properly caught and re-thrown with the message: `'The save file is corrupted or incomplete.'` (ADR 010).
+- Verify that all memory offsets, lengths, bit locations, and shifts are explicitly defined as reusable constants at the module level. Inline magic numbers are forbidden (ADR 028).
+- Verify that relative section offsets (like `section1Offset`) are used instead of absolute offsets.
+- Verify that internal location IDs are correctly mapped to Gen 3 map locations.
+
+## Acceptance Criteria
+- [ ] Code review passes, ensuring no magic numbers exist, correct offset sizes are used, and all ADRs are followed.
+- [ ] Unit tests cover out-of-bounds reads and correct extraction/mapping.


### PR DESCRIPTION
This PR resolves the permanent failure of the Gen 3 Secret Base Locations Parser.
- Created `research-333-348-investigate-secret-base-offsets.md` documenting the correct struct offset data.
- Drafted replacement implementation and QA tasks `task-333-349` and `task-333-350` referencing the research and enforcing ADRs.
- Updated the parent STORY node `story-324-333-parse-secret-base-locations.md` with the new workflow.
- Updated the Tech Lead journal.

---
*PR created automatically by Jules for task [17846287558025326046](https://jules.google.com/task/17846287558025326046) started by @szubster*