### PR TITLE
build(foundry): retain pending state for zod schema integration story

### DIFF
--- a/.foundry/journals/tech_lead/5542101591727077873.md
+++ b/.foundry/journals/tech_lead/5542101591727077873.md
@@ -1,0 +1,10 @@
+# Tech Lead Journal - 5542101591727077873
+
+## Observations
+- Task `story-334-337-zod-schema-integration` was dispatched back to the Tech Lead because its implementation QA task (`task-337-368`) rejected the coder's implementation due to a bug in `schema.ts`.
+- The child tasks are not yet complete, and the parent node must remain in PENDING status.
+- According to the MACRO NODE COMPLETION EXCEPTION, we must not transition the node to VERIFYING (via checking off its child checkboxes) until all descendants are COMPLETED.
+- Thus, the node was left intact with its children unchecked and submitted as an Empty PR to pause its lifecycle while its children are retried.
+
+## Policies
+- Do not check off child task checkboxes in a STORY node's markdown body when submitting an empty PR if the child tasks are still active or failing. This correctly handles Idempotent Generation Bypasses.


### PR DESCRIPTION
Submitted empty PR for `story-334-337-zod-schema-integration` to retain its `PENDING` state while its child tasks are retried after a QA rejection. Adhered to the MACRO NODE COMPLETION EXCEPTION policy by keeping the descendant task checkboxes unchecked.

---
*PR created automatically by Jules for task [5542101591727077873](https://jules.google.com/task/5542101591727077873) started by @szubster*