### PR TITLE
Check off acceptance criteria for Phase 3.6 CANCELLED nodes passthrough task

### DIFF
--- a/.foundry/tasks/task-346-388-extend-phase-3-6-cancelled-nodes-passthrough.md
+++ b/.foundry/tasks/task-346-388-extend-phase-3-6-cancelled-nodes-passthrough.md
@@ -33,5 +33,5 @@ The required changes and tests for the parent story have already been implemente
 - Verify the tests in `.github/scripts/foundry-orchestrator.test.ts` assert this behavior.
 
 ## Acceptance Criteria
-- [ ] Verify the implementation is already present.
-- [ ] Submit an Empty PR using the `submit` tool.
+- [x] Verify the implementation is already present.
+- [x] Submit an Empty PR using the `submit` tool.


### PR DESCRIPTION
This PR satisfies a passthrough task where the implementation and tests for verifying Phase 3.6 for CANCELLED nodes (due to reaching the max rejection threshold) were already completed in the parent story. The changes to `.github/scripts/foundry-orchestrator.ts` and `.github/scripts/foundry-orchestrator.test.ts` were confirmed, and the task's markdown acceptance criteria have been checked off.

---
*PR created automatically by Jules for task [14763409627936914631](https://jules.google.com/task/14763409627936914631) started by @szubster*