### PR TITLE
🧭 Strategist: Prompt improvement - Cleanup retired personas and centralized policies

### DIFF
--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -6,9 +6,7 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 
 1.  **Establish Context**: When you begin a session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 2.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.
-3.  **Integration Rule**: You MUST enforce a process where every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification.
 3.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
-4.  **Integration Requirement**: You MUST enforce a process where every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification.
 
 ## Output
 

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -6,7 +6,7 @@ You are the Product Manager. Your primary responsibility is transforming IDEA ->
 
 ## Core Directives
 
-- When a target Foundry artifact (such as a downstream PRD or generated node file) unexpectedly exists prior to the session, create a small journal entry detailing the anomaly for the Agile Coach to review later.
+- When a target Foundry artifact (such as a downstream PRD or generated node file) unexpectedly exists prior to the session, create a small journal entry detailing the anomaly for later review.
 
 ## Journal
 

--- a/.jules/strategist/2026-08-06-04-18-00.md
+++ b/.jules/strategist/2026-08-06-04-18-00.md
@@ -1,0 +1,5 @@
+## 2026-08-06 - [Accepted] - Prompt improvement - Cleanup retired personas and centralized policies
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `product_manager` schedule had a reference to the `Agile Coach` persona which has been retired. The `epic_planner` schedule had duplicated `Integration Rule` and `Integration Requirement` directives which have been centralized to `core_policies.md`.
+**Pattern:** Regularly scrub agent schedules to remove references to retired personas and eliminate duplicate directives that are centralized in `core_policies.md` to keep prompts concise.


### PR DESCRIPTION
## Proposal
Remove references to retired personas and eliminate duplicate directives that are now centralized in `core_policies.md`.

## Justification
- The `Agile Coach` persona has been retired and references to it in `.github/agents/product_manager.md` are obsolete and confusing.
- The `Integration Rule` and `Integration Requirement` directives in `.github/agents/epic_planner.md` are redundant since they are now enforced globally via `core_policies.md`. Consolidating this reduces context window usage and ensures all agents operate from a single source of truth.

## Evidence
A previous session (`2026-08-05 - [Accepted] - Prompt improvement - Centralize E2E Orchestrator Safeguard`) centralized the E2E Orchestrator Safeguard into `core_policies.md`. The `epic_planner.md` still contained duplicated language. Additionally, searches confirmed that `agile_coach` is no longer a valid agent file in `.github/agents/`.

---
*PR created automatically by Jules for task [7563187091049265178](https://jules.google.com/task/7563187091049265178) started by @szubster*