### PR TITLE
QA: Reject Pokemon Types Data Impl (Missing sort by slot)

### DIFF
--- a/.foundry/journals/qa/9292922148767915467.md
+++ b/.foundry/journals/qa/9292922148767915467.md
@@ -1,0 +1,7 @@
+# QA Journal Entry - Session 9292922148767915467
+
+## Validation of task-333-363-pokemon-types-data-impl
+
+1. **Verify schemas & generator**: `POKEMON_TYPE` and `POKEMON_TYPE_MAP` are properly defined in `src/db/schema.ts`. `types` was added to `PokemonMetadata`.
+2. **Verify generate-pokedata.ts sorting**: The code reads `pData.types` and maps them using `POKEMON_TYPE_MAP`, but it **fails to sort by slot** before mapping, violating the specific acceptance criterion: "sorts by slot (if applicable)".
+3. **Conclusion**: Implementation is incomplete. Rejecting the task and setting `status: FAILED`, incrementing `rejection_count`, and providing the reason. My own QA task remains `ACTIVE`.

--- a/.foundry/tasks/task-333-363-pokemon-types-data-impl.md
+++ b/.foundry/tasks/task-333-363-pokemon-types-data-impl.md
@@ -2,7 +2,7 @@
 id: task-333-363-pokemon-types-data-impl
 type: TASK
 title: Add Pokemon Types to Data Pipeline
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-29'
 updated_at: '2026-07-30'
@@ -14,8 +14,8 @@ tags:
   - data
   - pokemon
 research_references: []
-rejection_count: 1
-rejection_reason: ''
+rejection_count: 2
+rejection_reason: 'The generate-pokedata.ts script maps types but fails to sort them by slot as required by the acceptance criteria.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-333-364-pokemon-types-data-qa.md
+++ b/.foundry/tasks/task-333-364-pokemon-types-data-qa.md
@@ -30,3 +30,6 @@ The coder has implemented typing data extraction in the Pokemon database pipelin
 - [ ] Verify `generate-pokedata.ts` correctly reads `pData.types`, sorts by slot (if applicable), and stores integer IDs.
 - [ ] Run the generation script locally or verify the source code to ensure types are correctly assigned to `pokemon.push(...)`.
 - [ ] Ensure `pnpm lint` and `pnpm test` pass.
+
+### QA Rejection Note
+Rejected task-333-363-pokemon-types-data-impl. The `generate-pokedata.ts` script extracts types but fails to sort them by `slot` before pushing them into the array, which is required by the acceptance criteria.


### PR DESCRIPTION
The `generate-pokedata.ts` script successfully extracts and maps `pData.types` using the updated schema mappings. However, it fails to meet the specific acceptance criterion to **sort by slot** before pushing the types into the metadata array.

Because this violates the specific contract (which is especially critical for correctly parsing dual-typed Pokemon where order matters for primary vs secondary typing), the target task (`task-333-363-pokemon-types-data-impl`) has been rejected and marked as `FAILED`.

The QA task itself remains `ACTIVE` pending a new implementation attempt.

---
*PR created automatically by Jules for task [9292922148767915467](https://jules.google.com/task/9292922148767915467) started by @szubster*