### PR TITLE
Late bind research-322-396 for task-319-322

### DIFF
--- a/.foundry/journals/coder/YYYY-MM-DD-HH-MM-SS.md
+++ b/.foundry/journals/coder/YYYY-MM-DD-HH-MM-SS.md
@@ -1,0 +1,3 @@
+
+## Suspended task-319-322-gen3-trainer-flags-extraction-impl
+Lacked critical context for exact memory offsets for standard trainer defeat flags in Gen 3 saves. Spawning research node research-322-396-gen3-trainer-defeat-flags-offsets.md and late-binding.

--- a/.foundry/research/research-322-396-gen3-trainer-defeat-flags-offsets.md
+++ b/.foundry/research/research-322-396-gen3-trainer-defeat-flags-offsets.md
@@ -1,0 +1,33 @@
+---
+id: research-322-396-gen3-trainer-defeat-flags-offsets
+type: RESEARCH
+title: Investigate Gen 3 Trainer Defeat Flags Offsets
+status: PENDING
+owner_persona: researcher
+created_at: '2026-08-04'
+updated_at: '2026-08-04'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-319-322-gen3-trainer-flags-extraction-impl
+tags:
+  - data-extraction
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate Gen 3 Trainer Defeat Flags Offsets
+
+## Objective
+Investigate the exact memory offsets, lengths, bit locations, and bit shifts for trainer defeat flags (both standard and rematch flags) in Generation 3 save files (Ruby, Sapphire, Emerald, FireRed, LeafGreen).
+
+## Context
+The current implementation of the Missed Trainer Radar requires extracting trainer defeat flags from Gen 3 save files. However, the exact memory locations and structures for these flags (especially standard trainer defeat flags) are currently missing from the knowledge base. This information is needed to implement the extraction logic correctly without relying on magic numbers or guessing.
+
+## Questions to Answer
+1. Where are the standard trainer defeat flags located in Gen 3 saves (RSE and FRLG)? Which section/offset? Are they within `SaveBlock1` or `SaveBlock2`?
+2. How are standard trainer defeat flags structured (e.g. array of bytes, bitfield)? How many flags are there?
+3. What are the specific offsets and logic for Rematch flags (e.g. VS Seeker data in FRLG)?

--- a/.foundry/tasks/task-319-322-gen3-trainer-flags-extraction-impl.md
+++ b/.foundry/tasks/task-319-322-gen3-trainer-flags-extraction-impl.md
@@ -42,3 +42,6 @@ Implement the logic to extract standard and rematch trainer defeat flags from Ge
 - **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
 - **Permanent Failures:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - **Empty PR Submission:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not manually update the status.
+
+## Late Binding Dependencies
+- [ ] research-322-396-gen3-trainer-defeat-flags-offsets


### PR DESCRIPTION
Suspended task pending research for exact memory offsets for Gen 3 standard and rematch trainer defeat flags. Spawns research-322-396 and late binds it to task-319-322 as an unchecked markdown dependency to avoid invalid YAML modifications.

---
*PR created automatically by Jules for task [3577794938993948534](https://jules.google.com/task/3577794938993948534) started by @szubster*