### PR TITLE
Draft tasks for Gen 3 mixed record trainer data extraction

### DIFF
--- a/.foundry/stories/story-324-334-extract-mixed-record-trainer-data.md
+++ b/.foundry/stories/story-324-334-extract-mixed-record-trainer-data.md
@@ -33,4 +33,7 @@ When players mix records in Gen 3, they exchange Secret Bases and trainer data. 
 - Calculate or extract the EV yields associated with defeating these trainers.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break this Story down into actionable Tasks.
+- [x] Tech Lead: Break this Story down into actionable Tasks.
+- [ ] task-334-351-parse-secret-base-trainer-info-impl
+- [ ] task-334-352-parse-secret-base-trainer-party-impl
+- [ ] task-334-353-gen3-mixed-record-trainer-qa

--- a/.foundry/tasks/task-334-351-parse-secret-base-trainer-info-impl.md
+++ b/.foundry/tasks/task-334-351-parse-secret-base-trainer-info-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-334-351-parse-secret-base-trainer-info-impl
+type: TASK
+title: Implement Gen 3 Secret Base Trainer Info Extraction
+status: READY
+owner_persona: coder
+created_at: '2026-07-29'
+updated_at: '2026-07-29'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-324-334-extract-mixed-record-trainer-data
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# TASK: Implement Gen 3 Secret Base Trainer Info Extraction
+
+## Objective
+Implement extraction of NPC trainer details (name, ID) associated with Secret Bases from mixed record data in Gen 3 save files.
+
+## Requirements
+1.  Strictly adhere to Section 13 ("Save File Parsing & Extraction Guidelines") of `.foundry/docs/schema.md`.
+2.  Define all offsets and lengths as module-level constants. No inline magic numbers.
+3.  Use relative offsets based on the resolved section offset for Gen 3.
+4.  Catch `RangeError` during DataView reads and throw a new error with the message "The save file is corrupted or incomplete."
+5.  Extract `trainerName` (7 bytes) and `trainerId` (4 bytes).
+6.  Write unit tests validating the extraction logic.
+
+## Acceptance Criteria
+- [ ] Implement extraction logic for trainer name and ID for Gen 3 Secret Bases.
+- [ ] Conform to all rules in Section 13 of `schema.md`.
+- [ ] Unit tests added for the extraction logic.

--- a/.foundry/tasks/task-334-352-parse-secret-base-trainer-party-impl.md
+++ b/.foundry/tasks/task-334-352-parse-secret-base-trainer-party-impl.md
@@ -1,0 +1,40 @@
+---
+id: task-334-352-parse-secret-base-trainer-party-impl
+type: TASK
+title: Implement Gen 3 Secret Base Party Info Extraction
+status: READY
+owner_persona: coder
+created_at: '2026-07-29'
+updated_at: '2026-07-29'
+depends_on:
+  - task-334-351-parse-secret-base-trainer-info-impl
+jules_session_id: null
+pr_number: null
+parent: story-324-334-extract-mixed-record-trainer-data
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# TASK: Implement Gen 3 Secret Base Party Info Extraction
+
+## Objective
+Implement extraction of NPC team composition (Pokémon, levels, moves, EVs) associated with Secret Bases from mixed record data in Gen 3 save files.
+
+## Requirements
+1.  Strictly adhere to Section 13 ("Save File Parsing & Extraction Guidelines") of `.foundry/docs/schema.md`.
+2.  Define all offsets and lengths as module-level constants. No inline magic numbers.
+3.  Use relative offsets based on the resolved section offset for Gen 3.
+4.  Catch `RangeError` during DataView reads and throw a new error with the message "The save file is corrupted or incomplete."
+5.  Extract the `party` (108 bytes, 6 Pokémon max). For each Pokémon, extract: `personality`, `moves`, `species`, `heldItems`, `levels`, `EVs`.
+6.  Write unit tests validating the extraction logic.
+
+## Acceptance Criteria
+- [ ] Implement extraction logic for party details (Pokémon, levels, moves, EVs) for Gen 3 Secret Bases.
+- [ ] Conform to all rules in Section 13 of `schema.md`.
+- [ ] Unit tests added for the extraction logic.

--- a/.foundry/tasks/task-334-353-gen3-mixed-record-trainer-qa.md
+++ b/.foundry/tasks/task-334-353-gen3-mixed-record-trainer-qa.md
@@ -1,0 +1,35 @@
+---
+id: task-334-353-gen3-mixed-record-trainer-qa
+type: TASK
+title: QA Gen 3 Mixed Record Trainer Data Extraction
+status: READY
+owner_persona: qa
+created_at: '2026-07-29'
+updated_at: '2026-07-29'
+depends_on:
+  - task-334-352-parse-secret-base-trainer-party-impl
+jules_session_id: null
+pr_number: null
+parent: story-324-334-extract-mixed-record-trainer-data
+tags:
+  - qa
+  - gen3
+  - secret-base
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# TASK: QA Gen 3 Mixed Record Trainer Data Extraction
+
+## Objective
+Verify the implementation of Gen 3 mixed record trainer data extraction.
+
+## Requirements
+1.  Verify that the implementation strictly adheres to Section 13 of `.foundry/docs/schema.md`.
+2.  Verify the correctness of offsets and sizes used for extracting trainer name, ID, and party data.
+3.  Review the unit tests to ensure they provide adequate coverage for the extraction logic.
+
+## Acceptance Criteria
+- [ ] Verification complete.


### PR DESCRIPTION
Drafted technical blueprints (Tasks) to implement Gen 3 mixed record trainer data extraction as per the story requirements. Adhered to the `Two-Tasks-Max` anti-pattern by splitting the implementation into `trainer info` and `party info` parsing tasks, followed by a dedicated QA verification task (Intelligent Verification Protocol) due to the complexity of save file parsing. Ensured tasks mandate adherence to Section 13 of `.foundry/docs/schema.md` (no magic numbers, relative offsets, RangeError handling). Added task references to the story's acceptance criteria without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [3454513976554032710](https://jules.google.com/task/3454513976554032710) started by @szubster*