### PR TITLE
chore: suspend gen 3 wonder card extraction pending research

### DIFF
--- a/.foundry/journals/coder/15859836416427117556.md
+++ b/.foundry/journals/coder/15859836416427117556.md
@@ -1,0 +1,10 @@
+# Session 15859836416427117556
+
+Attempted to implement `task-354-391-gen3-wonder-card-extraction-impl`. However, exact memory offsets and structure for Gen 3 Wonder Cards were not available in `.foundry/docs/schema.md` or anywhere in the codebase.
+
+Following the Late Binding for Missing Context policy from `.foundry/docs/knowledge_base/agents/core_policies.md`:
+1. I spawned a new RESEARCH node (`research-391-393-gen3-wonder-card-offsets`) to investigate the missing information.
+2. I appended the new node to the markdown body as an unchecked task instead of directly modifying the task's frontmatter, to comply with the strict rule against modifying YAML frontmatter for task nodes.
+3. I am failing the PR via code review, indicating I am suspending this pending research without modifying the node frontmatter directly, since it was strictly forbidden.
+
+This ensures we do not guess offsets or fallback to generic code when critical technical details are unknown, and avoids violating the frontmatter rules.

--- a/.foundry/research/research-391-393-gen3-wonder-card-offsets.md
+++ b/.foundry/research/research-391-393-gen3-wonder-card-offsets.md
@@ -1,0 +1,37 @@
+---
+id: research-391-393-gen3-wonder-card-offsets
+type: RESEARCH
+title: Investigate Gen 3 Wonder Card Offsets
+status: READY
+owner_persona: researcher
+created_at: '2026-08-03'
+updated_at: '2026-08-03'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-345-354-gen3-wonder-card-extraction
+tags:
+  - gen3
+  - mystery-gift
+  - data-extraction
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: 'Created via late binding as specific memory offsets for Wonder Cards are unknown.'
+---
+
+# Investigate Gen 3 Wonder Card Offsets
+
+## Context
+The task `task-354-391-gen3-wonder-card-extraction-impl` requires implementing Gen 3 Wonder Card Extraction. However, the exact memory offsets, structure, bit locations, lengths, and sizes of Wonder Card blocks in Gen 3 saves (Ruby, Sapphire, Emerald, FireRed, LeafGreen) are currently missing from the provided context (`.foundry/docs/schema.md` does not specify them). Following the late-binding policy, this research task is needed to find the specific technical details required to implement the parser correctly.
+
+## Requirements
+1. Determine the memory block / section in Gen 3 save files (e.g., SaveBlock1, SaveBlock2, or a specific Section ID) where Wonder Card data is stored.
+2. Determine the exact offsets for Wonder Card data relative to the block/section start.
+3. Determine the structure of a Wonder Card (ID, Title, Subtitle, Text, Item, Pokemon, etc.) and lengths/offsets of fields.
+4. Distinguish between different Gen 3 games (Ruby/Sapphire vs Emerald/FRLG) if applicable, as Mystery Gift data structure can vary.
+5. Provide actionable constants and types that can be directly mapped to code.
+
+## Acceptance Criteria
+- [ ] Researcher: Identify the exact memory offsets and structures for Gen 3 Wonder Cards.
+- [ ] Researcher: Update `.foundry/docs/schema.md` or provide a detailed breakdown in the ticket for the Coder to use.

--- a/.foundry/tasks/task-354-391-gen3-wonder-card-extraction-impl.md
+++ b/.foundry/tasks/task-354-391-gen3-wonder-card-extraction-impl.md
@@ -35,3 +35,6 @@ You must explicitly adhere to the guidelines defined in **Section 13 ("Save File
 ## Acceptance Criteria
 - [ ] Coder: Implement Gen 3 Wonder Card Extraction in accordance with Section 13 guidelines.
 - [ ] Coder: Write unit tests verifying the extraction logic.
+
+### Suspended Pending Research
+- [ ] research-391-393-gen3-wonder-card-offsets


### PR DESCRIPTION
This PR suspends the task `task-354-391-gen3-wonder-card-extraction-impl` because the exact memory offsets, structure, bit locations, lengths, and sizes of Wonder Card blocks in Gen 3 saves (Ruby, Sapphire, Emerald, FireRed, LeafGreen) are missing from the provided context (`.foundry/docs/schema.md` does not specify them). 

Following the Late Binding for Missing Context policy, I spawned a new `RESEARCH` node (`research-391-393-gen3-wonder-card-offsets`) to investigate the missing information. To comply with the strict rule against modifying YAML frontmatter for task nodes, I appended the new node to the markdown body as an unchecked task.

---
*PR created automatically by Jules for task [15859836416427117556](https://jules.google.com/task/15859836416427117556) started by @szubster*