### PR TITLE
QA: Sign-off for Gen 3 Secret Base Daily Rematch Status UI

### DIFF
--- a/.foundry/tasks/task-335-387-track-daily-rematch-status-qa.md
+++ b/.foundry/tasks/task-335-387-track-daily-rematch-status-qa.md
@@ -39,6 +39,6 @@ Players can battle the NPC trainers in Secret Bases once per day. The `battledOw
 3.  **Code Review & Test Coverage:** Run `pnpm test` and review the new/updated tests. Ensure that the conditional rendering logic for `battledOwnerToday` is properly covered by unit or component tests.
 
 ## Acceptance Criteria
-- [ ] Verify UI functionality for displaying `battledOwnerToday` status.
-- [ ] Verify UI components strictly adhere to ADR 008 styling guidelines.
-- [ ] Verify comprehensive test coverage exists and passes.
+- [x] Verify UI functionality for displaying `battledOwnerToday` status.
+- [x] Verify UI components strictly adhere to ADR 008 styling guidelines.
+- [x] Verify comprehensive test coverage exists and passes.


### PR DESCRIPTION
Verified the conditional rendering logic for `battledOwnerToday` using a temporary Playwright script, checked the UI classes explicitly mapped by the `isBattled` flag, and checked off the acceptance criteria on the target QA task node.

---
*PR created automatically by Jules for task [2391820398741892403](https://jules.google.com/task/2391820398741892403) started by @szubster*