### PR TITLE
Handle IndexedDB schema permanent failure loop

### DIFF
--- a/.foundry/epics/epic-099-397-indexeddb-schema-design-retry.md
+++ b/.foundry/epics/epic-099-397-indexeddb-schema-design-retry.md
@@ -1,0 +1,37 @@
+---
+id: epic-099-397-indexeddb-schema-design-retry
+type: EPIC
+title: IndexedDB Storage Schema Design (Retry)
+status: ACTIVE
+owner_persona: story_owner
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on:
+  - research-099-396-investigate-indexeddb-schema-failure
+jules_session_id: null
+pr_number: null
+parent: prd-066-099-save-state-history-storage
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: IndexedDB Storage Schema Design (Retry)
+
+## Overview
+Define the storage schema for the save state history, including DB name, object stores, and indexes. This forms the foundation for storing sequential `.sav` file uploads for a given playthrough. This is a retry of the previously failed epic-099-130-indexeddb-schema-design.
+
+## Acceptance Criteria
+- [ ] Incorporate learnings and architectural shifts from `research-099-396-investigate-indexeddb-schema-failure`.
+- [ ] Define the database name and version.
+- [ ] Define object stores for storing save files, metadata, and indexes for efficient retrieval.
+- [ ] Document the schema.
+- [ ] Create a final STORY dedicated exclusively to Integration and E2E Verification.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/epics/epic-099-398-save-state-read-write-api-retry.md
+++ b/.foundry/epics/epic-099-398-save-state-read-write-api-retry.md
@@ -1,0 +1,33 @@
+---
+id: epic-099-398-save-state-read-write-api-retry
+type: EPIC
+title: Save State Read/Write API (Retry)
+status: ACTIVE
+owner_persona: story_owner
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on:
+  - epic-099-397-indexeddb-schema-design-retry
+jules_session_id: null
+pr_number: null
+parent: prd-066-099-save-state-history-storage
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Save State Read/Write API (Retry)
+
+## Overview
+Implement the core read and write APIs to store new save states and retrieve them, ordered by time. This is a retry of the cancelled epic-099-131-save-state-read-write-api.
+
+## Acceptance Criteria
+- [ ] Implement write API to store a new save state file along with its metadata (timestamp, playthrough ID).
+- [ ] Implement read API to retrieve the most recent save state for a playthrough.
+- [ ] Implement read API to retrieve the *previous* state relative to a given state for diffing purposes.
+- [ ] Create a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-099-399-save-state-lru-eviction-and-limits-retry.md
+++ b/.foundry/epics/epic-099-399-save-state-lru-eviction-and-limits-retry.md
@@ -1,0 +1,33 @@
+---
+id: epic-099-399-save-state-lru-eviction-and-limits-retry
+type: EPIC
+title: Save State Storage Limits and LRU Eviction (Retry)
+status: ACTIVE
+owner_persona: story_owner
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on:
+  - epic-099-398-save-state-read-write-api-retry
+jules_session_id: null
+pr_number: null
+parent: prd-066-099-save-state-history-storage
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Save State Storage Limits and LRU Eviction (Retry)
+
+## Overview
+Implement mechanisms to handle storage limits gracefully, including maximum number of states per playthrough and LRU eviction if necessary. This is a retry of the cancelled epic-099-132-save-state-lru-eviction-and-limits.
+
+## Acceptance Criteria
+- [ ] Define and implement the maximum number of save states allowed per playthrough.
+- [ ] Implement LRU (Least Recently Used) eviction logic to remove older states when limits are reached.
+- [ ] Ensure the storage engine handles quota exceeded errors gracefully.
+- [ ] Create a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/journals/epic_planner/2026-08-04-00-27-08.md
+++ b/.foundry/journals/epic_planner/2026-08-04-00-27-08.md
@@ -1,0 +1,16 @@
+# Epic Planner Session Journal
+
+## Session ID
+6110336391984079559 (or 2026-08-04-00-27-08)
+
+## Target Node
+prd-066-099-save-state-history-storage
+
+## Action Taken
+Handled the "Impossible Loop" where a child node (`epic-099-130-indexeddb-schema-design`) reached Max Rejection Count and failed permanently. This also caused its downstream dependencies (`epic-099-131`, `epic-099-132`) to be cancelled.
+
+## Key Learnings
+1. **The Impossible Loop Policy**: When a child node permanently fails, we must explicitly spawn a `RESEARCH` node to investigate the root cause *before* spawning new retry epics.
+2. **Dependency Chaining**: The newly spawned retry epics must explicitly depend on the new `RESEARCH` node to ensure the root cause is resolved before implementation resumes.
+3. **Markdown Checkboxes**: The permanently failed/cancelled child nodes *must* be checked off (`- [x]`) in the parent PRD's markdown body. Leaving them unchecked will cause ADR 007 to permanently block the parent PRD from transitioning to COMPLETED.
+4. **E2E Verification Enforcement**: All newly spawned EPICs must now explicitly include a final STORY dedicated exclusively to Integration and E2E Verification, per updated Core Directives.

--- a/.foundry/prds/prd-066-099-save-state-history-storage.md
+++ b/.foundry/prds/prd-066-099-save-state-history-storage.md
@@ -36,6 +36,10 @@ To support save state version history, we need a robust local storage solution. 
 - [ ] Define storage schema (DB name, object stores, indexes).
 - [ ] Implement write API to store a new save state.
 - [ ] Implement read API to retrieve states (by playthrough, ordered by time).
-- [ ] epic-099-130-indexeddb-schema-design
-- [ ] epic-099-131-save-state-read-write-api
-- [ ] epic-099-132-save-state-lru-eviction-and-limits
+- [x] epic-099-130-indexeddb-schema-design
+- [x] epic-099-131-save-state-read-write-api
+- [x] epic-099-132-save-state-lru-eviction-and-limits
+- [ ] research-099-396-investigate-indexeddb-schema-failure
+- [ ] epic-099-397-indexeddb-schema-design-retry
+- [ ] epic-099-398-save-state-read-write-api-retry
+- [ ] epic-099-399-save-state-lru-eviction-and-limits-retry

--- a/.foundry/research/research-099-396-investigate-indexeddb-schema-failure.md
+++ b/.foundry/research/research-099-396-investigate-indexeddb-schema-failure.md
@@ -1,0 +1,37 @@
+---
+id: research-099-396-investigate-indexeddb-schema-failure
+type: RESEARCH
+title: Investigate IndexedDB Schema Design Failure
+status: ACTIVE
+owner_persona: researcher
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-066-099-save-state-history-storage
+tags:
+  - storage
+  - indexeddb
+  - history
+  - debug
+research_references:
+  - epic-099-130-indexeddb-schema-design
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Investigate IndexedDB Schema Design Failure
+
+## Objective
+Investigate the root cause behind the permanent failure (Max Rejection Count reached) of `epic-099-130-indexeddb-schema-design`.
+
+## Context
+The epic `epic-099-130-indexeddb-schema-design` failed permanently, causing its downstream dependencies (`epic-099-131-save-state-read-write-api`, `epic-099-132-save-state-lru-eviction-and-limits`) to be cancelled. According to the "Handling Permanent Child Failures (The Impossible Loop)" policy, we must spawn a RESEARCH node to investigate the root cause before replacing the failed children.
+
+## Tasks
+- [ ] Read the rejection reasons for `epic-099-130-indexeddb-schema-design` and its child stories to identify why it failed three times.
+- [ ] Check `.foundry/journals/auditor/` and `.foundry/journals/qa/` for specific error logs or feedback regarding this feature.
+- [ ] Propose a concrete solution or architectural shift to avoid repeating the failure in the retry epics.
+- [ ] Document findings in this file.


### PR DESCRIPTION
Handled the permanent failure of `epic-099-130-indexeddb-schema-design` by following the Impossible Loop policy.
Spawned `research-099-396` to investigate the root cause.
Spawned replacement retry epics `epic-099-397`, `epic-099-398`, and `epic-099-399` that explicitly depend on the new research node and include E2E verification requirements.
Checked off the cancelled epics in `prd-066-099` and appended the new nodes.

---
*PR created automatically by Jules for task [6110336391984079559](https://jules.google.com/task/6110336391984079559) started by @szubster*