### PR TITLE
⚡ Bolt: [performance] wrap LcdGrid and TelemetryDecoration in React.memo

### DIFF
--- a/src/components/LcdGrid.tsx
+++ b/src/components/LcdGrid.tsx
@@ -6,8 +6,9 @@ interface LcdGridProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: number;
 }
 
-export const LcdGrid = React.forwardRef<HTMLDivElement, LcdGridProps>(
-  ({ color = 'white', size = 4, className, style, ...props }, ref) => {
+// ⚡ Bolt: Wrapped LcdGrid in React.memo since it is used extensively across the app and its props rarely change.
+export const LcdGrid = React.memo(
+  React.forwardRef<HTMLDivElement, LcdGridProps>(({ color = 'white', size = 4, className, style, ...props }, ref) => {
     return (
       <div
         ref={ref}
@@ -20,7 +21,7 @@ export const LcdGrid = React.forwardRef<HTMLDivElement, LcdGridProps>(
         {...props}
       />
     );
-  },
+  }),
 );
 
 LcdGrid.displayName = 'LcdGrid';

--- a/src/components/TelemetryDecoration.tsx
+++ b/src/components/TelemetryDecoration.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { cn } from '../utils/cn';
 
 interface TelemetryDecorationProps {
@@ -7,7 +8,13 @@ interface TelemetryDecorationProps {
   textClassName?: string;
 }
 
-export function TelemetryDecoration({ label, className, dotClassName, textClassName }: TelemetryDecorationProps) {
+// ⚡ Bolt: Wrapped TelemetryDecoration in React.memo as it is used heavily and its props rarely change.
+export const TelemetryDecoration = React.memo(function TelemetryDecoration({
+  label,
+  className,
+  dotClassName,
+  textClassName,
+}: TelemetryDecorationProps) {
   return (
     <div
       className={cn(
@@ -19,4 +26,4 @@ export function TelemetryDecoration({ label, className, dotClassName, textClassN
       <span className={textClassName}>{label}</span>
     </div>
   );
-}
+});


### PR DESCRIPTION
Wrapped `LcdGrid` and `TelemetryDecoration` in `React.memo` to prevent unnecessary re-renders. These components are deeply nested and widely used across the app (in `PokedexCard`, `StorageGrid`, `SearchAndFilters`, etc.). Their props rarely change, so memoization will help prevent redundant DOM evaluations when their parents re-render.

---
*PR created automatically by Jules for task [14615298356531109481](https://jules.google.com/task/14615298356531109481) started by @szubster*