### PR TITLE
chore(story): mark secret base location tasks as complete

### DIFF
--- a/.foundry/stories/story-324-333-parse-secret-base-locations.md
+++ b/.foundry/stories/story-324-333-parse-secret-base-locations.md
@@ -34,6 +34,6 @@ As part of the Gen 3 Secret Base and Mixed Record Viewer, we need to extract the
 - [x] Tech Lead: Break this Story down into actionable Tasks.
 - [x] task-333-334-gen3-secret-base-locations-impl
 - [x] task-333-335-gen3-secret-base-locations-qa
-- [ ] research-333-348-investigate-secret-base-offsets
-- [ ] task-333-349-gen3-secret-base-locations-retry-impl
-- [ ] task-333-350-gen3-secret-base-locations-retry-qa
+- [x] research-333-348-investigate-secret-base-offsets
+- [x] task-333-349-gen3-secret-base-locations-retry-impl
+- [x] task-333-350-gen3-secret-base-locations-retry-qa


### PR DESCRIPTION
This PR updates the `story-324-333-parse-secret-base-locations` node by checking off the checkboxes for the completed descendant nodes (`research-333-348-investigate-secret-base-offsets`, `task-333-349-gen3-secret-base-locations-retry-impl`, and `task-333-350-gen3-secret-base-locations-retry-qa`). This is to fulfill the ADR 007 completeness contract and allow the orchestrator to correctly transition the story state.

---
*PR created automatically by Jules for task [7847994527769731114](https://jules.google.com/task/7847994527769731114) started by @szubster*