### PR TITLE
fix: Cloudflare R2 Graceful Degradation

### DIFF
--- a/.foundry/tasks/task-266-377-r2-graceful-degradation-impl.md
+++ b/.foundry/tasks/task-266-377-r2-graceful-degradation-impl.md
@@ -31,5 +31,5 @@ The application currently attempts to sync files to R2 when the user is logged i
 - Ensure the UI does not show a global error when only the R2 sync fails, but the local save is successful.
 
 ## Acceptance Criteria
-- [ ] R2 API failures in `useFileSyncController.ts` are caught and gracefully ignored, allowing local sync to continue.
-- [ ] R2 API failures in `AppLayout.tsx` are caught and gracefully ignored, allowing file uploads to continue locally.
+- [x] R2 API failures in `useFileSyncController.ts` are caught and gracefully ignored, allowing local sync to continue.
+- [x] R2 API failures in `AppLayout.tsx` are caught and gracefully ignored, allowing file uploads to continue locally.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -65,9 +65,13 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           try {
             const saves = await r2Client.listSaves();
             const saveId = saves.length > 0 && saves[0] ? saves[0].id : 'save-1';
-            await r2Client.putSave(saveId, new Uint8Array(buffer), file.lastModified);
+            try {
+              await r2Client.putSave(saveId, new Uint8Array(buffer), file.lastModified);
+            } catch {
+              console.warn('System: push to cloud failed');
+            }
           } catch {
-            console.error('System: push to cloud failed');
+            console.warn('System: list saves from cloud failed');
           }
         }
       } catch {

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -362,7 +362,7 @@ describe('AppLayout file upload', () => {
     localStorage.setItem(AUTH_LOGGED_IN_INDICATOR, 'true');
     vi.mocked(r2Client.listSaves).mockRejectedValue(new Error('Network error'));
 
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await render(
       <QueryClientProvider client={queryClient}>
@@ -400,13 +400,13 @@ describe('AppLayout file upload', () => {
 
     await vi.waitFor(
       () => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith('System: push to cloud failed');
+        expect(consoleWarnSpy).toHaveBeenCalledWith('System: list saves from cloud failed');
       },
       { timeout: 3000 },
     );
 
     vi.unstubAllGlobals();
     localStorage.clear();
-    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/src/hooks/useFileSyncController.test.tsx
+++ b/src/hooks/useFileSyncController.test.tsx
@@ -330,7 +330,7 @@ describe('useFileSyncController', () => {
     localStorage.setItem(AUTH_LOGGED_IN_INDICATOR, 'true');
     vi.mocked(r2Client.listSaves).mockRejectedValue(new Error('Network error'));
 
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     // Setup file mock
     const mockFile = {
@@ -361,11 +361,11 @@ describe('useFileSyncController', () => {
     await page.getByTestId('request-btn').click();
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith('System: push to cloud failed');
+    expect(consoleWarnSpy).toHaveBeenCalledWith('System: list saves from cloud failed');
     // Ensure state still transitioned to live despite the R2 error
     await expect.element(page.getByTestId('status')).toHaveTextContent('live');
 
-    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 
   it('should clean up interval on unmount', async () => {

--- a/src/hooks/useFileSyncController.ts
+++ b/src/hooks/useFileSyncController.ts
@@ -84,7 +84,12 @@ export function useFileSyncController() {
 
             if (cloudSaveInfo?.lastModified && file.lastModified < cloudSaveInfo.lastModified) {
               // Cloud is newer, we should pull instead of pushing local (Conflict Resolution: pull-wins if newer)
-              const cloudSave = await r2Client.getSave(saveId);
+              let cloudSave = null;
+              try {
+                cloudSave = await r2Client.getSave(saveId);
+              } catch {
+                console.warn('System: pull from cloud failed');
+              }
               if (cloudSave) {
                 const cloudData = parseSaveFile(cloudSave.data.buffer, manualVersion || undefined);
                 setSaveData(cloudData);
@@ -103,9 +108,13 @@ export function useFileSyncController() {
             }
 
             await saveDB.putSave('last_save_file', new Uint8Array(buffer));
-            await r2Client.putSave(saveId, new Uint8Array(buffer), file.lastModified);
+            try {
+              await r2Client.putSave(saveId, new Uint8Array(buffer), file.lastModified);
+            } catch {
+              console.warn('System: push to cloud failed');
+            }
           } catch {
-            console.error('System: push to cloud failed');
+            console.warn('System: list saves from cloud failed');
             await saveDB.putSave('last_save_file', new Uint8Array(buffer));
           }
         } else {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -186,6 +186,30 @@ describe('Zustand Store', () => {
         setItem: vi.fn<() => void>(),
         removeItem: vi.fn<() => void>(),
       });
+      vi.mocked(r2Client.listSaves).mockResolvedValue([{ id: 'cloud-save-id' }]);
+      vi.mocked(r2Client.getSave).mockRejectedValue(new Error('Network error'));
+
+      const localData = new Uint8Array([1, 2, 3]);
+      vi.spyOn(saveDB, 'getSave').mockResolvedValue(localData);
+      const mockSaveData = { trainerName: 'LOCAL', generation: 1, gameVersion: 'red' };
+      vi.mocked(parseSaveFile).mockReturnValue(mockSaveData as unknown as ReturnType<typeof parseSaveFile>);
+
+      await useStore.getState().loadSaveFromStorage();
+
+      expect(r2Client.listSaves).toHaveBeenCalled();
+      expect(r2Client.getSave).toHaveBeenCalledWith('cloud-save-id');
+      expect(saveDB.getSave).toHaveBeenCalledWith('last_save_file');
+      expect(useStore.getState().saveData).toEqual(mockSaveData);
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should fallback to local DB if R2 list saves fails', async () => {
+      vi.stubGlobal('localStorage', {
+        getItem: () => 'true',
+        setItem: vi.fn<() => void>(),
+        removeItem: vi.fn<() => void>(),
+      });
       vi.mocked(r2Client.listSaves).mockRejectedValue(new Error('Network error'));
 
       const localData = new Uint8Array([1, 2, 3]);

--- a/src/store.ts
+++ b/src/store.ts
@@ -206,14 +206,19 @@ export const useStore = create<AppStore>()(
             try {
               const saves = await r2Client.listSaves();
               if (saves.length > 0 && saves[0]) {
-                const cloudSave = await r2Client.getSave(saves[0].id);
+                let cloudSave = null;
+                try {
+                  cloudSave = await r2Client.getSave(saves[0].id);
+                } catch {
+                  console.warn('System: failed to pull save from cloud');
+                }
                 if (cloudSave) {
                   await saveDB.putSave('last_save_file', cloudSave.data);
                   buffer = cloudSave.data;
                 }
               }
             } catch {
-              console.error('System: failed to pull from cloud');
+              console.warn('System: failed to list saves from cloud');
             }
           }
 


### PR DESCRIPTION
This PR addresses the issue of fatal errors breaking local functionality when Cloudflare R2 is unreachable.

Changes:
- Added explicit try/catch blocks for `r2Client.getSave` and `r2Client.putSave` operations in `useFileSyncController.ts`, `AppLayout.tsx`, and `store.ts`.
- Replaced `console.error` with `console.warn` for R2-related exceptions to gracefully degrade network failures while still keeping debug logs.
- Updated unit test mock assertions to check for `console.warn` in the `useFileSyncController.test.tsx` and `AppLayout.test.tsx`.
- Checked off task acceptance criteria in `.foundry/tasks/task-266-377-r2-graceful-degradation-impl.md`.

---
*PR created automatically by Jules for task [37586618707610940](https://jules.google.com/task/37586618707610940) started by @szubster*