### PR TITLE
chore: Empty PR for completed epic epic-045-070

### DIFF
--- a/.foundry/journals/story_owner/YYYY-MM-DD-HH-MM-SS.md
+++ b/.foundry/journals/story_owner/YYYY-MM-DD-HH-MM-SS.md
@@ -13,3 +13,6 @@ This reinforces the critical rule from ADR 007 regarding the Parent-Linked DAG e
 * This pattern of having a generative persona (Story Owner) wake up to resolve its own completed children via an empty PR is standard operating procedure for the Foundry graph.
 ## Epic 045-070
 I verified that all child stories are marked as completed and all acceptance criteria are met. The Epic is already complete and I will submit an empty PR.
+# Session YYYY-MM-DD-HH-MM-SS
+
+Assigned to epic-045-070-orchestrator-strict-completion. The epic is already fully implemented because all acceptance criteria checkboxes and child references are marked as completed `[x]`. No new downstream stories were generated.


### PR DESCRIPTION
The epic is already fully implemented as all acceptance criteria and child node references are checked [x]. Submitted an empty PR as no new stories were spawned.

---
*PR created automatically by Jules for task [15966663207683891967](https://jules.google.com/task/15966663207683891967) started by @szubster*