### PR TITLE
🧠 Trainer: Support Gen 3 Static Gifts in Suggestion Engine

### DIFF
--- a/src/engine/assistant/__tests__/fetchAssistantApiDataGen23.test.ts
+++ b/src/engine/assistant/__tests__/fetchAssistantApiDataGen23.test.ts
@@ -1,0 +1,41 @@
+import 'fake-indexeddb/auto';
+import { expect, test, vi } from 'vitest';
+import { dexDataLoader } from '../../../db/DexDataLoader';
+import { pokeDB } from '../../../db/PokeDB';
+import type { SaveData } from '../../saveParser/index';
+import { fetchAssistantApiData } from '../suggestionEngine';
+
+test('fetchAssistantApiData for gen3', async () => {
+  const mockSaveData = {
+    generation: 3,
+    currentMapId: 0,
+    party: [],
+    trainerName: 'MAY',
+    inventory: [],
+  } as unknown as SaveData;
+  vi.spyOn(pokeDB, 'getEncountersBulk').mockResolvedValue([]);
+  vi.spyOn(pokeDB, 'getAllAreas').mockResolvedValue([]);
+  vi.spyOn(pokeDB, 'getLocations').mockResolvedValue([]);
+  const spy = vi.spyOn(dexDataLoader.pokemon, 'loadMany').mockResolvedValue([]);
+  const result = await fetchAssistantApiData(mockSaveData, []);
+  expect(result).toBeDefined();
+  // Test that the mock was called
+  expect(spy).toHaveBeenCalled();
+});
+
+test('fetchAssistantApiData for gen2', async () => {
+  const mockSaveData = {
+    generation: 2,
+    currentMapId: 0,
+    party: [],
+    trainerName: 'GOLD',
+    inventory: [],
+  } as unknown as SaveData;
+  vi.spyOn(pokeDB, 'getEncountersBulk').mockResolvedValue([]);
+  vi.spyOn(pokeDB, 'getAllAreas').mockResolvedValue([]);
+  vi.spyOn(pokeDB, 'getLocations').mockResolvedValue([]);
+  const spy = vi.spyOn(dexDataLoader.pokemon, 'loadMany').mockResolvedValue([]);
+  const result = await fetchAssistantApiData(mockSaveData, []);
+  expect(result).toBeDefined();
+  expect(spy).toHaveBeenCalled();
+});

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -39,6 +39,7 @@ import { getGenerationConfig } from '../../utils/generationConfig';
 
 import { STATIC_GIFT_DATA as STATIC_GIFT_DATA_GEN1 } from '../data/gen1/assistantData';
 import { STATIC_GIFT_DATA as STATIC_GIFT_DATA_GEN2 } from '../data/gen2/assistantData';
+import { STATIC_GIFT_DATA as STATIC_GIFT_DATA_GEN3 } from '../data/gen3/assistantData';
 import type { PokemonInstance, SaveData } from '../saveParser/index';
 import { generateBreedingSuggestions } from './generators/breedGenerator';
 // Generators
@@ -53,6 +54,7 @@ import { extractPlayerTools, filterSuggestionsByMissingTools } from './utils/enc
 // ⚡ Bolt: Eliminate O(N) tuple allocation and string parsing by pre-calculating static gift arrays
 const STATIC_GIFT_PIDS_GEN1 = Object.keys(STATIC_GIFT_DATA_GEN1).map((id) => parseInt(id, 10));
 const STATIC_GIFT_PIDS_GEN2 = Object.keys(STATIC_GIFT_DATA_GEN2).map((id) => parseInt(id, 10));
+const STATIC_GIFT_PIDS_GEN3 = Object.keys(STATIC_GIFT_DATA_GEN3).map((id) => parseInt(id, 10));
 
 /**
  * Fetches all necessary background data from local IndexedDB to power the suggestion engine.
@@ -126,7 +128,12 @@ export async function fetchAssistantApiData(saveData: SaveData, queryTargets: nu
 
   // 1. Get all relevant Pokemon details (Target, Party, Gifts)
   const partyPids = saveData.party || [];
-  const giftPids = saveData.generation === 2 ? STATIC_GIFT_PIDS_GEN2 : STATIC_GIFT_PIDS_GEN1;
+  const giftPids =
+    saveData.generation === 3
+      ? STATIC_GIFT_PIDS_GEN3
+      : saveData.generation === 2
+        ? STATIC_GIFT_PIDS_GEN2
+        : STATIC_GIFT_PIDS_GEN1;
   const allNeededPids = [...new Set([...queryTargets, ...partyPids, ...giftPids])];
 
   const allPokemon = await dexDataLoader.pokemon.loadMany(allNeededPids);


### PR DESCRIPTION
**What**
Added support for Gen 3 static gifts (`STATIC_GIFT_DATA_GEN3`) to the Assistant recommendation engine.

**Why**
Previously, the engine only checked for Gen 1 and Gen 2 static gifts, which caused missing data or incorrect evaluations for Generation 3 save files regarding gifts and events.

**Impact on recommendation quality**
Gen 3 static gifts are now properly tracked, evaluated, and suggested, leading to better and more accurate recommendations for Generation 3 games.

**Test coverage**
Passed `pnpm lint`, `pnpm test`, and E2E tests via `xvfb-run pnpm test:e2e`.

---
*PR created automatically by Jules for task [12257712465908847445](https://jules.google.com/task/12257712465908847445) started by @szubster*