### PR TITLE
fix: Update SaveHistoryDB schema to strictly adhere to V1

### DIFF
--- a/.foundry/tasks/task-341-355-define-indexeddb-schema-retry-v2-impl.md
+++ b/.foundry/tasks/task-341-355-define-indexeddb-schema-retry-v2-impl.md
@@ -27,9 +27,9 @@ notes: ''
 Implement the database configuration and schema initialization logic for `SaveHistoryDB` in `src/db/schema.ts` and `src/db/SaveHistoryDB.ts`. You must **strictly adhere** to the schema defined in Section 14 of `.foundry/docs/schema.md`.
 
 ## Acceptance Criteria
-- [ ] Read the findings from `research-341-354-investigate-indexeddb-schema-failure`.
-- [ ] In `src/db/schema.ts`, update `SAVE_HISTORY_DB_CONFIG` to exactly `VERSION: 1`.
-- [ ] In `src/db/schema.ts`, remove the `TRAINERS` object store from both `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema`.
-- [ ] In `src/db/SaveHistoryDB.ts`, update the `getDB` function to ensure it does not create the `TRAINERS` object store and does not create the `trainerId` index.
-- [ ] In `src/db/__tests__/SaveHistoryDB.test.ts`, ensure tests related to the `TRAINERS` object store or `trainerId` index are removed or fixed.
-- [ ] Ensure only the `saves`, `metadata`, and `indexes` object stores are defined and created.
+- [x] Read the findings from `research-341-354-investigate-indexeddb-schema-failure`.
+- [x] In `src/db/schema.ts`, update `SAVE_HISTORY_DB_CONFIG` to exactly `VERSION: 1`.
+- [x] In `src/db/schema.ts`, remove the `TRAINERS` object store from both `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema`.
+- [x] In `src/db/SaveHistoryDB.ts`, update the `getDB` function to ensure it does not create the `TRAINERS` object store and does not create the `trainerId` index.
+- [x] In `src/db/__tests__/SaveHistoryDB.test.ts`, ensure tests related to the `TRAINERS` object store or `trainerId` index are removed or fixed.
+- [x] Ensure only the `saves`, `metadata`, and `indexes` object stores are defined and created.

--- a/src/db/SaveHistoryDB.ts
+++ b/src/db/SaveHistoryDB.ts
@@ -11,16 +11,11 @@ let dbPromise: Promise<IDBPDatabase<SaveHistoryDBSchema>> | null = null;
 const getDB = async (): Promise<IDBPDatabase<SaveHistoryDBSchema>> => {
   if (!dbPromise) {
     dbPromise = openDB<SaveHistoryDBSchema>(SAVE_HISTORY_DB_CONFIG.NAME, SAVE_HISTORY_DB_CONFIG.VERSION, {
-      upgrade(db, oldVersion, _newVersion, transaction) {
+      upgrade(db, oldVersion, _newVersion, _transaction) {
         if (oldVersion < 1) {
           db.createObjectStore(SAVE_HISTORY_DB_CONFIG.STORES.SAVES);
           db.createObjectStore(SAVE_HISTORY_DB_CONFIG.STORES.METADATA);
           db.createObjectStore(SAVE_HISTORY_DB_CONFIG.STORES.INDEXES);
-        }
-        if (oldVersion < 2) {
-          db.createObjectStore(SAVE_HISTORY_DB_CONFIG.STORES.TRAINERS);
-          const indexesStore = transaction.objectStore(SAVE_HISTORY_DB_CONFIG.STORES.INDEXES);
-          indexesStore.createIndex('trainerId', 'trainerId');
         }
       },
     });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -237,12 +237,11 @@ export interface PokeDBSchema extends DBSchema {
 
 export const SAVE_HISTORY_DB_CONFIG = {
   NAME: 'SaveHistoryDB',
-  VERSION: 2,
+  VERSION: 1,
   STORES: {
     SAVES: 'saves',
     METADATA: 'metadata',
     INDEXES: 'indexes',
-    TRAINERS: 'trainers',
   },
 } as const;
 
@@ -256,11 +255,6 @@ export interface SaveHistoryDBSchema extends DBSchema {
     value: Record<string, unknown>;
   };
   [SAVE_HISTORY_DB_CONFIG.STORES.INDEXES]: {
-    key: string;
-    value: Record<string, unknown>;
-    indexes: { trainerId: string };
-  };
-  [SAVE_HISTORY_DB_CONFIG.STORES.TRAINERS]: {
     key: string;
     value: Record<string, unknown>;
   };


### PR DESCRIPTION
Fixes the IndexedDB schema definition for `SaveHistoryDB` to strictly adhere to the V1 schema requirements defined in Section 14 of `.foundry/docs/schema.md`. This resolves the permanent failure caused by incorrect schema initialization.

---
*PR created automatically by Jules for task [8239222687700882622](https://jules.google.com/task/8239222687700882622) started by @szubster*