### PR TITLE
feat: add missing E2E story for egg move pathfinding engine

### DIFF
--- a/.foundry/epics/epic-055-113-egg-move-pathfinding-engine.md
+++ b/.foundry/epics/epic-055-113-egg-move-pathfinding-engine.md
@@ -31,7 +31,8 @@ Develop the core algorithmic engine for calculating valid breeding chains. This 
 - [x] Exclude invalid breeding pairs (e.g., "No Eggs" group).
 - [x] Support chains requiring multiple intermediate parents.
 - [x] Story Owner: Break this Epic down into actionable STORIES.
-- [x] story-113-258-egg-move-pathfinding-core
-- [x] story-113-259-egg-move-breeding-rules
-- [x] story-113-260-egg-move-multi-step-chains
-- [x] research-113-248-egg-move-precomputation
+- [x] [story-113-258-egg-move-pathfinding-core](.foundry/stories/story-113-258-egg-move-pathfinding-core.md)
+- [x] [story-113-259-egg-move-breeding-rules](.foundry/stories/story-113-259-egg-move-breeding-rules.md)
+- [x] [story-113-260-egg-move-multi-step-chains](.foundry/stories/story-113-260-egg-move-multi-step-chains.md)
+- [x] [research-113-248-egg-move-precomputation](.foundry/archive/research/research-113-248-egg-move-precomputation.md)
+- [ ] [story-113-348-egg-move-pathfinding-e2e](.foundry/stories/story-113-348-egg-move-pathfinding-e2e.md)

--- a/.foundry/stories/story-113-348-egg-move-pathfinding-e2e.md
+++ b/.foundry/stories/story-113-348-egg-move-pathfinding-e2e.md
@@ -1,0 +1,30 @@
+---
+id: story-113-348-egg-move-pathfinding-e2e
+type: STORY
+title: E2E Tests for Egg Move Pathfinding Engine
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-07-29'
+updated_at: '2026-07-29'
+depends_on:
+  - story-113-260-egg-move-multi-step-chains
+jules_session_id: null
+pr_number: null
+parent: epic-055-113-egg-move-pathfinding-engine
+tags:
+  - e2e
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: E2E Tests for Egg Move Pathfinding Engine
+
+## Overview
+Implement end-to-end (E2E) tests for the Egg Move Pathfinding Engine to ensure that valid breeding chains are correctly calculated and surfaced to the user. This satisfies the orchestrator E2E safeguard requirement.
+
+## Acceptance Criteria
+- [ ] Implement Playwright E2E tests for the pathfinding engine.
+- [ ] Break down this story into tasks.


### PR DESCRIPTION
Added the missing E2E test story for the Egg Move Pathfinding Engine to satisfy the orchestrator safeguard. The acceptance criteria nodes in the epic were formatted as proper markdown links, and the new `story-113-348-egg-move-pathfinding-e2e.md` node was appended as an unchecked task.

---
*PR created automatically by Jules for task [12122822608574039464](https://jules.google.com/task/12122822608574039464) started by @szubster*