### PR TITLE
Tech Lead: Generate Task to Remove Orphaned QA Rule

### DIFF
--- a/.foundry/journals/tech_lead/2026-08-02-13-23-06.md
+++ b/.foundry/journals/tech_lead/2026-08-02-13-23-06.md
@@ -1,0 +1,6 @@
+# Tech Lead Journal - 2026-08-02
+
+## Task Blueprint Generation
+- **Story**: `story-331-333-remove-orphaned-qa-rule`
+- **Generated Task**: `task-333-386-remove-orphaned-qa-rule-impl`
+- **Verification Decision**: Based on the Intelligent Verification Protocol, I decided that a separate QA task is unnecessary. The required change is a simple, low-risk documentation update (removing an obsolete rule from `core_policies.md`). The Coder will self-verify the change.

--- a/.foundry/stories/story-331-333-remove-orphaned-qa-rule.md
+++ b/.foundry/stories/story-331-333-remove-orphaned-qa-rule.md
@@ -29,3 +29,4 @@ This story tracks identifying and removing those obsolete instructions from `.fo
 
 ## Acceptance Criteria
 - [x] Tech Lead: Break down into Tasks
+- [ ] task-333-386-remove-orphaned-qa-rule-impl

--- a/.foundry/tasks/task-333-386-remove-orphaned-qa-rule-impl.md
+++ b/.foundry/tasks/task-333-386-remove-orphaned-qa-rule-impl.md
@@ -1,0 +1,33 @@
+---
+id: task-333-386-remove-orphaned-qa-rule-impl
+type: TASK
+title: Implement - Remove Orphaned QA Rule from Documentation
+status: READY
+owner_persona: coder
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-331-333-remove-orphaned-qa-rule
+tags:
+  - docs
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement - Remove Orphaned QA Rule from Documentation
+
+## Context
+The "Orphaned QA Task Cancellation Rule" mentioned in `.foundry/docs/knowledge_base/agents/core_policies.md` is obsolete and causes confusion. The orchestrator now automatically handles cascaded cancellations (Phase 3.6). We need to remove any instructions telling personas to manually modify the markdown bodies of orphaned tasks.
+
+## Objective
+Remove the obsolete instructions related to the "Orphaned QA Task Cancellation Rule" from the `core_policies.md` file.
+
+## Technical Details
+- Locate references to the obsolete rule in `.foundry/docs/knowledge_base/agents/core_policies.md` and carefully remove the outdated instructions. Ensure the rest of the documentation flows naturally after removal.
+
+## Acceptance Criteria
+- [ ] Coder: Remove obsolete instructions regarding the "Orphaned QA Task Cancellation Rule" from `.foundry/docs/knowledge_base/agents/core_policies.md`.


### PR DESCRIPTION
Generated task blueprint to instruct the coder to remove the obsolete orphaned QA rule from `core_policies.md`. Followed the Intelligent Verification Protocol to omit a separate QA task.

---
*PR created automatically by Jules for task [17499408104976024866](https://jules.google.com/task/17499408104976024866) started by @szubster*