### PR TITLE
Reject Gen 3 Static Encounters UI Implementation

### DIFF
--- a/.foundry/journals/qa/12335444189339326262.md
+++ b/.foundry/journals/qa/12335444189339326262.md
@@ -1,0 +1,3 @@
+# QA Session 12335444189339326262
+
+Rejected task `task-295-338-gen3-static-encounters-ui-impl` because the implementation failed to integrate the new component into the main dashboard (`src/routes/dashboard.tsx`).

--- a/.foundry/tasks/task-295-338-gen3-static-encounters-ui-impl.md
+++ b/.foundry/tasks/task-295-338-gen3-static-encounters-ui-impl.md
@@ -2,7 +2,7 @@
 id: task-295-338-gen3-static-encounters-ui-impl
 type: TASK
 title: Gen 3 Static Encounters UI Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-20'
 updated_at: '2026-08-01'
@@ -15,8 +15,8 @@ tags:
   - feature
   - ui
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Missing integration with Gen 3 dashboard in src/routes/dashboard.tsx'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-295-339-gen3-static-encounters-ui-qa.md
+++ b/.foundry/tasks/task-295-339-gen3-static-encounters-ui-qa.md
@@ -26,6 +26,9 @@ notes: ''
 
 Verify the Gen 3 static encounters UI implementation.
 
+### QA Rejection Note
+The implementation failed validation. The `Gen3StaticEncountersDashboard` component was created and tested, but it was not integrated into the central Gen 3 dashboard (`src/routes/dashboard.tsx`). Missing this integration means the UI is not accessible to users.
+
 ## Acceptance Criteria
 - [ ] Verify the UI correctly displays the static encounter checklist based on save file flags.
 - [ ] Verify the UI strictly adheres to the 'tactical hardware/snooping' design constraints (e.g., rounded-none, border-dashed, monospaced telemetry fonts).


### PR DESCRIPTION
The implementation for the Gen3 Static Encounters UI (task-295-338) failed validation because the component was not integrated into the central Gen 3 dashboard (`src/routes/dashboard.tsx`). Missing this integration means the UI is not accessible to users. This PR formally rejects the implementation, updating the task status to FAILED, providing the rejection reason, incrementing the rejection count, and noting the failure in the QA task.

---
*PR created automatically by Jules for task [12335444189339326262](https://jules.google.com/task/12335444189339326262) started by @szubster*