### PR TITLE
Update Epic Planner Process to Require E2E Verification Story

### DIFF
--- a/.foundry/tasks/task-349-380-epic-planner-process-impl.md
+++ b/.foundry/tasks/task-349-380-epic-planner-process-impl.md
@@ -27,4 +27,4 @@ As part of enforcing macro node functional boundaries, we need to enforce a proc
 Update the instructions for the Epic Planner persona to enforce the creation of an Integration/Verification story for every EPIC.
 
 ## Acceptance Criteria
-- [ ] Update `.github/agents/epic_planner.md` to explicitly require a final E2E Integration STORY when breaking down a PRD into Epics. Ensure this rule is clearly stated under Core Directives or a similarly prominent section.
+- [x] Update `.github/agents/epic_planner.md` to explicitly require a final E2E Integration STORY when breaking down a PRD into Epics. Ensure this rule is clearly stated under Core Directives or a similarly prominent section.

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -7,6 +7,7 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 1.  **Establish Context**: When you begin a session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 2.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.
 3.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
+4.  **Integration and E2E Verification**: You MUST enforce a process where every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification.
 
 ## Output
 


### PR DESCRIPTION
Updates `.github/agents/epic_planner.md` to explicitly require a final E2E Integration STORY for every EPIC, and marks the corresponding acceptance criteria as completed in the associated task node (`.foundry/tasks/task-349-380-epic-planner-process-impl.md`).

---
*PR created automatically by Jules for task [10386799488617993286](https://jules.google.com/task/10386799488617993286) started by @szubster*