### PR TITLE
🛠️ Infras: Update Biome configuration to 2.5.7

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: "2.5.4"
+          version: "2.5.7"
 
       - name: Run Biome
         run: biome ci --error-on-warnings .

--- a/.jules/infras/2026-08-07-02-39-03.md
+++ b/.jules/infras/2026-08-07-02-39-03.md
@@ -1,0 +1,7 @@
+# Infras Journal - Session $(date +"%Y-%m-%d-%H-%M-%S")
+
+## Critical Learnings
+- **Tooling configuration context**: Discovered that Biome schema in `biome.jsonc` was outdated (`2.5.6`) while the CI workflow (`.github/workflows/biome.yml`) was using `2.5.4` and the `package.json` had `^2.5.7`. Upgraded CI workflow to `2.5.7` and schema to `2.5.7` to align with the package version, resolving the schema mismatch error raised during `pnpm run check:biome`.
+- **Knip configuration context**: `knip.json` ignored a file that was already deleted or implicitly resolved (`src/engine/saveParser/parsers/feebas.worker.ts`), causing knip to throw an unnecessary configuration hint. Removed it to silence the warning.
+- **Action Taken**: Updated the Biome versions in `biome.jsonc` and `biome.yml` to match `package.json` (`2.5.7`). Removed stale ignore entry in `knip.json`.
+- **Package Manager Lockfiles**: When upgrading tooling versions, especially those defined in `package.json`, ensure that you also update the `pnpm-lock.yaml` file (or equivalent) to enforce consistent resolution across all developer environments. However, since we merely bumped the CI versions and `package.json` already specified `^2.5.7`, a `pnpm install` did not result in a lockfile change in this session.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/knip.json
+++ b/knip.json
@@ -13,8 +13,8 @@
     "scripts/gen3-fetch-locations.ts",
     "functions/_middleware.ts",
     "functions/api/saves/index.ts",
-    "functions/api/saves/[id].ts",
-    "src/engine/saveParser/parsers/feebas.worker.ts"
+    "functions/api/saves/[id].ts"
+
   ],
   "rules": {
     "files": "warn",


### PR DESCRIPTION
**What:**
- Updates `biome.jsonc` schema reference to version 2.5.7.
- Updates `.github/workflows/biome.yml` to run version 2.5.7.
- Removes an unused ignore configuration from `knip.json` targeting `feebas.worker.ts`.

**Why:**
- `package.json` specifies `@biomejs/biome: ^2.5.7`. The schema version inside `biome.jsonc` was stuck at `2.5.6`, causing CLI schema validation warnings. The CI workflow was stuck at `2.5.4`, potentially causing pipeline failures due to formatting rule deviations.
- Knip was outputting a configuration hint for an unnecessary ignore pattern.

**Impact on DX/CI:**
- Cleaner local test/lint logs without version mismatch warnings.
- Ensures CI strictly validates code using the same version locally.

**Setup Notes:**
- N/A - Seamless upgrade since dependencies already resolve to 2.5.7.

---
*PR created automatically by Jules for task [7034001186430027492](https://jules.google.com/task/7034001186430027492) started by @szubster*