### PR TITLE
Sync Acceptance Criteria for Orchestrator Strict Completion Epic

### DIFF
--- a/.foundry/epics/epic-045-070-orchestrator-strict-completion.md
+++ b/.foundry/epics/epic-045-070-orchestrator-strict-completion.md
@@ -36,9 +36,9 @@ Update the DAG Orchestrator to ensure strict hierarchical completion. A node mus
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] Implement hierarchical completion logic in `foundry-orchestrator.ts`.
-- [ ] Add unit tests verifying the behavior blocks transition when children are not completed.
-- [ ] Ensure tests cover both `parent` field links and markdown body references.
+- [x] Implement hierarchical completion logic in `foundry-orchestrator.ts`.
+- [x] Add unit tests verifying the behavior blocks transition when children are not completed.
+- [x] Ensure tests cover both `parent` field links and markdown body references.
 
 - [x] story-070-108-orchestrator-hierarchical-completion-logic
 - [x] story-070-109-orchestrator-hierarchical-completion-tests


### PR DESCRIPTION
Synced the status of the Epic's acceptance criteria to reflect the completed state of its child story nodes (story-070-108, story-070-109, story-070-276), ensuring proper progression towards completion.

---
*PR created automatically by Jules for task [11597320492369133577](https://jules.google.com/task/11597320492369133577) started by @szubster*