### PR TITLE
feat(engine): add filtering for high-value gen 2 phone calls (swarms & items)

### DIFF
--- a/.foundry/journals/coder/12236130546163448785.md
+++ b/.foundry/journals/coder/12236130546163448785.md
@@ -1,0 +1,5 @@
+# Session 12236130546163448785
+
+* **TypeScript strictness**: Remember to use `import type { ... }` or `import { type ... }` when importing interfaces/types because `verbatimModuleSyntax` is enabled in `tsconfig.json`. Failing to do so causes `TS1484` errors during linting/type-checking.
+* **Gen 2 Save File Parsing**: Identified high-value phone contacts (swarms and items) and successfully mapped them to `GEN2_PHONE_CALLER_REGISTRY`. Ensure tests cover these specific offsets. Adhered to Section 13 guidelines by avoiding magic numbers and using constants.
+* **Cleanup**: Ensure scratchpad `.py` scripts and temporary `plan.md` files are deleted before submission to avoid polluting the repository.

--- a/.foundry/tasks/task-286-314-filter-swarm-item-calls-impl.md
+++ b/.foundry/tasks/task-286-314-filter-swarm-item-calls-impl.md
@@ -35,6 +35,6 @@ Memory offsets are documented in `.foundry/docs/knowledge_base/gen2_phone_offset
 - Create a filtering layer or flag in the data structure for high-value calls.
 
 ## Acceptance Criteria
-- [ ] Implement constant definitions for phone offsets (Crystal vs G/S)
-- [ ] Implement data logic for identifying high-value Pokegear calls (swarm & item-giving)
-- [ ] Comply strictly with Section 13 parsing guidelines (module-level constants, no magic numbers, catch RangeError)
+- [x] Implement constant definitions for phone offsets (Crystal vs G/S)
+- [x] Implement data logic for identifying high-value Pokegear calls (swarm & item-giving)
+- [x] Comply strictly with Section 13 parsing guidelines (module-level constants, no magic numbers, catch RangeError)

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,0 @@
-1. Explore the task context.
-2. Archive COMPLETED/CANCELLED nodes conservatively (already done via my tools).
-3. Aggregate and archive old journal entries, ignoring transient logs (done).
-4. Verify changes locally.
-5. Create an empty PR or actual PR with the above changes.

--- a/src/engine/saveParser/parsers/gen2/phone/constants.ts
+++ b/src/engine/saveParser/parsers/gen2/phone/constants.ts
@@ -1,0 +1,47 @@
+export type CallerType = 'SWARM' | 'ITEM' | 'TRAINER' | 'STORY' | 'NONE';
+
+export interface HighValueContact {
+  id: number;
+  name: string;
+  type: CallerType;
+  details?: string;
+}
+
+// Module-level constants for phone contact IDs
+export const GEN2_CONTACT_RALPH = 17;
+export const GEN2_CONTACT_ANTHONY = 19;
+export const GEN2_CONTACT_ARNIE = 23;
+export const GEN2_CONTACT_CHAD = 27;
+
+export const GEN2_CONTACT_BEVERLY = 6;
+export const GEN2_CONTACT_JOSE = 13;
+export const GEN2_CONTACT_WADE = 16;
+export const GEN2_CONTACT_TODD = 20;
+export const GEN2_CONTACT_GINA = 21;
+export const GEN2_CONTACT_ALAN = 24;
+export const GEN2_CONTACT_DANA = 26;
+export const GEN2_CONTACT_TULLY = 29;
+export const GEN2_CONTACT_TIFFANY = 31;
+export const GEN2_CONTACT_WILTON = 33;
+export const GEN2_CONTACT_KENJI = 34;
+
+export const GEN2_PHONE_CALLER_REGISTRY: Record<number, Omit<HighValueContact, 'id'>> = {
+  // Swarm callers
+  [GEN2_CONTACT_RALPH]: { name: 'Fisher Ralph', type: 'SWARM', details: 'Qwilfish' },
+  [GEN2_CONTACT_ANTHONY]: { name: 'Hiker Anthony', type: 'SWARM', details: 'Dunsparce' },
+  [GEN2_CONTACT_ARNIE]: { name: 'Bug Catcher Arnie', type: 'SWARM', details: 'Yanma' },
+  [GEN2_CONTACT_CHAD]: { name: 'Schoolboy Chad', type: 'SWARM', details: 'Snubbull' },
+
+  // Item callers
+  [GEN2_CONTACT_BEVERLY]: { name: 'Pokefan Beverly', type: 'ITEM', details: 'Nugget' },
+  [GEN2_CONTACT_JOSE]: { name: 'Bird Keeper Jose', type: 'ITEM', details: 'Star Piece' },
+  [GEN2_CONTACT_WADE]: { name: 'Bug Catcher Wade', type: 'ITEM', details: 'Berry / Berry Juice' },
+  [GEN2_CONTACT_TODD]: { name: 'Camper Todd', type: 'ITEM', details: 'HP Up' },
+  [GEN2_CONTACT_GINA]: { name: 'Picnicker Gina', type: 'ITEM', details: 'Leaf Stone' },
+  [GEN2_CONTACT_ALAN]: { name: 'Schoolboy Alan', type: 'ITEM', details: 'Fire Stone' },
+  [GEN2_CONTACT_DANA]: { name: 'Lass Dana', type: 'ITEM', details: 'Thunderstone' },
+  [GEN2_CONTACT_TULLY]: { name: 'Fisher Tully', type: 'ITEM', details: 'Water Stone' },
+  [GEN2_CONTACT_TIFFANY]: { name: 'Picnicker Tiffany', type: 'ITEM', details: 'Pink Bow' },
+  [GEN2_CONTACT_WILTON]: { name: 'Fisher Wilton', type: 'ITEM', details: 'Poke Ball / Great Ball / Ultra Ball' },
+  [GEN2_CONTACT_KENJI]: { name: 'Blackbelt Kenji', type: 'ITEM', details: 'PP Up' },
+};

--- a/src/engine/saveParser/parsers/gen2/phone/filter.test.ts
+++ b/src/engine/saveParser/parsers/gen2/phone/filter.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { GEN2_CONTACT_GINA, GEN2_CONTACT_RALPH, GEN2_CONTACT_TULLY } from './constants';
+import { filterHighValueCalls } from './filter';
+
+describe('filterHighValueCalls', () => {
+  it('should return an empty array if phoneList is empty', () => {
+    expect(filterHighValueCalls([])).toEqual([]);
+  });
+
+  it('should filter out zeroes and unmapped contacts', () => {
+    // 0 is unused, 1 is MOM, 2 is OAK (which we haven't mapped as high value)
+    const phoneList = [0, 1, 2, 0, 99];
+    expect(filterHighValueCalls(phoneList)).toEqual([]);
+  });
+
+  it('should correctly identify SWARM and ITEM callers', () => {
+    // 17 is Ralph (Swarm), 29 is Tully (Item), 21 is Gina (Item)
+    const phoneList = [0, 1, GEN2_CONTACT_RALPH, GEN2_CONTACT_TULLY, 2, GEN2_CONTACT_GINA];
+    const result = filterHighValueCalls(phoneList);
+
+    expect(result).toHaveLength(3);
+
+    // Check Ralph (Swarm)
+    const ralph = result.find((c) => c.id === GEN2_CONTACT_RALPH);
+    expect(ralph).toBeDefined();
+    expect(ralph?.name).toBe('Fisher Ralph');
+    expect(ralph?.type).toBe('SWARM');
+    expect(ralph?.details).toBe('Qwilfish');
+
+    // Check Tully (Item)
+    const tully = result.find((c) => c.id === GEN2_CONTACT_TULLY);
+    expect(tully).toBeDefined();
+    expect(tully?.name).toBe('Fisher Tully');
+    expect(tully?.type).toBe('ITEM');
+    expect(tully?.details).toBe('Water Stone');
+
+    // Check Gina (Item)
+    const gina = result.find((c) => c.id === GEN2_CONTACT_GINA);
+    expect(gina).toBeDefined();
+    expect(gina?.name).toBe('Picnicker Gina');
+    expect(gina?.type).toBe('ITEM');
+    expect(gina?.details).toBe('Leaf Stone');
+  });
+});

--- a/src/engine/saveParser/parsers/gen2/phone/filter.ts
+++ b/src/engine/saveParser/parsers/gen2/phone/filter.ts
@@ -1,0 +1,26 @@
+import { GEN2_PHONE_CALLER_REGISTRY, type HighValueContact } from './constants';
+
+/**
+ * Filters a list of phone contact IDs to identify high-value callers (Swarms or Items).
+ *
+ * @param phoneList - An array of contact IDs registered in the player's Pokegear.
+ * @returns An array of HighValueContact objects for matching contacts.
+ */
+export function filterHighValueCalls(phoneList: number[]): HighValueContact[] {
+  const highValueContacts: HighValueContact[] = [];
+
+  for (const contactId of phoneList) {
+    if (contactId === 0) continue; // 0 represents an empty/unused slot
+
+    const registryEntry = GEN2_PHONE_CALLER_REGISTRY[contactId];
+
+    if (registryEntry) {
+      highValueContacts.push({
+        id: contactId,
+        ...registryEntry,
+      });
+    }
+  }
+
+  return highValueContacts;
+}

--- a/src/engine/saveParser/parsers/gen2/phone/parser.test.ts
+++ b/src/engine/saveParser/parsers/gen2/phone/parser.test.ts
@@ -25,6 +25,10 @@ describe('Gen 2 Pokegear Parser', () => {
     expect(result.phoneList[0]).toBe(1);
     expect(result.phoneList[10]).toBe(11);
     expect(result.swarmFlags).toBeUndefined();
+    // In our test loop above, we populate IDs 1 to 11.
+    // ID 6 is Beverly (Nugget)
+    expect(result.highValueContacts).toBeDefined();
+    expect(result.highValueContacts?.some((c) => c.id === 6)).toBe(true);
   });
 
   it('should parse Crystal data correctly', () => {
@@ -51,6 +55,10 @@ describe('Gen 2 Pokegear Parser', () => {
     expect(result.dailyPhoneTimeOfDayFlags).toBe(0x87654321);
     expect(result.phoneList).toHaveLength(PHONE_LIST_LENGTH);
     expect(result.phoneList[0]).toBe(20);
+    // In our loop, we populate IDs from 20 down to 10.
+    // ID 20 is Camper Todd (HP Up), ID 17 is Ralph (Swarm), ID 16 is Wade, ID 13 is Jose.
+    expect(result.highValueContacts).toBeDefined();
+    expect(result.highValueContacts?.length).toBeGreaterThan(0);
   });
 
   it('should throw an error on out of bounds reads', () => {

--- a/src/engine/saveParser/parsers/gen2/phone/parser.ts
+++ b/src/engine/saveParser/parsers/gen2/phone/parser.ts
@@ -19,10 +19,14 @@ export const CRYSTAL_WPHONE_LIST = 0xdc7c;
 export const CONTACT_LIST_SIZE = 10;
 export const PHONE_LIST_LENGTH = CONTACT_LIST_SIZE + 1;
 
+import type { HighValueContact } from './constants';
+import { filterHighValueCalls } from './filter';
+
 export interface PokegearPhoneData {
   phoneListIndex: number;
   specialPhoneCallId: number;
   phoneList: number[];
+  highValueContacts?: HighValueContact[];
   swarmFlags?: number;
   dailyPhoneItemFlags?: number;
   dailyPhoneTimeOfDayFlags?: number;
@@ -53,6 +57,7 @@ export function parseGen2PokegearData(dataView: DataView, isCrystal: boolean): P
         dailyPhoneItemFlags,
         dailyPhoneTimeOfDayFlags,
         phoneList,
+        highValueContacts: filterHighValueCalls(phoneList),
       };
     } else {
       const phoneListIndex = dataView.getUint8(GS_WPHONE_LIST_INDEX - SRAM_WRAM_OFFSET_ADJUST);
@@ -68,6 +73,7 @@ export function parseGen2PokegearData(dataView: DataView, isCrystal: boolean): P
         phoneListIndex,
         specialPhoneCallId,
         phoneList,
+        highValueContacts: filterHighValueCalls(phoneList),
       };
     }
   } catch (error) {


### PR DESCRIPTION
This PR implements data filtering logic for Gen 2 (Gold, Silver, Crystal) Pokegear phone calls to identify active NPCs that offer rare items (like evolutionary stones) or swarm notifications (like Dunsparce or Yanma).

Changes:
1. Created `constants.ts` with module-level definitions for specific Gen 2 caller IDs and mapped them in `GEN2_PHONE_CALLER_REGISTRY`.
2. Implemented `filterHighValueCalls` logic in `filter.ts` to process the parsed `phoneList`.
3. Extended `PokegearPhoneData` with a `highValueContacts` array that holds matched Swarm and Item contacts.
4. Added comprehensive unit tests in `filter.test.ts` and updated `parser.test.ts` to assert that high-value contacts are returned properly.

---
*PR created automatically by Jules for task [12236130546163448785](https://jules.google.com/task/12236130546163448785) started by @szubster*