### PR TITLE
fix(orchestrator): spawn late-binding e2e story for zod schema epic

### DIFF
--- a/.foundry/epics/epic-117-334-define-zod-schema.md
+++ b/.foundry/epics/epic-117-334-define-zod-schema.md
@@ -26,3 +26,4 @@ This epic focuses on creating a strict Zod schema for parsing and validating `.f
 - [x] Break down into Stories
 - [x] story-334-336-zod-schema-definition
 - [x] story-334-337-zod-schema-integration
+- [ ] story-334-356-zod-schema-e2e

--- a/.foundry/journals/story_owner/2026-08-03-22-07-17.md
+++ b/.foundry/journals/story_owner/2026-08-03-22-07-17.md
@@ -1,0 +1,5 @@
+# Session 2026-08-03-22-07-17
+
+Epic `epic-117-334-define-zod-schema` could not be marked as COMPLETED because none of its existing children (`story-334-336-zod-schema-definition` and `story-334-337-zod-schema-integration`) had an `e2e` or `integration` tag, violating the orchestrator's macro node E2E safeguard (`.github/scripts/foundry-orchestrator.ts`).
+
+To unblock the Epic, I created a new late-binding story `story-334-356-zod-schema-e2e` with the required `e2e` tag and appended it as an unchecked task (`- [ ]`) to the epic's markdown body. As the Story Owner, I submitted an empty PR without checking off the overarching epic acceptance criteria, allowing the orchestrator to correctly demote the epic to PENDING while it waits for the new e2e story to be completed.

--- a/.foundry/stories/story-334-356-zod-schema-e2e.md
+++ b/.foundry/stories/story-334-356-zod-schema-e2e.md
@@ -1,0 +1,25 @@
+---
+id: story-334-356-zod-schema-e2e
+type: STORY
+title: Zod Schema Orchestrator E2E
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-03'
+updated_at: '2026-08-03'
+depends_on:
+  - story-334-337-zod-schema-integration
+jules_session_id: null
+parent: epic-117-334-define-zod-schema
+tags:
+  - e2e
+  - orchestrator
+  - schema
+rejection_reason: ''
+---
+
+# Zod Schema Orchestrator E2E
+
+Implement End-to-End verification of the Zod schema validation within the Foundry Orchestrator environment.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
This PR addresses the failure of `epic-117-334-define-zod-schema` to complete due to the orchestrator's E2E safeguard. 

A new late-binding story, `story-334-356-zod-schema-e2e`, has been generated with the required `e2e` tag and appended to the epic's acceptance criteria as an unchecked task (`- [ ]`). In accordance with the Late-Binding Orchestrator Demotion Compliance Rule, the overarching acceptance criteria for the epic remain unchecked, allowing the orchestrator to correctly demote the epic to PENDING while it waits for the new e2e story.

The epic's YAML frontmatter has deliberately not been modified.

---
*PR created automatically by Jules for task [986049868608614968](https://jules.google.com/task/986049868608614968) started by @szubster*