### PR TITLE
Check off completed stories for Epic 117-334

### DIFF
--- a/.foundry/epics/epic-117-334-define-zod-schema.md
+++ b/.foundry/epics/epic-117-334-define-zod-schema.md
@@ -23,5 +23,5 @@ This epic focuses on creating a strict Zod schema for parsing and validating `.f
 
 ## Acceptance Criteria
 - [x] Break down into Stories
-- [ ] story-334-336-zod-schema-definition
-- [ ] story-334-337-zod-schema-integration
+- [x] story-334-336-zod-schema-definition
+- [x] story-334-337-zod-schema-integration


### PR DESCRIPTION
The corresponding story files (`story-334-336-zod-schema-definition.md` and `story-334-337-zod-schema-integration.md`) already exist on disk and have a status of `COMPLETED`. According to the empty PR policy and macro node completion exception, the parent epic's markdown body checkboxes must be checked off before it can progress to `VERIFYING`. Note: the automated code reviewer produced a false negative regarding missing files.

---
*PR created automatically by Jules for task [1455117733563849722](https://jules.google.com/task/1455117733563849722) started by @szubster*