### PR TITLE
Break down In-Game Trade Data Extraction v2 Epic into Stories

### DIFF
--- a/.foundry/epics/epic-056-349-in-game-trade-data-extraction-v2.md
+++ b/.foundry/epics/epic-056-349-in-game-trade-data-extraction-v2.md
@@ -35,5 +35,8 @@ Implement and standardize the extraction of in-game NPC trade completion flags f
 - [ ] Gen 3 NPC trade flags are identified and extracted for all core versions.
 - [ ] The `npcTradeFlags` field in `SaveData` is consistently populated across both generations.
 - [ ] All parsing logic strictly adheres to the `DataView` API and handles `RangeError` for corrupted saves.
-- [ ] Story Owner: Break down this Epic into executable Stories.
-- [ ] Story Owner: Generate a final STORY dedicated exclusively to Integration and E2E Verification.
+- [x] Story Owner: Break down this Epic into executable Stories.
+- [x] Story Owner: Generate a final STORY dedicated exclusively to Integration and E2E Verification.
+- [ ] story-349-361-gen2-trade-extraction
+- [ ] story-349-362-gen3-trade-extraction
+- [ ] story-349-363-trade-extraction-e2e

--- a/.foundry/stories/story-349-361-gen2-trade-extraction.md
+++ b/.foundry/stories/story-349-361-gen2-trade-extraction.md
@@ -1,0 +1,30 @@
+---
+id: story-349-361-gen2-trade-extraction
+type: STORY
+title: Gen 2 NPC Trade Extraction
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-06'
+updated_at: '2026-08-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-056-349-in-game-trade-data-extraction-v2
+tags:
+  - feature
+  - backend
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Story: Gen 2 NPC Trade Extraction
+
+## Objective
+Implement extraction of in-game NPC trade completion flags from Generation 2 save files.
+
+## Acceptance Criteria
+- [ ] Gen 2 NPC trade flags are accurately extracted and mapped.
+- [ ] Parsing logic strictly adheres to the `DataView` API and handles `RangeError` for corrupted saves.
+- [ ] Tech Lead: Break down this Story into executable Tasks.

--- a/.foundry/stories/story-349-362-gen3-trade-extraction.md
+++ b/.foundry/stories/story-349-362-gen3-trade-extraction.md
@@ -1,0 +1,31 @@
+---
+id: story-349-362-gen3-trade-extraction
+type: STORY
+title: Gen 3 NPC Trade Extraction
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-06'
+updated_at: '2026-08-06'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-056-349-in-game-trade-data-extraction-v2
+tags:
+  - feature
+  - backend
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Story: Gen 3 NPC Trade Extraction
+
+## Objective
+Implement extraction of in-game NPC trade completion flags from Generation 3 (RSE, FRLG) save files.
+
+## Acceptance Criteria
+- [ ] Gen 3 NPC trade flags are identified and extracted for all core versions.
+- [ ] The `npcTradeFlags` field in `SaveData` is consistently populated.
+- [ ] Parsing logic strictly adheres to the `DataView` API and handles `RangeError` for corrupted saves.
+- [ ] Tech Lead: Break down this Story into executable Tasks.

--- a/.foundry/stories/story-349-363-trade-extraction-e2e.md
+++ b/.foundry/stories/story-349-363-trade-extraction-e2e.md
@@ -1,0 +1,32 @@
+---
+id: story-349-363-trade-extraction-e2e
+type: STORY
+title: NPC Trade Extraction Integration & E2E
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-06'
+updated_at: '2026-08-06'
+depends_on:
+  - story-349-361-gen2-trade-extraction
+  - story-349-362-gen3-trade-extraction
+jules_session_id: null
+pr_number: null
+parent: epic-056-349-in-game-trade-data-extraction-v2
+tags:
+  - feature
+  - backend
+  - save-parsing
+  - e2e
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Story: NPC Trade Extraction Integration & E2E
+
+## Objective
+Verify the end-to-end integration of NPC trade flag extraction for Generation 2 and Generation 3 save files.
+
+## Acceptance Criteria
+- [ ] Ensure end-to-end extraction works for both generations.
+- [ ] Tech Lead: Break down this Story into executable Tasks.


### PR DESCRIPTION
- Decomposed `epic-056-349-in-game-trade-data-extraction-v2` into three stories.
- Created `story-349-361-gen2-trade-extraction` for Gen 2 NPC trade flags.
- Created `story-349-362-gen3-trade-extraction` for Gen 3 NPC trade flags.
- Created `story-349-363-trade-extraction-e2e` for E2E Integration and verification, which depends on the previous two stories.
- Updated Epic's `epic-056-349-in-game-trade-data-extraction-v2.md` body to check off acceptance criteria and append unchecked boxes for the new stories.
- Checked and passed `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [15592042785956533773](https://jules.google.com/task/15592042785956533773) started by @szubster*