### PR TITLE
QA: Reject Progression Timeline UI for duplicate components

### DIFF
--- a/.foundry/journals/qa/5848252374865416625.md
+++ b/.foundry/journals/qa/5848252374865416625.md
@@ -1,0 +1,7 @@
+# Session 5848252374865416625
+
+## Validation Results
+Task task-257-373-progression-timeline-ui-impl was FAILED.
+
+## Architectural Lessons
+Found duplicate components for ProgressionTimeline. One at `src/components/dashboard/progression/ProgressionTimeline.tsx` and another at `src/components/timeline/ProgressionTimeline.tsx`. The developer also left placeholders and didn't implement the true SaveHistory integration yet. Future QA validations should explicitly check for duplicate components and verify data integrations.

--- a/.foundry/tasks/task-257-373-progression-timeline-ui-impl.md
+++ b/.foundry/tasks/task-257-373-progression-timeline-ui-impl.md
@@ -2,7 +2,7 @@
 id: task-257-373-progression-timeline-ui-impl
 type: TASK
 title: Progression Timeline UI
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-31'
 updated_at: '2026-07-31'
@@ -16,8 +16,8 @@ tags:
   - progression
   - ui
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Duplicate ProgressionTimeline components exist in src/components/dashboard/progression and src/components/timeline. Component uses a placeholder for history integration.'
 notes: ''
 ---
 
@@ -31,4 +31,4 @@ Build a timeline or visualization showing the progression of a specific playthro
 - Build the visualization UI.
 
 ## Acceptance Criteria
-- [x] Implement the Progression Timeline UI.
+- [ ] Implement the Progression Timeline UI.

--- a/.foundry/tasks/task-257-374-progression-timeline-ui-qa.md
+++ b/.foundry/tasks/task-257-374-progression-timeline-ui-qa.md
@@ -31,3 +31,6 @@ QA verification for the Progression Timeline UI.
 
 ## Acceptance Criteria
 - [ ] Verify the Progression Timeline UI implementation.
+
+## Notes
+- Failed target implementation due to duplicate ProgressionTimeline components and lack of history integration.


### PR DESCRIPTION
This PR rejects the Progression Timeline UI implementation due to the discovery of duplicate component files (`src/components/dashboard/progression/ProgressionTimeline.tsx` and `src/components/timeline/ProgressionTimeline.tsx`) and the usage of placeholder data rather than a true integration with the actual save history logic. The task has been marked as `FAILED` and sent back for rework, and QA logs have been updated.

---
*PR created automatically by Jules for task [5848252374865416625](https://jules.google.com/task/5848252374865416625) started by @szubster*