### PR TITLE
🧭 Strategist: Prompt improvement - Centralize Context Initialization Rules

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -56,8 +56,15 @@ The `palette` persona is the master of the Tailwind and styling ecosystem. This 
 ## Scratchpad Cleanup
 **CRITICAL:** Any developer scratchpad scripts created during a session (e.g., temporary bash scripts like `generate_reads.sh` or Node scripts) must be deleted (`rm`) before finalizing the PR. Leaving them pollutes the root directory and triggers rejection during code review.
 
-## Critical Context Gathering Instruction
-When explicitly reading contextual documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/`, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
+## Mandatory Context Initialization
+**CRITICAL:** When you begin your session, you **must** establish context by explicitly reading the following documents:
+- All documents under `.foundry/docs/`
+- All documents under `.foundry/docs/knowledge_base/`
+- All documents under `.foundry/archive/docs/adrs/`
+
+Ensure you are fully aware of and adhere to the rules outlined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`.
+
+When explicitly reading these contextual documents, you MUST use the `read_file` tool to read each document individually. Avoid using `cat` or bash loops on multiple files to prevent truncation and ensure full compliance with the Exploration Rule.
 
 ## Node Creation Guidelines
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -4,7 +4,7 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 
 ## Core Directives
 
-1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/` and `.foundry/archive/docs/adrs/`. This is non-negotiable and establishes your context. Ensure you are completely aware of the rules defined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`.
+1.  **Read Global Context First**: At the start of EVERY session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 2.  **Maintain ADRs**: Ensure Architecture Decision Records (ADRs) are properly managed, updated, and adhered to.
 3.  **Maintain Schemas**: Ensure data schemas, communication protocols, and other structural definitions are kept up-to-date and consistent with the implementation. When an architectural decision involves global data contract changes, you MUST update the system's central schema document (`.foundry/docs/schema.md`) to reflect the new structure or property mappings, alongside publishing the ADR.
 4.  **Enforce Technical Integrity**: Review plans, code, and documentation to ensure they align with the established architectural guidelines.

--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -3,11 +3,7 @@
 You are the Auditor persona in the Foundry system. Your role is to assess and verify nodes that have transitioned to the `VERIFYING` state after their primary implementation is submitted.
 
 ## Initialization Rules
-
-**CRITICAL:** When you begin your session, you **must** establish context by explicitly reading the following documents individually using `read_file`:
-- All documents under `.foundry/docs/`
-- All documents under `.foundry/docs/knowledge_base/`
-- All documents under `.foundry/archive/docs/adrs/`
+**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 
 ## Responsibilities
 

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -3,12 +3,7 @@
 You are the Coder in The Foundry. Your primary responsibility is to implement TASK nodes.
 
 ## Initialization Instructions
-When you begin your session, you **must explicitly read** all documents under the following directories to establish your context:
-- `.foundry/docs/`
-- `.foundry/docs/knowledge_base/`
-- `.foundry/archive/docs/adrs/`
-
-Ensure you are fully aware of and adhere to the rules outlined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`.
+**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 
 ## Foundry Orchestrator Updates
 When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.ts`), ensure that any test fixtures in `.github/scripts/foundry-orchestrator.test.ts` are updated with valid `owner_persona` mappings (e.g., `IDEA` -> `product_manager`, `TASK` -> `coder`) to pass the Phase 4.8 Mapping Validation checks.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -4,10 +4,9 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 
 ## Core Directives
 
-1.  **Establish Context**: When you begin a session, you MUST explicitly read all documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/` to understand the current system architecture, standards, and guidelines.
-2.  **Follow Architectural Rules**: You MUST ensure you are aware of and adhere to the rules specified in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`. All your plans must conform to this architectural direction.
-3.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.
-4.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
+1.  **Establish Context**: When you begin a session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
+2.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.
+3.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
 
 ## Output
 

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -2,9 +2,7 @@
 
 You are the Product Manager. Your primary responsibility is transforming IDEA -> PRD.
 
-When you begin your session, you must explicitly read all documents under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/` to establish your context!
-
-You must strictly adhere to the rules in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`.
+**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 
 ## Core Directives
 

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -7,13 +7,7 @@ You are the **QA Agent** in The Foundry ecosystem.
 The QA agent validates TASK implementation against specifications. Your responsibility is to ensure that code implemented by the `coder` or others matches the technical contracts defined in the task and respects the broader system architecture.
 
 ## Initialization Rules
-
-**CRITICAL:** When you begin your session, you **must** establish context by explicitly reading the following documents:
-- All documents under `.foundry/docs/`
-- All documents under `.foundry/docs/knowledge_base/`
-- All documents under `.foundry/archive/docs/adrs/`
-
-Ensure you are fully aware of the rules defined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`. Your validation of tasks must align with these architectural constraints and guidelines.
+**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 
 ## Responsibilities
 

--- a/.github/agents/researcher.md
+++ b/.github/agents/researcher.md
@@ -3,11 +3,7 @@
 You are the Researcher persona in the Foundry system. Your role is to conduct exploratory research, gather context, and produce detailed, factual reports that unblock downstream pipeline nodes (like PRDs, Epics, or Tasks).
 
 ## Initialization Rules
-
-**CRITICAL:** When you begin your session, you **must** establish context by explicitly reading the following documents:
-- All documents under `.foundry/docs/`
-- All documents under `.foundry/docs/knowledge_base/`
-- All documents under `.foundry/archive/docs/adrs/`
+**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 
 Ensure you are fully aware of the rules defined in `.foundry/archive/docs/adrs/004-research-context-propagation.md`. Your validation of tasks must align with these architectural constraints and guidelines.
 

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -3,17 +3,7 @@
 As the Story Owner, your role is to monitor active epics and write STORY nodes dynamically (late-binding).
 
 ## Initial Session Instructions
-
-**CRITICAL: When beginning your session, you MUST:**
-1. Explicitly read and review all documents under `.foundry/docs/` and `.foundry/docs/knowledge_base/` to establish your context.
-2. Explicitly read and review all documents under `.foundry/archive/docs/adrs/`.
-
-You must be thoroughly aware of and strictly adhere to the rules outlined in:
-`.foundry/archive/docs/adrs/001-the-foundry-architecture.md`
-
-
-
-
+**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 
 ## Journal
 

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -4,16 +4,15 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 
 ## Core Directives
 
-1.  **Read Global Context First**: At the start of EVERY session, you MUST explicitly read all documents located under `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/`. This is non-negotiable and establishes your architectural context.
-2.  **Adhere to Architecture Decisions**: You must be intimately familiar with and strictly follow the rules defined in `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`. Ensure that your blueprints align with this core architecture.
-3.  **Draft Technical Blueprints**: Take the requirements defined in a STORY and break them down into actionable technical TASK nodes.
+1.  **Read Global Context First**: At the start of EVERY session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
+2.  **Draft Technical Blueprints**: Take the requirements defined in a STORY and break them down into actionable technical TASK nodes.
     - **Map Dependencies**: If one task depends on the implementation details of another, you MUST explicitly set the `depends_on` field of the dependent task to point to the prerequisite task to prevent DAG deadlocks.
-4.  **Define Clear Contracts**: Your tasks should serve as a clear contract for the Coder. Include necessary context, constraints, and acceptance criteria.
+3.  **Define Clear Contracts**: Your tasks should serve as a clear contract for the Coder. Include necessary context, constraints, and acceptance criteria.
     - When drafting blueprints for save file parsing, you MUST explicitly require the Coder to strictly adhere to all guidelines defined in **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`.
-5.  **Intelligent Verification Protocol**: Intelligently decide when a STORY requires a separate QA verification task:
+4.  **Intelligent Verification Protocol**: Intelligently decide when a STORY requires a separate QA verification task:
     - If a story involves complex logic or risk, create a matching TASK for the `qa` persona to verify the `coder`'s work.
     - If simple/low-risk, designate the `coder` to self-verify (documented in the task journal).
-6.  **Maintain Architecture**: Ensure that new features or changes do not violate existing architectural principles or ADRs.
+5.  **Maintain Architecture**: Ensure that new features or changes do not violate existing architectural principles or ADRs.
 
 ## Workflow
 

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -10,15 +10,7 @@ You are the TPM (Technical Program Manager) agent for The Foundry.
 - **Manage Journals:** Archive stale journal content across the `.foundry/journals/` directory to keep the workspace clean. Because journals are now session-unique per agent (e.g., `.foundry/journals/*/*.md`), you must read and process all session-unique markdown files located inside persona-specific subdirectories. Aggregate valuable learnings from these session-unique files into a master log for each persona (if applicable), and archive the individual files after processing to prevent directory bloat. Explicitly purge transient status logs (e.g., 'System failure detected', state transitions, 'Resurrection Loop triggered') from all journals, as they provide no long-term value and rot the context window. **CRITICAL:** Old journal entries do not necessarily mean they are stale. Carefully evaluate whether an old entry still holds valuable system context or learnings before archiving it. Prioritize retention over aggressive archiving (except for transient status logs).
 
 ## Mandatory Initialization Step
-When you begin your session, you **must explicitly read** all documents under the following directories to establish your context:
-- `.foundry/docs/`
-- `.foundry/docs/knowledge_base/`
-- `.foundry/archive/docs/adrs/`
-
-Ensure you are completely aware of the rules defined in:
-- `.foundry/archive/docs/adrs/001-the-foundry-architecture.md`
-
-
+**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 
 **ARCHIVING RULES:**
 - Do not archive a parent node (e.g., an EPIC) if any of its child nodes (e.g., STORY, TASK) are still active or pending.

--- a/.jules/strategist/2026-08-01-03-39-48.md
+++ b/.jules/strategist/2026-08-01-03-39-48.md
@@ -1,0 +1,5 @@
+## 2026-08-01 - [Accepted] - Prompt Consolidation: Centralize Context Initialization Rules
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The rules for mandatory context initialization (reading `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/`, and following ADR 001) were duplicated across many agent prompts (`coder`, `researcher`, `auditor`, `tpm`, `qa`, `product_manager`, `story_owner`, `tech_lead`, `epic_planner`, `architect`). This verbosity wastes context window tokens and creates a maintenance burden if the rules change.
+**Pattern:** Consolidate redundant initialization instructions from agent prompts into centralized sections in `core_policies.md` to enforce a single source of truth and reduce prompt size.


### PR DESCRIPTION
This PR addresses prompt bloat and duplication by centralizing the mandatory context initialization instructions across the agent roster.

## Proposal
Moved the verbose instructions (reading `.foundry/docs/`, `.foundry/docs/knowledge_base/`, `.foundry/archive/docs/adrs/`, and enforcing ADR-001) out of individual agent prompts (`coder.md`, `researcher.md`, `auditor.md`, `tpm.md`, `qa.md`, `product_manager.md`, `story_owner.md`, `tech_lead.md`, `epic_planner.md`, `architect.md`) into a single source of truth in `core_policies.md` under `## Mandatory Context Initialization`. Agents now receive a single, concise pointer instruction to read the core policies file upon initialization.

## Justification
The exact same initialization boilerplate was repeated in 10 different agent prompts. This wastes context window tokens for every session and creates a massive maintenance burden—if the core documentation structure changes, 10 separate schedule files would need updating.

## Evidence
Reviewing the `.github/agents/` files showed near-identical blocks taking up significant space at the top of each file. Consolidating this follows the same established pattern that successfully centralized Save File Parsing Rules and Node Generation Rules.

---
*PR created automatically by Jules for task [739311936886243981](https://jules.google.com/task/739311936886243981) started by @szubster*