### PR TITLE
Reject missing implementation for Gen 2 call filtering

### DIFF
--- a/.foundry/journals/qa/2564293867211876841.md
+++ b/.foundry/journals/qa/2564293867211876841.md
@@ -1,0 +1,10 @@
+# QA Session: 2564293867211876841
+Date: 2026-07-30
+
+## Validated Tasks
+- `task-286-314-filter-swarm-item-calls-impl`: FAILED
+
+## Notes
+- The implementation for Gen 2 phone call filtering is completely missing. Searching the codebase for `wSwarmFlags` or `wDailyPhoneItemFlags` within the source files yields no results.
+- The previous coder submitted an empty PR because they were blocked on memory offsets, which have since been researched. However, no implementation was ever written.
+- Rejected `task-286-314-filter-swarm-item-calls-impl`, incremented its `rejection_count`, updated its status to `FAILED`, and added a `rejection_reason`.

--- a/.foundry/tasks/task-286-314-filter-swarm-item-calls-impl.md
+++ b/.foundry/tasks/task-286-314-filter-swarm-item-calls-impl.md
@@ -2,7 +2,7 @@
 id: task-286-314-filter-swarm-item-calls-impl
 type: TASK
 title: Implement High-Value Pokegear Call Filtering
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-11'
 updated_at: '2026-07-24'
@@ -16,8 +16,8 @@ tags:
   - data
   - implement
 research_references: []
-rejection_count: 1
-rejection_reason: ''
+rejection_count: 2
+rejection_reason: 'Implementation missing. No Gen 2 phone call mechanics were implemented in the source code.'
 notes: ''
 ---
 
@@ -37,8 +37,8 @@ This task requires understanding of Gen 2 phone mechanics:
 - **Empty PR Policy:** If the required logic is already present or you must submit an empty PR, you **MUST check off all Acceptance Criteria checkboxes** below before submitting. Submitting an empty PR with unchecked boxes violates ADR 007/009 and will result in immediate rejection.
 
 ## Acceptance Criteria
-- [x] Create or update the logic layer to identify callers associated with swarms.
-- [x] Create or update the logic layer to identify callers that offer rare items.
-- [x] Implement a filtering mechanism or add a flag to the data structure that distinguishes these "high-value" calls from standard calls.
-- [x] Ensure all necessary flags and bitmasks (`wSwarmFlags`, `wDailyPhoneItemFlags`, etc.) are mapped correctly without using magic numbers in inline logic.
-- [x] research-286-336-gen2-phone-memory-offsets
+- [ ] Create or update the logic layer to identify callers associated with swarms.
+- [ ] Create or update the logic layer to identify callers that offer rare items.
+- [ ] Implement a filtering mechanism or add a flag to the data structure that distinguishes these "high-value" calls from standard calls.
+- [ ] Ensure all necessary flags and bitmasks (`wSwarmFlags`, `wDailyPhoneItemFlags`, etc.) are mapped correctly without using magic numbers in inline logic.
+- [ ] research-286-336-gen2-phone-memory-offsets

--- a/.foundry/tasks/task-286-315-filter-swarm-item-calls-qa.md
+++ b/.foundry/tasks/task-286-315-filter-swarm-item-calls-qa.md
@@ -40,3 +40,6 @@ This task follows the implementation of `task-286-314-filter-swarm-item-calls-im
 - [ ] Verify that logic correctly identifies item-giving callers based on `wDailyPhoneItemFlags`.
 - [ ] Verify that a filtering mechanism or flag correctly distinguishes high-value calls.
 - [ ] **ARCHITECTURAL CHECK:** Verify that NO inline magic numbers are used for memory offsets, lengths, or bitwise operations. All such values must be extracted into module-level constants.
+
+### Rejections
+- **2026-07-30**: Rejected `task-286-314-filter-swarm-item-calls-impl`. The implementation is completely missing from the codebase. The previous coder submitted an empty PR due to missing offsets, but even with research complete, no code exists to extract `wSwarmFlags` or `wDailyPhoneItemFlags`.


### PR DESCRIPTION
- Failed `task-286-314-filter-swarm-item-calls-impl` because the implementation is completely missing from the codebase.
- Incremented `rejection_count` and added a `rejection_reason` to the target task.
- Unchecked acceptance criteria in the target task.
- Documented the rejection in `task-286-315-filter-swarm-item-calls-qa` markdown.
- Documented QA session notes in `.foundry/journals/qa/2564293867211876841.md`.

---
*PR created automatically by Jules for task [2564293867211876841](https://jules.google.com/task/2564293867211876841) started by @szubster*