### PR TITLE
docs: Add Gen 3 trainer flags offsets research

### DIFF
--- a/.foundry/docs/knowledge_base/gen3_trainer_flags_offsets.md
+++ b/.foundry/docs/knowledge_base/gen3_trainer_flags_offsets.md
@@ -1,0 +1,32 @@
+# Gen 3 Trainer Flags and Offsets
+
+## Standard Trainer Defeat Flags
+In Generation 3 (RSE and FRLG), standard trainer defeat flags are stored in `SaveBlock1` as a bitfield.
+The flags start at a logical offset `TRAINER_FLAGS_START = 0x500` inside the `flags` array.
+
+### RSE (Ruby, Sapphire, Emerald)
+- **Emerald:** The `flags` array begins at byte offset `0x1270` in `SaveBlock1`.
+- **Ruby/Sapphire:** The `flags` array begins at byte offset `0x1220` in `SaveBlock1`.
+- The logical flag ID for standard trainers begins at `0x500`. Since each flag is 1 bit (8 flags per byte), the byte offset within the `flags` array is `0x500 / 8 = 0xA0` (160 bytes).
+- **Total Trainers:** `MAX_TRAINERS_COUNT = 864` (Emerald), or `NUMBER_OF_TRAINERS = 693` (Ruby/Sapphire).
+- **Max Bytes:** `864 / 8 = 108 bytes`.
+
+### FRLG (FireRed, LeafGreen)
+- The `flags` array begins at byte offset `0x0EE0` in `SaveBlock1`.
+- The logical flag ID for standard trainers begins at `0x500`. The byte offset within the `flags` array is `0xA0` (160 bytes).
+- **Total Trainers:** `MAX_TRAINERS_COUNT = 768`.
+- **Max Bytes:** `768 / 8 = 96 bytes`.
+
+## Rematch Flags (VS Seeker / Match Call / Trainer's Eyes)
+In Generation 3, rematch readiness flags are also stored in `SaveBlock1` in an array called `trainerRematches`.
+
+### RSE (Ruby, Sapphire, Emerald)
+- **Emerald:** The `trainerRematches` array starts at byte offset `0x9CA` in `SaveBlock1`.
+- **Ruby/Sapphire:** The `trainerRematches` array starts at byte offset `0x97A` in `SaveBlock1`.
+- **Size:** `MAX_REMATCH_ENTRIES = 100` (1 byte per entry).
+- Each byte corresponds to a rematch table entry ID, not an absolute trainer flag ID. A non-zero value indicates the trainer wants a rematch.
+
+### FRLG (FireRed, LeafGreen)
+- The `trainerRematches` array starts at byte offset `0x063A` in `SaveBlock1`.
+- **Size:** `MAX_REMATCH_ENTRIES = 100` (1 byte per entry).
+- Each FRLG map uses this array to store standard VS seeker rematch states, indexed by the local Object Event ID.

--- a/.foundry/journals/researcher/2026-08-04.md
+++ b/.foundry/journals/researcher/2026-08-04.md
@@ -1,0 +1,1 @@
+Session 2026-08-04: Investigated Gen 3 trainer flag offsets and saved to .foundry/docs/knowledge_base/gen3_trainer_flags_offsets.md

--- a/.foundry/research/research-322-396-gen3-trainer-defeat-flags-offsets.md
+++ b/.foundry/research/research-322-396-gen3-trainer-defeat-flags-offsets.md
@@ -31,3 +31,21 @@ The current implementation of the Missed Trainer Radar requires extracting train
 1. Where are the standard trainer defeat flags located in Gen 3 saves (RSE and FRLG)? Which section/offset? Are they within `SaveBlock1` or `SaveBlock2`?
 2. How are standard trainer defeat flags structured (e.g. array of bytes, bitfield)? How many flags are there?
 3. What are the specific offsets and logic for Rematch flags (e.g. VS Seeker data in FRLG)?
+
+## Findings
+1. Standard trainer defeat flags are located in `SaveBlock1` as a bitfield.
+   - **Emerald:** `flags` array starts at byte offset `0x1270`.
+   - **Ruby/Sapphire:** `flags` array starts at byte offset `0x1220`.
+   - **FRLG:** `flags` array starts at byte offset `0x0EE0`.
+   - Logical ID for standard trainers starts at `0x500`, so the byte offset within the `flags` array is `0x500 / 8 = 0xA0` (160 bytes).
+2. Standard trainer defeat flags are structured as a bitfield (1 bit per trainer).
+   - **Emerald:** `MAX_TRAINERS_COUNT = 864` (108 bytes).
+   - **Ruby/Sapphire:** `NUMBER_OF_TRAINERS = 693` (87 bytes, although it might use up to 108 depending on save block).
+   - **FRLG:** `MAX_TRAINERS_COUNT = 768` (96 bytes).
+3. Rematch flags are stored in `SaveBlock1` in the `trainerRematches` array.
+   - **Emerald:** Byte offset `0x9CA`, length 100 bytes.
+   - **Ruby/Sapphire:** Byte offset `0x97A`, length 100 bytes.
+   - **FRLG:** Byte offset `0x063A`, length 100 bytes.
+   - Each entry is 1 byte indicating a rematch state (either the rematch table entry ID for RSE or state indexed by local ID for FRLG).
+
+For a complete documentation reference, see `.foundry/docs/knowledge_base/gen3_trainer_flags_offsets.md`.


### PR DESCRIPTION
Adds detailed documentation on standard trainer defeat flags and VS seeker/match call rematch flags for Generation 3 Pokemon games, satisfying the research task.

---
*PR created automatically by Jules for task [5739507086916954407](https://jules.google.com/task/5739507086916954407) started by @szubster*