### PR TITLE
Implement Gen 3 Pokéblock Case Parsing

### DIFF
--- a/.foundry/journals/coder/14349731040270638568.md
+++ b/.foundry/journals/coder/14349731040270638568.md
@@ -1,0 +1,7 @@
+# Coder Session 14349731040270638568
+
+Implemented Pokéblock parsing for Gen 3 save files.
+* Created types (`Gen3Pokeblock`) and parsing logic in `src/engine/saveParser/gen3/pokeblock/`.
+* Parsed the 8-byte structure including color and flavors, adhering to schema guidelines (module constants, relative offsets, catching RangeError).
+* Integrated with the `SaveData` schema in `common.ts` and the main `parseGen3` function.
+* Created tests for `emerald`, `ruby`/`sapphire`, and checked `firered`/`leafgreen` behavior (no pokeblocks).

--- a/.foundry/tasks/task-332-367-gen3-pokeblock-extraction-impl.md
+++ b/.foundry/tasks/task-332-367-gen3-pokeblock-extraction-impl.md
@@ -29,10 +29,10 @@ Implement the extraction logic for Pokéblocks from Gen 3 save files in the back
 Reference: `.foundry/docs/knowledge_base/gen3_pokeblock_offsets.md`
 
 ## Acceptance Criteria
-- [ ] Implement parsing logic for the Pokéblock array in SaveBlock1.
+- [x] Implement parsing logic for the Pokéblock array in SaveBlock1.
   - Emerald: Offset `0x0848`
   - Ruby / Sapphire: Offset `0x07F8`
-- [ ] Implement parsing for the exact 8-byte structure of individual Pokéblocks:
+- [x] Implement parsing for the exact 8-byte structure of individual Pokéblocks:
   - `color` (Byte 0)
   - `spicy` (Byte 1)
   - `dry` (Byte 2)
@@ -40,8 +40,8 @@ Reference: `.foundry/docs/knowledge_base/gen3_pokeblock_offsets.md`
   - `bitter` (Byte 4)
   - `sour` (Byte 5)
   - `feel` (Byte 6)
-- [ ] Explicitly map the flavors correctly based on the docs.
-- [ ] Strictly adhere to Section 13 ("Save File Parsing & Extraction Guidelines") of `.foundry/docs/schema.md`.
+- [x] Explicitly map the flavors correctly based on the docs.
+- [x] Strictly adhere to Section 13 ("Save File Parsing & Extraction Guidelines") of `.foundry/docs/schema.md`.
   - Use module-level constants.
   - No magic numbers.
   - Use relative offsets (Gen 3).

--- a/src/engine/saveParser/gen3/pokeblock/parser.test.ts
+++ b/src/engine/saveParser/gen3/pokeblock/parser.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { parseGen3Pokeblocks } from './parser';
+
+describe('parseGen3Pokeblocks', () => {
+  it('returns undefined for firered and leafgreen', () => {
+    const view = new DataView(new ArrayBuffer(100));
+    expect(parseGen3Pokeblocks(view, 0, 'firered')).toBeUndefined();
+    expect(parseGen3Pokeblocks(view, 0, 'leafgreen')).toBeUndefined();
+  });
+
+  it('parses pokeblocks correctly for emerald', () => {
+    const buffer = new ArrayBuffer(0x1000);
+    const view = new DataView(buffer);
+    const saveBlock1Offset = 0x100;
+    const emeraldOffset = 0x0848;
+    const firstBlockIndex = saveBlock1Offset + emeraldOffset;
+
+    // Set first pokeblock
+    view.setUint8(firstBlockIndex + 0, 1); // color
+    view.setUint8(firstBlockIndex + 1, 10); // spicy
+    view.setUint8(firstBlockIndex + 2, 20); // dry
+    view.setUint8(firstBlockIndex + 3, 30); // sweet
+    view.setUint8(firstBlockIndex + 4, 40); // bitter
+    view.setUint8(firstBlockIndex + 5, 50); // sour
+    view.setUint8(firstBlockIndex + 6, 60); // feel
+
+    // Set second pokeblock to color 0 (empty)
+    const secondBlockIndex = firstBlockIndex + 8;
+    view.setUint8(secondBlockIndex + 0, 0);
+
+    const result = parseGen3Pokeblocks(view, saveBlock1Offset, 'emerald');
+    expect(result).toBeDefined();
+    expect(result?.length).toBe(1);
+    expect(result?.[0]).toEqual({
+      color: 1,
+      spicy: 10,
+      dry: 20,
+      sweet: 30,
+      bitter: 40,
+      sour: 50,
+      feel: 60,
+    });
+  });
+
+  it('parses pokeblocks correctly for ruby/sapphire', () => {
+    const buffer = new ArrayBuffer(0x1000);
+    const view = new DataView(buffer);
+    const saveBlock1Offset = 0x200;
+    const rsOffset = 0x07f8;
+    const firstBlockIndex = saveBlock1Offset + rsOffset;
+
+    // Set first pokeblock
+    view.setUint8(firstBlockIndex + 0, 2); // color
+    view.setUint8(firstBlockIndex + 1, 15); // spicy
+    view.setUint8(firstBlockIndex + 2, 25); // dry
+    view.setUint8(firstBlockIndex + 3, 35); // sweet
+    view.setUint8(firstBlockIndex + 4, 45); // bitter
+    view.setUint8(firstBlockIndex + 5, 55); // sour
+    view.setUint8(firstBlockIndex + 6, 65); // feel
+
+    const result = parseGen3Pokeblocks(view, saveBlock1Offset, 'ruby');
+    expect(result).toBeDefined();
+    expect(result?.length).toBe(1);
+    expect(result?.[0]).toEqual({
+      color: 2,
+      spicy: 15,
+      dry: 25,
+      sweet: 35,
+      bitter: 45,
+      sour: 55,
+      feel: 65,
+    });
+  });
+
+  it('throws an error if out of bounds', () => {
+    const buffer = new ArrayBuffer(0x500); // Too small
+    const view = new DataView(buffer);
+
+    expect(() => parseGen3Pokeblocks(view, 0, 'emerald')).toThrowError('The save file is corrupted or incomplete.');
+  });
+});

--- a/src/engine/saveParser/gen3/pokeblock/parser.ts
+++ b/src/engine/saveParser/gen3/pokeblock/parser.ts
@@ -1,0 +1,56 @@
+import type { GameVersion } from '../../parsers/common';
+import type { Gen3Pokeblock } from './types';
+
+// Constants defined in .foundry/docs/knowledge_base/gen3_pokeblock_offsets.md
+const POKEBLOCK_ARRAY_OFFSET_EMERALD = 0x0848;
+const POKEBLOCK_ARRAY_OFFSET_RS = 0x07f8;
+const POKEBLOCK_STRUCT_SIZE = 8;
+const POKEBLOCKS_COUNT = 40;
+
+const COLOR_OFFSET = 0;
+const SPICY_OFFSET = 1;
+const DRY_OFFSET = 2;
+const SWEET_OFFSET = 3;
+const BITTER_OFFSET = 4;
+const SOUR_OFFSET = 5;
+const FEEL_OFFSET = 6;
+
+export function parseGen3Pokeblocks(
+  view: DataView,
+  saveBlock1Offset: number,
+  gameVersion: GameVersion,
+): Gen3Pokeblock[] | undefined {
+  if (gameVersion === 'firered' || gameVersion === 'leafgreen') {
+    return undefined; // Pokeblocks do not exist in FRLG
+  }
+
+  const baseOffset = gameVersion === 'emerald' ? POKEBLOCK_ARRAY_OFFSET_EMERALD : POKEBLOCK_ARRAY_OFFSET_RS;
+  const pokeblocks: Gen3Pokeblock[] = [];
+
+  try {
+    for (let i = 0; i < POKEBLOCKS_COUNT; i++) {
+      const blockOffset = saveBlock1Offset + baseOffset + i * POKEBLOCK_STRUCT_SIZE;
+      const color = view.getUint8(blockOffset + COLOR_OFFSET);
+
+      // If color is 0 (None), we skip or we can include it. Let's include it only if it's non-zero.
+      if (color !== 0) {
+        pokeblocks.push({
+          color,
+          spicy: view.getUint8(blockOffset + SPICY_OFFSET),
+          dry: view.getUint8(blockOffset + DRY_OFFSET),
+          sweet: view.getUint8(blockOffset + SWEET_OFFSET),
+          bitter: view.getUint8(blockOffset + BITTER_OFFSET),
+          sour: view.getUint8(blockOffset + SOUR_OFFSET),
+          feel: view.getUint8(blockOffset + FEEL_OFFSET),
+        });
+      }
+    }
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+
+  return pokeblocks;
+}

--- a/src/engine/saveParser/gen3/pokeblock/types.ts
+++ b/src/engine/saveParser/gen3/pokeblock/types.ts
@@ -1,0 +1,9 @@
+export interface Gen3Pokeblock {
+  color: number;
+  spicy: number;
+  dry: number;
+  sweet: number;
+  bitter: number;
+  sour: number;
+  feel: number;
+}

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -195,6 +195,7 @@ export interface Gen3BattleFrontierSymbols {
 }
 
 export interface SaveData {
+  gen3Pokeblocks?: import('../gen3/pokeblock/types').Gen3Pokeblock[];
   gen3TrickHouse?: import('./../gen3/trickHouse/parser').Gen3TrickHouse;
   gen3MatchCall?: import('../../gen3/matchCall/parser').Gen3MatchCall;
   /** The generation of the parsed save file (1 or 2). */

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -27,6 +27,7 @@ import {
   parseGen3BattlePoints,
   parseGen3TotalBattlePoints,
 } from '../gen3/battleFrontier/parser';
+import { parseGen3Pokeblocks } from '../gen3/pokeblock/parser';
 import { parseTrickHouse } from '../gen3/trickHouse/parser';
 import type {
   GameVersion,
@@ -1008,6 +1009,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     const gen3BerryPatches = extractBerryPatches(view, section1Offset);
     const gen3SecretBases = parseGen3SecretBases(view, section1Offset, _forcedVersion || 'ruby');
 
+    const gen3Pokeblocks = parseGen3Pokeblocks(view, section1Offset, _forcedVersion || 'ruby');
     const gen3PokeNews = parseGen3PokeNews(view, section1Offset + POKE_NEWS_OFFSET);
     const gen3MixRecords = parseGen3MixRecords(view, section1Offset + TV_SHOWS_OFFSET);
     const gen3ActiveSwarm = parseGen3ActiveSwarm(view, section1Offset + TV_SHOWS_OFFSET);
@@ -1206,6 +1208,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       gen3VolcanicAsh,
       gen3TMHMs,
       gen3TMEventFlags,
+      ...(gen3Pokeblocks ? { gen3Pokeblocks } : {}),
       gen3TrickHouse: parseTrickHouse(view, section1Offset),
       ...(gen3MatchCall ? { gen3MatchCall } : {}),
     };


### PR DESCRIPTION
Implemented Pokéblock parsing for Gen 3 save files.
* Created types (`Gen3Pokeblock`) and parsing logic in `src/engine/saveParser/gen3/pokeblock/`.
* Parsed the 8-byte structure including color and flavors, adhering to schema guidelines (module constants, relative offsets, catching RangeError).
* Integrated with the `SaveData` schema in `common.ts` and the main `parseGen3` function.
* Created tests for `emerald`, `ruby`/`sapphire`, and checked `firered`/`leafgreen` behavior (no pokeblocks).
* Verified tests via `pnpm test` and `pnpm lint`, and E2E via `xvfb-run pnpm test:e2e`.

---
*PR created automatically by Jules for task [14349731040270638568](https://jules.google.com/task/14349731040270638568) started by @szubster*