### PR TITLE
Fix magic numbers in Gen 3 parsing logic

### DIFF
--- a/.foundry/journals/coder/151059372485234069.md
+++ b/.foundry/journals/coder/151059372485234069.md
@@ -1,0 +1,1 @@
+# Coder Journal - 151059372485234069\n\nWhen writing parsing logic to satisfy Save File Parsing & Extraction Guidelines, ensure ALL DataView reads, including reads inside loops, are wrapped in a try/catch block that translates native RangeError into the application-specific error message, otherwise QA will reject the task for unsafe memory reads.

--- a/.foundry/tasks/task-319-361-gen3-hof-pokedex-extraction-retry-impl.md
+++ b/.foundry/tasks/task-319-361-gen3-hof-pokedex-extraction-retry-impl.md
@@ -43,14 +43,14 @@ Implement the logic to extract the Hall of Fame entry flag (`GAME_STAT_ENTERED_H
 - **Testing:** You MUST write corresponding Vitest unit tests to cover the new extraction logic.
 
 ## Acceptance Criteria
-- [ ] `DataView` API is used for parsing.
-- [ ] All offsets, limits, and multipliers are defined at the module level (no magic numbers).
-- [ ] Section 13 of `.foundry/docs/schema.md` is strictly adhered to.
-- [ ] Relative offsets from `section1Offset` are used for `SaveBlock1` data.
-- [ ] `RangeError` is caught and translated to `"The save file is corrupted or incomplete."`.
-- [ ] `GAME_STAT_ENTERED_HOF` or equivalent Hall of Fame entry flag is extracted.
-- [ ] Number of caught Pokémon in Hoenn and National Dex is extracted.
-- [ ] Tests are written and pass.
+- [x] `DataView` API is used for parsing.
+- [x] All offsets, limits, and multipliers are defined at the module level (no magic numbers).
+- [x] Section 13 of `.foundry/docs/schema.md` is strictly adhered to.
+- [x] Relative offsets from `section1Offset` are used for `SaveBlock1` data.
+- [x] `RangeError` is caught and translated to `"The save file is corrupted or incomplete."`.
+- [x] `GAME_STAT_ENTERED_HOF` or equivalent Hall of Fame entry flag is extracted.
+- [x] Number of caught Pokémon in Hoenn and National Dex is extracted.
+- [x] Tests are written and pass.
 
 ## Persona Instructions
 - **Coder & QA:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -300,6 +300,8 @@ export const GEN3_GAME_STATS_OFFSET_EMERALD = 0x159c;
 export const GEN3_GAME_STATS_OFFSET_RS = 0x1540;
 export const GEN3_GAME_STATS_OFFSET_FRLG = 0x1200;
 export const GAME_STAT_ENTERED_HOF_ID = 10;
+export const BYTES_PER_GAME_STAT = 4;
+export const BITS_PER_BYTE = 8;
 
 export const GEN3_POKEDEX_OFFSET = 0x18;
 export const GEN3_POKEDEX_OWNED_OFFSET = 0x10;
@@ -1130,7 +1132,10 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
 
     let hallOfFameCount = 0;
     try {
-      hallOfFameCount = view.getUint32(section1Offset + gameStatsOffset + GAME_STAT_ENTERED_HOF_ID * 4, true);
+      hallOfFameCount = view.getUint32(
+        section1Offset + gameStatsOffset + GAME_STAT_ENTERED_HOF_ID * BYTES_PER_GAME_STAT,
+        true,
+      );
     } catch (error) {
       if (error instanceof RangeError) {
         throw new Error('The save file is corrupted or incomplete.');
@@ -1148,8 +1153,8 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       for (let dexId = 1; dexId <= NATIONAL_DEX_MAX; dexId++) {
         // Internal flags are 0-indexed where index 0 is Bulbasaur (Dex ID 1)
         const bitIndex = dexId - 1;
-        const byteIdx = Math.floor(bitIndex / 8);
-        const bitPos = bitIndex % 8;
+        const byteIdx = Math.floor(bitIndex / BITS_PER_BYTE);
+        const bitPos = bitIndex % BITS_PER_BYTE;
         const oByte = view.getUint8(pokedexOwnedOffset + byteIdx);
         const sByte = view.getUint8(pokedexSeenOffset + byteIdx);
         if ((oByte & (1 << bitPos)) !== 0) owned.add(dexId);


### PR DESCRIPTION
- Replace magic numbers 4 and 8 with module constants BYTES_PER_GAME_STAT and BITS_PER_BYTE in Gen 3 parser.
- Ensure the extraction logic adheres to Save File Parsing Guidelines.

---
*PR created automatically by Jules for task [151059372485234069](https://jules.google.com/task/151059372485234069) started by @szubster*