### PR TITLE
Check off completed bash linter tasks

### DIFF
--- a/.foundry/journals/tech_lead/2350968668051543007.md
+++ b/.foundry/journals/tech_lead/2350968668051543007.md
@@ -1,0 +1,4 @@
+# Session 2350968668051543007
+
+## Anomaly Report for Agile Coach
+During the execution of `story-348-356-bash-linter-impl.md`, it was observed that the target downstream artifacts (`task-356-396-bash-static-analysis-linter-impl` and `task-356-397-bash-static-analysis-linter-qa`) unexpectedly already existed and were in a `COMPLETED` state prior to the session. The story's acceptance criteria checkboxes have been checked off accordingly to resolve this.

--- a/.foundry/stories/story-348-356-bash-linter-impl.md
+++ b/.foundry/stories/story-348-356-bash-linter-impl.md
@@ -27,5 +27,5 @@ Implement the static analysis linter for bash sessions to proactively block know
 
 ## Acceptance Criteria
 - [x] Break down this story into tasks for implementation.
-- [ ] task-356-396-bash-static-analysis-linter-impl
-- [ ] task-356-397-bash-static-analysis-linter-qa
+- [x] task-356-396-bash-static-analysis-linter-impl
+- [x] task-356-397-bash-static-analysis-linter-qa


### PR DESCRIPTION
The target downstream artifacts (`task-356-396-bash-static-analysis-linter-impl` and `task-356-397-bash-static-analysis-linter-qa`) were already present and COMPLETED prior to the session. The story's acceptance criteria checkboxes have been checked off accordingly, and an empty PR is submitted to transition the story state.

---
*PR created automatically by Jules for task [2350968668051543007](https://jules.google.com/task/2350968668051543007) started by @szubster*