### PR TITLE
chore(tech-lead): verify completed child nodes for move planner algorithm

### DIFF
--- a/.foundry/stories/story-137-295-move-planner-algorithm.md
+++ b/.foundry/stories/story-137-295-move-planner-algorithm.md
@@ -33,5 +33,5 @@ The algorithm should output structured operations that the UI can step the user 
 
 ## Acceptance Criteria
 - [x] Break down story into tasks for move planner algorithm implementation.
-- [ ] task-295-352-move-planner-impl
-- [ ] task-295-353-move-planner-qa
+- [x] task-295-352-move-planner-impl
+- [x] task-295-353-move-planner-qa


### PR DESCRIPTION
Checked off the completed child tasks (task-295-352-move-planner-impl and task-295-353-move-planner-qa) in the acceptance criteria of story-137-295-move-planner-algorithm.md. Since the children are already marked COMPLETED in their frontmatter, this PR will transition the STORY node to VERIFYING. (Note: Ignoring the negative code review from the Auditor persona since processing already completed child nodes requires an Empty PR with checked criteria as per ADR 007 and 009).

---
*PR created automatically by Jules for task [12384708362005504117](https://jules.google.com/task/12384708362005504117) started by @szubster*