### PR TITLE
Epic Planner: Break down Move Tutor Availability Dashboard PRD

### DIFF
--- a/.foundry/epics/epic-055-405-gen3-move-tutor-save-parsing.md
+++ b/.foundry/epics/epic-055-405-gen3-move-tutor-save-parsing.md
@@ -1,0 +1,30 @@
+---
+id: epic-055-405-gen3-move-tutor-save-parsing
+type: EPIC
+title: "Gen 3 Move Tutor Save Parsing Engine"
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-08-06"
+updated_at: "2026-08-06"
+depends_on:
+  - research-055-404-gen3-move-tutor-offsets
+jules_session_id: null
+pr_number: null
+parent: prd-094-055-move-tutor-tracker
+tags: ["gen3", "move-tutor", "save-parsing"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen 3 Move Tutor Save Parsing Engine
+
+Parse Gen 3 save files to read specific event flags associated with one-time Move Tutors. Utilize the DataView API as mandated by ADR 010.
+
+## Integration & E2E Requirements
+This epic MUST generate a final STORY dedicated exclusively to Integration and E2E Verification.
+
+## Acceptance Criteria
+- [ ] Move Tutor flags are correctly parsed from Emerald and FireRed/LeafGreen save files using DataView.
+- [ ] DataView API RangeErrors are caught and handled gracefully (ADR 010).

--- a/.foundry/epics/epic-055-406-gen3-move-tutor-compatibility.md
+++ b/.foundry/epics/epic-055-406-gen3-move-tutor-compatibility.md
@@ -1,0 +1,30 @@
+---
+id: epic-055-406-gen3-move-tutor-compatibility
+type: EPIC
+title: "Gen 3 Move Tutor Compatibility Cross-Referencing"
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-08-06"
+updated_at: "2026-08-06"
+depends_on:
+  - epic-055-405-gen3-move-tutor-save-parsing
+jules_session_id: null
+pr_number: null
+parent: prd-094-055-move-tutor-tracker
+tags: ["gen3", "move-tutor", "compatibility"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen 3 Move Tutor Compatibility Cross-Referencing
+
+Cross-reference the move's compatibility matrix with the Pokémon currently stored in the player's PC boxes (and Party). Leverage the existing PokeData MsgPack architecture (ADR 015) for move compatibility data.
+
+## Integration & E2E Requirements
+This epic MUST generate a final STORY dedicated exclusively to Integration and E2E Verification.
+
+## Acceptance Criteria
+- [ ] For each available tutor, identify the specific move taught.
+- [ ] Identify compatible Pokémon from the player's save file (PC/Party) relying on the MsgPack PokeData system.

--- a/.foundry/epics/epic-055-407-gen3-move-tutor-dashboard-ui.md
+++ b/.foundry/epics/epic-055-407-gen3-move-tutor-dashboard-ui.md
@@ -1,0 +1,30 @@
+---
+id: epic-055-407-gen3-move-tutor-dashboard-ui
+type: EPIC
+title: "Gen 3 Move Tutor Dashboard UI"
+status: PENDING
+owner_persona: "story_owner"
+created_at: "2026-08-06"
+updated_at: "2026-08-06"
+depends_on:
+  - epic-055-406-gen3-move-tutor-compatibility
+jules_session_id: null
+pr_number: null
+parent: prd-094-055-move-tutor-tracker
+tags: ["gen3", "move-tutor", "ui"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Gen 3 Move Tutor Dashboard UI
+
+Create a dedicated dashboard view for Move Tutors. Display a list of all one-time Move Tutors, distinguishing between "Available" and "Used" tutors based on save file flags. Visually adhere to the tactical hardware/snooping aesthetic (ADR 008).
+
+## Integration & E2E Requirements
+This epic MUST generate a final STORY dedicated exclusively to Integration and E2E Verification.
+
+## Acceptance Criteria
+- [ ] Dashboard UI displays available and used Move Tutors clearly, adhering to the tactical aesthetic (sharp edges, dashed borders, monospaced telemetry fonts).
+- [ ] A list of compatible Pokémon from the player's save file (PC/Party) is displayed for each available tutor.

--- a/.foundry/journals/epic_planner/13331266722467107063.md
+++ b/.foundry/journals/epic_planner/13331266722467107063.md
@@ -1,0 +1,12 @@
+## 13331266722467107063
+
+Started session as Epic Planner to break down PRD `prd-094-055-move-tutor-tracker` into actionable Epics.
+
+Read core policies.
+Checked sequence number for epics. Next available sequence number is 404.
+
+Need to create the following child nodes (as indicated by the PRD's Generated Epics list, though I should create the files with actual sequence numbers and update the PRD checkboxes to match):
+- research-055-404-gen3-move-tutor-offsets
+- epic-055-405-gen3-move-tutor-save-parsing
+- epic-055-406-gen3-move-tutor-compatibility
+- epic-055-407-gen3-move-tutor-dashboard-ui

--- a/.foundry/prds/prd-094-055-move-tutor-tracker.md
+++ b/.foundry/prds/prd-094-055-move-tutor-tracker.md
@@ -73,7 +73,7 @@ In Gen 3 games (FireRed/LeafGreen, Emerald), one-time Move Tutors are scattered 
 
 ## Generated Epics
 <!-- Append generated child EPIC nodes here as unchecked checkboxes -->
-- [ ] research-055-247-gen3-move-tutor-offsets
-- [ ] epic-055-119-gen3-move-tutor-save-parsing
-- [ ] epic-055-120-gen3-move-tutor-compatibility
-- [ ] epic-055-121-gen3-move-tutor-dashboard-ui
+- [ ] research-055-404-gen3-move-tutor-offsets
+- [ ] epic-055-405-gen3-move-tutor-save-parsing
+- [ ] epic-055-406-gen3-move-tutor-compatibility
+- [ ] epic-055-407-gen3-move-tutor-dashboard-ui

--- a/.foundry/tasks/research-055-404-gen3-move-tutor-offsets.md
+++ b/.foundry/tasks/research-055-404-gen3-move-tutor-offsets.md
@@ -1,0 +1,22 @@
+---
+id: research-055-404-gen3-move-tutor-offsets
+type: RESEARCH
+title: "Research Gen 3 Move Tutor Memory Offsets"
+status: PENDING
+owner_persona: "researcher"
+created_at: "2026-08-06"
+updated_at: "2026-08-06"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-094-055-move-tutor-tracker
+tags: ["gen3", "move-tutor", "research"]
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Research Gen 3 Move Tutor Memory Offsets
+
+Identify memory offsets and event flag IDs for Move Tutors in Gen 3 games (Emerald and FireRed/LeafGreen).


### PR DESCRIPTION
Generated the required EPIC and RESEARCH nodes for the Gen 3 Move Tutor Availability Dashboard based on PRD-094-055-move-tutor-tracker. Updated the PRD's Generated Epics checklist with the concrete node IDs. Added `## Integration & E2E Requirements` blocks to each EPIC.

---
*PR created automatically by Jules for task [13331266722467107063](https://jules.google.com/task/13331266722467107063) started by @szubster*