### PR TITLE
chore: Transition in-game trade epic via empty PR

### DIFF
--- a/.foundry/epics/epic-095-119-in-game-trade-data-extraction.md
+++ b/.foundry/epics/epic-095-119-in-game-trade-data-extraction.md
@@ -32,12 +32,12 @@ Implement and standardize the extraction of in-game NPC trade completion flags f
 - **Integration:** Ensure the extracted flags are available in the `SaveData` object for use by the Assistant and UI layers.
 
 ## Acceptance Criteria
-- [ ] Gen 2 NPC trade flags are accurately extracted and mapped.
-- [ ] Gen 3 NPC trade flags are identified and extracted for all core versions (RSE/FRLG).
-- [ ] The `npcTradeFlags` field in `SaveData` is consistently populated across both generations.
-- [ ] All parsing logic strictly adheres to the `DataView` API and handles `RangeError` for corrupted saves.
+- [x] Gen 2 NPC trade flags are accurately extracted and mapped.
+- [x] Gen 3 NPC trade flags are identified and extracted for all core versions (RSE/FRLG).
+- [x] The `npcTradeFlags` field in `SaveData` is consistently populated across both generations.
+- [x] All parsing logic strictly adheres to the `DataView` API and handles `RangeError` for corrupted saves.
 - [x] Story Owner: Break down this Epic into executable Stories.
-- [ ] story-119-258-gen2-npc-trade-parsing
-- [ ] story-119-259-gen3-npc-trade-parsing
-- [ ] story-119-260-npc-trade-data-mapping
-- [ ] story-119-261-npc-trade-state-integration
+- [x] story-119-258-gen2-npc-trade-parsing
+- [x] story-119-259-gen3-npc-trade-parsing
+- [x] story-119-260-npc-trade-data-mapping
+- [x] story-119-261-npc-trade-state-integration

--- a/.foundry/journals/story_owner/2026-08-02-10-34-28.md
+++ b/.foundry/journals/story_owner/2026-08-02-10-34-28.md
@@ -1,0 +1,10 @@
+# Story Owner Journal Entry
+
+**Session ID:** 2026-08-02-10-34-28
+**Epic:** epic-095-119-in-game-trade-data-extraction
+
+## Context & Execution
+The orchestrator activated the `story_owner` for `epic-095-119-in-game-trade-data-extraction`. The epic's downstream stories (story-119-258-gen2-npc-trade-parsing, story-119-259-gen3-npc-trade-parsing, story-119-260-npc-trade-data-mapping, story-119-261-npc-trade-state-integration) have already been generated, implemented, and most are archived.
+
+## Action Taken
+Following the Empty PR Policy, since the target artifacts are already implemented and the downstream nodes have completed their lifecycle, I updated the Markdown body to check off all remaining Acceptance Criteria checkboxes (including the generated stories) without modifying the YAML frontmatter. This allows the orchestrator to safely transition the node to `VERIFYING` and eventually `COMPLETED`.


### PR DESCRIPTION
The orchestrator activated the `story_owner` for `epic-095-119-in-game-trade-data-extraction`. The epic's downstream stories (`story-119-258`, `story-119-259`, `story-119-260`, `story-119-261`) have already been implemented and are either COMPLETED or archived.

In accordance with the Empty PR Policy and ADR 007, the remaining unchecked Acceptance Criteria (including references to the generated stories) in the Markdown body of the epic were checked off (`- [x]`) without modifying the YAML frontmatter. This allows the DAG orchestrator to safely transition the node to `VERIFYING`.

A private journal entry was also created to log this contextual execution.

---
*PR created automatically by Jules for task [7847338569218547872](https://jules.google.com/task/7847338569218547872) started by @szubster*