### PR TITLE
Fix DAG Orchestrator circular dependency warning

### DIFF
--- a/.foundry/research/research-327-385-gen3-pc-box-offsets.md
+++ b/.foundry/research/research-327-385-gen3-pc-box-offsets.md
@@ -2,21 +2,21 @@
 id: research-327-385-gen3-pc-box-offsets
 type: RESEARCH
 title: Research PC Box Memory Offsets for Generation 3
-status: FAILED
+status: PENDING
 owner_persona: researcher
 created_at: '2026-08-02'
 updated_at: '2026-08-03'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: task-273-327-living-dex-pc-mapping-impl
+parent: story-133-273-living-dex-pc-mapping
 tags:
   - backend
   - save-parsing
   - gen3
 research_references: []
 rejection_count: 0
-rejection_reason: Circular dependency detected
+rejection_reason: ''
 notes: ''
 ---
 

--- a/.foundry/tasks/task-273-327-living-dex-pc-mapping-impl.md
+++ b/.foundry/tasks/task-273-327-living-dex-pc-mapping-impl.md
@@ -16,7 +16,7 @@ tags:
   - data-mapping
 research_references: []
 rejection_count: 2
-rejection_reason: Circular dependency detected
+rejection_reason: Suspended pending research
 notes: ''
 ---
 


### PR DESCRIPTION
This PR fixes the circular dependency warning identified during the Foundry orchestrator resolution run.
It modifies the frontmatter metadata of:
1. `.foundry/research/research-327-385-gen3-pc-box-offsets.md` (re-parents to the story and sets status to PENDING).
2. `.foundry/tasks/task-273-327-living-dex-pc-mapping-impl.md` (updates the rejection reason to Suspended pending research).

Verification of the fix has been done via running the orchestrator script in dry-run mode, which confirmed that 0 cycles are detected and the DAG parses perfectly.

Fixes #5575

---
*PR created automatically by Jules for task [4084096515306657971](https://jules.google.com/task/4084096515306657971) started by @szubster*