### PR TITLE
QA: verify Feebas IDs to Coordinates mapping

### DIFF
--- a/.foundry/journals/qa/4230931540957269591.md
+++ b/.foundry/journals/qa/4230931540957269591.md
@@ -1,0 +1,13 @@
+# Session 4230931540957269591
+
+## Task
+task-342-370-feebas-coordinates-qa
+
+## Findings
+- Verified `gen3FeebasTiles` in `SaveData` is correctly typed as `[number, number][]`.
+- Verified `mapSpotIdsToCoordinates` is properly integrated in `src/engine/saveParser/parsers/gen3.ts`.
+- Verified the code adhered to "Save File Parsing & Extraction Guidelines" (Section 13). Constants used, catching `RangeError`, using `DataView` API.
+- Verified tests pass (`gen3.test.ts` and `feebas.test.ts`) and ensure it's coordinates.
+
+## Action
+Checked off acceptance criteria and preparing empty PR.

--- a/.foundry/tasks/task-342-370-feebas-coordinates-qa.md
+++ b/.foundry/tasks/task-342-370-feebas-coordinates-qa.md
@@ -27,10 +27,10 @@ notes: ''
 Verify the `coder` correctly updated `gen3FeebasTiles` to be an array of 2D coordinates `[number, number][]` and successfully integrated `mapSpotIdsToCoordinates` into the parsing logic.
 
 ## Acceptance Criteria
-- [ ] Review PR/code to ensure `gen3FeebasTiles` in `SaveData` is correctly typed as `[number, number][]` in `src/engine/saveParser/parsers/common.ts`.
-- [ ] Verify that the extraction logic correctly calls `mapSpotIdsToCoordinates` before populating `gen3FeebasTiles` in the returned `SaveData` object.
-- [ ] Verify the coder strictly adhered to the "Save File Parsing & Extraction Guidelines" in `.foundry/docs/schema.md` (Section 13).
-- [ ] Verify corresponding tests pass and specifically check that the returned tiles are coordinates and not scalar IDs.
+- [x] Review PR/code to ensure `gen3FeebasTiles` in `SaveData` is correctly typed as `[number, number][]` in `src/engine/saveParser/parsers/common.ts`.
+- [x] Verify that the extraction logic correctly calls `mapSpotIdsToCoordinates` before populating `gen3FeebasTiles` in the returned `SaveData` object.
+- [x] Verify the coder strictly adhered to the "Save File Parsing & Extraction Guidelines" in `.foundry/docs/schema.md` (Section 13).
+- [x] Verify corresponding tests pass and specifically check that the returned tiles are coordinates and not scalar IDs.
 
 ## Failure Rules & Instructions
 - If the coder's implementation is flawed, reject the task by setting the coder task's frontmatter to `status: FAILED` with a detailed `rejection_reason`.


### PR DESCRIPTION
Verified coder correctly updated gen3FeebasTiles to [number, number][], utilized mapSpotIdsToCoordinates, and strictly adhered to Section 13 guidelines. All corresponding tests pass.

---
*PR created automatically by Jules for task [4230931540957269591](https://jules.google.com/task/4230931540957269591) started by @szubster*