### PR TITLE
Draft UI tasks for Gen 3 Secret Base rematch status

### DIFF
--- a/.foundry/journals/tech_lead/5103666048886432530.md
+++ b/.foundry/journals/tech_lead/5103666048886432530.md
@@ -1,0 +1,3 @@
+# Session 5103666048886432530
+
+The engine components (parser) have already been fully implemented for extracting the `battledOwnerToday` flag for Gen 3 Secret Bases. However, the objective was also to integrate it into the UI. Therefore, I drafted an explicit TASK node (`task-335-386-track-daily-rematch-status-impl`) to instruct the Coder to implement the UI conditionally rendering the availability of Secret Base trainers for rematch, maintaining strict compliance with ADR 008 (tactical aesthetics). I also created a QA verification node (`task-335-387-track-daily-rematch-status-qa`). This highlights the importance of checking if the target artifacts already exist before planning Tasks, but ensuring all missing components (e.g. UI layer) are still appropriately captured.

--- a/.foundry/stories/story-324-335-track-daily-rematch-status.md
+++ b/.foundry/stories/story-324-335-track-daily-rematch-status.md
@@ -32,4 +32,6 @@ Players can battle the NPC trainers in Secret Bases once per day. We need to tra
 - Integrate this status into the extracted trainer data so the UI can display availability.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break this Story down into actionable Tasks.
+- [x] Tech Lead: Break this Story down into actionable Tasks.
+- [ ] task-335-386-track-daily-rematch-status-impl
+- [ ] task-335-387-track-daily-rematch-status-qa

--- a/.foundry/tasks/task-335-386-track-daily-rematch-status-impl.md
+++ b/.foundry/tasks/task-335-386-track-daily-rematch-status-impl.md
@@ -1,0 +1,41 @@
+---
+id: task-335-386-track-daily-rematch-status-impl
+type: TASK
+title: Integrate Gen 3 Secret Base Daily Rematch Status UI
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-324-335-track-daily-rematch-status
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Integrate Gen 3 Secret Base Daily Rematch Status UI
+
+## Context
+Players can battle the NPC trainers in Secret Bases once per day. The core data extraction engine already successfully extracts the `battledOwnerToday` flag from Gen 3 save files (see `src/engine/gen3/secretBase/parser.ts`). We need to integrate this extracted status into the frontend UI so that players can clearly see which Secret Base trainers are available for a battle today.
+
+## Objective
+Integrate the `battledOwnerToday` status into the extracted Secret Base trainer data UI representation so the UI can display availability.
+
+## Requirements
+1.  **Strictly adhere to ADR 008** for UI component aesthetics (tactical hardware/snooping, sharp edges `rounded-none`, dashed borders `border-dashed`, monospaced telemetry fonts `font-mono`).
+2.  Update the relevant UI components that display Gen 3 Secret Bases to show the rematch status (e.g., "Battle Available" or "Already Battled").
+3.  Ensure the new UI elements use the data correctly from the parsed `gen3SecretBases` array.
+4.  Write or update relevant tests to ensure the UI correctly conditionally renders the battle status based on the `battledOwnerToday` boolean flag.
+
+## Acceptance Criteria
+- [ ] Implement UI integration for the `battledOwnerToday` status in Gen 3 Secret Base views.
+- [ ] Strictly adhere to ADR 008 styling guidelines.
+- [ ] Add/update relevant unit or component tests.

--- a/.foundry/tasks/task-335-387-track-daily-rematch-status-qa.md
+++ b/.foundry/tasks/task-335-387-track-daily-rematch-status-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-335-387-track-daily-rematch-status-qa
+type: TASK
+title: QA Gen 3 Secret Base Daily Rematch Status UI
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on:
+  - task-335-386-track-daily-rematch-status-impl
+jules_session_id: null
+pr_number: null
+parent: story-324-335-track-daily-rematch-status
+tags:
+  - feature
+  - gen3
+  - secret-base
+  - ui
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Gen 3 Secret Base Daily Rematch Status UI
+
+## Context
+Players can battle the NPC trainers in Secret Bases once per day. The `battledOwnerToday` flag has been integrated into the UI. This task verifies that the implementation correctly reflects this status and adheres to project standards.
+
+## Objectives
+- Verify that the UI correctly displays the daily rematch status for Gen 3 Secret Base trainers based on the `battledOwnerToday` flag.
+- Verify adherence to UI guidelines (ADR 008).
+- Verify adequate test coverage.
+
+## Verification Steps
+1.  **UI Testing:** Run the development server and verify that the Secret Base UI conditionally renders the correct status based on mock save file data (e.g., test cases where `battledOwnerToday` is true, false, or undefined).
+2.  **ADR Compliance:** Review the implemented React components to ensure they strictly adhere to ADR 008 (tactical hardware/snooping aesthetic, `rounded-none`, `border-dashed`, `font-mono`).
+3.  **Code Review & Test Coverage:** Run `pnpm test` and review the new/updated tests. Ensure that the conditional rendering logic for `battledOwnerToday` is properly covered by unit or component tests.
+
+## Acceptance Criteria
+- [ ] Verify UI functionality for displaying `battledOwnerToday` status.
+- [ ] Verify UI components strictly adhere to ADR 008 styling guidelines.
+- [ ] Verify comprehensive test coverage exists and passes.


### PR DESCRIPTION
Drafted `task-335-386-track-daily-rematch-status-impl` and `task-335-387-track-daily-rematch-status-qa` to track Gen 3 Secret Base daily rematch status. The parser logic was already implemented, so these tasks focus strictly on integrating the extracted status into the UI in accordance with ADR 008.

Updated `story-324-335-track-daily-rematch-status` acceptance criteria to include these tasks.

---
*PR created automatically by Jules for task [5103666048886432530](https://jules.google.com/task/5103666048886432530) started by @szubster*