### PR TITLE
chore(qa): verify bash static analysis linter

### DIFF
--- a/.foundry/journals/qa/3422444418495626110.md
+++ b/.foundry/journals/qa/3422444418495626110.md
@@ -1,0 +1,3 @@
+# QA Session Journal
+
+Verified the bash static analysis linter correctly blocks `tail -f` from executing, ensuring agent processes do not hang indefinitely and preventing useless timeout waiting. It correctly handles legitimate commands such as `tail -n 50`. The e2e tests were successful and confirm the linter logic fails fast when necessary. This aligns with our core policy against executing blocking bash commands in `run_in_bash_session`.

--- a/.foundry/tasks/task-356-397-bash-static-analysis-linter-qa.md
+++ b/.foundry/tasks/task-356-397-bash-static-analysis-linter-qa.md
@@ -24,6 +24,6 @@ rejection_reason: ''
 Verify the static analysis linter for bash sessions correctly blocks known infinite-blocking commands like `tail -f` before execution.
 
 ## Acceptance Criteria
-- [ ] Verify that commands like `tail -f` are proactively blocked with a helpful error message before execution.
-- [ ] Verify that legitimate commands (e.g., `tail -n 50`) are allowed to execute normally.
-- [ ] Ensure all unit tests pass and the linter implementation does not introduce regressions.
+- [x] Verify that commands like `tail -f` are proactively blocked with a helpful error message before execution.
+- [x] Verify that legitimate commands (e.g., `tail -n 50`) are allowed to execute normally.
+- [x] Ensure all unit tests pass and the linter implementation does not introduce regressions.


### PR DESCRIPTION
This PR completes the QA verification for the bash static analysis linter. The linter correctly identifies and blocks known blocking commands (like `tail -f`) to prevent agents from unintentionally hanging their `run_in_bash_session` environments indefinitely. The implementation allows valid commands (like `tail -n`) and successfully passes its newly written Playwright e2e test suite (`tests/e2e/bash_timeout.spec.ts`).

- Verified blocking command (`tail -f`) fails with a descriptive error.
- Verified non-blocking command (`tail -n`) executes.
- E2E bash wrapper timeout tests pass successfully.
- Checked off acceptance criteria on QA task.
- Written QA session journal logging the verification.

---
*PR created automatically by Jules for task [3422444418495626110](https://jules.google.com/task/3422444418495626110) started by @szubster*