### PR TITLE
feat(foundry): implement bash static analysis linter

### DIFF
--- a/.foundry/journals/coder/9029543228350100736.md
+++ b/.foundry/journals/coder/9029543228350100736.md
@@ -1,0 +1,1 @@
+The `run_in_bash_session` tool blocks execution if the command string contains the word `exit`. To create or modify scripts containing `exit`, avoid inline bash creation (like `cat <<EOF`) and instead use `replace_with_git_merge_diff` or `write_file`.

--- a/.foundry/tasks/task-356-396-bash-static-analysis-linter-impl.md
+++ b/.foundry/tasks/task-356-396-bash-static-analysis-linter-impl.md
@@ -26,6 +26,6 @@ Implement the static analysis linter for bash sessions to proactively block know
 We need a linter or pre-execution check that detects and blocks commands known to hang indefinitely, such as `tail -f`. The goal is to fail fast before the command is passed to the shell, preventing indefinite hangs that require timeouts to catch.
 
 ## Acceptance Criteria
-- [ ] Implement a static analysis check that scans bash commands for known blocking patterns (like `tail -f`).
-- [ ] If a blocking pattern is detected, immediately return a clear error preventing execution and suggesting non-blocking alternatives.
-- [ ] Add unit tests verifying the static analysis correctly flags blocking commands and allows valid commands.
+- [x] Implement a static analysis check that scans bash commands for known blocking patterns (like `tail -f`).
+- [x] If a blocking pattern is detected, immediately return a clear error preventing execution and suggesting non-blocking alternatives.
+- [x] Add unit tests verifying the static analysis correctly flags blocking commands and allows valid commands.

--- a/scripts/safe_bash.sh
+++ b/scripts/safe_bash.sh
@@ -6,6 +6,15 @@ if [ "$#" -eq 0 ]; then
     exit 1
 fi
 
+COMMAND_STR="$*"
+
+if [[ "$COMMAND_STR" == *"tail -f"* ]]; then
+    echo "Error: Static analysis detected a known blocking command ('tail -f')." >&2
+    echo "Execution prevented to avoid infinite hangs." >&2
+    echo "Please use non-blocking alternatives like 'cat' or 'tail -n'." >&2
+    exit 1
+fi
+
 # Set a threshold of 30 seconds
 TIMEOUT_DURATION=30
 

--- a/tests/e2e/bash_timeout.spec.ts
+++ b/tests/e2e/bash_timeout.spec.ts
@@ -11,6 +11,25 @@ test.describe('Bash Timeout Wrapper E2E', () => {
     expect(result).toBe('Hello Timeout');
   });
 
+  test('should block known blocking commands before execution via static analysis', () => {
+    try {
+      execSync(`${safeBashPath} tail -f mylog.log`, { stdio: 'pipe' });
+      // If it doesn't throw, the test should fail
+      expect(true).toBe(false);
+    } catch (error: unknown) {
+      const err = error as { status?: number; stderr?: { toString: () => string } };
+      expect(err.status).toBe(1);
+      if (err.stderr) {
+        const stderr = err.stderr.toString();
+        expect(stderr).toContain("Error: Static analysis detected a known blocking command ('tail -f').");
+        expect(stderr).toContain('Execution prevented to avoid infinite hangs.');
+        expect(stderr).toContain("Please use non-blocking alternatives like 'cat' or 'tail -n'.");
+      } else {
+        expect(true).toBe(false); // Force fail if stderr is missing
+      }
+    }
+  });
+
   test('should terminate a blocking command and return exit code 124', () => {
     try {
       test.setTimeout(40000);


### PR DESCRIPTION
Implemented a bash static analysis linter for `run_in_bash_session` to proactively detect and block known infinite-blocking commands like `tail -f` before they execute and hang the agent's sandbox. Added tests to verify functionality.

---
*PR created automatically by Jules for task [9029543228350100736](https://jules.google.com/task/9029543228350100736) started by @szubster*