### PR TITLE
🧭 Tech Lead: [blueprint] - Extend Phase 3.6 for CANCELLED nodes

### DIFF
--- a/.foundry/journals/tech_lead/2026-08-02-16-06-04.md
+++ b/.foundry/journals/tech_lead/2026-08-02-16-06-04.md
@@ -1,0 +1,6 @@
+# Tech Lead Journal Entry - 2026-08-02 16:06:04
+
+## Passthrough Task Generation
+**Observation**: A STORY explicitly noted that the required changes and tests were already implemented during a previous attempt, and requested a "passthrough" task.
+**Action**: Rather than attempting re-implementation or skipping the TASK layer, I created a TASK node explicitly instructing the Coder to verify the existing logic and submit an Empty PR.
+**Rule/Pattern**: When a STORY requires passthrough verification for already implemented code (often due to resilience/retry workflows in the DAG), the Tech Lead must generate a matching passthrough verification TASK for the Coder, ensuring the DAG progresses correctly through the formal pipeline.

--- a/.foundry/stories/story-340-346-extend-phase-3-6-cancelled-nodes.md
+++ b/.foundry/stories/story-340-346-extend-phase-3-6-cancelled-nodes.md
@@ -32,7 +32,8 @@ Update `.github/scripts/foundry-orchestrator.ts` Phase 3.6 logic to correctly aw
 - Update tests in `.github/scripts/foundry-orchestrator.test.ts` to assert that parent nodes are awakened when child nodes are cancelled due to max rejections.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks
+- [x] Break down into Tasks
+- [ ] task-346-388-extend-phase-3-6-cancelled-nodes-passthrough
 
 ### Passthrough Validation Note
 The required changes and tests for this story have already been implemented in `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-orchestrator.test.ts` during a previous attempt. The tech lead should create the required passthrough tasks.

--- a/.foundry/tasks/task-346-388-extend-phase-3-6-cancelled-nodes-passthrough.md
+++ b/.foundry/tasks/task-346-388-extend-phase-3-6-cancelled-nodes-passthrough.md
@@ -1,0 +1,37 @@
+---
+id: task-346-388-extend-phase-3-6-cancelled-nodes-passthrough
+type: TASK
+title: Verify and passthrough Phase 3.6 for CANCELLED nodes
+status: READY
+owner_persona: coder
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-340-346-extend-phase-3-6-cancelled-nodes
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Verify and passthrough Phase 3.6 for CANCELLED nodes
+
+## Objective
+Verify that the `.github/scripts/foundry-orchestrator.ts` Phase 3.6 logic already correctly awakens parent nodes for nodes transitioning to `CANCELLED` status with `rejection_reason === 'Max rejection count reached'`. Since this is a passthrough task, you are expected to submit an Empty PR to complete this task.
+
+## Context
+The required changes and tests for the parent story have already been implemented in `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-orchestrator.test.ts` during a previous attempt. This task serves as a formal completion step to advance the DAG without modifying code.
+
+## Requirements
+- Verify that the condition `node.frontmatter.status === 'CANCELLED'` and `node.frontmatter.rejection_reason === 'Max rejection count reached'` is present in the Phase 3.6 impossible loop checks in `.github/scripts/foundry-orchestrator.ts`.
+- Verify the tests in `.github/scripts/foundry-orchestrator.test.ts` assert this behavior.
+
+## Acceptance Criteria
+- [ ] Verify the implementation is already present.
+- [ ] Submit an Empty PR using the `submit` tool.


### PR DESCRIPTION
## What
- Generated a passthrough TASK node (`task-346-388-extend-phase-3-6-cancelled-nodes-passthrough`) for the Coder.
- Updated the parent STORY node (`story-340-346-extend-phase-3-6-cancelled-nodes`) to append the new child task and check off the decomposition acceptance criteria.
- Added a journal entry detailing the pattern for generating passthrough tasks when required implementations already exist.

## Why
The STORY explicitly noted that the necessary logic and tests (extending Phase 3.6 to handle `CANCELLED` nodes) were already implemented in `.github/scripts/foundry-orchestrator.ts` during a previous attempt, and requested a "passthrough" task. Rather than skipping the TASK layer (which would break the DAG pipeline) or attempting unnecessary re-implementation, a passthrough verification task was created to formalize the Coder's step and correctly advance the pipeline via an Empty PR.

---
*PR created automatically by Jules for task [17532805627293078101](https://jules.google.com/task/17532805627293078101) started by @szubster*