### PR TITLE
feat(nuzlocke): Implement Aggregate First Catch by Route

### DIFF
--- a/.foundry/journals/coder/2026-08-02-02-10-55.md
+++ b/.foundry/journals/coder/2026-08-02-02-10-55.md
@@ -1,0 +1,9 @@
+# Coder Journal Entry: 2026-08-02
+
+## Learnings & Observations
+
+*   **Gen 3 Save State Proxies for Time:** Since Generation 3 does not record exact capture timestamps in save files, chronologically ordering captures requires using proxies. `PokemonInstance.storageLocation` alongside `PokemonInstance.slot` serves as the most reliable indicator of sequence, provided the player hasn't extensively reordered their PC. The heuristic rule is:
+    1.  `Party` comes before PC Box storage.
+    2.  If both are in PC Boxes, order ascending by Box number (e.g., `Box 1` < `Box 2`).
+    3.  If in the same Box, order ascending by `slot`.
+*   **Testing React Callbacks:** Remember Vitest rule `vitest(require-mock-type-parameters)`. Need to explicitly provide generic types when mocking callback props (e.g., `vi.fn<(val: string) => void>()`).

--- a/.foundry/tasks/task-262-375-aggregate-first-catch-impl.md
+++ b/.foundry/tasks/task-262-375-aggregate-first-catch-impl.md
@@ -31,5 +31,5 @@ Implement logic to aggregate caught Pokémon by their `met_location` and identif
 - Adhere to Section 13 ("Save File Parsing & Extraction Guidelines") of `.foundry/docs/schema.md`.
 
 ## Acceptance Criteria
-- [ ] Aggregation logic is implemented and can identify the first catch for each distinct location.
-- [ ] Code follows project conventions.
+- [x] Aggregation logic is implemented and can identify the first catch for each distinct location.
+- [x] Code follows project conventions.

--- a/src/engine/nuzlocke/tracker.test.ts
+++ b/src/engine/nuzlocke/tracker.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { PokemonInstance, SaveData } from '../saveParser/parsers/common';
 import {
   aggregateEncountersByLocation,
+  aggregateFirstCatchByRoute,
   detectNuzlockeViolations,
   getDeadPokemon,
   getGraveyardPokemon,
@@ -187,5 +188,62 @@ describe('getGraveyardPokemon', () => {
     const saveData: Partial<SaveData> = {};
     const result = getGraveyardPokemon(saveData as SaveData, 'Box 14');
     expect(result).toHaveLength(0);
+  });
+});
+
+describe('aggregateFirstCatchByRoute', () => {
+  it('should identify the first catch correctly based on storageLocation and slot', () => {
+    const saveData: Partial<SaveData> = {
+      partyDetails: [
+        {
+          speciesId: 2,
+          caughtData: { location: 1, locationName: 'Route 1' },
+          storageLocation: 'Party',
+          slot: 2,
+        } as unknown as PokemonInstance,
+      ],
+      pcDetails: [
+        {
+          speciesId: 1,
+          caughtData: { metLocation: 1, locationName: 'Route 1' },
+          storageLocation: 'Box 1',
+          slot: 1,
+        } as unknown as PokemonInstance,
+        {
+          speciesId: 3,
+          caughtData: { location: 2, locationName: 'Route 2' },
+          storageLocation: 'Box 2',
+          slot: 5,
+        } as unknown as PokemonInstance,
+        {
+          speciesId: 4,
+          caughtData: { location: 2, locationName: 'Route 2' },
+          storageLocation: 'Box 1',
+          slot: 2,
+        } as unknown as PokemonInstance,
+        {
+          speciesId: 5,
+          caughtData: { location: 2, locationName: 'Route 2' },
+          storageLocation: 'Box 1',
+          slot: 1,
+        } as unknown as PokemonInstance,
+      ],
+    };
+
+    const result = aggregateFirstCatchByRoute(saveData as SaveData);
+
+    expect(result).toHaveLength(2);
+
+    const route1 = result.find((r) => r.locationId === 1);
+    expect(route1).toBeDefined();
+    expect(route1?.encounters).toHaveLength(1);
+    // Party takes precedence over PC
+    expect(route1?.encounters[0]?.speciesId).toBe(2);
+
+    const route2 = result.find((r) => r.locationId === 2);
+    expect(route2).toBeDefined();
+    expect(route2?.encounters).toHaveLength(1);
+    // Box 1 slot 1 takes precedence over Box 1 slot 2 and Box 2 slot 5
+    expect(route2?.encounters[0]?.speciesId).toBe(5);
   });
 });

--- a/src/engine/nuzlocke/tracker.ts
+++ b/src/engine/nuzlocke/tracker.ts
@@ -28,8 +28,9 @@ export function aggregateEncountersByLocation(saveData: SaveData): LocationEncou
   const processInstances = (instances: PokemonInstance[]) => {
     for (let i = 0; i < instances.length; i++) {
       const instance = instances[i];
-      if (instance?.caughtData?.location) {
-        const { location, locationName } = instance.caughtData;
+      if (instance?.caughtData?.location !== undefined || instance?.caughtData?.metLocation !== undefined) {
+        const location = instance.caughtData.metLocation ?? (instance.caughtData.location as number);
+        const locationName = instance.caughtData.locationName;
 
         let entry = locationMap.get(location);
         if (!entry) {
@@ -127,4 +128,69 @@ export function getGraveyardPokemon(saveData: SaveData, graveyardBox: string): P
     }
   }
   return dead;
+}
+
+/**
+ * Aggregates caught Pokémon by their location (using metLocation as primary for Gen 3)
+ * and identifies the first catch for each distinct location.
+ *
+ * @param saveData - The parsed save data.
+ * @returns An array of locations with only the first catch in the encounters array.
+ */
+export function aggregateFirstCatchByRoute(saveData: SaveData): LocationEncounters[] {
+  const aggregates = aggregateEncountersByLocation(saveData);
+
+  const firstCatches: LocationEncounters[] = [];
+
+  for (let i = 0; i < aggregates.length; i++) {
+    const loc = aggregates[i];
+    if (!loc || loc.encounters.length === 0) continue;
+
+    // Determine the first catch based on storageLocation and slot
+    let firstEncounter = loc.encounters[0] as PokemonInstance;
+
+    for (let j = 1; j < loc.encounters.length; j++) {
+      const current = loc.encounters[j] as PokemonInstance;
+
+      const isFirstBetter = compareEncounters(firstEncounter, current);
+      if (!isFirstBetter) {
+        firstEncounter = current;
+      }
+    }
+
+    firstCatches.push({
+      locationId: loc.locationId,
+      locationName: loc.locationName,
+      encounters: [firstEncounter],
+    });
+  }
+
+  return firstCatches;
+}
+
+/**
+ * Helper to compare two PokemonInstances to find which was caught earlier.
+ * Party comes first.
+ * Then PC Boxes ordered by box number ascending, then by slot ascending.
+ *
+ * @returns true if a is 'earlier' than b, false otherwise.
+ */
+function compareEncounters(a: PokemonInstance, b: PokemonInstance): boolean {
+  if (a.storageLocation === 'Party' && b.storageLocation !== 'Party') return true;
+  if (b.storageLocation === 'Party' && a.storageLocation !== 'Party') return false;
+
+  const aBoxMatch = a.storageLocation.match(/Box (\d+)/);
+  const bBoxMatch = b.storageLocation.match(/Box (\d+)/);
+
+  const aBoxNum = aBoxMatch ? parseInt(aBoxMatch[1], 10) : 999;
+  const bBoxNum = bBoxMatch ? parseInt(bBoxMatch[1], 10) : 999;
+
+  if (aBoxNum !== bBoxNum) {
+    return aBoxNum < bBoxNum;
+  }
+
+  const aSlot = a.slot ?? 999;
+  const bSlot = b.slot ?? 999;
+
+  return aSlot <= bSlot;
 }

--- a/src/engine/nuzlocke/tracker.ts
+++ b/src/engine/nuzlocke/tracker.ts
@@ -179,11 +179,11 @@ function compareEncounters(a: PokemonInstance, b: PokemonInstance): boolean {
   if (a.storageLocation === 'Party' && b.storageLocation !== 'Party') return true;
   if (b.storageLocation === 'Party' && a.storageLocation !== 'Party') return false;
 
-  const aBoxMatch = a.storageLocation.match(/Box (\d+)/);
-  const bBoxMatch = b.storageLocation.match(/Box (\d+)/);
+  const aBoxMatch = a.storageLocation ? a.storageLocation.match(/Box (\d+)/) : null;
+  const bBoxMatch = b.storageLocation ? b.storageLocation.match(/Box (\d+)/) : null;
 
-  const aBoxNum = aBoxMatch ? parseInt(aBoxMatch[1], 10) : 999;
-  const bBoxNum = bBoxMatch ? parseInt(bBoxMatch[1], 10) : 999;
+  const aBoxNum = aBoxMatch?.[1] ? parseInt(aBoxMatch[1], 10) : 999;
+  const bBoxNum = bBoxMatch?.[1] ? parseInt(bBoxMatch[1], 10) : 999;
 
   if (aBoxNum !== bBoxNum) {
     return aBoxNum < bBoxNum;


### PR DESCRIPTION
Implemented the \`aggregateFirstCatchByRoute\` function for Nuzlocke tracking, resolving task-262-375-aggregate-first-catch-impl.

The function correctly groups encounters by their distinct location (prioritizing Gen 3's \`metLocation\`) and extracts the first catch. Since Gen 3 lacks explicit catch timestamps, it implements a sequential heuristic by inspecting the \`storageLocation\` and \`slot\` properties, evaluating \`Party\` over PC Boxes, and Box/Slot ascending order. Tests were included to ensure correct grouping and sequence identification.

---
*PR created automatically by Jules for task [11071084393546674960](https://jules.google.com/task/11071084393546674960) started by @szubster*