### PR TITLE
feat(dashboard): implement Gen 2 static encounters checklist

### DIFF
--- a/.foundry/tasks/task-334-386-gen2-checklist-ui-retry-impl.md
+++ b/.foundry/tasks/task-334-386-gen2-checklist-ui-retry-impl.md
@@ -30,7 +30,7 @@ The design must adhere strictly to the project's "tactical hardware/snooping" ae
 - Apply monospaced telemetry fonts (`font-mono`).
 
 ## Acceptance Criteria
-- [ ] Implement `Gen2Checklist` React component.
-- [ ] Component successfully displays Sudowoodo, Snorlax, Red Gyarados, and Ho-Oh/Lugia based on event flag props.
-- [ ] UI strictly applies the tactical hardware aesthetic (`rounded-none`, `border-dashed`, `font-mono`).
-- [ ] Include explicit integration steps and tests for rendering the component to ensure it is properly integrated into the application's view hierarchy.
+- [x] Implement `Gen2Checklist` React component.
+- [x] Component successfully displays Sudowoodo, Snorlax, Red Gyarados, and Ho-Oh/Lugia based on event flag props.
+- [x] UI strictly applies the tactical hardware aesthetic (`rounded-none`, `border-dashed`, `font-mono`).
+- [x] Include explicit integration steps and tests for rendering the component to ensure it is properly integrated into the application's view hierarchy.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@tailwindcss/vite": "4.3.3",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@tanstack/router-plugin": "^1.168.23",
+    "@testing-library/react": "^16.3.2",
     "@tsconfig/strictest": "^2.0.8",
     "@tsconfig/vite-react": "^8.0.6",
     "@types/dagre": "^0.7.54",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.168.23
         version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.3)(supports-color@10.2.2)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tsconfig/strictest':
         specifier: ^2.0.8
         version: 2.0.8
@@ -2195,6 +2198,25 @@ packages:
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
     engines: {node: '>=20.19'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1':
     resolution: {integrity: sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==}
     engines: {node: '>=12'}
@@ -2223,6 +2245,9 @@ packages:
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2545,6 +2570,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -2564,6 +2593,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -2929,6 +2961,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-indent@7.0.2:
     resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
     engines: {node: '>=12.20'}
@@ -2987,6 +3023,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3814,6 +3853,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   madge@8.0.0:
     resolution: {integrity: sha512-9sSsi3TBPhmkTCIpVQF0SPiChj1L7Rq9kU2KDG1o6v2XH9cCw086MopjVCD+vuoL5v8S77DTbVopTO8OUiQpIw==}
     engines: {node: '>=18'}
@@ -4079,6 +4122,10 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@7.0.1:
     resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
     engines: {node: '>=10'}
@@ -4101,6 +4148,9 @@ packages:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
       react: ^19.2.8
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
@@ -6663,6 +6713,27 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1':
     dependencies:
       ejs: 3.1.10
@@ -6693,6 +6764,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -7024,6 +7097,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   ansis@4.3.1: {}
@@ -7037,6 +7112,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -7413,6 +7492,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  dequal@2.0.3: {}
+
   detect-indent@7.0.2: {}
 
   detect-libc@2.1.2: {}
@@ -7476,6 +7557,8 @@ snapshots:
       - supports-color
 
   diff@8.0.4: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -8285,6 +8368,8 @@ snapshots:
     dependencies:
       react: 19.2.8
 
+  lz-string@1.5.0: {}
+
   madge@8.0.0(supports-color@10.2.2)(typescript@7.0.2):
     dependencies:
       chalk: 4.1.2
@@ -8625,6 +8710,12 @@ snapshots:
 
   pretty-bytes@6.1.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-ms@7.0.1:
     dependencies:
       parse-ms: 2.1.0
@@ -8646,6 +8737,8 @@ snapshots:
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react@19.2.8: {}
 

--- a/src/components/dashboard/encounters/Gen2Checklist.tsx
+++ b/src/components/dashboard/encounters/Gen2Checklist.tsx
@@ -1,0 +1,49 @@
+import type React from 'react';
+import type { SaveData } from '../../../engine/saveParser/parsers/common';
+import { TacticalPanel } from '../../TacticalPanel';
+import { TelemetryDecoration } from '../../TelemetryDecoration';
+
+export interface Gen2ChecklistProps {
+  saveData: SaveData;
+}
+
+export const Gen2Checklist: React.FC<Gen2ChecklistProps> = ({ saveData }) => {
+  if (saveData.generation !== 2 || !saveData.gen2StaticEncounters) {
+    return null;
+  }
+
+  const entries = Object.entries(saveData.gen2StaticEncounters);
+
+  return (
+    <TacticalPanel className="mt-4 flex flex-col gap-4 border-[var(--theme-primary)]/50 border-t-2 p-4 pt-6">
+      <TelemetryDecoration label="SYS.STATIC_ENCOUNTERS_GEN2" className="-top-[17px] left-[-1px]" />
+
+      <div className="z-10 flex items-center justify-between">
+        <span className="tactical-text font-black text-lg text-white">GEN 2 STATIC ENCOUNTERS</span>
+      </div>
+
+      <div className="z-10 grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {entries.map(([key, isClaimed]) => {
+          const displayLabel = key
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/^./, (str) => str.toUpperCase())
+            .trim();
+
+          return (
+            <div
+              key={key}
+              className={`flex items-center justify-between rounded-none border-2 border-dashed p-2 font-mono text-xs ${
+                isClaimed
+                  ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)]/10 text-[var(--theme-primary)]'
+                  : 'border-zinc-700 bg-black/40 text-zinc-500'
+              }`}
+            >
+              <span className="truncate">{displayLabel}</span>
+              <span className="flex-shrink-0 font-black">{isClaimed ? '[X]' : '[ ]'}</span>
+            </div>
+          );
+        })}
+      </div>
+    </TacticalPanel>
+  );
+};

--- a/src/components/dashboard/encounters/__tests__/Gen2Checklist.test.tsx
+++ b/src/components/dashboard/encounters/__tests__/Gen2Checklist.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { SaveData } from '../../../../engine/saveParser/parsers/common';
+import { Gen2Checklist } from '../Gen2Checklist';
+
+describe('Gen2Checklist', () => {
+  it('renders null if generation is not 2', () => {
+    const saveData = { generation: 3, gen2StaticEncounters: {} } as SaveData;
+    const { container } = render(<Gen2Checklist saveData={saveData} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders null if gen2StaticEncounters is missing', () => {
+    const saveData = { generation: 2 } as SaveData;
+    const { container } = render(<Gen2Checklist saveData={saveData} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders correctly with claims', () => {
+    const saveData = {
+      generation: 2,
+      gen2StaticEncounters: {
+        sudowoodo: true,
+        snorlax: false,
+        redGyarados: true,
+        hoOh: false,
+        lugia: false,
+      },
+    } as SaveData;
+
+    render(<Gen2Checklist saveData={saveData} />);
+
+    expect(screen.getByText('GEN 2 STATIC ENCOUNTERS')).toBeInTheDocument();
+
+    const sudowoodo = screen.getByText('Sudowoodo').parentElement;
+    expect(sudowoodo).toHaveTextContent('[X]');
+
+    const snorlax = screen.getByText('Snorlax').parentElement;
+    expect(snorlax).toHaveTextContent('[ ]');
+
+    const redGyarados = screen.getByText('Red Gyarados').parentElement;
+    expect(redGyarados).toHaveTextContent('[X]');
+  });
+});

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -16,6 +16,11 @@ const ShinyCarrierBreedingDashboard = React.lazy(() =>
     default: m.ShinyCarrierBreedingDashboard,
   })),
 );
+const Gen2Checklist = React.lazy(() =>
+  import('../components/dashboard/encounters/Gen2Checklist').then((m) => ({
+    default: m.Gen2Checklist,
+  })),
+);
 const GlobalRibbonChecklistDashboard = React.lazy(() =>
   import('../components/dashboard/ribbons/GlobalRibbonChecklistDashboard').then((m) => ({
     default: m.GlobalRibbonChecklistDashboard,
@@ -42,7 +47,10 @@ function DashboardPage() {
             <GlobalRibbonChecklistDashboard />
           </>
         ) : (
-          <ShinyCarrierBreedingDashboard />
+          <>
+            <ShinyCarrierBreedingDashboard />
+            <Gen2Checklist saveData={saveData} />
+          </>
         )}
       </Suspense>
     </div>


### PR DESCRIPTION
This PR implements the Gen 2 Checklist UI to display the static encounters (Sudowoodo, Snorlax, Red Gyarados, and Ho-Oh/Lugia).

### Changes:
1. Created `Gen2Checklist` component inside `src/components/dashboard/encounters/` adhering to ADR 008 (tactical hardware aesthetic).
2. Added unit tests for the component inside `src/components/dashboard/encounters/__tests__/`.
3. Integrated the component into the `DashboardPage` (`src/routes/dashboard.tsx`) so it conditionally lazy loads and renders when `generation === 2`.
4. Checked the acceptance criteria checkboxes in `.foundry/tasks/task-334-386-gen2-checklist-ui-retry-impl.md`.

All tests (including unit, e2e) pass locally. Playwright E2E UI testing successfully verified visual rendering of the checklist UI over Gen 2 save data.

---
*PR created automatically by Jules for task [4822719619031629821](https://jules.google.com/task/4822719619031629821) started by @szubster*