### PR TITLE
Foundry: Check off child tasks for Graveyard Box UI

### DIFF
--- a/.foundry/journals/tech_lead/2026-07-30-15-51-35.md
+++ b/.foundry/journals/tech_lead/2026-07-30-15-51-35.md
@@ -1,0 +1,7 @@
+# Tech Lead Session Log: 2026-07-30-15-51-35
+
+## Action Taken
+Checked off completed child tasks for `story-131-334-graveyard-box-ui` and submitted an Empty PR.
+
+## Lesson Learned
+The Orchestrator's dependency graph requires explicit checkbox completion in parent nodes to progress. Even if child task files are marked as COMPLETED in their frontmatter, the parent node's markdown must reflect this via checked boxes (`[x]`) to prevent infinite DAG stalls.

--- a/.foundry/stories/story-131-334-graveyard-box-ui.md
+++ b/.foundry/stories/story-131-334-graveyard-box-ui.md
@@ -32,5 +32,5 @@ Implement a UI setting to allow users to designate a specific PC box as the Grav
 
 ## Acceptance Criteria
 - [x] Tasks are generated
-- [ ] task-334-346-graveyard-box-ui-impl
-- [ ] task-334-347-graveyard-box-ui-qa
+- [x] task-334-346-graveyard-box-ui-impl
+- [x] task-334-347-graveyard-box-ui-qa


### PR DESCRIPTION
Submitted an Empty PR to check off completed child tasks (`task-334-346-graveyard-box-ui-impl` and `task-334-347-graveyard-box-ui-qa`) in `story-131-334-graveyard-box-ui.md` to unblock the Foundry DAG. Created a Tech Lead journal entry documenting the action and lesson learned regarding explicit checkbox completion in parent nodes.

---
*PR created automatically by Jules for task [9814241103886333459](https://jules.google.com/task/9814241103886333459) started by @szubster*