### PR TITLE
Tech Lead: Verify and transition completed story

### DIFF
--- a/.foundry/stories/story-340-356-extend-phase-3-6-cancelled-nodes-e2e.md
+++ b/.foundry/stories/story-340-356-extend-phase-3-6-cancelled-nodes-e2e.md
@@ -33,4 +33,4 @@ Implement e2e/integration verification to ensure Phase 3.6 logic in `foundry-orc
 
 ## Acceptance Criteria
 - [x] Break down into Tasks
-- [ ] .foundry/tasks/task-356-396-extend-phase-3-6-cancelled-nodes-e2e-impl.md
+- [x] .foundry/tasks/task-356-396-extend-phase-3-6-cancelled-nodes-e2e-impl.md


### PR DESCRIPTION
This is an empty PR handoff. The implementation for the e2e tests was already present and completed in a previous step, so the only change here is checking off the acceptance criteria for `task-356-396-extend-phase-3-6-cancelled-nodes-e2e-impl.md` in `.foundry/stories/story-340-356-extend-phase-3-6-cancelled-nodes-e2e.md` to trigger the Orchestrator transition and satisfy ADR 007. No code changes were needed.

---
*PR created automatically by Jules for task [11867957388287768324](https://jules.google.com/task/11867957388287768324) started by @szubster*