### PR TITLE
QA Rejection: Living Dex PC Mapping Retry Implementation

### DIFF
--- a/.foundry/journals/qa/2026-08-05-14-00-00.md
+++ b/.foundry/journals/qa/2026-08-05-14-00-00.md
@@ -1,0 +1,4 @@
+## QA Session: Living Dex PC Mapping Retry Rejection
+- **Issue**: Coder implementations consistently use inline magic numbers in `DataView` parsing functions for Gen 3 save files, specifically for bitmasking (e.g., `0xffff`), bit shifting (e.g., `16`), and nested offset additions (e.g., `+ 2`, `+ 4`).
+- **Action**: Rejected the implementation of `task-273-394-living-dex-pc-mapping-retry-impl`.
+- **Guideline Reinforcement**: All memory offsets, lengths, bit locations, shifts, and masks MUST be explicitly defined as reusable constants at the module level to comply with Section 13 of `.foundry/docs/schema.md`. Inline magic numbers in parsing functions are strictly forbidden.

--- a/.foundry/tasks/task-273-394-living-dex-pc-mapping-retry-impl.md
+++ b/.foundry/tasks/task-273-394-living-dex-pc-mapping-retry-impl.md
@@ -2,7 +2,7 @@
 id: task-273-394-living-dex-pc-mapping-retry-impl
 type: TASK
 title: Living Dex PC Mapping Retry Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-08-04'
 updated_at: '2026-08-05'
@@ -15,8 +15,8 @@ tags:
   - living-dex
   - data-mapping
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Implementation rejected due to the usage of inline magic numbers (+ 2, + 4, + 6 for offsets, 0xffff for masking, 16 for shifting) in parseGen3PCBoxes, violating Section 13 of the schema.'
 notes: ''
 ---
 
@@ -27,8 +27,8 @@ This task implements the mapping layer to identify which Pokémon the player cur
 This is a retry task generated after the permanent failure of `task-273-327-living-dex-pc-mapping-impl` due to missing Gen 3 memory offsets. Implementation MUST follow the findings from the prerequisite research node `research-273-393-gen3-pc-box-offsets-root-cause`.
 
 ## Acceptance Criteria
-- [x] Implement data mapping functions to extract PC Box and Slot locations for owned Pokémon.
-- [x] Parse PC Box data correctly according to Gen 3 architecture specifications.
+- [ ] Implement data mapping functions to extract PC Box and Slot locations for owned Pokémon.
+- [ ] Parse PC Box data correctly according to Gen 3 architecture specifications.
 
 ## Technical Blueprint
 

--- a/.foundry/tasks/task-273-395-living-dex-pc-mapping-retry-qa.md
+++ b/.foundry/tasks/task-273-395-living-dex-pc-mapping-retry-qa.md
@@ -48,3 +48,13 @@ This QA task verifies the retry implementation of the Living Dex PC Mapping laye
 - **Permanent Failures**: If you must abort or permanently fail a task, you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - **Target Rejections**: If you reject the Coder's implementation, you MUST update the **TARGET task's** YAML frontmatter (`status: FAILED`, increment `rejection_count`, add `rejection_reason`) and do not check its Acceptance Criteria. You MUST NOT modify your own QA task's YAML frontmatter; instead, note the failure in your markdown body and submit an Empty PR.
 - **Empty PR Submission**: If you submit an empty PR for a successfully completed QA task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+## QA Rejection Notes
+Implementation of `task-273-394-living-dex-pc-mapping-retry-impl` has been rejected due to violation of Section 13 ("Save File Parsing & Extraction Guidelines") in `src/engine/saveParser/parsers/gen3.ts`.
+
+Specifically, inline magic numbers were used in `parseGen3PCBoxes`:
+- `+ 2`, `+ 4`, `+ 6` for move offset calculations.
+- `0xffff` for bit masking decryption keys.
+- `16` for right-shifting decryption keys.
+
+All these values must be explicitly defined as reusable constants at the module level.


### PR DESCRIPTION
This PR records the rejection of `task-273-394-living-dex-pc-mapping-retry-impl` during QA verification.

The coder implementation violated Section 13 ("Save File Parsing & Extraction Guidelines") by utilizing inline magic numbers (`+ 2`, `+ 4`, `+ 6`, `0xffff`, `16`) directly in the `DataView` parsing functions for Gen 3 PC Box data extraction.

This empty PR applies the rejection process outlined in the QA Persona instructions:
1. Target task frontmatter updated to `status: FAILED` with a rejection reason and incremented `rejection_count`.
2. Target task acceptance criteria unchecked.
3. Rejection details appended to QA task markdown body (QA frontmatter untouched).
4. Persistent failure documented in QA persona journal.

---
*PR created automatically by Jules for task [16957350871133418927](https://jules.google.com/task/16957350871133418927) started by @szubster*