### PR TITLE
fix(qa): execute QA rejection for orphaned Gen 3 static encounters UI

### DIFF
--- a/.foundry/journals/qa/6263901320770891683.md
+++ b/.foundry/journals/qa/6263901320770891683.md
@@ -1,0 +1,4 @@
+# QA Journal - Session 6263901320770891683
+
+## Lesson Learned
+When implementing new dashboard components (like Gen3StaticEncountersDashboard), always verify they are actually imported and rendered in the main dashboard route (src/routes/dashboard.tsx). A component being implemented and passing tests is insufficient if it is completely orphaned from the application UI flow.

--- a/.foundry/tasks/task-295-338-gen3-static-encounters-ui-impl.md
+++ b/.foundry/tasks/task-295-338-gen3-static-encounters-ui-impl.md
@@ -2,7 +2,7 @@
 id: task-295-338-gen3-static-encounters-ui-impl
 type: TASK
 title: Gen 3 Static Encounters UI Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-20'
 updated_at: '2026-08-05'
@@ -15,8 +15,8 @@ tags:
   - feature
   - ui
 research_references: []
-rejection_count: 2
-rejection_reason: ''
+rejection_count: 3
+rejection_reason: 'QA Rejection: Component Gen3StaticEncountersDashboard is orphaned and not integrated into the central Gen 3 dashboard.'
 notes: ''
 ---
 


### PR DESCRIPTION
This PR addresses a QA validation failure where the `Gen3StaticEncountersDashboard` component was created but orphaned and never integrated into the central Gen 3 dashboard route.

Following the strict QA rejection protocol:
1. The target task (`task-295-338-gen3-static-encounters-ui-impl.md`) has been updated to `status: FAILED` in its YAML frontmatter, its `rejection_count` incremented, and a clear `rejection_reason` added. The markdown checkboxes remain unchecked.
2. The QA task (`task-295-339-gen3-static-encounters-ui-qa.md`) remains ACTIVE in its YAML frontmatter, and its markdown checkboxes remain unchecked (reverting a previous mistake).
3. A QA journal entry was written to `.foundry/journals/qa/6263901320770891683.md` to document the lesson learned regarding verifying UI component integration.

This correctly routes the target task back for remediation in the DAG.

---
*PR created automatically by Jules for task [6263901320770891683](https://jules.google.com/task/6263901320770891683) started by @szubster*