### PR TITLE
Foundry: Verify epic-055-119-gen3-move-tutor-save-parsing

### DIFF
--- a/.foundry/journals/story_owner/5146266895926827310.md
+++ b/.foundry/journals/story_owner/5146266895926827310.md
@@ -1,0 +1,2 @@
+# Session 5146266895926827310
+The target artifact `epic-055-119-gen3-move-tutor-save-parsing` is already completely implemented. All acceptance criteria and child nodes are completed and checked off. I am proceeding with an empty PR to transition this macro node without modifying its YAML frontmatter.

--- a/src/engine/data/__tests__/schema.test.ts
+++ b/src/engine/data/__tests__/schema.test.ts
@@ -4,11 +4,13 @@ import { ENCOUNTER_METHOD_MAP } from '../../../db/schema';
 describe('schema', () => {
   describe('ENCOUNTER_METHOD_MAP', () => {
     it('should contain expected encounter methods including static and roaming-water', () => {
-      expect(ENCOUNTER_METHOD_MAP.static).toBe(19);
+      // biome-ignore lint/complexity/useLiteralKeys: TS4111 strict index signature access requires bracket notation
+      expect(ENCOUNTER_METHOD_MAP['static']).toBe(19);
       expect(ENCOUNTER_METHOD_MAP['roaming-water']).toBe(20);
       expect(ENCOUNTER_METHOD_MAP['devon-scope']).toBe(21);
       expect(ENCOUNTER_METHOD_MAP['feebas-tile-fishing']).toBe(22);
-      expect(ENCOUNTER_METHOD_MAP.walk).toBe(1);
+      // biome-ignore lint/complexity/useLiteralKeys: TS4111 strict index signature access requires bracket notation
+      expect(ENCOUNTER_METHOD_MAP['walk']).toBe(1);
     });
   });
 });

--- a/src/engine/data/__tests__/schema.test.ts
+++ b/src/engine/data/__tests__/schema.test.ts
@@ -4,11 +4,11 @@ import { ENCOUNTER_METHOD_MAP } from '../../../db/schema';
 describe('schema', () => {
   describe('ENCOUNTER_METHOD_MAP', () => {
     it('should contain expected encounter methods including static and roaming-water', () => {
-      expect(ENCOUNTER_METHOD_MAP['static']).toBe(19);
+      expect(ENCOUNTER_METHOD_MAP.static).toBe(19);
       expect(ENCOUNTER_METHOD_MAP['roaming-water']).toBe(20);
       expect(ENCOUNTER_METHOD_MAP['devon-scope']).toBe(21);
       expect(ENCOUNTER_METHOD_MAP['feebas-tile-fishing']).toBe(22);
-      expect(ENCOUNTER_METHOD_MAP['walk']).toBe(1);
+      expect(ENCOUNTER_METHOD_MAP.walk).toBe(1);
     });
   });
 });


### PR DESCRIPTION
The target artifact `epic-055-119-gen3-move-tutor-save-parsing` was already completely implemented and all acceptance criteria checked off via prior child stories (`story-119-267-gen3-move-tutor-emerald-parsing`, `story-119-318-gen3-move-tutor-frlg-parsing`, `story-119-268-gen3-move-tutor-frlg-parsing`). This empty PR triggers the orchestrator's Empty PR Policy to advance the macro node without mutating its YAML frontmatter, as dictated by system policies.

---
*PR created automatically by Jules for task [5146266895926827310](https://jules.google.com/task/5146266895926827310) started by @szubster*