### PR TITLE
Late Binding: Suspend Living Dex PC Mapping Implementation for Research

### DIFF
--- a/.foundry/journals/coder/4125946599341574796.md
+++ b/.foundry/journals/coder/4125946599341574796.md
@@ -1,0 +1,9 @@
+# Coder Session: 4125946599341574796
+
+## Context
+Assigned to `task-273-327-living-dex-pc-mapping-impl` to implement Gen 3 PC Box parsing.
+
+## Findings & Actions
+- The codebase lacks knowledge of the exact memory offsets and structures for PC Boxes in Generation 3 save files.
+- The task cannot be implemented without this data.
+- Applied the Late Binding policy: spawned a new `RESEARCH` node (`research-327-385-gen3-pc-box-offsets`), appended its ID to the current task's `depends_on` array, updated the task's `status` to `FAILED`, and provided a clear `rejection_reason`.

--- a/.foundry/research/research-327-385-gen3-pc-box-offsets.md
+++ b/.foundry/research/research-327-385-gen3-pc-box-offsets.md
@@ -1,0 +1,36 @@
+---
+id: research-327-385-gen3-pc-box-offsets
+type: RESEARCH
+title: Research PC Box Memory Offsets for Generation 3
+status: PENDING
+owner_persona: researcher
+created_at: '2026-08-02'
+updated_at: '2026-08-02'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-273-327-living-dex-pc-mapping-impl
+tags:
+  - backend
+  - save-parsing
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research PC Box Memory Offsets for Generation 3
+
+## Objective
+Research the exact memory offsets and structure for PC Box data in Generation 3 save files to enable accurate data extraction of PC Box Pokemon and Box configurations for the Living Dex.
+
+## Context
+Task `task-273-327-living-dex-pc-mapping-impl` requires implementing backend data mapping to extract PC Box and Slot locations for owned Pokémon in Generation 3. The exact offsets and structure of this data within the `SaveBlock1` or `SaveBlock2` sections are currently missing in the codebase.
+
+## Acceptance Criteria
+- [ ] Research and document the memory structure of PC Boxes in Gen 3 saves (Ruby, Sapphire, Emerald, FireRed, LeafGreen).
+- [ ] Determine the exact base offset for PC Box data.
+- [ ] Determine the exact offset for the box configurations (names, wallpapers).
+- [ ] Detail the structure and offsets of the Pokémon stored within the boxes.
+- [ ] Document these findings in `.foundry/docs/knowledge_base/engine/save_parsing/`.

--- a/.foundry/tasks/task-273-327-living-dex-pc-mapping-impl.md
+++ b/.foundry/tasks/task-273-327-living-dex-pc-mapping-impl.md
@@ -2,11 +2,11 @@
 id: task-273-327-living-dex-pc-mapping-impl
 type: TASK
 title: Living Dex PC Mapping Implementation
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-16'
 updated_at: '2026-08-02'
-depends_on: []
+depends_on: [research-327-385-gen3-pc-box-offsets]
 jules_session_id: '4125946599341574796'
 pr_number: null
 parent: story-133-273-living-dex-pc-mapping
@@ -15,7 +15,7 @@ tags:
   - data-mapping
 research_references: []
 rejection_count: 1
-rejection_reason: ''
+rejection_reason: 'Missing context regarding Gen 3 PC Box data structure and memory offsets. Late binding required to spawn RESEARCH node.'
 notes: ''
 ---
 


### PR DESCRIPTION
Applied Late Binding to task-273-327-living-dex-pc-mapping-impl because the required Gen 3 PC Box memory structure and offsets are missing from the codebase. Spawned research-327-385-gen3-pc-box-offsets and updated the task to FAILED to suspend it until the research is complete.

---
*PR created automatically by Jules for task [4125946599341574796](https://jules.google.com/task/4125946599341574796) started by @szubster*