### PR TITLE
🎨 Palette: [Enforce tactical aesthetic for glass-card]

### DIFF
--- a/.jules/palette/YYYY-MM-DD-HH-MM-SS.md
+++ b/.jules/palette/YYYY-MM-DD-HH-MM-SS.md
@@ -1,0 +1,11 @@
+# Session Journal
+
+## Task
+Find and implement ONE micro-UX improvement that makes the interface more intuitive, accessible, or pleasant.
+
+## Action Taken
+- Identified that `.glass-card` in `src/index.css` used a solid border (`1px solid`) which violated the project's tactical hardware aesthetic (ADR 008).
+- Replaced the solid border with a dashed border (`1px dashed`) and explicitly added `border-radius: 0;` (sharp edges).
+
+## Learnings & Constraints
+- **Aesthetic Enforcement:** ADR 008 strictly dictates sharp edges (`rounded-none` or `border-radius: 0`) and dashed borders (`border-dashed` or `1px dashed`). Future styling components must ensure these patterns are followed instead of generic styling like solid borders.

--- a/src/index.css
+++ b/src/index.css
@@ -80,7 +80,8 @@ body {
 .glass-card {
   background: var(--theme-surface);
   backdrop-filter: blur(12px);
-  border: 1px solid var(--theme-border);
+  border: 1px dashed var(--theme-border);
+  border-radius: 0;
   box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
 }
 


### PR DESCRIPTION
Updated `.glass-card` in `src/index.css` to have `border: 1px dashed` and `border-radius: 0` replacing the `solid` border which violates ADR 008.

This is a micro-UX improvement that enforces the tactical hardware aesthetic.

---
*PR created automatically by Jules for task [15660542475819084697](https://jules.google.com/task/15660542475819084697) started by @szubster*