### PR TITLE
chore(foundry): verify completed child tasks for r2 conflict resolution story

### DIFF
--- a/.foundry/journals/tech_lead/1358911210581686844.md
+++ b/.foundry/journals/tech_lead/1358911210581686844.md
@@ -1,0 +1,5 @@
+# Tech Lead Session Log
+
+Encountered a scenario where a STORY node (`story-039-265-r2-offline-conflict-resolution`) had child TASKS (`task-265-352-r2-conflict-resolution-impl`, `task-265-353-r2-conflict-resolution-qa`) that were already fully completed, but the Acceptance Criteria checkboxes on the parent STORY node remained unchecked.
+
+Applied the 'Empty PR' policy by checking off these acceptance criteria checkboxes on the parent node. Proceeding to submit the changes without modifying the application code or the YAML frontmatter. This correctly satisfies ADR 007 and ADR 009, enabling the DAG Orchestrator to transition the parent node to VERIFYING.

--- a/.foundry/stories/story-039-265-r2-offline-conflict-resolution.md
+++ b/.foundry/stories/story-039-265-r2-offline-conflict-resolution.md
@@ -32,5 +32,5 @@ Because the app is offline-first, a user might make local changes while disconne
 
 ## Acceptance Criteria
 - [x] Break down into Tasks.
-- [ ] .foundry/tasks/task-265-352-r2-conflict-resolution-impl.md
-- [ ] .foundry/tasks/task-265-353-r2-conflict-resolution-qa.md
+- [x] .foundry/tasks/task-265-352-r2-conflict-resolution-impl.md
+- [x] .foundry/tasks/task-265-353-r2-conflict-resolution-qa.md

--- a/src/engine/data/__tests__/schema.test.ts
+++ b/src/engine/data/__tests__/schema.test.ts
@@ -4,10 +4,12 @@ import { ENCOUNTER_METHOD_MAP } from '../../../db/schema';
 describe('schema', () => {
   describe('ENCOUNTER_METHOD_MAP', () => {
     it('should contain expected encounter methods including static and roaming-water', () => {
+      // biome-ignore lint/complexity/useLiteralKeys: TS4111 requires bracket notation for index signatures
       expect(ENCOUNTER_METHOD_MAP['static']).toBe(19);
       expect(ENCOUNTER_METHOD_MAP['roaming-water']).toBe(20);
       expect(ENCOUNTER_METHOD_MAP['devon-scope']).toBe(21);
       expect(ENCOUNTER_METHOD_MAP['feebas-tile-fishing']).toBe(22);
+      // biome-ignore lint/complexity/useLiteralKeys: TS4111 requires bracket notation for index signatures
       expect(ENCOUNTER_METHOD_MAP['walk']).toBe(1);
     });
   });


### PR DESCRIPTION
Encountered a scenario where STORY node `story-039-265-r2-offline-conflict-resolution` had completed child TASKS, but the Acceptance Criteria checkboxes remained unchecked. Applied the Empty PR policy to verify the tasks without generating duplicate blueprint nodes.

---
*PR created automatically by Jules for task [1358911210581686844](https://jules.google.com/task/1358911210581686844) started by @szubster*