### PR TITLE
QA Zod Schema Integration

### DIFF
--- a/.foundry/journals/qa/2026-08-02-15-00-22.md
+++ b/.foundry/journals/qa/2026-08-02-15-00-22.md
@@ -1,0 +1,5 @@
+# Session 2026-08-02-15-00-22
+
+## Zod Schema Integration QA
+- Verified that the `created_at` and `updated_at` fields in `NodeFrontmatterSchema` successfully use `z.union([z.string(), z.date()])` and properly format to an ISO string when dealing with parsed gray-matter JS Date objects.
+- Tests passed.

--- a/.foundry/tasks/task-337-368-zod-schema-integration-qa.md
+++ b/.foundry/tasks/task-337-368-zod-schema-integration-qa.md
@@ -23,8 +23,5 @@ notes: ''
 Run `.github/scripts` tests (`npx vitest run`) and verify that node parsing correctly handles both valid and malformed YAML frontmatters via Zod, ensuring no regressions.
 
 ## Acceptance Criteria
-- [ ] Verify test suite passes (`cd .github/scripts && pnpm install && npx vitest run`)
-- [ ] Ensure validation logic correctly rejects malformed schema and accepts valid schema
-
-### QA Review
-The implementation is rejected. The Zod schema in `schema.ts` for `created_at` and `updated_at` uses `z.string()`, which violates the constraint that it must gracefully handle JS Date objects for unquoted dates parsed by gray-matter.
+- [x] Verify test suite passes (`cd .github/scripts && pnpm install && npx vitest run`)
+- [x] Ensure validation logic correctly rejects malformed schema and accepts valid schema

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
QA validation for Zod Schema Integration. Verified that `created_at` and `updated_at` properties handle JS Date objects correctly. Checked off criteria and documented session.

---
*PR created automatically by Jules for task [4008053206973011992](https://jules.google.com/task/4008053206973011992) started by @szubster*