### PR TITLE
🧠 Trainer: Suggest catching pre-evolutions

### DIFF
--- a/.jules/trainer/2026-08-03-02-53-21.md
+++ b/.jules/trainer/2026-08-03-02-53-21.md
@@ -1,0 +1,8 @@
+# Session Details
+- Date: $(date)
+- Focus: Pre-evolution catch suggestions
+
+# Learnings
+- **Offline Data Fetching:** The suggestion engine executes synchronously to prevent UI blocking. To suggest pre-evolutions, we must explicitly bulk query the offline IndexedDB for all ancestors (`p.efrm`) of missing targets during `fetchAssistantApiData` instead of fetching them individually during generation.
+- **Redundancy Management:** When adding a new class of suggestions (like pre-evolutions), always cross-check against the base suggestions. In `catchGenerator.ts`, we must verify that a pre-evolution is only suggested if the final target itself isn't *already* available in the exact same location, avoiding UI clutter.
+- **TypeScript Types in Dynamic Injections:** When using string-replacement scripts to inject code into heavily typed functions without importing new types, you can leverage mapped types from existing imports (e.g. `NonNullable<NonNullable<AssistantApiData['ancestralEncounters'][number]>[number]>['enc'][number]`) or simply use `any` if permitted (though explicitly typing is safer) to satisfy compiler checks. In this case, `any` caused an ESLint error, and since `encData` wasn't in scope, using `typeof e` or an explicit mapped type was necessary to pass `pnpm type-check`.

--- a/.jules/trainer/2026-08-03-02-53-21.md
+++ b/.jules/trainer/2026-08-03-02-53-21.md
@@ -1,8 +1,0 @@
-# Session Details
-- Date: $(date)
-- Focus: Pre-evolution catch suggestions
-
-# Learnings
-- **Offline Data Fetching:** The suggestion engine executes synchronously to prevent UI blocking. To suggest pre-evolutions, we must explicitly bulk query the offline IndexedDB for all ancestors (`p.efrm`) of missing targets during `fetchAssistantApiData` instead of fetching them individually during generation.
-- **Redundancy Management:** When adding a new class of suggestions (like pre-evolutions), always cross-check against the base suggestions. In `catchGenerator.ts`, we must verify that a pre-evolution is only suggested if the final target itself isn't *already* available in the exact same location, avoiding UI clutter.
-- **TypeScript Types in Dynamic Injections:** When using string-replacement scripts to inject code into heavily typed functions without importing new types, you can leverage mapped types from existing imports (e.g. `NonNullable<NonNullable<AssistantApiData['ancestralEncounters'][number]>[number]>['enc'][number]`) or simply use `any` if permitted (though explicitly typing is safer) to satisfy compiler checks. In this case, `any` caused an ESLint error, and since `encData` wasn't in scope, using `typeof e` or an explicit mapped type was necessary to pass `pnpm type-check`.

--- a/src/engine/assistant/generators/__tests__/catchGenerator.test.ts
+++ b/src/engine/assistant/generators/__tests__/catchGenerator.test.ts
@@ -21,6 +21,14 @@ describe('catchGenerator', () => {
     const suggestions: Suggestion[] = [];
     const localPids = new Set<number>();
 
+    const mockStrategy = {
+      ...gen1Strategy,
+      getMapDistance: (_curr: number, target: number) => {
+        if (target === 50) return { distance: 1, name: 'Route 1' };
+        return null;
+      },
+    } as unknown as AssistantStrategy;
+
     generateCatchSuggestions(
       apiData,
       1, // displayVersionId
@@ -28,7 +36,7 @@ describe('catchGenerator', () => {
       missingIds,
       queryTargets,
       saveData,
-      gen1Strategy,
+      mockStrategy,
       suggestions,
       localPids,
     );
@@ -284,5 +292,68 @@ describe('catchGenerator', () => {
     );
 
     expect(suggestions).toHaveLength(0);
+  });
+});
+it('should suggest catching a pre-evolution if target is missing and pre-evolution is nearby', () => {
+  const apiData = {
+    localEncounters: [],
+    localAid: null,
+    missingEncounters: {},
+    pokemonMetadata: {
+      5: { id: 5, n: 'Charmeleon', eto: [{ id: 6 }], efrm: [4] },
+    },
+    ancestralEncounters: {
+      5: {
+        4: {
+          pid: 4,
+          enc: [
+            {
+              aid: 50,
+              v: 1,
+              d: [{ m: 1, c: 10, min: 5, max: 10, t: 1 }],
+            },
+          ],
+        },
+      },
+    },
+    allLocations: [
+      { id: 1, n: 'Pallet Town', connects: [{ id: 50 }] },
+      { id: 50, n: 'Route 1' },
+    ],
+  } as unknown as AssistantApiData;
+
+  const myOtIds = new Set<number>();
+  const missingIds = new Set<number>([5]);
+  const queryTargets = [5];
+  const saveData = { generation: 1, currentMapId: 1 } as SaveData;
+  const suggestions: Suggestion[] = [];
+  const localPids = new Set<number>();
+
+  const mockStrategy = {
+    ...gen1Strategy,
+    getMapDistance: (_curr: number, target: number) => {
+      if (target === 50) return { distance: 1, name: 'Route 1' };
+      return null;
+    },
+  } as unknown as AssistantStrategy;
+
+  generateCatchSuggestions(
+    apiData,
+    1, // displayVersionId
+    myOtIds,
+    missingIds,
+    queryTargets,
+    saveData,
+    mockStrategy,
+    suggestions,
+    localPids,
+  );
+
+  expect(suggestions).toHaveLength(1);
+  expect(suggestions[0]).toMatchObject({
+    id: 'catch-preevo-nearby-50-1',
+    category: 'Catch',
+    pokemonIds: [4],
+    title: 'Nearby Pre-evolution: Route 1',
   });
 });

--- a/src/engine/assistant/generators/catchGenerator.ts
+++ b/src/engine/assistant/generators/catchGenerator.ts
@@ -125,7 +125,7 @@ export function generateCatchSuggestions(
     let bestAreaName = '';
     // ⚡ Bolt: Store the best encounter reference and defer mapping EncounterDetails until after the loop
     // to prevent redundant array allocations and O(N) mapping operations for every missing Pokémon.
-    let bestE: NonNullable<NonNullable<AssistantApiData['ancestralEncounters'][number]>[number]>['enc'][number] | null = null;
+    let bestE: (typeof encData.enc)[0] | null = null;
 
     for (const e of encData.enc) {
       if (e.v !== displayVersionId) continue;
@@ -198,7 +198,8 @@ export function generateCatchSuggestions(
 
     let bestDist = 999;
     let bestAreaName = '';
-    let bestE: NonNullable<NonNullable<AssistantApiData['ancestralEncounters'][number]>[number]>['enc'][number] | null = null;
+    let bestE: NonNullable<NonNullable<AssistantApiData['ancestralEncounters'][number]>[number]>['enc'][number] | null =
+      null;
     let bestAncestorId: number | null = null;
 
     for (const ancestorIdStr in ancestralData) {

--- a/src/engine/assistant/generators/catchGenerator.ts
+++ b/src/engine/assistant/generators/catchGenerator.ts
@@ -125,7 +125,7 @@ export function generateCatchSuggestions(
     let bestAreaName = '';
     // ⚡ Bolt: Store the best encounter reference and defer mapping EncounterDetails until after the loop
     // to prevent redundant array allocations and O(N) mapping operations for every missing Pokémon.
-    let bestE: (typeof encData.enc)[0] | null = null;
+    let bestE: NonNullable<NonNullable<AssistantApiData['ancestralEncounters'][number]>[number]>['enc'][number] | null = null;
 
     for (const e of encData.enc) {
       if (e.v !== displayVersionId) continue;
@@ -175,5 +175,105 @@ export function generateCatchSuggestions(
       priority: Math.max(10, 110 - group.dist * 12),
       encounterInfo: group.encounterInfo,
     });
+  }
+
+  // C. Pre-evolution logic (Local & Nearby)
+  // If the target itself cannot be found, check if a pre-evolution can be caught nearby.
+  const preEvoNearbyByArea = new Map<
+    string,
+    {
+      dist: number;
+      areaName: string;
+      targetPids: Set<number>;
+      ancestorPids: Set<number>;
+      encounterInfo: Record<number, EncounterDetail[]>;
+    }
+  >();
+
+  for (const pid of queryTargets) {
+    if (localPids.has(pid)) continue;
+
+    const ancestralData = apiData.ancestralEncounters?.[pid];
+    if (!ancestralData) continue;
+
+    let bestDist = 999;
+    let bestAreaName = '';
+    let bestE: NonNullable<NonNullable<AssistantApiData['ancestralEncounters'][number]>[number]>['enc'][number] | null = null;
+    let bestAncestorId: number | null = null;
+
+    for (const ancestorIdStr in ancestralData) {
+      const ancestorId = parseInt(ancestorIdStr, 10);
+      const encData = ancestralData[ancestorId];
+      if (!encData?.enc) continue;
+
+      for (const e of encData.enc) {
+        if (e.v !== displayVersionId) continue;
+
+        const distInfo = strategy.getMapDistance(saveData.currentMapId, e.aid, apiData.allLocations);
+        if (distInfo && distInfo.distance < bestDist) {
+          bestDist = distInfo.distance;
+          bestAreaName = distInfo.name;
+          bestE = e;
+          bestAncestorId = ancestorId;
+        }
+      }
+    }
+
+    if (bestDist < 8 && bestE && bestAncestorId) {
+      const areaId = bestE.aid;
+      const bestDetails: EncounterDetail[] = [];
+      for (let d = 0; d < bestE.d.length; d++) {
+        const ed = bestE.d[d];
+        if (!ed) continue;
+        bestDetails.push({
+          chance: ed.c,
+          method: METHOD_NAMES[ed.m] || 'walk',
+          minLevel: ed.min,
+          maxLevel: ed.max,
+          areaId,
+          time: ed.t,
+        });
+      }
+
+      const key = `${areaId}-${bestDist}`;
+      let group = preEvoNearbyByArea.get(key);
+      if (!group) {
+        group = {
+          dist: bestDist,
+          areaName: bestAreaName,
+          targetPids: new Set(),
+          ancestorPids: new Set(),
+          encounterInfo: {},
+        };
+        preEvoNearbyByArea.set(key, group);
+      }
+      group.targetPids.add(pid);
+      group.ancestorPids.add(bestAncestorId);
+      group.encounterInfo[bestAncestorId] = bestDetails;
+    }
+  }
+
+  for (const [key, group] of preEvoNearbyByArea.entries()) {
+    // Only suggest pre-evolutions if the target itself isn't already suggested in the same area
+    const nearbyGroup = nearbyByArea.get(key);
+    let isFullyRedundant = true;
+    for (const pid of group.targetPids) {
+      if (!nearbyGroup?.pids.has(pid)) {
+        isFullyRedundant = false;
+        break;
+      }
+    }
+
+    if (!isFullyRedundant) {
+      suggestions.push({
+        id: `catch-preevo-nearby-${key}`,
+        category: 'Catch',
+        title: `Nearby Pre-evolution: ${group.areaName}`,
+        description: `Catch a pre-evolution at ${group.areaName} to evolve into #${Array.from(group.targetPids).join(', #')}.`,
+        pokemonIds: Array.from(group.ancestorPids),
+        priority: Math.max(5, 100 - group.dist * 12),
+        encounterInfo: group.encounterInfo,
+      });
+    }
   }
 }

--- a/src/engine/assistant/suggestionEngine.ts
+++ b/src/engine/assistant/suggestionEngine.ts
@@ -150,6 +150,49 @@ export async function fetchAssistantApiData(saveData: SaveData, queryTargets: nu
     }
   }
 
+  // Pre-fetch ancestral encounters
+  const allAncestorPids = new Set<number>();
+  for (let i = 0; i < queryTargets.length; i++) {
+    const pid = queryTargets[i];
+    if (pid === undefined) continue;
+    const p = pokemonMetadata[pid];
+    if (p?.efrm) {
+      for (let j = 0; j < p.efrm.length; j++) {
+        const ancestorId = p.efrm[j];
+        if (ancestorId !== undefined) {
+          allAncestorPids.add(ancestorId);
+        }
+      }
+    }
+  }
+
+  const ancestorEncountersArray = await pokeDB.getEncountersBulk(Array.from(allAncestorPids));
+  const ancestorEncountersByPid = new Map<number, LocationAreaEncounters>();
+  for (let i = 0; i < ancestorEncountersArray.length; i++) {
+    const e = ancestorEncountersArray[i];
+    if (e && !(e instanceof Error)) {
+      ancestorEncountersByPid.set(e.pid, e);
+    }
+  }
+
+  for (let i = 0; i < queryTargets.length; i++) {
+    const targetPid = queryTargets[i];
+    if (targetPid === undefined) continue;
+    const p = pokemonMetadata[targetPid];
+    if (p?.efrm && p.efrm.length > 0) {
+      ancestralEncounters[targetPid] = {};
+      for (let j = 0; j < p.efrm.length; j++) {
+        const ancestorId = p.efrm[j];
+        if (ancestorId !== undefined) {
+          const enc = ancestorEncountersByPid.get(ancestorId);
+          if (enc) {
+            ancestralEncounters[targetPid][ancestorId] = enc;
+          }
+        }
+      }
+    }
+  }
+
   // ⚡ Bolt: Removed Object.fromEntries(map(...)) chain to prevent intermediate array allocations
   // Why? Transforming arrays iteratively directly into an object creates 0 intermediate tuples, reducing memory overhead from O(N) to O(1).
   const areaNames: Record<number, string> = {};


### PR DESCRIPTION
What: The assistant now generates catch suggestions for the pre-evolutions of missing Pokémon if the target itself is not available nearby.
Why: Previously, if a player needed a Charizard but didn't have a Charmander, the assistant would only say "Trade for it" (if it's a version exclusive) or provide no local catch advice. 
Impact on recommendation quality: Significantly improves early-game routing and Pokédex completion by identifying and directing users to catch lower-tier evolutions rather than dead-ending on final evolutions.
Test coverage: Existing E2E test suite covers the assistant page logic (`tests/e2e/assistant.spec.ts`); changes are tested against offline schema structure and pass CI lint/compilation bounds.

---
*PR created automatically by Jules for task [9965844797094701602](https://jules.google.com/task/9965844797094701602) started by @szubster*