### PR TITLE
test: implement move planner and diff engine edge case tests

### DIFF
--- a/.foundry/tasks/task-296-360-move-planner-tests-impl.md
+++ b/.foundry/tasks/task-296-360-move-planner-tests-impl.md
@@ -35,7 +35,7 @@ Also, we need to add edge case tests for `boxDiff.ts`.
 4. Add tests in `boxDiff.test.ts` to handle storage locations that do not match the expected `Box N` regex.
 
 ## Acceptance Criteria
-- [ ] Implement disjoint cycle tests in `movePlanner.test.ts`.
-- [ ] Implement open-chain move tests in `movePlanner.test.ts`.
-- [ ] Implement complex mixed operation tests in `movePlanner.test.ts`.
-- [ ] Implement invalid format storage location test in `boxDiff.test.ts`.
+- [x] Implement disjoint cycle tests in `movePlanner.test.ts`.
+- [x] Implement open-chain move tests in `movePlanner.test.ts`.
+- [x] Implement complex mixed operation tests in `movePlanner.test.ts`.
+- [x] Implement invalid format storage location test in `boxDiff.test.ts`.

--- a/src/engine/saveParser/utils/boxDiff.test.ts
+++ b/src/engine/saveParser/utils/boxDiff.test.ts
@@ -109,4 +109,19 @@ describe('calculateBoxDiff', () => {
     expect(diff.relocations[0]?.sourceBox).toBe(1);
     expect(diff.relocations[0]?.targetBox).toBe(2);
   });
+
+  test('handles storage locations that do not match expected Box N regex', () => {
+    const current: PokemonInstance[] = [createPoke(1, 'Test', 'Party', 0)];
+    const target: PokemonInstance[] = [createPoke(1, 'Test', 'Daycare', 1)];
+
+    const diff = calculateBoxDiff(current, target);
+    expect(diff.relocations).toHaveLength(1);
+    expect(diff.relocations[0]).toEqual({
+      pokemon: target[0],
+      sourceBox: -1,
+      sourceSlot: 0,
+      targetBox: -1,
+      targetSlot: 1,
+    });
+  });
 });

--- a/src/engine/saveParser/utils/movePlanner.test.ts
+++ b/src/engine/saveParser/utils/movePlanner.test.ts
@@ -145,4 +145,67 @@ describe('movePlanner', () => {
       { type: 'MOVE', sourceBox: -1, sourceSlot: -1, targetBox: 1, targetSlot: 2 },
     ]);
   });
+
+  it('handles overlapping/disjoint cycles', () => {
+    const diff: BoxDiffResult = {
+      additions: [],
+      removals: [],
+      relocations: [
+        // Cycle 1: 1:1 -> 1:2 -> 1:1 (SWAP)
+        { pokemon: createMockPokemon('A', 1, 1), sourceBox: 1, sourceSlot: 1, targetBox: 1, targetSlot: 2 },
+        { pokemon: createMockPokemon('B', 1, 2), sourceBox: 1, sourceSlot: 2, targetBox: 1, targetSlot: 1 },
+        // Cycle 2: 2:1 -> 2:2 -> 2:3 -> 2:1
+        { pokemon: createMockPokemon('C', 2, 1), sourceBox: 2, sourceSlot: 1, targetBox: 2, targetSlot: 2 },
+        { pokemon: createMockPokemon('D', 2, 2), sourceBox: 2, sourceSlot: 2, targetBox: 2, targetSlot: 3 },
+        { pokemon: createMockPokemon('E', 2, 3), sourceBox: 2, sourceSlot: 3, targetBox: 2, targetSlot: 1 },
+      ],
+    };
+
+    const plan = calculateMovePlan(diff);
+    expect(plan).toEqual(expect.arrayContaining([
+      { type: 'SWAP', sourceBox: 1, sourceSlot: 1, targetBox: 1, targetSlot: 2 },
+      { type: 'MOVE', sourceBox: 2, sourceSlot: 1, targetBox: -1, targetSlot: -1 },
+      { type: 'MOVE', sourceBox: 2, sourceSlot: 3, targetBox: 2, targetSlot: 1 },
+      { type: 'MOVE', sourceBox: 2, sourceSlot: 2, targetBox: 2, targetSlot: 3 },
+      { type: 'MOVE', sourceBox: -1, sourceSlot: -1, targetBox: 2, targetSlot: 2 },
+    ]));
+  });
+
+  it('handles an open-chain move (chain ending in empty slot)', () => {
+    const diff: BoxDiffResult = {
+      additions: [],
+      removals: [],
+      relocations: [
+        // Chain: 1:1 -> 1:2 -> 1:3 (1:3 is empty)
+        { pokemon: createMockPokemon('A', 1, 1), sourceBox: 1, sourceSlot: 1, targetBox: 1, targetSlot: 2 },
+        { pokemon: createMockPokemon('B', 1, 2), sourceBox: 1, sourceSlot: 2, targetBox: 1, targetSlot: 3 },
+      ],
+    };
+
+    const plan = calculateMovePlan(diff);
+    expect(plan).toEqual([
+      { type: 'MOVE', sourceBox: 1, sourceSlot: 2, targetBox: 1, targetSlot: 3 },
+      { type: 'MOVE', sourceBox: 1, sourceSlot: 1, targetBox: 1, targetSlot: 2 },
+    ]);
+  });
+
+  it('handles complex mixed operations (add, remove, move, cycle, swap)', () => {
+    const diff: BoxDiffResult = {
+      additions: [createMockPokemon('Add1', 3, 1)],
+      removals: [createMockPokemon('Rem1', 3, 2)],
+      relocations: [
+        { pokemon: createMockPokemon('A', 1, 1), sourceBox: 1, sourceSlot: 1, targetBox: 1, targetSlot: 2 },
+        { pokemon: createMockPokemon('B', 1, 2), sourceBox: 1, sourceSlot: 2, targetBox: 1, targetSlot: 1 },
+        { pokemon: createMockPokemon('C', 2, 1), sourceBox: 2, sourceSlot: 1, targetBox: 2, targetSlot: 2 },
+      ],
+    };
+
+    const plan = calculateMovePlan(diff);
+    expect(plan).toEqual(expect.arrayContaining([
+      { type: 'WITHDRAW', sourceBox: 3, sourceSlot: 2, targetBox: -1, targetSlot: -1 },
+      { type: 'MOVE', sourceBox: 2, sourceSlot: 1, targetBox: 2, targetSlot: 2 },
+      { type: 'SWAP', sourceBox: 1, sourceSlot: 1, targetBox: 1, targetSlot: 2 },
+      { type: 'DEPOSIT', sourceBox: -1, sourceSlot: -1, targetBox: 3, targetSlot: 1 },
+    ]));
+  });
 });

--- a/src/engine/saveParser/utils/movePlanner.test.ts
+++ b/src/engine/saveParser/utils/movePlanner.test.ts
@@ -162,13 +162,15 @@ describe('movePlanner', () => {
     };
 
     const plan = calculateMovePlan(diff);
-    expect(plan).toEqual(expect.arrayContaining([
-      { type: 'SWAP', sourceBox: 1, sourceSlot: 1, targetBox: 1, targetSlot: 2 },
-      { type: 'MOVE', sourceBox: 2, sourceSlot: 1, targetBox: -1, targetSlot: -1 },
-      { type: 'MOVE', sourceBox: 2, sourceSlot: 3, targetBox: 2, targetSlot: 1 },
-      { type: 'MOVE', sourceBox: 2, sourceSlot: 2, targetBox: 2, targetSlot: 3 },
-      { type: 'MOVE', sourceBox: -1, sourceSlot: -1, targetBox: 2, targetSlot: 2 },
-    ]));
+    expect(plan).toEqual(
+      expect.arrayContaining([
+        { type: 'SWAP', sourceBox: 1, sourceSlot: 1, targetBox: 1, targetSlot: 2 },
+        { type: 'MOVE', sourceBox: 2, sourceSlot: 1, targetBox: -1, targetSlot: -1 },
+        { type: 'MOVE', sourceBox: 2, sourceSlot: 3, targetBox: 2, targetSlot: 1 },
+        { type: 'MOVE', sourceBox: 2, sourceSlot: 2, targetBox: 2, targetSlot: 3 },
+        { type: 'MOVE', sourceBox: -1, sourceSlot: -1, targetBox: 2, targetSlot: 2 },
+      ]),
+    );
   });
 
   it('handles an open-chain move (chain ending in empty slot)', () => {
@@ -201,11 +203,13 @@ describe('movePlanner', () => {
     };
 
     const plan = calculateMovePlan(diff);
-    expect(plan).toEqual(expect.arrayContaining([
-      { type: 'WITHDRAW', sourceBox: 3, sourceSlot: 2, targetBox: -1, targetSlot: -1 },
-      { type: 'MOVE', sourceBox: 2, sourceSlot: 1, targetBox: 2, targetSlot: 2 },
-      { type: 'SWAP', sourceBox: 1, sourceSlot: 1, targetBox: 1, targetSlot: 2 },
-      { type: 'DEPOSIT', sourceBox: -1, sourceSlot: -1, targetBox: 3, targetSlot: 1 },
-    ]));
+    expect(plan).toEqual(
+      expect.arrayContaining([
+        { type: 'WITHDRAW', sourceBox: 3, sourceSlot: 2, targetBox: -1, targetSlot: -1 },
+        { type: 'MOVE', sourceBox: 2, sourceSlot: 1, targetBox: 2, targetSlot: 2 },
+        { type: 'SWAP', sourceBox: 1, sourceSlot: 1, targetBox: 1, targetSlot: 2 },
+        { type: 'DEPOSIT', sourceBox: -1, sourceSlot: -1, targetBox: 3, targetSlot: 1 },
+      ]),
+    );
   });
 });


### PR DESCRIPTION
Implemented comprehensive unit tests for the diff engine (`boxDiff.ts`) and move planner (`movePlanner.ts`) to handle edge cases like disjoint cycles, open-chains, complex mixed operations, and non-conforming storage locations, fulfilling all acceptance criteria for TASK `task-296-360-move-planner-tests-impl`.

---
*PR created automatically by Jules for task [6748988311056516439](https://jules.google.com/task/6748988311056516439) started by @szubster*