### PR TITLE
test: extend phase 3.6 cancelled nodes e2e

### DIFF
--- a/.foundry/journals/coder/7758135811857039899.md
+++ b/.foundry/journals/coder/7758135811857039899.md
@@ -1,0 +1,10 @@
+
+## Session 7758135811857039899 - Extend Phase 3.6 for CANCELLED nodes E2E
+
+### Task Description
+Implement e2e/integration verification to ensure Phase 3.6 logic in `foundry-orchestrator.ts` correctly awakens parent nodes for child nodes transitioning to `CANCELLED` status with `rejection_reason === 'Max rejection count reached'`.
+
+### Implementation & Results
+Added E2E test `'Phase 3.6 E2E: Lifecycle from max rejection to node cancellation and parent awakening'` which correctly sets up a parent node (`story-e2e`) and a child node (`task-e2e-1`) with `rejection_reason: "Failed a lot"` and `rejection_count: 3`. It verifies that when the orchestrator runs, `task-e2e-1` gets cancelled with `rejection_reason: '[ACKNOWLEDGED] Max rejection count reached'` and the parent is set to `READY` state.
+
+I verified all tests in `.github/scripts` using `pnpm install && npx vitest run`, and they all passed successfully. The acceptance criteria checkboxes in `.foundry/tasks/task-356-396-extend-phase-3-6-cancelled-nodes-e2e-impl.md` have been checked.

--- a/.foundry/tasks/task-356-396-extend-phase-3-6-cancelled-nodes-e2e-impl.md
+++ b/.foundry/tasks/task-356-396-extend-phase-3-6-cancelled-nodes-e2e-impl.md
@@ -34,6 +34,6 @@ Implement e2e/integration verification to ensure Phase 3.6 logic in `foundry-orc
 The coder is responsible for self-verifying this task. Document the test results in the coder journal.
 
 ## Acceptance Criteria
-- [ ] Add E2E tests in `.github/scripts/foundry-orchestrator.test.ts`
-- [ ] Verify test passes successfully
-- [ ] Document results in coder journal
+- [x] Add E2E tests in `.github/scripts/foundry-orchestrator.test.ts`
+- [x] Verify test passes successfully
+- [x] Document results in coder journal

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1532,6 +1532,36 @@ vi.doMock('node:url', async (importOriginal) => {
     expect(result).toContain('status: READY');
   });
 
+  test('Phase 3.6 E2E: Lifecycle from max rejection to node cancellation and parent awakening', () => {
+    createValidTestNode(tmpDir, '.foundry/stories/story-e2e.md', {
+      id: "story-e2e",
+      type: "STORY",
+      title: "Story E2E",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+    }, "- [ ] .foundry/tasks/task-e2e-1.md");
+
+    createValidTestNode(tmpDir, '.foundry/tasks/task-e2e-1.md', {
+      id: "task-e2e-1",
+      type: "TASK",
+      title: "Task E2E 1",
+      status: "FAILED",
+      owner_persona: "coder",
+      parent: "story-e2e",
+      rejection_reason: "Failed a lot",
+      rejection_count: 3
+    });
+
+    main();
+
+    const task1Content = fs.readFileSync(path.join(tmpDir, '.foundry/tasks/task-e2e-1.md'), 'utf-8');
+    expect(task1Content).toContain('status: CANCELLED');
+    expect(task1Content).toContain("rejection_reason: '[ACKNOWLEDGED] Max rejection count reached'");
+
+    const storyContent = fs.readFileSync(path.join(tmpDir, '.foundry/stories/story-e2e.md'), 'utf-8');
+    expect(storyContent).toContain('status: READY');
+  });
+
   test('Impossible Loop: Auto-cancels node when max rejection count is reached', async () => {
     createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
       id: "story-001",


### PR DESCRIPTION
Fixes task-356-396-extend-phase-3-6-cancelled-nodes-e2e-impl.

Adds an end-to-end integration test verifying that Phase 3.6 logic in `foundry-orchestrator.ts` correctly awakens parent nodes for child nodes transitioning to `CANCELLED` status with `rejection_reason === 'Max rejection count reached'`. The implementation was added as a new synchronous test in `.github/scripts/foundry-orchestrator.test.ts`. Acceptance criteria updated and coder journal created.

---
*PR created automatically by Jules for task [7758135811857039899](https://jules.google.com/task/7758135811857039899) started by @szubster*