### PR TITLE
feat: Implement Gen 3 Trainer Defeat Flags Extraction

### DIFF
--- a/.foundry/tasks/task-319-322-gen3-trainer-flags-extraction-impl.md
+++ b/.foundry/tasks/task-319-322-gen3-trainer-flags-extraction-impl.md
@@ -32,11 +32,11 @@ Implement the logic to extract standard and rematch trainer defeat flags from Ge
 5. **Data Structure:** The extracted flags must be structured correctly for use in the UI.
 
 ## Acceptance Criteria
-- [ ] Implement `DataView` parsing for standard trainer defeat flags.
-- [ ] Implement `DataView` parsing for rematch trainer defeat flags.
-- [ ] Ensure all offsets and bit shifts are module-level constants.
-- [ ] Ensure A/B bank relative offset logic is used.
-- [ ] Add unit tests covering extraction logic (including absolute zero and boundary states per ADR 026).
+ - [x] Implement `DataView` parsing for standard trainer defeat flags.
+ - [x] Implement `DataView` parsing for rematch trainer defeat flags.
+ - [x] Ensure all offsets and bit shifts are module-level constants.
+ - [x] Ensure A/B bank relative offset logic is used.
+ - [x] Add unit tests covering extraction logic (including absolute zero and boundary states per ADR 026).
 
 ## Node Handling Policies
 - **Transient Failures:** If you experience a transient failure requiring retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
@@ -44,4 +44,4 @@ Implement the logic to extract standard and rematch trainer defeat flags from Ge
 - **Empty PR Submission:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting. Do not manually update the status.
 
 ## Late Binding Dependencies
-- [ ] research-322-396-gen3-trainer-defeat-flags-offsets
+ - [x] research-322-396-gen3-trainer-defeat-flags-offsets

--- a/fix_test.js
+++ b/fix_test.js
@@ -1,5 +1,0 @@
-import fs from 'fs';
-const testPath = 'src/engine/saveParser/gen3/trainerFlags/parser.test.ts';
-let code = fs.readFileSync(testPath, 'utf-8');
-code = code.replace(/const buffer = new ArrayBuffer\(4000\);/, 'const buffer = new ArrayBuffer(5000);');
-fs.writeFileSync(testPath, code);

--- a/fix_test.js
+++ b/fix_test.js
@@ -1,0 +1,5 @@
+import fs from 'fs';
+const testPath = 'src/engine/saveParser/gen3/trainerFlags/parser.test.ts';
+let code = fs.readFileSync(testPath, 'utf-8');
+code = code.replace(/const buffer = new ArrayBuffer\(4000\);/, 'const buffer = new ArrayBuffer(5000);');
+fs.writeFileSync(testPath, code);

--- a/src/engine/saveParser/gen3/trainerFlags/parser.test.ts
+++ b/src/engine/saveParser/gen3/trainerFlags/parser.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FRLG_FLAGS_OFFSET,
+  parseGen3TrainerDefeatFlags,
+  parseGen3TrainerRematchFlags,
+  REMATCH_OFFSET_E,
+  REMATCH_OFFSET_FRLG,
+  REMATCH_OFFSET_RS,
+  RSE_FLAGS_OFFSET_E,
+  RSE_FLAGS_OFFSET_RS,
+  TRAINER_FLAGS_BYTE_OFFSET,
+} from './parser';
+
+describe('Gen 3 Trainer Flags Parser', () => {
+  describe('parseGen3TrainerDefeatFlags', () => {
+    it('correctly parses trainer defeat flags for Emerald', () => {
+      const buffer = new ArrayBuffer(5000);
+      const view = new DataView(buffer);
+      const saveBlock1Offset = 0;
+
+      const startOffset = saveBlock1Offset + RSE_FLAGS_OFFSET_E + TRAINER_FLAGS_BYTE_OFFSET;
+
+      view.setUint8(startOffset, 0b00000101); // 5
+      view.setUint8(startOffset + 107, 0b10000000); // 128
+
+      const flags = parseGen3TrainerDefeatFlags(view, saveBlock1Offset, 'emerald');
+
+      expect(flags.length).toBe(864);
+      expect(flags[0]).toBe(true);
+      expect(flags[1]).toBe(false);
+      expect(flags[2]).toBe(true);
+      expect(flags[863]).toBe(true);
+    });
+
+    it('correctly parses trainer defeat flags for Ruby/Sapphire', () => {
+      const buffer = new ArrayBuffer(5000);
+      const view = new DataView(buffer);
+      const saveBlock1Offset = 0;
+
+      const startOffset = saveBlock1Offset + RSE_FLAGS_OFFSET_RS + TRAINER_FLAGS_BYTE_OFFSET;
+
+      view.setUint8(startOffset, 0b00000001);
+
+      const flags = parseGen3TrainerDefeatFlags(view, saveBlock1Offset, 'ruby');
+
+      expect(flags.length).toBe(693);
+      expect(flags[0]).toBe(true);
+      expect(flags[1]).toBe(false);
+    });
+
+    it('correctly parses trainer defeat flags for FRLG', () => {
+      const buffer = new ArrayBuffer(5000);
+      const view = new DataView(buffer);
+      const saveBlock1Offset = 0;
+
+      const startOffset = saveBlock1Offset + FRLG_FLAGS_OFFSET + TRAINER_FLAGS_BYTE_OFFSET;
+
+      view.setUint8(startOffset, 0b00000010); // Trainer 1 -> 1
+
+      const flags = parseGen3TrainerDefeatFlags(view, saveBlock1Offset, 'firered');
+
+      expect(flags.length).toBe(768);
+      expect(flags[0]).toBe(false);
+      expect(flags[1]).toBe(true);
+    });
+
+    it('throws custom error on out-of-bounds read (boundary test)', () => {
+      const buffer = new ArrayBuffer(10); // Too small
+      const view = new DataView(buffer);
+      const saveBlock1Offset = 0;
+
+      expect(() => {
+        parseGen3TrainerDefeatFlags(view, saveBlock1Offset, 'emerald');
+      }).toThrow('The save file is corrupted or incomplete.');
+    });
+  });
+
+  describe('parseGen3TrainerRematchFlags', () => {
+    it('correctly parses rematch flags for Emerald', () => {
+      const buffer = new ArrayBuffer(3000);
+      const view = new DataView(buffer);
+      const saveBlock1Offset = 0;
+
+      const startOffset = saveBlock1Offset + REMATCH_OFFSET_E;
+      view.setUint8(startOffset, 5); // Entry 0
+      view.setUint8(startOffset + 99, 12); // Entry 99
+
+      const flags = parseGen3TrainerRematchFlags(view, saveBlock1Offset, 'emerald');
+
+      expect(flags.length).toBe(100);
+      expect(flags[0]).toBe(5);
+      expect(flags[99]).toBe(12);
+    });
+
+    it('correctly parses rematch flags for RS', () => {
+      const buffer = new ArrayBuffer(3000);
+      const view = new DataView(buffer);
+      const saveBlock1Offset = 0;
+
+      const startOffset = saveBlock1Offset + REMATCH_OFFSET_RS;
+      view.setUint8(startOffset, 3); // Entry 0
+
+      const flags = parseGen3TrainerRematchFlags(view, saveBlock1Offset, 'sapphire');
+
+      expect(flags.length).toBe(100);
+      expect(flags[0]).toBe(3);
+    });
+
+    it('correctly parses rematch flags for FRLG', () => {
+      const buffer = new ArrayBuffer(3000);
+      const view = new DataView(buffer);
+      const saveBlock1Offset = 0;
+
+      const startOffset = saveBlock1Offset + REMATCH_OFFSET_FRLG;
+      view.setUint8(startOffset, 8); // Entry 0
+
+      const flags = parseGen3TrainerRematchFlags(view, saveBlock1Offset, 'leafgreen');
+
+      expect(flags.length).toBe(100);
+      expect(flags[0]).toBe(8);
+    });
+
+    it('throws custom error on out-of-bounds read', () => {
+      const buffer = new ArrayBuffer(10); // Too small
+      const view = new DataView(buffer);
+      const saveBlock1Offset = 0;
+
+      expect(() => {
+        parseGen3TrainerRematchFlags(view, saveBlock1Offset, 'firered');
+      }).toThrow('The save file is corrupted or incomplete.');
+    });
+  });
+});

--- a/src/engine/saveParser/gen3/trainerFlags/parser.ts
+++ b/src/engine/saveParser/gen3/trainerFlags/parser.ts
@@ -1,0 +1,116 @@
+/**
+ * Gen 3 Trainer Defeat Flags and Rematch Flags Parser
+ */
+
+// --- Module-Level Constants ---
+
+// Game-specific offset for `flags` array in SaveBlock1
+export const RSE_FLAGS_OFFSET_E = 0x1270;
+export const RSE_FLAGS_OFFSET_RS = 0x1220;
+export const FRLG_FLAGS_OFFSET = 0x0ee0;
+
+// Logical ID start inside flags array
+export const TRAINER_FLAGS_START = 0x500;
+// Since flags start at 0x500 and 1 flag = 1 bit (8 per byte):
+export const TRAINER_FLAGS_BYTE_OFFSET = 0xa0; // (160)
+
+// Max standard trainers per game
+export const MAX_TRAINERS_EMERALD = 864;
+export const MAX_TRAINERS_RS = 693;
+export const MAX_TRAINERS_FRLG = 768;
+
+// Rematch array (trainerRematches) game-specific offset in SaveBlock1
+export const REMATCH_OFFSET_E = 0x09ca;
+export const REMATCH_OFFSET_RS = 0x097a;
+export const REMATCH_OFFSET_FRLG = 0x063a;
+
+// Size of the trainerRematches array
+export const MAX_REMATCH_ENTRIES = 100;
+
+export const BITS_PER_BYTE = 8;
+export const BIT_MASK = 1;
+
+/**
+ * Parses the standard trainer defeat flags from a Gen 3 save file.
+ * Returns an array of booleans indicating whether each trainer index has been defeated.
+ *
+ * @param view - The DataView of the save file.
+ * @param saveBlock1Offset - The absolute offset of SaveBlock1.
+ * @param gameVersion - The game version string.
+ * @returns An array of boolean flags where index represents the logical trainer ID - 0x500.
+ */
+export function parseGen3TrainerDefeatFlags(view: DataView, saveBlock1Offset: number, gameVersion: string): boolean[] {
+  try {
+    let baseFlagsOffset = 0;
+    let maxTrainers = 0;
+
+    if (gameVersion === 'emerald') {
+      baseFlagsOffset = saveBlock1Offset + RSE_FLAGS_OFFSET_E;
+      maxTrainers = MAX_TRAINERS_EMERALD;
+    } else if (gameVersion === 'ruby' || gameVersion === 'sapphire') {
+      baseFlagsOffset = saveBlock1Offset + RSE_FLAGS_OFFSET_RS;
+      maxTrainers = MAX_TRAINERS_RS;
+    } else if (gameVersion === 'firered' || gameVersion === 'leafgreen') {
+      baseFlagsOffset = saveBlock1Offset + FRLG_FLAGS_OFFSET;
+      maxTrainers = MAX_TRAINERS_FRLG;
+    } else {
+      return []; // Unsupported
+    }
+
+    const startOffset = baseFlagsOffset + TRAINER_FLAGS_BYTE_OFFSET;
+    const defeatedFlags: boolean[] = [];
+
+    for (let i = 0; i < maxTrainers; i++) {
+      const byteOffset = startOffset + Math.floor(i / BITS_PER_BYTE);
+      const bitIndex = i % BITS_PER_BYTE;
+
+      const byteValue = view.getUint8(byteOffset);
+      const isDefeated = !!((byteValue >> bitIndex) & BIT_MASK);
+      defeatedFlags.push(isDefeated);
+    }
+
+    return defeatedFlags;
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+/**
+ * Parses the trainer rematch flags from a Gen 3 save file.
+ * Returns an array of raw byte states representing rematch status.
+ *
+ * @param view - The DataView of the save file.
+ * @param saveBlock1Offset - The absolute offset of SaveBlock1.
+ * @param gameVersion - The game version string.
+ * @returns An array of number values indicating the rematch state per entry.
+ */
+export function parseGen3TrainerRematchFlags(view: DataView, saveBlock1Offset: number, gameVersion: string): number[] {
+  try {
+    let baseRematchOffset = 0;
+
+    if (gameVersion === 'emerald') {
+      baseRematchOffset = saveBlock1Offset + REMATCH_OFFSET_E;
+    } else if (gameVersion === 'ruby' || gameVersion === 'sapphire') {
+      baseRematchOffset = saveBlock1Offset + REMATCH_OFFSET_RS;
+    } else if (gameVersion === 'firered' || gameVersion === 'leafgreen') {
+      baseRematchOffset = saveBlock1Offset + REMATCH_OFFSET_FRLG;
+    } else {
+      return []; // Unsupported
+    }
+
+    const rematchFlags: number[] = [];
+    for (let i = 0; i < MAX_REMATCH_ENTRIES; i++) {
+      rematchFlags.push(view.getUint8(baseRematchOffset + i));
+    }
+
+    return rematchFlags;
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -1970,3 +1970,4 @@ export function parseGen3MetLocation(view: DataView, miscSubstructureOffset: num
     throw error;
   }
 }
+export * from '../gen3/trainerFlags/parser';


### PR DESCRIPTION
Implemented Gen 3 save file parsing for standard and rematch trainer defeat flags using DataView, complete with module-level constants and error handling as per ADR 010 and ADR 026.

---
*PR created automatically by Jules for task [3525135119173082569](https://jules.google.com/task/3525135119173082569) started by @szubster*