### PR TITLE
feat: integrate PokerusBadge in PC box view

### DIFF
--- a/.foundry/journals/coder/2026-08-01-08-18-27.md
+++ b/.foundry/journals/coder/2026-08-01-08-18-27.md
@@ -1,0 +1,10 @@
+# Session Journal
+
+**Objective**: Integrate the `PokerusBadge` component into the PC Box storage grid component (`src/components/StorageGrid.tsx`) to visually display the Pokerus strain for each Pokemon.
+
+## Self-Verification Log
+1. Replaced the strict condition `location === 'Party' && p.pokerus && p.pokerus.strain > 0` with `p.pokerus && p.pokerus.strain > 0` inside `src/components/StorageGrid.tsx`.
+2. This safely allows the `PokerusBadge` to render appropriately within the grid view without breaking existing constraints.
+3. Verified by inspecting the file `StorageGrid.tsx` via `sed`.
+4. Executed tests via `pnpm test` (after playwright initialization) and validated that existing component tests pass successfully without regression.
+5. Code meets production requirements and fulfills the objective cleanly.

--- a/.foundry/tasks/task-324-346-integrate-pokerus-strain-box-view-impl.md
+++ b/.foundry/tasks/task-324-346-integrate-pokerus-strain-box-view-impl.md
@@ -32,5 +32,5 @@ Integrate the `PokerusBadge` component into the PC Box storage grid component (`
 - The Coder will self-verify this UI integration as per the Intelligent Verification Protocol for simple UI tasks.
 
 ## 3. Acceptance Criteria
-- [ ] Coder: Integrate `PokerusBadge` into the `StorageCard` component within `src/components/StorageGrid.tsx`.
-- [ ] Coder: Self-verify the integration and log findings in `.foundry/journals/coder/<session_id>.md`.
+- [x] Coder: Integrate `PokerusBadge` into the `StorageCard` component within `src/components/StorageGrid.tsx`.
+- [x] Coder: Self-verify the integration and log findings in `.foundry/journals/coder/<session_id>.md`.

--- a/src/components/StorageGrid.tsx
+++ b/src/components/StorageGrid.tsx
@@ -79,7 +79,7 @@ const StorageCard = React.memo(
               {p.otName}
             </TacticalBadge>
           )}
-          {location === 'Party' && p.pokerus && p.pokerus.strain > 0 && <PokerusBadge strain={p.pokerus.strain} />}
+          {p.pokerus && p.pokerus.strain > 0 && <PokerusBadge strain={p.pokerus.strain} />}
         </div>
         <div className="relative mb-4 flex h-20 w-20 items-center justify-center sm:h-24 sm:w-24">
           <PokemonSprite


### PR DESCRIPTION
Integrates `PokerusBadge` to the `StorageGrid` PC Box view UI by removing the restrictive party check, checks off acceptance criteria for the node, and logs self-verification context in the persona journal.

---
*PR created automatically by Jules for task [8541221980582332310](https://jules.google.com/task/8541221980582332310) started by @szubster*