### PR TITLE
📝 Story Owner: Breakdown epic-122-404-refactor-savedata-typing into stories

### DIFF
--- a/.foundry/epics/epic-122-404-refactor-savedata-typing.md
+++ b/.foundry/epics/epic-122-404-refactor-savedata-typing.md
@@ -36,4 +36,8 @@ The current `SaveData` type is monolithic, lacking generation-specific constrain
 - [ ] Refactor `SaveData` in `src/engine/saveParser/parsers/common.ts` into a discriminated union.
 - [ ] Update generation-specific parsers to return the correctly narrowed types.
 - [ ] Ensure all existing parser tests pass without regressions.
-- [ ] Generate a final STORY dedicated exclusively to Integration and E2E Verification.
+- [x] Generate a final STORY dedicated exclusively to Integration and E2E Verification.
+- [ ] story-404-361-draft-savedata-adr
+- [ ] story-404-362-refactor-savedata-type
+- [ ] story-404-363-update-parsers
+- [ ] story-404-364-savedata-e2e-verification

--- a/.foundry/journals/story_owner/15700522367460075049.md
+++ b/.foundry/journals/story_owner/15700522367460075049.md
@@ -1,0 +1,3 @@
+# 15700522367460075049
+
+Enforced the Orchestrator E2E Safeguard by generating a final STORY node dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`).

--- a/.foundry/stories/story-404-361-draft-savedata-adr.md
+++ b/.foundry/stories/story-404-361-draft-savedata-adr.md
@@ -1,0 +1,28 @@
+---
+id: story-404-361-draft-savedata-adr
+type: STORY
+title: "Draft ADR for SaveData Typed Schema"
+status: PENDING
+owner_persona: "tech_lead"
+created_at: "2026-08-07"
+updated_at: "2026-08-07"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-122-404-refactor-savedata-typing
+tags:
+  - savedata
+  - typescript
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Draft ADR for SaveData Typed Schema
+
+## Description
+Draft an Architecture Decision Record (ADR) detailing the typed schema and downstream consumer impact for the new discriminated union SaveData type.
+
+## Acceptance Criteria
+- [ ] Create tasks for the architect to draft the ADR.

--- a/.foundry/stories/story-404-362-refactor-savedata-type.md
+++ b/.foundry/stories/story-404-362-refactor-savedata-type.md
@@ -1,0 +1,30 @@
+---
+id: story-404-362-refactor-savedata-type
+type: STORY
+title: "Refactor SaveData Type into Discriminated Union"
+status: PENDING
+owner_persona: "tech_lead"
+created_at: "2026-08-07"
+updated_at: "2026-08-07"
+depends_on:
+  - story-404-361-draft-savedata-adr
+jules_session_id: null
+pr_number: null
+parent: epic-122-404-refactor-savedata-typing
+tags:
+  - savedata
+  - typescript
+  - refactoring
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Refactor SaveData Type into Discriminated Union
+
+## Description
+Refactor the `SaveData` type in `src/engine/saveParser/parsers/common.ts` into a discriminated union based on the `generation` field.
+
+## Acceptance Criteria
+- [ ] Create task to refactor the `SaveData` type.

--- a/.foundry/stories/story-404-363-update-parsers.md
+++ b/.foundry/stories/story-404-363-update-parsers.md
@@ -1,0 +1,30 @@
+---
+id: story-404-363-update-parsers
+type: STORY
+title: "Update Generation-Specific Parsers and Tests"
+status: PENDING
+owner_persona: "tech_lead"
+created_at: "2026-08-07"
+updated_at: "2026-08-07"
+depends_on:
+  - story-404-362-refactor-savedata-type
+jules_session_id: null
+pr_number: null
+parent: epic-122-404-refactor-savedata-typing
+tags:
+  - savedata
+  - typescript
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Update Generation-Specific Parsers and Tests
+
+## Description
+Update `gen1.ts`, `gen2.ts`, and `gen3.ts` parsers to return correctly narrowed types, and ensure all existing parser tests pass without regressions.
+
+## Acceptance Criteria
+- [ ] Create task for coder to update parsers and tests.
+- [ ] Create task for qa to verify parser tests and type narrowing.

--- a/.foundry/stories/story-404-364-savedata-e2e-verification.md
+++ b/.foundry/stories/story-404-364-savedata-e2e-verification.md
@@ -1,0 +1,30 @@
+---
+id: story-404-364-savedata-e2e-verification
+type: STORY
+title: "SaveData Refactoring E2E Verification"
+status: PENDING
+owner_persona: "tech_lead"
+created_at: "2026-08-07"
+updated_at: "2026-08-07"
+depends_on:
+  - story-404-363-update-parsers
+jules_session_id: null
+pr_number: null
+parent: epic-122-404-refactor-savedata-typing
+tags:
+  - savedata
+  - e2e
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# SaveData Refactoring E2E Verification
+
+## Description
+Final integration and E2E verification of the SaveData type refactoring across all supported generations.
+
+## Acceptance Criteria
+- [ ] Create task for E2E verification.


### PR DESCRIPTION
This PR breaks down epic-122-404-refactor-savedata-typing into 4 story nodes including an e2e verification story, and updates the epic's markdown body with the new dependencies.

---
*PR created automatically by Jules for task [15700522367460075049](https://jules.google.com/task/15700522367460075049) started by @szubster*