### PR TITLE
feat: Implement PC Box Sorting Strategies

### DIFF
--- a/.foundry/journals/coder/1822939805966644680.md
+++ b/.foundry/journals/coder/1822939805966644680.md
@@ -1,0 +1,20 @@
+# Session 1822939805966644680
+
+## Objective
+Implement PC Box Sorting Strategies (`DexNumberSorter`, `LevelSorter`, `TypeSorter`, `AlphaSorter`) in `src/engine/sorting/StandardSorters.ts` according to task `task-333-365-sorting-strategies-impl.md`.
+
+## Actions Taken
+- Created `StandardSorters.ts` providing standard implementations of `SortingStrategy`.
+  - Added `DexNumberSorter` configuring `national` and failing on `regional`.
+  - Added `LevelSorter` supporting asc/desc logic.
+  - Added `TypeSorter` sorting by primary then secondary types appropriately correctly handling cases where objects might missing types array. Also fixed a bug with returning `NaN` in JS `Array.prototype.sort()` returning `0` if two missing types were compared directly.
+  - Added `AlphaSorter` to sort by `nickname`, `species name`, and string-based `speciesId` correctly.
+- Discovered and addressed a few `tsc` compilation rules issues:
+  - `erasableSyntaxOnly`: Could not use `constructor(private config: ...)` syntax. Instead explicitly declared `private config` class property and assigned in `constructor`.
+  - `exactOptionalPropertyTypes: true`: Could not set `undefined` to `metadata` property if it's optional in `SortablePokemon`. Had to conditionally assign `metadata` if it is not undefined.
+- Wrote and passed comprehensive unit tests in `src/engine/sorting/StandardSorters.test.ts`.
+- Checkboxes in `task-333-365-sorting-strategies-impl.md` are marked checked.
+
+## Learnings
+- **erasableSyntaxOnly**: Do not use constructor parameter properties.
+- **exactOptionalPropertyTypes**: Cannot assign an explicit `undefined` to an optional property (`?`), instead conditionally omit the property or conditionally assign it.

--- a/.foundry/tasks/task-333-365-sorting-strategies-impl.md
+++ b/.foundry/tasks/task-333-365-sorting-strategies-impl.md
@@ -48,8 +48,8 @@ Implement the following sorter functions/classes that conform to the `SortingStr
 - Write comprehensive unit tests for each strategy using Vitest in a corresponding `.test.ts` file.
 
 ## Acceptance Criteria
-- [ ] `DexNumberSorter` is implemented.
-- [ ] `LevelSorter` is implemented with asc/desc support.
-- [ ] `TypeSorter` is implemented and utilizes the new `types` metadata.
-- [ ] `AlphaSorter` is implemented.
-- [ ] Unit tests are provided for all sorters and `pnpm test` passes.
+- [x] `DexNumberSorter` is implemented.
+- [x] `LevelSorter` is implemented with asc/desc support.
+- [x] `TypeSorter` is implemented and utilizes the new `types` metadata.
+- [x] `AlphaSorter` is implemented.
+- [x] Unit tests are provided for all sorters and `pnpm test` passes.

--- a/src/engine/sorting/StandardSorters.test.ts
+++ b/src/engine/sorting/StandardSorters.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import type { PokemonMetadata } from '../../db/schema';
+import type { PokemonInstance } from '../saveParser/parsers/common';
+import type { SortablePokemon } from './SortingStrategy';
+import { AlphaSorter, DexNumberSorter, LevelSorter, TypeSorter } from './StandardSorters';
+
+describe('StandardSorters', () => {
+  const createSortable = (
+    id: number,
+    level: number,
+    nickname?: string,
+    types?: number[],
+    speciesName?: string,
+  ): SortablePokemon => {
+    const metadata =
+      types || speciesName
+        ? ({
+            id,
+            n: speciesName || '',
+            cr: 100,
+            baby: false,
+            eto: [],
+            efrm: [],
+            det: [],
+            types,
+          } as unknown as PokemonMetadata)
+        : undefined;
+
+    const result: SortablePokemon = {
+      instance: {
+        speciesId: id,
+        level,
+        isShiny: false,
+        hash: '',
+        moves: [],
+        storageLocation: 'Box 1',
+        nickname,
+      } as unknown as PokemonInstance,
+    };
+    if (metadata) {
+      result.metadata = metadata;
+    }
+    return result;
+  };
+
+  describe('DexNumberSorter', () => {
+    it('sorts by speciesId for national variant', () => {
+      const sorter = new DexNumberSorter({ variant: 'national' }).sort;
+      const p1 = createSortable(2, 5);
+      const p2 = createSortable(1, 10);
+      expect(sorter(p1, p2)).toBeGreaterThan(0);
+      expect(sorter(p2, p1)).toBeLessThan(0);
+    });
+
+    it('throws error for regional variant', () => {
+      expect(() =>
+        new DexNumberSorter({ variant: 'regional' }).sort(createSortable(1, 1), createSortable(2, 1)),
+      ).toThrow('Regional variant sorting is not supported yet.');
+    });
+  });
+
+  describe('LevelSorter', () => {
+    it('sorts asc', () => {
+      const sorter = new LevelSorter({ direction: 'asc' }).sort;
+      const p1 = createSortable(1, 5);
+      const p2 = createSortable(2, 10);
+      expect(sorter(p1, p2)).toBeLessThan(0);
+      expect(sorter(p2, p1)).toBeGreaterThan(0);
+    });
+
+    it('sorts desc', () => {
+      const sorter = new LevelSorter({ direction: 'desc' }).sort;
+      const p1 = createSortable(1, 5);
+      const p2 = createSortable(2, 10);
+      expect(sorter(p1, p2)).toBeGreaterThan(0);
+      expect(sorter(p2, p1)).toBeLessThan(0);
+    });
+  });
+
+  describe('TypeSorter', () => {
+    it('sorts by primary type', () => {
+      const sorter = new TypeSorter().sort;
+      const p1 = createSortable(1, 5, undefined, [1, 3]);
+      const p2 = createSortable(2, 5, undefined, [2, 3]);
+      expect(sorter(p1, p2)).toBeLessThan(0);
+    });
+
+    it('sorts by secondary type if primary type is equal', () => {
+      const sorter = new TypeSorter().sort;
+      const p1 = createSortable(1, 5, undefined, [1, 2]);
+      const p2 = createSortable(2, 5, undefined, [1, 3]);
+      expect(sorter(p1, p2)).toBeLessThan(0);
+    });
+
+    it('puts missing metadata or types at the end', () => {
+      const sorter = new TypeSorter().sort;
+      const p1 = createSortable(1, 5, undefined, [1]);
+      const p2 = createSortable(2, 5); // missing metadata
+      expect(sorter(p1, p2)).toBeLessThan(0);
+    });
+
+    it('returns 0 if primary and secondary types are equal', () => {
+      const sorter = new TypeSorter().sort;
+      const p1 = createSortable(1, 5, undefined, [1]);
+      const p2 = createSortable(2, 5, undefined, [1]);
+      expect(sorter(p1, p2)).toBe(0);
+    });
+  });
+
+  describe('AlphaSorter', () => {
+    it('sorts alphabetically by nickname', () => {
+      const sorter = new AlphaSorter().sort;
+      const p1 = createSortable(1, 5, 'Bulba');
+      const p2 = createSortable(2, 5, 'Ivysaur');
+      expect(sorter(p1, p2)).toBeLessThan(0);
+    });
+
+    it('falls back to species name if nickname is missing', () => {
+      const sorter = new AlphaSorter().sort;
+      const p1 = createSortable(1, 5, undefined, undefined, 'Zubat');
+      const p2 = createSortable(2, 5, undefined, undefined, 'Abra');
+      expect(sorter(p1, p2)).toBeGreaterThan(0);
+    });
+
+    it('falls back to string speciesId if metadata is missing', () => {
+      const sorter = new AlphaSorter().sort;
+      const p1 = createSortable(2, 5);
+      const p2 = createSortable(10, 5);
+      expect(sorter(p1, p2)).toBeGreaterThan(0); // '2' > '10' string comparison
+    });
+  });
+});

--- a/src/engine/sorting/StandardSorters.ts
+++ b/src/engine/sorting/StandardSorters.ts
@@ -47,7 +47,7 @@ export class TypeSorter {
     const secondaryB = typesB[1] ?? Infinity;
 
     if (secondaryA === secondaryB) {
-        return 0;
+      return 0;
     }
 
     return secondaryA - secondaryB;

--- a/src/engine/sorting/StandardSorters.ts
+++ b/src/engine/sorting/StandardSorters.ts
@@ -1,0 +1,64 @@
+import type { SortingStrategy } from './SortingStrategy';
+
+export class DexNumberSorter {
+  private config: { variant: 'national' | 'regional' };
+
+  constructor(config: { variant: 'national' | 'regional' }) {
+    this.config = config;
+  }
+
+  public sort: SortingStrategy = (a, b) => {
+    if (this.config.variant === 'regional') {
+      throw new Error('Regional variant sorting is not supported yet.');
+    }
+    return a.instance.speciesId - b.instance.speciesId;
+  };
+}
+
+export class LevelSorter {
+  private config: { direction: 'asc' | 'desc' };
+
+  constructor(config: { direction: 'asc' | 'desc' }) {
+    this.config = config;
+  }
+
+  public sort: SortingStrategy = (a, b) => {
+    if (this.config.direction === 'asc') {
+      return a.instance.level - b.instance.level;
+    } else {
+      return b.instance.level - a.instance.level;
+    }
+  };
+}
+
+export class TypeSorter {
+  public sort: SortingStrategy = (a, b) => {
+    const typesA = a.metadata?.types ?? [];
+    const typesB = b.metadata?.types ?? [];
+
+    const primaryA = typesA[0] ?? Infinity;
+    const primaryB = typesB[0] ?? Infinity;
+
+    if (primaryA !== primaryB) {
+      return primaryA - primaryB;
+    }
+
+    const secondaryA = typesA[1] ?? Infinity;
+    const secondaryB = typesB[1] ?? Infinity;
+
+    if (secondaryA === secondaryB) {
+        return 0;
+    }
+
+    return secondaryA - secondaryB;
+  };
+}
+
+export class AlphaSorter {
+  public sort: SortingStrategy = (a, b) => {
+    const nameA = a.instance.nickname || a.metadata?.n || String(a.instance.speciesId);
+    const nameB = b.instance.nickname || b.metadata?.n || String(b.instance.speciesId);
+
+    return nameA.localeCompare(nameB);
+  };
+}


### PR DESCRIPTION
Implemented four standard sorting strategies according to task `task-333-365-sorting-strategies-impl.md`.
Added unit tests covering normal behaviour and edge cases for missing data.
Updated task node.
Written a learning record addressing compilation issues with `erasableSyntaxOnly` and `exactOptionalPropertyTypes`.

---
*PR created automatically by Jules for task [1822939805966644680](https://jules.google.com/task/1822939805966644680) started by @szubster*