### PR TITLE
🗿 Sculptor: Refactor Gen 3 berry patch magic number bitmasks to explicit constants

### DIFF
--- a/.jules/sculptor/2026-07-31-02-08-56.md
+++ b/.jules/sculptor/2026-07-31-02-08-56.md
@@ -1,0 +1,6 @@
+# Sculptor Journal - Gen 3 Berry Patch Magic Numbers
+
+## Critical Learnings
+* **Inline magic numbers obfuscate bitwise logic:** Using inline hex values (like `0x7f`, `0x80`, `0x0f`) as bitmasks deeply embedded in parsing logic makes it extremely difficult for AI to grasp the binary architecture and bounds of save files.
+* **Top-level constants provide semantic mapping:** Extracting these to named constants (`BERRY_STAGE_MASK`, `BERRY_STOP_GROWTH_MASK`, etc.) immediately clarifies their purpose and limits.
+* **Refactoring Strategy:** Using Node `.js` scripts is significantly safer and more precise than standard bash `sed` or `grep` tools for manipulating large TypeScript parsing files.

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -50,6 +50,15 @@ const BERRY_STAGE_OFFSET = 1;
 const BERRY_MINUTES_OFFSET = 2;
 const BERRY_YIELD_OFFSET = 4;
 const BERRY_WATERED_OFFSET = 5;
+const BERRY_STAGE_MASK = 0x7f;
+const BERRY_STOP_GROWTH_MASK = 0x80;
+const BERRY_REGROWTH_MASK = 0x0f;
+const BERRY_WATERED_1_MASK = 0x10;
+const BERRY_WATERED_2_MASK = 0x20;
+const BERRY_WATERED_3_MASK = 0x40;
+const BERRY_WATERED_4_MASK = 0x80;
+const NIBBLE_MASK = 0x0f;
+
 const HIDDEN_ITEM_FLAGS_OFFSET = 62;
 
 const SECTION_SIZE = 4096;
@@ -428,18 +437,18 @@ function extractBerryPatches(view: DataView, saveBlock1Offset: number) {
     try {
       const berryId = view.getUint8(offset);
       const stageByte = view.getUint8(offset + BERRY_STAGE_OFFSET);
-      const stage = stageByte & 0x7f;
-      const stopGrowth = (stageByte & 0x80) !== 0;
+      const stage = stageByte & BERRY_STAGE_MASK;
+      const stopGrowth = (stageByte & BERRY_STOP_GROWTH_MASK) !== 0;
 
       const minutesUntilNextStage = view.getUint16(offset + BERRY_MINUTES_OFFSET, true);
       const berryYield = view.getUint8(offset + BERRY_YIELD_OFFSET);
 
       const wateredByte = view.getUint8(offset + BERRY_WATERED_OFFSET);
-      const regrowthCount = wateredByte & 0x0f;
-      const watered1 = (wateredByte & 0x10) !== 0;
-      const watered2 = (wateredByte & 0x20) !== 0;
-      const watered3 = (wateredByte & 0x40) !== 0;
-      const watered4 = (wateredByte & 0x80) !== 0;
+      const regrowthCount = wateredByte & BERRY_REGROWTH_MASK;
+      const watered1 = (wateredByte & BERRY_WATERED_1_MASK) !== 0;
+      const watered2 = (wateredByte & BERRY_WATERED_2_MASK) !== 0;
+      const watered3 = (wateredByte & BERRY_WATERED_3_MASK) !== 0;
+      const watered4 = (wateredByte & BERRY_WATERED_4_MASK) !== 0;
 
       patches.push({
         berryId,
@@ -1046,7 +1055,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     for (let i = 0; i < 14; i++) {
       const currentByte = view.getUint8(flagsOffset + HIDDEN_ITEM_FLAGS_OFFSET + i);
       const nextByte = view.getUint8(flagsOffset + HIDDEN_ITEM_FLAGS_OFFSET + i + 1);
-      hiddenItemFlags[i] = ((currentByte >> 4) | ((nextByte & 0x0f) << 4)) & 0xff;
+      hiddenItemFlags[i] = ((currentByte >> 4) | ((nextByte & NIBBLE_MASK) << 4)) & 0xff;
     }
 
     const mirageIslandOffset = _forcedVersion === 'emerald' ? MIRAGE_ISLAND_OFFSET_EMERALD : MIRAGE_ISLAND_OFFSET_RS;


### PR DESCRIPTION
🎯 **What:** Extracted inline hexadecimal magic numbers (e.g., `0x7f`, `0x80`, `0x0f`, `0x10`, `0x20`, `0x40`) used for bitwise masking in `src/engine/saveParser/parsers/gen3.ts` to top-level constants (`BERRY_STAGE_MASK`, `BERRY_STOP_GROWTH_MASK`, `BERRY_REGROWTH_MASK`, etc.).

💡 **Why (AI Readability Impact):** Inline magic numbers in binary parsers map poorly to context for AI agents, obfuscating data structures. By adhering to ADR 028 and extracting magic numbers to top-level constants with explicit names, AI agents can immediately infer the context, bounds, and purpose of bitwise operations.

✅ **Verification:** Verified safe by running `pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e`. Used a temporary script to ensure string replacement was precise. Cleaned up scratchpad files before submitting.

✨ **Result:** A more semantically clear save parser where binary masks explicitly detail their functionality instead of relying on ambiguous raw hex strings.

---
*PR created automatically by Jules for task [6530112656299694844](https://jules.google.com/task/6530112656299694844) started by @szubster*