### PR TITLE
🖼️ Canvas: redesign PokemonStatusBadge

### DIFF
--- a/.jules/canvas/2026-08-07-02-34-45.md
+++ b/.jules/canvas/2026-08-07-02-34-45.md
@@ -1,0 +1,5 @@
+## 2026-08-07 - [Accepted] - 🖼️ Canvas: Redesign PokemonStatusBadge
+**What:** Redesigned the `PokemonStatusBadge` to include diagonal warning stripes and a diagnostic light for SECURED states.
+**Outcome:** Accepted -> wait for review
+**Why:** The previous text-only badge felt too plain for a tactical hardware interface. Adding diagnostic stripes and hardware LED elements increases the realism and density of the tactical aesthetic.
+**Pattern:** Shifting from basic text badges to hardware-inspired modules with animated elements (like warning stripes and pulsing LEDs) improves immersion.

--- a/src/components/pokemon/PokemonStatusBadge.tsx
+++ b/src/components/pokemon/PokemonStatusBadge.tsx
@@ -18,11 +18,33 @@ export const PokemonStatusBadge = React.memo(function PokemonStatusBadge({
     return (
       <div
         className={cn(
-          'flex w-full items-center justify-center border-t border-dashed py-1.5',
-          isShiny ? 'border-amber-500/50 bg-amber-500/10' : 'border-emerald-500/50 bg-emerald-500/10',
+          'relative flex w-full items-center gap-2 overflow-hidden border-t border-dashed px-3 py-1.5',
+          isShiny
+            ? 'border-amber-500/50 bg-amber-500/10 text-amber-500/20'
+            : 'border-emerald-500/50 bg-emerald-500/10 text-emerald-500/20',
         )}
       >
-        <span className={cn('tactical-text font-black text-[8px]', isShiny ? 'text-amber-400' : 'text-emerald-400')}>
+        <div
+          className="absolute inset-0 opacity-20"
+          style={{
+            background:
+              'repeating-linear-gradient(45deg, transparent, transparent 4px, currentColor 4px, currentColor 8px)',
+          }}
+        />
+        <div
+          className={cn(
+            'relative z-10 flex h-2 w-2 items-center justify-center rounded-none border border-current text-opacity-80',
+            isShiny ? 'animate-pulse text-amber-500' : 'text-emerald-500',
+          )}
+        >
+          <div className="h-1 w-1 bg-current" />
+        </div>
+        <span
+          className={cn(
+            'relative z-10 font-black font-mono text-[9px] uppercase tracking-widest',
+            isShiny ? 'text-amber-400' : 'text-emerald-400',
+          )}
+        >
           [ SECURED ]
         </span>
       </div>

--- a/src/components/pokemon/__tests__/PokemonStatusBadge.test.tsx
+++ b/src/components/pokemon/__tests__/PokemonStatusBadge.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { PokemonStatusBadge } from '../PokemonStatusBadge';
+
+describe('PokemonStatusBadge', () => {
+  it('renders SECURED badge for shiny pokemon in storage', async () => {
+    await render(<PokemonStatusBadge hasInStorage={true} isOwnedInDex={false} isSeenInDex={false} isShiny={true} />);
+    await expect.element(page.getByText('[ SECURED ]')).toBeInTheDocument();
+  });
+
+  it('renders SECURED badge for normal pokemon in storage', async () => {
+    await render(<PokemonStatusBadge hasInStorage={true} isOwnedInDex={true} isSeenInDex={true} isShiny={false} />);
+    await expect.element(page.getByText('[ SECURED ]')).toBeInTheDocument();
+  });
+
+  it('renders DEX_ONLY badge', async () => {
+    await render(<PokemonStatusBadge hasInStorage={false} isOwnedInDex={true} isSeenInDex={true} isShiny={false} />);
+    await expect.element(page.getByText('[ DEX_ONLY ]')).toBeInTheDocument();
+  });
+
+  it('renders SEEN badge', async () => {
+    await render(<PokemonStatusBadge hasInStorage={false} isOwnedInDex={false} isSeenInDex={true} isShiny={false} />);
+    await expect.element(page.getByText('[ SEEN ]')).toBeInTheDocument();
+  });
+
+  it('renders UNKNOWN badge when not seen', async () => {
+    await render(<PokemonStatusBadge hasInStorage={false} isOwnedInDex={false} isSeenInDex={false} isShiny={false} />);
+    await expect.element(page.getByText('[ UNKNOWN ]')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Redesigns the PokemonStatusBadge to include diagonal warning stripes and a diagnostic light for SECURED states.

---
*PR created automatically by Jules for task [7860460515179246702](https://jules.google.com/task/7860460515179246702) started by @szubster*