### PR TITLE
feat(epic-planner): Draft epics for Gen 2 Kurt Apricorn tracker

### DIFF
--- a/.foundry/epics/epic-338-404-kurt-apricorn-data-engine.md
+++ b/.foundry/epics/epic-338-404-kurt-apricorn-data-engine.md
@@ -1,0 +1,33 @@
+---
+id: epic-338-404-kurt-apricorn-data-engine
+type: EPIC
+title: Gen 2 Kurt Apricorn Data Parsing Engine
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-08-06"
+updated_at: "2026-08-06"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-121-338-gen2-kurt-apricorn-tracker
+tags:
+  - gen2
+  - items
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+# Gen 2 Kurt Apricorn Data Parsing Engine
+
+## Context
+As defined in PRD `prd-121-338-gen2-kurt-apricorn-tracker`, we need to track Kurt's Apricorn crafting state in Generation 2 games. This involves parsing the save file to determine the type and quantity of Apricorns given to Kurt and tracking the active order.
+
+## Objectives
+- Extract the memory offset corresponding to Kurt's active Apricorn crafting state.
+- Parse the extracted byte data to identify the Apricorn type and resulting Poké Ball.
+- Extract the quantity of Apricorns currently in Kurt's possession.
+- Extract the timestamp or active day flag for when the crafting was initiated.
+
+## Acceptance Criteria
+- [ ] story_owner: Break this EPIC down into actionable STORY nodes.
+- [ ] story_owner: Generate a final STORY dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`).

--- a/.foundry/epics/epic-338-405-kurt-apricorn-dashboard-ui.md
+++ b/.foundry/epics/epic-338-405-kurt-apricorn-dashboard-ui.md
@@ -1,0 +1,34 @@
+---
+id: epic-338-405-kurt-apricorn-dashboard-ui
+type: EPIC
+title: Gen 2 Kurt Apricorn Dashboard UI
+status: PENDING
+owner_persona: story_owner
+created_at: "2026-08-06"
+updated_at: "2026-08-06"
+depends_on:
+  - "epic-338-404-kurt-apricorn-data-engine"
+jules_session_id: null
+pr_number: null
+parent: prd-121-338-gen2-kurt-apricorn-tracker
+tags:
+  - gen2
+  - ui
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+# Gen 2 Kurt Apricorn Dashboard UI
+
+## Context
+As defined in PRD `prd-121-338-gen2-kurt-apricorn-tracker`, the UI layer must display the state of Kurt's Apricorn crafting process. This includes showing active orders, providing ready-for-pickup notifications based on the system clock, and tallying Apricorn resources.
+
+## Objectives
+- Implement an Active Order Tracker component to show what type of Apricorn was given, the expected Poké Ball, and the quantity.
+- Implement a notification component that checks the crafting state against the system clock to alert when the balls are ready for pickup.
+- Implement a Resource Dashboard comparing uncrafted Apricorns in the bag to those currently with Kurt.
+- Ensure strict adherence to ADR 008 (tactical UI aesthetic: sharp edges, dashed borders, monospace fonts).
+
+## Acceptance Criteria
+- [ ] story_owner: Break this EPIC down into actionable STORY nodes.
+- [ ] story_owner: Generate a final STORY dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`).

--- a/.foundry/journals/epic_planner/10078134061899292064.md
+++ b/.foundry/journals/epic_planner/10078134061899292064.md
@@ -1,0 +1,11 @@
+# Epic Planner Session: 10078134061899292064
+
+**Task:** PRD Breakdown (`prd-121-338-gen2-kurt-apricorn-tracker`)
+
+**Breakdown Strategy:**
+- Separated the feature into two distinct epics:
+  1. Data Engine (`epic-338-404-kurt-apricorn-data-engine`): Focuses purely on save file parsing, offset extraction, and crafting state.
+  2. UI Layer (`epic-338-405-kurt-apricorn-dashboard-ui`): Depends on the data engine and handles presentation according to ADR 008.
+
+**Lessons Learned / Course Corrections:**
+- Enforced the orchestrator safeguard (E2E/Integration Requirement) correctly by adding it as an explicit acceptance criteria to *each* epic, delegating the generation of the E2E story node to the `story_owner`, rather than incorrectly attempting to create a standalone E2E epic myself.

--- a/.foundry/prds/prd-121-338-gen2-kurt-apricorn-tracker.md
+++ b/.foundry/prds/prd-121-338-gen2-kurt-apricorn-tracker.md
@@ -31,4 +31,6 @@ Leverage DexHelper's save file parsing to track the hidden event flags related t
 - **Resource Dashboard:** Show a quick tally of uncrafted Apricorns currently in the player's bag vs. what is currently with Kurt.
 
 ## Acceptance Criteria
-- [ ] epic_planner: Break this PRD down into actionable Epics.
+- [x] epic_planner: Break this PRD down into actionable Epics.
+- [ ] epic-338-404-kurt-apricorn-data-engine
+- [ ] epic-338-405-kurt-apricorn-dashboard-ui


### PR DESCRIPTION
This PR drafts two epics from PRD `prd-121-338-gen2-kurt-apricorn-tracker`:
1. `epic-338-404-kurt-apricorn-data-engine` (Data Engine)
2. `epic-338-405-kurt-apricorn-dashboard-ui` (UI Layer)

Each epic contains explicit instructions for the `story_owner` to generate an E2E Integration story to satisfy the Orchestrator safeguard. The PRD's acceptance criteria are marked complete and the new child nodes are appended as unchecked tasks.

---
*PR created automatically by Jules for task [10078134061899292064](https://jules.google.com/task/10078134061899292064) started by @szubster*