### PR TITLE
Update story 136-334 acceptance criteria

### DIFF
--- a/.foundry/journals/tech_lead/6629083021265480732.md
+++ b/.foundry/journals/tech_lead/6629083021265480732.md
@@ -1,0 +1,12 @@
+# Tech Lead Session Journal
+
+## Session ID
+6629083021265480732
+
+## Action Taken
+1. Recognized that tasks `task-334-386-cross-gen-sorting-adapters-impl` and `task-334-387-cross-gen-sorting-adapters-qa` were successfully completed.
+2. Verified their completion by checking their frontmatter.
+3. Updated `.foundry/stories/story-136-334-sorting-cross-gen-considerations-retry.md` to check off the acceptance criteria for the completed child tasks without modifying the YAML frontmatter.
+
+## Reflections & Future Application
+- When checking off completed tasks in a STORY markdown, it is important to remember not to transition the node status directly in the YAML frontmatter and to submit an empty PR to let the Orchestrator manage the transition.

--- a/.foundry/stories/story-136-334-sorting-cross-gen-considerations-retry.md
+++ b/.foundry/stories/story-136-334-sorting-cross-gen-considerations-retry.md
@@ -36,5 +36,5 @@ While `PokeData` provides a unified interface, certain properties (e.g., regiona
 - [x] Ensure `TypeSorter` correctly handles Gen 1 type differences (e.g., Magnemite missing Steel type) if data mapping does not already normalize this.
 - [x] Implement robust handling for null/undefined properties that may be missing in older generations.
 - [x] Break down story into tasks for technical blueprinting, implementation, and cross-generation test suites.
-- [ ] task-334-386-cross-gen-sorting-adapters-impl
-- [ ] task-334-387-cross-gen-sorting-adapters-qa
+- [x] task-334-386-cross-gen-sorting-adapters-impl
+- [x] task-334-387-cross-gen-sorting-adapters-qa


### PR DESCRIPTION
Checks off the acceptance criteria for tasks 386 and 387 in story 136-334 since they were verified as completed. Leaves frontmatter unmodified per YAML Modification constraints. Adheres to Empty PR policy.

---
*PR created automatically by Jules for task [6629083021265480732](https://jules.google.com/task/6629083021265480732) started by @szubster*