### PR TITLE
QA: Reject task-319-323-gen3-hof-pokedex-extraction-impl for ADR 028 violation

### DIFF
--- a/.foundry/journals/qa/9971056220031896239.md
+++ b/.foundry/journals/qa/9971056220031896239.md
@@ -1,0 +1,18 @@
+# QA Validation: Gen 3 Hall of Fame & Pokédex Data Extraction
+
+**Date:** 2026-07-28
+**Task:** `task-319-324-gen3-hof-pokedex-extraction-qa`
+**Target Implementation:** `task-319-323-gen3-hof-pokedex-extraction-impl`
+
+## Validation Results
+
+**Result:** REJECTED
+
+**Reason:**
+The implementation in `src/engine/saveParser/parsers/gen3.ts` violates architectural guideline ADR 028 (Relative Offsets & Magic Numbers).
+Specifically, the coder used inline magic numbers for offset calculations and bit operations:
+- Line 1055: `GAME_STAT_ENTERED_HOF_ID * 4` (uses the magic number `4`).
+- Line 1073: `Math.floor(bitIndex / 8)` (uses the magic number `8`).
+- Line 1074: `bitIndex % 8` (uses the magic number `8`).
+
+ADR 028 mandates that all memory offsets, lengths, bit locations, and shifts must be explicitly defined as reusable constants at the module level. The target implementation task has been updated with `status: FAILED` and `rejection_count` incremented.

--- a/.foundry/tasks/task-319-323-gen3-hof-pokedex-extraction-impl.md
+++ b/.foundry/tasks/task-319-323-gen3-hof-pokedex-extraction-impl.md
@@ -2,7 +2,7 @@
 id: task-319-323-gen3-hof-pokedex-extraction-impl
 type: TASK
 title: Implement Gen 3 Hall of Fame & Pokédex Data Extraction
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-15'
 updated_at: '2026-07-28'
@@ -16,8 +16,8 @@ tags:
 research_references:
   - .foundry/docs/knowledge_base/engine/save_parsing/gen3_hall_of_fame.md
   - .foundry/docs/knowledge_base/gen3_pokemon_data_structure.md
-rejection_count: 1
-rejection_reason: ''
+rejection_count: 2
+rejection_reason: 'Violation of ADR 028: Usage of inline magic numbers for offset calculations (GAME_STAT_ENTERED_HOF_ID * 4) and bit operations (Math.floor(bitIndex / 8) and bitIndex % 8) in src/engine/saveParser/parsers/gen3.ts.'
 notes: ''
 ---
 
@@ -37,13 +37,13 @@ Implement the logic to extract the Hall of Fame entry flag (`GAME_STAT_ENTERED_H
 - **Testing:** You MUST write corresponding Vitest unit tests to cover the new extraction logic.
 
 ## Acceptance Criteria
-- [x] `DataView` API is used for parsing.
-- [x] All offsets and constants are defined at the module level.
-- [x] Relative offsets from `section1Offset` are used for `SaveBlock1` data.
-- [x] `RangeError` is caught and translated to `"The save file is corrupted or incomplete."`.
-- [x] `GAME_STAT_ENTERED_HOF` or equivalent Hall of Fame entry flag is extracted.
-- [x] Number of caught Pokémon in Hoenn and National Dex is extracted.
-- [x] Tests are written and pass.
+- [ ] `DataView` API is used for parsing.
+- [ ] All offsets and constants are defined at the module level.
+- [ ] Relative offsets from `section1Offset` are used for `SaveBlock1` data.
+- [ ] `RangeError` is caught and translated to `"The save file is corrupted or incomplete."`.
+- [ ] `GAME_STAT_ENTERED_HOF` or equivalent Hall of Fame entry flag is extracted.
+- [ ] Number of caught Pokémon in Hoenn and National Dex is extracted.
+- [ ] Tests are written and pass.
 
 ## Persona Instructions
 - **Coder & QA:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/.foundry/tasks/task-319-324-gen3-hof-pokedex-extraction-qa.md
+++ b/.foundry/tasks/task-319-324-gen3-hof-pokedex-extraction-qa.md
@@ -27,6 +27,9 @@ notes: ''
 ## Objective
 Verify the implementation of the Gen 3 Hall of Fame entry and Pokédex data extraction logic against the architectural requirements.
 
+**Validation Result:**
+REJECTED: The implementation in `src/engine/saveParser/parsers/gen3.ts` violates ADR 028. It uses inline magic numbers for offset calculations (`GAME_STAT_ENTERED_HOF_ID * 4`) and bit operations (`Math.floor(bitIndex / 8)` and `bitIndex % 8`).
+
 ## Verification Tasks
 1.  **Architecture Verification (ADR 010):** Verify that the `coder` exclusively used the `DataView` API. If they used raw `Uint8Array` manipulations, reject the PR.
 2.  **Architecture Verification (ADR 028):** Verify that all memory offsets, limits, bit locations, and shifts are defined as reusable module-level constants. Inline magic numbers are forbidden.


### PR DESCRIPTION
This PR rejects the implementation for `task-319-323-gen3-hof-pokedex-extraction-impl` because it violates the ADR 028 (Relative Offsets & Magic Numbers). Specifically, it uses inline magic numbers for offset calculations and bit operations (`GAME_STAT_ENTERED_HOF_ID * 4`, `Math.floor(bitIndex / 8)`, and `bitIndex % 8`).
The task's YAML frontmatter has been updated with `status: FAILED` and an incremented rejection count, and a QA journal entry detailing the violation was added.

---
*PR created automatically by Jules for task [9971056220031896239](https://jules.google.com/task/9971056220031896239) started by @szubster*