### PR TITLE
Retry standard sorting strategies and pokemon type extraction

### DIFF
--- a/.foundry/journals/tech_lead/8328727666729636231.md
+++ b/.foundry/journals/tech_lead/8328727666729636231.md
@@ -1,0 +1,10 @@
+# Session 8328727666729636231
+
+I was woken up because `task-333-363-pokemon-types-data-impl` permanently failed (reached max rejection count of 3) due to failing acceptance criteria related to sorting Pokemon types by `slot`.
+
+As required by the "Handling Permanent Child Failures (The Impossible Loop)" policy, I created a new `RESEARCH` node (`research-333-361-investigate-pokemon-types-failure`) to investigate this sorting issue. I also created replacement tasks:
+- `task-333-369-pokemon-types-data-retry-impl`
+- `task-333-370-pokemon-types-data-retry-qa`
+- `task-333-371-sorting-strategies-retry-qa`
+
+These downstream tasks correctly depend on the `RESEARCH` node being completed. I checked off the permanently failed and cancelled child nodes (`task-333-363`, `task-333-364`, `task-333-365`, `task-333-366`) in my story's markdown body so that ADR 007's requirement is met and the parent node can eventually transition to COMPLETED once the replacement nodes finish.

--- a/.foundry/research/research-333-361-investigate-pokemon-types-failure.md
+++ b/.foundry/research/research-333-361-investigate-pokemon-types-failure.md
@@ -1,0 +1,33 @@
+---
+id: research-333-361-investigate-pokemon-types-failure
+type: RESEARCH
+title: Investigate Pokemon Types Data Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-30'
+updated_at: '2026-07-30'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-136-333-sorting-standard-strategies-retry
+tags:
+  - data
+  - pokemon
+research_references:
+  - task-333-363-pokemon-types-data-impl
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Pokemon Types Data Failure
+
+## Context
+`task-333-363-pokemon-types-data-impl` was rejected (likely due to failing the acceptance criteria related to `generate-pokedata.ts` sorting). We need to investigate the true root cause.
+
+## Requirements
+- Investigate the sorting issue in `generate-pokedata.ts`.
+- Document how to correctly map and sort the types by `slot`.
+
+## Acceptance Criteria
+- [ ] Root cause identified and documented.

--- a/.foundry/stories/story-136-333-sorting-standard-strategies-retry.md
+++ b/.foundry/stories/story-136-333-sorting-standard-strategies-retry.md
@@ -34,7 +34,11 @@ Building upon the standard interface, we need specific, actionable sorters that 
 - [ ] Implement a `TypeSorter` (sorts by primary type, then secondary type).
 - [ ] Implement an `AlphaSorter` (alphabetical by nickname/species name).
 - [x] Break down story into tasks for technical blueprinting and implementation.
-- [ ] [task-333-363-pokemon-types-data-impl](.foundry/tasks/task-333-363-pokemon-types-data-impl.md)
-- [ ] [task-333-364-pokemon-types-data-qa](.foundry/tasks/task-333-364-pokemon-types-data-qa.md)
-- [ ] [task-333-365-sorting-strategies-impl](.foundry/tasks/task-333-365-sorting-strategies-impl.md)
-- [ ] [task-333-366-sorting-strategies-qa](.foundry/tasks/task-333-366-sorting-strategies-qa.md)
+- [x] [task-333-363-pokemon-types-data-impl](.foundry/tasks/task-333-363-pokemon-types-data-impl.md)
+- [x] [task-333-364-pokemon-types-data-qa](.foundry/tasks/task-333-364-pokemon-types-data-qa.md)
+- [x] [task-333-365-sorting-strategies-impl](.foundry/tasks/task-333-365-sorting-strategies-impl.md)
+- [x] [task-333-366-sorting-strategies-qa](.foundry/tasks/task-333-366-sorting-strategies-qa.md)
+- [ ] [research-333-361-investigate-pokemon-types-failure](.foundry/research/research-333-361-investigate-pokemon-types-failure.md)
+- [ ] [task-333-369-pokemon-types-data-retry-impl](.foundry/tasks/task-333-369-pokemon-types-data-retry-impl.md)
+- [ ] [task-333-370-pokemon-types-data-retry-qa](.foundry/tasks/task-333-370-pokemon-types-data-retry-qa.md)
+- [ ] [task-333-371-sorting-strategies-retry-qa](.foundry/tasks/task-333-371-sorting-strategies-retry-qa.md)

--- a/.foundry/tasks/task-333-369-pokemon-types-data-retry-impl.md
+++ b/.foundry/tasks/task-333-369-pokemon-types-data-retry-impl.md
@@ -1,0 +1,42 @@
+---
+id: task-333-369-pokemon-types-data-retry-impl
+type: TASK
+title: Add Pokemon Types to Data Pipeline (Retry)
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-30'
+updated_at: '2026-07-30'
+depends_on:
+  - research-333-361-investigate-pokemon-types-failure
+jules_session_id: null
+pr_number: null
+parent: story-136-333-sorting-standard-strategies-retry
+tags:
+  - data
+  - pokemon
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Add Pokemon Types to Data Pipeline (Retry)
+
+## Context
+A retry of `task-333-363`. We need to expose a Pokemon's primary and secondary types to the client application, sorting them by `slot`.
+
+## Requirements
+1. **Schema Update (`src/db/schema.ts`)**:
+   - Define and export a `POKEMON_TYPE` constant object mapping type names to integer IDs.
+   - Define a `POKEMON_TYPE_MAP` object mapping string keys to those integers.
+   - Add `types?: number[]` to the `PokemonMetadata` interface. Note: use `types` instead of minified `tps` in accordance with ADR 015 principles.
+2. **Data Generation**:
+   - Modify the `generate-pokedata.ts` script to extract `types`.
+   - Map the string types to our integer IDs using `POKEMON_TYPE_MAP`.
+   - **CRITICAL**: Ensure the types are sorted by their `slot` property before storing them.
+
+## Acceptance Criteria
+- [ ] `POKEMON_TYPE` and `POKEMON_TYPE_MAP` are exported in `schema.ts`.
+- [ ] `PokemonMetadata` includes the `types?: number[]` property.
+- [ ] `generate-pokedata.ts` populates `types`, sorted by `slot`.
+- [ ] Running `pnpm lint` and `pnpm test` passes successfully.

--- a/.foundry/tasks/task-333-370-pokemon-types-data-retry-qa.md
+++ b/.foundry/tasks/task-333-370-pokemon-types-data-retry-qa.md
@@ -1,0 +1,32 @@
+---
+id: task-333-370-pokemon-types-data-retry-qa
+type: TASK
+title: QA Pokemon Types Data Pipeline (Retry)
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-30'
+updated_at: '2026-07-30'
+depends_on:
+  - task-333-369-pokemon-types-data-retry-impl
+jules_session_id: null
+pr_number: null
+parent: story-136-333-sorting-standard-strategies-retry
+tags:
+  - data
+  - pokemon
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Pokemon Types Data Pipeline (Retry)
+
+## Context
+QA verification for `task-333-369-pokemon-types-data-retry-impl`.
+
+## Acceptance Criteria
+- [ ] Verify `POKEMON_TYPE` and `POKEMON_TYPE_MAP` are defined in `src/db/schema.ts`.
+- [ ] Verify `generate-pokedata.ts` correctly extracts types, sorts by slot, and stores integer IDs.
+- [ ] Run the generation script locally or verify the source code to ensure types are correctly assigned in `generate-pokedata.ts`.
+- [ ] Ensure `pnpm lint` and `pnpm test` pass.

--- a/.foundry/tasks/task-333-371-sorting-strategies-retry-qa.md
+++ b/.foundry/tasks/task-333-371-sorting-strategies-retry-qa.md
@@ -1,0 +1,33 @@
+---
+id: task-333-371-sorting-strategies-retry-qa
+type: TASK
+title: QA PC Box Sorting Strategies (Retry)
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-30'
+updated_at: '2026-07-30'
+depends_on:
+  - task-333-370-pokemon-types-data-retry-qa
+  - task-333-365-sorting-strategies-impl
+jules_session_id: null
+pr_number: null
+parent: story-136-333-sorting-standard-strategies-retry
+tags:
+  - feature
+  - sorting
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA PC Box Sorting Strategies (Retry)
+
+## Context
+QA for the sorting strategies implementation in `task-333-365-sorting-strategies-impl`. This was cancelled due to its dependency failing, but now that the data pipeline will be fixed, we can re-verify the sorting logic.
+
+## Acceptance Criteria
+- [ ] Verify `DexNumberSorter`, `LevelSorter`, `TypeSorter`, and `AlphaSorter` correctly implement the `SortingStrategy` signature.
+- [ ] Verify edge cases (e.g. missing data) are handled gracefully without throwing errors during sort.
+- [ ] Run `pnpm test` to ensure all sorting unit tests pass and properly assert correct sorting orders.
+- [ ] Verify `pnpm lint` passes.


### PR DESCRIPTION
I woke up to `task-333-363` having failed permanently due to failing acceptance criteria regarding sorting Pokemon types by `slot`. To fix this according to the "Handling Permanent Child Failures (The Impossible Loop)" policy, I created a new RESEARCH node (`research-333-361-investigate-pokemon-types-failure.md`) to investigate and fix the problem in `generate-pokedata.ts`. I also created the subsequent TASKs (`task-333-369`, `task-333-370`, and `task-333-371`) to implement and verify the retry attempt for both the types generation and the standard sorting algorithms. I've updated the parent story's markdown and documented my steps in the tech lead journal.

---
*PR created automatically by Jules for task [8328727666729636231](https://jules.google.com/task/8328727666729636231) started by @szubster*