### PR TITLE
Create task to update monolithic journal references

### DIFF
--- a/.foundry/stories/story-338-338-update-downstream-references.md
+++ b/.foundry/stories/story-338-338-update-downstream-references.md
@@ -32,4 +32,5 @@ Various nodes, scripts, and personas (like the Agile Coach or resurrected FAILED
 - Update them to either reference the new directory structure, the TPM's aggregated master logs, or instruct them to read fragmented files dynamically.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break this Story down into actionable Tasks.
+- [x] Tech Lead: Break this Story down into actionable Tasks.
+- [ ] task-338-388-update-journal-references

--- a/.foundry/tasks/task-338-388-update-journal-references.md
+++ b/.foundry/tasks/task-338-388-update-journal-references.md
@@ -1,0 +1,37 @@
+---
+id: task-338-388-update-journal-references
+type: TASK
+title: Update Journal References in Agent Prompts and Docs
+status: READY
+owner_persona: coder
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-338-338-update-downstream-references
+tags:
+  - foundry
+  - journals
+  - workflow
+  - DX
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TASK: Update Journal References in Agent Prompts and Docs
+
+## Context
+Various nodes, scripts, and personas (like the Agile Coach or resurrected FAILED nodes) currently reference monolithic journal files (e.g., `.foundry/journals/coder.md`). With the transition to session-unique and TPM-aggregated journals, these references must be updated.
+
+## Requirements
+- Identify all scripts, documents, and agent prompts that reference old journal paths.
+- Search for `.foundry/journals/` and `.jules/` and ensure they point to directory globs (e.g., `.foundry/journals/coder/*.md`) when referring to past journals.
+- Check `.github/agents/*.md`, `.foundry/docs/knowledge_base/agents/core_policies.md`, and any orchestration scripts.
+- Update them to either reference the new directory structure, the TPM's aggregated master logs, or instruct them to read fragmented files dynamically.
+
+## Acceptance Criteria
+- [ ] Coder: Update all monolithic journal references (e.g. `.foundry/journals/coder.md`) to the new session-unique glob structure (`.foundry/journals/coder/*.md`) across agent prompts and documentation.
+- [ ] Coder: Self-verify that no hardcoded paths to monolithic `.md` journal files exist (using `grep`).


### PR DESCRIPTION
This PR introduces a new task (`task-338-388-update-journal-references.md`) to find and update all old monolithic journal references (e.g., `.foundry/journals/coder.md`, `.jules/coder.md`) across the repository to the new session-unique glob structure. The parent story (`story-338-338-update-downstream-references.md`) has been updated with the new task and the acceptance criteria has been checked off. The task is low risk, and the coder is instructed to self-verify.

- [x] Tech Lead: Break this Story down into actionable Tasks.
- [ ] task-338-388-update-journal-references

---
*PR created automatically by Jules for task [17585573154336270447](https://jules.google.com/task/17585573154336270447) started by @szubster*