### PR TITLE
Reject Gen 3 secret base party extraction implementation

### DIFF
--- a/.foundry/journals/qa/5239641501844674364.md
+++ b/.foundry/journals/qa/5239641501844674364.md
@@ -1,0 +1,2 @@
+# QA Journal
+- Rejected `task-334-352-parse-secret-base-trainer-party-impl` for violating Section 13 (No Magic Numbers) by hardcoding `0` for empty secret bases and in the bitwise check instead of using explicit module-level constants.

--- a/.foundry/tasks/task-334-352-parse-secret-base-trainer-party-impl.md
+++ b/.foundry/tasks/task-334-352-parse-secret-base-trainer-party-impl.md
@@ -2,7 +2,7 @@
 id: task-334-352-parse-secret-base-trainer-party-impl
 type: TASK
 title: Implement Gen 3 Secret Base Party Info Extraction
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-29'
 updated_at: '2026-07-29'
@@ -17,8 +17,8 @@ tags:
   - secret-base
   - save-parsing
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'The implementation violates Section 13 (No Magic Numbers) by hardcoding `0` for empty secret bases. A module-level constant (e.g. EMPTY_SECRET_BASE_ID) must be defined and used. Additionally, it hardcodes `0` in the bitwise check `!== 0`.'
 notes: ''
 ---
 # TASK: Implement Gen 3 Secret Base Party Info Extraction


### PR DESCRIPTION
The implementation of task `task-334-352-parse-secret-base-trainer-party-impl` has been rejected by the QA agent for violating Section 13 (No Magic Numbers) of the schema guidelines. The implementation hardcoded `0` for empty secret bases and in a bitwise check instead of using explicit module-level constants. Additionally, it used `decodeGen12String` for a Gen 3 string extraction. The task status has been updated to FAILED, the rejection count incremented, and the rejection reason added. A QA journal entry has also been created.

---
*PR created automatically by Jules for task [5239641501844674364](https://jules.google.com/task/5239641501844674364) started by @szubster*