### PR TITLE
Implement regional dex sorting strategy

### DIFF
--- a/.foundry/tasks/task-333-375-sorting-strategies-regional-dex-impl.md
+++ b/.foundry/tasks/task-333-375-sorting-strategies-regional-dex-impl.md
@@ -30,6 +30,6 @@ The `DexNumberSorter` in `src/engine/sorting/StandardSorters.ts` currently throw
 3. Update `src/engine/sorting/StandardSorters.test.ts` to cover the new functionality.
 
 ## Acceptance Criteria
-- [ ] `DexNumberSorter` successfully sorts by regional dex order when configured with `variant: 'regional'`.
-- [ ] Unit tests in `StandardSorters.test.ts` pass and assert correct regional sorting orders.
-- [ ] `pnpm lint` and `pnpm test` pass.
+- [x] `DexNumberSorter` successfully sorts by regional dex order when configured with `variant: 'regional'`.
+- [x] Unit tests in `StandardSorters.test.ts` pass and assert correct regional sorting orders.
+- [x] `pnpm lint` and `pnpm test` pass.

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -319,7 +319,7 @@ export const GEN3_POKEDEX_OWNED_OFFSET = 0x10;
 export const GEN3_POKEDEX_SEEN_OFFSET = 0x44;
 export const NATIONAL_DEX_MAX = 386;
 
-export const HOENN_DEX_NATIONAL_IDS = new Set<number>([
+export const HOENN_DEX_ORDER = [
   252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274,
   275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 63, 64, 65, 290, 291, 292, 293, 294, 295,
   296, 297, 118, 119, 129, 130, 298, 183, 184, 74, 75, 76, 299, 300, 301, 41, 42, 169, 72, 73, 302, 303, 304, 305, 306,
@@ -329,7 +329,9 @@ export const HOENN_DEX_NATIONAL_IDS = new Set<number>([
   353, 354, 355, 356, 357, 358, 359, 37, 38, 172, 25, 26, 54, 55, 360, 202, 177, 178, 203, 231, 232, 127, 214, 111, 112,
   361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 222, 170, 171, 371, 116, 117, 230, 372, 373, 374, 375, 376, 377,
   378, 379, 380, 381, 382, 383, 384, 385, 386,
-]);
+];
+
+export const HOENN_DEX_NATIONAL_IDS = new Set<number>(HOENN_DEX_ORDER);
 
 /**
  * Locates the most recent memory offset for a specific save section in Gen 3 flash memory.

--- a/src/engine/sorting/StandardSorters.test.ts
+++ b/src/engine/sorting/StandardSorters.test.ts
@@ -52,10 +52,28 @@ describe('StandardSorters', () => {
       expect(sorter(p2, p1)).toBeLessThan(0);
     });
 
-    it('throws error for regional variant', () => {
-      expect(() =>
-        new DexNumberSorter({ variant: 'regional' }).sort(createSortable(1, 1), createSortable(2, 1)),
-      ).toThrow('Regional variant sorting is not supported yet.');
+    it('sorts by Hoenn dex order for regional variant', () => {
+      const sorter = new DexNumberSorter({ variant: 'regional' }).sort;
+      // Treecko (252) is #1 in Hoenn Dex, Abra (63) is #39, Bulbasaur (1) is not in Hoenn Dex
+      const treecko = createSortable(252, 5);
+      const abra = createSortable(63, 5);
+      const bulbasaur = createSortable(1, 5);
+
+      expect(sorter(treecko, abra)).toBeLessThan(0);
+      expect(sorter(abra, treecko)).toBeGreaterThan(0);
+      expect(sorter(treecko, bulbasaur)).toBeLessThan(0);
+      expect(sorter(bulbasaur, treecko)).toBeGreaterThan(0);
+    });
+
+    it('sorts by National Dex order for regional variant if both are not in Hoenn Dex', () => {
+      const sorter = new DexNumberSorter({ variant: 'regional' }).sort;
+      // Bulbasaur (1) and Charmander (4) are not in Hoenn Dex
+      const bulbasaur = createSortable(1, 5);
+      const charmander = createSortable(4, 5);
+
+      expect(sorter(bulbasaur, charmander)).toBeLessThan(0);
+      expect(sorter(charmander, bulbasaur)).toBeGreaterThan(0);
+      expect(sorter(bulbasaur, bulbasaur)).toBe(0);
     });
   });
 

--- a/src/engine/sorting/StandardSorters.ts
+++ b/src/engine/sorting/StandardSorters.ts
@@ -1,3 +1,4 @@
+import { HOENN_DEX_ORDER } from '../saveParser/parsers/gen3';
 import type { SortingStrategy } from './SortingStrategy';
 
 export class DexNumberSorter {
@@ -9,7 +10,14 @@ export class DexNumberSorter {
 
   public sort: SortingStrategy = (a, b) => {
     if (this.config.variant === 'regional') {
-      throw new Error('Regional variant sorting is not supported yet.');
+      const idxA = HOENN_DEX_ORDER.indexOf(a.instance.speciesId);
+      const idxB = HOENN_DEX_ORDER.indexOf(b.instance.speciesId);
+      const rankA = idxA !== -1 ? idxA : Infinity;
+      const rankB = idxB !== -1 ? idxB : Infinity;
+      if (rankA === rankB) {
+        return a.instance.speciesId - b.instance.speciesId;
+      }
+      return rankA - rankB;
     }
     return a.instance.speciesId - b.instance.speciesId;
   };


### PR DESCRIPTION
This PR resolves an issue where the `DexNumberSorter` threw a "Not supported yet" error when attempting to sort a box using a regional variant. It now maps the instance's `speciesId` against the actual Regional Dex order for Gen 3 (using `HOENN_DEX_ORDER`). 

If both Pokémon compared are not present in the Regional Dex (e.g. they both return an index of -1/Infinity), the sorter falls back to standard National Dex sorting to ensure the algorithm doesn't break due to `NaN` calculations. Extensive test coverage has been added.

---
*PR created automatically by Jules for task [9002915095100024659](https://jules.google.com/task/9002915095100024659) started by @szubster*