### PR TITLE
chore(foundry): generate tasks for nuzlocke route violations

### DIFF
--- a/.foundry/journals/tech_lead/2026-08-02-12-01-38.md
+++ b/.foundry/journals/tech_lead/2026-08-02-12-01-38.md
@@ -1,0 +1,13 @@
+# Session Log: 2026-08-02-12-01-38
+
+## Tasks Created
+- `.foundry/tasks/task-263-386-nuzlocke-route-violations-impl.md`: Implements validation logic for Nuzlocke rules to flag violations where multiple Pokémon share the same `met_location` and output the violations. Added instructions for coder to adhere to the `Save File Parsing & Extraction Guidelines` (Section 13 in schema.md).
+- `.foundry/tasks/task-263-387-nuzlocke-route-violations-qa.md`: QA task to verify the validation logic correctly flags route duplicate violations.
+
+## Reasoning
+The STORY requires comparing the extracted catching history against Nuzlocke rules and flagging violations where multiple Pokémon share the same `met_location`. It requires an implementation and a QA verification task to ensure the validation logic correctly identifies route duplicates based on `met_location`.
+
+## Blueprint Notes
+- Ensured the implementer adheres strictly to Section 13 guidelines regarding `Save File Parsing & Extraction` to prevent fragile and erroneous logic when working with save data.
+- Structured the QA task to depend directly on the implementation task to avoid DAG deadlock and follow the sequential deployment strategy.
+- Verified the generation of tasks on the overarching STORY node without changing its original YAML.

--- a/.foundry/stories/story-097-263-flag-nuzlocke-route-violations.md
+++ b/.foundry/stories/story-097-263-flag-nuzlocke-route-violations.md
@@ -30,4 +30,6 @@ Compare the extracted catching history against Nuzlocke rules and flag violation
 - Provide structured output for flagged violations.
 
 ## Acceptance Criteria
-- [ ] Tasks are generated
+- [x] Tasks are generated
+- [ ] task-263-386-nuzlocke-route-violations-impl
+- [ ] task-263-387-nuzlocke-route-violations-qa

--- a/.foundry/tasks/task-263-386-nuzlocke-route-violations-impl.md
+++ b/.foundry/tasks/task-263-386-nuzlocke-route-violations-impl.md
@@ -1,0 +1,35 @@
+---
+id: task-263-386-nuzlocke-route-violations-impl
+type: TASK
+title: Implement Nuzlocke Route Violations Validation
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-097-263-flag-nuzlocke-route-violations
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Implement Nuzlocke Route Violations Validation
+
+## Objective
+Implement validation logic for Nuzlocke rules to compare the extracted catching history and flag violations where multiple Pokémon share the same `met_location`. Output these violations in a structured format.
+
+## Requirements
+- Identify duplicate Pokémon per route based on their `met_location`.
+- Provide a structured output of flagged violations, detailing the Pokémon involved and the duplicated route.
+- Strictly adhere to all guidelines defined in **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`.
+
+## Acceptance Criteria
+- [ ] Logic correctly identifies route duplicates based on `met_location`.
+- [ ] Structured output format is implemented for the flagged violations.
+- [ ] Code follows all Save File Parsing & Extraction Guidelines.

--- a/.foundry/tasks/task-263-387-nuzlocke-route-violations-qa.md
+++ b/.foundry/tasks/task-263-387-nuzlocke-route-violations-qa.md
@@ -1,0 +1,36 @@
+---
+id: task-263-387-nuzlocke-route-violations-qa
+type: TASK
+title: QA Nuzlocke Route Violations Validation
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on:
+  - task-263-386-nuzlocke-route-violations-impl
+jules_session_id: null
+pr_number: null
+parent: story-097-263-flag-nuzlocke-route-violations
+tags:
+  - feature
+  - nuzlocke
+  - verification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: QA Nuzlocke Route Violations Validation
+
+## Objective
+Verify the validation logic correctly flags Nuzlocke route violations where multiple Pokémon share the same `met_location`.
+
+## Requirements
+- Review the implemented validation logic against the Nuzlocke rules.
+- Test the system with mock save data containing both valid route catches and duplicate route violations.
+- Verify that the structured output for flagged violations correctly identifies the Pokémon involved and the duplicated route.
+
+## Acceptance Criteria
+- [ ] Logic correctly identifies route duplicates based on `met_location` in tests.
+- [ ] Structured output format is correct for the flagged violations.
+- [ ] Tests cover various edge cases (e.g., no duplicates, multiple duplicates on same route, duplicates on multiple routes).


### PR DESCRIPTION
This PR transitions the `story-097-263-flag-nuzlocke-route-violations` node by drafting the necessary downstream tasks:
1.  **Implementation Task (`task-263-386-nuzlocke-route-violations-impl`)**: Instructs the Coder to implement the validation logic for Nuzlocke rules to flag duplicate routes and provide a structured output. Crucially, it enforces adherence to Section 13 ("Save File Parsing & Extraction Guidelines") of `schema.md`.
2.  **QA Task (`task-263-387-nuzlocke-route-violations-qa`)**: Instructs the QA persona to verify the validation logic correctly flags duplicate routes using mock data, explicitly declaring a dependency on the implementation task to prevent DAG deadlocks.

The acceptance criteria checkboxes on the STORY node have been updated without modifying the YAML frontmatter. A corresponding tech lead journal entry has also been created.

---
*PR created automatically by Jules for task [4887611095932787292](https://jules.google.com/task/4887611095932787292) started by @szubster*