### PR TITLE
📝 QA: Verify Gen 2 trainer flags extraction logic

### DIFF
--- a/.foundry/tasks/task-320-323-gen2-trainer-flags-qa.md
+++ b/.foundry/tasks/task-320-323-gen2-trainer-flags-qa.md
@@ -39,6 +39,6 @@ Verify the implementation of the Gen 2 trainer defeat flags extraction logic.
 - If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Verify Gen 2 trainer flags extraction logic works as intended.
-- [ ] Confirm ADR 026 compliance.
-- [ ] Confirm ADR 028 compliance.
+- [x] Verify Gen 2 trainer flags extraction logic works as intended.
+- [x] Confirm ADR 026 compliance.
+- [x] Confirm ADR 028 compliance.


### PR DESCRIPTION
Verified that explicit bitwise shifting and masking was used to isolate trainer defeat flags in Gen 2 saves, and that constants are defined at the module level in `src/engine/saveParser/parsers/gen2.ts`, as required by ADR 026 and ADR 028. Tests passed locally. Checked off acceptance criteria.

---
*PR created automatically by Jules for task [4828026640105975745](https://jules.google.com/task/4828026640105975745) started by @szubster*