### PR TITLE
Late Binding: Missing Gen 3 Party and PC Box Offsets

### DIFF
--- a/.foundry/journals/coder/14382996938646149882.md
+++ b/.foundry/journals/coder/14382996938646149882.md
@@ -1,0 +1,2 @@
+# Late Binding for Missing Context
+When a task asks to implement extraction from memory (e.g. Gen 3 Party and PC box extraction), but the specific memory offsets for these structures are not yet defined as constants in the parser (`src/engine/saveParser/parsers/gen3.ts`), I must not guess. Following the core policies, I must suspend the current task by setting its `status` to `FAILED` with an appropriate `rejection_reason`, create a new `RESEARCH` node to find the offsets, append the new node to the `depends_on` array and body of the task.

--- a/.foundry/research/research-157-369-gen3-party-box-offsets.md
+++ b/.foundry/research/research-157-369-gen3-party-box-offsets.md
@@ -1,0 +1,35 @@
+---
+id: research-157-369-gen3-party-box-offsets
+type: RESEARCH
+title: Research Gen 3 Party and PC Box Memory Offsets
+status: PENDING
+owner_persona: researcher
+created_at: '2026-07-31'
+updated_at: '2026-07-31'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - backend
+  - save-parsing
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research Gen 3 Party and PC Box Memory Offsets
+
+## Objective
+Research the exact memory offsets and structure for Party Pokémon and PC Box Pokémon in Generation 3 save files to enable accurate data extraction of PIDs.
+
+## Context
+Task `task-099-157-gen3-extract-pokemon-pids-impl` requires implementing backend data extraction for Gen 3 Party and PC Box PIDs. The exact memory offsets and structure of this data within the save file are currently unknown in the codebase, preventing implementation without risking memory layout errors.
+
+## Acceptance Criteria
+- [ ] Research and document the memory offsets and structure for Party Pokémon in Gen 3 saves (Ruby/Sapphire, Emerald, FireRed/LeafGreen).
+- [ ] Research and document the memory offsets and structure for PC Box data in Gen 3 saves (Ruby/Sapphire, Emerald, FireRed/LeafGreen).
+- [ ] Detail the structure and offsets of the PIDs for Pokémon stored within the party and boxes.
+- [ ] Document these findings in `.foundry/docs/knowledge_base/engine/save_parsing/`.

--- a/.foundry/tasks/task-099-157-gen3-extract-pokemon-pids-impl.md
+++ b/.foundry/tasks/task-099-157-gen3-extract-pokemon-pids-impl.md
@@ -2,11 +2,12 @@
 id: task-099-157-gen3-extract-pokemon-pids-impl
 type: TASK
 title: Implement Gen 3 Pokemon PID Extraction
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-06-10'
 updated_at: '2026-07-31'
-depends_on: []
+depends_on:
+  - research-157-369-gen3-party-box-offsets
 jules_session_id: '14382996938646149882'
 pr_number: null
 parent: story-061-099-extract-pokemon-pids
@@ -16,7 +17,7 @@ tags:
   - mirage-island
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Late binding: spawned research node to find exact memory offsets for Gen 3 party and PC boxes to prevent incorrect memory reading, as required by the Late Binding for Missing Context policy.'
 notes: ''
 ---
 
@@ -39,3 +40,5 @@ As part of the Mirage Island Engine updates, we need to extract the 32-bit Perso
 ## Coder Persona Reminders
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
 - If you submit an empty PR for a completed task (e.g., if the work is already done), you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the frontmatter in this case.
+
+- [ ] research-157-369-gen3-party-box-offsets


### PR DESCRIPTION
This empty PR is being submitted to spawn a RESEARCH node (`research-157-369-gen3-party-box-offsets`) as the exact memory offsets for Gen 3 Party and PC Box PID extraction are currently undocumented in the codebase. As per the Late Binding policy, I have suspended the current task (`task-099-157-gen3-extract-pokemon-pids-impl`) by changing its status to FAILED and adding a `rejection_reason`, and appended the new research node to `depends_on`.

---
*PR created automatically by Jules for task [14382996938646149882](https://jules.google.com/task/14382996938646149882) started by @szubster*