### PR TITLE
chore: Empty PR for epic-097-130-nuzlocke-route-tracking transition

### DIFF
--- a/.foundry/journals/story_owner/4843341106317558855.md
+++ b/.foundry/journals/story_owner/4843341106317558855.md
@@ -1,0 +1,3 @@
+# Session 4843341106317558855
+
+All descendant stories (`story-097-261-extract-pokemon-met-locations`, `story-097-262-aggregate-first-catch-by-route`, and `story-097-263-flag-nuzlocke-route-violations`) for `epic-097-130-nuzlocke-route-tracking` are fully COMPLETED. The acceptance criteria checkboxes in `epic-097-130-nuzlocke-route-tracking.md` are already checked off. I am submitting an empty PR to transition this EPIC node.


### PR DESCRIPTION
As the Story Owner, I verified that all child stories for `epic-097-130-nuzlocke-route-tracking` (`story-097-261`, `story-097-262`, `story-097-263`) are COMPLETED. The acceptance criteria checkboxes are properly checked. Submitting an empty PR (only adding the journal entry) to trigger the orchestrator transition, per ADR 007 and late-binding rules.

---
*PR created automatically by Jules for task [4843341106317558855](https://jules.google.com/task/4843341106317558855) started by @szubster*