### PR TITLE
Tech Lead: Finalize story-137-334-gen2-checklist-ui-retry

### DIFF
--- a/.foundry/journals/tech_lead/4277472244991059073.md
+++ b/.foundry/journals/tech_lead/4277472244991059073.md
@@ -1,0 +1,4 @@
+# Session 4277472244991059073
+
+## Empty PR Checkbox Policy execution
+When a macro node (like a STORY) is assigned to the tech_lead, but the child tasks are already completely implemented and in `COMPLETED` state (as verified by reading `.foundry/tasks/task-334-386-gen2-checklist-ui-retry-impl.md` and `.foundry/tasks/task-334-387-gen2-checklist-ui-retry-qa.md`), the `tech_lead` must fulfill the Empty PR Checkbox Policy. This means updating the markdown body of the story to check off the acceptance criteria checkboxes for the completed tasks (`- [x]`), without modifying the YAML frontmatter, and then submitting an Empty PR to transition the node.

--- a/.foundry/stories/story-137-334-gen2-checklist-ui-retry.md
+++ b/.foundry/stories/story-137-334-gen2-checklist-ui-retry.md
@@ -26,5 +26,5 @@ Create the UI component to display the checklist of Gen 2 static encounters (Sud
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] task-334-386-gen2-checklist-ui-retry-impl
-- [ ] task-334-387-gen2-checklist-ui-retry-qa
+- [x] task-334-386-gen2-checklist-ui-retry-impl
+- [x] task-334-387-gen2-checklist-ui-retry-qa


### PR DESCRIPTION
When a macro node (STORY) assigned to the tech_lead has all its child tasks fully resolved and in `COMPLETED` state, the node's acceptance criteria checkboxes must be updated to `- [x]`. This commit fulfills the Empty PR Checkbox Policy, allowing the Foundry DAG to transition `story-137-334-gen2-checklist-ui-retry` to `VERIFYING` while logging the context in the tech lead's journal.

---
*PR created automatically by Jules for task [4277472244991059073](https://jules.google.com/task/4277472244991059073) started by @szubster*