### PR TITLE
Research: Define Constants for Gen 3 HOF Magic Numbers

### DIFF
--- a/.foundry/docs/knowledge_base/engine/save_parsing/gen3_hall_of_fame.md
+++ b/.foundry/docs/knowledge_base/engine/save_parsing/gen3_hall_of_fame.md
@@ -39,3 +39,11 @@ The total number of times the player has entered the Hall of Fame is tracked glo
 - It is located in the `gameStats` array in `SaveBlock1` (Offset `0x228C` in Emerald `SaveBlock1` for the array base, but the game stat ID logic will be handled dynamically or by parsing the stats array).
 - This stat acts as the "page number" or "times entered" counter.
 - While the stat can exceed 50 (up to 999), only the last 50 teams are kept in memory. The game uses a shift mechanism (moving `beforeTeam = afterTeam`) to drop the oldest team and append the new one at the end if the 50 limit is reached.
+
+## 5. Game Stat Parsing Constants
+When parsing the `gameStats` array, each stat is a 32-bit (4-byte) integer. To avoid inline magic numbers as mandated by the Save File Parsing Guidelines, the following module-level constant must be defined:
+- `BYTES_PER_GAME_STAT = 4`: Used to calculate the offset within the `gameStats` array (e.g., `GAME_STAT_ENTERED_HOF_ID * BYTES_PER_GAME_STAT`).
+
+## 6. Bitwise Operation Constants
+When extracting bitwise data such as Pokedex entries or event flags, literal magic numbers must be avoided. The following module-level constant must be defined:
+- `BITS_PER_BYTE = 8`: Used for byte index calculation (`Math.floor(bitIndex / BITS_PER_BYTE)`) and bit offset calculation (`bitIndex % BITS_PER_BYTE`).

--- a/.foundry/journals/researcher/7509224859674163249.md
+++ b/.foundry/journals/researcher/7509224859674163249.md
@@ -1,0 +1,4 @@
+# Session 7509224859674163249
+
+## Save File Parsing - Magic Numbers
+When reviewing the Hall of Fame parsing implementation, it was rejected for using inline magic numbers (e.g. `4` for bytes per stat, and `8` for bits per byte). The "No Magic Numbers" architectural rule requires explicitly defining module-level constants (like `BYTES_PER_GAME_STAT` and `BITS_PER_BYTE`). I have documented these specific constants in `.foundry/docs/knowledge_base/engine/save_parsing/gen3_hall_of_fame.md` to prevent future implementers from repeating this violation during offset and bitwise calculations.

--- a/.foundry/research/research-319-360-gen3-hof-magic-numbers.md
+++ b/.foundry/research/research-319-360-gen3-hof-magic-numbers.md
@@ -31,5 +31,13 @@ Investigate how to avoid using magic numbers for offset calculations in the Gen 
 - Provide a summary of the required constants and their purposes.
 
 ## Acceptance Criteria
-- [ ] Determine module-level constants for `4` (bytes per stat) and `8` (bits per byte) to avoid inline magic numbers.
-- [ ] Provide documentation on how these constants should be used in the parsing logic.
+- [x] Determine module-level constants for `4` (bytes per stat) and `8` (bits per byte) to avoid inline magic numbers.
+- [x] Provide documentation on how these constants should be used in the parsing logic.
+
+## Findings
+To adhere to the "No Magic Numbers" policy outlined in the Save File Parsing & Extraction Guidelines (Section 13 of `.foundry/docs/schema.md`), the following module-level constants have been identified and must be defined in the parsing module:
+
+- **`BYTES_PER_GAME_STAT = 4`**: Since each game stat is a 32-bit integer, this constant replaces the inline `4` when calculating offsets in the `gameStats` array. It should be used as: `offset = GAME_STAT_ENTERED_HOF_ID * BYTES_PER_GAME_STAT`.
+- **`BITS_PER_BYTE = 8`**: This constant replaces the inline `8` used during bitwise operations (like Pokédex extraction). It should be used to calculate the byte index (`Math.floor(bitIndex / BITS_PER_BYTE)`) and the remaining bit offset (`bitIndex % BITS_PER_BYTE`).
+
+These requirements have been documented in `.foundry/docs/knowledge_base/engine/save_parsing/gen3_hall_of_fame.md`.


### PR DESCRIPTION
Provides module-level constant definitions to replace magic numbers in offset calculation and bitwise parsing for Gen 3 HOF.

---
*PR created automatically by Jules for task [7509224859674163249](https://jules.google.com/task/7509224859674163249) started by @szubster*