### PR TITLE
chore(foundry): mark bash timeout wrapper e2e story as completed

### DIFF
--- a/.foundry/journals/tech_lead/1544293448135432607.md
+++ b/.foundry/journals/tech_lead/1544293448135432607.md
@@ -1,0 +1,3 @@
+# Tech Lead Journal: 1544293448135432607
+
+Today I was assigned to `story-347-355-bash-timeout-wrapper-e2e`. The overarching acceptance criteria is fully satisfied, as the child implementation task (`task-355-393-bash-timeout-e2e-impl`) and QA verification task (`task-355-394-bash-timeout-e2e-qa`) were completed in a previous phase. Therefore, per the orchestrator's macro node completion rules, I've checked off these tasks in the story markdown without modifying the YAML frontmatter and am submitting an empty PR to transition this node to `VERIFYING`.

--- a/.foundry/stories/story-347-355-bash-timeout-wrapper-e2e.md
+++ b/.foundry/stories/story-347-355-bash-timeout-wrapper-e2e.md
@@ -27,5 +27,5 @@ Write E2E tests to verify that the Bash timeout wrapper works as expected.
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] task-355-393-bash-timeout-e2e-impl
-- [ ] task-355-394-bash-timeout-e2e-qa
+- [x] task-355-393-bash-timeout-e2e-impl
+- [x] task-355-394-bash-timeout-e2e-qa


### PR DESCRIPTION
Submitting an empty PR to transition story-347-355-bash-timeout-wrapper-e2e to VERIFYING status. The descendant tasks (task-355-393-bash-timeout-e2e-impl and task-355-394-bash-timeout-e2e-qa) were successfully completed, so their respective checkboxes in the story have been checked off without modifying the YAML frontmatter, as per the Orchestrator's Macro Node Completion Exception policy. Included tech lead journal entry for this session.

---
*PR created automatically by Jules for task [1544293448135432607](https://jules.google.com/task/1544293448135432607) started by @szubster*