### PR TITLE
story_owner: generate e2e story for orchestrator safeguard epic

### DIFF
--- a/.foundry/epics/epic-057-127-orchestrator-safeguard-investigation.md
+++ b/.foundry/epics/epic-057-127-orchestrator-safeguard-investigation.md
@@ -29,4 +29,5 @@ Investigate `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/found
 ## Acceptance Criteria
 - [x] Analyze orchestrator scripts for programmatic safeguards.
 - [x] Create necessary STORY nodes for investigation and implementation if viable.
-- [x] story-127-269-epic-e2e-safeguard
+- [x] [story-127-269-epic-e2e-safeguard](.foundry/stories/story-127-269-epic-e2e-safeguard.md)
+- [ ] [story-127-347-orchestrator-safeguard-e2e](.foundry/stories/story-127-347-orchestrator-safeguard-e2e.md)

--- a/.foundry/stories/story-127-347-orchestrator-safeguard-e2e.md
+++ b/.foundry/stories/story-127-347-orchestrator-safeguard-e2e.md
@@ -1,0 +1,31 @@
+---
+id: story-127-347-orchestrator-safeguard-e2e
+type: STORY
+title: E2E Integration for Orchestrator Safeguards
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-29'
+updated_at: '2026-07-29'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-057-127-orchestrator-safeguard-investigation
+tags:
+  - process
+  - orchestrator
+  - e2e
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# STORY: E2E Integration for Orchestrator Safeguards
+
+## Context
+As part of enforcing macro node functional boundaries, we need to ensure that an EPIC cannot be marked `COMPLETED` until its functional requirements are verifiably integrated and tested. The orchestrator now requires an E2E story.
+
+## Goal
+Implement E2E testing for the new orchestrator safeguard to verify that an EPIC node cannot be promoted to VERIFYING or COMPLETED unless it contains at least one child STORY that explicitly represents integration or E2E testing.
+
+## Acceptance Criteria
+- [ ] Implement E2E tests for the orchestrator safeguard.


### PR DESCRIPTION
I have reviewed the `epic-057-127-orchestrator-safeguard-investigation` macro node. The epic required a dedicated E2E testing STORY to be generated as part of its acceptance criteria to satisfy the new orchestrator safeguard (`story-127-269-epic-e2e-safeguard`). I verified that `story-127-269-epic-e2e-safeguard` exists and was completed.

To complete the breakdown:
1.  I generated the required missing child node `story-127-347-orchestrator-safeguard-e2e.md` (tagged with `e2e`) to cover the E2E integration tests for this epic.
2.  I updated the EPIC's markdown body. I formatted the existing completed child as a markdown link (`- [x] [story-127-269-epic-e2e-safeguard](.foundry/stories/story-127-269-epic-e2e-safeguard.md)`).
3.  I appended the newly generated E2E story as an unchecked markdown link (`- [ ] [story-127-347-orchestrator-safeguard-e2e](.foundry/stories/story-127-347-orchestrator-safeguard-e2e.md)`).

Because the new child story is unchecked, this PR allows the orchestrator to correctly demote the epic to `PENDING` until the new E2E story is completed. I have also verified that `pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e` all pass successfully.

---
*PR created automatically by Jules for task [4790383428928474681](https://jules.google.com/task/4790383428928474681) started by @szubster*