### PR TITLE
chore: complete epic-100-130-rng-tid-sid-display

### DIFF
--- a/.foundry/epics/epic-100-130-rng-tid-sid-display.md
+++ b/.foundry/epics/epic-100-130-rng-tid-sid-display.md
@@ -25,13 +25,13 @@ notes: ''
 Provide UI elements to clearly display both the Trainer ID (TID) and Secret ID (SID) together, including an easy way to copy these values to the clipboard for external RNG tool usage.
 
 ## Acceptance Criteria
-- [ ] Ensure TID and SID are displayed together in the UI.
-- [ ] Implement a copy-to-clipboard button for the TID/SID combination.
+- [x] Ensure TID and SID are displayed together in the UI.
+- [x] Implement a copy-to-clipboard button for the TID/SID combination.
 - [x] Story Owner: Convert this Epic into actionable Stories.
 - [x] story-130-269-rng-tid-sid-component
 - [x] story-130-270-rng-tid-sid-integration
-- [ ] research-130-332-rng-tid-sid-integration-failure
-- [ ] story-130-333-rng-tid-sid-integration-retry
+- [x] research-130-332-rng-tid-sid-integration-failure
+- [x] story-130-333-rng-tid-sid-integration-retry
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/journals/story_owner/11163296237589080000.md
+++ b/.foundry/journals/story_owner/11163296237589080000.md
@@ -1,0 +1,10 @@
+# Session: 11163296237589080000
+
+## Activities
+- Reviewed Epic: epic-100-130-rng-tid-sid-display.
+- Verified that all child nodes, including research and integration retry, are COMPLETED.
+- Marked all acceptance criteria in the epic as completed.
+- Generated empty PR to allow the DAG to progress, as no further story generation is needed.
+
+## Learnings
+- When child tasks fail (like the integration), research nodes and retries correctly re-evaluate the DAG. Wait until retries complete to mark the epic as resolved.


### PR DESCRIPTION
Marked all acceptance criteria in epic-100-130-rng-tid-sid-display as complete because all child nodes (story-130-269, story-130-270, research-130-332, story-130-333) are completed. Logged session in story owner journal.

---
*PR created automatically by Jules for task [11163296237589080000](https://jules.google.com/task/11163296237589080000) started by @szubster*