### PR TITLE
docs: check off completed child task for orphaned qa rule story

### DIFF
--- a/.foundry/stories/story-331-333-remove-orphaned-qa-rule.md
+++ b/.foundry/stories/story-331-333-remove-orphaned-qa-rule.md
@@ -29,4 +29,4 @@ This story tracks identifying and removing those obsolete instructions from `.fo
 
 ## Acceptance Criteria
 - [x] Tech Lead: Break down into Tasks
-- [ ] task-333-386-remove-orphaned-qa-rule-impl
+- [x] task-333-386-remove-orphaned-qa-rule-impl


### PR DESCRIPTION
This PR checks off the already-completed child task `task-333-386-remove-orphaned-qa-rule-impl` in the acceptance criteria of `story-331-333-remove-orphaned-qa-rule`. The target task node was already created and completed prior to this session, so no new tasks were generated. This submission adheres to the Empty PR policy to transition the parent node correctly.

---
*PR created automatically by Jules for task [9684007976102843950](https://jules.google.com/task/9684007976102843950) started by @szubster*