### PR TITLE
Update Epic 112-324 (NPC Size Record Data Extraction) Checkboxes

### DIFF
--- a/.foundry/epics/epic-112-324-npc-size-record-data-extraction.md
+++ b/.foundry/epics/epic-112-324-npc-size-record-data-extraction.md
@@ -30,7 +30,7 @@ Extract the necessary internal data structures from Gen 2 and Gen 3 save files t
 - **Gen 3:** Extract Personality Value (PV) and IVs (HP, Attack, Defense, Speed, Special Attack, Special Defense) for each Pokémon. Handle the 48-byte encrypted Data block taking into account the substructure order determined by `PV % 24`.
 
 ## Acceptance Criteria
-- [ ] Implement data extraction for Gen 2 DVs.
-- [ ] Implement data extraction for Gen 3 PV and IVs.
-- [ ] story-324-322-gen2-dv-extraction
-- [ ] story-324-346-gen3-pv-iv-extraction
+- [x] Implement data extraction for Gen 2 DVs.
+- [x] Implement data extraction for Gen 3 PV and IVs.
+- [x] story-324-322-gen2-dv-extraction
+- [x] story-324-346-gen3-pv-iv-extraction

--- a/.foundry/journals/story_owner/2026-07-31-00-12-09.md
+++ b/.foundry/journals/story_owner/2026-07-31-00-12-09.md
@@ -1,0 +1,3 @@
+# Session Log
+
+Observed that the children stories `story-324-322-gen2-dv-extraction` and `story-324-346-gen3-pv-iv-extraction` are already in `COMPLETED` status. Checked off the acceptance criteria checkboxes in `epic-112-324-npc-size-record-data-extraction.md` to allow the orchestrator to transition the node. Empty PR policy applied.


### PR DESCRIPTION
This PR updates the `epic-112-324-npc-size-record-data-extraction` by checking off the acceptance criteria for its two children stories (`story-324-322-gen2-dv-extraction` and `story-324-346-gen3-pv-iv-extraction`), which are both already in the `COMPLETED` state. A journal entry was also written.

---
*PR created automatically by Jules for task [10993928217220230323](https://jules.google.com/task/10993928217220230323) started by @szubster*