### PR TITLE
🎨 Palette: Introduce Tactical Skeleton

### DIFF
--- a/.jules/palette/2024-05-15-12-00-00.md
+++ b/.jules/palette/2024-05-15-12-00-00.md
@@ -1,0 +1,5 @@
+# Palette Session Log
+
+## Learnings
+* **Tactical Skeletons:** Introduced `@utility tactical-skeleton` in `index.css` to centralize the loading state styling, enforcing the 'tactical hardware' aesthetic (`rounded-none`, `border-dashed`, `border-zinc-800/50`, `bg-zinc-900/50`, `animate-pulse`).
+* **Vite Dev Server Port:** When running `pnpm run dev`, the server defaults to port 3000, not 5173. Tests running against localhost must target port 3000.

--- a/src/components/AssistantPanel.tsx
+++ b/src/components/AssistantPanel.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Bug, Egg, Flag, Info, Loader2, Sparkles, Target, Zap } from 'lucide-react';
+import { Bug, Egg, Flag, Info, Sparkles, Target, Zap } from 'lucide-react';
 import React from 'react';
 import type { SuggestionCategory } from '../engine/assistant/strategies/types';
 import type { SaveData } from '../engine/saveParser/index';
@@ -163,13 +163,10 @@ export function AssistantPanel({ saveData, isLivingDex, manualVersion }: Assista
 
       {isLoading ? (
         <div
-          className="relative flex items-center justify-center border border-zinc-800/50 bg-zinc-900/50 p-12"
-          // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
+          className="tactical-skeleton h-64 w-full" // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
           role="status"
           aria-live="polite"
         >
-          <CornerCrosshairs thickness={2} className="h-2 w-2 border-white/20" />
-          <Loader2 className="animate-spin text-zinc-500" size={32} />
           <span className="sr-only">Loading suggestions...</span>
         </div>
       ) : suggestions.length === 0 ? (

--- a/src/components/PokemonDetails.tsx
+++ b/src/components/PokemonDetails.tsx
@@ -314,16 +314,12 @@ export function PokemonDetails({
           {/* Left Column Data Feed */}
           <div className="flex flex-col gap-6 xl:gap-8">
             {catchRate !== null && (
-              <React.Suspense
-                fallback={<div className="h-24 animate-pulse rounded border border-zinc-800/50 bg-zinc-900/50" />}
-              >
+              <React.Suspense fallback={<div className="tactical-skeleton h-24" />}>
                 <PokemonCatchProbability catchRate={catchRate} effectivePokeball={effectivePokeball} />
               </React.Suspense>
             )}
 
-            <React.Suspense
-              fallback={<div className="h-48 animate-pulse rounded border border-zinc-800/50 bg-zinc-900/50" />}
-            >
+            <React.Suspense fallback={<div className="tactical-skeleton h-48" />}>
               <PokemonEvolutions
                 evoReq={evoReq}
                 evolvesTo={evolvesTo || []}
@@ -343,9 +339,7 @@ export function PokemonDetails({
             <PokemonCaughtDetails yourPokemon={yourPokemon} />
             {pokemonId === 201 && saveData?.generation === 2 && <UnownDexPanel yourPokemon={yourPokemon} />}
 
-            <React.Suspense
-              fallback={<div className="h-48 animate-pulse rounded border border-zinc-800/50 bg-zinc-900/50" />}
-            >
+            <React.Suspense fallback={<div className="tactical-skeleton h-48" />}>
               <PokemonLocations
                 pokemonId={pokemonId}
                 gameVersion={gameVersion}

--- a/src/components/pokemon/details/PokemonLocations.tsx
+++ b/src/components/pokemon/details/PokemonLocations.tsx
@@ -20,7 +20,6 @@ import { SectionHeader } from '../../SectionHeader';
 import { TacticalBadge } from '../../TacticalBadge';
 import { TacticalBlockHeader } from '../../TacticalBlockHeader';
 import { TacticalNode } from '../../TacticalNode';
-import { TacticalPanel } from '../../TacticalPanel';
 import { LocationRow } from './LocationRow';
 
 interface EvoReq {
@@ -72,7 +71,7 @@ export function PokemonLocations({
       </div>
 
       {loading ? (
-        <TacticalPanel className="h-40 animate-pulse rounded-none border border-dashed" />
+        <div className="tactical-skeleton h-40" />
       ) : (
         <div className="relative z-10 grid grid-cols-1 gap-4" data-testid="location-list">
           {hasEncounters ? (

--- a/src/index.css
+++ b/src/index.css
@@ -206,3 +206,6 @@ body {
     @apply tactical-focus;
   }
 }
+@utility tactical-skeleton {
+  @apply animate-pulse rounded-none border border-dashed border-zinc-800/50 bg-zinc-900/50;
+}

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -47,7 +47,7 @@ function DashboardPage() {
 
   return (
     <div className="mb-20 flex h-full flex-col gap-6 pt-4 pb-[env(safe-area-inset-bottom,16px)] md:mb-0">
-      <Suspense fallback={<div className="h-32 animate-pulse rounded-lg bg-zinc-900/50" />}>
+      <Suspense fallback={<div className="tactical-skeleton h-32" />}>
         {saveData.generation === 3 ? (
           <>
             <BattleFrontierDashboard saveData={saveData} />


### PR DESCRIPTION
**What**
Introduced a new `@utility tactical-skeleton` in `src/index.css` and applied it across various components (`PokemonDetails`, `AssistantPanel`, `PokemonLocations`, `dashboard`) to replace hardcoded skeleton classes.

**Why**
Centralizes the loading state styling to strictly adhere to the "tactical hardware" aesthetic (`rounded-none`, `border-dashed`, `font-mono`) defined in ADR 008, and avoids repetition of Tailwind classes across components.

**Before/After**
Before: Hardcoded classes like `animate-pulse rounded border border-zinc-800/50 bg-zinc-900/50`.
After: Replaced with `tactical-skeleton` mapping to `animate-pulse rounded-none border border-dashed border-zinc-800/50 bg-zinc-900/50`.

**Accessibility notes**
All elements using the skeleton class properly retain `role="status"` and `aria-live="polite"` when applicable. A linting rule for `jsx-a11y/prefer-tag-over-role` was explicitly disabled for these to avoid using `<output>` for structural skeletons, which is the established project convention.

---
*PR created automatically by Jules for task [6139402004413972239](https://jules.google.com/task/6139402004413972239) started by @szubster*