### PR TITLE
Empty PR for Task 334-351

### DIFF
--- a/.foundry/journals/coder/15191680231732694959.md
+++ b/.foundry/journals/coder/15191680231732694959.md
@@ -1,0 +1,3 @@
+# Empty PR for Task 334-351
+
+The extraction logic for Gen 3 Secret Base trainer info (name and ID) and its unit tests were already implemented in `src/engine/gen3/secretBase/parser.ts` and `src/engine/gen3/secretBase/parser.test.ts`. Submitted an empty PR as per the empty PR policy.

--- a/.foundry/tasks/task-334-351-parse-secret-base-trainer-info-impl.md
+++ b/.foundry/tasks/task-334-351-parse-secret-base-trainer-info-impl.md
@@ -34,6 +34,6 @@ Implement extraction of NPC trainer details (name, ID) associated with Secret Ba
 6.  Write unit tests validating the extraction logic.
 
 ## Acceptance Criteria
-- [ ] Implement extraction logic for trainer name and ID for Gen 3 Secret Bases.
-- [ ] Conform to all rules in Section 13 of `schema.md`.
-- [ ] Unit tests added for the extraction logic.
+- [x] Implement extraction logic for trainer name and ID for Gen 3 Secret Bases.
+- [x] Conform to all rules in Section 13 of `schema.md`.
+- [x] Unit tests added for the extraction logic.


### PR DESCRIPTION
Checked off all Acceptance Criteria checkboxes for Task 334-351 since the required implementation (Gen 3 Secret Base trainer info extraction, `RangeError` handling, relative offsets, and unit tests) is already fully present in `src/engine/gen3/secretBase/parser.ts` and `src/engine/gen3/secretBase/parser.test.ts`. Also added a journal entry in `.foundry/journals/coder/15191680231732694959.md` explaining the empty PR context.

---
*PR created automatically by Jules for task [15191680231732694959](https://jules.google.com/task/15191680231732694959) started by @szubster*