### PR TITLE
test: verify 3+ step breeding chains and priority logic

### DIFF
--- a/.foundry/tasks/task-260-353-egg-move-multi-step-chains-qa.md
+++ b/.foundry/tasks/task-260-353-egg-move-multi-step-chains-qa.md
@@ -30,6 +30,6 @@ Verify the implementation of multi-step breeding chains support.
 - Write test cases in `src/engine/assistant/__tests__/generateSuggestions.test.ts` to ensure multi-step chains correctly generate suggestions when only an early ancestor is owned.
 
 ## Acceptance Criteria
-- [ ] Tests verify a 3+ step breeding chain correctly identifies an owned ancestor multiple steps back.
-- [ ] Tests verify priority logic works as expected.
-- [ ] Ensure no regressions in existing breeding generation tests.
+- [x] Tests verify a 3+ step breeding chain correctly identifies an owned ancestor multiple steps back.
+- [x] Tests verify priority logic works as expected.
+- [x] Ensure no regressions in existing breeding generation tests.

--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -1194,4 +1194,140 @@ describe('generateSuggestions', () => {
     expect(emSuggestion?.description).toBe('Breed your #274 (which knows the Egg Move) to get a #1!');
     expect(emSuggestion?.priority).toBe(88);
   });
+
+  it('should generate breeding suggestions for Egg Moves when owning an ancestor multiple steps back in a 3+ step chain', () => {
+    const ownedSet = new Set(Array.from({ length: 251 }, (_, i) => i + 1));
+    ownedSet.delete(1); // Missing final evolution
+
+    const mockSaveData = {
+      generation: 2,
+      gameVersion: 'gold',
+      trainerName: 'ASH',
+      owned: ownedSet,
+      party: [],
+      pc: [100], // Owns the earliest ancestor (e.g., step 1 in a 3-step chain)
+      inventory: [],
+      partyDetails: [],
+      pcDetails: [
+        {
+          speciesId: 100,
+          level: 20,
+          isShiny: false,
+          hash: '',
+          moves: [], // No moves initially
+          storageLocation: 'Box 1',
+          otName: 'ASH',
+        },
+      ],
+    } as unknown as SaveData;
+
+    const mockApiData = {
+      pokemonMetadata: {
+        1: {
+          id: 1,
+          n: 'TestFinal',
+          cr: 45,
+          baby: false,
+          eto: [],
+          efrm: [],
+          det: [],
+          em: {
+            20: [100, 101, 1], // Move 20, chain: 100 -> 101 -> 1
+          },
+        },
+        100: {
+          id: 100,
+          n: 'TestBase',
+          cr: 45,
+          baby: false,
+          eto: [],
+          efrm: [],
+          det: [],
+        },
+      } as Record<number, PokemonMetadata>,
+      localAid: null,
+      localEncounters: null,
+      missingEncounters: {},
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const strategy = getStrategy(2);
+    const result = generateSuggestions(mockSaveData, false, 'gold', mockApiData, strategy);
+
+    const emSuggestion = result.suggestions.find((s) => s.id === 'egg-move-1-20-100');
+    expect(emSuggestion).toBeDefined();
+    expect(emSuggestion?.description).toBe('Breed your #100 to get a #101 with the Egg Move!');
+    expect(emSuggestion?.priority).toBe(82);
+    expect(emSuggestion?.pokemonId).toBe(101);
+  });
+
+  it('should generate higher priority breeding suggestions for Egg Moves in a 3+ step chain when the early ancestor knows the move', () => {
+    const ownedSet = new Set(Array.from({ length: 251 }, (_, i) => i + 1));
+    ownedSet.delete(1); // Missing final evolution
+
+    const mockSaveData = {
+      generation: 2,
+      gameVersion: 'gold',
+      trainerName: 'ASH',
+      owned: ownedSet,
+      party: [],
+      pc: [100], // Owns the earliest ancestor
+      inventory: [],
+      partyDetails: [],
+      pcDetails: [
+        {
+          speciesId: 100,
+          level: 20,
+          isShiny: false,
+          hash: '',
+          moves: [20], // Knows the Egg Move
+          storageLocation: 'Box 1',
+          otName: 'ASH',
+        },
+      ],
+    } as unknown as SaveData;
+
+    const mockApiData = {
+      pokemonMetadata: {
+        1: {
+          id: 1,
+          n: 'TestFinal',
+          cr: 45,
+          baby: false,
+          eto: [],
+          efrm: [],
+          det: [],
+          em: {
+            20: [100, 101, 1], // Move 20, chain: 100 -> 101 -> 1
+          },
+        },
+        100: {
+          id: 100,
+          n: 'TestBase',
+          cr: 45,
+          baby: false,
+          eto: [],
+          efrm: [],
+          det: [],
+        },
+      } as Record<number, PokemonMetadata>,
+      localAid: null,
+      localEncounters: null,
+      missingEncounters: {},
+      ancestralEncounters: {},
+      areaNames: {},
+      allLocations: [],
+    } as unknown as AssistantApiData;
+
+    const strategy = getStrategy(2);
+    const result = generateSuggestions(mockSaveData, false, 'gold', mockApiData, strategy);
+
+    const emSuggestion = result.suggestions.find((s) => s.id === 'egg-move-1-20-100');
+    expect(emSuggestion).toBeDefined();
+    expect(emSuggestion?.description).toBe('Breed your #100 (which knows the Egg Move) to get a #101!');
+    expect(emSuggestion?.priority).toBe(88);
+    expect(emSuggestion?.pokemonId).toBe(101);
+  });
 });


### PR DESCRIPTION
- Added test case to verify a 3-step breeding chain correctly identifies an early ancestor.
- Added test case to verify priority is correctly elevated when an early ancestor knows the required egg move.
- Checked off acceptance criteria in `task-260-353-egg-move-multi-step-chains-qa.md`.

---
*PR created automatically by Jules for task [7181633806701509626](https://jules.google.com/task/7181633806701509626) started by @szubster*