### PR TITLE
🧭 Tech Lead: Blueprint regional dex sorting tasks

### DIFF
--- a/.foundry/journals/tech_lead/8328727666729636231.md
+++ b/.foundry/journals/tech_lead/8328727666729636231.md
@@ -8,3 +8,7 @@ As required by the "Handling Permanent Child Failures (The Impossible Loop)" pol
 - `task-333-371-sorting-strategies-retry-qa`
 
 These downstream tasks correctly depend on the `RESEARCH` node being completed. I checked off the permanently failed and cancelled child nodes (`task-333-363`, `task-333-364`, `task-333-365`, `task-333-366`) in my story's markdown body so that ADR 007's requirement is met and the parent node can eventually transition to COMPLETED once the replacement nodes finish.
+
+Later, I was woken up again because `task-333-371-sorting-strategies-retry-qa` completed, but the story's initial acceptance criteria (to implement regional variants in `DexNumberSorter`) was never fully satisfied because the coder threw a `NotImplementedError` for the regional variant check in `task-333-365` which wasn't fully caught by the initial QA process since the task was cancelled.
+
+Since the regional variant implementation was still missing, I adhered to the Late Binding and Blueprinting directives. I did not attempt to map or implement the missing components myself, but explicitly generated `task-333-375-sorting-strategies-regional-dex-impl` for a coder to determine how to map Hoenn Dex/Regional variants correctly, along with `task-333-376-sorting-strategies-regional-dex-qa` for QA to verify it. I appended these task references as unchecked boxes to the `## Acceptance Criteria` of the parent story `story-136-333-sorting-standard-strategies-retry`.

--- a/.foundry/stories/story-136-333-sorting-standard-strategies-retry.md
+++ b/.foundry/stories/story-136-333-sorting-standard-strategies-retry.md
@@ -42,3 +42,5 @@ Building upon the standard interface, we need specific, actionable sorters that 
 - [ ] [task-333-369-pokemon-types-data-retry-impl](.foundry/tasks/task-333-369-pokemon-types-data-retry-impl.md)
 - [ ] [task-333-370-pokemon-types-data-retry-qa](.foundry/tasks/task-333-370-pokemon-types-data-retry-qa.md)
 - [ ] [task-333-371-sorting-strategies-retry-qa](.foundry/tasks/task-333-371-sorting-strategies-retry-qa.md)
+- [ ] task-333-375-sorting-strategies-regional-dex-impl
+- [ ] task-333-376-sorting-strategies-regional-dex-qa

--- a/.foundry/tasks/task-333-375-sorting-strategies-regional-dex-impl.md
+++ b/.foundry/tasks/task-333-375-sorting-strategies-regional-dex-impl.md
@@ -1,0 +1,35 @@
+---
+id: task-333-375-sorting-strategies-regional-dex-impl
+type: TASK
+title: Implement Regional Dex Sorting Strategy
+status: READY
+owner_persona: coder
+created_at: '2026-07-31'
+updated_at: '2026-07-31'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-136-333-sorting-standard-strategies-retry
+tags:
+  - feature
+  - sorting
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Regional Dex Sorting Strategy
+
+## Context
+The `DexNumberSorter` in `src/engine/sorting/StandardSorters.ts` currently throws an error for regional variants. We need to implement regional dex sorting.
+
+## Requirements
+1. Update `DexNumberSorter` in `src/engine/sorting/StandardSorters.ts` to properly handle `regional` variant sorting.
+2. Identify or implement a mapping of National Dex IDs to Regional Dex IDs (e.g., Hoenn Dex) to perform the sorting correctly.
+3. Update `src/engine/sorting/StandardSorters.test.ts` to cover the new functionality.
+
+## Acceptance Criteria
+- [ ] `DexNumberSorter` successfully sorts by regional dex order when configured with `variant: 'regional'`.
+- [ ] Unit tests in `StandardSorters.test.ts` pass and assert correct regional sorting orders.
+- [ ] `pnpm lint` and `pnpm test` pass.

--- a/.foundry/tasks/task-333-376-sorting-strategies-regional-dex-qa.md
+++ b/.foundry/tasks/task-333-376-sorting-strategies-regional-dex-qa.md
@@ -1,0 +1,31 @@
+---
+id: task-333-376-sorting-strategies-regional-dex-qa
+type: TASK
+title: QA Regional Dex Sorting Strategy
+status: READY
+owner_persona: qa
+created_at: '2026-07-31'
+updated_at: '2026-07-31'
+depends_on:
+  - task-333-375-sorting-strategies-regional-dex-impl
+jules_session_id: null
+pr_number: null
+parent: story-136-333-sorting-standard-strategies-retry
+tags:
+  - feature
+  - sorting
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Regional Dex Sorting Strategy
+
+## Context
+QA verification for the regional dex sorting strategy implemented in `task-333-375-sorting-strategies-regional-dex-impl`.
+
+## Acceptance Criteria
+- [ ] Verify `DexNumberSorter` correctly sorts using the regional dex when configured with `variant: 'regional'`.
+- [ ] Verify `pnpm test` passes for sorting unit tests.
+- [ ] Verify `pnpm lint` passes.


### PR DESCRIPTION
Adds task-333-375 and task-333-376 for implementing regional dex sorting support in DexNumberSorter.

---
*PR created automatically by Jules for task [15956662085994948810](https://jules.google.com/task/15956662085994948810) started by @szubster*