### PR TITLE
📓 Story Owner: Apply empty PR policy for completed epic

### DIFF
--- a/.foundry/journals/story_owner/2026-08-02-12-00-00.md
+++ b/.foundry/journals/story_owner/2026-08-02-12-00-00.md
@@ -1,0 +1,9 @@
+---
+id: journal-2026-08-02-12-00-00
+type: JOURNAL
+owner_persona: story_owner
+---
+
+# Session Log
+
+Assigned to epic-109-306-missed-trainer-data-extraction-gen1-gen2. All child stories are already generated and completed. Acceptance criteria checkboxes are all checked. Applying the Empty PR policy to transition the parent EPIC node.


### PR DESCRIPTION
Applied the Empty PR policy to transition `epic-109-306-missed-trainer-data-extraction-gen1-gen2`, as all child stories are already generated, completed, and acceptance criteria checkboxes are checked. Logged the session in the private journal.

---
*PR created automatically by Jules for task [8776993269747604707](https://jules.google.com/task/8776993269747604707) started by @szubster*