### PR TITLE
fix: support parsing of unquoted Date frontmatter fields in orchestrator schema

### DIFF
--- a/.github/scripts/schema.test.ts
+++ b/.github/scripts/schema.test.ts
@@ -114,4 +114,21 @@ describe('NodeFrontmatterSchema', () => {
     };
     expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow(Error);
   });
+
+  it('coerces Date objects to string format', () => {
+    const nodeWithDates = {
+      id: "idea-001",
+      type: "IDEA",
+      title: "New Idea",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: new Date("2026-06-30T00:00:00.000Z"),
+      updated_at: new Date("2026-07-03T12:00:00.000Z"),
+      depends_on: [],
+      jules_session_id: null
+    };
+    const parsed = NodeFrontmatterSchema.parse(nodeWithDates);
+    expect(parsed.created_at).toBe("2026-06-30");
+    expect(parsed.updated_at).toBe("2026-07-03");
+  });
 });

--- a/.github/scripts/schema.ts
+++ b/.github/scripts/schema.ts
@@ -38,14 +38,22 @@ export const OwnerPersonaEnum = z.enum([
   'auditor',
 ]);
 
+export const DateCoercionSchema = z.preprocess((arg) => {
+  if (arg instanceof Date) {
+    // If it's a Date object, convert to YYYY-MM-DD format based on UTC or ISO string
+    return arg.toISOString().split('T')[0];
+  }
+  return arg;
+}, z.string());
+
 export const NodeFrontmatterSchema = z.object({
   id: z.string(),
   type: NodeTypeEnum,
   title: z.string(),
   status: NodeStatusEnum,
   owner_persona: OwnerPersonaEnum,
-  created_at: z.string(),
-  updated_at: z.string(),
+  created_at: DateCoercionSchema,
+  updated_at: DateCoercionSchema,
   depends_on: z.array(z.string()),
   jules_session_id: z.string().nullable(),
   pr_number: z.number().int().nullable().optional(),


### PR DESCRIPTION
This PR fixes the DAG resolution warnings caused by Zod schema validation failures on `created_at` and `updated_at` frontmatter fields. 

Because `gray-matter` parses unquoted date strings (e.g. `2026-06-30T00:00:00.000Z` or `2026-06-30`) as JavaScript `Date` objects, the previous strict `z.string()` schemas rejected valid files. To resolve this, a robust `DateCoercionSchema` was introduced using `z.preprocess` to split native `Date` objects to their date-only `YYYY-MM-DD` strings, allowing them to pass validation and resolve safely.

Verified against `.github/scripts` unit tests and by running the Foundry orchestrator in dry-run mode (successfully resolved all previously skipped files).

Fixes #5441

---
*PR created automatically by Jules for task [17334396985235408084](https://jules.google.com/task/17334396985235408084) started by @szubster*