### PR TITLE
docs(foundry): mark PRD as completed in IDEA for Pokerus Strain UI

### DIFF
--- a/.foundry/ideas/idea-107-pokerus-strain-ui-tracker.md
+++ b/.foundry/ideas/idea-107-pokerus-strain-ui-tracker.md
@@ -26,4 +26,4 @@ With the standardization of bitwise extraction for Pokerus (`parsePokerus` in `c
 
 ## Acceptance Criteria
 - [x] Product Manager: Convert this idea into a PRD.
-- [ ] prd-107-112-pokerus-strain-ui-tracker
+- [x] prd-107-112-pokerus-strain-ui-tracker

--- a/.foundry/journals/product_manager/YYYY-MM-DD-HH-MM-SS.md
+++ b/.foundry/journals/product_manager/YYYY-MM-DD-HH-MM-SS.md
@@ -1,0 +1,1 @@
+## Empty PR Policy Triggered\nTarget PRD `prd-107-112-pokerus-strain-ui-tracker.md` already exists and was found to be COMPLETED prior to the session. Empty PR to be submitted.


### PR DESCRIPTION
The target PRD `prd-107-112-pokerus-strain-ui-tracker.md` was found to already exist in `.foundry/prds/`. The acceptance criteria in the parent IDEA node (`idea-107-pokerus-strain-ui-tracker.md`) has been updated to check off the PRD generation step. An empty PR is submitted to transition the IDEA to VERIFYING. A journal entry was created documenting the anomaly.

---
*PR created automatically by Jules for task [10108792700210574818](https://jules.google.com/task/10108792700210574818) started by @szubster*