### PR TITLE
🗺️ Tech Lead: Draft task for Bash Timeout Wrapper Implementation

### DIFF
--- a/.foundry/journals/tech_lead/16981402898077233868.md
+++ b/.foundry/journals/tech_lead/16981402898077233868.md
@@ -1,0 +1,2 @@
+# 2026-08-02: Bash Timeout Wrapper Implementation Task
+For the implementation of the bash timeout wrapper (story-347-354-bash-timeout-wrapper-impl), I decided to use the Intelligent Verification Protocol to assign the coder to self-verify. The implementation is actually already completed via an instructional policy in core_policies.md, as found in previous research, making it extremely low-risk and simple. Thus, a separate QA task is not needed.

--- a/.foundry/stories/story-347-354-bash-timeout-wrapper-impl.md
+++ b/.foundry/stories/story-347-354-bash-timeout-wrapper-impl.md
@@ -25,4 +25,5 @@ notes: ''
 Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that run over a specific threshold.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks
+- [x] Break down into Tasks
+- [ ] task-354-390-bash-timeout-wrapper-impl

--- a/.foundry/tasks/task-354-390-bash-timeout-wrapper-impl.md
+++ b/.foundry/tasks/task-354-390-bash-timeout-wrapper-impl.md
@@ -1,0 +1,32 @@
+---
+id: task-354-390-bash-timeout-wrapper-impl
+type: TASK
+title: Bash Timeout Wrapper Implementation (Retry)
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-347-354-bash-timeout-wrapper-impl
+tags:
+  - foundry
+  - resilience
+research_references:
+  - research-057-346-investigate-bash-timeout-failure
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Bash Timeout Wrapper Implementation (Retry)
+
+## Objective
+Implement a timeout wrapper for run_in_bash_session to interrupt commands that run over a specific threshold. Based on previous research, this is implemented as an instructional policy in core_policies.md.
+
+## Instructions for Coder
+The core implementation work was already completed in previous tasks (via instructional policy enforcement in core_policies.md). You must verify that the policy exists, check off the acceptance criteria, self-verify, and submit an Empty PR to complete this task.
+
+## Acceptance Criteria
+- [ ] Verify that .foundry/docs/knowledge_base/agents/core_policies.md contains the bash timeout wrapper instructions.


### PR DESCRIPTION
Draft task for Bash Timeout Wrapper Implementation

Created `task-354-390-bash-timeout-wrapper-impl.md` to instruct the coder to self-verify the timeout wrapper policy and submit an Empty PR. Updated the story node to check off the breakdown criteria.

---
*PR created automatically by Jules for task [16981402898077233868](https://jules.google.com/task/16981402898077233868) started by @szubster*