### PR TITLE
chore: verify completed children for story-304-319-gen3-hof-pokedex-extraction

### DIFF
--- a/.foundry/journals/tech_lead/10057604791182292706.md
+++ b/.foundry/journals/tech_lead/10057604791182292706.md
@@ -1,0 +1,10 @@
+# Tech Lead Journal - 10057604791182292706
+
+## Session Context
+- Node: story-304-319-gen3-hof-pokedex-extraction
+- Status: Verifying completed children.
+
+## Learnings & Actions
+- The Hall of Fame and Pokédex extraction logic was successfully implemented in retry tasks after an initial magic numbers failure.
+- All child tasks (`research-319-360-gen3-hof-magic-numbers`, `task-319-361-gen3-hof-pokedex-extraction-retry-impl`, `task-319-362-gen3-hof-pokedex-extraction-retry-qa`) have reached `COMPLETED` status.
+- Checked off all acceptance criteria and child nodes in the story's markdown body to allow the Orchestrator to transition it to VERIFYING.

--- a/.foundry/stories/story-304-319-gen3-hof-pokedex-extraction.md
+++ b/.foundry/stories/story-304-319-gen3-hof-pokedex-extraction.md
@@ -31,11 +31,11 @@ Extract the `GAME_STAT_ENTERED_HOF` (ID 10) to determine Hall of Fame entry and 
 - Extract magic numbers into module-level reusable constants (ADR 028).
 
 ## Acceptance Criteria
-- [ ] Implement Hall of Fame extraction logic.
-- [ ] Implement Pokédex extraction logic.
+- [x] Implement Hall of Fame extraction logic.
+- [x] Implement Pokédex extraction logic.
 
 - [x] task-319-323-gen3-hof-pokedex-extraction-impl
 - [x] task-319-324-gen3-hof-pokedex-extraction-qa
-- [ ] [research-319-360-gen3-hof-magic-numbers](.foundry/research/research-319-360-gen3-hof-magic-numbers.md)
-- [ ] [task-319-361-gen3-hof-pokedex-extraction-retry-impl](.foundry/tasks/task-319-361-gen3-hof-pokedex-extraction-retry-impl.md)
-- [ ] [task-319-362-gen3-hof-pokedex-extraction-retry-qa](.foundry/tasks/task-319-362-gen3-hof-pokedex-extraction-retry-qa.md)
+- [x] [research-319-360-gen3-hof-magic-numbers](.foundry/research/research-319-360-gen3-hof-magic-numbers.md)
+- [x] [task-319-361-gen3-hof-pokedex-extraction-retry-impl](.foundry/tasks/task-319-361-gen3-hof-pokedex-extraction-retry-impl.md)
+- [x] [task-319-362-gen3-hof-pokedex-extraction-retry-qa](.foundry/tasks/task-319-362-gen3-hof-pokedex-extraction-retry-qa.md)


### PR DESCRIPTION
Checked off acceptance criteria checkboxes and created Tech Lead journal entry to verify completed child tasks for the Gen 3 Hall of Fame & Pokédex Data Extraction story.

---
*PR created automatically by Jules for task [10057604791182292706](https://jules.google.com/task/10057604791182292706) started by @szubster*