### PR TITLE
chore(foundry): add core sorting strategies task blueprints

### DIFF
--- a/.foundry/journals/tech_lead/10011728327050311015.md
+++ b/.foundry/journals/tech_lead/10011728327050311015.md
@@ -1,0 +1,1 @@
+- Always ensure to actually create task markdown files when technical blueprinting.

--- a/.foundry/stories/story-136-333-sorting-standard-strategies-retry.md
+++ b/.foundry/stories/story-136-333-sorting-standard-strategies-retry.md
@@ -44,3 +44,5 @@ Building upon the standard interface, we need specific, actionable sorters that 
 - [ ] [task-333-371-sorting-strategies-retry-qa](.foundry/tasks/task-333-371-sorting-strategies-retry-qa.md)
 - [ ] task-333-375-sorting-strategies-regional-dex-impl
 - [ ] task-333-376-sorting-strategies-regional-dex-qa
+- [ ] task-333-382-sorting-strategies-core-impl
+- [ ] task-333-383-sorting-strategies-core-qa

--- a/.foundry/tasks/task-333-382-sorting-strategies-core-impl.md
+++ b/.foundry/tasks/task-333-382-sorting-strategies-core-impl.md
@@ -1,0 +1,45 @@
+---
+id: task-333-382-sorting-strategies-core-impl
+type: TASK
+title: Implement Core PC Box Sorting Strategies
+status: READY
+owner_persona: coder
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-136-333-sorting-standard-strategies-retry
+tags:
+  - feature
+  - sorting
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Core PC Box Sorting Strategies
+
+## Context
+We need specific, actionable sorters that understand the `PokeData` structure. These standard strategies will allow users to sort their PC Boxes by common criteria such as Dex Number, Level, and Type.
+
+## Requirements
+Implement concrete sorting strategies using the base `SortingStrategy` interface defined in `story-136-294`. Place implementations in `src/engine/sorting/StandardSorters.ts`.
+
+1. **`DexNumberSorter`**: Supports both National and Regional variants via configuration (`variant: 'national' | 'regional'`). If `regional` is requested but unsupported, fallback to `speciesId` or throw a clear error.
+2. **`LevelSorter`**: Constructor takes `direction: 'asc' | 'desc'`. Sort by `instance.level`.
+3. **`TypeSorter`**: Sort by primary type, then secondary type. Handle missing metadata or missing types gracefully (put them at the end).
+4. **`AlphaSorter`**: Sort alphabetically by `instance.nickname`. If missing, fallback to species name, then string representation of `speciesId`.
+
+## Important Guidelines
+- Strictly adhere to **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`.
+- Write comprehensive unit tests for each strategy using Vitest in a corresponding `.test.ts` file.
+
+## Acceptance Criteria
+- [ ] `DexNumberSorter` is implemented and supports both National and Regional variants.
+- [ ] `LevelSorter` is implemented with asc/desc support.
+- [ ] `TypeSorter` is implemented and gracefully handles missing data.
+- [ ] `AlphaSorter` is implemented.
+- [ ] Comprehensive unit tests are provided in `StandardSorters.test.ts`.
+- [ ] `pnpm lint` and `pnpm test` pass.

--- a/.foundry/tasks/task-333-383-sorting-strategies-core-qa.md
+++ b/.foundry/tasks/task-333-383-sorting-strategies-core-qa.md
@@ -1,0 +1,32 @@
+---
+id: task-333-383-sorting-strategies-core-qa
+type: TASK
+title: QA Core PC Box Sorting Strategies
+status: READY
+owner_persona: qa
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on:
+  - task-333-382-sorting-strategies-core-impl
+jules_session_id: null
+pr_number: null
+parent: story-136-333-sorting-standard-strategies-retry
+tags:
+  - feature
+  - sorting
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA Core PC Box Sorting Strategies
+
+## Context
+The coder has implemented standard PC Box sorting strategies (Dex, Level, Type, Alpha).
+
+## Acceptance Criteria
+- [ ] Verify `DexNumberSorter`, `LevelSorter`, `TypeSorter`, and `AlphaSorter` correctly implement the `SortingStrategy` signature in `src/engine/sorting/StandardSorters.ts`.
+- [ ] Verify edge cases (missing metadata, missing types, missing nicknames) are handled gracefully without throwing errors during sort.
+- [ ] Run `pnpm test` to ensure all sorting unit tests pass and properly assert correct sorting orders.
+- [ ] Verify `pnpm lint` passes.


### PR DESCRIPTION
Created task nodes for the remaining implementation criteria in `story-136-333-sorting-standard-strategies-retry`, specifically `DexNumberSorter`, `LevelSorter`, `TypeSorter`, and `AlphaSorter`. Appended references as unchecked checkboxes to the story.

---
*PR created automatically by Jules for task [10011728327050311015](https://jules.google.com/task/10011728327050311015) started by @szubster*