### PR TITLE
🖼️ Canvas: Pokedex Grid & Blade Redesign

### DIFF
--- a/.jules/canvas/2025-02-12-pokedex-blade-redesign.md
+++ b/.jules/canvas/2025-02-12-pokedex-blade-redesign.md
@@ -1,0 +1,5 @@
+## 2025-02-12 - [Accepted] - 🖼️ Canvas: Pokedex Grid & Blade Redesign
+**What:** Redesigned the `PokedexGrid.tsx` and `PokedexCard.tsx` from a simple square matrix into a horizontal "Server Blade" design inside a "Sector Database" layout with structural borders.
+**Outcome:** Accepted -> wait for review
+**Why:** Improves the industrial and hardware aesthetic. The old design felt like a standard app list; the horizontal blades feel like physical data drives slotted into a server rack.
+**Pattern:** Shifting from pure squares to denser horizontal layouts for list items increases the "terminal" feel while allowing for more detailed data presentation without taking up excessive vertical height.

--- a/src/components/PokedexCard.tsx
+++ b/src/components/PokedexCard.tsx
@@ -4,14 +4,12 @@ import React from 'react';
 import type { SaveData } from '../engine/saveParser';
 import { cn } from '../utils/cn';
 import type { PokemonListItem } from '../utils/pokemonQueries';
-import { DataPoint } from './DataPoint';
 import { HoverScanner } from './HoverScanner';
 import { LcdGrid } from './LcdGrid';
 import { PokemonSprite } from './pokemon/PokemonSprite';
 import { PokemonStatusBadge } from './pokemon/PokemonStatusBadge';
 import { ScanlineOverlay } from './ScanlineOverlay';
 import { TacticalCard } from './TacticalCard';
-import { TelemetryDecoration } from './TelemetryDecoration';
 
 interface PokedexCardProps {
   pokemon: PokemonListItem;
@@ -93,72 +91,79 @@ export const PokedexCard = React.memo(function PokedexCard({
       style={{ animationDelay: `${(idx % 20) * 0.02}s` }}
       className="!p-0"
     >
-      <TelemetryDecoration
-        label={pokemon.name}
-        className="top-0 right-0 left-0 justify-center border-r-0 border-l-0"
-        textClassName={cn(isUnseen ? 'text-zinc-700' : isShiny ? 'text-amber-400' : 'text-white')}
-        dotClassName={cn(isUnseen ? 'hidden' : '')}
-      />
+      <div className="flex h-full w-full flex-row">
+        {/* Sprite Container - Left Side */}
+        <div className="relative flex aspect-square h-24 w-24 shrink-0 items-center justify-center overflow-hidden border-zinc-800 border-r border-dashed bg-black/40 transition-colors group-hover:bg-black/60">
+          {/* LCD Grid Background */}
+          <LcdGrid className="opacity-[0.05]" />
 
-      {/* Sprite Container */}
-      <div className="relative mt-6 flex aspect-square items-center justify-center overflow-hidden border-zinc-800 border-b border-dashed bg-black/40 transition-colors group-hover:bg-black/60">
-        {/* LCD Grid Background */}
-        <LcdGrid className="opacity-[0.05]" />
-
-        {isShiny && (
-          <div className="absolute -top-1 -right-1 z-10 animate-[spin_4s_linear_infinite] text-amber-400 drop-shadow-[0_0_8px_rgba(251,191,36,0.5)]">
-            <Sparkles size={16} fill="currentColor" className="animate-[pulse_4s_cubic-bezier(0.4,0,0.6,1)_infinite]" />
-          </div>
-        )}
-
-        <HoverScanner />
-
-        <PokemonSprite
-          pokemonId={pokemon.id}
-          generation={saveData?.generation ?? 1}
-          isShiny={isShiny}
-          alt={pokemon.name}
-          className={cn(
-            'z-10 h-[85%] w-[85%] object-contain transition-all duration-500',
-            isUnseen
-              ? 'opacity-10 brightness-0'
-              : isSeenNotOwned
-                ? 'opacity-50 grayscale'
-                : 'drop-shadow-[0_0_15px_rgba(255,255,255,0.1)] group-hover:scale-110',
-          )}
-        />
-
-        {/* Scanline overlay for sprite */}
-        <ScanlineOverlay />
-      </div>
-
-      <div className="flex w-full divide-x divide-dashed divide-zinc-800">
-        <div className="flex-1 p-2">
-          <DataPoint
-            label="ID"
-            value={pokemon.id.toString().padStart(3, '0')}
-            labelClassName="text-[7px]"
-            valueClassName="text-[10px]"
-          />
-        </div>
-        {saveData && !isUnseen && (
-          <div className="flex items-center justify-center p-2">
-            <div className="flex gap-1.5">
-              {inParty && <CircleDot size={12} className="animate-pulse text-rose-500" />}
-              {inPC && <Monitor size={12} className="text-[var(--theme-primary)]" />}
+          {isShiny && (
+            <div className="absolute top-1 left-1 z-10 animate-[spin_4s_linear_infinite] text-amber-400 drop-shadow-[0_0_8px_rgba(251,191,36,0.5)]">
+              <Sparkles
+                size={12}
+                fill="currentColor"
+                className="animate-[pulse_4s_cubic-bezier(0.4,0,0.6,1)_infinite]"
+              />
             </div>
-          </div>
-        )}
-      </div>
+          )}
 
-      {saveData && (
-        <PokemonStatusBadge
-          hasInStorage={hasInStorage}
-          isOwnedInDex={isOwnedInDex}
-          isSeenInDex={isSeenInDex}
-          isShiny={isShiny}
-        />
-      )}
+          <HoverScanner />
+
+          <PokemonSprite
+            pokemonId={pokemon.id}
+            generation={saveData?.generation ?? 1}
+            isShiny={isShiny}
+            alt={pokemon.name}
+            className={cn(
+              'z-10 h-[80%] w-[80%] object-contain transition-all duration-500',
+              isUnseen
+                ? 'opacity-10 brightness-0'
+                : isSeenNotOwned
+                  ? 'opacity-50 grayscale'
+                  : 'drop-shadow-[0_0_15px_rgba(255,255,255,0.1)] group-hover:scale-110',
+            )}
+          />
+
+          {/* Scanline overlay for sprite */}
+          <ScanlineOverlay opacityClass="opacity-20" />
+        </div>
+
+        {/* Data Container - Right Side */}
+        <div className="flex flex-1 flex-col justify-between">
+          <div className="flex flex-col gap-1 p-2">
+            <div className="flex items-center justify-between">
+              <span className="font-mono text-[8px] text-zinc-500 uppercase tracking-widest">
+                NO.{pokemon.id.toString().padStart(3, '0')}
+              </span>
+              {saveData && !isUnseen && (
+                <div className="flex gap-1.5">
+                  {inParty && <CircleDot size={10} className="animate-pulse text-rose-500" />}
+                  {inPC && <Monitor size={10} className="text-[var(--theme-primary)]" />}
+                </div>
+              )}
+            </div>
+            <h3
+              className={cn(
+                'truncate font-bold font-mono text-sm uppercase tracking-tight',
+                isUnseen ? 'text-zinc-700' : isShiny ? 'text-amber-400' : 'text-white',
+              )}
+            >
+              {pokemon.name}
+            </h3>
+          </div>
+
+          {saveData && (
+            <div className="mt-auto border-zinc-800 border-t border-dashed">
+              <PokemonStatusBadge
+                hasInStorage={hasInStorage}
+                isOwnedInDex={isOwnedInDex}
+                isSeenInDex={isSeenInDex}
+                isShiny={isShiny}
+              />
+            </div>
+          )}
+        </div>
+      </div>
     </TacticalCard>
   );
 });

--- a/src/components/PokedexGrid.tsx
+++ b/src/components/PokedexGrid.tsx
@@ -132,19 +132,37 @@ export function PokedexGrid({ pokemonList }: { pokemonList: PokemonListItem[] })
   }
 
   return (
-    <div className="fade-in grid animate-in grid-cols-2 gap-5 px-1 pb-10 duration-500 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-      {finalPokemon.map((pokemon, idx) => (
-        <PokedexCard
-          key={pokemon.id}
-          pokemon={pokemon}
-          idx={idx}
-          saveData={saveData}
-          isLivingDex={isLivingDex}
-          partySet={partySet}
-          pcSet={pcSet}
-          shinySpeciesIds={shinySpeciesIds}
-        />
-      ))}
+    <div className="fade-in animate-in pb-10 duration-500">
+      <div className="mb-4 flex items-center justify-between border-[var(--theme-primary)]/30 border-b border-dashed bg-[var(--theme-primary)]/5 px-4 py-2">
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-[10px] text-[var(--theme-primary)] uppercase tracking-[0.2em]">
+            SYS.SECTOR_SCAN
+          </span>
+          <div className="h-4 w-px border-r border-dashed bg-[var(--theme-primary)]/30" />
+          <span className="font-bold font-mono text-white text-xs uppercase tracking-wider">Pokedex Matrix</span>
+        </div>
+        <div className="flex items-center gap-2 font-mono text-[10px] text-zinc-400">
+          <span>ENTITIES:</span>
+          <span className="font-bold text-[var(--theme-primary)]">
+            {finalPokemon.length.toString().padStart(3, '0')}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 px-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {finalPokemon.map((pokemon, idx) => (
+          <PokedexCard
+            key={pokemon.id}
+            pokemon={pokemon}
+            idx={idx}
+            saveData={saveData}
+            isLivingDex={isLivingDex}
+            partySet={partySet}
+            pcSet={pcSet}
+            shinySpeciesIds={shinySpeciesIds}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/__tests__/PokedexCard.test.tsx
+++ b/src/components/__tests__/PokedexCard.test.tsx
@@ -54,8 +54,7 @@ describe('PokedexCard', () => {
     await render(<RouterProvider router={router} />);
 
     // Test for ID styling
-    await expect.element(page.getByText('[ ID ]', { exact: true })).toBeInTheDocument();
-    await expect.element(page.getByText('001', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('NO.001', { exact: true })).toBeInTheDocument();
   });
 
   test('renders [ SECURED ] when in storage', async () => {


### PR DESCRIPTION
Redesigned the PokedexGrid.tsx and PokedexCard.tsx from a simple square matrix into a horizontal 'Server Blade' design inside a 'Sector Database' layout with structural borders.

Improves the industrial and hardware aesthetic. The old design felt like a standard app list; the horizontal blades feel like physical data drives slotted into a server rack.

Pattern: Shifting from pure squares to denser horizontal layouts for list items increases the 'terminal' feel while allowing for more detailed data presentation without taking up excessive vertical height.

---
*PR created automatically by Jules for task [15234445426548334976](https://jules.google.com/task/15234445426548334976) started by @szubster*