### PR TITLE
feat: Concurrent Game Switcher UI

### DIFF
--- a/.foundry/journals/coder/16019314865216773266.md
+++ b/.foundry/journals/coder/16019314865216773266.md
@@ -1,0 +1,5 @@
+# Session 16019314865216773266
+
+- For Vitest browser tests, import `page` and `userEvent` from `vitest/browser` (do not use the deprecated `@vitest/browser/context`).
+- The project uses `biome` for linting and code formatting. Run `pnpm check:fix` to automatically resolve fixable biome issues across the codebase.
+- ADR 008 explicitly requires `rounded-none` to be present on UI components for the "tactical hardware/snooping" aesthetic, even if standard elements like `div` are sharp by default.

--- a/.foundry/tasks/task-257-371-concurrent-game-switcher-ui-impl.md
+++ b/.foundry/tasks/task-257-371-concurrent-game-switcher-ui-impl.md
@@ -31,4 +31,4 @@ Develop a UI for users to select and manage multiple active playthroughs across 
 - Build the switcher component.
 
 ## Acceptance Criteria
-- [ ] Implement the Concurrent Game Switcher UI.
+- [x] Implement the Concurrent Game Switcher UI.

--- a/src/components/concurrent/GameSwitcher.tsx
+++ b/src/components/concurrent/GameSwitcher.tsx
@@ -1,0 +1,30 @@
+import type React from 'react';
+import { useConcurrentGame } from '../../contexts/ConcurrentGameContext';
+
+export const GameSwitcher: React.FC = () => {
+  const { state, setActivePlaythrough } = useConcurrentGame();
+
+  if (state.playthroughs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2 rounded-none border border-zinc-800 border-dashed bg-zinc-950/80 px-3 py-1.5">
+      <span className="font-mono text-[10px] text-zinc-500 uppercase tracking-widest">Active PT</span>
+      <select
+        className="bg-transparent font-mono text-[11px] text-[var(--theme-primary)] outline-none"
+        value={state.activePlaythroughId || ''}
+        onChange={(e) => setActivePlaythrough(e.target.value || null)}
+      >
+        <option value="" className="bg-zinc-900">
+          None
+        </option>
+        {state.playthroughs.map((pt) => (
+          <option key={pt.id} value={pt.id} className="bg-zinc-900 text-white">
+            {pt.name} ({pt.gameVersion})
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};

--- a/src/components/concurrent/__tests__/GameSwitcher.test.tsx
+++ b/src/components/concurrent/__tests__/GameSwitcher.test.tsx
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import type { ConcurrentGameContextType } from '../../../contexts/ConcurrentGameContext';
+import { useConcurrentGame } from '../../../contexts/ConcurrentGameContext';
+import { GameSwitcher } from '../GameSwitcher';
+
+vi.mock('../../../contexts/ConcurrentGameContext', () => ({
+  useConcurrentGame: vi.fn<() => ConcurrentGameContextType>(),
+}));
+
+describe('GameSwitcher', () => {
+  const mockSetActivePlaythrough = vi.fn<(id: string | null) => void>();
+  const mockRemovePlaythrough = vi.fn<(id: string) => void>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders null when there are no playthroughs', async () => {
+    vi.mocked(useConcurrentGame).mockReturnValue({
+      state: { playthroughs: [], activePlaythroughId: null },
+      setActivePlaythrough: mockSetActivePlaythrough,
+      removePlaythrough: mockRemovePlaythrough,
+      addPlaythrough: vi.fn<() => void>(),
+    });
+
+    await render(<GameSwitcher />);
+    await expect.element(page.getByText('Active PT')).not.toBeInTheDocument();
+  });
+
+  it('renders a select dropdown when playthroughs exist', async () => {
+    vi.mocked(useConcurrentGame).mockReturnValue({
+      state: {
+        playthroughs: [{ id: '1', name: 'Emerald PT', gameVersion: 'emerald', lastPlayed: Date.now() }],
+        activePlaythroughId: '1',
+      },
+      setActivePlaythrough: mockSetActivePlaythrough,
+      removePlaythrough: mockRemovePlaythrough,
+      addPlaythrough: vi.fn<() => void>(),
+    });
+
+    await render(<GameSwitcher />);
+    await expect.element(page.getByText('Active PT')).toBeVisible();
+    await expect.element(page.getByRole('combobox')).toBeVisible();
+    // Options are not inherently visible unless dropdown is open in vitest-browser-react/playwright sometimes
+    await expect.element(page.getByText('Emerald PT (emerald)')).toBeInTheDocument();
+  });
+
+  it('calls setActivePlaythrough on selection change', async () => {
+    vi.mocked(useConcurrentGame).mockReturnValue({
+      state: {
+        playthroughs: [
+          { id: '1', name: 'Emerald PT', gameVersion: 'emerald', lastPlayed: Date.now() },
+          { id: '2', name: 'Ruby PT', gameVersion: 'ruby', lastPlayed: Date.now() },
+        ],
+        activePlaythroughId: '1',
+      },
+      setActivePlaythrough: mockSetActivePlaythrough,
+      removePlaythrough: mockRemovePlaythrough,
+      addPlaythrough: vi.fn<() => void>(),
+    });
+
+    await render(<GameSwitcher />);
+    const select = page.getByRole('combobox');
+    await userEvent.selectOptions(select, '2');
+
+    expect(mockSetActivePlaythrough).toHaveBeenCalledWith('2');
+  });
+});


### PR DESCRIPTION
Implements the Concurrent Game Switcher component as specified in the UI task node `task-257-371-concurrent-game-switcher-ui-impl`.

- Created `GameSwitcher.tsx`
- Created `GameSwitcher.test.tsx` using `vitest-browser-react`
- Uses `useConcurrentGame` context
- Adheres to tactical UI styling constraints
- Includes E2E/browser test coverage

---
*PR created automatically by Jules for task [16019314865216773266](https://jules.google.com/task/16019314865216773266) started by @szubster*