### PR TITLE
fix: replace magic number with constant in Gen 3 extraction

### DIFF
--- a/.foundry/journals/coder/17592435228941965730.md
+++ b/.foundry/journals/coder/17592435228941965730.md
@@ -1,0 +1,1 @@
+Session 17592435228941965730: Learned that all array lengths and mathematical modulos used in save parsing logic MUST be explicitly defined as module-level constants to avoid magic number violations during QA.

--- a/src/engine/data/__tests__/schema.test.ts
+++ b/src/engine/data/__tests__/schema.test.ts
@@ -4,10 +4,12 @@ import { ENCOUNTER_METHOD_MAP } from '../../../db/schema';
 describe('schema', () => {
   describe('ENCOUNTER_METHOD_MAP', () => {
     it('should contain expected encounter methods including static and roaming-water', () => {
+      // biome-ignore lint/complexity/useLiteralKeys: Requires index access per TS4111 strict config
       expect(ENCOUNTER_METHOD_MAP['static']).toBe(19);
       expect(ENCOUNTER_METHOD_MAP['roaming-water']).toBe(20);
       expect(ENCOUNTER_METHOD_MAP['devon-scope']).toBe(21);
       expect(ENCOUNTER_METHOD_MAP['feebas-tile-fishing']).toBe(22);
+      // biome-ignore lint/complexity/useLiteralKeys: Requires index access per TS4111 strict config
       expect(ENCOUNTER_METHOD_MAP['walk']).toBe(1);
     });
   });

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -202,6 +202,7 @@ export const GEN3_POKEMON_OT_ID_OFFSET = 4;
 export const GEN3_POKEMON_DATA_OFFSET = 32;
 export const MISC_IVS_OFFSET = 4;
 export const SUBSTRUCTURE_SIZE = 12;
+export const NUM_SUBSTRUCTURE_PERMUTATIONS = 24;
 
 export const SUBSTRUCTURE_ORDER = [
   'GAEM',
@@ -506,7 +507,7 @@ export function parseGen3PokemonPVAndIVs(view: DataView, offset: number) {
     const otId = view.getUint32(offset + GEN3_POKEMON_OT_ID_OFFSET, true);
 
     const decryptionKey = pv ^ otId;
-    const permutationIndex = pv % 24;
+    const permutationIndex = pv % NUM_SUBSTRUCTURE_PERMUTATIONS;
     const permutation = SUBSTRUCTURE_ORDER[permutationIndex];
     if (!permutation) {
       throw new Error('The save file is corrupted or incomplete.');


### PR DESCRIPTION
Fixes the QA rejection for `task-346-352-gen3-pv-iv-extraction-impl` by removing the inline magic number (24) used for substructure permutation index calculation, replacing it with the module-level constant `NUM_SUBSTRUCTURE_PERMUTATIONS`. Also adds `// biome-ignore` to suppress a linter complexity warning for string literal access in tests which are required to fix TS4111.

---
*PR created automatically by Jules for task [17592435228941965730](https://jules.google.com/task/17592435228941965730) started by @szubster*