### PR TITLE
Tech Lead: Draft E2E tasks for permanent failure dashboard filtering

### DIFF
--- a/.foundry/journals/tech_lead/2026-08-03-16-22-36.md
+++ b/.foundry/journals/tech_lead/2026-08-03-16-22-36.md
@@ -1,0 +1,8 @@
+# Session 2026-08-03-16-22-36
+
+- Explored the issue for writing E2E tests for DAG Dashboard permanent failure filtering.
+- Noticed `DagDashboard` toggles permanent failures based on `MAX_REJECTION_THRESHOLD`.
+- Drafted technical blueprints:
+  - `task-353-393-lift-rejection-constant-e2e-impl`: Coder task to write Playwright test toggling "Permanent failures only" filter.
+  - `task-353-394-lift-rejection-constant-e2e-qa`: QA task to verify the new E2E test correctly checks the filter behavior.
+- Appended child task links to the parent STORY `story-343-353-lift-rejection-constant-e2e` as unchecked checkboxes and checked off "Break down into Tasks", ensuring the YAML frontmatter remained untouched as per the CRITICAL RULE.

--- a/.foundry/stories/story-343-353-lift-rejection-constant-e2e.md
+++ b/.foundry/stories/story-343-353-lift-rejection-constant-e2e.md
@@ -29,4 +29,8 @@ Write E2E tests to verify that the DAG Dashboard still correctly displays perman
 1. E2E test verifying permanent failure nodes on the dashboard.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks
+- [x] Break down into Tasks
+
+### Tasks
+- [ ] task-353-393-lift-rejection-constant-e2e-impl
+- [ ] task-353-394-lift-rejection-constant-e2e-qa

--- a/.foundry/tasks/task-353-393-lift-rejection-constant-e2e-impl.md
+++ b/.foundry/tasks/task-353-393-lift-rejection-constant-e2e-impl.md
@@ -1,0 +1,34 @@
+---
+id: task-353-393-lift-rejection-constant-e2e-impl
+type: TASK
+title: Implement E2E Test for Permanent Failure Dashboard
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-03'
+updated_at: '2026-08-03'
+depends_on:
+  - story-343-352-lift-rejection-constant-impl
+jules_session_id: null
+pr_number: null
+parent: story-343-353-lift-rejection-constant-e2e
+tags:
+  - e2e
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement E2E Test for Permanent Failure Dashboard
+
+## Objective
+Write an E2E test to verify that the DAG Dashboard still correctly displays permanent failures after lifting the rejection count constant.
+
+## Requirements
+1. E2E test verifying permanent failure nodes on the dashboard.
+
+## Acceptance Criteria
+- [ ] Create a Playwright test file at `tests/e2e/dashboard/permanent_failures.spec.ts`.
+- [ ] Implement a test that opens the dashboard, toggles the "Permanent failures only" filter, and asserts that permanent failures are correctly highlighted.
+- [ ] The test must verify that the UI correctly identifies nodes with a `rejection_count` of at least `MAX_REJECTION_THRESHOLD` as permanent failures.

--- a/.foundry/tasks/task-353-394-lift-rejection-constant-e2e-qa.md
+++ b/.foundry/tasks/task-353-394-lift-rejection-constant-e2e-qa.md
@@ -1,0 +1,32 @@
+---
+id: task-353-394-lift-rejection-constant-e2e-qa
+type: TASK
+title: QA E2E Test for Permanent Failure Dashboard
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-03'
+updated_at: '2026-08-03'
+depends_on:
+  - task-353-393-lift-rejection-constant-e2e-impl
+jules_session_id: null
+pr_number: null
+parent: story-343-353-lift-rejection-constant-e2e
+tags:
+  - e2e
+  - testing
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA E2E Test for Permanent Failure Dashboard
+
+## Objective
+Verify the implementation of the E2E test for the Permanent Failure Dashboard.
+
+## Acceptance Criteria
+- [ ] Verify the Playwright test file at `tests/e2e/dashboard/permanent_failures.spec.ts` exists.
+- [ ] Run the E2E tests and ensure the new test passes.
+- [ ] Verify that the test correctly asserts the behaviour of the "Permanent failures only" filter.


### PR DESCRIPTION
Drafted technical blueprints (`task-353-393-lift-rejection-constant-e2e-impl` and `task-353-394-lift-rejection-constant-e2e-qa`) from `story-343-353-lift-rejection-constant-e2e`, adhering to the Intelligent Verification Protocol. Appended the missing references to the newly generated children in the parent's markdown body, checked off the overarching acceptance criteria without modifying its YAML frontmatter, and documented the session in the Tech Lead journal.

---
*PR created automatically by Jules for task [15126975706780519185](https://jules.google.com/task/15126975706780519185) started by @szubster*