### PR TITLE
Gen 1 Trainer Data Extraction Implementation

### DIFF
--- a/.foundry/tasks/task-319-322-gen1-trainer-data-extraction-impl.md
+++ b/.foundry/tasks/task-319-322-gen1-trainer-data-extraction-impl.md
@@ -35,7 +35,7 @@ We need to extract the trainer defeat flags for Generation 1 games. This is part
 7. If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Implement Gen 1 trainer data extraction.
-- [ ] Define all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level.
-- [ ] Use explicit bitwise logic with boundary testing.
-- [ ] Write unit tests for extraction.
+- [x] Implement Gen 1 trainer data extraction.
+- [x] Define all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level.
+- [x] Use explicit bitwise logic with boundary testing.
+- [x] Write unit tests for extraction.

--- a/src/engine/saveParser/parsers/gen1.test.ts
+++ b/src/engine/saveParser/parsers/gen1.test.ts
@@ -210,6 +210,38 @@ describe('parseGen1 - specific data extraction', () => {
   });
 });
 
+describe('parseGen1 - trainerFlags extraction', () => {
+  it('should extract trainerFlags with absolute zero state and boundary values (ADR 026)', () => {
+    const buffer = new ArrayBuffer(32768);
+    const view = new DataView(buffer);
+
+    // Absolute zero state
+    let data = parseGen1(view);
+    expect(data.trainerFlags).toBeDefined();
+    expect(data.trainerFlags?.length).toBe(2240);
+    expect(data.trainerFlags?.every((flag) => flag === false)).toBe(true);
+
+    // Set all bits to 1
+    for (let i = 0; i < 0x118; i++) {
+      view.setUint8(0x29e6 + i, 0xff);
+    }
+    data = parseGen1(view);
+    expect(data.trainerFlags?.every((flag) => flag === true)).toBe(true);
+
+    // Set specific boundaries (first bit and last bit)
+    for (let i = 0; i < 0x118; i++) {
+      view.setUint8(0x29e6 + i, 0x00);
+    }
+    view.setUint8(0x29e6, 0x01); // 1st bit
+    view.setUint8(0x29e6 + 0x117, 0x80); // Last bit
+    data = parseGen1(view);
+    expect(data.trainerFlags?.[0]).toBe(true);
+    expect(data.trainerFlags?.[1]).toBe(false);
+    expect(data.trainerFlags?.[2239]).toBe(true);
+    expect(data.trainerFlags?.[2238]).toBe(false);
+  });
+});
+
 describe('parseGen1 - additional branches', () => {
   it('should ignore invalid species when extracting party', () => {
     const buffer = new ArrayBuffer(32768);

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -26,6 +26,8 @@ const POKEDEX_SEEN_OFFSET_FROM_OWNED = 19;
 const POKEDEX_TOTAL_MONS = 151;
 const POKEDEX_PADDING_BYTE_OFFSET = 18;
 const BITS_PER_BYTE = 8;
+const EVENT_FLAGS_MAX_BITS = EVENT_FLAGS_LENGTH * BITS_PER_BYTE;
+const BIT_MASK = 1;
 const POKEDEX_PADDING_BIT_MASK = 0x80;
 const PC_CURRENT_BOX_NUM_OFFSET = 0x284c;
 const PC_CURRENT_BOX_COUNT_OFFSET = 0x30c0;
@@ -817,6 +819,15 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
     if (e instanceof RangeError) throw new Error('The save file is corrupted or incomplete.');
     throw e;
   }
+
+  const trainerFlags: boolean[] = [];
+  for (let i = 0; i < EVENT_FLAGS_MAX_BITS; i++) {
+    const byteIdx = Math.floor(i / BITS_PER_BYTE);
+    const bitIdx = i % BITS_PER_BYTE;
+    const byte = eventFlags[byteIdx] ?? 0;
+    trainerFlags.push(((byte >> bitIdx) & BIT_MASK) !== 0);
+  }
+
   const hiddenItemFlagsOffset = HIDDEN_ITEM_FLAGS_OFFSET + offsetShift;
   const hiddenItemFlags = new Uint8Array(HIDDEN_ITEM_FLAGS_LENGTH);
   try {
@@ -859,6 +870,7 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
     hallOfFameCount,
     hallOfFameRecords,
     eventFlags,
+    trainerFlags,
     hiddenItemFlags,
     hiddenCoinFlags,
     gen1StaticEncounters: parseGen1StaticEncounters(eventFlags),


### PR DESCRIPTION
This PR implements trainer defeat flags extraction for Generation 1 games.

- Extracts trainer defeat flags from the Gen 1 save file.
- Uses explicit bitwise logic with boundary testing.
- Defines all memory offsets, lengths, bit locations, and shifts as reusable constants at the module level.
- Implements unit tests covering absolute zero state, boundary states, and max boundary values.

---
*PR created automatically by Jules for task [12472746352732801066](https://jules.google.com/task/12472746352732801066) started by @szubster*