### PR TITLE
📜 Scribe: Added architecture overview to Gen 2 save parser

### DIFF
--- a/.jules/scribe/2026-08-03-03-09-10.md
+++ b/.jules/scribe/2026-08-03-03-09-10.md
@@ -1,0 +1,5 @@
+# Scribe Session Log
+
+- Task: Add architecture overview to Gen 2 save parser (`src/engine/saveParser/parsers/gen2.ts`).
+- Observation: When analyzing memory operations in Gen 2, it is critical to note that version detection (Gold/Silver vs Crystal) dictates all base offsets. Instead of static offset maps, the codebase heavily utilizes ternary operations predicated on the `isCrystal` boolean. Inventory parsing also features dynamic length-prefixed lists rather than fixed structs.
+- Rule: Ensure architectural documentation does not hallucinate hex offsets or complex structures (e.g., roaming legendaries) if they are not definitively proven in the `run_in_bash_session` output. Strict adherence to grounded facts is required.

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -1,3 +1,25 @@
+/**
+ * @module gen2Parser
+ *
+ * Contains logic for parsing Generation 2 (Gold, Silver, Crystal) Game Boy Color save files.
+ *
+ * ## Architecture Overview
+ *
+ * Generation 2 maintains a linear memory layout, but with a critical distinction:
+ * Memory offsets differ significantly between Gold/Silver and Crystal.
+ *
+ * 1. **Version Detection & Offset Alignment**:
+ *    Because the save file doesn't explicitly declare its version, the parser must
+ *    heuristically determine it to apply the correct memory map. Once detected,
+ *    a boolean (`isCrystal`) is used to dynamically select the correct offset
+ *    variable via ternary operations (e.g., `DAYCARE_SLOT_1_OFFSET_CRYSTAL` vs
+ *    `DAYCARE_SLOT_1_OFFSET_GS`).
+ *
+ * 2. **Length-Prefixed Lists (Inventory)**:
+ *    Backpack inventory items (Items, Key Items, Balls) are stored dynamically as
+ *    length-prefixed lists. The first byte specifies the total count, followed by
+ *    alternating bytes for Item ID and Quantity.
+ */
 import gen2Landmarks from '../../data/gen2/landmarks.json';
 import gen2MapLocations from '../../data/gen2/mapLocations.json';
 import { GEN2_VERSION_EXCLUSIVES } from '../../exclusives/gen2Exclusives';


### PR DESCRIPTION
What: Added an @module architecture overview to `src/engine/saveParser/parsers/gen2.ts`.
Why this module needed docs: The Gen 2 save parser has complex logic handling memory offset shifts between Gold/Silver and Crystal, and dynamic inventory lengths. Adding a top-level architectural comment helps clarify these nuances for future maintainers.
Summary of additions: Documented the version detection heuristic (using isCrystal and ternary operators) and the length-prefixed inventory structure.

---
*PR created automatically by Jules for task [11685798918566628832](https://jules.google.com/task/11685798918566628832) started by @szubster*