### PR TITLE
chore: update completed child tasks in safari zone story

### DIFF
--- a/.foundry/journals/tech_lead/2026-07-30-15-58-19.md
+++ b/.foundry/journals/tech_lead/2026-07-30-15-58-19.md
@@ -1,0 +1,5 @@
+# Tech Lead Journal
+
+- Noticed that story `story-324-339-gen1-safari-zone-save-state` had pending child tasks.
+- Checked the status of `task-339-346-gen1-safari-zone-logic-impl` and `task-339-347-gen1-safari-zone-logic-qa`. Both were marked as COMPLETED.
+- Proceeded to check off these completed child tasks in the story's acceptance criteria to allow the story to transition to VERIFYING.

--- a/.foundry/stories/story-324-339-gen1-safari-zone-save-state.md
+++ b/.foundry/stories/story-324-339-gen1-safari-zone-save-state.md
@@ -33,5 +33,5 @@ This story covers extracting current Pokédex and PC Box state from Gen 1 save f
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] task-339-346-gen1-safari-zone-logic-impl
-- [ ] task-339-347-gen1-safari-zone-logic-qa
+- [x] task-339-346-gen1-safari-zone-logic-impl
+- [x] task-339-347-gen1-safari-zone-logic-qa

--- a/src/engine/data/__tests__/schema.test.ts
+++ b/src/engine/data/__tests__/schema.test.ts
@@ -4,10 +4,12 @@ import { ENCOUNTER_METHOD_MAP } from '../../../db/schema';
 describe('schema', () => {
   describe('ENCOUNTER_METHOD_MAP', () => {
     it('should contain expected encounter methods including static and roaming-water', () => {
+      // biome-ignore lint/complexity/useLiteralKeys: Requires bracket notation due to TS4111 strict noPropertyAccessFromIndexSignature
       expect(ENCOUNTER_METHOD_MAP['static']).toBe(19);
       expect(ENCOUNTER_METHOD_MAP['roaming-water']).toBe(20);
       expect(ENCOUNTER_METHOD_MAP['devon-scope']).toBe(21);
       expect(ENCOUNTER_METHOD_MAP['feebas-tile-fishing']).toBe(22);
+      // biome-ignore lint/complexity/useLiteralKeys: Requires bracket notation due to TS4111 strict noPropertyAccessFromIndexSignature
       expect(ENCOUNTER_METHOD_MAP['walk']).toBe(1);
     });
   });


### PR DESCRIPTION
Checked off completed implementation and QA tasks in the acceptance criteria for the Gen 1 Safari Zone story, and created the corresponding Tech Lead journal entry to record the action.

---
*PR created automatically by Jules for task [13333375094086358569](https://jules.google.com/task/13333375094086358569) started by @szubster*