### PR TITLE
chore(foundry): mark r2 conflict tasks as completed in story

### DIFF
--- a/.foundry/stories/story-039-265-r2-offline-conflict-resolution.md
+++ b/.foundry/stories/story-039-265-r2-offline-conflict-resolution.md
@@ -32,5 +32,5 @@ Because the app is offline-first, a user might make local changes while disconne
 
 ## Acceptance Criteria
 - [x] Break down into Tasks.
-- [ ] .foundry/tasks/task-265-352-r2-conflict-resolution-impl.md
-- [ ] .foundry/tasks/task-265-353-r2-conflict-resolution-qa.md
+- [x] .foundry/tasks/task-265-352-r2-conflict-resolution-impl.md
+- [x] .foundry/tasks/task-265-353-r2-conflict-resolution-qa.md


### PR DESCRIPTION
Executes the empty PR policy to check off the acceptance criteria for the completed R2 conflict resolution child tasks within the parent story node.

---
*PR created automatically by Jules for task [5985976522382267905](https://jules.google.com/task/5985976522382267905) started by @szubster*