### PR TITLE
chore: update downstream references for fragmented journals

### DIFF
--- a/.foundry/journals/tech_lead/5253103258856818130.md
+++ b/.foundry/journals/tech_lead/5253103258856818130.md
@@ -1,0 +1,18 @@
+# Tech Lead Session Journal: 5253103258856818130
+
+## Overview
+- **Session ID:** 5253103258856818130
+- **Target Node:** `story-338-338-update-downstream-references`
+- **Objective:** Update Downstream References for Fragmented Journals
+
+## Actions Taken
+- Read `.foundry/docs/knowledge_base/agents/core_policies.md` to refresh initialization rules and constraints.
+- Reviewed the target STORY node `story-338-338-update-downstream-references`.
+- The child node `task-338-388-update-journal-references` has been implemented (`status: COMPLETED`).
+- Identified that the only required action is to check off the completed task in the parent STORY's acceptance criteria in its markdown body.
+- The STORY node's YAML frontmatter will not be modified to avoid Orchestrator rejection.
+- Checked off `- [x] task-338-388-update-journal-references` in `.foundry/stories/story-338-338-update-downstream-references.md`.
+
+## Observations & Lessons
+- It's critical to remember that parent node progression relies on checking off the markdown checkboxes of child nodes, rather than modifying the YAML frontmatter. This complies with ADR 007 and ADR 009.
+- This ensures the Orchestrator can properly evaluate if all dependent downstream nodes have been completed and transition the parent node to `VERIFYING`.

--- a/.foundry/stories/story-338-338-update-downstream-references.md
+++ b/.foundry/stories/story-338-338-update-downstream-references.md
@@ -33,4 +33,4 @@ Various nodes, scripts, and personas (like the Agile Coach or resurrected FAILED
 
 ## Acceptance Criteria
 - [x] Tech Lead: Break this Story down into actionable Tasks.
-- [ ] task-338-388-update-journal-references
+- [x] task-338-388-update-journal-references


### PR DESCRIPTION
This PR fulfills the Tech Lead persona role for `story-338-338-update-downstream-references`.

- Logged the session details to `.foundry/journals/tech_lead/5253103258856818130.md`.
- Identified that `task-338-388-update-journal-references` was already completed.
- Updated the parent STORY node's markdown body to check off the acceptance criteria for the completed task.
- Explicitly avoided modifying the YAML frontmatter of the STORY node to comply with Orchestrator rules.

---
*PR created automatically by Jules for task [5253103258856818130](https://jules.google.com/task/5253103258856818130) started by @szubster*