### PR TITLE
Complete story-338-337-update-tpm-aggregation via Empty PR

### DIFF
--- a/.foundry/journals/tech_lead/3812543643284052044.md
+++ b/.foundry/journals/tech_lead/3812543643284052044.md
@@ -1,0 +1,1 @@
+Applied the Empty PR Policy to check off the completed task `task-337-346-update-tpm-persona-instructions` in `.foundry/stories/story-338-337-update-tpm-aggregation.md`. The target artifact was already implemented and completed. No new code changes were required.

--- a/.foundry/stories/story-338-337-update-tpm-aggregation.md
+++ b/.foundry/stories/story-338-337-update-tpm-aggregation.md
@@ -33,4 +33,4 @@ With agents writing to session-unique journal files, the TPM persona must be upd
 
 ## Acceptance Criteria
 - [x] Tech Lead: Break this Story down into actionable Tasks.
-- [ ] task-337-346-update-tpm-persona-instructions
+- [x] task-337-346-update-tpm-persona-instructions


### PR DESCRIPTION
This PR marks the completion of `story-338-337-update-tpm-aggregation` by checking off its acceptance criteria. 

The required task node (`task-337-346-update-tpm-persona-instructions.md`) was already created and marked as COMPLETED in a previous iteration. Therefore, following the **Empty PR Policy**, I am checking off the acceptance criteria box in the STORY node without modifying its YAML frontmatter, and submitting this PR to allow the DAG orchestrator to progress the parent node.

A session journal entry has also been created to log this action.

---
*PR created automatically by Jules for task [3812543643284052044](https://jules.google.com/task/3812543643284052044) started by @szubster*