### PR TITLE
chore: Complete story-347-354-bash-timeout-wrapper-impl

### DIFF
--- a/.foundry/journals/tech_lead/2026-08-03-06-19-56.md
+++ b/.foundry/journals/tech_lead/2026-08-03-06-19-56.md
@@ -1,0 +1,12 @@
+# Session 2026-08-03-06-19-56
+
+## Context
+Resumed execution for story node `story-347-354-bash-timeout-wrapper-impl`.
+
+## Actions
+The single child task `task-354-390-bash-timeout-wrapper-impl` has been completed.
+I need to check off the acceptance criteria for this task in the story node's markdown body so that the Orchestrator can transition the parent story node to COMPLETED.
+
+## Lessons Learned
+- When a child task is marked as COMPLETED, its reference must be explicitly checked off (`- [x]`) in the parent node's markdown body.
+- Submitting an empty PR is the correct mechanism for transitioning a parent node after all its child nodes have completed, provided all acceptance criteria checkboxes are marked.

--- a/.foundry/stories/story-347-354-bash-timeout-wrapper-impl.md
+++ b/.foundry/stories/story-347-354-bash-timeout-wrapper-impl.md
@@ -26,4 +26,4 @@ Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] task-354-390-bash-timeout-wrapper-impl
+- [x] task-354-390-bash-timeout-wrapper-impl


### PR DESCRIPTION
Submitted empty PR to check off completed child task in `story-347-354-bash-timeout-wrapper-impl.md` to trigger orchestrator state transition to COMPLETED. Checked acceptance criteria and added corresponding entry to the tech lead journal.

---
*PR created automatically by Jules for task [9813682289436146574](https://jules.google.com/task/9813682289436146574) started by @szubster*