### PR TITLE
Empty PR for story-130-342-document-indexeddb-schema-retry

### DIFF
--- a/.foundry/journals/tech_lead/4572901324227939275.md
+++ b/.foundry/journals/tech_lead/4572901324227939275.md
@@ -1,0 +1,3 @@
+# 2026-07-29 Session 4572901324227939275
+
+The target artifact for story-130-342-document-indexeddb-schema-retry (documenting the SaveHistoryDB IndexedDB schema) already exists in `.foundry/docs/schema.md` (Section 14) and matches the required state. I am submitting an Empty PR to complete this story node as per the Empty PR Policy (ADR 009). No new downstream TASKs were generated.

--- a/.foundry/stories/story-130-342-document-indexeddb-schema-retry.md
+++ b/.foundry/stories/story-130-342-document-indexeddb-schema-retry.md
@@ -28,7 +28,7 @@ notes: ''
 Document the structure and specifications of the `SaveHistoryDB` IndexedDB schema that was defined. This documentation should outline the overall configuration, database name, version, and the structure of each object store (`saves`, `metadata`, `indexes`).
 
 ## Acceptance Criteria
-- [ ] Create or update schema documentation to reflect the `SaveHistoryDB` configuration.
-- [ ] Detail the structure and key-value types for the `saves` object store.
-- [ ] Detail the structure and key-value types for the `metadata` object store.
-- [ ] Detail the structure and key-value types for the `indexes` object store.
+- [x] Create or update schema documentation to reflect the `SaveHistoryDB` configuration.
+- [x] Detail the structure and key-value types for the `saves` object store.
+- [x] Detail the structure and key-value types for the `metadata` object store.
+- [x] Detail the structure and key-value types for the `indexes` object store.


### PR DESCRIPTION
The documentation for SaveHistoryDB IndexedDB schema already exists in Section 14 of `.foundry/docs/schema.md`. Submitted an empty PR and marked the story as complete as per ADR 009.

---
*PR created automatically by Jules for task [4572901324227939275](https://jules.google.com/task/4572901324227939275) started by @szubster*