### PR TITLE
Update epic-099-130-indexeddb-schema-design to reflect completed stories

### DIFF
--- a/.foundry/epics/epic-099-130-indexeddb-schema-design.md
+++ b/.foundry/epics/epic-099-130-indexeddb-schema-design.md
@@ -31,8 +31,8 @@ Define the storage schema for the save state history, including DB name, object 
 - [x] Document the schema.
 - [x] story-130-315-define-indexeddb-schema
 - [x] story-130-316-document-indexeddb-schema
-- [ ] story-130-341-define-indexeddb-schema-retry
-- [ ] story-130-342-document-indexeddb-schema-retry
+- [x] story-130-341-define-indexeddb-schema-retry
+- [x] story-130-342-document-indexeddb-schema-retry
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Checked off completed stories `story-130-341-define-indexeddb-schema-retry` and `story-130-342-document-indexeddb-schema-retry` in `epic-099-130-indexeddb-schema-design.md` as they are already marked as `COMPLETED`.

---
*PR created automatically by Jules for task [15771041926152251544](https://jules.google.com/task/15771041926152251544) started by @szubster*