### PR TITLE
chore(deps-dev): bump @11ty/gray-matter from 2.1.0 to 3.0.0

### DIFF
--- a/.foundry/epics/epic-054-269-gen3-ash-dashboard.md
+++ b/.foundry/epics/epic-054-269-gen3-ash-dashboard.md
@@ -6,9 +6,8 @@ status: PENDING
 owner_persona: story_owner
 created_at: "2026-07-17"
 updated_at: "2026-07-17"
-depends_on: [
-  "epic-054-268-gen3-ash-save-parsing"
-]
+depends_on:
+  - "epic-054-268-gen3-ash-save-parsing"
 jules_session_id: null
 pr_number: null
 parent: prd-089-054-gen3-ash-gathering-tracker

--- a/.foundry/epics/epic-054-270-gen3-ash-goal-planner.md
+++ b/.foundry/epics/epic-054-270-gen3-ash-goal-planner.md
@@ -6,9 +6,8 @@ status: PENDING
 owner_persona: story_owner
 created_at: "2026-07-17"
 updated_at: "2026-07-17"
-depends_on: [
-  "epic-054-269-gen3-ash-dashboard"
-]
+depends_on:
+  - "epic-054-269-gen3-ash-dashboard"
 jules_session_id: null
 pr_number: null
 parent: prd-089-054-gen3-ash-gathering-tracker

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
-    "@11ty/gray-matter": "^2.1.0",
+    "@11ty/gray-matter": "^3.0.0",
     "@biomejs/biome": "^2.5.6",
     "@cloudflare/workers-types": "^5.20260729.1",
     "@codecov/vite-plugin": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         version: 5.0.14(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     devDependencies:
       '@11ty/gray-matter':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.0
+        version: 3.0.0
       '@biomejs/biome':
         specifier: ^2.5.6
         version: 2.5.6
@@ -193,8 +193,8 @@ importers:
 
 packages:
 
-  '@11ty/gray-matter@2.1.0':
-    resolution: {integrity: sha512-fNdBOb3MgDz/1UCIoeY4wDuGbp+/3s5y6UrsyfMabECbh/CVycj7Er33JXqSxRwxrRKXcGE1Jipuq/1mODInsQ==}
+  '@11ty/gray-matter@3.0.0':
+    resolution: {integrity: sha512-mi6KB36DZCpCfCb9XP3NtDDNXe1N0jKtuFj9mTCZNy5H7vTabODyMgFmmOiGIGJKt+i8mJqEb/REtK+JTEzlpQ==}
     engines: {node: '>=11'}
 
   '@actions/core@3.0.1':
@@ -3534,6 +3534,10 @@ packages:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
+    hasBin: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -4945,9 +4949,9 @@ packages:
 
 snapshots:
 
-  '@11ty/gray-matter@2.1.0':
+  '@11ty/gray-matter@3.0.0':
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 5.2.2
       section-matter: 1.0.0
 
   '@actions/core@3.0.1':
@@ -8067,6 +8071,10 @@ snapshots:
       esprima: 4.0.1
 
   js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
This PR bumps `@11ty/gray-matter` from `2.1.0` to `3.0.0` in package.json and updates the pnpm lockfile. It also fixes two YAML frontmatter bracket flow array sequences that cause YAMLException parsing errors with the new version of `js-yaml` brought in by the dependency upgrade.

Fixes #5387

---
*PR created automatically by Jules for task [5644678693910069605](https://jules.google.com/task/5644678693910069605) started by @szubster*