### PR TITLE
Fix DAG Resolution Warnings for Frontmatter Dates

### DIFF
--- a/.github/scripts/schema.test.ts
+++ b/.github/scripts/schema.test.ts
@@ -114,4 +114,22 @@ describe('NodeFrontmatterSchema', () => {
     };
     expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow(Error);
   });
+
+  it('validates handling JS Date objects for created_at and updated_at', () => {
+    const dateObj = new Date("2026-07-26T12:00:00.000Z");
+    const node = {
+      id: "idea-001",
+      type: "IDEA",
+      title: "New Idea",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: dateObj,
+      updated_at: dateObj,
+      depends_on: [],
+      jules_session_id: null
+    };
+    const parsed = NodeFrontmatterSchema.parse(node);
+    expect(parsed.created_at).toBe(dateObj.toISOString());
+    expect(parsed.updated_at).toBe(dateObj.toISOString());
+  });
 });

--- a/.github/scripts/schema.ts
+++ b/.github/scripts/schema.ts
@@ -38,14 +38,19 @@ export const OwnerPersonaEnum = z.enum([
   'auditor',
 ]);
 
+export const DateOrStringSchema = z.union([
+  z.string(),
+  z.date().transform((val) => val.toISOString()),
+]);
+
 export const NodeFrontmatterSchema = z.object({
   id: z.string(),
   type: NodeTypeEnum,
   title: z.string(),
   status: NodeStatusEnum,
   owner_persona: OwnerPersonaEnum,
-  created_at: z.string(),
-  updated_at: z.string(),
+  created_at: DateOrStringSchema,
+  updated_at: DateOrStringSchema,
   depends_on: z.array(z.string()),
   jules_session_id: z.string().nullable(),
   pr_number: z.number().int().nullable().optional(),


### PR DESCRIPTION
This fix modifies the DAG orchestrator frontmatter validation schema `NodeFrontmatterSchema` in `.github/scripts/schema.ts` to use `DateOrStringSchema`, which is a `z.union` of `z.string()` and `z.date().transform(val => val.toISOString())`.

Previously, dates in frontmatter without quotes were parsed by `@11ty/gray-matter` (which internally uses `js-yaml`) as JS `Date` objects, failing the strict string schema check of `z.string()`. This resulted in the skipping of 17 important files and causing unresolvable node references downstream. 

With this change:
- JS `Date` objects are successfully parsed and transformed into ISO strings.
- Strings are parsed directly.
- Standard downstream properties are preserved since the parsed object contains standard string dates.
- All skipped nodes are successfully parsed without warnings, and tests have been added to verify this.

Fixes #5427

---
*PR created automatically by Jules for task [12539348404096888277](https://jules.google.com/task/12539348404096888277) started by @szubster*