### PR TITLE
chore(coder): verify bash timeout wrapper implementation (Retry)

### DIFF
--- a/.foundry/journals/coder/14672935916813700627.md
+++ b/.foundry/journals/coder/14672935916813700627.md
@@ -1,0 +1,8 @@
+# Coder Journal - Session 14672935916813700627
+
+## Observations & Lessons Learned
+
+- **Timeout Interruption Feedback:** When wrapping commands with the GNU `timeout` command in `run_in_bash_session`, if the process returns exit code 124, it explicitly indicates a timeout. Instead of retrying the blocking command (like `tail -f`), I must switch to non-blocking alternatives like `cat` or `tail -n`. This enforces the non-blocking execution rule to prevent indefinite hangs.
+- **Empty PR Checkbox Policy Compliance:** When checking off acceptance criteria for tasks that are already complete via instructional policies (e.g., verifying a wrapper exists in docs), I must successfully check the markdown box using `write_file` without altering the YAML frontmatter before submitting the Empty PR.
+- **Plan Specificity for Edits:** For file edits in the execution plan, using `replace_with_git_merge_diff` is discouraged in this project context; instead, I must use `write_file` and supply the full file content (including unchanged frontmatter) to strictly adhere to the Specificity Rule.
+- **Untruncated Exploration:** When inspecting files during the exploration phase to verify conditions before drafting a plan, `read_file` is preferable to `cat` via `run_in_bash_session` to avoid terminal truncation, preventing false positives and ensuring complete context is retrieved.

--- a/.foundry/tasks/task-354-390-bash-timeout-wrapper-impl.md
+++ b/.foundry/tasks/task-354-390-bash-timeout-wrapper-impl.md
@@ -29,4 +29,4 @@ Implement a timeout wrapper for run_in_bash_session to interrupt commands that r
 The core implementation work was already completed in previous tasks (via instructional policy enforcement in core_policies.md). You must verify that the policy exists, check off the acceptance criteria, self-verify, and submit an Empty PR to complete this task.
 
 ## Acceptance Criteria
-- [ ] Verify that .foundry/docs/knowledge_base/agents/core_policies.md contains the bash timeout wrapper instructions.
+- [x] Verify that .foundry/docs/knowledge_base/agents/core_policies.md contains the bash timeout wrapper instructions.


### PR DESCRIPTION
Submit Empty PR to transition the completed task `task-354-390-bash-timeout-wrapper-impl` after verifying the instructional policy exists and checking off the acceptance criteria checkboxes.

---
*PR created automatically by Jules for task [14672935916813700627](https://jules.google.com/task/14672935916813700627) started by @szubster*