### PR TITLE
feat(orchestrator): add e2e story for rng tid sid display epic

### DIFF
--- a/.foundry/epics/epic-100-130-rng-tid-sid-display.md
+++ b/.foundry/epics/epic-100-130-rng-tid-sid-display.md
@@ -33,5 +33,7 @@ Provide UI elements to clearly display both the Trainer ID (TID) and Secret ID (
 - [x] research-130-332-rng-tid-sid-integration-failure
 - [x] story-130-333-rng-tid-sid-integration-retry
 
+- [ ] story-130-349-rng-tid-sid-e2e
+
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/journals/story_owner/1969587438162257968.md
+++ b/.foundry/journals/story_owner/1969587438162257968.md
@@ -1,0 +1,9 @@
+# Session 1969587438162257968
+
+## Epic Status
+Working on `epic-100-130-rng-tid-sid-display`.
+
+## Learnings & Observations
+- **Orchestrator Safeguard E2E**: Discovered that EPIC nodes cannot transition to COMPLETED unless they possess at least one child STORY node tagged with `e2e` or `integration`.
+- **Action Taken**: Dynamically created an E2E story node (`story-130-349-rng-tid-sid-e2e`) explicitly tagged with `e2e` and added it to the Epic's Acceptance Criteria to satisfy the safeguard.
+- **Future Implication**: When creating Stories for an Epic as the Story Owner, I must remember to include an E2E/integration story if it doesn't already exist, otherwise the parent Epic will fail to complete due to the orchestrator's E2E safeguard.

--- a/.foundry/stories/story-130-349-rng-tid-sid-e2e.md
+++ b/.foundry/stories/story-130-349-rng-tid-sid-e2e.md
@@ -1,0 +1,32 @@
+---
+id: story-130-349-rng-tid-sid-e2e
+type: STORY
+title: RNG TID and SID Display UI E2E Tests
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on:
+  - story-130-333-rng-tid-sid-integration-retry
+jules_session_id: null
+pr_number: null
+parent: epic-100-130-rng-tid-sid-display
+tags:
+  - e2e
+  - rng
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# RNG TID and SID Display UI E2E Tests
+
+## Objective
+Write end-to-end tests for the RNG TID and SID Display UI to ensure it is functioning as expected in the Trainer dashboard, particularly that the correct TID and SID are displayed and that the copy-to-clipboard functionality works.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Generate actionable Tasks.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
### 🎯 Objective
The `epic-100-130-rng-tid-sid-display` requires an E2E story to successfully transition to COMPLETED due to the Foundry Orchestrator's strict E2E safeguard policy.

### 🛠️ Changes
- Created a new STORY node: `story-130-349-rng-tid-sid-e2e` tagged with `e2e` and assigned to `owner_persona: tech_lead`.
- Appended the new story reference (`- [ ] story-130-349-rng-tid-sid-e2e`) to the `epic-100-130-rng-tid-sid-display` markdown body.
- Recorded the session details and the orchestrator safeguard interaction in `.foundry/journals/story_owner/1969587438162257968.md`.

### 🧪 Verification
- Verified file creation and content formatting with `cat`.
- Ran `pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e` to ensure no regressions were introduced. Tests pass locally.

---
*PR created automatically by Jules for task [1969587438162257968](https://jules.google.com/task/1969587438162257968) started by @szubster*