### PR TITLE
chore: complete egg move pathfinding epic

### DIFF
--- a/.foundry/epics/epic-055-113-egg-move-pathfinding-engine.md
+++ b/.foundry/epics/epic-055-113-egg-move-pathfinding-engine.md
@@ -26,12 +26,12 @@ notes: ''
 Develop the core algorithmic engine for calculating valid breeding chains. This engine will use the static database (Egg Groups, learnsets, Egg Moves) to find the shortest possible breeding path to pass a desired Egg Move to a target Pokémon species.
 
 ## Acceptance Criteria
-- [ ] Implement pathfinding algorithm (e.g., Breadth-First Search or Dijkstra's) to find the shortest breeding chains.
-- [ ] Ensure the algorithm correctly adheres to Gen 2 and Gen 3 breeding mechanics (matching Egg Groups, opposite genders).
-- [ ] Exclude invalid breeding pairs (e.g., "No Eggs" group).
-- [ ] Support chains requiring multiple intermediate parents.
+- [x] Implement pathfinding algorithm (e.g., Breadth-First Search or Dijkstra's) to find the shortest breeding chains.
+- [x] Ensure the algorithm correctly adheres to Gen 2 and Gen 3 breeding mechanics (matching Egg Groups, opposite genders).
+- [x] Exclude invalid breeding pairs (e.g., "No Eggs" group).
+- [x] Support chains requiring multiple intermediate parents.
 - [x] Story Owner: Break this Epic down into actionable STORIES.
-- [ ] story-113-258-egg-move-pathfinding-core
-- [ ] story-113-259-egg-move-breeding-rules
-- [ ] story-113-260-egg-move-multi-step-chains
-- [ ] research-113-248-egg-move-precomputation
+- [x] story-113-258-egg-move-pathfinding-core
+- [x] story-113-259-egg-move-breeding-rules
+- [x] story-113-260-egg-move-multi-step-chains
+- [x] research-113-248-egg-move-precomputation

--- a/.foundry/journals/story_owner/17349959000128358027.md
+++ b/.foundry/journals/story_owner/17349959000128358027.md
@@ -1,0 +1,6 @@
+# Story Owner Journal
+
+## Session 17349959000128358027
+
+### Lessons Learned
+- **Precomputation Priority**: When evaluating complex algorithms on static data (like the Egg Move pathfinding mechanics across species), it is critical to spawn research nodes explicitly evaluating the feasibility of precomputation (e.g., `research-113-248-egg-move-precomputation`). Precomputing the entire static state space during the ETL phase shifts expensive runtime traversals away from the client to O(1) lookups, which must be standard practice for static mechanics.


### PR DESCRIPTION
Marks the epic-055-113-egg-move-pathfinding-engine acceptance criteria as checked and adds a journal entry detailing lessons learned about precomputations, as the child stories are already complete.

---
*PR created automatically by Jules for task [17349959000128358027](https://jules.google.com/task/17349959000128358027) started by @szubster*