### PR TITLE
QA Zod Schema Integration Reject

### DIFF
--- a/.foundry/journals/qa/16672278174141634420.md
+++ b/.foundry/journals/qa/16672278174141634420.md
@@ -1,0 +1,14 @@
+# QA Journal - 16672278174141634420
+
+## Task: task-337-368-zod-schema-integration-qa
+
+### Context
+QA review for Zod schema integration within `.github/scripts`.
+
+### Validation
+- Ran `cd .github/scripts && pnpm install && npx vitest run`. Test suite passed.
+- Analyzed `schema.ts`. Discovered that `created_at` and `updated_at` use `z.string()`.
+- The Foundry DAG orchestrator validates frontmatter fields `created_at` and `updated_at` using Zod schema which accepts both strings and JS Date objects (coercing Date objects into ISO strings) to gracefully handle unquoted dates parsed by gray-matter. `z.string()` alone does not satisfy this architectural requirement.
+
+### Result
+Target implementation rejected. `task-337-367-zod-schema-integration-impl.md` was updated to `status: FAILED` with a rejection count of 1.

--- a/.foundry/tasks/task-337-367-zod-schema-integration-impl.md
+++ b/.foundry/tasks/task-337-367-zod-schema-integration-impl.md
@@ -2,7 +2,7 @@
 id: task-337-367-zod-schema-integration-impl
 type: TASK
 title: Zod Schema Integration Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-30'
 updated_at: '2026-07-31'
@@ -12,8 +12,8 @@ pr_number: null
 parent: story-334-337-zod-schema-integration
 tags: []
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Schema validation for created_at and updated_at fails to gracefully handle unquoted JS Date objects.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-337-368-zod-schema-integration-qa.md
+++ b/.foundry/tasks/task-337-368-zod-schema-integration-qa.md
@@ -25,3 +25,6 @@ Run `.github/scripts` tests (`npx vitest run`) and verify that node parsing corr
 ## Acceptance Criteria
 - [ ] Verify test suite passes (`cd .github/scripts && pnpm install && npx vitest run`)
 - [ ] Ensure validation logic correctly rejects malformed schema and accepts valid schema
+
+### QA Review
+The implementation is rejected. The Zod schema in `schema.ts` for `created_at` and `updated_at` uses `z.string()`, which violates the constraint that it must gracefully handle JS Date objects for unquoted dates parsed by gray-matter.


### PR DESCRIPTION
The target task `task-337-367-zod-schema-integration-impl` was rejected.
The Zod schema introduced for `created_at` and `updated_at` uses `z.string()`, which violates the architectural constraint defined for `gray-matter`. It must gracefully handle unquoted JS Date objects by coercing them to ISO strings. The target task has been marked `FAILED` with a detailed `rejection_reason`.

I documented the architectural constraint violation in a QA persona journal entry and updated this QA task markdown body accordingly. No code changes were made to `.github/scripts/schema.ts` as the fix should be implemented by a coder in a subsequent active session for the rejected task.

---
*PR created automatically by Jules for task [16672278174141634420](https://jules.google.com/task/16672278174141634420) started by @szubster*