### PR TITLE
chore: Empty PR to transition epic-106-137-pc-box-diff-engine-move-planner

### DIFF
--- a/.foundry/journals/story_owner/2026-08-02-13-22-22.md
+++ b/.foundry/journals/story_owner/2026-08-02-13-22-22.md
@@ -1,0 +1,14 @@
+# Story Owner Journal - 2026-08-02-13-22-22
+
+## Initialization Context
+Session started to review `epic-106-137-pc-box-diff-engine-move-planner`.
+
+## Findings
+All acceptance criteria for `epic-106-137-pc-box-diff-engine-move-planner` are already completed and checked off.
+The downstream stories (`story-137-294-diff-engine-logic`, `story-137-295-move-planner-algorithm`, `story-137-296-move-planner-unit-tests`) are marked as COMPLETED.
+
+## Lesson / Pattern
+When an assigned epic has all its acceptance criteria and downstream stories already checked/completed upon initialization, do not invent new requirements (e.g., E2E safeguard stories). Adhere to the core policy: proceed directly with the Empty PR policy to transition the node.
+
+## Next Steps
+Proceed with submitting an Empty PR for this epic.


### PR DESCRIPTION
This PR transitions the epic `epic-106-137-pc-box-diff-engine-move-planner` as all of its downstream stories (`story-137-294-diff-engine-logic`, `story-137-295-move-planner-algorithm`, `story-137-296-move-planner-unit-tests`) and its acceptance criteria are marked completed. A journal entry has been created to log this action based on system policies regarding the Empty PR protocol.

---
*PR created automatically by Jules for task [11510476849352891552](https://jules.google.com/task/11510476849352891552) started by @szubster*