### PR TITLE
Update epic-108-340-extend-phase-3-6-cancelled-nodes-retry acceptance criteria

### DIFF
--- a/.foundry/epics/epic-108-340-extend-phase-3-6-cancelled-nodes-retry.md
+++ b/.foundry/epics/epic-108-340-extend-phase-3-6-cancelled-nodes-retry.md
@@ -39,4 +39,4 @@ In `foundry-orchestrator.ts` Phase 3.6, nodes transitioning to `CANCELLED` statu
 ## Acceptance Criteria
 - [x] Break down into Stories
 - [x] [.foundry/stories/story-340-346-extend-phase-3-6-cancelled-nodes.md](.foundry/stories/story-340-346-extend-phase-3-6-cancelled-nodes.md)
-- [ ] story-340-356-extend-phase-3-6-cancelled-nodes-e2e
+- [x] story-340-356-extend-phase-3-6-cancelled-nodes-e2e


### PR DESCRIPTION
Check off completed E2E story story-340-356-extend-phase-3-6-cancelled-nodes-e2e to mark this epic as ready for verification.

---
*PR created automatically by Jules for task [12397904483976699549](https://jules.google.com/task/12397904483976699549) started by @szubster*