### PR TITLE
🧭 Strategist: Prompt improvement - Remove redundant prompt engineering from mechanic

### DIFF
--- a/.github/agents/mechanic.md
+++ b/.github/agents/mechanic.md
@@ -7,8 +7,7 @@ You are the Mechanic of The Foundry. You run on a daily schedule as a meta-agent
 1. **System Health Check**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/archive/docs/adrs/`. establish your architectural context.
 2. **Analyze State & History**: Look into commit history, current nodes in `.foundry/`, and persona journals (e.g., `.foundry/journals/`) to detect friction, deadlocks, or loops that aren't being automatically resolved.
 3. **Oil the Machine**: Resolve structural problems in the DAG, fix broken templates, or suggest improvements to the orchestrator scripts.
-4. **Improve Personas**: If you notice personas are struggling with specific patterns, update their `.github/agents/*.md` prompts to provide better guidance.
-5. **Proactive Innovation**: Create new `IDEA` nodes in `.foundry/ideas/` for long-term system improvements or new automation capabilities.
+4. **Proactive Innovation**: Create new `IDEA` nodes in `.foundry/ideas/` for long-term system improvements or new automation capabilities.
 
 ## Journal
 

--- a/.jules/strategist/2026-08-25-remove-mechanic-prompt-improvement.md
+++ b/.jules/strategist/2026-08-25-remove-mechanic-prompt-improvement.md
@@ -1,0 +1,5 @@
+## 2026-08-25 - [Accepted] - Remove prompt improvement from mechanic persona
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The responsibilities of the `mechanic` persona included updating persona prompts ("Improve Personas"), which is exactly duplicated by the `strategist` persona's primary directive. Removing this from `mechanic` eliminates redundancy and centralizes prompt engineering to the `strategist`.
+**Pattern:** Remove overlapping directives between daily and weekly meta-agents to ensure clear separation of concerns.


### PR DESCRIPTION
Removed the overlapping "Improve Personas" directive from the `mechanic` persona as it directly duplicated the responsibilities of the `strategist` persona, centralizing prompt engineering to the weekly strategist schedule.

---
*PR created automatically by Jules for task [4270657752296043645](https://jules.google.com/task/4270657752296043645) started by @szubster*