### PR TITLE
Implement Gen 3 Volcanic Ash UI Integration

### DIFF
--- a/.foundry/journals/coder/11806030505333644093.md
+++ b/.foundry/journals/coder/11806030505333644093.md
@@ -1,0 +1,5 @@
+# Session: 11806030505333644093
+## Gen 3 Volcanic Ash UI Implementation
+- Added a `DiagnosticCard` to `AssistantDebugView.tsx` to display Volcanic Ash for Gen 3 saves.
+- Encountered no issues, correctly conditionally rendering based on `saveData.generation === 3` and `saveData.gen3VolcanicAsh`.
+- Self-verified implementation by running unit and e2e tests.

--- a/.foundry/tasks/task-348-100-gen3-ash-ui-impl.md
+++ b/.foundry/tasks/task-348-100-gen3-ash-ui-impl.md
@@ -32,6 +32,6 @@ Integrate the `gen3VolcanicAsh` property into the frontend UI, displaying it in 
 - The UI structure must remain consistent with the existing layout in `AssistantDebugView.tsx`.
 
 ## Acceptance Criteria
-- [ ] Add a `DiagnosticCard` in `src/components/assistant/AssistantDebugView.tsx` to display the Volcanic Ash count.
-- [ ] The card should conditionally render based on the presence of `saveData.gen3VolcanicAsh` and `saveData.generation === 3`.
-- [ ] Self-verify the implementation and document the results in the `coder` persona journal.
+- [x] Add a `DiagnosticCard` in `src/components/assistant/AssistantDebugView.tsx` to display the Volcanic Ash count.
+- [x] The card should conditionally render based on the presence of `saveData.gen3VolcanicAsh` and `saveData.generation === 3`.
+- [x] Self-verify the implementation and document the results in the `coder` persona journal.

--- a/src/components/assistant/AssistantDebugView.tsx
+++ b/src/components/assistant/AssistantDebugView.tsx
@@ -44,6 +44,9 @@ export function AssistantDebugView({ rejected, getPokemonName, saveData }: Assis
             valueClassName="truncate px-2"
             subValue={`ID: ${saveData.trainerId}`}
           />
+          {saveData.generation === 3 && saveData.gen3VolcanicAsh !== undefined && (
+            <DiagnosticCard label="ASH.CNT" value={saveData.gen3VolcanicAsh} subValue="Volcanic Ash" />
+          )}
         </div>
       </TacticalPanel>
 

--- a/src/components/assistant/__tests__/AssistantDebugView.test.tsx
+++ b/src/components/assistant/__tests__/AssistantDebugView.test.tsx
@@ -68,4 +68,18 @@ describe('AssistantDebugView', () => {
     await expect.element(page.getByText('MISSING_DATA')).toBeVisible();
     await expect.element(page.getByText('"This is a test reason"')).toBeVisible();
   });
+
+  it('renders Volcanic Ash count for Gen 3 saves', async () => {
+    const gen3SaveData: SaveData = {
+      ...mockSaveData,
+      generation: 3,
+      gameVersion: 'emerald',
+      gen3VolcanicAsh: 450,
+    };
+
+    await render(<AssistantDebugView rejected={[]} getPokemonName={mockGetPokemonName} saveData={gen3SaveData} />);
+
+    await expect.element(page.getByText('450', { exact: true })).toBeVisible();
+    await expect.element(page.getByText('Volcanic Ash')).toBeVisible();
+  });
 });


### PR DESCRIPTION
Integrate the `gen3VolcanicAsh` property into the frontend UI, conditionally displaying it in the Assistant Debug View using the existing `DiagnosticCard` component. The integration adheres to the aesthetic requirements defined in ADR 008. Self-verified changes using local tests and frontend validation.

---
*PR created automatically by Jules for task [11806030505333644093](https://jules.google.com/task/11806030505333644093) started by @szubster*