### PR TITLE
Auditor: reject idea-107-pokerus-strain-ui-tracker

### DIFF
--- a/.foundry/ideas/idea-107-pokerus-strain-ui-tracker.md
+++ b/.foundry/ideas/idea-107-pokerus-strain-ui-tracker.md
@@ -26,4 +26,7 @@ With the standardization of bitwise extraction for Pokerus (`parsePokerus` in `c
 
 ## Acceptance Criteria
 - [x] Product Manager: Convert this idea into a PRD.
-- [x] prd-107-112-pokerus-strain-ui-tracker
+- [ ] prd-107-112-pokerus-strain-ui-tracker
+
+### Auditor Rejection
+The PRD and its descendant epics (epic-112-322-pokerus-strain-ui-detail-view, epic-112-323-pokerus-strain-ui-grid-view, and epic-112-335-pokerus-strain-ui-detail-view-v2) were CANCELLED. Therefore, the functional requirements for this idea have not been implemented. Sending back to trigger the Resurrection Loop.

--- a/.foundry/journals/auditor/YYYY-MM-DD-HH-MM-SS.md
+++ b/.foundry/journals/auditor/YYYY-MM-DD-HH-MM-SS.md
@@ -8,3 +8,11 @@ The epic for the bash timeout wrapper has been successfully completed. The imple
 Node is verified and will be submitted via an empty PR.# Session YYYY-MM-DD-HH-MM-SS
 
 Macro nodes (like PRDs) must not be verified until all descendant nodes are fully completed. In this case, the epic child was FAILED, so the PRD verification was rejected.
+
+# Session 2026-08-06 (idea-107-pokerus-strain-ui-tracker)
+
+Verified `idea-107-pokerus-strain-ui-tracker`. The target PRD (`prd-107-112-pokerus-strain-ui-tracker`) and its descendant epics (`epic-112-322-pokerus-strain-ui-detail-view`, `epic-112-323-pokerus-strain-ui-grid-view`, and `epic-112-335-pokerus-strain-ui-detail-view-v2`) were all permanently cancelled. Therefore, the overarching functional requirements of this idea were not actually implemented.
+
+Rejected the verification. Unchecked the acceptance criteria for the PRD and added an `### Auditor Rejection` section in the markdown body explaining the failure to send it back to the resurrection loop.
+
+**Learnings**: Do not blindly pass macro nodes (IDEA, PRD, EPIC) if their underlying functional implementations were ultimately aborted or cancelled downstream. Always verify the full chain of descendants.


### PR DESCRIPTION
Reject IDEA because descendant epics were cancelled and the feature is not implemented.

---
*PR created automatically by Jules for task [235985108815209509](https://jules.google.com/task/235985108815209509) started by @szubster*