### PR TITLE
fix: sort pokemon types by slot in generation script

### DIFF
--- a/.foundry/journals/coder/2026-07-31-13-04-25.md
+++ b/.foundry/journals/coder/2026-07-31-13-04-25.md
@@ -1,0 +1,16 @@
+# Session Journal: task-333-369-pokemon-types-data-retry-impl
+
+## Observations
+- The previous task `task-333-363` correctly updated `schema.ts` to export `POKEMON_TYPE` and `POKEMON_TYPE_MAP`.
+- The generation script `generate-pokedata.ts` was mapping the type string to the ID but wasn't sorting by `slot`.
+- The fix required sorting `pData.types` array by `slot` before passing it to the mapping logic, ensuring primary and secondary types were inserted correctly into the database.
+
+## Learnings
+- When updating data pipelines, small omissions like sorting by slot (for primary/secondary typing) can fail entire tasks.
+- Always use `pnpm run data:gen` to test generation scripts locally, but remember to revert the untracked modified data generated in `data/db/` if you only intend to submit the script changes to keep the PR clean.
+- Ensure strict adherence to the exact wording required for the pre-commit step in the plan.
+
+## Actions Taken
+- Appended a `.sort((a, b) => a.slot - b.slot)` in the map mapping function inside `generate-pokedata.ts`.
+- Reverted locally generated JSONL files inside `data/db/` to prevent committing generated artifacts.
+- Checked off acceptance criteria in `.foundry/tasks/task-333-369-pokemon-types-data-retry-impl.md`.

--- a/.foundry/tasks/task-333-369-pokemon-types-data-retry-impl.md
+++ b/.foundry/tasks/task-333-369-pokemon-types-data-retry-impl.md
@@ -36,7 +36,7 @@ A retry of `task-333-363`. We need to expose a Pokemon's primary and secondary t
    - **CRITICAL**: Ensure the types are sorted by their `slot` property before storing them.
 
 ## Acceptance Criteria
-- [ ] `POKEMON_TYPE` and `POKEMON_TYPE_MAP` are exported in `schema.ts`.
-- [ ] `PokemonMetadata` includes the `types?: number[]` property.
-- [ ] `generate-pokedata.ts` populates `types`, sorted by `slot`.
-- [ ] Running `pnpm lint` and `pnpm test` passes successfully.
+- [x] `POKEMON_TYPE` and `POKEMON_TYPE_MAP` are exported in `schema.ts`.
+- [x] `PokemonMetadata` includes the `types?: number[]` property.
+- [x] `generate-pokedata.ts` populates `types`, sorted by `slot`.
+- [x] Running `pnpm lint` and `pnpm test` passes successfully.

--- a/scripts/generate-pokedata.ts
+++ b/scripts/generate-pokedata.ts
@@ -261,7 +261,7 @@ async function main() {
       cr: sData.capture_rate,
       gr: sData.gender_rate,
       eg: sData.egg_groups?.map((g: any) => EGG_GROUP_MAP[g.name] || 0) || [],
-      types: pData.types?.map((t: any) => POKEMON_TYPE_MAP[t.type.name] || 0) || [],
+      types: pData.types?.sort((a: any, b: any) => a.slot - b.slot).map((t: any) => POKEMON_TYPE_MAP[t.type.name] || 0) || [],
       baby: sData.is_baby,
       em: undefined, // Will be populated in second pass
       // Temporaries to be filled in second pass


### PR DESCRIPTION
Fixes the data generation logic to sort types by slot, addressing the requirements of task 333-369.

### What
Added a sorting step based on the `slot` property of the `types` array from PokeAPI before mapping the types in `generate-pokedata.ts`.

### Why
To ensure the correct primary and secondary typing order is strictly preserved.

### Acceptance Criteria
- [x] POKEMON_TYPE and POKEMON_TYPE_MAP are exported in schema.ts.
- [x] PokemonMetadata includes the types?: number[] property.
- [x] generate-pokedata.ts populates types, sorted by slot.
- [x] Running pnpm lint and pnpm test passes successfully.

---
*PR created automatically by Jules for task [1478875382022248861](https://jules.google.com/task/1478875382022248861) started by @szubster*