### PR TITLE
chore: Apply empty PR policy for story-137-296-move-planner-unit-tests

### DIFF
--- a/.foundry/journals/tech_lead/5031591788488001874.md
+++ b/.foundry/journals/tech_lead/5031591788488001874.md
@@ -1,0 +1,8 @@
+# Session 5031591788488001874
+
+## Policy Application: Empty PRs for Completed Artifacts
+Observed an instance where child tasks were marked as COMPLETED, but the parent STORY node still had unchecked acceptance criteria checkboxes for these children, preventing DAG progression.
+
+### Lesson / Guideline
+- When child tasks complete out-of-band or via manual processes, parent nodes will stall in ACTIVE state until their markdown body checkboxes are explicitly checked.
+- It is critical to regularly verify and check off acceptance criteria in macro nodes when verifying state to ensure the DAG unblocks, even if no new implementation work is required (the Empty PR Policy).

--- a/.foundry/stories/story-137-296-move-planner-unit-tests.md
+++ b/.foundry/stories/story-137-296-move-planner-unit-tests.md
@@ -31,5 +31,5 @@ The move planner logic involves complex states (full boxes, swap chains, cyclic 
 
 ## Acceptance Criteria
 - [x] Break down story into tasks to implement unit tests for diff engine and move planner scenarios.
-- [ ] [task-296-360-move-planner-tests-impl](../tasks/task-296-360-move-planner-tests-impl.md)
-- [ ] [task-296-361-move-planner-tests-qa](../tasks/task-296-361-move-planner-tests-qa.md)
+- [x] [task-296-360-move-planner-tests-impl](../tasks/task-296-360-move-planner-tests-impl.md)
+- [x] [task-296-361-move-planner-tests-qa](../tasks/task-296-361-move-planner-tests-qa.md)

--- a/src/engine/data/__tests__/schema.test.ts
+++ b/src/engine/data/__tests__/schema.test.ts
@@ -4,10 +4,12 @@ import { ENCOUNTER_METHOD_MAP } from '../../../db/schema';
 describe('schema', () => {
   describe('ENCOUNTER_METHOD_MAP', () => {
     it('should contain expected encounter methods including static and roaming-water', () => {
+      // biome-ignore lint/complexity/useLiteralKeys: Satisfies TS4111
       expect(ENCOUNTER_METHOD_MAP['static']).toBe(19);
       expect(ENCOUNTER_METHOD_MAP['roaming-water']).toBe(20);
       expect(ENCOUNTER_METHOD_MAP['devon-scope']).toBe(21);
       expect(ENCOUNTER_METHOD_MAP['feebas-tile-fishing']).toBe(22);
+      // biome-ignore lint/complexity/useLiteralKeys: Satisfies TS4111
       expect(ENCOUNTER_METHOD_MAP['walk']).toBe(1);
     });
   });


### PR DESCRIPTION
This PR addresses an issue where the parent story `story-137-296-move-planner-unit-tests` was stalled in the ACTIVE state because its acceptance criteria checkboxes for already completed child tasks (`task-296-360-move-planner-tests-impl` and `task-296-361-move-planner-tests-qa`) were left unchecked.

According to the Empty PR Policy, these checkboxes have been checked to unblock the DAG. A Tech Lead journal entry has also been created to document this event.

Additionally, a minor fix was applied to `src/engine/data/__tests__/schema.test.ts` to suppress a Biome `useLiteralKeys` lint error that conflicts with TypeScript's strict `noPropertyAccessFromIndexSignature` (TS4111) configuration, restoring CI health.

---
*PR created automatically by Jules for task [5031591788488001874](https://jules.google.com/task/5031591788488001874) started by @szubster*