### PR TITLE
Transition epic-097-130-nuzlocke-route-tracking to COMPLETED

### DIFF
--- a/.foundry/journals/story_owner/6846021697555165673.md
+++ b/.foundry/journals/story_owner/6846021697555165673.md
@@ -1,0 +1,4 @@
+# Session 6846021697555165673
+
+All stories for EPIC epic-097-130-nuzlocke-route-tracking have been completed.
+No further stories needed. Checkboxes are checked. Submitting an empty PR to transition to COMPLETED.

--- a/test-review.js
+++ b/test-review.js
@@ -1,4 +1,0 @@
-const fs = require('fs');
-console.log(fs.existsSync('.foundry/stories/story-097-261-extract-pokemon-met-locations.md'));
-console.log(fs.existsSync('.foundry/stories/story-097-262-aggregate-first-catch-by-route.md'));
-console.log(fs.existsSync('.foundry/stories/story-097-263-flag-nuzlocke-route-violations.md'));

--- a/test-review.js
+++ b/test-review.js
@@ -1,0 +1,4 @@
+const fs = require('fs');
+console.log(fs.existsSync('.foundry/stories/story-097-261-extract-pokemon-met-locations.md'));
+console.log(fs.existsSync('.foundry/stories/story-097-262-aggregate-first-catch-by-route.md'));
+console.log(fs.existsSync('.foundry/stories/story-097-263-flag-nuzlocke-route-violations.md'));


### PR DESCRIPTION
All child stories (`story-097-261-extract-pokemon-met-locations`, `story-097-262-aggregate-first-catch-by-route`, `story-097-263-flag-nuzlocke-route-violations`) have been completed and their Acceptance Criteria within the `epic-097-130-nuzlocke-route-tracking.md` node are checked off. Submitting an empty PR to allow the macro node to transition to COMPLETED.

---
*PR created automatically by Jules for task [6846021697555165673](https://jules.google.com/task/6846021697555165673) started by @szubster*