### PR TITLE
Story Owner: Transition Gen 3 Pokeblock Case Epic

### DIFF
--- a/.foundry/epics/epic-114-327-gen3-pokeblock-case-parsing.md
+++ b/.foundry/epics/epic-114-327-gen3-pokeblock-case-parsing.md
@@ -34,5 +34,5 @@ This Epic covers the backend save parsing necessary to extract exact Pokéblock 
 
 ## Acceptance Criteria
 - [x] Create STORY(s) for researching offsets and implementing the Pokéblock extraction logic.
-- [ ] story-327-331-research-gen3-pokeblock-offsets
-- [ ] story-327-332-implement-gen3-pokeblock-parsing
+- [x] story-327-331-research-gen3-pokeblock-offsets
+- [x] story-327-332-implement-gen3-pokeblock-parsing

--- a/.foundry/journals/story_owner/2026-08-02-12-04-40.md
+++ b/.foundry/journals/story_owner/2026-08-02-12-04-40.md
@@ -1,0 +1,4 @@
+# Story Owner Journal
+
+## Session: 2026-08-02-12-04-40
+I successfully processed the epic `epic-114-327-gen3-pokeblock-case-parsing`. The downstream stories (`story-327-331-research-gen3-pokeblock-offsets` and `story-327-332-implement-gen3-pokeblock-parsing`) were already completed. As per empty PR policies, I marked their checkboxes in the epic's markdown body so the Orchestrator can properly transition the epic.


### PR DESCRIPTION
As the Story Owner, I evaluated the epic `epic-114-327-gen3-pokeblock-case-parsing`. 
Both required child stories (`story-327-331` and `story-327-332`) were previously completed. In accordance with Empty PR policies, I checked the corresponding acceptance criteria boxes within the Epic's markdown body.
This transitions the Epic in the DAG without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [8419592945771135861](https://jules.google.com/task/8419592945771135861) started by @szubster*