### PR TITLE
Research: Root cause of permanent failure for epic-107-301

### DIFF
--- a/.foundry/research/research-107-342-investigate-lift-rejection-count-failure.md
+++ b/.foundry/research/research-107-342-investigate-lift-rejection-count-failure.md
@@ -27,5 +27,8 @@ Investigate the permanent failure of `epic-107-301-lift-rejection-count-state` a
 ## Context
 The permanent failure threshold filtering logic (`rejection_count >= 3`) is hardcoded in several components. Attempting to lift this state failed in downstream execution.
 
+## Findings
+`epic-107-301-lift-rejection-count-state` failed permanently (reaching max rejection count) because its generated stories were missing the `e2e` or `integration` tag. This caused the Orchestrator's late-binding macro completion safeguard to continually reject the Epic (promoting it to FAILED) when it attempted to transition to COMPLETED, eventually hitting the max rejection count. This gap has already been addressed by the Story Owner who spawned `epic-107-339-lift-rejection-count-state` to replace the failed node and explicitly require E2E testing.
+
 ## Acceptance Criteria
-- [ ] Research root cause of failure.
+- [x] Research root cause of failure.


### PR DESCRIPTION
Investigated and documented the root cause of the permanent failure for `epic-107-301-lift-rejection-count-state` within the corresponding `RESEARCH` node. The Epic failed because its generated stories lacked the mandatory `e2e` or `integration` tag, violating the Orchestrator's late-binding macro completion safeguard and causing it to hit its maximum rejection count. Marked the acceptance criteria as completed.

---
*PR created automatically by Jules for task [3342895641457752433](https://jules.google.com/task/3342895641457752433) started by @szubster*