### PR TITLE
chore: late-bind hidden items checklist integration

### DIFF
--- a/.foundry/stories/story-060-157-hidden-items-e2e-tests.md
+++ b/.foundry/stories/story-060-157-hidden-items-e2e-tests.md
@@ -35,3 +35,4 @@ To ensure the Hidden Items Finder UI functions as expected and integrates proper
 ## Tasks
 - [ ] task-157-338-hidden-items-e2e-tests-impl
 - [ ] task-157-339-hidden-items-e2e-tests-qa
+- [ ] story-060-158-hidden-items-checklist-integration

--- a/.foundry/stories/story-060-158-hidden-items-checklist-integration.md
+++ b/.foundry/stories/story-060-158-hidden-items-checklist-integration.md
@@ -1,0 +1,34 @@
+---
+id: story-060-158-hidden-items-checklist-integration
+type: STORY
+title: Integrate Hidden Items Checklist into Dashboard
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-037-060-hidden-items-ui
+tags:
+  - ui
+  - integration
+rejection_count: 0
+rejection_reason: ''
+notes: 'Spawned via late-binding to integrate the unmounted HiddenItemsChecklist component.'
+---
+
+# Story: Integrate Hidden Items Checklist into Dashboard
+
+## 1. Context & Background
+During the implementation of E2E tests for the `HiddenItemsChecklist` component (`task-157-338`), it was discovered that the component is not currently mounted anywhere within the application routes (e.g., `src/routes/dashboard.tsx`). To write effective E2E tests, the component must first be integrated into the application's view hierarchy.
+
+## 2. Product Requirements
+- Integrate the `HiddenItemsChecklist` component into a suitable route, such as `src/routes/dashboard.tsx` or as part of a run progression view.
+- Ensure it receives the correct hydrated save data format (`LocationGroupedHiddenItems[]`).
+
+## 3. Acceptance Criteria
+- [ ] The `HiddenItemsChecklist` component is mounted in the application and accessible via a route.
+- [ ] It correctly receives and renders grouped hidden items data.
+
+## Tasks

--- a/.foundry/tasks/task-157-338-hidden-items-e2e-tests-impl.md
+++ b/.foundry/tasks/task-157-338-hidden-items-e2e-tests-impl.md
@@ -2,7 +2,7 @@
 id: task-157-338-hidden-items-e2e-tests-impl
 type: TASK
 title: Implement E2E Tests for Hidden Items UI
-status: ACTIVE
+status: CANCELLED
 owner_persona: coder
 created_at: '2026-07-21'
 updated_at: '2026-08-01'
@@ -16,7 +16,7 @@ tags:
   - ui
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'HiddenItemsChecklist is not integrated into any route, making E2E testing impossible. Task cancelled. Need integration first.'
 notes: ''
 ---
 
@@ -44,3 +44,6 @@ To ensure the Hidden Items Finder UI functions as expected and integrates proper
 - [ ] The tests verify that the Hidden Items view renders correctly after save hydration.
 - [ ] The tests verify that acquired items are visually checked off.
 - [ ] Tests pass consistently.
+
+
+- [ ] story-060-158-hidden-items-checklist-integration


### PR DESCRIPTION
Suspends the E2E testing task by marking it as `CANCELLED` because the target `HiddenItemsChecklist` component is not currently mounted in any application route. Created a new story (`story-060-158-hidden-items-checklist-integration`) via late-binding to integrate the component into the dashboard so that E2E testing can proceed correctly. The new story has been added to the parent story and task dependencies.

---
*PR created automatically by Jules for task [14231591339788772509](https://jules.google.com/task/14231591339788772509) started by @szubster*