### PR TITLE
chore: investigate and document sorting strategies failure

### DIFF
--- a/.foundry/journals/researcher/2026-07-29-investigate-sorting-failure.md
+++ b/.foundry/journals/researcher/2026-07-29-investigate-sorting-failure.md
@@ -1,0 +1,4 @@
+---
+trigger: `story-136-295-sorting-standard-strategies`
+---
+Founding issue: The task failed because it asks to sort by type, and `PokemonMetadata` doesn't have type info.

--- a/.foundry/research/research-136-330-investigate-sorting-strategies-failure.md
+++ b/.foundry/research/research-136-330-investigate-sorting-strategies-failure.md
@@ -25,5 +25,11 @@ notes: ''
 Investigate the root cause for the `story-136-295-sorting-standard-strategies` task failing with `Max rejection count reached`.
 
 ## Acceptance Criteria
-- [ ] Investigate the rejection reasons for `story-136-295-sorting-standard-strategies`.
-- [ ] Write a summary of the failure causes and proposed technical solutions in this file.
+- [x] Investigate the rejection reasons for `story-136-295-sorting-standard-strategies`.
+- [x] Write a summary of the failure causes and proposed technical solutions in this file.
+
+## Findings
+The tasks for `story-136-295-sorting-standard-strategies` failed because they asked the coder to implement a `TypeSorter` that sorts by primary and secondary types. However, the `PokemonMetadata` interface in `src/db/schema.ts` lacks any typing fields. Therefore, the implementer lacked the data required to build the sorter.
+
+## Proposed Solution
+We need a new node to add `types` (or similar) to `PokemonMetadata`, potentially sourcing this data from PokeAPI or our Pokedata generator (`scripts/generate-pokedata.ts`). Once the schema includes type data, the sorting strategies can be safely resurrected.


### PR DESCRIPTION
- Updated `.foundry/research/research-136-330-investigate-sorting-strategies-failure.md` to document the findings regarding the `TypeSorter` failure (missing typing data in `PokemonMetadata`).
- Checked off the task acceptance criteria checkboxes.

---
*PR created automatically by Jules for task [16211481775175713151](https://jules.google.com/task/16211481775175713151) started by @szubster*