### PR TITLE
chore: verify gen 1 trainer data extraction story

### DIFF
--- a/.foundry/journals/tech_lead/4075027378976492253.md
+++ b/.foundry/journals/tech_lead/4075027378976492253.md
@@ -1,0 +1,3 @@
+# Session 4075027378976492253
+
+I was assigned to `story-306-319-gen1-trainer-data-extraction`. Upon reviewing the child tasks (`task-319-322-gen1-trainer-data-extraction-impl` and `task-319-323-gen1-trainer-data-extraction-qa`), I found they were already marked as `COMPLETED`. Since the tasks were successfully completed, I checked off their checkboxes in the story's acceptance criteria to allow the orchestrator to advance the DAG, as an exception to the Empty PR policy.

--- a/.foundry/stories/story-306-319-gen1-trainer-data-extraction.md
+++ b/.foundry/stories/story-306-319-gen1-trainer-data-extraction.md
@@ -32,5 +32,5 @@ Extract and parse the trainer defeat flags for Generation 1 games.
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] task-319-322-gen1-trainer-data-extraction-impl
-- [ ] task-319-323-gen1-trainer-data-extraction-qa
+- [x] task-319-322-gen1-trainer-data-extraction-impl
+- [x] task-319-323-gen1-trainer-data-extraction-qa


### PR DESCRIPTION
Checked off acceptance criteria checkboxes for `story-306-319-gen1-trainer-data-extraction` because its child tasks (`task-319-322-gen1-trainer-data-extraction-impl` and `task-319-323-gen1-trainer-data-extraction-qa`) were already completed. Created a private journal entry to log this Empty PR exception.

---
*PR created automatically by Jules for task [4075027378976492253](https://jules.google.com/task/4075027378976492253) started by @szubster*