### PR TITLE
feat: Cloudflare R2 Offline Conflict Resolution - Implementation

### DIFF
--- a/.foundry/journals/coder/3577743536037796835.md
+++ b/.foundry/journals/coder/3577743536037796835.md
@@ -1,0 +1,8 @@
+# Coder Journal: R2 Conflict Resolution
+
+## 2026-07-28
+- **R2 Meta Data**: When utilizing custom metadata in Cloudflare R2 `list` requests, you must specify the `include: ['customMetadata']` parameter in the list options. Otherwise, `customMetadata` is undefined on the returned objects.
+- **R2 Headers**: Retrieving metadata via `get` requires reading headers from the Response (e.g., `client-last-modified`), whereas putting metadata via `put` allows defining it in a `customMetadata` option passed to the SDK.
+- **Conflict Strategy Implementation**: Implemented a timestamp-based last-write-wins (LWW) conflict strategy. The application compares the `lastModified` of the local save file to the `client-last-modified` metadata from the remote R2 storage. If the remote version is newer, the local upload is aborted, and the remote version is pulled down to replace the local state.
+- **Vitest Environment**: Ensure tests using `vi.mocked` reflect updated interface types correctly (e.g., changing from an array of strings to an array of objects for `listSaves()`).
+- **Playwright Tests Error Fix**: Encountered error about missing Playwright browsers (executable doesn't exist). Successfully fixed by running `npx playwright install`.

--- a/.foundry/tasks/task-265-352-r2-conflict-resolution-impl.md
+++ b/.foundry/tasks/task-265-352-r2-conflict-resolution-impl.md
@@ -33,6 +33,6 @@ Because DexHelper is offline-first, a user might make local changes while discon
 - Add error handling for cases where timestamps cannot be reliably determined.
 
 ## Acceptance Criteria
-- [ ] Logic implemented to detect conflicts between local file state and remote R2 state.
-- [ ] Conflict resolution strategy (e.g., last-write-wins) implemented and correctly handling offline/online transitions.
-- [ ] API endpoints and `r2Client` updated to handle and expose timestamps for sync comparison.
+- [x] Logic implemented to detect conflicts between local file state and remote R2 state.
+- [x] Conflict resolution strategy (e.g., last-write-wins) implemented and correctly handling offline/online transitions.
+- [x] API endpoints and `r2Client` updated to handle and expose timestamps for sync comparison.

--- a/functions/api/saves/[id].ts
+++ b/functions/api/saves/[id].ts
@@ -14,6 +14,11 @@ export const onRequestGet: PagesFunction<Env, 'id', PluginData> = async ({ env, 
   const headers = new Headers();
   object.writeHttpMetadata(headers as any);
   headers.set('etag', object.httpEtag);
+
+  if (object.customMetadata?.['client-last-modified']) {
+    headers.set('client-last-modified', object.customMetadata['client-last-modified']);
+  }
+
   return new globalThis.Response(object.body as unknown as ReadableStream, { headers }) as any;
 };
 
@@ -21,6 +26,16 @@ export const onRequestPut: PagesFunction<Env, 'id', PluginData> = async ({ reque
   const email = data.cloudflareAccess?.JWT?.payload?.email;
   if (!email) return new globalThis.Response('Unauthorized', { status: 401 }) as any;
   const id = params.id as string;
-  await env.SAVES_BUCKET.put(`${email}/${id}`, request.body as any);
+
+  const clientLastModified = request.headers.get('client-last-modified');
+
+  const customMetadata: Record<string, string> = {};
+  if (clientLastModified) {
+    customMetadata['client-last-modified'] = clientLastModified;
+  }
+
+  await env.SAVES_BUCKET.put(`${email}/${id}`, request.body as any, {
+    customMetadata
+  });
   return new globalThis.Response('Created', { status: 201 }) as any;
 };

--- a/functions/api/saves/index.ts
+++ b/functions/api/saves/index.ts
@@ -12,8 +12,11 @@ export const onRequestGet: PagesFunction<Env, any, PluginData> = async ({ env, d
   }
 
   const prefix = `${email}/`;
-  const list = await env.SAVES_BUCKET.list({ prefix });
-  const files = list.objects.map((obj: any) => obj.key.substring(prefix.length));
+  const list = await env.SAVES_BUCKET.list({ prefix, include: ['customMetadata'] });
+  const files = list.objects.map((obj: any) => ({
+    id: obj.key.substring(prefix.length),
+    lastModified: obj.customMetadata?.['client-last-modified'] ? parseInt(obj.customMetadata['client-last-modified'], 10) : undefined,
+  }));
 
   return new globalThis.Response(JSON.stringify(files), {
     headers: { 'Content-Type': 'application/json' },

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -64,8 +64,8 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         if (localStorage.getItem(AUTH_LOGGED_IN_INDICATOR) === 'true') {
           try {
             const saves = await r2Client.listSaves();
-            const saveId = saves.length > 0 && saves[0] ? saves[0] : 'save-1';
-            await r2Client.putSave(saveId, new Uint8Array(buffer));
+            const saveId = saves.length > 0 && saves[0] ? saves[0].id : 'save-1';
+            await r2Client.putSave(saveId, new Uint8Array(buffer), file.lastModified);
           } catch {
             console.error('System: push to cloud failed');
           }

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -244,7 +244,7 @@ describe('AppLayout file upload', () => {
     const { r2Client } = await import('../../utils/r2/client');
 
     localStorage.setItem(AUTH_LOGGED_IN_INDICATOR, 'true');
-    vi.mocked(r2Client.listSaves).mockResolvedValue(['existing-save']);
+    vi.mocked(r2Client.listSaves).mockResolvedValue([{ id: 'existing-save' }]);
     vi.mocked(r2Client.putSave).mockResolvedValue();
 
     const putSaveSpy = vi.spyOn(saveDB, 'putSave').mockResolvedValue(undefined);
@@ -293,7 +293,7 @@ describe('AppLayout file upload', () => {
         expect(parseSaveFile).toHaveBeenCalled();
         expect(putSaveSpy).toHaveBeenCalled();
         expect(r2Client.listSaves).toHaveBeenCalled();
-        expect(r2Client.putSave).toHaveBeenCalledWith('existing-save', expect.any(Uint8Array));
+        expect(r2Client.putSave).toHaveBeenCalledWith('existing-save', expect.any(Uint8Array), file.lastModified);
       },
       { timeout: 3000 },
     );
@@ -346,7 +346,7 @@ describe('AppLayout file upload', () => {
 
     await vi.waitFor(
       () => {
-        expect(r2Client.putSave).toHaveBeenCalledWith('save-1', expect.any(Uint8Array));
+        expect(r2Client.putSave).toHaveBeenCalledWith('save-1', expect.any(Uint8Array), file.lastModified);
       },
       { timeout: 3000 },
     );

--- a/src/hooks/useFileSyncController.test.tsx
+++ b/src/hooks/useFileSyncController.test.tsx
@@ -11,8 +11,9 @@ import { useFileSyncController } from './useFileSyncController';
 // Mock dependencies
 vi.mock('../utils/r2/client', () => ({
   r2Client: {
-    listSaves: vi.fn<() => Promise<string[]>>(),
-    putSave: vi.fn<(id: string, data: Uint8Array) => Promise<void>>(),
+    listSaves: vi.fn<() => Promise<{ id: string; lastModified?: number }[]>>(),
+    getSave: vi.fn<(id: string) => Promise<{ data: Uint8Array; lastModified?: number } | undefined>>(),
+    putSave: vi.fn<(id: string, data: Uint8Array, lastModified?: number) => Promise<void>>(),
   },
 }));
 
@@ -171,7 +172,7 @@ describe('useFileSyncController', () => {
     const { r2Client } = await import('../utils/r2/client');
 
     localStorage.setItem(AUTH_LOGGED_IN_INDICATOR, 'true');
-    vi.mocked(r2Client.listSaves).mockResolvedValue(['existing-save-id']);
+    vi.mocked(r2Client.listSaves).mockResolvedValue([{ id: 'existing-save-id', lastModified: 900 }]);
 
     // Setup file mock
     const mockFile = {
@@ -203,7 +204,7 @@ describe('useFileSyncController', () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(r2Client.listSaves).toHaveBeenCalled();
-    expect(r2Client.putSave).toHaveBeenCalledWith('existing-save-id', expect.any(Uint8Array));
+    expect(r2Client.putSave).toHaveBeenCalledWith('existing-save-id', expect.any(Uint8Array), 1000);
   });
 
   it('should fallback to save-1 if no R2 saves exist', async () => {
@@ -240,7 +241,7 @@ describe('useFileSyncController', () => {
     await page.getByTestId('request-btn').click();
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(r2Client.putSave).toHaveBeenCalledWith('save-1', expect.any(Uint8Array));
+    expect(r2Client.putSave).toHaveBeenCalledWith('save-1', expect.any(Uint8Array), 1000);
   });
 
   it('should gracefully handle R2 failure', async () => {

--- a/src/hooks/useFileSyncController.ts
+++ b/src/hooks/useFileSyncController.ts
@@ -76,16 +76,40 @@ export function useFileSyncController() {
           setManualVersion(null);
         }
 
-        await saveDB.putSave('last_save_file', new Uint8Array(buffer));
-
         if (localStorage.getItem(AUTH_LOGGED_IN_INDICATOR) === 'true') {
           try {
             const saves = await r2Client.listSaves();
-            const saveId = saves.length > 0 && saves[0] ? saves[0] : 'save-1';
-            await r2Client.putSave(saveId, new Uint8Array(buffer));
+            const saveId = saves.length > 0 && saves[0] ? saves[0].id : 'save-1';
+            const cloudSaveInfo = saves.find(s => s.id === saveId);
+
+            if (cloudSaveInfo?.lastModified && file.lastModified < cloudSaveInfo.lastModified) {
+               // Cloud is newer, we should pull instead of pushing local (Conflict Resolution: pull-wins if newer)
+               const cloudSave = await r2Client.getSave(saveId);
+               if (cloudSave) {
+                 const cloudData = parseSaveFile(cloudSave.data.buffer, manualVersion || undefined);
+                 setSaveData(cloudData);
+
+                 if (cloudData.gameVersion === 'unknown') {
+                   setIsVersionModalOpen(true);
+                 } else {
+                   setManualVersion(null);
+                 }
+
+                 await saveDB.putSave('last_save_file', cloudSave.data);
+                 setStatus('live');
+                 setErrorMsg(null);
+                 return; // Abort pushing local
+               }
+            }
+
+            await saveDB.putSave('last_save_file', new Uint8Array(buffer));
+            await r2Client.putSave(saveId, new Uint8Array(buffer), file.lastModified);
           } catch {
             console.error('System: push to cloud failed');
+            await saveDB.putSave('last_save_file', new Uint8Array(buffer));
           }
+        } else {
+          await saveDB.putSave('last_save_file', new Uint8Array(buffer));
         }
 
         setStatus('live');

--- a/src/hooks/useFileSyncController.ts
+++ b/src/hooks/useFileSyncController.ts
@@ -80,26 +80,26 @@ export function useFileSyncController() {
           try {
             const saves = await r2Client.listSaves();
             const saveId = saves.length > 0 && saves[0] ? saves[0].id : 'save-1';
-            const cloudSaveInfo = saves.find(s => s.id === saveId);
+            const cloudSaveInfo = saves.find((s) => s.id === saveId);
 
             if (cloudSaveInfo?.lastModified && file.lastModified < cloudSaveInfo.lastModified) {
-               // Cloud is newer, we should pull instead of pushing local (Conflict Resolution: pull-wins if newer)
-               const cloudSave = await r2Client.getSave(saveId);
-               if (cloudSave) {
-                 const cloudData = parseSaveFile(cloudSave.data.buffer, manualVersion || undefined);
-                 setSaveData(cloudData);
+              // Cloud is newer, we should pull instead of pushing local (Conflict Resolution: pull-wins if newer)
+              const cloudSave = await r2Client.getSave(saveId);
+              if (cloudSave) {
+                const cloudData = parseSaveFile(cloudSave.data.buffer, manualVersion || undefined);
+                setSaveData(cloudData);
 
-                 if (cloudData.gameVersion === 'unknown') {
-                   setIsVersionModalOpen(true);
-                 } else {
-                   setManualVersion(null);
-                 }
+                if (cloudData.gameVersion === 'unknown') {
+                  setIsVersionModalOpen(true);
+                } else {
+                  setManualVersion(null);
+                }
 
-                 await saveDB.putSave('last_save_file', cloudSave.data);
-                 setStatus('live');
-                 setErrorMsg(null);
-                 return; // Abort pushing local
-               }
+                await saveDB.putSave('last_save_file', cloudSave.data);
+                setStatus('live');
+                setErrorMsg(null);
+                return; // Abort pushing local
+              }
             }
 
             await saveDB.putSave('last_save_file', new Uint8Array(buffer));

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -7,8 +7,8 @@ import { r2Client } from './utils/r2/client';
 
 vi.mock('./utils/r2/client', () => ({
   r2Client: {
-    listSaves: vi.fn<() => Promise<string[]>>(),
-    getSave: vi.fn<(id: string) => Promise<Uint8Array | undefined>>(),
+    listSaves: vi.fn<() => Promise<{ id: string; lastModified?: number }[]>>(),
+    getSave: vi.fn<(id: string) => Promise<{ data: Uint8Array; lastModified?: number } | undefined>>(),
   },
 }));
 
@@ -162,9 +162,9 @@ describe('Zustand Store', () => {
         setItem: vi.fn<() => void>(),
         removeItem: vi.fn<() => void>(),
       });
-      vi.mocked(r2Client.listSaves).mockResolvedValue(['cloud-save-id']);
+      vi.mocked(r2Client.listSaves).mockResolvedValue([{ id: 'cloud-save-id' }]);
       const cloudData = new Uint8Array([9, 9, 9]);
-      vi.mocked(r2Client.getSave).mockResolvedValue(cloudData);
+      vi.mocked(r2Client.getSave).mockResolvedValue({ data: cloudData });
       const putSaveSpy = vi.spyOn(saveDB, 'putSave').mockResolvedValue(undefined);
 
       const mockSaveData = { trainerName: 'CLOUD', generation: 1, gameVersion: 'red' };

--- a/src/store.ts
+++ b/src/store.ts
@@ -206,10 +206,10 @@ export const useStore = create<AppStore>()(
             try {
               const saves = await r2Client.listSaves();
               if (saves.length > 0 && saves[0]) {
-                const cloudSave = await r2Client.getSave(saves[0]);
+                const cloudSave = await r2Client.getSave(saves[0].id);
                 if (cloudSave) {
-                  await saveDB.putSave('last_save_file', cloudSave);
-                  buffer = cloudSave;
+                  await saveDB.putSave('last_save_file', cloudSave.data);
+                  buffer = cloudSave.data;
                 }
               }
             } catch {

--- a/src/utils/r2/__tests__/client.test.ts
+++ b/src/utils/r2/__tests__/client.test.ts
@@ -15,13 +15,13 @@ describe('r2Client', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ['save1', 'save2'],
+      json: async () => [{ id: 'save1' }, { id: 'save2', lastModified: 100 }],
       // biome-ignore lint/suspicious/noExplicitAny: Mocking fetch requires any
     } as any);
 
     const saves = await r2Client.listSaves();
     expect(mockFetch).toHaveBeenCalledWith('/api/saves');
-    expect(saves).toEqual(['save1', 'save2']);
+    expect(saves).toEqual([{ id: 'save1' }, { id: 'save2', lastModified: 100 }]);
   });
 
   it('handles list saves error', async () => {
@@ -34,17 +34,20 @@ describe('r2Client', () => {
   });
 
   it('gets a save', async () => {
+    const mockHeaders = new Headers();
+    mockHeaders.set('client-last-modified', '12345');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
       arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+      headers: mockHeaders,
       // biome-ignore lint/suspicious/noExplicitAny: Mocking fetch requires any
     } as any);
 
     const save = await r2Client.getSave('save1');
     expect(mockFetch).toHaveBeenCalledWith('/api/saves/save1');
-    expect(save).toEqual(new Uint8Array([1, 2, 3]));
+    expect(save).toEqual({ data: new Uint8Array([1, 2, 3]), lastModified: 12345 });
   });
 
   it('handles getSave error', async () => {
@@ -78,11 +81,11 @@ describe('r2Client', () => {
     } as any);
 
     const data = new Uint8Array([1, 2, 3]);
-    await r2Client.putSave('save1', data);
+    await r2Client.putSave('save1', data, 100);
     expect(mockFetch).toHaveBeenCalledWith('/api/saves/save1', {
       method: 'PUT',
       body: expect.anything(),
-      headers: { 'Content-Type': 'application/octet-stream' },
+      headers: { 'Content-Type': 'application/octet-stream', 'client-last-modified': '100' },
     });
   });
 

--- a/src/utils/r2/client.ts
+++ b/src/utils/r2/client.ts
@@ -1,21 +1,35 @@
+export interface RemoteSave {
+  id: string;
+  lastModified?: number;
+}
+
 export const r2Client = {
-  async listSaves(): Promise<string[]> {
+  async listSaves(): Promise<RemoteSave[]> {
     const res = await fetch('/api/saves');
     if (!res.ok) throw new Error('Failed to list saves');
     return res.json();
   },
-  async getSave(id: string): Promise<Uint8Array | undefined> {
+  async getSave(id: string): Promise<{ data: Uint8Array; lastModified?: number } | undefined> {
     const res = await fetch(`/api/saves/${id}`);
     if (res.status === 404) return undefined;
     if (!res.ok) throw new Error('Failed to get save');
+
+    const clientLastModifiedStr = res.headers.get('client-last-modified');
+    const lastModified = clientLastModifiedStr ? parseInt(clientLastModifiedStr, 10) : undefined;
+
     const buffer = await res.arrayBuffer();
-    return new Uint8Array(buffer);
+    return { data: new Uint8Array(buffer), lastModified };
   },
-  async putSave(id: string, data: Uint8Array<ArrayBuffer>): Promise<void> {
+  async putSave(id: string, data: Uint8Array<ArrayBuffer>, lastModified?: number): Promise<void> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/octet-stream' };
+    if (lastModified !== undefined) {
+      headers['client-last-modified'] = lastModified.toString();
+    }
+
     const res = await fetch(`/api/saves/${id}`, {
       method: 'PUT',
       body: data,
-      headers: { 'Content-Type': 'application/octet-stream' },
+      headers,
     });
     if (!res.ok) throw new Error('Failed to put save');
   },

--- a/src/utils/r2/client.ts
+++ b/src/utils/r2/client.ts
@@ -18,7 +18,10 @@ export const r2Client = {
     const lastModified = clientLastModifiedStr ? parseInt(clientLastModifiedStr, 10) : undefined;
 
     const buffer = await res.arrayBuffer();
-    return { data: new Uint8Array(buffer), lastModified };
+    if (lastModified !== undefined) {
+      return { data: new Uint8Array(buffer), lastModified };
+    }
+    return { data: new Uint8Array(buffer) };
   },
   async putSave(id: string, data: Uint8Array<ArrayBuffer>, lastModified?: number): Promise<void> {
     const headers: Record<string, string> = { 'Content-Type': 'application/octet-stream' };


### PR DESCRIPTION
Implements robust timestamp-based conflict resolution for Cloudflare R2 offline-first sync.

## Context
When a user updates a `.sav` file locally while disconnected, and the remote R2 state has advanced, we need to correctly resolve the mismatch upon reconnecting.

## Changes
1. **API Endpoints (`functions/api/saves`)**: 
   - Exposes `client-last-modified` via `customMetadata`. 
   - `listSaves` now returns object structures containing `{ id, lastModified }`.
2. **Client `r2Client`**: 
   - Updates `r2Client` interfaces to correctly retrieve headers and send timestamp data.
3. **Conflict Resolution (`useFileSyncController.ts`)**: 
   - Validates if the local file's `lastModified` is strictly older than the cloud's. If the cloud is newer, it triggers a pull request and sets the application state to reflect the cloud rather than replacing the cloud data with stale local changes.
4. **Journals**: Documented learnings in the Coder journal.

---
*PR created automatically by Jules for task [3577743536037796835](https://jules.google.com/task/3577743536037796835) started by @szubster*