### PR TITLE
feat: Add Core Story Node for Gen 3 Spinda PID Extraction

### DIFF
--- a/.foundry/epics/epic-335-345-spinda-pid-extraction.md
+++ b/.foundry/epics/epic-335-345-spinda-pid-extraction.md
@@ -29,3 +29,4 @@ This Epic focuses on parsing the Gen 3 save file to extract all owned Spinda Pok
 - [ ] Parse PC Box data and Party data to identify Spinda Pokemon.
 - [ ] Extract the 32-bit PID for each identified Spinda.
 - [ ] Create a clean data structure or store to pass the extracted Spinda data to the UI and Rendering layers.
+- [ ] story-345-349-gen3-spinda-extraction-core

--- a/.foundry/journals/story_owner/2026-08-01-08-18-39.md
+++ b/.foundry/journals/story_owner/2026-08-01-08-18-39.md
@@ -1,0 +1,3 @@
+# Journal
+
+When extracting Gen 3 Spinda PIDs, we need to handle parsing from PC Box data as well as Party data correctly according to their specific structures.

--- a/.foundry/stories/story-345-349-gen3-spinda-extraction-core.md
+++ b/.foundry/stories/story-345-349-gen3-spinda-extraction-core.md
@@ -1,0 +1,31 @@
+---
+id: story-345-349-gen3-spinda-extraction-core
+type: STORY
+title: Core Spinda Data Extraction
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-335-345-spinda-pid-extraction
+tags:
+  - gen3
+  - spinda
+  - data-extraction
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Core Spinda Data Extraction
+
+## Description
+Extract Gen 3 Spinda PID data from PC Boxes and Active Party.
+
+## Acceptance Criteria
+- [ ] Implement parsing logic to identify Spinda Pokémon in both PC Box and Party datasets.
+- [ ] Extract the 32-bit PID for each identified Spinda.
+- [ ] Define the interface/data structure to store the extracted Spinda info for the UI layer.


### PR DESCRIPTION
This PR dynamically creates the first STORY node (`story-345-349-gen3-spinda-extraction-core`) for parsing Gen 3 Spinda data from PC Box and Party datasets to extract PIDs. 

It delegates the new story to the `tech_lead` owner persona and updates the parent EPIC (`epic-335-345-spinda-pid-extraction`) by appending the new story to its Acceptance Criteria in the markdown body without modifying the YAML frontmatter.

A journal entry was also logged to persist constraints and details regarding Gen 3 data extraction across datasets.

---
*PR created automatically by Jules for task [6784122782136516082](https://jules.google.com/task/6784122782136516082) started by @szubster*