### PR TITLE
🧹 Clean up unused exports and knip config

### DIFF
--- a/.jules/sweeper/sweeper-exports.md
+++ b/.jules/sweeper/sweeper-exports.md
@@ -1,0 +1,6 @@
+## Sweeper Journal - Clean up unused exports and knip config
+
+**What:** Removed unused exports in `constants.ts` and updated `knip.json`.
+**Why:** To resolve tech debt regarding unused exports.
+**Outcome:** Successfully updated the code and `knip.json` configuration without issue.
+**Pattern:** Found that removing exports only used in tests/locally does not negatively impact the codebase and helps with tree shaking. Verified usage with global grep first before making changes.

--- a/knip.json
+++ b/knip.json
@@ -13,8 +13,7 @@
     "scripts/gen3-fetch-locations.ts",
     "functions/_middleware.ts",
     "functions/api/saves/index.ts",
-    "functions/api/saves/[id].ts",
-    "src/engine/saveParser/parsers/feebas.worker.ts"
+    "functions/api/saves/[id].ts"
   ],
   "rules": {
     "files": "warn",

--- a/src/engine/saveParser/parsers/gen2/phone/constants.ts
+++ b/src/engine/saveParser/parsers/gen2/phone/constants.ts
@@ -9,21 +9,21 @@ export interface HighValueContact {
 
 // Module-level constants for phone contact IDs
 export const GEN2_CONTACT_RALPH = 17;
-export const GEN2_CONTACT_ANTHONY = 19;
-export const GEN2_CONTACT_ARNIE = 23;
-export const GEN2_CONTACT_CHAD = 27;
+const GEN2_CONTACT_ANTHONY = 19;
+const GEN2_CONTACT_ARNIE = 23;
+const GEN2_CONTACT_CHAD = 27;
 
-export const GEN2_CONTACT_BEVERLY = 6;
-export const GEN2_CONTACT_JOSE = 13;
-export const GEN2_CONTACT_WADE = 16;
-export const GEN2_CONTACT_TODD = 20;
+const GEN2_CONTACT_BEVERLY = 6;
+const GEN2_CONTACT_JOSE = 13;
+const GEN2_CONTACT_WADE = 16;
+const GEN2_CONTACT_TODD = 20;
 export const GEN2_CONTACT_GINA = 21;
-export const GEN2_CONTACT_ALAN = 24;
-export const GEN2_CONTACT_DANA = 26;
+const GEN2_CONTACT_ALAN = 24;
+const GEN2_CONTACT_DANA = 26;
 export const GEN2_CONTACT_TULLY = 29;
-export const GEN2_CONTACT_TIFFANY = 31;
-export const GEN2_CONTACT_WILTON = 33;
-export const GEN2_CONTACT_KENJI = 34;
+const GEN2_CONTACT_TIFFANY = 31;
+const GEN2_CONTACT_WILTON = 33;
+const GEN2_CONTACT_KENJI = 34;
 
 export const GEN2_PHONE_CALLER_REGISTRY: Record<number, Omit<HighValueContact, 'id'>> = {
   // Swarm callers


### PR DESCRIPTION
🎯 What
Remove unused exports from gen2 phone constants and remove unnecessary ignore rule from knip.json.

💡 Why
To improve code health by removing dead exports and keeping tools configuration up to date.

✅ Verification
Ran pnpm knip, pnpm lint, pnpm test, and e2e tests.

✨ Result
Cleaner codebase with no knip warnings.

---
*PR created automatically by Jules for task [853707165049357673](https://jules.google.com/task/853707165049357673) started by @szubster*