### PR TITLE
Story Owner: Break down Epic into implementation and e2e stories

### DIFF
--- a/.foundry/epics/epic-107-343-lift-rejection-count-state.md
+++ b/.foundry/epics/epic-107-343-lift-rejection-count-state.md
@@ -32,4 +32,6 @@ Currently, the threshold for determining if a node has permanently failed (`reje
 1. Extract `MAX_REJECTION_THRESHOLD = 3` to `DagContext.tsx` or a shared constants file.
 
 ## Acceptance Criteria
-- [ ] Break down into Stories
+- [x] Break down into Stories
+- [ ] story-343-352-lift-rejection-constant-impl
+- [ ] story-343-353-lift-rejection-constant-e2e

--- a/.foundry/journals/story_owner/2026-08-02-13-26-15.md
+++ b/.foundry/journals/story_owner/2026-08-02-13-26-15.md
@@ -1,0 +1,8 @@
+# Session: 2026-08-02-13-26-15
+
+## Activities
+- Broke down `epic-107-343-lift-rejection-count-state` into implementation and e2e stories.
+- Created `story-343-352-lift-rejection-constant-impl` and `story-343-353-lift-rejection-constant-e2e`.
+
+## Learnings
+- Consistently applied the E2E safeguard policy by including an `e2e` tagged story when decomposing Epics.

--- a/.foundry/stories/story-343-352-lift-rejection-constant-impl.md
+++ b/.foundry/stories/story-343-352-lift-rejection-constant-impl.md
@@ -1,0 +1,35 @@
+---
+id: story-343-352-lift-rejection-constant-impl
+type: STORY
+title: Extract MAX_REJECTION_THRESHOLD Constant
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-107-343-lift-rejection-count-state
+tags:
+  - refactor
+  - dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extract MAX_REJECTION_THRESHOLD Constant
+
+## Objective
+Extract the `MAX_REJECTION_THRESHOLD` constant (value: 3) from local file scopes into `DagContext.tsx` or a dedicated shared constants utility.
+
+## Context
+Required by ADR 017. The value is currently hardcoded in multiple files.
+
+## Requirements
+1. Extract `MAX_REJECTION_THRESHOLD` to a shared context/constants file.
+2. Update usages in `DagDashboard.tsx`, `DagNode.tsx`, etc., to use the lifted constant.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks

--- a/.foundry/stories/story-343-353-lift-rejection-constant-e2e.md
+++ b/.foundry/stories/story-343-353-lift-rejection-constant-e2e.md
@@ -1,0 +1,32 @@
+---
+id: story-343-353-lift-rejection-constant-e2e
+type: STORY
+title: E2E Tests for Lift Rejection Constant
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on:
+  - story-343-352-lift-rejection-constant-impl
+jules_session_id: null
+pr_number: null
+parent: epic-107-343-lift-rejection-count-state
+tags:
+  - e2e
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# E2E Tests for Lift Rejection Constant
+
+## Objective
+Write E2E tests to verify that the DAG Dashboard still correctly displays permanent failures after lifting the rejection count constant.
+
+## Requirements
+1. E2E test verifying permanent failure nodes on the dashboard.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
This PR fulfills the responsibilities of the Story Owner by actively managing `epic-107-343-lift-rejection-count-state`. The Epic was broken down into manageable and specific implementation and E2E verification stories to lift the rejection constant from component files as required by ADR 017. 

Key changes include:
*   Updating the markdown body of the Epic to reflect the generated stories and checking the breakdown acceptance criteria, strictly avoiding YAML frontmatter modification.
*   Generating the new implementation (`story-343-352-lift-rejection-constant-impl`) and E2E testing (`story-343-353-lift-rejection-constant-e2e`) downstream nodes with appropriate personas assigned.
*   Logging the activities and adherence to the orchestrator safeguard E2E requirements in the Story Owner's journal.

---
*PR created automatically by Jules for task [4678229428119202354](https://jules.google.com/task/4678229428119202354) started by @szubster*