### PR TITLE
💡 Visionary: Implement Resource Locking (Mutex) in DAG Orchestrator

### DIFF
--- a/.foundry/ideas/idea-131-orchestrator-resource-locking-mutex.md
+++ b/.foundry/ideas/idea-131-orchestrator-resource-locking-mutex.md
@@ -1,0 +1,36 @@
+---
+id: idea-131-orchestrator-resource-locking-mutex
+type: IDEA
+title: Implement Resource Locking (Mutex) in DAG Orchestrator
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-07-31'
+updated_at: '2026-07-31'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - orchestrator
+  - architecture
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Implement Resource Locking (Mutex) in DAG Orchestrator
+
+## Context
+As the Foundry multi-agent pipeline scales, multiple active agents may attempt to modify the same shared resources (e.g., global configuration files, aggregated index files, or specific node files) concurrently. We've seen issues such as git merge conflicts on `.foundry/journals/*.md` files, which sparked idea-120 (Conflictless Agent Journals). However, the core issue of concurrent resource contention remains in the DAG orchestrator.
+
+## Proposal
+Introduce a formal "Resource Locking" (Mutex) mechanism within the DAG orchestrator.
+- **Resource Declarations:** Nodes (Tasks, Stories) can declare specific file paths or directories they need exclusive access to in a new `locks` field in their YAML frontmatter.
+- **Mutex Engine:** During the `RESOLVE` phase, the orchestrator checks if any currently `ACTIVE` node holds a lock on a requested resource. If so, the `READY` node is temporarily blocked from being dispatched until the lock is released.
+- **Deadlock Prevention:** Implement a simple timeout or cycle detection for locks to prevent deadlocks.
+
+## Value Proposition
+This ensures that multiple agents do not stomp on each other's work or cause complex git merge conflicts when dealing with central configuration or index files. It moves the Foundry from simple state tracking to true concurrent execution safety.
+
+## Next Steps
+- [ ] Product Manager: Draft a PRD outlining the YAML schema changes and the orchestrator logic for lock acquisition and release.

--- a/.jules/visionary/2026-07-31-01-56-15.md
+++ b/.jules/visionary/2026-07-31-01-56-15.md
@@ -1,0 +1,9 @@
+# Visionary Journal
+
+- **Active Session ID:** null
+- **Domain:** Foundry System (Orchestrator)
+- **Proposed Idea:** Implement Resource Locking (Mutex) in DAG Orchestrator (IDEA-131)
+- **Rationale & Concept:**
+  To prevent concurrent agents from stomping on shared resources or causing git merge conflicts, we need a formal resource locking mechanism built directly into the DAG orchestrator. Nodes will declare resources they need exclusive access to, and the orchestrator will ensure mutually exclusive dispatch.
+- **How this idea maintains the 50/50 balance between DexHelper and Foundry:**
+  In the previous session, we proposed a DexHelper idea (IDEA-130 Shoal Cave Tide & Item Tracker). To adhere to the strict 50/50 split requirement, this session focuses entirely on the internal Foundry system, proposing a core structural improvement to the orchestrator's concurrency model.


### PR DESCRIPTION
This idea proposes adding a resource locking (mutex) mechanism to the Foundry DAG orchestrator to prevent concurrent agents from stomping on shared resources or causing git merge conflicts. This ensures execution safety as the multi-agent pipeline scales.

---
*PR created automatically by Jules for task [12641457462639404355](https://jules.google.com/task/12641457462639404355) started by @szubster*