### PR TITLE
feat: Add Zod Schema E2E Test Fixtures

### DIFF
--- a/.foundry/fixtures/schema-e2e/invalid-missing-field-001.md
+++ b/.foundry/fixtures/schema-e2e/invalid-missing-field-001.md
@@ -1,0 +1,21 @@
+---
+id: task-invalid-missing-field-001
+type: TASK
+title: Missing Required Field
+status: PENDING
+# owner_persona is missing
+created_at: "2026-08-04"
+updated_at: "2026-08-04"
+depends_on: []
+jules_session_id: null
+parent: story-334-356-zod-schema-e2e
+tags:
+  - e2e
+  - testing
+  - fixtures
+rejection_reason: ''
+---
+
+# Missing Required Field
+
+This fixture is invalid because it is missing the required `owner_persona` field in the frontmatter.

--- a/.foundry/fixtures/schema-e2e/invalid-persona-001.md
+++ b/.foundry/fixtures/schema-e2e/invalid-persona-001.md
@@ -1,0 +1,21 @@
+---
+id: task-invalid-persona-001
+type: TASK
+title: Invalid Persona
+status: PENDING
+owner_persona: INVALID_PERSONA
+created_at: "2026-08-04"
+updated_at: "2026-08-04"
+depends_on: []
+jules_session_id: null
+parent: story-334-356-zod-schema-e2e
+tags:
+  - e2e
+  - testing
+  - fixtures
+rejection_reason: ''
+---
+
+# Invalid Persona
+
+This fixture is invalid because the `owner_persona` field is set to a value not allowed by the `OwnerPersonaEnum`.

--- a/.foundry/fixtures/schema-e2e/invalid-type-001.md
+++ b/.foundry/fixtures/schema-e2e/invalid-type-001.md
@@ -1,0 +1,21 @@
+---
+id: invalid-type-001
+type: INVALID_TYPE
+title: Invalid Node Type
+status: PENDING
+owner_persona: coder
+created_at: "2026-08-04"
+updated_at: "2026-08-04"
+depends_on: []
+jules_session_id: null
+parent: story-334-356-zod-schema-e2e
+tags:
+  - e2e
+  - testing
+  - fixtures
+rejection_reason: ''
+---
+
+# Invalid Node Type
+
+This fixture is invalid because the `type` field is set to a value not allowed by the `NodeTypeEnum`.

--- a/.foundry/fixtures/schema-e2e/valid-epic-001.md
+++ b/.foundry/fixtures/schema-e2e/valid-epic-001.md
@@ -1,0 +1,22 @@
+---
+id: epic-300-334-schema-validation
+type: EPIC
+title: Robust Schema Validation
+status: ACTIVE
+owner_persona: epic_planner
+created_at: "2026-07-15"
+updated_at: "2026-07-20"
+depends_on: []
+jules_session_id: "987654321"
+tags:
+  - architecture
+rejection_reason: ''
+---
+
+# Robust Schema Validation
+
+Implement robust schema validation across the system to ensure data integrity.
+
+## Acceptance Criteria
+- [x] Integrate Zod.
+- [ ] Add E2E validation.

--- a/.foundry/fixtures/schema-e2e/valid-story-001.md
+++ b/.foundry/fixtures/schema-e2e/valid-story-001.md
@@ -1,0 +1,24 @@
+---
+id: story-334-356-zod-schema-e2e
+type: STORY
+title: E2E Tests for Zod Schema Validation
+status: COMPLETED
+owner_persona: story_owner
+created_at: "2026-08-01"
+updated_at: "2026-08-03"
+depends_on: []
+jules_session_id: "1234567890"
+parent: epic-300-334-schema-validation
+tags:
+  - testing
+  - schema
+rejection_reason: ''
+---
+
+# E2E Tests for Zod Schema Validation
+
+Ensure that the Zod schema is tested end-to-end to correctly accept and reject valid and invalid objects.
+
+## Acceptance Criteria
+- [x] Create valid fixtures.
+- [x] Create invalid fixtures.

--- a/.foundry/fixtures/schema-e2e/valid-task-001.md
+++ b/.foundry/fixtures/schema-e2e/valid-task-001.md
@@ -2,12 +2,12 @@
 id: task-356-396-zod-schema-e2e-fixtures-impl
 type: TASK
 title: Implement Zod Schema E2E Test Fixtures
-status: ACTIVE
+status: PENDING
 owner_persona: coder
-created_at: '2026-08-04'
-updated_at: '2026-08-05'
+created_at: "2026-08-04"
+updated_at: "2026-08-04"
 depends_on: []
-jules_session_id: '7809644036285331866'
+jules_session_id: null
 parent: story-334-356-zod-schema-e2e
 tags:
   - e2e
@@ -21,5 +21,5 @@ rejection_reason: ''
 Create valid and invalid test fixtures for Foundry orchestrator E2E testing of the Zod schema validation. The valid fixtures should conform strictly to the Schema, and the invalid fixtures should contain various schema violations (e.g. missing fields, incorrect types).
 
 ## Acceptance Criteria
-- [x] Create at least 3 valid Foundry node fixtures.
-- [x] Create at least 3 invalid Foundry node fixtures that fail Zod validation.
+- [ ] Create at least 3 valid Foundry node fixtures.
+- [ ] Create at least 3 invalid Foundry node fixtures that fail Zod validation.

--- a/.foundry/journals/coder/7809644036285331866.md
+++ b/.foundry/journals/coder/7809644036285331866.md
@@ -1,0 +1,1 @@
+Implemented 3 valid and 3 invalid Zod schema E2E test fixtures under .foundry/fixtures/schema-e2e to properly test the orchestrator's schema validation without breaking it.


### PR DESCRIPTION
This PR adds valid and invalid test fixtures to test the end-to-end validation for the Zod schema used by the Foundry Orchestrator. It implements the acceptance criteria for task-356-396-zod-schema-e2e-fixtures-impl.

---
*PR created automatically by Jules for task [7809644036285331866](https://jules.google.com/task/7809644036285331866) started by @szubster*