### PR TITLE
🎨 Palette: Add slide-up motion to tactical-tooltip

### DIFF
--- a/.jules/palette/2026-07-31-02-17-19.md
+++ b/.jules/palette/2026-07-31-02-17-19.md
@@ -1,0 +1,11 @@
+# Palette Session: 2026-07-31-02-17-19
+
+## Actions Taken
+- Evaluated `src/index.css` for micro-UX improvement opportunities.
+- Implemented a slide-up animation (`translate-y-1` to `translate-y-0`) coupled with `transition-all` on the `tactical-tooltip` utility class.
+- The update applies to both `group-hover` and `group-focus-visible` states to improve the visual feedback when interacting with tooltipped items, making the interface feel more dynamic.
+
+## Critical Learnings
+- When updating utility classes in `src/index.css`, ensure test scripts and artifacts are cleaned up before committing (received feedback about residual test html files).
+- Always use specific `git add` instead of `git add .` to avoid committing temporary artifacts.
+- Modifying shared layout utilities in Tailwind v4 with custom `@utility` directives is straightforward, keeping adjustments <50 lines in accordance with ADR 024.

--- a/src/index.css
+++ b/src/index.css
@@ -161,7 +161,7 @@ body {
 }
 
 @utility tactical-tooltip {
-  @apply pointer-events-none absolute top-full left-1/2 z-50 mt-2 -translate-x-1/2 opacity-0 transition-opacity duration-200 group-hover:delay-300 group-hover:opacity-100 group-focus-visible:delay-300 group-focus-visible:opacity-100 rounded-none border border-dashed border-[var(--theme-border)] bg-zinc-950 px-2 py-1 font-mono text-[9px] text-zinc-300 uppercase tracking-widest whitespace-nowrap shadow-md;
+  @apply pointer-events-none absolute top-full left-1/2 z-50 mt-2 -translate-x-1/2 translate-y-1 opacity-0 transition-all duration-200 group-hover:delay-300 group-hover:translate-y-0 group-hover:opacity-100 group-focus-visible:delay-300 group-focus-visible:translate-y-0 group-focus-visible:opacity-100 rounded-none border border-dashed border-[var(--theme-border)] bg-zinc-950 px-2 py-1 font-mono text-[9px] text-zinc-300 uppercase tracking-widest whitespace-nowrap shadow-md;
 }
 
 @utility tactical-icon-button {


### PR DESCRIPTION
### What
Added a slide-up motion to the `tactical-tooltip` utility class in `src/index.css`. The base state now uses `translate-y-1` and `transition-all`, which animates to `translate-y-0` on `group-hover` and `group-focus-visible`.

### Why
A simple opacity fade is functional but feels static. Adding a slight vertical translation makes the tooltip feel more responsive and dynamic, which is a classic micro-UX enhancement that requires very few lines of code (under 50 lines constraint) and adheres to ADR 024 by maintaining custom `@utility` design system primitives.

### Before/After
*Before:* Tooltips appear with a simple opacity fade on hover/focus.
*After:* Tooltips smoothly slide up from slightly below their final position while fading in, providing a tactile, hardware-like snappiness that aligns with the telemetry aesthetic. (A screenshot showing the tooltip's presence was captured during frontend verification).

### Accessibility notes
The translation is applied consistently to both `group-hover` and `group-focus-visible` states, ensuring keyboard users receive the exact same polished visual feedback as mouse users when tabbing through tooltipped elements like the tactical-icon-button.

---
*PR created automatically by Jules for task [17537636200806471099](https://jules.google.com/task/17537636200806471099) started by @szubster*