### PR TITLE
chore(qa): Complete QA for bash timeout wrapper E2E tests

### DIFF
--- a/.foundry/journals/qa/4628964964798248082.md
+++ b/.foundry/journals/qa/4628964964798248082.md
@@ -1,0 +1,19 @@
+# QA Session Journal
+
+Session ID: 4628964964798248082
+Date: 2026-08-03
+
+## Context
+Assigned to `task-355-394-bash-timeout-e2e-qa` to verify the implementation of E2E tests for the Bash timeout wrapper.
+The implementation was completed in `task-355-393-bash-timeout-e2e-impl`.
+
+## Actions Taken
+1. Reviewed the PR for `task-355-393-bash-timeout-e2e-impl`. Found that it added tests to `tests/e2e/bash_timeout.spec.ts`.
+2. Encountered an issue where playwright tests were failing because browsers were not installed. Addressed this by running `pnpm exec playwright install`.
+3. Ran the E2E tests successfully using `xvfb-run pnpm test:e2e tests/e2e/bash_timeout.spec.ts`.
+4. Verified that the new E2E tests for the Bash timeout wrapper passed reliably.
+5. Checked off the acceptance criteria in the markdown body of `task-355-394-bash-timeout-e2e-qa`.
+6. Verified no regressions were introduced.
+
+## Learnings & Patterns
+- When running Playwright E2E tests for the first time in a new environment, make sure to install browsers via `pnpm exec playwright install` if they are missing. This is a common requirement in CI or fresh development environments.

--- a/.foundry/tasks/task-355-394-bash-timeout-e2e-qa.md
+++ b/.foundry/tasks/task-355-394-bash-timeout-e2e-qa.md
@@ -26,5 +26,5 @@ notes: ''
 Verify the implementation of the E2E tests for the Bash timeout wrapper.
 
 ## Acceptance Criteria
-- [ ] Review PR for `task-355-393-bash-timeout-e2e-impl`.
-- [ ] Run the test suite and verify new E2E tests pass reliably.
+- [x] Review PR for `task-355-393-bash-timeout-e2e-impl`.
+- [x] Run the test suite and verify new E2E tests pass reliably.


### PR DESCRIPTION
- Verified the implementation of E2E tests for the bash timeout wrapper (`task-355-393-bash-timeout-e2e-impl`).
- Checked off acceptance criteria in `task-355-394-bash-timeout-e2e-qa.md`.
- Ran E2E test suite locally using xvfb and Playwright. Verified no regressions were introduced.
- Logged findings to QA journal `4628964964798248082.md`.

---
*PR created automatically by Jules for task [4628964964798248082](https://jules.google.com/task/4628964964798248082) started by @szubster*