### PR TITLE
🗿 Sculptor: Extract Gen 1/2 Checksum magic numbers

### DIFF
--- a/.jules/sculptor/2026-08-04-01-46-33.md
+++ b/.jules/sculptor/2026-08-04-01-46-33.md
@@ -1,0 +1,6 @@
+# Sculptor Journal - Gen 1/2 Checksum Refactor
+
+## Critical Learnings
+* **Hexadecimal Context in Parsers**: Adhering to ADR 028 by extracting checksum-related bounds and offsets (e.g., `0x2598`, `0x3522`, `0x3523` for Gen 1, and `0x2009`, `0x2d0c`, `0x2d0d` for Gen 2) to clearly named constants (`GEN1_CHECKSUM_DATA_START`, `GEN1_CHECKSUM_OFFSET`, etc.) drastically improves semantic readability for AI agents parsing `DataView` operations.
+* **Test File Tautology**: When replicating these constants in the `.test.ts` file, you technically create tautological tests (tests that pass because they use the exact same constants). While not ideal for true boundary testing, it significantly clarifies intent in an AI-readability refactoring context.
+* **Scripting Tools in ESM Repo**: This repository sets `"type": "module"` in `package.json`. When writing ad-hoc node scripts to do regex-based search-and-replace, the file *must* end in `.cjs` if it uses `require()`, otherwise it will fail with a module scope error.

--- a/src/engine/saveParser/index.test.ts
+++ b/src/engine/saveParser/index.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { parseSaveFile } from './index';
+
+const GEN1_CHECKSUM_DATA_START = 0x2598;
+const GEN2_CHECKSUM_DATA_START = 0x2009;
+const GEN2_CHECKSUM_DATA_END = 0x2d0c;
+const GEN2_CHECKSUM_OFFSET = 0x2d0d;
+
 import * as gen3Module from './parsers/gen3';
 
 vi.mock('./parsers/gen3', async (importOriginal) => {
@@ -122,11 +128,11 @@ describe('saveParser - Error Handling and Fallbacks', () => {
 
     // Gen 2 checksum
     let gen2Sum = 0;
-    for (let i = 0x2009; i <= 0x2d0c; i++) {
+    for (let i = GEN2_CHECKSUM_DATA_START; i <= GEN2_CHECKSUM_DATA_END; i++) {
       gen2Sum += buffer[i] as number;
     }
     const view = new DataView(buffer.buffer);
-    view.setUint16(0x2d0d, gen2Sum, true);
+    view.setUint16(GEN2_CHECKSUM_OFFSET, gen2Sum, true);
 
     const data = parseSaveFile(buffer.buffer);
     expect(data.generation).toBe(2);
@@ -140,11 +146,11 @@ describe('saveParser - Error Handling and Fallbacks', () => {
 
     // Gen 2 checksum
     let gen2Sum = 0;
-    for (let i = 0x2009; i <= 0x2d0c; i++) {
+    for (let i = GEN2_CHECKSUM_DATA_START; i <= GEN2_CHECKSUM_DATA_END; i++) {
       gen2Sum += buffer[i] as number;
     }
     const view = new DataView(buffer.buffer);
-    view.setUint16(0x2d0d, gen2Sum, true);
+    view.setUint16(GEN2_CHECKSUM_OFFSET, gen2Sum, true);
 
     const data = parseSaveFile(buffer.buffer);
     expect(data.generation).toBe(2);
@@ -161,11 +167,11 @@ describe('saveParser - Error Handling and Fallbacks', () => {
 
     // Gen 2 checksum
     let gen2Sum = 0;
-    for (let i = 0x2009; i <= 0x2d0c; i++) {
+    for (let i = GEN2_CHECKSUM_DATA_START; i <= GEN2_CHECKSUM_DATA_END; i++) {
       gen2Sum += buffer[i] as number;
     }
     const view = new DataView(buffer.buffer);
-    view.setUint16(0x2d0d, gen2Sum, true);
+    view.setUint16(GEN2_CHECKSUM_OFFSET, gen2Sum, true);
 
     const data = parseSaveFile(buffer.buffer);
     expect(data.generation).toBe(2);
@@ -189,7 +195,7 @@ describe('saveParser - Error Handling and Fallbacks', () => {
         this.byteLength = byteLength ?? buffer.byteLength;
       }
       getUint8(byteOffset: number) {
-        if (byteOffset === 0x2598) {
+        if (byteOffset === GEN1_CHECKSUM_DATA_START) {
           throw new RangeError('Out of bounds');
         }
         return new originalDataView(this.buffer, this.byteOffset, this.byteLength).getUint8(byteOffset);

--- a/src/engine/saveParser/index.ts
+++ b/src/engine/saveParser/index.ts
@@ -3,6 +3,14 @@ import { isGen1Save, parseGen1 } from './parsers/gen1';
 import { isGen2Save, parseGen2 } from './parsers/gen2';
 import { isGen3Save, parseGen3 } from './parsers/gen3';
 
+const GEN1_CHECKSUM_DATA_START = 0x2598;
+const GEN1_CHECKSUM_DATA_END = 0x3522;
+const GEN1_CHECKSUM_OFFSET = 0x3523;
+
+const GEN2_CHECKSUM_DATA_START = 0x2009;
+const GEN2_CHECKSUM_DATA_END = 0x2d0c;
+const GEN2_CHECKSUM_OFFSET = 0x2d0d;
+
 export type { GameVersion, PokemonInstance, SaveData };
 
 /**
@@ -28,19 +36,19 @@ export function parseSaveFile(buffer: ArrayBufferLike, forcedVersion?: GameVersi
     // subtracting each byte's value from an initial value of 255 (0xFF).
     // The result is stored at 0x3523.
     let gen1Sum = 255;
-    for (let i = 0x2598; i <= 0x3522; i++) {
+    for (let i = GEN1_CHECKSUM_DATA_START; i <= GEN1_CHECKSUM_DATA_END; i++) {
       gen1Sum -= view.getUint8(i);
     }
-    const isGen1ChecksumValid = (gen1Sum & 0xff) === view.getUint8(0x3523);
+    const isGen1ChecksumValid = (gen1Sum & 0xff) === view.getUint8(GEN1_CHECKSUM_OFFSET);
 
     // Gen 2 Checksum
     // Gen 2 calculates its checksum by summing up the bytes in the main save data block (0x2009 to 0x2D0C).
     // The expected total is stored as a 16-bit little-endian integer at 0x2D0D.
     let gen2Sum = 0;
-    for (let i = 0x2009; i <= 0x2d0c; i++) {
+    for (let i = GEN2_CHECKSUM_DATA_START; i <= GEN2_CHECKSUM_DATA_END; i++) {
       gen2Sum += view.getUint8(i);
     }
-    const gen2Checksum = view.getUint16(0x2d0d, true);
+    const gen2Checksum = view.getUint16(GEN2_CHECKSUM_OFFSET, true);
     const isGen2ChecksumValid = (gen2Sum & 0xffff) === gen2Checksum;
 
     if (isGen1ChecksumValid && isGen1Save(view)) {


### PR DESCRIPTION
🎯 What
Extracted hardcoded hexadecimal magic numbers used for Gen 1 and Gen 2 checksum validation in `src/engine/saveParser/index.ts` and `src/engine/saveParser/index.test.ts` into explicitly named top-level constants (e.g., `GEN1_CHECKSUM_DATA_START`, `GEN2_CHECKSUM_OFFSET`).

💡 Why (AI Readability Impact)
Inline hex values deeply embedded in `DataView` parsing logic are difficult for AI agents to contextually map to save file structures. By adhering to ADR 028 and creating explicitly named constants, the semantic intent of the binary read operations is immediately clear. This makes the bounds and targets of the checksum logic highly predictable.

✅ Verification
- `pnpm lint` passed cleanly.
- `pnpm test src/engine/saveParser/index.test.ts` passed cleanly.
- `xvfb-run pnpm test:e2e` passed without regressions.

✨ Result
The checksum validation blocks now clearly express *what* they are summing and *where* they are reading the expected value from, rather than just iterating over opaque numbers.

---
*PR created automatically by Jules for task [10095628774625885642](https://jules.google.com/task/10095628774625885642) started by @szubster*