### PR TITLE
feat: add e2e story for cloudflare r2 save sync

### DIFF
--- a/.foundry/epics/epic-030-039-cloudflare-r2-save-sync.md
+++ b/.foundry/epics/epic-030-039-cloudflare-r2-save-sync.md
@@ -43,3 +43,4 @@ Following the establishment of a secure authentication layer, the application ne
 - [x] story-039-264-r2-push-sync-logic
 - [x] story-039-265-r2-offline-conflict-resolution
 - [x] story-039-266-r2-graceful-degradation
+- [ ] story-039-356-r2-sync-e2e

--- a/.foundry/journals/story_owner/13681390101516268428.md
+++ b/.foundry/journals/story_owner/13681390101516268428.md
@@ -1,0 +1,3 @@
+# Journal Entry
+
+During the review of `epic-030-039-cloudflare-r2-save-sync`, all of its explicit descendant stories were completed or archived. Based on the Orchestrator safeguard policy which requires an EPIC to have at least one child STORY node with 'e2e' or 'integration' in its tags, I created a new story node `story-039-356-r2-sync-e2e` for the e2e requirement. The EPIC acceptance criteria has been updated, and an empty PR is NOT submitted, as the newly appended child node is now pending.

--- a/.foundry/stories/story-039-356-r2-sync-e2e.md
+++ b/.foundry/stories/story-039-356-r2-sync-e2e.md
@@ -1,0 +1,33 @@
+---
+id: story-039-356-r2-sync-e2e
+type: STORY
+title: Cloudflare R2 Offline-First Save Syncing E2E
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-030-039-cloudflare-r2-save-sync
+tags:
+  - backend
+  - sync
+  - r2
+  - e2e
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Cloudflare R2 Offline-First Save Syncing E2E
+
+## Context
+Based on Orchestrator safeguards, an EPIC must have at least one child STORY node with 'e2e' or 'integration' in its tags to ensure full end-to-end testing of the features. This story encompasses the end-to-end verification for Cloudflare R2 syncing functionality.
+
+## Requirements
+- Ensure proper end-to-end tests exist for R2 sync functionality.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks.


### PR DESCRIPTION
Added a new E2E story node to fulfill the Orchestrator safeguard policy. Appended the unchecked task to the EPIC's acceptance criteria, created the new story file, and logged the decision in the journal.

---
*PR created automatically by Jules for task [13681390101516268428](https://jules.google.com/task/13681390101516268428) started by @szubster*