### PR TITLE
chore(foundry): generate stories for gen3 trainer data extraction

### DIFF
--- a/.foundry/epics/epic-099-346-gen3-trainer-data-extraction.md
+++ b/.foundry/epics/epic-099-346-gen3-trainer-data-extraction.md
@@ -32,4 +32,9 @@ Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file.
 - Include E2E/integration testing to ensure reliability and correct rendering.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Convert this Epic into Stories.
+- [x] Story Owner: Convert this Epic into Stories.
+- [ ] story-346-356-gen3-trainer-data-extraction-core
+- [ ] story-346-357-gen3-trainer-data-e2e
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/journals/story_owner/12820592256470894785.md
+++ b/.foundry/journals/story_owner/12820592256470894785.md
@@ -1,0 +1,9 @@
+# Session 2026-08-04-12-00-00
+
+I reviewed the `epic-099-346-gen3-trainer-data-extraction` EPIC, which required extracting the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file, updating interfaces, and adding tests.
+
+I broke this Epic down into two Stories:
+1. `story-346-356-gen3-trainer-data-extraction-core`: To handle the core extraction logic and interface updates.
+2. `story-346-357-gen3-trainer-data-e2e`: To handle the E2E and integration testing, satisfying the rule that every EPIC must generate a final STORY dedicated to Integration and E2E Verification. This story depends on the core implementation story.
+
+I appended these new stories as unchecked tasks to the markdown body of the parent EPIC and checked off the requirement for the Story Owner to convert the Epic into Stories. I did not modify the parent EPIC's YAML frontmatter.

--- a/.foundry/stories/story-346-356-gen3-trainer-data-extraction-core.md
+++ b/.foundry/stories/story-346-356-gen3-trainer-data-extraction-core.md
@@ -1,0 +1,34 @@
+---
+id: story-346-356-gen3-trainer-data-extraction-core
+type: STORY
+title: Core Gen 3 Trainer Data Extraction
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-099-346-gen3-trainer-data-extraction
+tags:
+  - feature
+  - gen3
+  - trainer
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Core Gen 3 Trainer Data Extraction
+
+## Objective
+Extract the Trainer ID (TID) and Secret ID (SID) from a Gen 3 save file and update the common interface.
+
+## Requirements
+- Identify memory offsets for Trainer ID, and Secret ID in a save file.
+- Update the relevant interface to include Secret ID.
+- Implement extraction logic in `src/engine/saveParser/parsers/gen3.ts`.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break down the core logic implementation into `TASK` nodes.

--- a/.foundry/stories/story-346-357-gen3-trainer-data-e2e.md
+++ b/.foundry/stories/story-346-357-gen3-trainer-data-e2e.md
@@ -1,0 +1,35 @@
+---
+id: story-346-357-gen3-trainer-data-e2e
+type: STORY
+title: Gen 3 Trainer Data Extraction E2E/Integration
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-01'
+updated_at: '2026-08-01'
+depends_on:
+  - .foundry/stories/story-346-356-gen3-trainer-data-extraction-core.md
+jules_session_id: null
+pr_number: null
+parent: epic-099-346-gen3-trainer-data-extraction
+tags:
+  - feature
+  - gen3
+  - trainer
+  - e2e
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Trainer Data Extraction E2E/Integration
+
+## Objective
+Implement E2E and integration testing for the Gen 3 Trainer Data Extraction logic to ensure reliability and correct rendering.
+
+## Requirements
+- Include E2E/integration testing to ensure reliability and correct rendering of the TID and SID.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break down E2E and Integration test requirements into `TASK` nodes.


### PR DESCRIPTION
Broke down `epic-099-346-gen3-trainer-data-extraction` into actionable `STORY` nodes for core implementation and E2E testing. Updated the EPIC's acceptance criteria without modifying its YAML frontmatter. Documented the breakdown process in the Story Owner's journal.

---
*PR created automatically by Jules for task [12820592256470894785](https://jules.google.com/task/12820592256470894785) started by @szubster*