### PR TITLE
🎨 Palette: Refactor ClearFiltersBadge to use TacticalButton

### DIFF
--- a/.jules/palette/2026-08-01-02-23-25.md
+++ b/.jules/palette/2026-08-01-02-23-25.md
@@ -1,0 +1,15 @@
+# Palette Session - Refactor ClearFiltersBadge
+
+## Observations
+- `ClearFiltersBadge` used an ad-hoc `<button>` with many hardcoded tailwind classes to match the design system.
+- It also duplicated the corner crosshairs implementation.
+
+## Actions Taken
+- Replaced the custom `<button>` with the design system's `<TacticalButton>`.
+- Set `variant="sidebar"` and `hasCrosshairs={true}` to leverage existing primitive styling.
+- Maintained all existing ARIA attributes and click handlers.
+- Reduced CSS bloat while reinforcing the "tactical hardware" aesthetic.
+
+## Learnings
+- **Component Reuse:** When maintaining the tactical aesthetic, always check if `<TacticalButton>` or `<TacticalPanel>` can replace custom implementations, specifically for components matching the sidebar style.
+- **Frontend Verification:** When running Playwright test scripts against the dev server, the application is mounted at `/dexhelper/` (e.g., `http://localhost:3000/dexhelper/`).

--- a/src/components/ClearFiltersBadge.tsx
+++ b/src/components/ClearFiltersBadge.tsx
@@ -1,4 +1,5 @@
 import { cn } from '../utils/cn';
+import { TacticalButton } from './TacticalButton';
 
 interface ClearFiltersBadgeProps {
   isActive: boolean;
@@ -7,17 +8,18 @@ interface ClearFiltersBadgeProps {
 
 export function ClearFiltersBadge({ isActive, onClick }: ClearFiltersBadgeProps) {
   return (
-    <button
-      type="button"
+    <TacticalButton
       onClick={onClick}
       aria-pressed={isActive}
       title="Clear filters"
       aria-label="Clear filters"
+      variant="sidebar"
+      hasCrosshairs={true}
       className={cn(
-        'group tactical-badge h-10 min-w-[80px] xl:min-w-[100px]',
+        'h-10 min-w-[80px] border-r-0 xl:min-w-[100px]',
         isActive
           ? '!border-[var(--theme-primary)] bg-[var(--theme-primary)]/20 text-[var(--theme-primary)] shadow-[inset_0_0_15px_rgba(var(--theme-primary-rgb),0.2)]'
-          : '!border-zinc-800 hover:!border-zinc-600 bg-zinc-950/80 text-zinc-600 hover:bg-zinc-900 hover:text-zinc-400',
+          : '',
       )}
     >
       <div
@@ -27,6 +29,6 @@ export function ClearFiltersBadge({ isActive, onClick }: ClearFiltersBadgeProps)
         )}
       />
       [ ALL ]
-    </button>
+    </TacticalButton>
   );
 }


### PR DESCRIPTION
Refactored `ClearFiltersBadge` to use `<TacticalButton>` component instead of an ad-hoc native `<button>` element with custom styles.

**What:**
- Replaced custom `<button>` with `<TacticalButton>` in `src/components/ClearFiltersBadge.tsx`.
- Applied `variant="sidebar"` and `hasCrosshairs={true}` to inherit design system styles.
- Maintained all ARIA attributes (`aria-pressed`, `aria-label`).
- Ran `pnpm check:fix` and `pnpm test` (including `test:e2e`).

**Why:**
- Reduces CSS bloat by eliminating duplicate tailwind classes and custom crosshairs implementation.
- Enforces consistency with the "tactical hardware" design system across the application.
- Adheres to the < 50 line modification limit for micro-UX improvements.

**Accessibility Notes:**
- Standard ARIA attributes are preserved.
- Tab order and keyboard focus styles remain accessible, utilizing `focus-visible:tactical-focus` via the `TacticalButton` component.

---
*PR created automatically by Jules for task [6000739024271262068](https://jules.google.com/task/6000739024271262068) started by @szubster*