### PR TITLE
QA Define SaveHistoryDB Schema V2

### DIFF
--- a/.foundry/journals/qa/7878801567692380266.md
+++ b/.foundry/journals/qa/7878801567692380266.md
@@ -1,0 +1,8 @@
+# QA Agent Journal - 7878801567692380266
+
+Validated the `SaveHistoryDB` schema configuration and operations.
+- The `VERSION` is accurately set to `1`.
+- The `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema` in `src/db/schema.ts` correctly configure the three required stores: `saves`, `metadata`, and `indexes`.
+- Removed `TRAINERS` and `trainerId` store/index implementation and verified this through `src/db/SaveHistoryDB.ts` and the associated test suite `src/db/__tests__/SaveHistoryDB.test.ts`.
+
+The implementation matches the constraints defined in `.foundry/docs/schema.md` Section 14.

--- a/.foundry/tasks/task-341-356-define-indexeddb-schema-retry-v2-qa.md
+++ b/.foundry/tasks/task-341-356-define-indexeddb-schema-retry-v2-qa.md
@@ -27,8 +27,8 @@ notes: ''
 Verify the implementation of the `SaveHistoryDB` schema configuration in `src/db/schema.ts`, `src/db/SaveHistoryDB.ts`, and `src/db/__tests__/SaveHistoryDB.test.ts` strictly adheres to Section 14 of `.foundry/docs/schema.md`.
 
 ## Acceptance Criteria
-- [ ] Verify `SAVE_HISTORY_DB_CONFIG.VERSION` is exactly `1` in `src/db/schema.ts`.
-- [ ] Verify `SaveHistoryDB` configuration in `src/db/schema.ts` has exactly three stores: `saves`, `metadata`, and `indexes` in both `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema`.
-- [ ] Verify there is NO `TRAINERS` store creation in `src/db/SaveHistoryDB.ts`.
-- [ ] Verify there is NO `trainerId` index creation in `src/db/SaveHistoryDB.ts`.
-- [ ] Verify tests pass and have no references to the removed `TRAINERS` store in `src/db/__tests__/SaveHistoryDB.test.ts`.
+- [x] Verify `SAVE_HISTORY_DB_CONFIG.VERSION` is exactly `1` in `src/db/schema.ts`.
+- [x] Verify `SaveHistoryDB` configuration in `src/db/schema.ts` has exactly three stores: `saves`, `metadata`, and `indexes` in both `SAVE_HISTORY_DB_CONFIG` and `SaveHistoryDBSchema`.
+- [x] Verify there is NO `TRAINERS` store creation in `src/db/SaveHistoryDB.ts`.
+- [x] Verify there is NO `trainerId` index creation in `src/db/SaveHistoryDB.ts`.
+- [x] Verify tests pass and have no references to the removed `TRAINERS` store in `src/db/__tests__/SaveHistoryDB.test.ts`.


### PR DESCRIPTION
Verified the `SaveHistoryDB` schema changes match Section 14 of `.foundry/docs/schema.md`. The store configuration is exactly `saves`, `metadata`, and `indexes`, and `TRAINERS` is completely removed. Acceptance criteria are checked off and documented in the QA journal.

---
*PR created automatically by Jules for task [7878801567692380266](https://jules.google.com/task/7878801567692380266) started by @szubster*