### PR TITLE
QA Agent: Reject Gen 3 PV and IV Extraction Implementation

### DIFF
--- a/.foundry/journals/qa/10381463315677890878.md
+++ b/.foundry/journals/qa/10381463315677890878.md
@@ -1,0 +1,16 @@
+# QA Journal
+Session: 10381463315677890878
+Task: task-346-353-gen3-pv-iv-extraction-qa
+Target Task: task-346-352-gen3-pv-iv-extraction-impl
+
+## QA Results: FAILED
+
+The implementation of `parseGen3PokemonPVAndIVs` in `src/engine/saveParser/parsers/gen3.ts` successfully implements PV and IV extraction logic and catches the RangeError correctly.
+
+However, the implementation violated the strict Code Contract Verification and Section 13 guidelines ("Save File Parsing & Extraction Guidelines" in schema.md).
+Specifically, there is a magic number violation on line 507 of `src/engine/saveParser/parsers/gen3.ts`:
+`const permutationIndex = pv % 24;`
+
+The number `24` must be defined as a module-level constant (e.g. `const NUM_SUBSTRUCTURE_PERMUTATIONS = 24;`), as the use of inline magic numbers is strictly forbidden.
+
+I have set `task-346-352-gen3-pv-iv-extraction-impl.md` to FAILED and updated its `rejection_count` and `rejection_reason`. I am keeping my own task's acceptance criteria unchecked to keep it active.

--- a/.foundry/tasks/task-346-352-gen3-pv-iv-extraction-impl.md
+++ b/.foundry/tasks/task-346-352-gen3-pv-iv-extraction-impl.md
@@ -2,7 +2,7 @@
 id: task-346-352-gen3-pv-iv-extraction-impl
 type: TASK
 title: Implement Gen 3 PV and IV Data Extraction
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-28'
 updated_at: '2026-07-29'
@@ -15,8 +15,8 @@ tags:
   - generation-3
   - save-parsing
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Implementation violated Section 13 Guidelines by using an inline magic number (24) for the `pv % 24` permutation index calculation.'
 notes: ''
 ---
 


### PR DESCRIPTION
This PR rejects the Gen 3 PV and IV Extraction implementation. The implementation violated the Section 13 guidelines in schema.md by using an inline magic number (24) rather than a module-level constant when determining the `pv % 24` permutation index. The target task has been set to FAILED and a QA journal entry has been recorded.

---
*PR created automatically by Jules for task [10381463315677890878](https://jules.google.com/task/10381463315677890878) started by @szubster*