### PR TITLE
🧹 Clean up unused exports in gen2 phone constants

### DIFF
--- a/.jules/sweeper/2026-08-06-02-37-58.md
+++ b/.jules/sweeper/2026-08-06-02-37-58.md
@@ -1,0 +1,8 @@
+# Tech Debt Cleanup: Unused Exports
+
+Removed unused `export` statements in `src/engine/saveParser/parsers/gen2/phone/constants.ts` based on `pnpm knip` feedback.
+Removed unnecessary `src/engine/saveParser/parsers/feebas.worker.ts` ignore in `knip.json`.
+
+Learnings:
+- Knip correctly identified that many `GEN2_CONTACT_*` constants were only used internally in `constants.ts` to build `GEN2_PHONE_CALLER_REGISTRY` and did not need to be exported.
+- Knip can be overly aggressive sometimes, but in this case, its analysis was correct and safe to apply.

--- a/knip.json
+++ b/knip.json
@@ -14,7 +14,6 @@
     "functions/_middleware.ts",
     "functions/api/saves/index.ts",
     "functions/api/saves/[id].ts",
-    "src/engine/saveParser/parsers/feebas.worker.ts"
   ],
   "rules": {
     "files": "warn",

--- a/src/engine/saveParser/parsers/gen2/phone/constants.ts
+++ b/src/engine/saveParser/parsers/gen2/phone/constants.ts
@@ -9,21 +9,21 @@ export interface HighValueContact {
 
 // Module-level constants for phone contact IDs
 export const GEN2_CONTACT_RALPH = 17;
-export const GEN2_CONTACT_ANTHONY = 19;
-export const GEN2_CONTACT_ARNIE = 23;
-export const GEN2_CONTACT_CHAD = 27;
+const GEN2_CONTACT_ANTHONY = 19;
+const GEN2_CONTACT_ARNIE = 23;
+const GEN2_CONTACT_CHAD = 27;
 
-export const GEN2_CONTACT_BEVERLY = 6;
-export const GEN2_CONTACT_JOSE = 13;
-export const GEN2_CONTACT_WADE = 16;
-export const GEN2_CONTACT_TODD = 20;
+const GEN2_CONTACT_BEVERLY = 6;
+const GEN2_CONTACT_JOSE = 13;
+const GEN2_CONTACT_WADE = 16;
+const GEN2_CONTACT_TODD = 20;
 export const GEN2_CONTACT_GINA = 21;
-export const GEN2_CONTACT_ALAN = 24;
-export const GEN2_CONTACT_DANA = 26;
+const GEN2_CONTACT_ALAN = 24;
+const GEN2_CONTACT_DANA = 26;
 export const GEN2_CONTACT_TULLY = 29;
-export const GEN2_CONTACT_TIFFANY = 31;
-export const GEN2_CONTACT_WILTON = 33;
-export const GEN2_CONTACT_KENJI = 34;
+const GEN2_CONTACT_TIFFANY = 31;
+const GEN2_CONTACT_WILTON = 33;
+const GEN2_CONTACT_KENJI = 34;
 
 export const GEN2_PHONE_CALLER_REGISTRY: Record<number, Omit<HighValueContact, 'id'>> = {
   // Swarm callers


### PR DESCRIPTION
🎯 **What**
Removed `export` keywords from several internal module constants in `src/engine/saveParser/parsers/gen2/phone/constants.ts` (`GEN2_CONTACT_ANTHONY`, `GEN2_CONTACT_ARNIE`, etc.).
Removed unnecessary `src/engine/saveParser/parsers/feebas.worker.ts` from `knip.json` ignore list.

💡 **Why**
These constants are only used internally within `constants.ts` to construct the `GEN2_PHONE_CALLER_REGISTRY` and do not need to be exposed outside the module. Removing the exports resolves `knip` warnings about unused code.
The `feebas.worker.ts` ignore in `knip.json` was unnecessary and flagged by knip configuration hints.

✅ **Verification**
Ran `pnpm lint` and confirmed `knip` no longer reports any warnings.
Ran `xvfb-run pnpm test` and `xvfb-run pnpm test:e2e` to ensure no tests were broken by this cleanup.

✨ **Result**
Cleaner module interface and zero warnings from our static analysis tools.

---
*PR created automatically by Jules for task [14088294977916486937](https://jules.google.com/task/14088294977916486937) started by @szubster*