### PR TITLE
chore(foundry): update epic 131 checkboxes and add journal entry

### DIFF
--- a/.foundry/epics/epic-097-131-nuzlocke-death-tracking.md
+++ b/.foundry/epics/epic-097-131-nuzlocke-death-tracking.md
@@ -32,5 +32,5 @@ Implement the logic to track dead Pokémon based on HP and Graveyard box assignm
 ## Acceptance Criteria
 - [x] Stories are generated
 - [x] story-131-317-detect-party-zero-hp
-- [ ] story-131-333-graveyard-box-state
-- [ ] story-131-334-graveyard-box-ui
+- [x] story-131-333-graveyard-box-state
+- [x] story-131-334-graveyard-box-ui

--- a/.foundry/journals/story_owner/1590629296744893676.md
+++ b/.foundry/journals/story_owner/1590629296744893676.md
@@ -1,0 +1,3 @@
+# Session 1590629296744893676
+
+Lesson learned: When processing an Epic whose child stories are already in a COMPLETED state, ensure all their acceptance criteria checkboxes in the Epic markdown body are explicitly checked off to allow the Orchestrator to transition the Epic to VERIFYING without violating the macro node completion invariants.


### PR DESCRIPTION
This PR updates the checkboxes for the completed stories in the `epic-097-131-nuzlocke-death-tracking.md` epic. Since the child stories are already marked as `COMPLETED`, checking off their respective acceptance criteria in the epic's markdown body allows the Orchestrator to transition the Epic to the `VERIFYING` state without violating macro node completion invariants.

A journal entry has also been added to document this procedure.

---
*PR created automatically by Jules for task [1590629296744893676](https://jules.google.com/task/1590629296744893676) started by @szubster*