### PR TITLE
story-owner: Add circular dependency detection e2e story

### DIFF
--- a/.foundry/epics/epic-334-338-circular-dependency-detection.md
+++ b/.foundry/epics/epic-334-338-circular-dependency-detection.md
@@ -30,3 +30,4 @@ Implement robust circular dependency detection during the MAP or RESOLVE phases 
 
 ## Acceptance Criteria
 - [ ] story-338-336-implement-orchestrator-cycle-detection
+- [ ] story-338-356-circular-dependency-detection-e2e

--- a/.foundry/journals/story_owner/4294930077557137229.md
+++ b/.foundry/journals/story_owner/4294930077557137229.md
@@ -1,0 +1,3 @@
+# Session 4294930077557137229
+
+Added an e2e story for `epic-334-338-circular-dependency-detection` to satisfy the Orchestrator Safeguard rule, which requires every EPIC to have at least one child STORY with 'e2e' or 'integration' in its tags. If missing, the orchestrator will automatically fail the EPIC.

--- a/.foundry/stories/story-338-356-circular-dependency-detection-e2e.md
+++ b/.foundry/stories/story-338-356-circular-dependency-detection-e2e.md
@@ -1,0 +1,31 @@
+---
+id: story-338-356-circular-dependency-detection-e2e
+type: STORY
+title: Circular Dependency Detection E2E
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on:
+  - story-338-336-implement-orchestrator-cycle-detection
+jules_session_id: null
+pr_number: null
+parent: epic-334-338-circular-dependency-detection
+tags:
+  - e2e
+  - integration
+  - foundry
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Circular Dependency Detection E2E
+
+## Overview
+Write E2E tests to verify the circular dependency detection feature in the DAG orchestrator. This satisfies the Orchestrator Safeguard requirement for epics to have integration or e2e tests.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
Added an e2e story for `epic-334-338-circular-dependency-detection` to satisfy the Orchestrator Safeguard rule, which requires every EPIC to have at least one child STORY with 'e2e' or 'integration' in its tags.

---
*PR created automatically by Jules for task [4294930077557137229](https://jules.google.com/task/4294930077557137229) started by @szubster*