### PR TITLE
🧠 Trainer: Add Box Full Warning to Gen 2 Strategy

### DIFF
--- a/src/engine/assistant/strategies/gen2Strategy.test.ts
+++ b/src/engine/assistant/strategies/gen2Strategy.test.ts
@@ -24,6 +24,7 @@ describe('gen2Strategy', () => {
   const mockLocations: UnifiedLocation[] = [];
   const mockSaveData = {
     currentMapId: 0x0306,
+    currentBoxCount: 0,
   } as SaveData;
 
   it('has generation 2', () => {
@@ -70,6 +71,21 @@ describe('gen2Strategy', () => {
     expect(suggestions[1]?.id).toBe('headbutt-reminder');
     expect(suggestions[2]?.id).toBe('rocksmash-reminder');
     expect(suggestions[3]?.id).toBe('time-based-reminder');
+  });
+
+  it('warns when the current box is almost full', () => {
+    const saveData = {
+      ...mockSaveData,
+      currentBoxCount: 19,
+      johtoBadges: 0,
+      inventory: [],
+      partyDetails: [],
+    } as unknown as SaveData;
+
+    const suggestions = gen2Strategy.getSpecialSuggestions(saveData, []);
+    const warning = suggestions.find((s) => s.id === 'box-full-warning');
+    expect(warning).toBeDefined();
+    expect(warning?.description).toContain('Your current box has 19/20 Pokémon');
   });
 
   it('handles tyrogue evo paths for Hitmonchan and Hitmontop', () => {

--- a/src/engine/assistant/strategies/gen2Strategy.ts
+++ b/src/engine/assistant/strategies/gen2Strategy.ts
@@ -1,4 +1,5 @@
 import type { UnifiedLocation } from '../../../db/schema';
+import { getGenerationConfig } from '../../../utils/generationConfig';
 import { getGen2UnobtainableReason } from '../../exclusives/gen2Exclusives';
 import { getDistanceToMap, resolveOutdoorMapId } from '../../mapGraph/gen2Graph';
 import type { SaveData } from '../../saveParser/index';
@@ -23,6 +24,18 @@ export const gen2Strategy: AssistantStrategy = {
   getSpecialSuggestions(saveData: SaveData, missingIds: number[]): Suggestion[] {
     const suggestions: Suggestion[] = [];
     const missingSet = new Set(missingIds);
+    const genConfig = getGenerationConfig(2);
+
+    if (saveData.currentBoxCount >= genConfig.boxWarningThreshold) {
+      suggestions.push({
+        id: 'box-full-warning',
+        pokemonId: 0,
+        title: 'Current Box Almost Full',
+        category: 'Event',
+        priority: 1000,
+        description: `Your current box has ${saveData.currentBoxCount}/${genConfig.boxCapacity} Pokémon. Switch boxes at a Pokémon Center PC or new catches will fail!`,
+      });
+    }
 
     // 1. Roamer tracking
     const roamers = [


### PR DESCRIPTION
## What
Added the "Current Box Almost Full" suggestion to the Assistant for Gen 2 save files.

## Why
In Generations 1 and 2, when the active PC box reaches capacity (20 Pokémon), any new catches will fail. Providing an early warning (at 19/20) helps players proactively switch boxes and avoid losing out on rare encounters.

## Impact on recommendation quality
Increases safety and historical accuracy of the recommendations for Gen 2 players by warning them about a critical progression-blocking mechanic.

## Test coverage
Updated `gen2Strategy.test.ts` to assert that the `box-full-warning` suggestion is generated when `currentBoxCount` is high (e.g., 19). Verified with `pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e` to ensure no regressions.

---
*PR created automatically by Jules for task [5936360673048305681](https://jules.google.com/task/5936360673048305681) started by @szubster*