### PR TITLE
🔐 Security: Upgrade vulnerable brace-expansion dependency

### DIFF
--- a/.jules/shield/2026-08-01-01-58-16.md
+++ b/.jules/shield/2026-08-01-01-58-16.md
@@ -1,0 +1,11 @@
+# Shield Security Journal - brace-expansion Vulnerability
+
+**Vulnerability:**
+A high-severity DoS vulnerability via unbounded expansion length (GHSA-mh99-v99m-4gvg) was discovered in `brace-expansion < 2.1.3`.
+
+**Action Taken:**
+Added a pnpm override in `pnpm-workspace.yaml` for `brace-expansion@<2.1.3` to resolve to `^2.1.3`.
+
+**Key Learnings:**
+- In a pnpm workspaces setup, dependency overrides must be configured using the `overrides:` block within `pnpm-workspace.yaml`. The `pnpm.overrides` field in `package.json` is deprecated and ignored by newer versions of pnpm.
+- When applying overrides, ensure the resolution string is a valid semver range and preserves major version bounds (e.g. `^2.1.3` instead of `>=2.1.3`) to prevent pulling in breaking changes (like ESM-only updates) that could cause runtime crashes in dependencies.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@<2.1.3: ^2.1.3
+
 importers:
 
   .:
@@ -2649,8 +2652,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -7138,7 +7141,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -8348,7 +8351,7 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,6 @@ allowBuilds:
 auditConfig:
   ignoreGhsas:
     - GHSA-rmmr-r34h-pfm5
+
+overrides:
+  "brace-expansion@<2.1.3": "^2.1.3"


### PR DESCRIPTION
🎯 What
Added a pnpm override in `pnpm-workspace.yaml` for `brace-expansion`.

⚠️ Risk
High severity Denial of Service (DoS) vulnerability in `brace-expansion < 2.1.3` via unbounded expansion length (GHSA-mh99-v99m-4gvg).

🛡️ Solution
Forced resolution of `brace-expansion@<2.1.3` to `^2.1.3` via `pnpm-workspace.yaml` overrides, resolving the vulnerability while staying safely within the 2.x major release to avoid breaking changes.

---
*PR created automatically by Jules for task [6899508827634458845](https://jules.google.com/task/6899508827634458845) started by @szubster*