### PR TITLE
chore: remove orphaned QA rule from documentation

### DIFF
--- a/.foundry/journals/coder/18086198181454023699.md
+++ b/.foundry/journals/coder/18086198181454023699.md
@@ -1,0 +1,4 @@
+# Session 18086198181454023699
+
+- Discovered that the obsolete "Orphaned QA Task Cancellation Rule" in `.foundry/docs/knowledge_base/agents/core_policies.md` had already been removed prior to this task executing.
+- Marked the acceptance criteria in `.foundry/tasks/task-333-386-remove-orphaned-qa-rule-impl.md` as checked (`- [x]`) and completed the empty PR policy, noting the absence of the target rule.

--- a/.foundry/tasks/task-333-386-remove-orphaned-qa-rule-impl.md
+++ b/.foundry/tasks/task-333-386-remove-orphaned-qa-rule-impl.md
@@ -30,4 +30,4 @@ Remove the obsolete instructions related to the "Orphaned QA Task Cancellation R
 - Locate references to the obsolete rule in `.foundry/docs/knowledge_base/agents/core_policies.md` and carefully remove the outdated instructions. Ensure the rest of the documentation flows naturally after removal.
 
 ## Acceptance Criteria
-- [ ] Coder: Remove obsolete instructions regarding the "Orphaned QA Task Cancellation Rule" from `.foundry/docs/knowledge_base/agents/core_policies.md`.
+- [x] Coder: Remove obsolete instructions regarding the "Orphaned QA Task Cancellation Rule" from `.foundry/docs/knowledge_base/agents/core_policies.md`.


### PR DESCRIPTION
This PR satisfies the `task-333-386-remove-orphaned-qa-rule-impl` task.

**Note:** The instructions to remove the "Orphaned QA Task Cancellation Rule" were already implemented in `.foundry/docs/knowledge_base/agents/core_policies.md` prior to this task executing. This PR serves to check off the acceptance criteria on the task node and submit the empty PR as directed by the Foundry's "Empty PR Policy".

---
*PR created automatically by Jules for task [18086198181454023699](https://jules.google.com/task/18086198181454023699) started by @szubster*