### PR TITLE
Integrate Pokerus Strain Badge in Party View

### DIFF
--- a/.foundry/journals/coder/9901766214864946898.md
+++ b/.foundry/journals/coder/9901766214864946898.md
@@ -1,0 +1,5 @@
+# Session: 9901766214864946898
+- Integrated `PokerusBadge` into `StorageCard` in `src/components/StorageGrid.tsx`.
+- Displayed the badge when a Pokémon is in the Party and its Pokerus strain > 0.
+- Updated `src/components/__tests__/StorageGrid.test.tsx` to ensure `[PKRS STRN: 3]` renders.
+- Completed the task to integrate the Pokerus strain badge for Party Pokémon.

--- a/.foundry/tasks/task-323-346-integrate-pokerus-strain-party-view-impl.md
+++ b/.foundry/tasks/task-323-346-integrate-pokerus-strain-party-view-impl.md
@@ -34,6 +34,6 @@ Implement the integration of the Pokerus Strain Badge into the StorageGrid compo
 - **Intelligent Verification Protocol:** As this is a UI integration task that involves simple rendering logic with low risk, self-verification by the coder is sufficient. Ensure component integration tests are updated in `src/components/__tests__/StorageGrid.test.tsx`.
 
 ## 3. Acceptance Criteria
-- [ ] Integrate `PokerusBadge` into the `StorageCard` component for Party Pokémon in `src/components/StorageGrid.tsx`.
-- [ ] Extract Pokerus data from the parsed Pokémon structure (`p.pokerus.strain`) and pass it down.
-- [ ] Update `src/components/__tests__/StorageGrid.test.tsx` to verify the badge is rendered when appropriate data is provided.
+- [x] Integrate `PokerusBadge` into the `StorageCard` component for Party Pokémon in `src/components/StorageGrid.tsx`.
+- [x] Extract Pokerus data from the parsed Pokémon structure (`p.pokerus.strain`) and pass it down.
+- [x] Update `src/components/__tests__/StorageGrid.test.tsx` to verify the badge is rendered when appropriate data is provided.

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -6,6 +6,7 @@ import { useStore } from '../store';
 import { getGenerationConfig } from '../utils/generationConfig';
 import { getTimeCapsuleValidation } from '../utils/timeCapsule';
 import { CapacitySegmentedBar } from './CapacitySegmentedBar';
+import { PokerusBadge } from './PokerusBadge';
 import { PokemonSprite } from './pokemon/PokemonSprite';
 import { ShinyBadge } from './ShinyBadge';
 import { TacticalBadge } from './TacticalBadge';
@@ -78,6 +79,7 @@ const StorageCard = React.memo(
               {p.otName}
             </TacticalBadge>
           )}
+          {location === 'Party' && p.pokerus && p.pokerus.strain > 0 && <PokerusBadge strain={p.pokerus.strain} />}
         </div>
         <div className="relative mb-4 flex h-20 w-20 items-center justify-center sm:h-24 sm:w-24">
           <PokemonSprite

--- a/src/components/__tests__/StorageGrid.test.tsx
+++ b/src/components/__tests__/StorageGrid.test.tsx
@@ -52,7 +52,17 @@ test('renders grid with pokemon', async () => {
       (selector as (state: unknown) => unknown)({
         saveData: {
           generation: 1,
-          partyDetails: [{ speciesId: 1, storageLocation: 'Party', level: 5, isShiny: false, hash: '', otName: 'RED' }],
+          partyDetails: [
+            {
+              speciesId: 1,
+              storageLocation: 'Party',
+              level: 5,
+              isShiny: false,
+              hash: '',
+              otName: 'RED',
+              pokerus: { strain: 3, daysRemaining: 2 },
+            },
+          ],
           pcDetails: [
             { speciesId: 4, storageLocation: 'Box 1', level: 10, isShiny: true, hash: '', otName: 'BLUE' },
             {
@@ -82,6 +92,7 @@ test('renders grid with pokemon', async () => {
   // Check party pokemon
   await expect.element(page.getByText('Bulbasaur')).toBeInTheDocument();
   await expect.element(page.getByText('RED')).toBeInTheDocument();
+  await expect.element(page.getByText('[PKRS STRN: 3]')).toBeInTheDocument();
 
   // Check box pokemon
   await expect.element(page.getByText('Charmander')).toBeInTheDocument();


### PR DESCRIPTION
Implements TASK task-323-346-integrate-pokerus-strain-party-view-impl

- Integrate `PokerusBadge` into `StorageCard` component for Party Pokémon
- Check `location === 'Party'` and `p.pokerus.strain > 0` before rendering
- Add test assertions in `StorageGrid.test.tsx` to ensure `PokerusBadge` renders

---
*PR created automatically by Jules for task [9901766214864946898](https://jules.google.com/task/9901766214864946898) started by @szubster*