### PR TITLE
feat(tech_lead): decompose concurrent game management story into tasks

### DIFF
--- a/.foundry/journals/tech_lead/4551867605052812174.md
+++ b/.foundry/journals/tech_lead/4551867605052812174.md
@@ -1,0 +1,9 @@
+# Tech Lead Session: 4551867605052812174
+
+## Context
+Decomposing STORY `story-036-257-concurrent-game-management` into TASK nodes.
+
+## Lessons Learned
+- Followed the architectural scaffolding policy (ADR 013, ADR 017) to explicitly break out the shared React Context state layer (`task-257-369`) separate from the UI components (`task-257-371`, `task-257-373`). This prevents tight coupling and ensures a clean single source of truth for the Concurrent Game Management feature.
+- Enforced the Intelligent Verification Protocol by creating matching QA tasks for all components due to the complexity of shared state and concurrent playthrough swapping.
+- Strictly used exact node IDs (without file extensions) in the `depends_on` arrays and unchecked markdown references to prevent DAG deadlocks.

--- a/.foundry/stories/story-036-257-concurrent-game-management.md
+++ b/.foundry/stories/story-036-257-concurrent-game-management.md
@@ -31,4 +31,10 @@ Users may play multiple games simultaneously (e.g., swapping between Pokémon Re
 - Build a timeline or visualization showing the progression of a specific playthrough over its saved history.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break this Story down into Tasks to implement the concurrent game switcher UI, state management, and progression visualization.
+- [x] Tech Lead: Break this Story down into Tasks to implement the concurrent game switcher UI, state management, and progression visualization.
+- [ ] task-257-369-concurrent-game-context-impl
+- [ ] task-257-370-concurrent-game-context-qa
+- [ ] task-257-371-concurrent-game-switcher-ui-impl
+- [ ] task-257-372-concurrent-game-switcher-ui-qa
+- [ ] task-257-373-progression-timeline-ui-impl
+- [ ] task-257-374-progression-timeline-ui-qa

--- a/.foundry/tasks/task-257-369-concurrent-game-context-impl.md
+++ b/.foundry/tasks/task-257-369-concurrent-game-context-impl.md
@@ -1,0 +1,33 @@
+---
+id: task-257-369-concurrent-game-context-impl
+type: TASK
+title: Concurrent Game Context Layer
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-31'
+updated_at: '2026-07-31'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-036-257-concurrent-game-management
+tags:
+  - frontend
+  - progression
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Concurrent Game Context Layer
+
+## Context
+As part of the Concurrent Game Management feature, we need a robust React Context layer to manage the state of multiple active playthroughs and enable swapping between them.
+
+## Requirements
+- Define the React Context layer first before implementing the UI components, as mandated by the architectural scaffolding rules to prevent tight coupling.
+- Implement state management for active playthroughs across different game versions.
+
+## Acceptance Criteria
+- [ ] Implement the React Context layer for concurrent game management.

--- a/.foundry/tasks/task-257-370-concurrent-game-context-qa.md
+++ b/.foundry/tasks/task-257-370-concurrent-game-context-qa.md
@@ -1,0 +1,33 @@
+---
+id: task-257-370-concurrent-game-context-qa
+type: TASK
+title: QA Concurrent Game Context Layer
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-31'
+updated_at: '2026-07-31'
+depends_on:
+  - task-257-369-concurrent-game-context-impl
+jules_session_id: null
+pr_number: null
+parent: story-036-257-concurrent-game-management
+tags:
+  - frontend
+  - progression
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Concurrent Game Context Layer
+
+## Context
+QA verification for the React Context layer managing concurrent game state.
+
+## Requirements
+- Validate the Context layer manages state correctly without tight coupling.
+
+## Acceptance Criteria
+- [ ] Verify the Context layer implementation.

--- a/.foundry/tasks/task-257-371-concurrent-game-switcher-ui-impl.md
+++ b/.foundry/tasks/task-257-371-concurrent-game-switcher-ui-impl.md
@@ -1,0 +1,34 @@
+---
+id: task-257-371-concurrent-game-switcher-ui-impl
+type: TASK
+title: Concurrent Game Switcher UI
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-31'
+updated_at: '2026-07-31'
+depends_on:
+  - task-257-369-concurrent-game-context-impl
+jules_session_id: null
+pr_number: null
+parent: story-036-257-concurrent-game-management
+tags:
+  - frontend
+  - progression
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Concurrent Game Switcher UI
+
+## Context
+Develop a UI for users to select and manage multiple active playthroughs across different game versions.
+
+## Requirements
+- Consume the Concurrent Game React Context layer.
+- Build the switcher component.
+
+## Acceptance Criteria
+- [ ] Implement the Concurrent Game Switcher UI.

--- a/.foundry/tasks/task-257-372-concurrent-game-switcher-ui-qa.md
+++ b/.foundry/tasks/task-257-372-concurrent-game-switcher-ui-qa.md
@@ -1,0 +1,33 @@
+---
+id: task-257-372-concurrent-game-switcher-ui-qa
+type: TASK
+title: QA Concurrent Game Switcher UI
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-31'
+updated_at: '2026-07-31'
+depends_on:
+  - task-257-371-concurrent-game-switcher-ui-impl
+jules_session_id: null
+pr_number: null
+parent: story-036-257-concurrent-game-management
+tags:
+  - frontend
+  - progression
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Concurrent Game Switcher UI
+
+## Context
+QA verification for the Concurrent Game Switcher UI.
+
+## Requirements
+- Validate the UI component works correctly.
+
+## Acceptance Criteria
+- [ ] Verify the UI component implementation.

--- a/.foundry/tasks/task-257-373-progression-timeline-ui-impl.md
+++ b/.foundry/tasks/task-257-373-progression-timeline-ui-impl.md
@@ -1,0 +1,34 @@
+---
+id: task-257-373-progression-timeline-ui-impl
+type: TASK
+title: Progression Timeline UI
+status: PENDING
+owner_persona: coder
+created_at: '2026-07-31'
+updated_at: '2026-07-31'
+depends_on:
+  - task-257-369-concurrent-game-context-impl
+jules_session_id: null
+pr_number: null
+parent: story-036-257-concurrent-game-management
+tags:
+  - frontend
+  - progression
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Progression Timeline UI
+
+## Context
+Build a timeline or visualization showing the progression of a specific playthrough over its saved history.
+
+## Requirements
+- Consume the Concurrent Game React Context layer.
+- Build the visualization UI.
+
+## Acceptance Criteria
+- [ ] Implement the Progression Timeline UI.

--- a/.foundry/tasks/task-257-374-progression-timeline-ui-qa.md
+++ b/.foundry/tasks/task-257-374-progression-timeline-ui-qa.md
@@ -1,0 +1,33 @@
+---
+id: task-257-374-progression-timeline-ui-qa
+type: TASK
+title: QA Progression Timeline UI
+status: PENDING
+owner_persona: qa
+created_at: '2026-07-31'
+updated_at: '2026-07-31'
+depends_on:
+  - task-257-373-progression-timeline-ui-impl
+jules_session_id: null
+pr_number: null
+parent: story-036-257-concurrent-game-management
+tags:
+  - frontend
+  - progression
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Progression Timeline UI
+
+## Context
+QA verification for the Progression Timeline UI.
+
+## Requirements
+- Validate the timeline visualization.
+
+## Acceptance Criteria
+- [ ] Verify the Progression Timeline UI implementation.


### PR DESCRIPTION
Decomposed STORY `story-036-257-concurrent-game-management` into TASK nodes.
- Created `task-257-369-concurrent-game-context-impl` and corresponding QA task.
- Created `task-257-371-concurrent-game-switcher-ui-impl` and corresponding QA task.
- Created `task-257-373-progression-timeline-ui-impl` and corresponding QA task.
- Updated parent story markdown checkboxes.
- Logged session to Tech Lead journal.

---
*PR created automatically by Jules for task [4551867605052812174](https://jules.google.com/task/4551867605052812174) started by @szubster*