### PR TITLE
Epic Breakdown: Gen 3 Roamer Tracker v5

### DIFF
--- a/.foundry/epics/epic-044-397-gen3-roamer-core-extraction-v5.md
+++ b/.foundry/epics/epic-044-397-gen3-roamer-core-extraction-v5.md
@@ -1,0 +1,37 @@
+---
+id: epic-044-397-gen3-roamer-core-extraction-v5
+type: EPIC
+title: Gen 3 Roamer Core Extraction v5
+status: ACTIVE
+owner_persona: story_owner
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on:
+  - research-044-396-gen3-roamer-tracker-failure
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+research_references:
+  - research-071-138-gen3-roamer-offsets
+rejection_count: 0
+rejection_reason: ''
+notes: 'Replacement for epic-044-149'
+---
+
+# Gen 3 Roamer Core Extraction v5
+
+## Objective
+Extract the core data structure of the roaming legendary from Gen 3 save files, accounting for the new UI direction.
+
+## Description
+Parse the `Roamer` struct from the save file (SaveBlock1) to extract the IVs, Personality Value, Species, HP, Level, Status, and Active boolean. This must support Emerald, Ruby/Sapphire, and FireRed/LeafGreen offsets.
+
+## Acceptance Criteria
+- [ ] Implement robust `DataView` parsing for the Gen 3 `Roamer` struct across all Gen 3 game versions.
+- [ ] Extract and expose the `active` boolean to determine if the roamer is currently available in the game world.
+- [ ] Write unit tests verifying extraction against known good save fixtures for each game version.
+- [ ] Generate a final STORY dedicated exclusively to Integration and E2E Verification to ensure proper system-wide rendering.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-044-398-gen3-roamer-iv-glitch-v5.md
+++ b/.foundry/epics/epic-044-398-gen3-roamer-iv-glitch-v5.md
@@ -1,0 +1,38 @@
+---
+id: epic-044-398-gen3-roamer-iv-glitch-v5
+type: EPIC
+title: Gen 3 Roamer IV Glitch Detection v5
+status: ACTIVE
+owner_persona: story_owner
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on:
+  - epic-044-397-gen3-roamer-core-extraction-v5
+  - research-044-396-gen3-roamer-tracker-failure
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - iv-glitch
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: 'Replacement for epic-044-150'
+---
+
+# Gen 3 Roamer IV Glitch Detection v5
+
+## Objective
+Implement detection logic for the infamous "Roamer IV Glitch" affecting Gen 3 games.
+
+## Description
+Analyze the extracted IV bitfield from the `Roamer` struct. The glitch causes the top bits to be lost, resulting in very low maximum IVs for certain stats. The logic should determine if the parsed IVs match the signature of a glitched roamer and provide a boolean flag or warning message.
+
+## Acceptance Criteria
+- [ ] Implement a function to analyze the 32-bit IV field and detect the Roamer IV Glitch signature.
+- [ ] Return a clear boolean or enum state indicating if the glitch is present.
+- [ ] Write unit tests verifying the glitch detection logic with both glitched and non-glitched IV spreads.
+- [ ] Generate a final STORY dedicated exclusively to Integration and E2E Verification to ensure proper system-wide rendering.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/epics/epic-044-399-gen3-roamer-dashboard-ui-v7.md
+++ b/.foundry/epics/epic-044-399-gen3-roamer-dashboard-ui-v7.md
@@ -1,0 +1,39 @@
+---
+id: epic-044-399-gen3-roamer-dashboard-ui-v7
+type: EPIC
+title: Gen 3 Roamer Dashboard UI v7
+status: ACTIVE
+owner_persona: story_owner
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on:
+  - epic-044-398-gen3-roamer-iv-glitch-v5
+  - epic-044-397-gen3-roamer-core-extraction-v5
+  - research-044-396-gen3-roamer-tracker-failure
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: 'Replacement for epic-044-151'
+---
+
+# Gen 3 Roamer Dashboard UI v7
+
+## Objective
+Create a user interface to display the comprehensive breakdown of the roaming legendary's internal state (Note: Route Radar mapping is impossible per ADR 108-027, focusing solely on stat breakdown).
+
+## Description
+Develop a dashboard view that presents the exact state of the roaming Pokémon, utilizing the parsed data. It should clearly display the Pokémon's Nature, individual IVs, current HP, status condition, and provide a prominent warning if the IV Glitch has corrupted its stats. This fulfills the PRD by providing an exact breakdown of internal state; location extraction via Route Radar has been proven impossible (ADR 108-027).
+
+## Acceptance Criteria
+- [ ] Build a UI component to display the roamer's Nature, IVs, HP, and Status.
+- [ ] Implement a visual warning indicator for the IV Glitch.
+- [ ] Ensure the UI adheres to the alternative design determined by the research phase.
+- [ ] Generate a final STORY dedicated exclusively to Integration and E2E Verification to ensure proper system-wide rendering.
+- [ ] Story Owner: Break down this Epic into executable Stories.

--- a/.foundry/journals/epic_planner/YYYY-MM-DD-HH-MM-SS.md
+++ b/.foundry/journals/epic_planner/YYYY-MM-DD-HH-MM-SS.md
@@ -1,0 +1,5 @@
+## Session 2026-08-04 - Epic Planner Hand-off
+
+*   **Observation:** The previous generated epics (`epic-044-149-gen3-roamer-core-extraction-v4`, `epic-044-150-gen3-roamer-iv-glitch-v4`, `epic-044-151-gen3-roamer-dashboard-ui-v6`) reached maximum rejection count and were permanently cancelled due to integration failures or impossible loop conditions.
+*   **Action:** Created `research-044-396-gen3-roamer-tracker-failure` to investigate the root cause, satisfying the rule for handling permanently failed child nodes.
+*   **Action:** Created replacement epics (`epic-044-397-gen3-roamer-core-extraction-v5`, `epic-044-398-gen3-roamer-iv-glitch-v5`, `epic-044-399-gen3-roamer-dashboard-ui-v7`). Crucially, enforced the Epic Planner Core Directive by explicitly adding an acceptance criterion to each EPIC requiring a final STORY dedicated exclusively to Integration and E2E Verification to ensure proper system-wide rendering and prevent future integration failures.

--- a/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
+++ b/.foundry/prds/prd-071-044-gen3-roamer-tracker.md
@@ -49,5 +49,10 @@ Provide an immediate, exact breakdown of a roaming legendary's internal state (N
 - [x] epic-044-148-gen3-roamer-dashboard-ui-v5
 - [x] epic-044-151-gen3-roamer-dashboard-ui-v6
 
+- [ ] research-044-396-gen3-roamer-tracker-failure
+- [ ] epic-044-397-gen3-roamer-core-extraction-v5
+- [ ] epic-044-398-gen3-roamer-iv-glitch-v5
+- [ ] epic-044-399-gen3-roamer-dashboard-ui-v7
+
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/research/research-044-396-gen3-roamer-tracker-failure.md
+++ b/.foundry/research/research-044-396-gen3-roamer-tracker-failure.md
@@ -1,0 +1,32 @@
+---
+id: research-044-396-gen3-roamer-tracker-failure
+type: RESEARCH
+title: Investigate Gen 3 Roamer Tracker Failures
+status: ACTIVE
+owner_persona: researcher
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-071-044-gen3-roamer-tracker
+tags:
+  - gen3
+  - roamer
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 3 Roamer Tracker Failures
+
+## Objective
+Investigate the root cause of the previous permanent failures (max rejection count) in the Gen 3 Roamer Tracker epics.
+
+## Description
+The previous epics (`epic-044-149`, `epic-044-150`, `epic-044-151`) failed permanently. We need to identify why the tasks could not be completed and ensure the replacement epics and stories account for the failure and avoid repeating it.
+
+## Acceptance Criteria
+- [ ] Investigate why the previous tasks/stories under `epic-044-149-gen3-roamer-core-extraction-v4` failed and reached the max rejection count.
+- [ ] Provide actionable recommendations for the implementation to avoid the same failure.


### PR DESCRIPTION
This PR handles the permanent failure (max rejection count) of the previous Gen 3 Roamer Epics by creating a `RESEARCH` node to investigate the root cause, creating replacement `EPIC` nodes (`epic-044-397`, `epic-044-398`, `epic-044-399`) that strictly require a final E2E verification `STORY`, appending these to the parent PRD, and logging the action in the Epic Planner's journal.

---
*PR created automatically by Jules for task [13938790329825521384](https://jules.google.com/task/13938790329825521384) started by @szubster*