### PR TITLE
Story Owner: add bash timeout e2e story and impl

### DIFF
--- a/.foundry/epics/epic-057-347-bash-timeout-wrapper-retry.md
+++ b/.foundry/epics/epic-057-347-bash-timeout-wrapper-retry.md
@@ -28,4 +28,6 @@ notes: ''
 Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that run over a specific threshold (e.g., 30 seconds), based on findings from the research phase.
 
 ## Acceptance Criteria
-- [ ] Break down this epic into stories.
+- [x] Break down this epic into stories.
+- [ ] story-347-354-bash-timeout-wrapper-impl
+- [ ] story-347-355-bash-timeout-wrapper-e2e

--- a/.foundry/journals/story_owner/12393468792075411173.md
+++ b/.foundry/journals/story_owner/12393468792075411173.md
@@ -1,0 +1,3 @@
+# Session 12393468792075411173
+
+When creating stories for Epics that previously failed due to missing E2E checks (e.g. bash timeout wrappers), always explicitly include a child STORY node tagged with `e2e` or `integration` to satisfy orchestrator macro node safeguards.

--- a/.foundry/stories/story-347-354-bash-timeout-wrapper-impl.md
+++ b/.foundry/stories/story-347-354-bash-timeout-wrapper-impl.md
@@ -1,0 +1,28 @@
+---
+id: story-347-354-bash-timeout-wrapper-impl
+type: STORY
+title: Bash Timeout Wrapper Implementation (Retry)
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-057-347-bash-timeout-wrapper-retry
+tags:
+  - foundry
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Bash Timeout Wrapper Implementation (Retry)
+
+## Objective
+Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that run over a specific threshold.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks

--- a/.foundry/stories/story-347-355-bash-timeout-wrapper-e2e.md
+++ b/.foundry/stories/story-347-355-bash-timeout-wrapper-e2e.md
@@ -1,0 +1,29 @@
+---
+id: story-347-355-bash-timeout-wrapper-e2e
+type: STORY
+title: Bash Timeout Wrapper E2E Tests
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on:
+  - story-347-354-bash-timeout-wrapper-impl
+jules_session_id: null
+pr_number: null
+parent: epic-057-347-bash-timeout-wrapper-retry
+tags:
+  - e2e
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Bash Timeout Wrapper E2E Tests
+
+## Objective
+Write E2E tests to verify that the Bash timeout wrapper works as expected.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
Fixes `epic-057-347-bash-timeout-wrapper-retry` by adding the missing E2E story which caused the previous failure on the `bash-timeout-wrapper` epic, and documents this failure pattern in the `story_owner` journal.

---
*PR created automatically by Jules for task [12393468792075411173](https://jules.google.com/task/12393468792075411173) started by @szubster*