### PR TITLE
test: Implement Bash Timeout Wrapper E2E Tests

### DIFF
--- a/.foundry/journals/coder/8307267315180839232.md
+++ b/.foundry/journals/coder/8307267315180839232.md
@@ -1,0 +1,7 @@
+# 2026-08-03: Bash Timeout Wrapper E2E Implementation
+
+- Successfully implemented Playwright E2E tests for the bash timeout wrapper script (`scripts/safe_bash.sh`).
+- Verified that executing non-blocking commands returns successfully.
+- Verified that executing blocking commands that exceed the timeout limit (like `sleep 35`) forcefully termiantes the command, exits with code 124, and prints the expected standard error warnings advising non-blocking commands.
+- Used `import.meta.dirname` over `__dirname` to ensure compatibility with modern Vite environments and avoid warnings.
+- Biome lint check fails if explicit `any` is used for caught errors (e.g., `catch (error: any)`). Refactored tests to use `unknown` typing instead and properly cast errors for assertion checks to pass `lint/suspicious/noExplicitAny`.

--- a/.foundry/tasks/task-355-393-bash-timeout-e2e-impl.md
+++ b/.foundry/tasks/task-355-393-bash-timeout-e2e-impl.md
@@ -27,4 +27,4 @@ This includes verifying that when commands exceed the threshold they return exit
 and that non-blocking commands proceed properly.
 
 ## Acceptance Criteria
-- [ ] Write tests verifying Bash timeout wrapper behavior.
+- [x] Write tests verifying Bash timeout wrapper behavior.

--- a/tests/e2e/bash_timeout.spec.ts
+++ b/tests/e2e/bash_timeout.spec.ts
@@ -1,0 +1,33 @@
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+
+test.describe('Bash Timeout Wrapper E2E', () => {
+  const safeBashPath = path.resolve(import.meta.dirname, '../../scripts/safe_bash.sh');
+
+  test('should execute a non-blocking command successfully', () => {
+    // Run a simple echo command that should not timeout
+    const result = execSync(`${safeBashPath} echo "Hello Timeout"`).toString().trim();
+    expect(result).toBe('Hello Timeout');
+  });
+
+  test('should terminate a blocking command and return exit code 124', () => {
+    try {
+      test.setTimeout(40000);
+      execSync(`${safeBashPath} sleep 35`, { stdio: 'pipe' });
+      // If it doesn't throw, the test should fail
+      expect(true).toBe(false);
+    } catch (error: unknown) {
+      const err = error as { status?: number; stderr?: { toString: () => string } };
+      expect(err.status).toBe(124);
+      if (err.stderr) {
+        const stderr = err.stderr.toString();
+        expect(stderr).toContain('Command exceeded the 30 second threshold and was terminated.');
+        expect(stderr).toContain("This is to prevent infinite hangs caused by blocking commands (e.g., 'tail -f').");
+        expect(stderr).toContain("Please use non-blocking alternatives like 'cat' or 'tail -n'.");
+      } else {
+        expect(true).toBe(false); // Force fail if stderr is missing
+      }
+    }
+  });
+});


### PR DESCRIPTION
Implemented E2E tests for the bash timeout wrapper script (`scripts/safe_bash.sh`) to satisfy the bash timeout e2e requirement. Verified tests pass and formatting is correct.

---
*PR created automatically by Jules for task [8307267315180839232](https://jules.google.com/task/8307267315180839232) started by @szubster*