### PR TITLE
QA: Gen 3 Hall of Fame & Pokedex Data Extraction (Retry)

### DIFF
--- a/.foundry/journals/qa/6970073752816280400.md
+++ b/.foundry/journals/qa/6970073752816280400.md
@@ -1,0 +1,12 @@
+# QA Session
+
+Validation of task `task-319-361-gen3-hof-pokedex-extraction-retry-impl`.
+
+1. Code uses only DataView API: Verified. `DataView.getUint32` and `DataView.getUint8` are used.
+2. No inline magic numbers: Verified. Constants `BYTES_PER_GAME_STAT` and `BITS_PER_BYTE` are used.
+3. Relative offsets based on `section1Offset`: Verified. `section1Offset + gameStatsOffset` is used.
+4. RangeError handling: Verified. Caught and re-thrown correctly.
+5. Logic extracts Hall of Fame entry and Pokedex caught counts: Verified.
+6. Tests exist and pass: Verified. `pnpm test src/engine/saveParser/parsers/gen3.test.ts` passed 75 tests.
+
+Implementation approved.

--- a/.foundry/tasks/task-319-362-gen3-hof-pokedex-extraction-retry-qa.md
+++ b/.foundry/tasks/task-319-362-gen3-hof-pokedex-extraction-retry-qa.md
@@ -36,12 +36,12 @@ Verify the implementation of the Gen 3 Hall of Fame entry and Pokédex data extr
 6.  **Test Verification:** Verify that the Vitest test suite is updated and all tests pass.
 
 ## Acceptance Criteria
-- [ ] Code uses only `DataView` API.
-- [ ] No inline magic numbers exist for offsets/limits/shifts/multipliers.
-- [ ] Relative offsets based on `section1Offset` are used.
-- [ ] `RangeError` handling is strictly implemented as specified.
-- [ ] Logic correctly extracts Hall of Fame entry flag and Pokédex caught counts.
-- [ ] Tests exist, are comprehensive, and pass.
+- [x] Code uses only `DataView` API.
+- [x] No inline magic numbers exist for offsets/limits/shifts/multipliers.
+- [x] Relative offsets based on `section1Offset` are used.
+- [x] `RangeError` handling is strictly implemented as specified.
+- [x] Logic correctly extracts Hall of Fame entry flag and Pokédex caught counts.
+- [x] Tests exist, are comprehensive, and pass.
 
 ## Persona Instructions
 - **Coder & QA:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.


### PR DESCRIPTION
Completed QA validation for the implementation of Gen 3 Hall of Fame and Pokedex Data extraction. Validated that it correctly uses the DataView API, avoids inline magic numbers, and handles errors appropriately. Logged findings in the QA journal and updated the task markdown.

---
*PR created automatically by Jules for task [6970073752816280400](https://jules.google.com/task/6970073752816280400) started by @szubster*