### PR TITLE
chore(story-306-320): check off acceptance criteria for completed tasks

### DIFF
--- a/.foundry/stories/story-306-320-gen2-trainer-data-extraction.md
+++ b/.foundry/stories/story-306-320-gen2-trainer-data-extraction.md
@@ -34,5 +34,5 @@ Extract and parse the trainer defeat flags for Generation 2 games from Bank 1.
 - [x] Break down into Tasks
 
 
-- [ ] task-320-322-gen2-trainer-flags-impl
-- [ ] task-320-323-gen2-trainer-flags-qa
+- [x] task-320-322-gen2-trainer-flags-impl
+- [x] task-320-323-gen2-trainer-flags-qa


### PR DESCRIPTION
The child tasks `task-320-322-gen2-trainer-flags-impl` and `task-320-323-gen2-trainer-flags-qa` were already created and completed during a previous session. This empty PR updates the story markdown to check off the acceptance criteria, allowing the orchestrator to advance the node to COMPLETED.

---
*PR created automatically by Jules for task [9784147015314850491](https://jules.google.com/task/9784147015314850491) started by @szubster*