### PR TITLE
Research PC Box Memory Offsets for Generation 3 Root Cause

### DIFF
--- a/.foundry/docs/knowledge_base/engine/save_parsing/gen3_pc_box_offsets.md
+++ b/.foundry/docs/knowledge_base/engine/save_parsing/gen3_pc_box_offsets.md
@@ -1,0 +1,58 @@
+# Gen 3 PC Box Memory Offsets
+
+This document outlines the memory offsets, structures, and layout used for PC Box data in Generation 3 save files (Ruby, Sapphire, Emerald, FireRed, LeafGreen). This information is necessary for extracting owned Pokémon and their Box/Slot configurations for the Living Dex.
+
+References:
+- Bulbapedia: [Save data structure (Generation III)](https://bulbapedia.bulbagarden.net/wiki/Save_data_structure_(Generation_III))
+- Bulbapedia: [Pokémon data structure (Generation III)](https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_data_structure_(Generation_III))
+
+## PC Buffer Organization (Sections 5-13)
+
+In Generation 3, the Pokémon Storage System (PC buffer) is split across multiple 4KB sections within the save file. Specifically, it occupies **9 sections** (Logical Sections 5 through 13).
+
+- **Sections 5 through 12**: Each contain 3968 bytes of PC buffer data.
+- **Section 13**: Contains the remaining 2000 bytes.
+- **Total PC Buffer Size**: 33,744 bytes.
+
+The PC buffer bytes are contiguous across these sections. When mapping offsets, the first byte of the PC buffer (`0x0000`) is located at the start of the data payload in Logical Section 5. Byte `3968` of the buffer is located at the start of Logical Section 6, and so on.
+
+### PC Buffer Layout
+
+The complete 33,744 byte PC buffer is laid out as follows:
+
+| Offset within PC Buffer | Size (Bytes) | Contents |
+| :--- | :--- | :--- |
+| `0x0000` | 4 | Current PC Box (Index of the most recently viewed box, minus 1) |
+| `0x0004` | 33,600 | PC Boxes Pokémon list (Array of 420 Pokémon records) |
+| `0x8344` | 126 | Box names (14 boxes × 9 bytes each) |
+| `0x83C2` | 14 | Box wallpapers (14 boxes × 1 byte each) |
+
+## PC Box Pokémon List
+
+The PC Box Pokémon list starts at offset `0x0004` within the PC buffer. It contains **420** Pokémon records.
+- There are 14 boxes in total.
+- Each box holds 30 Pokémon (arranged in a 5 rows × 6 columns grid).
+- Records are ordered left-to-right, top-to-bottom per box. (Records 0-29 belong to Box 1, Records 30-59 to Box 2, etc.)
+
+### PC Pokémon Data Structure
+
+While a full Generation 3 Pokémon record (e.g., in the party) is 100 bytes long, **Pokémon stored in the PC only utilize the first 80 bytes**. The remaining 20 bytes (which cover volatile battle stats, current HP, level, status conditions, etc.) are discarded to save space and regenerated when the Pokémon is withdrawn from the PC.
+
+Empty slots in a PC box are represented by 80 bytes of `0x00`.
+
+The 80-byte structure is as follows:
+
+| Offset within Record | Size (Bytes) | Field |
+| :--- | :--- | :--- |
+| `0x00` | 4 | Personality value (`u32`) |
+| `0x04` | 4 | Original Trainer (OT) ID (`u32`) |
+| `0x08` | 10 | Nickname (`u8[10]`) |
+| `0x12` | 1 | Language (`u8`) |
+| `0x13` | 1 | Misc. Flags (`u8`) |
+| `0x14` | 7 | OT name (`u8[7]`) |
+| `0x1B` | 1 | Markings (`u8`) |
+| `0x1C` | 2 | Checksum (`u16`) |
+| `0x1E` | 2 | Unknown/Padding (`u16`) |
+| `0x20` | 48 | Data / Substructures (`u8[48]`) |
+
+The `Data` block (48 bytes starting at offset `0x20`) is encrypted via XOR with a key derived from the Personality Value and OT ID. It contains 4 substructures of 12 bytes each, determining the Pokémon's species, item, moves, IVs, EVs, and other core attributes. (In party pokemon, the data after these 80 bytes starts at `0x50` with Status condition).

--- a/.foundry/journals/researcher/6535908287339075091.md
+++ b/.foundry/journals/researcher/6535908287339075091.md
@@ -1,0 +1,21 @@
+# Research Journal: Gen 3 PC Box Offsets Root Cause
+Session: 6535908287339075091
+
+## Goal
+Investigate the root cause of the previous failure related to Gen 3 PC Box extraction (`task-273-327-living-dex-pc-mapping-impl`) and the missing offsets, and research the exact memory structure of PC Boxes in Gen 3 saves.
+
+## Root Cause Analysis
+The task `task-273-327-living-dex-pc-mapping-impl` permanently failed because it was missing information regarding Gen 3 save parsing, specifically PC Box offsets.
+The previous research task (`research-327-385-gen3-pc-box-offsets`) was cancelled due to a cascading cancellation from its parent task (`task-273-327-living-dex-pc-mapping-impl`), which hit max rejections (3) because the implementation could not proceed without the missing offsets. This led to an 'impossible loop' where the implementation couldn't complete without the research, but the research was tied as a dependency that got cancelled when the parent failed. The late-bound node (`research-273-393-gen3-pc-box-offsets-root-cause`) was correctly spawned to break this loop by gathering the necessary context.
+
+## Findings
+I have successfully retrieved the missing Gen 3 PC Box memory structure from Bulbapedia:
+- **PC Buffer**: Spans logical sections 5 through 13. Sections 5-12 contain 3968 bytes, section 13 contains 2000 bytes. Total PC buffer size is 33,744 bytes.
+- **Current Box**: Offset `0x0000` (4 bytes).
+- **Pokémon List**: Starts at `0x0004` (33,600 bytes) covering 420 Pokémon (14 boxes * 30 Pokémon per box).
+- **Box Names**: Offset `0x8344` (126 bytes).
+- **Box Wallpapers**: Offset `0x83C2` (14 bytes).
+
+Furthermore, the data structure for Pokémon stored in the PC is only **80 bytes** long per record (compared to 100 bytes for party Pokémon). The data block from offset `0x20` to `0x50` contains the encrypted substructures. Information beyond the first 80 bytes (like status conditions) is regenerated upon withdrawing a Pokémon.
+
+These findings have been documented in `.foundry/docs/knowledge_base/engine/save_parsing/gen3_pc_box_offsets.md`.

--- a/.foundry/research/research-273-393-gen3-pc-box-offsets-root-cause.md
+++ b/.foundry/research/research-273-393-gen3-pc-box-offsets-root-cause.md
@@ -30,9 +30,9 @@ Additionally, investigate why the previous research task (`research-327-385-gen3
 Task `task-273-327-living-dex-pc-mapping-impl` requires implementing backend data mapping to extract PC Box and Slot locations for owned Pokémon in Generation 3. It permanently failed because of missing information regarding Gen 3 save parsing (specifically PC Box offsets). The previous research node was spawned incorrectly or with inadequate context, leading to a cascading failure. We must late-bind this research node to gather the required context before re-attempting implementation.
 
 ## Acceptance Criteria
-- [ ] Investigate the root cause of the previous failure related to Gen 3 PC Box extraction and missing offsets.
-- [ ] Research and document the exact memory structure of PC Boxes in Gen 3 saves (Ruby, Sapphire, Emerald, FireRed, LeafGreen).
-- [ ] Determine the exact base offset for PC Box data relative to the resolved `section` offsets.
-- [ ] Determine the exact offset for the box configurations (names, wallpapers).
-- [ ] Detail the structure and offsets of the Pokémon stored within the boxes.
-- [ ] Document these findings in `.foundry/docs/knowledge_base/engine/save_parsing/`.
+- [x] Investigate the root cause of the previous failure related to Gen 3 PC Box extraction and missing offsets.
+- [x] Research and document the exact memory structure of PC Boxes in Gen 3 saves (Ruby, Sapphire, Emerald, FireRed, LeafGreen).
+- [x] Determine the exact base offset for PC Box data relative to the resolved `section` offsets.
+- [x] Determine the exact offset for the box configurations (names, wallpapers).
+- [x] Detail the structure and offsets of the Pokémon stored within the boxes.
+- [x] Document these findings in `.foundry/docs/knowledge_base/engine/save_parsing/`.


### PR DESCRIPTION
This PR resolves the `research-273-393-gen3-pc-box-offsets-root-cause` node. 

The previous task `task-273-327-living-dex-pc-mapping-impl` failed due to missing PC Box memory offset context, which cascaded and cancelled the original research task. This late-bound research node was spawned to break the loop and gather the missing information. 

The memory offsets for the Generation 3 PC Box structure (including the layout across logical sections 5-13, the box start offsets, name/wallpaper offsets, and the specific 80-byte Pokémon data structure used within the PC) were successfully researched from Bulbapedia and documented in `.foundry/docs/knowledge_base/engine/save_parsing/gen3_pc_box_offsets.md`.

Additionally, the failure's root cause was documented in the researcher's journal (`.foundry/journals/researcher/6535908287339075091.md`). 

The node's acceptance criteria in the markdown body have been checked off. All tests pass.

---
*PR created automatically by Jules for task [6535908287339075091](https://jules.google.com/task/6535908287339075091) started by @szubster*