### PR TITLE
💡 Visionary: Gen 1-3 Automated Boss Level Cap Tracker

### DIFF
--- a/.foundry/ideas/idea-136-automated-boss-level-cap-tracker.md
+++ b/.foundry/ideas/idea-136-automated-boss-level-cap-tracker.md
@@ -1,0 +1,37 @@
+---
+id: idea-136-automated-boss-level-cap-tracker
+type: IDEA
+title: Automated Boss Level Cap Tracker
+status: READY
+owner_persona: product_manager
+created_at: '2026-08-06'
+updated_at: '2026-08-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - feature
+  - nuzlocke
+  - ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Automated Boss Level Cap Tracker
+
+## Context
+A ubiquitous rule in the Nuzlocke community is "Level Caps"—players restrict themselves from leveling their Pokémon higher than the ace Pokémon of the next Gym Leader or major boss fight before the battle begins. If a Pokémon accidentally exceeds this level, it is often considered unusable for that fight. Tracking this requires constantly cross-referencing external resources like wikis to check what the next boss's level cap is and diligently watching EXP gains in battle.
+
+## Proposal
+Leverage DexHelper's capability to read event flags and current party state to build an "Automated Boss Level Cap Tracker".
+- **Dynamic Progression Detection:** Parse the save file's event flags (e.g., badges earned, specific story events completed) to automatically determine the player's current progression state and identify the upcoming boss fight.
+- **Level Warning System:** Cross-reference the identified next boss's level cap against the exact EXP points of the player's current party members.
+- **UI Dashboard:** Create an overlay or dashboard that clearly displays the next boss's level cap, the player's current party levels, and visual warnings (e.g., yellow, red) when a Pokémon in the party is dangerously close to exceeding the cap.
+
+## Value Proposition
+This directly complements the existing Automated Nuzlocke Tracker (IDEA-057) by addressing another major pain point in challenge runs. By surfacing this hidden progression context and cross-referencing it with the player's current party, DexHelper eliminates the need for manual tracking and external wikis, providing significant value and peace of mind for the hardcore player base.
+
+## Acceptance Criteria
+- [ ] Product Manager: Draft a PRD defining the event flag mapping for Gen 1-3 boss progression and the UI for level cap warnings.

--- a/.jules/visionary/YYYY-MM-DD-HH-MM-SS.md
+++ b/.jules/visionary/YYYY-MM-DD-HH-MM-SS.md
@@ -1,9 +1,9 @@
 # Visionary Journal
 
-- **Active Session/Timestamp:** 2026-08-04
+- **Active Session/Timestamp:** 2026-08-06
 - **Domain:** Main Project (DexHelper)
-- **Proposed Idea:** Gen 1-3 Active Party Matchup Analyzer (IDEA-134)
+- **Proposed Idea:** Automated Boss Level Cap Tracker (IDEA-136)
 - **Rationale & Concept:**
-  As players progress through retro Pokémon games, they often hit roadblocks at major boss fights (Gym Leaders, Rivals). They may not realize their PC Box contains a perfect counter or that a TM in their inventory could solve their problem. By combining DexHelper's ability to read event flags (to know the next boss) with the player's full inventory and PC Box state, we can dynamically suggest party swaps and TM usage to optimize their team for the upcoming fight. This transforms DexHelper into an active strategic companion.
-- **How this idea maintains the 50/50 balance between DexHelper and Foundry:**
-  In the previous session, we proposed a Foundry orchestration feature (IDEA-133: Automated DAG Visualizer). To rigidly adhere to the required 50/50 strategic balance, this session pivots entirely to a direct product feature for DexHelper, aiming to improve the gameplay experience for end-users rather than optimizing the internal software factory.
+  Proposes a feature for DexHelper that reads event flags to detect the next boss fight and cross-references it with the player's party levels to warn them before exceeding Nuzlocke level caps. This addresses a major pain point for challenge runners who otherwise must manually check wikis and monitor EXP gains.
+- **Strategic Balance:**
+  In the previous session, we proposed IDEA-135 (Automated Agent A/B Testing Framework) for the Foundry Orchestrator. To strictly maintain the required 50/50 balance between product features and system improvements, this session pivots back to a direct product feature for DexHelper.


### PR DESCRIPTION
Creates a new IDEA node for an Automated Boss Level Cap Tracker to help Nuzlocke players track next boss level caps against their party. Also updates the visionary journal to document the strategic pivot to DexHelper.

---
*PR created automatically by Jules for task [13493418244730482040](https://jules.google.com/task/13493418244730482040) started by @szubster*