### PR TITLE
🔐 Replace insecure Math.random() with window.crypto in RetroBackground

### DIFF
--- a/.jules/shield/2026-08-01-01-45-00.md
+++ b/.jules/shield/2026-08-01-01-45-00.md
@@ -1,0 +1,8 @@
+# Shield Session - CWE-338 Mitigation
+
+## Action Taken
+Replaced an insecure `Math.random()` call in `src/components/RetroBackground.tsx` with `window.crypto.getRandomValues()`.
+
+## Learnings & Patterns
+**Pattern:** Even if pseudo-random generation is only used for UI/visual effects (like scrolling hex data streams), SAST tools will routinely flag `Math.random()` as a high-severity CWE-338 (Use of Cryptographically Weak PRNG) violation.
+**Policy Update:** Always default to `window.crypto.getRandomValues` in the browser or `node:crypto` in Node environments, regardless of the security context of the generated value, to maintain zero-warning compliance.

--- a/src/components/RetroBackground.tsx
+++ b/src/components/RetroBackground.tsx
@@ -37,7 +37,9 @@ export function RetroBackground(_props: RetroBackgroundProps) {
           <div className="animate-[scroll-up_60s_linear_infinite]">
             {Array.from({ length: 100 }).map((_, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: Array index is stable representing background items
-              <div key={`hex-${i}`}>0x{Math.random().toString(16).slice(2, 10).toUpperCase()}</div>
+              <div key={`hex-${i}`}>
+                0x{window.crypto.getRandomValues(new Uint32Array(1))[0]?.toString(16).padStart(8, '0').toUpperCase()}
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
🎯 What
Replaced the use of `Math.random()` in `src/components/RetroBackground.tsx` with a cryptographically secure alternative `window.crypto.getRandomValues()`.

⚠️ Risk
Using `Math.random()` triggers CWE-338 (Use of Cryptographically Weak Pseudo-Random Number Generator) warnings in SAST tools. While the risk here was low (only used for UI visual effects), standardizing on secure PRNGs improves overall security compliance.

🛡️ Solution
Used `window.crypto.getRandomValues()` combined with a typed array to generate a reliable hex string for the visual data streams without raising static analysis flags.

---
*PR created automatically by Jules for task [2199751441101316446](https://jules.google.com/task/2199751441101316446) started by @szubster*