### PR TITLE
chore: empty PR for completed task task-334-352

### DIFF
--- a/.foundry/journals/coder/9469146534230943501.md
+++ b/.foundry/journals/coder/9469146534230943501.md
@@ -1,0 +1,14 @@
+## 2026-07-29: Implementing Gen 3 Secret Base Party Info Extraction
+
+**Context / Action:**
+The task `task-334-352-parse-secret-base-trainer-party-impl` was assigned to implement the extraction of Secret Base party information in Gen 3. The objective was to extract Pokemon, levels, moves, EVs, etc., while adhering to Section 13 of `schema.md` (e.g., using module-level constants and avoiding inline magic numbers).
+
+**Findings / Reflection:**
+Upon exploring the codebase, specifically `src/engine/gen3/secretBase/parser.ts` and its associated tests in `parser.test.ts`, I discovered that the extraction logic (`parseSecretBaseParty`) and the overarching record parsing logic (`parseSecretBaseRecord`) were already fully implemented.
+
+The existing implementation correctly uses module-level constants (e.g., `POKEMON_PERSONALITY_OFFSET`, `POKEMON_MOVES_OFFSET`) instead of magic numbers. It correctly extracts the 6 properties (personality, species, moves, heldItem, level, evs) for the max 6 Pokemon. It also correctly includes `try/catch` blocks handling `RangeError` by throwing a standard "The save file is corrupted or incomplete." error, in full compliance with the requirements. All unit tests, including tests for valid parsing and `RangeError` conditions, were passing.
+
+The node `task-334-352-parse-secret-base-trainer-party-impl` also already had all of its Acceptance Criteria checkboxes checked (`- [x]`).
+
+**Conclusion:**
+Since the task's requirements are already fully satisfied in the main branch and the acceptance criteria are checked off, I am submitting an empty PR to allow the DAG orchestrator to advance this node to the `COMPLETED` state.


### PR DESCRIPTION
Submitting an empty PR as the implementation for `task-334-352-parse-secret-base-trainer-party-impl` is already complete in the codebase (src/engine/gen3/secretBase/parser.ts). The acceptance criteria checkboxes are also correctly checked off. A journal entry was added to document this finding.

---
*PR created automatically by Jules for task [9469146534230943501](https://jules.google.com/task/9469146534230943501) started by @szubster*