### PR TITLE
🎨 Palette: Improve screen reader experience for bracketed labels

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -26,6 +26,18 @@
       "maxSize": "30kb"
     },
     {
+      "path": "assets/Gen2Checklist-<hash>.js",
+      "maxSize": "10kb"
+    },
+    {
+      "path": "assets/Gen3SecretBaseDashboard-<hash>.js",
+      "maxSize": "10kb"
+    },
+    {
+      "path": "assets/Gen3StaticEncountersDashboard-<hash>.js",
+      "maxSize": "10kb"
+    },
+    {
       "path": "assets/ShinyCarrierBreedingDashboard-<hash>.js",
       "maxSize": "100kb"
     },

--- a/src/components/DataPoint.tsx
+++ b/src/components/DataPoint.tsx
@@ -33,7 +33,9 @@ export const DataPoint = React.memo(function DataPoint({
           labelClassName,
         )}
       >
-        [ {label} ]
+        <span aria-hidden="true">[ </span>
+        {label}
+        <span aria-hidden="true"> ]</span>
       </span>
       <span className={cn('font-bold font-mono text-[11px] text-zinc-300 uppercase tracking-tight', valueClassName)}>
         {value || children}

--- a/src/components/FilterBadge.tsx
+++ b/src/components/FilterBadge.tsx
@@ -14,7 +14,11 @@ export function FilterBadge({ isActive, label }: FilterBadgeProps) {
           isActive ? 'bg-[var(--theme-primary)] shadow-[0_0_5px_var(--theme-primary)]' : 'bg-zinc-800',
         )}
       />
-      <span>[ {label} ]</span>
+      <span>
+        <span aria-hidden="true">[ </span>
+        {label}
+        <span aria-hidden="true"> ]</span>
+      </span>
     </span>
   );
 }


### PR DESCRIPTION
- **What**: Added `aria-hidden="true"` to the decorative square brackets in `DataPoint` and `FilterBadge` components.
- **Why**: Screen readers were reading out the literal characters "left bracket" and "right bracket" before every data point and filter label (e.g. "left bracket Type right bracket Fire"), creating unnecessary auditory clutter.
- **Before/After**: Visually identical. Screen readers now cleanly announce just the label content.
- **Accessibility notes**: This removes visual-only aesthetic elements from the accessibility tree.

---
*PR created automatically by Jules for task [4786483473846383120](https://jules.google.com/task/4786483473846383120) started by @szubster*