### PR TITLE
💡 Visionary: Gen 3 Pal Park Migration Planner

### DIFF
--- a/.foundry/ideas/idea-132-gen3-pal-park-migration-planner.md
+++ b/.foundry/ideas/idea-132-gen3-pal-park-migration-planner.md
@@ -1,0 +1,39 @@
+---
+id: idea-132-gen3-pal-park-migration-planner
+type: IDEA
+title: Gen 3 Pal Park Migration Planner
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - feature
+  - gen3
+  - migration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Gen 3 Pal Park Migration Planner
+
+## Context
+When players transition from Generation 3 to Generation 4, they use the "Pal Park" feature to migrate their Pokémon. However, this process has strict limitations: Pokémon knowing HM moves cannot be migrated, and (in DP/Pt) you can only migrate exactly 6 Pokémon per day per GBA cartridge. Preparing Pokémon for migration is a highly manual process of checking movesets, stripping HMs, ensuring held items are correct, and organizing them into batches of 6 in the PC.
+
+## Proposal
+Create a "Pal Park Migration Planner" utility within DexHelper for Gen 3 save files.
+- **Migration Batching:** Allow users to flag Pokémon in their Gen 3 PC boxes that they intend to transfer and organize them into virtual "Batches of 6".
+- **HM Validation:** Automatically scan flagged Pokémon for HM moves (e.g., Surf, Cut, Strength) and visibly warn the user, as the game will reject them during the migration process.
+- **Item Transfer Optimization:** Highlight which Pokémon are holding rare items (e.g., Master Balls, rare berries, Leftovers) to ensure valuable items aren't left behind or accidentally brought over when not intended.
+- **Physical PC Locator:** Tell the player exactly which Box and Slot their flagged Pokémon are currently in, so they can easily move them into a dedicated "Migration Box" in-game.
+
+## Value Proposition
+This directly supports the hardcore collector and Ribbon Master communities who frequently migrate Pokémon upwards through the generations. It takes a tedious, error-prone preparation phase (where a single HM move can ruin a migration attempt) and turns it into a streamlined, automated checklist.
+
+## Next Steps
+- [ ] Product Manager: Convert this idea into a PRD to define the UI layout for the migration planner and the logic for HM move validation.

--- a/.jules/visionary/13048993490522208946.md
+++ b/.jules/visionary/13048993490522208946.md
@@ -11,3 +11,13 @@
   In the last session, we created `idea-128-gen3-acro-bike-route-planner.md`, which is a **DexHelper (Main Product)** feature designed to improve route planning.
   In this session, we are proposing an "Epic-Level Distillation and Cold Storage Archival" strategy, which is a **Foundry (Internal Orchestration)** infrastructure improvement.
   This maintains a strict and healthy **50/50 split** between developer-facing product features and system/orchestrator improvements, as outlined in the *Strategic Balance Learning* section of our journal.
+
+# Visionary Journal
+
+- **Active Session/Timestamp:** 2026-08-01
+- **Domain:** Main Project (DexHelper)
+- **Proposed Idea:** Gen 3 Pal Park Migration Planner (IDEA-132)
+- **Rationale & Concept:**
+  Migrating Pokémon from Gen 3 to Gen 4 via Pal Park is tedious, requiring players to strip HM moves, check held items, and organize exactly 6 Pokémon. A utility in DexHelper to automate these checks and assist in batching provides immense value for collectors and Ribbon Masters.
+- **How this idea maintains the 50/50 balance between DexHelper and Foundry:**
+  In the previous session, we proposed a Foundry orchestration feature (IDEA-131: Orchestrator Resource Locking). To strictly maintain the required 50/50 strategic balance, this session focuses on a direct product feature for DexHelper, aiming at Gen 3 players prepping for Gen 4 transfers.


### PR DESCRIPTION
Created `IDEA-132` proposing a feature to help players organize and validate batches of Pokémon before migrating them via Gen 4's Pal Park. This focuses on resolving HM move rejections and valuable item loss, addressing a key pain point for hardcore Ribbon Master challenge players.

Updated the Visionary journal to reflect the new idea and how it satisfies the strict 50/50 balance between DexHelper product features and Foundry infrastructure improvements.

---
*PR created automatically by Jules for task [15200556687177303474](https://jules.google.com/task/15200556687177303474) started by @szubster*