### PR TITLE
Feat: Append E2E Story to Epic-097-131

### DIFF
--- a/.foundry/epics/epic-097-131-nuzlocke-death-tracking.md
+++ b/.foundry/epics/epic-097-131-nuzlocke-death-tracking.md
@@ -34,3 +34,4 @@ Implement the logic to track dead Pokémon based on HP and Graveyard box assignm
 - [x] story-131-317-detect-party-zero-hp
 - [x] story-131-333-graveyard-box-state
 - [x] story-131-334-graveyard-box-ui
+- [ ] story-131-351-nuzlocke-death-tracking-e2e

--- a/.foundry/journals/story_owner/4854301433535350090.md
+++ b/.foundry/journals/story_owner/4854301433535350090.md
@@ -1,0 +1,4 @@
+# Session 4854301433535350090
+
+- Found that `epic-097-131-nuzlocke-death-tracking` lacked an `e2e` tagged STORY node, which violates the E2E safeguard policy and prevents the EPIC from completing.
+- Created `story-131-351-nuzlocke-death-tracking-e2e` dynamically (late-binding) with the `e2e` tag and appended it to the EPIC's acceptance criteria to unblock the EPIC.

--- a/.foundry/stories/story-131-351-nuzlocke-death-tracking-e2e.md
+++ b/.foundry/stories/story-131-351-nuzlocke-death-tracking-e2e.md
@@ -1,0 +1,33 @@
+---
+id: story-131-351-nuzlocke-death-tracking-e2e
+type: STORY
+title: Nuzlocke Death Tracking E2E Tests
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on: []
+jules_session_id: '4854301433535350090'
+pr_number: null
+parent: epic-097-131-nuzlocke-death-tracking
+tags:
+  - e2e
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Nuzlocke Death Tracking E2E Tests
+
+## Objective
+Implement End-to-End tests to verify the automated death tracking logic and Graveyard Box functionality.
+
+## Scope
+- Implement E2E tests covering the detection of party Pokémon at 0 HP.
+- Implement E2E tests verifying Graveyard box designation and UI settings.
+- Implement E2E tests verifying Pokémon in the Graveyard box are correctly identified as dead.
+
+## Acceptance Criteria
+- [ ] Breakdown into Tasks


### PR DESCRIPTION
- Dynamically created `story-131-351-nuzlocke-death-tracking-e2e.md` with the `e2e` tag.
- Appended the story to `epic-097-131-nuzlocke-death-tracking`'s Acceptance Criteria.
- Wrote a journal entry outlining the policy enforcement.
- This addresses the Epic E2E Safeguard blocking the Epic from completion.

---
*PR created automatically by Jules for task [4854301433535350090](https://jules.google.com/task/4854301433535350090) started by @szubster*