### PR TITLE
test: QA approve aggregate first catch by route

### DIFF
--- a/.foundry/journals/qa/6372821458457417512.md
+++ b/.foundry/journals/qa/6372821458457417512.md
@@ -1,0 +1,12 @@
+# QA Session: task-262-376-aggregate-first-catch-qa
+
+**Date:** 2026-08-02
+**Target Task:** `task-262-375-aggregate-first-catch-impl`
+
+## Review Notes
+- Validated implementation of `aggregateFirstCatchByRoute` in `src/engine/nuzlocke/tracker.ts`.
+- Verified the logic groups by location and selects the earliest catch correctly.
+- Confirmed unit tests in `src/engine/nuzlocke/tracker.test.ts` thoroughly cover the new logic and edge cases.
+- Execution matches the specifications and does not violate any core architecture or save file parsing constraints.
+- Implementation passes standard verification checks (`pnpm lint`, `pnpm test`, `xvfb-run pnpm test:e2e`).
+- Action: Approving implementation and checking off criteria for parent node completion.

--- a/.foundry/tasks/task-262-376-aggregate-first-catch-qa.md
+++ b/.foundry/tasks/task-262-376-aggregate-first-catch-qa.md
@@ -30,5 +30,5 @@ Verify the implementation of aggregating caught Pokémon by their `met_location`
 - Verify that the correct Pokémon is identified as the first catch based on catch sequence or time.
 
 ## Acceptance Criteria
-- [ ] Aggregation logic is verified and works correctly.
-- [ ] Tests pass and cover edge cases.
+- [x] Aggregation logic is verified and works correctly.
+- [x] Tests pass and cover edge cases.


### PR DESCRIPTION
- Created a journal entry for the session.
- Verified the implementation of `task-262-375-aggregate-first-catch-impl`.
- Checked off acceptance criteria in the QA task node.

---
*PR created automatically by Jules for task [6372821458457417512](https://jules.google.com/task/6372821458457417512) started by @szubster*