### PR TITLE
fix: improve orchestrator cycle detection and deadlock prevention

### DIFF
--- a/.foundry/tasks/task-336-388-implement-orchestrator-cycle-detection.md
+++ b/.foundry/tasks/task-336-388-implement-orchestrator-cycle-detection.md
@@ -29,6 +29,6 @@ We need to ensure robust circular dependency detection during the MAP or RESOLVE
 - Update tests in `foundry-orchestrator.test.ts` to cover these behaviors.
 
 ## Acceptance Criteria
-- [ ] Orchestrator detects circular dependencies and transitions involved nodes to `FAILED`.
-- [ ] Descriptive `rejection_reason` is appended in the frontmatter of failed nodes.
-- [ ] Tests verify this functionality without deadlocks.
+- [x] Orchestrator detects circular dependencies and transitions involved nodes to `FAILED`.
+- [x] Descriptive `rejection_reason` is appended in the frontmatter of failed nodes.
+- [x] Tests verify this functionality without deadlocks.

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -2562,6 +2562,57 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     expect(cContent).toContain("rejection_reason: Circular dependency detected");
   });
 
+  test('Deadlock Prevention: Correctly isolates cycle and doesn\'t fail innocent nodes pointing to cycle', () => {
+    // Task A points to B, but is not in the cycle
+    createValidTestNode(tmpDir, '.foundry/tasks/task-a.md', {
+      id: "task-a",
+      type: "TASK",
+      title: "Task A",
+      status: "PENDING",
+      owner_persona: "coder",
+      depends_on: [".foundry/tasks/task-b.md"],
+    });
+
+    // Task B and Task C form a cycle
+    createValidTestNode(tmpDir, '.foundry/tasks/task-b.md', {
+      id: "task-b",
+      type: "TASK",
+      title: "Task B",
+      status: "PENDING",
+      owner_persona: "coder",
+      depends_on: [".foundry/tasks/task-c.md"],
+    });
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-c.md', {
+      id: "task-c",
+      type: "TASK",
+      title: "Task C",
+      status: "PENDING",
+      owner_persona: "coder",
+      depends_on: [".foundry/tasks/task-b.md"],
+    });
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write');
+
+    main();
+
+    const output = stderrSpy.mock.calls.map(call => call[0] as string).join('');
+
+    // It should explicitly output the cycle format
+    expect(output).toContain('Detected circular dependency: .foundry/tasks/task-b.md -> .foundry/tasks/task-c.md -> .foundry/tasks/task-b.md');
+
+    const aContent = fs.readFileSync(path.join(tmpDir, ".foundry/tasks/task-a.md"), "utf-8");
+    const bContent = fs.readFileSync(path.join(tmpDir, ".foundry/tasks/task-b.md"), "utf-8");
+    const cContent = fs.readFileSync(path.join(tmpDir, ".foundry/tasks/task-c.md"), "utf-8");
+
+    // Task A should not fail from cycle
+    expect(aContent).toContain("status: PENDING");
+    expect(bContent).toContain("status: FAILED");
+    expect(bContent).toContain("rejection_reason: Circular dependency detected");
+    expect(cContent).toContain("status: FAILED");
+    expect(cContent).toContain("rejection_reason: Circular dependency detected");
+  });
+
   test('Late-Binding Completion: EPIC fails if it lacks E2E story', () => {
     createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
       id: "epic-001",

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -664,34 +664,36 @@ function main(): void {
   }
 
   const visitedForCycle = new Set<string>();
-  const recursionStack = new Set<string>();
+  const recursionStackPath: string[] = [];
+  const recursionSet = new Set<string>();
   const nodesInCycle = new Set<string>();
 
-  function dfsCycle(nodePath: string): boolean {
+  function dfsCycle(nodePath: string) {
     visitedForCycle.add(nodePath);
-    recursionStack.add(nodePath);
+    recursionStackPath.push(nodePath);
+    recursionSet.add(nodePath);
 
     const deps = dependencyGraph.get(nodePath) || [];
-    let hasCycle = false;
     for (const dep of deps) {
       if (!dependencyGraph.has(dep)) continue; // Only care about PENDING dependencies
 
       if (!visitedForCycle.has(dep)) {
-        if (dfsCycle(dep)) {
-          nodesInCycle.add(dep);
-          hasCycle = true;
+        dfsCycle(dep);
+      } else if (recursionSet.has(dep)) {
+        const cycleStartIndex = recursionStackPath.indexOf(dep);
+        const cyclePath = recursionStackPath.slice(cycleStartIndex);
+        cyclePath.push(dep);
+
+        warn(`Detected circular dependency: ${cyclePath.join(' -> ')}`);
+
+        for (const cycleNode of cyclePath) {
+          nodesInCycle.add(cycleNode);
         }
-      } else if (recursionStack.has(dep)) {
-        nodesInCycle.add(dep);
-        hasCycle = true;
       }
     }
 
-    recursionStack.delete(nodePath);
-    if (hasCycle) {
-       nodesInCycle.add(nodePath);
-    }
-    return hasCycle;
+    recursionStackPath.pop();
+    recursionSet.delete(nodePath);
   }
 
   for (const n of pendingNodesForCycleDetection) {
@@ -701,7 +703,6 @@ function main(): void {
   }
 
   if (nodesInCycle.size > 0) {
-    warn(`Detected circular dependency involving ${nodesInCycle.size} nodes.`);
     for (const nodePath of nodesInCycle) {
       const cycleNode = nodes.find(n => n.repoPath === nodePath);
       if (cycleNode) {


### PR DESCRIPTION
This commit improves the circular dependency detection in the Foundry Orchestrator (`dfsCycle`). Previously, innocent nodes pointing to a circular dependency were incorrectly flagged as being part of the cycle as the `hasCycle` flag propagated up the stack, causing them to falsely fail. By utilizing an isolated path tracking array (`recursionStackPath`) and a Set, the logic now isolates only the members of the cycle, explicitly logging the exact cycle path (`A -> B -> C -> A`). Corresponding test scenarios (e.g. `Deadlock Prevention: Correctly isolates cycle and doesn't fail innocent nodes pointing to cycle`) have been added and verified to ensure correct deadlock prevention without unintended collateral damage. All tests are passing (177/177).

---
*PR created automatically by Jules for task [8190986103606625335](https://jules.google.com/task/8190986103606625335) started by @szubster*