### PR TITLE
Check off acceptance criteria for completed Parse Registered Numbers tasks

### DIFF
--- a/.foundry/stories/story-116-283-parse-registered-numbers.md
+++ b/.foundry/stories/story-116-283-parse-registered-numbers.md
@@ -25,9 +25,9 @@ notes: ''
 Parse the registered numbers list from the Generation 2 save file based on research findings.
 
 ## Acceptance Criteria
-- [ ] Implement parsing logic for Pokegear registered numbers.
+- [x] Implement parsing logic for Pokegear registered numbers.
 - [x] task-283-312-parse-registered-numbers-impl
 - [x] task-283-313-parse-registered-numbers-qa
-- [ ] research-283-336-gen2-phone-memory-offsets
-- [ ] task-283-342-parse-registered-numbers-impl
-- [ ] task-283-343-parse-registered-numbers-qa
+- [x] research-283-336-gen2-phone-memory-offsets
+- [x] task-283-342-parse-registered-numbers-impl
+- [x] task-283-343-parse-registered-numbers-qa


### PR DESCRIPTION
Checked off the remaining acceptance criteria checkboxes in `.foundry/stories/story-116-283-parse-registered-numbers.md` for the completed tasks (`research-283-336-gen2-phone-memory-offsets`, `task-283-342-parse-registered-numbers-impl`, `task-283-343-parse-registered-numbers-qa`) and the overarching implementation checkbox to allow the orchestrator to transition the node to VERIFYING.

---
*PR created automatically by Jules for task [9819492269911096036](https://jules.google.com/task/9819492269911096036) started by @szubster*