### PR TITLE
Handle failed implementation of conflict-less journals

### DIFF
--- a/.foundry/epics/epic-335-401-implement-conflictless-journals-retry.md
+++ b/.foundry/epics/epic-335-401-implement-conflictless-journals-retry.md
@@ -1,0 +1,32 @@
+---
+id: epic-335-401-implement-conflictless-journals-retry
+type: EPIC
+title: Implement Conflict-less Agent Journals (Retry)
+status: READY
+owner_persona: story_owner
+created_at: '2026-08-05'
+updated_at: '2026-08-05'
+depends_on:
+  - research-335-400-investigate-conflictless-journals-failure
+jules_session_id: '17353405569114618226'
+parent: prd-120-335-conflictless-agent-journals
+tags:
+  - foundry
+  - journals
+  - workflow
+  - DX
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Implement Conflict-less Agent Journals (Retry)
+
+## Overview
+To resolve frequent git merge conflicts on `.foundry/journals/*.md` files, this Epic will transition the system to a conflict-less storage pattern for agent journals, incorporating findings from the previous failed attempt.
+
+## Acceptance Criteria
+- [ ] Implement timestamped or session-unique markdown files for journals.
+- [ ] Ensure storage is in persona-specific subdirectories (e.g. `.foundry/journals/coder/`).
+- [ ] Update the TPM persona responsibilities to aggregate and archive these individual files appropriately.
+- [ ] Update downstream nodes and scripts that reference journals.

--- a/.foundry/journals/auditor/17353405569114618226.md
+++ b/.foundry/journals/auditor/17353405569114618226.md
@@ -1,0 +1,1 @@
+Logged failure of epic-120-338-implement-conflictless-journals due to max rejection count. Spawned research-335-400-investigate-conflictless-journals-failure to investigate root cause, and epic-335-401-implement-conflictless-journals-retry as a replacement.

--- a/.foundry/prds/prd-120-335-conflictless-agent-journals.md
+++ b/.foundry/prds/prd-120-335-conflictless-agent-journals.md
@@ -32,7 +32,9 @@ To resolve frequent git merge conflicts on `.foundry/journals/*.md` files, we wi
 4. Downstream nodes must correctly reference these fragmented journal files if necessary, or rely on aggregation mechanisms.
 
 ## Acceptance Criteria
-- [ ] epic-120-338-implement-conflictless-journals
+- [x] epic-120-338-implement-conflictless-journals
+- [ ] research-335-400-investigate-conflictless-journals-failure
+- [ ] epic-335-401-implement-conflictless-journals-retry
 
 ### Auditor Rejection
-The generated descendant node epic-120-338-implement-conflictless-journals is currently in a FAILED state. A macro node MUST NOT be verified until its functional requirements are fully implemented and its child tasks are COMPLETED.
+The PRD verification failed because the original implementation Epic reached its max rejection count. A research node and a replacement epic have been spawned. A macro node MUST NOT be verified until its functional requirements are fully implemented and its child tasks are COMPLETED.

--- a/.foundry/research/research-335-400-investigate-conflictless-journals-failure.md
+++ b/.foundry/research/research-335-400-investigate-conflictless-journals-failure.md
@@ -1,0 +1,29 @@
+---
+id: research-335-400-investigate-conflictless-journals-failure
+type: RESEARCH
+title: Investigate Conflict-less Journals Failure
+status: READY
+owner_persona: researcher
+created_at: '2026-08-05'
+updated_at: '2026-08-05'
+depends_on: []
+jules_session_id: '17353405569114618226'
+parent: prd-120-335-conflictless-agent-journals
+tags:
+  - foundry
+  - journals
+  - failure-analysis
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Investigate Conflict-less Journals Failure
+
+## Objective
+Investigate the root cause of `epic-120-338-implement-conflictless-journals` reaching its max rejection count.
+
+## Tasks
+- [ ] Analyze the rejection reasons for `epic-120-338-implement-conflictless-journals`.
+- [ ] Identify the blockers preventing the transition to conflict-less storage patterns for agent journals.
+- [ ] Propose a new approach or architecture to overcome these blockers.


### PR DESCRIPTION
The original Epic `epic-120-338-implement-conflictless-journals` reached its max rejection count. A research node (`research-335-400-investigate-conflictless-journals-failure`) and a replacement epic (`epic-335-401-implement-conflictless-journals-retry`) have been spawned to investigate and address the blockers. The PRD's status was updated by checking off the failed epic, appending the new nodes to the Acceptance Criteria, and adding an Auditor Rejection block to trigger the Impossible Loop policy.

---
*PR created automatically by Jules for task [17353405569114618226](https://jules.google.com/task/17353405569114618226) started by @szubster*