### PR TITLE
Foundry: Investigate Conflict-less Journals Failure

### DIFF
--- a/.foundry/journals/researcher/17353405569114618226.md
+++ b/.foundry/journals/researcher/17353405569114618226.md
@@ -1,0 +1,5 @@
+# Session Log
+
+I investigated the permanent failure of `epic-120-338-implement-conflictless-journals`. The epic reached the max rejection count because it failed to comply with the Orchestrator Safeguard. Specifically, every EPIC must have at least one child STORY node dedicated to Integration and E2E Verification (tagged with `e2e` or `integration`) before it can transition to COMPLETED. Since `epic-120-338-implement-conflictless-journals` only had regular implementation stories without an E2E story, the orchestrator repeatedly rejected its completion attempt.
+
+The replacement epic (`epic-335-401-implement-conflictless-journals-retry`) must ensure an E2E story is created to satisfy this constraint.

--- a/.foundry/research/research-335-400-investigate-conflictless-journals-failure.md
+++ b/.foundry/research/research-335-400-investigate-conflictless-journals-failure.md
@@ -24,6 +24,11 @@ notes: ''
 Investigate the root cause of `epic-120-338-implement-conflictless-journals` reaching its max rejection count.
 
 ## Tasks
-- [ ] Analyze the rejection reasons for `epic-120-338-implement-conflictless-journals`.
-- [ ] Identify the blockers preventing the transition to conflict-less storage patterns for agent journals.
-- [ ] Propose a new approach or architecture to overcome these blockers.
+- [x] Analyze the rejection reasons for `epic-120-338-implement-conflictless-journals`.
+- [x] Identify the blockers preventing the transition to conflict-less storage patterns for agent journals.
+- [x] Propose a new approach or architecture to overcome these blockers.
+
+## Findings
+The epic `epic-120-338-implement-conflictless-journals` failed permanently and reached its max rejection count because it violated the Orchestrator Safeguard. Every EPIC node must have at least one child STORY node dedicated to Integration and E2E Verification (tagged with `e2e` or `integration`) before it can transition to `COMPLETED`. The epic lacked this E2E story, causing repeated rejections by the orchestrator upon completion attempts.
+
+To unblock the transition to conflict-less journals, the replacement epic (`epic-335-401-implement-conflictless-journals-retry`) must include a story dedicated to E2E verification of the new journal structure and TPM aggregation.


### PR DESCRIPTION
Investigated the root cause of the permanent failure of `epic-120-338-implement-conflictless-journals`. Recorded findings indicating that the epic violated the Orchestrator Safeguard by omitting an E2E testing story. Wrote the session log to `.foundry/journals/researcher/17353405569114618226.md` and checked off acceptance criteria in the task node without modifying its YAML frontmatter.

---
*PR created automatically by Jules for task [16193668753228588588](https://jules.google.com/task/16193668753228588588) started by @szubster*