### PR TITLE
chore: empty PR to demote epic-106-136

### DIFF
--- a/.foundry/journals/story_owner/2026-08-04-00-07-14.md
+++ b/.foundry/journals/story_owner/2026-08-04-00-07-14.md
@@ -1,0 +1,3 @@
+# Story Owner Session - 2026-08-04
+
+Encountered Epic `epic-106-136-pc-box-sorting-algorithms` in READY/ACTIVE state, which already contains pending child tasks from a previous iteration. Applied the Late-Binding Orchestrator Demotion Compliance Rule by submitting an empty PR without checking off acceptance criteria. This allows the orchestrator to correctly demote the parent node to PENDING while waiting for its child nodes to complete, maintaining DAG integrity without modifying frontmatter or overarching criteria.


### PR DESCRIPTION
Submitted empty PR to correctly demote epic-106-136 to PENDING state while waiting for its child research and story tasks to complete. This ensures the workflow DAG integrity is maintained per the late-binding orchestrator demotion rule.

---
*PR created automatically by Jules for task [418665841365915867](https://jules.google.com/task/418665841365915867) started by @szubster*