### PR TITLE
📝 Story Owner: Update node epic-057-347-bash-timeout-wrapper-retry

### DIFF
--- a/.foundry/epics/epic-057-347-bash-timeout-wrapper-retry.md
+++ b/.foundry/epics/epic-057-347-bash-timeout-wrapper-retry.md
@@ -29,5 +29,5 @@ Implement a timeout wrapper for `run_in_bash_session` to interrupt commands that
 
 ## Acceptance Criteria
 - [x] Break down this epic into stories.
-- [ ] story-347-354-bash-timeout-wrapper-impl
-- [ ] story-347-355-bash-timeout-wrapper-e2e
+- [x] story-347-354-bash-timeout-wrapper-impl
+- [x] story-347-355-bash-timeout-wrapper-e2e

--- a/.foundry/journals/story_owner/YYYY-MM-DD-HH-MM-SS.md
+++ b/.foundry/journals/story_owner/YYYY-MM-DD-HH-MM-SS.md
@@ -1,0 +1,13 @@
+# Story Owner Journal Entry
+
+## Issue
+I was woken up because the Epic `epic-057-347-bash-timeout-wrapper-retry` had missing checkboxes in its markdown body for its child nodes, even though the underlying stories (`story-347-354-bash-timeout-wrapper-impl` and `story-347-355-bash-timeout-wrapper-e2e`) were already marked as `COMPLETED`. This prevented the node from properly transitioning to the `VERIFYING` state.
+
+## Action Taken
+I updated the markdown body of `epic-057-347-bash-timeout-wrapper-retry` by checking off the missing boxes for its generated child stories (`- [x] story-347-354-bash-timeout-wrapper-impl` and `- [x] story-347-355-bash-timeout-wrapper-e2e`) in the `## Acceptance Criteria` section. I successfully resolved the DAG orchestration block without modifying the node's YAML frontmatter.
+
+## Learnings & Takeaways
+This reinforces the critical rule from ADR 007 regarding the Parent-Linked DAG execution model:
+* **The Empty PR Checkbox Policy**: Even when all downstream work is physically finished by implementation personas, the parent generative node (like this Epic) cannot automatically close itself. A generative persona MUST wake up and check off the exact string references to its children in its markdown body to formally signal to the orchestrator that the dependency chain is complete.
+* **YAML Immutability for Completions**: The only valid way to progress a successful node to `VERIFYING` is by updating its markdown checkboxes and submitting an empty PR. Manually editing the `status` field to `VERIFYING` or `COMPLETED` is strictly prohibited.
+* This pattern of having a generative persona (Story Owner) wake up to resolve its own completed children via an empty PR is standard operating procedure for the Foundry graph.


### PR DESCRIPTION
Empty PR submitted by the Story Owner to advance the DAG status.

---
*PR created automatically by Jules for task [17113239401186395872](https://jules.google.com/task/17113239401186395872) started by @szubster*