### PR TITLE
🧹 [Clean up] Remove unused .github/scripts/schema.ts from knip ignore

### DIFF
--- a/.jules/sweeper/2026-08-03-03-00-04.md
+++ b/.jules/sweeper/2026-08-03-03-00-04.md
@@ -1,0 +1,4 @@
+# Sweeper Run Journal
+
+## Learnings
+* **Leftover knip config**: `.github/scripts/schema.ts` was still listed in `ignore` in `knip.json` even though it is actively used and correctly imported. Removing it from `knip.json` safely resolves the warning and ensures it correctly gets type-checked and tracked by knip.

--- a/knip.json
+++ b/knip.json
@@ -8,7 +8,6 @@
   ],
   "ignore": [
     "src/test-setup.ts",
-    ".github/scripts/schema.ts",
     ".github/scripts/extract-research.ts",
     ".github/scripts/verify-dag-refs.ts",
     "scripts/gen3-fetch-locations.ts",


### PR DESCRIPTION
🎯 What: Removed `.github/scripts/schema.ts` from the `ignore` array in `knip.json`.
💡 Why: The schema is actively used and should be tracked/linted by `knip`. Ignoring it was tech debt/leftover configuration from a prior task.
✅ Verification: Ran `pnpm knip`, `pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e` to ensure no regressions and strict type checking successfully applied.
✨ Result: Cleaned up configuration, ensuring all actively used scripts are correctly analyzed.

---
*PR created automatically by Jules for task [3018410230294938620](https://jules.google.com/task/3018410230294938620) started by @szubster*