### PR TITLE
Add PRD for Pokemon-themed Foundry personas

### DIFF
--- a/.foundry/ideas/idea-122-pokemon-themed-foundry-personas.md
+++ b/.foundry/ideas/idea-122-pokemon-themed-foundry-personas.md
@@ -106,7 +106,8 @@ Node transitions in our DAG are reimagined as classic Gen 1 progression mechanic
 ---
 
 ## Acceptance Criteria
-- [ ] Product Manager: Convert this idea into a PRD specifying the theme integration and updating the Foundry schema.
+- [x] Product Manager: Convert this idea into a PRD specifying the theme integration and updating the Foundry schema.
+- [ ] prd-122-337-pokemon-themed-foundry-personas
 - [ ] Designer: Create custom visual icons/badges representing the mapped Pokémon roles on the DAG dashboard.
 - [ ] Coder: Update the DAG UI dashboard and log-viewing panels to show the themed names, statuses, and icons.
 - [ ] TPM: Update `.github/scripts/foundry-orchestrator.ts` to output themed messages and emoji badges to GitHub Action summaries.

--- a/.foundry/journals/product_manager/YYYY-MM-DD-HH-MM-SS.md
+++ b/.foundry/journals/product_manager/YYYY-MM-DD-HH-MM-SS.md
@@ -1,0 +1,3 @@
+## Pokémon Theme PRD Creation
+
+Converted `idea-122-pokemon-themed-foundry-personas` into `prd-122-337-pokemon-themed-foundry-personas.md`. Enforced setting `owner_persona: epic_planner` so the next pipeline stage takes over, breaking down the theme reskin into actionable Epics.

--- a/.foundry/prds/prd-122-337-pokemon-themed-foundry-personas.md
+++ b/.foundry/prds/prd-122-337-pokemon-themed-foundry-personas.md
@@ -1,0 +1,71 @@
+---
+id: prd-122-337-pokemon-themed-foundry-personas
+type: PRD
+title: Pokémon-Themed Foundry Persona Skins and Gamified Workflow
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-08-05'
+updated_at: '2026-08-05'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-122-pokemon-themed-foundry-personas
+tags:
+  - foundry
+  - ux
+  - gamification
+  - personas
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Pokémon-Themed Foundry Persona Skins and Gamified Workflow
+
+## Objective
+To bring character, engagement, and a distinct retro-gaming identity to the Foundry, this PRD proposes a cohesive Pokémon-themed visual and narrative reskin for both the **Foundry Owner Personas** (which govern system nodes) and the **Jules Agent Personas** (which execute sessions). Based on core user feedback, this theme strictly utilizes highly iconic **Generation 1 Pokémon and characters**.
+
+Additionally, it translates the system's strict directed acyclic graph (DAG) status transitions into gamified Pokémon concepts like **Egg Incubation, Evolution, Elite Four Verification, and Pokémon Center Recovery**.
+
+## Requirements
+
+### 1. Foundry Owner Personas (The Gym Leaders & Professors) Theme
+Update `.foundry/docs/schema.md` and related orchestration scripts to incorporate the Gen 1 mapping for all 13 system roles:
+- **`product_manager` ➔ Dragonite (#149 - The Delivery Messenger)**: Soars across the ocean to deliver raw ideas as perfectly structured PRD blueprints.
+- **`epic_planner` ➔ Alakazam (#065 - The 5,000 IQ Strategist)**: Organizes macroscopic epics and maps out structural dependencies in its head.
+- **`story_owner` ➔ Bill (The Prominent Gen 1 Scientist & Inventor)**: Dynamically writes individual stories based on real-time collection progress.
+- **`architect` ➔ Mewtwo (#150 - The Master Mind of the Blueprint)**: Demands absolute logical structural perfection.
+- **`tech_lead` ➔ Porygon (#137 - The Digital Blueprint Optimizer)**: Translates stories into clean, byte-level structural engineering tasks.
+- **`coder` ➔ Pikachu (#025 - The Spark of Implementation)**: Turns static markdown requirements into fully functional code.
+- **`qa` ➔ Ditto (#132 - The Contract Matcher)**: Transforms itself into the exact specification to verify the implementation.
+- **`human` ➔ Legendary Pokémon Trainer (Red)**: Commands the grand pipeline strategies.
+- **`tpm` ➔ Meowth (#052 - The Coin Finder & Archivist)**: Meticulously maintains learning logs and archives nodes.
+- **`agile_coach` ➔ Professor Oak (The Process Pioneer)**: Mentoring the factory, evolving agent prompts.
+- **`mechanic` ➔ Blastoise (#009 - The Torrential Pipeline Cleanser)**: Blasts through clogged pipelines with Hydro Pump.
+- **`researcher` ➔ Mew (#151 - The Exploratory Genesis)**: Spawns late-bound research nodes to explore and decode.
+- **`auditor` ➔ Lapras (#131 - The Gentle Final Guide)**: Navigates the PR artifacts safely to shore, distilling crucial lessons learned.
+
+### 2. Jules Agent Personas (The Companion Pokémon) Theme
+Apply the same thematic mapping to developer-facing personas defined under `.jules/`:
+- **Oak (Data Integrity)** ➔ **Professor Oak**
+- **Nurse (Type Safety)** ➔ **Nurse Joy (Chansey - #113)**
+- **Sentinel (Testing & Coverage)** ➔ **Gengar (#094)**
+- **Sweeper (Cleanup & Refactor)** ➔ **Scyther (#123)**
+- **Palette (Design & Styling)** ➔ **Pidgeot (#018)**
+- **Scribe (Documentation & Lore)** ➔ **Slowbro (#080)**
+- **Trainer (Quality & Improvement)** ➔ **Machamp (#068)**
+- **Visionary (Creative Ideation)** ➔ **Eevee (#133)**
+- **Sculptor (AI Readability)** ➔ **Sandslash (#028)**
+- **Infras (CI/CD Powerhouse)** ➔ **Golem (#076)**
+
+### 3. Gamified Status Lifecycle
+Update definitions in `.foundry/docs/schema.md` and related dashboard UI components to map node status transitions:
+- **`PENDING` ➔ 🥚 Pokémon Egg:** Incubating, blocked by prerequisites.
+- **`READY` ➔ 🐣 Hatched:** Ready for dispatch.
+- **`ACTIVE` ➔ ⚔️ In Battle:** A Jules agent is actively working on the task.
+- **`VERIFYING` ➔ 🏆 Elite Four Challenge:** QA/Auditor evaluates the work.
+- **`COMPLETED` ➔ 🌟 Fully Evolved / Hall of Fame:** Task successfully evolved and archived.
+- **`FAILED` / `BLOCKED` ➔ 🏥 Pokémon Center:** Task failed and is sent for recovery.
+
+## Acceptance Criteria
+- [ ] Epic Planner: Break down this PRD into Epics (e.g., Schema Updates, UI Dashboard Updates, GitHub Actions Orchestrator Updates).

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -7,6 +7,7 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 1.  **Establish Context**: When you begin a session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 2.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.
 3.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
+4.  **E2E Validation Requirement**: You MUST enforce a process where every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification.
 
 ## Output
 


### PR DESCRIPTION
Converts `idea-122-pokemon-themed-foundry-personas` to `prd-122-337-pokemon-themed-foundry-personas.md` and updates the orchestrator instructions to enforce E2E verification stories in EPIC generation.

---
*PR created automatically by Jules for task [5445688615812219382](https://jules.google.com/task/5445688615812219382) started by @szubster*