### PR TITLE
Create retry tasks for progression timeline UI

### DIFF
--- a/.foundry/journals/tech_lead/16694797876941020287.md
+++ b/.foundry/journals/tech_lead/16694797876941020287.md
@@ -1,0 +1,4 @@
+# Session 16694797876941020287
+
+## Learnings
+When attempting to implement complex UI features like a Progression Timeline, ensure that architectural blueprints explicitly address potential issues such as component duplication and integration complexity with external systems (like history). If a task fails repeatedly for these reasons, it is necessary to step back, conduct targeted research to understand the underlying constraints, and re-architect the solution before attempting implementation again. We must use the late binding pattern to handle failures by generating research tasks to unblock.

--- a/.foundry/research/research-257-377-investigate-progression-timeline-failure.md
+++ b/.foundry/research/research-257-377-investigate-progression-timeline-failure.md
@@ -1,0 +1,30 @@
+---
+id: research-257-377-investigate-progression-timeline-failure
+type: RESEARCH
+title: Investigate Progression Timeline UI Failure
+status: PENDING
+owner_persona: researcher
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-036-257-concurrent-game-management
+tags:
+  - frontend
+  - progression
+  - ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Progression Timeline UI Failure
+
+## Context
+The previous QA task `task-257-374-progression-timeline-ui-qa` failed due to duplicate `ProgressionTimeline` components and a lack of history integration. This research node aims to investigate the root cause of these issues and provide clear guidelines for the retry implementation.
+
+## Requirements
+- Investigate why there were duplicate `ProgressionTimeline` components.
+- Investigate why the history integration was missing or failing.
+- Provide a clear architectural solution to prevent these issues in the retry tasks.

--- a/.foundry/stories/story-036-257-concurrent-game-management.md
+++ b/.foundry/stories/story-036-257-concurrent-game-management.md
@@ -36,5 +36,8 @@ Users may play multiple games simultaneously (e.g., swapping between Pokémon Re
 - [ ] task-257-370-concurrent-game-context-qa
 - [ ] task-257-371-concurrent-game-switcher-ui-impl
 - [ ] task-257-372-concurrent-game-switcher-ui-qa
-- [ ] task-257-373-progression-timeline-ui-impl
-- [ ] task-257-374-progression-timeline-ui-qa
+- [x] task-257-373-progression-timeline-ui-impl
+- [x] task-257-374-progression-timeline-ui-qa
+- [ ] research-257-377-investigate-progression-timeline-failure
+- [ ] task-257-378-progression-timeline-ui-retry-impl
+- [ ] task-257-379-progression-timeline-ui-retry-qa

--- a/.foundry/tasks/task-257-378-progression-timeline-ui-retry-impl.md
+++ b/.foundry/tasks/task-257-378-progression-timeline-ui-retry-impl.md
@@ -1,0 +1,35 @@
+---
+id: task-257-378-progression-timeline-ui-retry-impl
+type: TASK
+title: Progression Timeline UI Retry
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on:
+  - research-257-377-investigate-progression-timeline-failure
+jules_session_id: null
+pr_number: null
+parent: story-036-257-concurrent-game-management
+tags:
+  - frontend
+  - progression
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Progression Timeline UI Retry
+
+## Context
+Retry implementing the timeline or visualization showing the progression of a specific playthrough over its saved history. The previous attempt failed due to duplicate `ProgressionTimeline` components and a lack of history integration.
+
+## Requirements
+- Consume the Concurrent Game React Context layer.
+- Build the visualization UI.
+- Address the issues identified in `research-257-377-investigate-progression-timeline-failure`.
+
+## Acceptance Criteria
+- [ ] Implement the Progression Timeline UI Retry.

--- a/.foundry/tasks/task-257-379-progression-timeline-ui-retry-qa.md
+++ b/.foundry/tasks/task-257-379-progression-timeline-ui-retry-qa.md
@@ -1,0 +1,34 @@
+---
+id: task-257-379-progression-timeline-ui-retry-qa
+type: TASK
+title: QA Progression Timeline UI Retry
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on:
+  - task-257-378-progression-timeline-ui-retry-impl
+jules_session_id: null
+pr_number: null
+parent: story-036-257-concurrent-game-management
+tags:
+  - frontend
+  - progression
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Progression Timeline UI Retry
+
+## Context
+QA verification for the Progression Timeline UI Retry.
+
+## Requirements
+- Validate the timeline visualization.
+- Ensure no duplicate `ProgressionTimeline` components exist and history integration is fully functional.
+
+## Acceptance Criteria
+- [ ] Verify the Progression Timeline UI Retry implementation.


### PR DESCRIPTION
Created `research-257-377-investigate-progression-timeline-failure` to investigate the duplicate UI components.
Created `task-257-378-progression-timeline-ui-retry-impl` and `task-257-379-progression-timeline-ui-retry-qa`.
Updated `story-036-257-concurrent-game-management.md` to check off the failed tasks and add the new retry tasks as unchecked checkboxes, preventing the story from deadlocking or transitioning to verified prematurely.
Added a journal entry detailing the late-binding resolution strategy.

---
*PR created automatically by Jules for task [16694797876941020287](https://jules.google.com/task/16694797876941020287) started by @szubster*