### PR TITLE
chore: submit empty PR for completed regional dex sorting task

### DIFF
--- a/.foundry/journals/coder/247304201345729590.md
+++ b/.foundry/journals/coder/247304201345729590.md
@@ -1,0 +1,1 @@
+# Session 247304201345729590\n\nTask task-333-375-sorting-strategies-regional-dex-impl was already completely implemented in the codebase (using HOENN_DEX_ORDER). As such, following the Empty PR policy, submitted an empty PR without making any code changes. The required core verification commands were successful.


### PR DESCRIPTION
The feature to sort by regional dex variant was already completely implemented in `src/engine/sorting/StandardSorters.ts` (using `HOENN_DEX_ORDER`). The tests in `src/engine/sorting/StandardSorters.test.ts` are also fully updated and passing. Following the Empty PR policy, submitting an empty PR to transition the node to COMPLETED, as the requirements are already met in the `main` branch.

---
*PR created automatically by Jules for task [247304201345729590](https://jules.google.com/task/247304201345729590) started by @szubster*