### PR TITLE
fix(orchestrator): allow date objects for created_at and updated_at in schema

### DIFF
--- a/.github/scripts/schema.test.ts
+++ b/.github/scripts/schema.test.ts
@@ -114,4 +114,21 @@ describe('NodeFrontmatterSchema', () => {
     };
     expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow(Error);
   });
+
+  it('validates and transforms JS Date objects for created_at and updated_at', () => {
+    const node = {
+      id: "idea-001",
+      type: "IDEA",
+      title: "New Idea",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: new Date("2026-07-26T12:00:00Z"),
+      updated_at: new Date("2026-07-26T13:00:00Z"),
+      depends_on: [],
+      jules_session_id: null
+    };
+    const parsed = NodeFrontmatterSchema.parse(node);
+    expect(parsed.created_at).toBe("2026-07-26T12:00:00.000Z");
+    expect(parsed.updated_at).toBe("2026-07-26T13:00:00.000Z");
+  });
 });

--- a/.github/scripts/schema.ts
+++ b/.github/scripts/schema.ts
@@ -44,8 +44,14 @@ export const NodeFrontmatterSchema = z.object({
   title: z.string(),
   status: NodeStatusEnum,
   owner_persona: OwnerPersonaEnum,
-  created_at: z.string(),
-  updated_at: z.string(),
+  created_at: z.union([
+    z.string(),
+    z.date().transform((val) => val.toISOString()),
+  ]),
+  updated_at: z.union([
+    z.string(),
+    z.date().transform((val) => val.toISOString()),
+  ]),
   depends_on: z.array(z.string()),
   jules_session_id: z.string().nullable(),
   pr_number: z.number().int().nullable().optional(),


### PR DESCRIPTION
Updated the Zod NodeFrontmatterSchema definition for created_at and updated_at to accept a union of string and date, transforming any date objects to ISO string representation. This resolves orchestrator warnings on unquoted dates parsed as Date objects by gray-matter.

Fixes #5433

---
*PR created automatically by Jules for task [6015383460385087759](https://jules.google.com/task/6015383460385087759) started by @szubster*