### PR TITLE
Verify Gen 3 Trainer Data Extraction Implementation

### DIFF
--- a/.foundry/tasks/task-356-396-gen3-trainer-data-extraction-core-impl.md
+++ b/.foundry/tasks/task-356-396-gen3-trainer-data-extraction-core-impl.md
@@ -33,6 +33,6 @@ Implement extraction logic for Trainer ID (TID) and Secret ID (SID) from a Gen 3
 - **CRITICAL**: You MUST strictly adhere to all guidelines defined in **Section 13 ("Save File Parsing & Extraction Guidelines")** of `.foundry/docs/schema.md`.
 
 ## Acceptance Criteria
-- [ ] Coder: Update `SaveData` interface to include `secretId`.
-- [ ] Coder: Update `parseGen3Save` return object to include `secretId`.
-- [ ] Coder: Verify the implementation's exact alignment with the documentation schemas (e.g., Section 14 of `.foundry/docs/schema.md`).
+- [x] Coder: Update `SaveData` interface to include `secretId`.
+- [x] Coder: Update `parseGen3Save` return object to include `secretId`.
+- [x] Coder: Verify the implementation's exact alignment with the documentation schemas (e.g., Section 14 of `.foundry/docs/schema.md`).


### PR DESCRIPTION
Checked off acceptance criteria in `task-356-396-gen3-trainer-data-extraction-core-impl.md`. The core implementation for Gen 3 TID/SID extraction (including updating the `SaveData` interface with `secretId?: number;` and modifying the `parseGen3Save` return object to include `secretId`) was already present in the codebase prior to this task assignment. All tests pass, and the task has been verified.

---
*PR created automatically by Jules for task [14727926831459962706](https://jules.google.com/task/14727926831459962706) started by @szubster*