### PR TITLE
Story Owner: Check E2E integration story in epic-054-338-trick-house-save-parsing

### DIFF
--- a/.foundry/epics/epic-054-338-trick-house-save-parsing.md
+++ b/.foundry/epics/epic-054-338-trick-house-save-parsing.md
@@ -38,4 +38,4 @@ Extract the Trick House puzzle state from Gen 3 save files using the `DataView` 
 - [x] story-111-249-investigate-trick-house-offsets
 - [x] story-111-276-trick-house-parser-impl
 - [x] story-111-277-trick-house-parser-qa
-- [ ] story-338-339-trick-house-e2e-integration
+- [x] story-338-339-trick-house-e2e-integration

--- a/.foundry/journals/story_owner/2026-08-02-13-23-43.md
+++ b/.foundry/journals/story_owner/2026-08-02-13-23-43.md
@@ -1,0 +1,6 @@
+# Story Owner Journal
+
+## Session: 2026-08-02-13-23-43
+
+### Learnings
+- **Empty PR Checkbox Policy**: When all downstream items of a parent node are completed, but the parent node's acceptance criteria checkboxes are still unchecked, I must explicitly check them before submitting a PR to transition the node. I applied this rule for `epic-054-338-trick-house-save-parsing`, checking the box for the completed `story-338-339-trick-house-e2e-integration` to satisfy ADR 007 and ADR 009 before proceeding. This pattern should be consistently followed to avoid transition rejections.


### PR DESCRIPTION
Applying the Empty PR Checkbox policy by checking the acceptance criteria checkbox for `story-338-339-trick-house-e2e-integration` in `.foundry/epics/epic-054-338-trick-house-save-parsing.md` since the downstream story is completed. A journal entry detailing this learning and adherence to ADR 007/009 is included in `.foundry/journals/story_owner/`.

---
*PR created automatically by Jules for task [8901884196265794110](https://jules.google.com/task/8901884196265794110) started by @szubster*