### PR TITLE
QA: Verify concurrent game switcher UI

### DIFF
--- a/.foundry/journals/qa/13133077931356205726.md
+++ b/.foundry/journals/qa/13133077931356205726.md
@@ -1,0 +1,11 @@
+# QA Session: 13133077931356205726
+
+## Validation of Concurrent Game Switcher UI
+
+The `GameSwitcher` component successfully implements the tactical UI requirements and interacts correctly with the `ConcurrentGameContext`.
+
+- Uses `font-mono`, `border-dashed`, and `rounded-none` confirming ADR 008 compliance.
+- Safely returns `null` if no active playthroughs exist, minimizing layout shift.
+- Integrates well with the React Context layer for managing active concurrent saves.
+
+No issues found. Validation passed.

--- a/.foundry/tasks/task-257-372-concurrent-game-switcher-ui-qa.md
+++ b/.foundry/tasks/task-257-372-concurrent-game-switcher-ui-qa.md
@@ -30,4 +30,4 @@ QA verification for the Concurrent Game Switcher UI.
 - Validate the UI component works correctly.
 
 ## Acceptance Criteria
-- [ ] Verify the UI component implementation.
+- [x] Verify the UI component implementation.


### PR DESCRIPTION
- Checked off acceptance criteria in the QA task markdown.
- Created a QA journal entry detailing successful validation.

---
*PR created automatically by Jules for task [13133077931356205726](https://jules.google.com/task/13133077931356205726) started by @szubster*