### PR TITLE
fix: handle permanent failure for npc trade state integration

### DIFF
--- a/.foundry/journals/tech_lead/5301939723423526707.md
+++ b/.foundry/journals/tech_lead/5301939723423526707.md
@@ -1,0 +1,6 @@
+# Session 5301939723423526707
+
+- Observed permanent failure for `task-261-331-npc-trade-state-integration-impl`.
+- Created research task `research-261-357-investigate-npc-trade-state-integration-failure` to investigate why Gen 3 parsing used `section2Offset` and test coverage failed for `SaveData`.
+- Spawned replacement tasks `task-261-358-npc-trade-state-integration-retry-impl` and `task-261-359-npc-trade-state-integration-retry-qa` depending on the research.
+- Checked off the permanently failed child nodes in `story-119-261-npc-trade-state-integration` to resolve the impossible loop.

--- a/.foundry/research/research-261-357-investigate-npc-trade-state-integration-failure.md
+++ b/.foundry/research/research-261-357-investigate-npc-trade-state-integration-failure.md
@@ -1,0 +1,29 @@
+---
+id: research-261-357-investigate-npc-trade-state-integration-failure
+type: RESEARCH
+title: Investigate NPC Trade State Integration Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-29'
+updated_at: '2026-07-29'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-119-261-npc-trade-state-integration
+tags:
+  - backend
+  - state-integration
+  - research
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate NPC Trade State Integration Failure
+
+## Objective
+Investigate the root cause of the permanent failure of `task-261-331-npc-trade-state-integration-impl`. The QA persona noted that tests in `gen3.test.ts` do not verify integration into the `SaveData` object, and the `parseGen3` function incorrectly used `section2Offset` instead of `section1Offset` for Emerald and FRLG.
+
+## Context
+See `.foundry/docs/knowledge_base/agents/core_policies.md` and `task-261-332-npc-trade-state-integration-qa` for QA notes.

--- a/.foundry/stories/story-119-261-npc-trade-state-integration.md
+++ b/.foundry/stories/story-119-261-npc-trade-state-integration.md
@@ -27,5 +27,8 @@ Integrate the extracted flags into the unified `SaveData` object, ensuring consi
 
 ## Acceptance Criteria
 - [x] Tech Lead: Break down into tasks for `SaveData` update and test coverage.
-- [ ] task-261-331-npc-trade-state-integration-impl
-- [ ] task-261-332-npc-trade-state-integration-qa
+- [x] task-261-331-npc-trade-state-integration-impl
+- [x] task-261-332-npc-trade-state-integration-qa
+- [ ] research-261-357-investigate-npc-trade-state-integration-failure
+- [ ] task-261-358-npc-trade-state-integration-retry-impl
+- [ ] task-261-359-npc-trade-state-integration-retry-qa

--- a/.foundry/tasks/task-261-358-npc-trade-state-integration-retry-impl.md
+++ b/.foundry/tasks/task-261-358-npc-trade-state-integration-retry-impl.md
@@ -1,0 +1,43 @@
+---
+id: task-261-358-npc-trade-state-integration-retry-impl
+type: TASK
+title: NPC Trade State Integration Retry Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-29'
+updated_at: '2026-07-29'
+depends_on:
+  - research-261-357-investigate-npc-trade-state-integration-failure
+jules_session_id: null
+pr_number: null
+parent: story-119-261-npc-trade-state-integration
+tags:
+  - backend
+  - state-integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: NPC Trade State Integration Retry Implementation
+
+## Objective
+Implement the logic to integrate the extracted NPC trade flags into the unified `SaveData` object, ensuring consistency and proper `RangeError` handling.
+
+## Context and Constraints
+- The `coder` MUST map the raw bitflags successfully extracted in previous tasks and integrate them into the unified `SaveData` structure for cross-generation compatibility.
+- Address QA feedback from the permanently failed implementation: Tests must verify integration into the `SaveData` object, and `parseGen3` must correctly use `section1Offset` for Gen 3 logic.
+- If a transient failure requiring retry is experienced, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If the task must be permanently aborted, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If an empty PR is submitted for a completed task, all Acceptance Criteria checkboxes MUST be checked off before submitting.
+- **CRITICAL:** When implementing parsing or data definitions, explicitly define and use reusable constants for memory offsets, lengths, bit locations, and shifts at the module level. Inline magic numbers are strictly forbidden.
+- **CRITICAL:** For Gen 3 data parsing, use the resolved section offset (`section1Offset`) for relative Gen 3 calculations. Do not use absolute hardcoded offsets.
+- **CRITICAL:** You must catch `RangeError` for out-of-bounds reads and explicitly throw a new error with the message "The save file is corrupted or incomplete."
+
+## Acceptance Criteria
+- [ ] Integrate Gen 2 and Gen 3 extracted NPC trade flags into the unified `SaveData` object.
+- [ ] Ensure `SaveData` interface properties are correctly typed and updated if necessary.
+- [ ] Explicitly define and use reusable constants for memory offsets, lengths, and bit locations.
+- [ ] Use `section1Offset` for relative Gen 3 calculations.
+- [ ] Properly catch `RangeError` and throw the exact error message: "The save file is corrupted or incomplete."

--- a/.foundry/tasks/task-261-359-npc-trade-state-integration-retry-qa.md
+++ b/.foundry/tasks/task-261-359-npc-trade-state-integration-retry-qa.md
@@ -1,0 +1,43 @@
+---
+id: task-261-359-npc-trade-state-integration-retry-qa
+type: TASK
+title: NPC Trade State Integration Retry QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-29'
+updated_at: '2026-07-29'
+depends_on:
+  - task-261-358-npc-trade-state-integration-retry-impl
+jules_session_id: null
+pr_number: null
+parent: story-119-261-npc-trade-state-integration
+tags:
+  - backend
+  - qa
+  - state-integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: NPC Trade State Integration Retry QA
+
+## Objective
+Verify the implementation of NPC Trade State Integration into the `SaveData` object, ensuring correct behavior, error handling, and robust test coverage.
+
+## Context and Constraints
+- The `qa` persona MUST verify that the `coder` correctly implemented the state integration logic for NPC Trade flags.
+- Verify that the `SaveData` object is updated accurately.
+- Verify that `RangeError` is correctly caught and a new Error with the message "The save file is corrupted or incomplete." is thrown.
+- Verify that all memory offsets and lengths are defined as reusable constants at the module level and that inline magic numbers are not used.
+- Verify that Gen 3 calculations use the relative `section1Offset` rather than absolute hardcoded offsets.
+- If a transient failure requiring retry is experienced, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
+- If the task must be permanently aborted, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
+- If an empty PR is submitted for a completed task, all Acceptance Criteria checkboxes MUST be checked off before submitting.
+
+## Acceptance Criteria
+- [ ] Test coverage includes robust tests for `SaveData` updating correctly with `npcTradeFlags` (Gen 2) and `gen3NPCTrades` (Gen 3).
+- [ ] Test coverage includes tests verifying `RangeError` is caught and the exact message "The save file is corrupted or incomplete." is thrown.
+- [ ] No inline magic numbers exist for memory offsets/lengths; constants are properly used.
+- [ ] Gen 3 parses with `section1Offset` as expected.


### PR DESCRIPTION
This PR handles the permanent failure of `task-261-331-npc-trade-state-integration-impl` by spawning a new `RESEARCH` node to investigate the failure, and new `TASK` nodes for retry. The parent story has been updated, and the Tech Lead journal has been updated with the decisions.

---
*PR created automatically by Jules for task [5301939723423526707](https://jules.google.com/task/5301939723423526707) started by @szubster*