### PR TITLE
chore: mark research node as completed in story

### DIFF
--- a/.foundry/journals/tech_lead/7981547266145883253.md
+++ b/.foundry/journals/tech_lead/7981547266145883253.md
@@ -1,0 +1,8 @@
+# Tech Lead Journal Entry
+**Session ID**: 7981547266145883253
+
+## Action Taken
+- Assigned to `story-133-273-living-dex-pc-mapping` which was `READY`.
+- Verified that `research-273-393-gen3-pc-box-offsets-root-cause` is now `COMPLETED`. Checked its box in the story's Acceptance Criteria.
+- Noted that child nodes `task-273-394-living-dex-pc-mapping-retry-impl` and `task-273-395-living-dex-pc-mapping-retry-qa` are still pending.
+- Following the LATE-BINDING ORCHESTRATOR DEMOTION COMPLIANCE RULE from `.foundry/docs/knowledge_base/agents/core_policies.md`, checking off completed children and submitting an Empty PR (leaving overarching criteria unchecked) to allow the orchestrator to correctly demote the parent to PENDING while it waits for its remaining children.

--- a/.foundry/stories/story-133-273-living-dex-pc-mapping.md
+++ b/.foundry/stories/story-133-273-living-dex-pc-mapping.md
@@ -26,7 +26,7 @@ This story involves creating the mapping layer to identify which Pokémon the pl
 ## Acceptance Criteria
 - [x] task-273-327-living-dex-pc-mapping-impl
 - [x] task-273-328-living-dex-pc-mapping-qa
-- [ ] research-273-393-gen3-pc-box-offsets-root-cause
+- [x] research-273-393-gen3-pc-box-offsets-root-cause
 - [ ] task-273-394-living-dex-pc-mapping-retry-impl
 - [ ] task-273-395-living-dex-pc-mapping-retry-qa
 


### PR DESCRIPTION
The prerequisite research node `research-273-393-gen3-pc-box-offsets-root-cause` was completed. The story has pending downstream tasks drafted from a previous iteration (`task-273-394-living-dex-pc-mapping-retry-impl`, `task-273-395-living-dex-pc-mapping-retry-qa`), so submitting an Empty PR to demote the story back to PENDING.

---
*PR created automatically by Jules for task [7981547266145883253](https://jules.google.com/task/7981547266145883253) started by @szubster*