### PR TITLE
chore(tech_lead): update story-137-333 with completed child tasks

### DIFF
--- a/.foundry/stories/story-137-333-gen2-event-flag-parsing-retry.md
+++ b/.foundry/stories/story-137-333-gen2-event-flag-parsing-retry.md
@@ -26,5 +26,5 @@ Extract the event flags for Gen 2 static encounters from the save file. This inv
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] task-137-338-gen2-event-flag-parsing-retry-impl
-- [ ] task-137-339-gen2-event-flag-parsing-retry-qa
+- [x] task-137-338-gen2-event-flag-parsing-retry-impl
+- [x] task-137-339-gen2-event-flag-parsing-retry-qa


### PR DESCRIPTION
This is an empty PR to allow the orchestrator to transition the parent STORY node `story-137-333-gen2-event-flag-parsing-retry` to VERIFYING now that its child tasks are completed. The acceptance criteria checkboxes in the STORY markdown have been checked off. The underlying child task files were already generated and completed in a previous cycle.

---
*PR created automatically by Jules for task [17339032025406485492](https://jules.google.com/task/17339032025406485492) started by @szubster*