### PR TITLE
feat: implement gen 2 trainer flags extraction

### DIFF
--- a/.foundry/tasks/task-320-322-gen2-trainer-flags-impl.md
+++ b/.foundry/tasks/task-320-322-gen2-trainer-flags-impl.md
@@ -37,6 +37,6 @@ Implement the logic to extract and parse the trainer defeat flags for Generation
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement Gen 2 trainer flags extraction logic.
-- [ ] Ensure ADR 026 compliance (explicit bitwise logic).
-- [ ] Ensure ADR 028 compliance (module-level constants, no magic numbers).
+- [x] Implement Gen 2 trainer flags extraction logic.
+- [x] Ensure ADR 026 compliance (explicit bitwise logic).
+- [x] Ensure ADR 028 compliance (module-level constants, no magic numbers).

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -260,6 +260,8 @@ export interface SaveData {
   }[];
   /** Raw byte array containing all in-game event flags (e.g., claimed static gifts, story progression). */
   eventFlags?: Uint8Array;
+  /** Boolean array mapping the 2048 trainer defeat and general event flags in Gen 2. */
+  trainerFlags?: boolean[];
   /** Raw byte array containing hidden item event flags. */
   hiddenItemFlags?: Uint8Array;
   /** Raw byte array containing hidden coin event flags. */

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -297,7 +297,7 @@ describe('gen2 parsers', () => {
       });
     });
 
-    it('should extract eventFlags and hiddenItemFlags for Gold/Silver', () => {
+    it('should extract eventFlags, trainerFlags, and hiddenItemFlags for Gold/Silver', () => {
       const buffer = new ArrayBuffer(32768);
       const view = new DataView(buffer);
       view.setUint8(0x288a, 1);
@@ -314,6 +314,39 @@ describe('gen2 parsers', () => {
       expect(data.eventFlags?.[255]).toBe(0x99);
       expect(data.eventFlags?.length).toBe(0x100);
       expect(data.hiddenItemFlags).toBe(data.eventFlags);
+      expect(data.trainerFlags).toBeDefined();
+      expect(data.trainerFlags?.length).toBe(2048);
+      // 0x11 = 00010001 in binary
+      expect(data.trainerFlags?.[0]).toBe(true);
+      expect(data.trainerFlags?.[1]).toBe(false);
+      expect(data.trainerFlags?.[4]).toBe(true);
+      // 0x99 = 10011001 in binary, index 255 byte starts at bit 2040
+      expect(data.trainerFlags?.[2040]).toBe(true);
+      expect(data.trainerFlags?.[2041]).toBe(false);
+      expect(data.trainerFlags?.[2043]).toBe(true);
+      expect(data.trainerFlags?.[2044]).toBe(true);
+      expect(data.trainerFlags?.[2047]).toBe(true);
+    });
+
+    it('should extract trainerFlags with absolute zero state and boundary values (ADR 026)', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x2865, 1); // Crystal valid party count
+      view.setUint8(0x2866, 1);
+      view.setUint8(0x2866 + 7, 1);
+
+      // Absolute zero state
+      let data = parseGen2(view, true);
+      expect(data.trainerFlags).toBeDefined();
+      expect(data.trainerFlags?.length).toBe(2048);
+      expect(data.trainerFlags?.every((flag) => flag === false)).toBe(true);
+
+      // Max boundary state
+      for (let i = 0; i < 256; i++) {
+        view.setUint8(0x2600 + i, 0xff);
+      }
+      data = parseGen2(view, true);
+      expect(data.trainerFlags?.every((flag) => flag === true)).toBe(true);
     });
 
     it('should extract eventFlags and hiddenItemFlags for Crystal', () => {

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -82,6 +82,9 @@ const MAP_ID_OFFSET_GS = 0x25b4;
 const MAP_ID_OFFSET_CRYSTAL = 0x25c7;
 
 const EVENT_FLAGS_LENGTH = 0x100;
+const EVENT_FLAGS_MAX_BITS = 2048;
+const BITS_PER_BYTE = 8;
+const BIT_MASK = 1;
 
 const CAUGHT_TIME_MASK = 0xc0;
 const CAUGHT_TIME_SHIFT = 6;
@@ -758,6 +761,14 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
   }
   const hiddenItemFlags = eventFlags;
 
+  const trainerFlags: boolean[] = [];
+  for (let i = 0; i < EVENT_FLAGS_MAX_BITS; i++) {
+    const byteIdx = Math.floor(i / BITS_PER_BYTE);
+    const bitIdx = i % BITS_PER_BYTE;
+    const byte = eventFlags[byteIdx] ?? 0;
+    trainerFlags.push(((byte >> bitIdx) & BIT_MASK) !== 0);
+  }
+
   const npcTradeFlags: boolean[] = [];
   try {
     const npcTradeFlagsOffset = isCrystal ? NPC_TRADE_FLAGS_OFFSET_CRYSTAL : NPC_TRADE_FLAGS_OFFSET_GS;
@@ -797,6 +808,7 @@ export function parseGen2(view: DataView, forceCrystal = false): SaveData {
     hallOfFameCount,
     roamingLegendaries,
     eventFlags,
+    trainerFlags,
     hiddenItemFlags,
     npcTradeFlags,
     gen2StaticEncounters: {


### PR DESCRIPTION
Implements `task-320-322-gen2-trainer-flags-impl`.

Parses the Gen 2 `wEventFlags` block (256 bytes) into an explicit 2048-length boolean array (`trainerFlags`) assigned in the returned `SaveData` payload. This complies with ADR 026 explicitly requesting discrete bitwise mapping. Tests correctly evaluate the absolute zero and maximum boundary conditions.

---
*PR created automatically by Jules for task [3859012993382043144](https://jules.google.com/task/3859012993382043144) started by @szubster*