### PR TITLE
Story Owner: Append E2E verification story for Epic 108-340

### DIFF
--- a/.foundry/epics/epic-108-340-extend-phase-3-6-cancelled-nodes-retry.md
+++ b/.foundry/epics/epic-108-340-extend-phase-3-6-cancelled-nodes-retry.md
@@ -38,4 +38,5 @@ In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` statu
 
 ## Acceptance Criteria
 - [x] Break down into Stories
-- [ ] [.foundry/stories/story-340-346-extend-phase-3-6-cancelled-nodes.md](.foundry/stories/story-340-346-extend-phase-3-6-cancelled-nodes.md)
+- [x] [.foundry/stories/story-340-346-extend-phase-3-6-cancelled-nodes.md](.foundry/stories/story-340-346-extend-phase-3-6-cancelled-nodes.md)
+- [ ] story-340-356-extend-phase-3-6-cancelled-nodes-e2e

--- a/.foundry/journals/story_owner/12084627167451036195.md
+++ b/.foundry/journals/story_owner/12084627167451036195.md
@@ -1,0 +1,8 @@
+# Session Log
+
+**Date:** 2026-08-04
+**Role:** Story Owner
+
+- Noticed that Epic nodes require an explicit e2e or integration test story child node in order to prevent Orchestrator completion safeguard failures.
+- When generating downstream execution tasks dynamically for older nodes, generated an explicit E2E/Integration validation STORY node to ensure we can successfully close out an epic and avoid false positives where test validation is ignored.
+- The parent node was also manually synced since its earlier generated child had been completed independently.

--- a/.foundry/stories/story-340-356-extend-phase-3-6-cancelled-nodes-e2e.md
+++ b/.foundry/stories/story-340-356-extend-phase-3-6-cancelled-nodes-e2e.md
@@ -1,0 +1,35 @@
+---
+id: story-340-356-extend-phase-3-6-cancelled-nodes-e2e
+type: STORY
+title: Extend Phase 3.6 for CANCELLED nodes (E2E Verification)
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on:
+  - story-340-346-extend-phase-3-6-cancelled-nodes
+jules_session_id: null
+pr_number: null
+parent: epic-108-340-extend-phase-3-6-cancelled-nodes-retry
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+  - e2e
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extend Phase 3.6 for CANCELLED nodes (E2E Verification)
+
+## Objective
+Implement e2e/integration verification to ensure Phase 3.6 logic in `foundry-orchestrator.ts` correctly awakens parent nodes for child nodes transitioning to `CANCELLED` status with `rejection_reason === 'Max rejection count reached'`.
+
+## Requirements
+- Add an end-to-end integration test or comprehensive unit test coverage verifying the entire lifecycle from rejection counting to node cancellation, and the subsequent parent state transition to PENDING/READY.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
Generates an E2E verification STORY node (`story-340-356-extend-phase-3-6-cancelled-nodes-e2e.md`) and appends it to `epic-108-340-extend-phase-3-6-cancelled-nodes-retry.md` to comply with the Orchestrator Epic Completion Safeguard. Also syncs the parent's markdown tracking by checking off the completed child story node without modifying the Epic's YAML frontmatter.

---
*PR created automatically by Jules for task [12084627167451036195](https://jules.google.com/task/12084627167451036195) started by @szubster*