### PR TITLE
💡 Visionary: Dynamic Task SLA Monitoring

### DIFF
--- a/.foundry/ideas/idea-133-dynamic-task-sla-monitoring.md
+++ b/.foundry/ideas/idea-133-dynamic-task-sla-monitoring.md
@@ -26,7 +26,8 @@ Currently, the DAG orchestrator does not monitor how long a task has been in a s
 Introduce Dynamic Task SLAs (Service Level Agreements) to the DAG Orchestrator:
 1. Define configurable threshold limits for node states based on their type (e.g., a TASK should resolve within X hours, an EPIC might take days).
 2. The orchestrator will periodically scan all `READY` and `ACTIVE` nodes against their SLA based on `created_at` or `updated_at`.
-3. If an SLA is breached, the orchestrator will automatically spawn an intervention node owned by the `agile_coach` or `mechanic` persona to investigate the bottleneck, redistribute resources, or forcibly demote the stalled task for re-evaluation.
+3. Nodes assigned to the `human` persona must be strictly exempt from SLA monitoring, as human response times are highly variable and out of the orchestrator's control.
+4. If an SLA is breached, the orchestrator will automatically spawn an intervention node owned by the `agile_coach` or `mechanic` persona to investigate the bottleneck, redistribute resources, or forcibly demote the stalled task for re-evaluation.
 
 This enhances the autonomous software factory's self-healing capabilities and guarantees better predictability in the multi-agent pipeline.
 

--- a/.foundry/ideas/idea-133-dynamic-task-sla-monitoring.md
+++ b/.foundry/ideas/idea-133-dynamic-task-sla-monitoring.md
@@ -26,7 +26,7 @@ Currently, the DAG orchestrator does not monitor how long a task has been in a s
 Introduce Dynamic Task SLAs (Service Level Agreements) to the DAG Orchestrator:
 1. Define configurable threshold limits for node states based on their type (e.g., a TASK should resolve within X hours, an EPIC might take days).
 2. The orchestrator will periodically scan all `READY` and `ACTIVE` nodes against their SLA based on `created_at` or `updated_at`.
-3. Nodes assigned to the `human` persona must be strictly exempt from SLA monitoring, as human response times are highly variable and out of the orchestrator's control. Additionally, any node in the `VERIFYING` state waiting for human PR approval is also exempt, as humans are required to verify PRs to move nodes forward.
+3. Nodes explicitly assigned to the `human` persona must be strictly exempt from SLA monitoring, as human response times are highly variable and out of the orchestrator's control. (Nodes in the `VERIFYING` state are managed by the `qa` persona and are subject to standard SLAs).
 4. If an SLA is breached, the orchestrator will automatically spawn an intervention node owned by the `agile_coach` or `mechanic` persona to investigate the bottleneck, redistribute resources, or forcibly demote the stalled task for re-evaluation.
 
 This enhances the autonomous software factory's self-healing capabilities and guarantees better predictability in the multi-agent pipeline.

--- a/.foundry/ideas/idea-133-dynamic-task-sla-monitoring.md
+++ b/.foundry/ideas/idea-133-dynamic-task-sla-monitoring.md
@@ -1,0 +1,35 @@
+---
+id: idea-133-dynamic-task-sla-monitoring
+type: IDEA
+title: Dynamic Task SLA Monitoring and Alerting
+status: PENDING
+owner_persona: "product_manager"
+created_at: "2026-08-02"
+updated_at: "2026-08-02"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags: ["foundry", "orchestrator", "scheduling"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Idea: Dynamic Task SLA Monitoring and Alerting
+
+## Problem
+Currently, the DAG orchestrator does not monitor how long a task has been in a specific state (`READY` or `ACTIVE`) unless it fails explicitly via a timeout or max rejection count. A node might remain unassigned (stuck in `READY` due to persona starvation) or trapped in an endless cycle of minor changes and re-assignments without triggering the Max Rejection Cancellation loop. This silent stalling degrades overall pipeline throughput.
+
+## Proposed Solution
+Introduce Dynamic Task SLAs (Service Level Agreements) to the DAG Orchestrator:
+1. Define configurable threshold limits for node states based on their type (e.g., a TASK should resolve within X hours, an EPIC might take days).
+2. The orchestrator will periodically scan all `READY` and `ACTIVE` nodes against their SLA based on `created_at` or `updated_at`.
+3. If an SLA is breached, the orchestrator will automatically spawn an intervention node owned by the `agile_coach` or `mechanic` persona to investigate the bottleneck, redistribute resources, or forcibly demote the stalled task for re-evaluation.
+
+This enhances the autonomous software factory's self-healing capabilities and guarantees better predictability in the multi-agent pipeline.
+
+## Acceptance Criteria
+- [ ] Investigate node SLA breach intervention node spawning
+- [ ] Implement DAG orchestrator SLA monitoring logic

--- a/.foundry/ideas/idea-133-dynamic-task-sla-monitoring.md
+++ b/.foundry/ideas/idea-133-dynamic-task-sla-monitoring.md
@@ -26,7 +26,7 @@ Currently, the DAG orchestrator does not monitor how long a task has been in a s
 Introduce Dynamic Task SLAs (Service Level Agreements) to the DAG Orchestrator:
 1. Define configurable threshold limits for node states based on their type (e.g., a TASK should resolve within X hours, an EPIC might take days).
 2. The orchestrator will periodically scan all `READY` and `ACTIVE` nodes against their SLA based on `created_at` or `updated_at`.
-3. Nodes assigned to the `human` persona must be strictly exempt from SLA monitoring, as human response times are highly variable and out of the orchestrator's control.
+3. Nodes assigned to the `human` persona must be strictly exempt from SLA monitoring, as human response times are highly variable and out of the orchestrator's control. Additionally, any node in the `VERIFYING` state waiting for human PR approval is also exempt, as humans are required to verify PRs to move nodes forward.
 4. If an SLA is breached, the orchestrator will automatically spawn an intervention node owned by the `agile_coach` or `mechanic` persona to investigate the bottleneck, redistribute resources, or forcibly demote the stalled task for re-evaluation.
 
 This enhances the autonomous software factory's self-healing capabilities and guarantees better predictability in the multi-agent pipeline.

--- a/.jules/visionary/2026-08-02-01-52-29.md
+++ b/.jules/visionary/2026-08-02-01-52-29.md
@@ -1,0 +1,9 @@
+# Visionary Journal
+
+- **Active Session/Timestamp:** 2026-08-02-01-52-29
+- **Domain:** Foundry System (Orchestrator)
+- **Proposed Idea:** Dynamic Task SLA Monitoring and Alerting (IDEA-133)
+- **Rationale & Concept:**
+  To improve pipeline predictability, the DAG orchestrator needs to track how long nodes sit in `READY` or `ACTIVE` states. If a node breaches a configurable SLA threshold, it should automatically trigger an intervention from the `agile_coach` or `mechanic` persona to unblock the pipeline before things stall completely.
+- **How this idea maintains the 50/50 balance between DexHelper and Foundry:**
+  In the previous session, we proposed a DexHelper idea (IDEA-132: Gen 3 Pal Park Migration Planner). To explicitly maintain the mandatory 50/50 split between product features and system infrastructure, this session's proposal focuses solely on the Foundry's internal orchestration and scheduling capabilities.


### PR DESCRIPTION
This PR introduces a new `IDEA` node (IDEA-133) proposing the implementation of Dynamic Task SLAs in the DAG orchestrator. This aims to prevent tasks from stalling silently without hitting Max Rejection Cancellation, thereby improving the overall health and speed of the multi-agent pipeline. It strictly adheres to the 50/50 balance between product features and system infrastructure.

---
*PR created automatically by Jules for task [17951257987637388022](https://jules.google.com/task/17951257987637388022) started by @szubster*