### PR TITLE
🧱 Mason: TacticalFileInput extraction

### DIFF
--- a/.jules/mason/2026-08-04-02-27-56.md
+++ b/.jules/mason/2026-08-04-02-27-56.md
@@ -1,0 +1,9 @@
+# Mason Refactoring Session
+
+## Refactoring Actions
+- Extracted duplicated `<input type="file" className="sr-only" tabIndex={-1} accept=".sav" />` pattern from `OfflineControls.tsx` and `SystemControls.tsx` into a reusable `TacticalFileInput` component.
+- Leveraged `React.forwardRef` and `React.InputHTMLAttributes` to provide full standard input capabilities (like `onChange`, `id`, `aria-label`) while keeping defaults clean and DRY.
+
+## Learnings
+- Repeated HTML elements that only differ by `id`, `aria-label`, and event handlers are prime targets for extraction, especially when they share functional constraints like being hidden (`sr-only`) and having specific tab indexing and accept attributes.
+- Replacing standard HTML elements with typed `Tactical*` components maintains codebase consistency with the overarching ADR 008 styling/tactical theme, even for invisible elements like file inputs.

--- a/src/components/TacticalFileInput.tsx
+++ b/src/components/TacticalFileInput.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { cn } from '../utils/cn';
+
+interface TacticalFileInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'className'> {
+  className?: string;
+}
+
+export const TacticalFileInput = React.forwardRef<HTMLInputElement, TacticalFileInputProps>(
+  ({ className = 'sr-only', accept = '.sav', tabIndex = -1, ...props }, ref) => {
+    return <input ref={ref} type="file" accept={accept} tabIndex={tabIndex} className={cn(className)} {...props} />;
+  },
+);
+
+TacticalFileInput.displayName = 'TacticalFileInput';

--- a/src/components/header/OfflineControls.tsx
+++ b/src/components/header/OfflineControls.tsx
@@ -1,6 +1,7 @@
 import { Activity, Upload } from 'lucide-react';
 import type React from 'react';
 import { CornerCrosshairs } from '../CornerCrosshairs';
+import { TacticalFileInput } from '../TacticalFileInput';
 
 interface OfflineControlsProps {
   requestSync: () => void;
@@ -19,15 +20,7 @@ export function OfflineControls({ requestSync, handleFileUpload }: OfflineContro
         <CornerCrosshairs className="h-2 w-2 border-current" />
         <Upload size={20} />[ UPLOAD.SYS ]
       </button>
-      <input
-        id="init-save-input"
-        type="file"
-        tabIndex={-1}
-        aria-label="Initialize Pokedex"
-        accept=".sav"
-        className="sr-only"
-        onChange={handleFileUpload}
-      />
+      <TacticalFileInput id="init-save-input" aria-label="Initialize Pokedex" onChange={handleFileUpload} />
 
       {typeof window !== 'undefined' && 'showOpenFilePicker' in window && (
         <button

--- a/src/components/header/SystemControls.tsx
+++ b/src/components/header/SystemControls.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { cn } from '../../utils/cn';
 import { CornerCrosshairs } from '../CornerCrosshairs';
 import { TacticalButton } from '../TacticalButton';
+import { TacticalFileInput } from '../TacticalFileInput';
 import { VerticalDivider } from '../VerticalDivider';
 
 interface SystemControlsProps {
@@ -131,15 +132,7 @@ export function SystemControls({
       >
         <RefreshCw size={16} />
       </TacticalButton>
-      <input
-        id="import-save-input"
-        type="file"
-        tabIndex={-1}
-        aria-label="Import New Save"
-        accept=".sav"
-        className="sr-only"
-        onChange={handleFileUpload}
-      />
+      <TacticalFileInput id="import-save-input" aria-label="Import New Save" onChange={handleFileUpload} />
     </div>
   );
 }


### PR DESCRIPTION
🎯 What
Extracted a duplicated hidden `<input type="file" />` element into a reusable `TacticalFileInput` component.

💡 Why
`OfflineControls.tsx` and `SystemControls.tsx` both contained identical hidden file inputs for importing `.sav` files, sharing the same `accept`, `tabIndex`, and `className` attributes. Centralizing this into a single component reduces code duplication and adheres to the project's pattern of using `Tactical*` prefixed components for consistent UI elements.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e` successfully after ensuring Playwright binaries were installed. The component accurately forwards refs and correctly merges standard HTML input attributes.

✨ Result
Improved modularity and DRYness for save file import inputs across header control components.

---
*PR created automatically by Jules for task [14577091403916884535](https://jules.google.com/task/14577091403916884535) started by @szubster*