### PR TITLE
QA: Verify Gen 3 Pokeblock extraction implementation

### DIFF
--- a/.foundry/journals/qa/9725628562564447045.md
+++ b/.foundry/journals/qa/9725628562564447045.md
@@ -1,0 +1,11 @@
+# Session 9725628562564447045
+
+Task: task-332-368-gen3-pokeblock-extraction-qa
+
+Verified the Gen 3 Pokeblock extraction implementation in `src/engine/saveParser/gen3/pokeblock/parser.ts`.
+- The Pokéblock array is successfully and correctly extracted from `SaveBlock1` using `0x0848` for Emerald and `0x07F8` for Ruby/Sapphire.
+- All properties (color, spicy, dry, sweet, bitter, sour, feel) are parsed using module-level offsets in an 8-byte struct.
+- The implementation strictly adheres to Section 13 guidelines (module-level constants, no magic numbers, relative offset `saveBlock1Offset` is used, and `RangeError` is caught with the exact required string).
+- Unit tests exist and pass correctly.
+
+The task meets all acceptance criteria. I have checked off the acceptance criteria in the task's markdown file and will submit an empty PR.

--- a/.foundry/tasks/task-332-368-gen3-pokeblock-extraction-qa.md
+++ b/.foundry/tasks/task-332-368-gen3-pokeblock-extraction-qa.md
@@ -30,7 +30,7 @@ notes: ''
 Verify the implementation of the Gen 3 Pokéblock Case parsing logic.
 
 ## Acceptance Criteria
-- [ ] Verify that the Pokéblock array is correctly extracted from `SaveBlock1` (Offsets: Emerald `0x0848`, RS `0x07F8`).
-- [ ] Verify that the 8-byte structure is parsed correctly for all properties (color, flavors, feel).
-- [ ] Verify strict adherence to Section 13 ("Save File Parsing & Extraction Guidelines") of `.foundry/docs/schema.md` (e.g., module-level constants, no magic numbers, relative offsets, and catching `RangeError` with the correct error message).
-- [ ] Verify tests exist and pass for extracting Pokéblocks.
+- [x] Verify that the Pokéblock array is correctly extracted from `SaveBlock1` (Offsets: Emerald `0x0848`, RS `0x07F8`).
+- [x] Verify that the 8-byte structure is parsed correctly for all properties (color, flavors, feel).
+- [x] Verify strict adherence to Section 13 ("Save File Parsing & Extraction Guidelines") of `.foundry/docs/schema.md` (e.g., module-level constants, no magic numbers, relative offsets, and catching `RangeError` with the correct error message).
+- [x] Verify tests exist and pass for extracting Pokéblocks.


### PR DESCRIPTION
Empty PR to check off the acceptance criteria for the QA verification of the Gen 3 Pokeblock extraction implementation, and providing a QA journal entry detailing the successful review.

---
*PR created automatically by Jules for task [9725628562564447045](https://jules.google.com/task/9725628562564447045) started by @szubster*