### PR TITLE
QA move planner algorithm

### DIFF
--- a/.foundry/tasks/task-295-353-move-planner-qa.md
+++ b/.foundry/tasks/task-295-353-move-planner-qa.md
@@ -39,6 +39,6 @@ You must verify the implementation handles the following scenarios correctly via
 6. **Full Box Constraints**: Testing behavior when there are very few or zero empty slots available for holding space.
 
 ## Acceptance Criteria
-- [ ] Verify the implementation of `calculateMovePlan` correctly resolves cyclic dependencies.
-- [ ] Verify unit tests cover direct swaps and N=3+ cycles.
-- [ ] Run `pnpm test` and ensure all tests pass.
+- [x] Verify the implementation of `calculateMovePlan` correctly resolves cyclic dependencies.
+- [x] Verify unit tests cover direct swaps and N=3+ cycles.
+- [x] Run `pnpm test` and ensure all tests pass.

--- a/src/engine/saveParser/utils/movePlanner.test.ts
+++ b/src/engine/saveParser/utils/movePlanner.test.ts
@@ -80,6 +80,30 @@ describe('movePlanner', () => {
     ]);
   });
 
+  it('handles empty state / no diffs', () => {
+    const diff: BoxDiffResult = {
+      additions: [],
+      removals: [],
+      relocations: [],
+    };
+    const plan = calculateMovePlan(diff);
+    expect(plan).toEqual([]);
+  });
+
+  it('handles simple additions and removals', () => {
+    const diff: BoxDiffResult = {
+      additions: [createMockPokemon('A', 1, 1)],
+      removals: [createMockPokemon('B', 1, 2)],
+      relocations: [],
+    };
+    const plan = calculateMovePlan(diff);
+    // Removals should be processed first as WITHDRAWs
+    expect(plan).toEqual([
+      { type: 'WITHDRAW', sourceBox: 1, sourceSlot: 2, targetBox: -1, targetSlot: -1 },
+      { type: 'DEPOSIT', sourceBox: -1, sourceSlot: -1, targetBox: 1, targetSlot: 1 },
+    ]);
+  });
+
   it('handles cycle resolutions (3+ Pokémon)', () => {
     const diff: BoxDiffResult = {
       additions: [],


### PR DESCRIPTION
Added unit tests to thoroughly test `calculateMovePlan`, specifically addressing empty states and additions/removals as outlined in `task-295-353-move-planner-qa.md`. Verifies that tests cover cycle resolution for direct swaps and complex cyclic dependencies (N=3+). Acceptance criteria are all checked off in the task file. Tests and lint checks pass perfectly.

---
*PR created automatically by Jules for task [12238424697542487405](https://jules.google.com/task/12238424697542487405) started by @szubster*