### PR TITLE
Draft tasks for Gen 3 Spinda PID extraction

### DIFF
--- a/.foundry/journals/tech_lead/6077590348936719751.md
+++ b/.foundry/journals/tech_lead/6077590348936719751.md
@@ -1,0 +1,2 @@
+# Session 6077590348936719751
+When drafting blueprints for save file parsing, such as `task-349-380-gen3-spinda-extraction-impl.md`, I must explicitly require the Coder to strictly adhere to all guidelines defined in Section 13 ("Save File Parsing & Extraction Guidelines") of `.foundry/docs/schema.md`. This prevents the use of inline magic numbers and incorrect memory boundary handling, ensuring long-term maintainability for new extractions.

--- a/.foundry/stories/story-345-349-gen3-spinda-extraction-core.md
+++ b/.foundry/stories/story-345-349-gen3-spinda-extraction-core.md
@@ -29,3 +29,5 @@ Extract Gen 3 Spinda PID data from PC Boxes and Active Party.
 - [ ] Implement parsing logic to identify Spinda Pokémon in both PC Box and Party datasets.
 - [ ] Extract the 32-bit PID for each identified Spinda.
 - [ ] Define the interface/data structure to store the extracted Spinda info for the UI layer.
+- [ ] task-349-380-gen3-spinda-extraction-impl
+- [ ] task-349-381-gen3-spinda-extraction-qa

--- a/.foundry/tasks/task-349-380-gen3-spinda-extraction-impl.md
+++ b/.foundry/tasks/task-349-380-gen3-spinda-extraction-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-349-380-gen3-spinda-extraction-impl
+type: TASK
+title: "Gen3 Spinda Extraction Implementation"
+status: PENDING
+owner_persona: "coder"
+created_at: "2026-08-01"
+updated_at: "2026-08-01"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-345-349-gen3-spinda-extraction-core
+tags:
+  - gen3
+  - spinda
+  - data-extraction
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen3 Spinda Extraction Implementation
+
+## Context
+Implement parsing logic to identify Spinda Pokémon in both PC Box and Party datasets for Generation 3 save files. The core requirement is to extract the 32-bit PID for each identified Spinda, and map this to a specific data structure.
+
+## Acceptance Criteria
+- [ ] Implement parsing logic to identify Spinda Pokémon in both PC Box and Party datasets.
+- [ ] Extract the 32-bit PID for each identified Spinda.
+- [ ] Define the interface/data structure to store the extracted Spinda info for the UI layer.
+
+## Critical Guidelines
+You MUST strictly adhere to all guidelines defined in **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`. Specifically:
+*   **Module-Level Constants:** All memory offsets, lengths, bit locations, shifts, and array bounds checking limits must be explicitly defined as reusable constants at the module level.
+*   **No Magic Numbers:** The use of inline magic numbers (e.g., `0x2dd6`, `>> 4`) directly in parsing functions is strictly forbidden.
+*   **Relative Offsets (Gen 3):** When extracting Gen 3 save blocks, you must pass and utilize the resolved section offset (e.g., `section1Offset` or `section2Offset`) to calculate relative memory offsets rather than absolute hardcoded offsets, supporting the A/B bank flash memory architecture.
+*   **Bitwise Mapping:** When parsing bitwise blocks (e.g., event flags) using the `DataView` API, you must explicitly map the specific bit offsets corresponding to target events. Just extracting the raw array is insufficient.
+*   **RangeError Handling:** When using the `DataView` API, you MUST catch `RangeError` for out-of-bounds reads and throw a new error with the message "The save file is corrupted or incomplete." to prevent application crashes.

--- a/.foundry/tasks/task-349-381-gen3-spinda-extraction-qa.md
+++ b/.foundry/tasks/task-349-381-gen3-spinda-extraction-qa.md
@@ -1,0 +1,37 @@
+---
+id: task-349-381-gen3-spinda-extraction-qa
+type: TASK
+title: "QA: Gen3 Spinda Extraction"
+status: PENDING
+owner_persona: "qa"
+created_at: "2026-08-01"
+updated_at: "2026-08-01"
+depends_on:
+  - task-349-380-gen3-spinda-extraction-impl
+jules_session_id: null
+pr_number: null
+parent: story-345-349-gen3-spinda-extraction-core
+tags:
+  - gen3
+  - spinda
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# QA: Gen3 Spinda Extraction
+
+## Context
+Verify the implementation of Spinda Pokémon extraction logic in Gen 3 save files from both PC Box and Party datasets. The goal is to ensure correct extraction of the 32-bit PID.
+Because this story involves extracting specific details from complex data structures, QA testing is needed as part of the Intelligent Verification Protocol.
+
+## Acceptance Criteria
+- [ ] Verify that the parsing logic correctly identifies Spinda Pokémon in both PC Box and Party datasets.
+- [ ] Verify that the 32-bit PID is correctly extracted for each identified Spinda.
+- [ ] Verify that the interface/data structure properly stores the extracted Spinda info for the UI layer.
+
+## Verification Checklist
+- [ ] The implementation correctly follows Section 13 ("Save File Parsing & Extraction Guidelines") of `.foundry/docs/schema.md`.
+- [ ] Tests pass (e.g., unit tests added for the new parsing logic).


### PR DESCRIPTION
Created tasks (`task-349-380-gen3-spinda-extraction-impl` and `task-349-381-gen3-spinda-extraction-qa`) based on `story-345-349-gen3-spinda-extraction-core`. Appended them to the story's acceptance criteria without modifying its YAML frontmatter. Documented schema rule enforcement in tech lead journal.

---
*PR created automatically by Jules for task [6077590348936719751](https://jules.google.com/task/6077590348936719751) started by @szubster*