### PR TITLE
Add parsing E2E story for Trainer Card

### DIFF
--- a/.foundry/epics/epic-111-400-gen3-trainer-card-data-extraction.md
+++ b/.foundry/epics/epic-111-400-gen3-trainer-card-data-extraction.md
@@ -33,4 +33,6 @@ Parse the Emerald save file to determine the status of the goals required for Tr
 - [ ] Parse Contest Master Rank flags (Cool, Beauty, Cute, Smart, Tough).
 - [ ] Parse Battle Frontier Gold Symbols flags.
 - [ ] Verify the implementation's exact alignment with the documentation schemas (e.g., Section 14 of .foundry/docs/schema.md) before marking tasks complete.
-- [ ] Create a final STORY dedicated exclusively to Integration and E2E Verification.
+- [x] Create a final STORY dedicated exclusively to Integration and E2E Verification.
+- [ ] story-400-358-gen3-trainer-card-parsing-core
+- [ ] story-400-359-gen3-trainer-card-parsing-e2e

--- a/.foundry/journals/story_owner/17094807873661096187.md
+++ b/.foundry/journals/story_owner/17094807873661096187.md
@@ -1,0 +1,3 @@
+# Session 17094807873661096187
+
+When defining acceptance criteria that refer to documentation (e.g., Section 14 of .foundry/docs/schema.md vs Section 13 for Save File Parsing Guidelines), verify the actual content of the documentation before propagating potentially incorrect section numbers to stories to prevent downstream confusion.

--- a/.foundry/stories/story-400-358-gen3-trainer-card-parsing-core.md
+++ b/.foundry/stories/story-400-358-gen3-trainer-card-parsing-core.md
@@ -1,0 +1,35 @@
+---
+id: story-400-358-gen3-trainer-card-parsing-core
+type: STORY
+title: Story - Gen 3 Trainer Card Data Parsing Core
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-05'
+updated_at: '2026-08-05'
+depends_on: []
+jules_session_id: '17094807873661096187'
+pr_number: null
+parent: epic-111-400-gen3-trainer-card-data-extraction
+tags:
+  - feature
+  - gen3
+  - achievements
+  - completionist
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Trainer Card Data Parsing Core
+
+## Description
+Implement the core parsing logic to extract the Gen 3 Trainer Card upgrade data from the save file. This includes Hall of Fame status, Pokédex catch counts, Contest Master Ranks, and Battle Frontier Gold Symbols. Ensure strict adherence to the schema guidelines.
+
+## Acceptance Criteria
+- [ ] Parse Hall of Fame flag.
+- [ ] Parse Hoenn Pokédex catch count (must be exactly 202).
+- [ ] Parse National Pokédex catch count (must be exactly 386).
+- [ ] Parse Contest Master Rank flags (Cool, Beauty, Cute, Smart, Tough).
+- [ ] Parse Battle Frontier Gold Symbols flags.
+- [ ] Verify the implementation's exact alignment with the documentation schemas (e.g., Section 13 of .foundry/docs/schema.md) before marking tasks complete.

--- a/.foundry/stories/story-400-359-gen3-trainer-card-parsing-e2e.md
+++ b/.foundry/stories/story-400-359-gen3-trainer-card-parsing-e2e.md
@@ -1,0 +1,30 @@
+---
+id: story-400-359-gen3-trainer-card-parsing-e2e
+type: STORY
+title: Story - Gen 3 Trainer Card Data Parsing E2E
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-05'
+updated_at: '2026-08-05'
+depends_on:
+  - story-400-358-gen3-trainer-card-parsing-core
+jules_session_id: '17094807873661096187'
+pr_number: null
+parent: epic-111-400-gen3-trainer-card-data-extraction
+tags:
+  - e2e
+  - integration
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Trainer Card Data Parsing E2E
+
+## Description
+Verify the complete end-to-end extraction and integration of the Gen 3 Trainer Card upgrade data parsing logic.
+
+## Acceptance Criteria
+- [ ] Write integration/E2E tests to verify Trainer Card upgrade data is properly extracted and exposed.


### PR DESCRIPTION
- Decomposed Epic `epic-111-400-gen3-trainer-card-data-extraction` by adding missing stories for core logic and integration tests.
- Replaced `- [ ] Create a final STORY dedicated exclusively to Integration and E2E Verification.` with `- [x]` in epic description.
- Created `story-400-358-gen3-trainer-card-parsing-core.md` to define core trainer card parsing logic requirements.
- Created `story-400-359-gen3-trainer-card-parsing-e2e.md` to fulfill the e2e test requirements, linking appropriately to core task.
- Documented session finding that section numbers referenced for schemas should be verified prior to creating stories to avoid propagating incorrect references in journals.

---
*PR created automatically by Jules for task [17094807873661096187](https://jules.google.com/task/17094807873661096187) started by @szubster*