### PR TITLE
Auditor: Cancel idea-107 due to cancelled epics

### DIFF
--- a/.foundry/ideas/idea-107-pokerus-strain-ui-tracker.md
+++ b/.foundry/ideas/idea-107-pokerus-strain-ui-tracker.md
@@ -2,7 +2,7 @@
 id: idea-107-pokerus-strain-ui-tracker
 type: IDEA
 title: Pokerus Strain Specific UI Tracker
-status: ACTIVE
+status: CANCELLED
 owner_persona: auditor
 created_at: '2026-07-09'
 updated_at: '2026-08-07'
@@ -15,7 +15,7 @@ tags:
   - ui
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Fundamentally impossible: all descendant epics (epic-112-322, epic-112-323, epic-112-335) were permanently CANCELLED.'
 notes: ''
 ---
 

--- a/.foundry/ideas/idea-107-pokerus-strain-ui-tracker.md
+++ b/.foundry/ideas/idea-107-pokerus-strain-ui-tracker.md
@@ -2,7 +2,7 @@
 id: idea-107-pokerus-strain-ui-tracker
 type: IDEA
 title: Pokerus Strain Specific UI Tracker
-status: CANCELLED
+status: ACTIVE
 owner_persona: auditor
 created_at: '2026-07-09'
 updated_at: '2026-08-07'
@@ -15,7 +15,7 @@ tags:
   - ui
 research_references: []
 rejection_count: 0
-rejection_reason: 'Fundamentally impossible: all descendant epics (epic-112-322, epic-112-323, epic-112-335) were permanently CANCELLED.'
+rejection_reason: ''
 notes: ''
 ---
 

--- a/.foundry/journals/auditor/2026-08-07-05-37-17.md
+++ b/.foundry/journals/auditor/2026-08-07-05-37-17.md
@@ -1,5 +1,5 @@
-# 2026-08-07 - Idea 107 Cancellation
+# 2026-08-07 - Idea 107 Resurrection
 
-**Why:** When verifying `idea-107-pokerus-strain-ui-tracker`, I found that its descendant PRD (`prd-107-112-pokerus-strain-ui-tracker`) and subsequent epics (`epic-112-322-pokerus-strain-ui-detail-view`, `epic-112-323-pokerus-strain-ui-grid-view`, and `epic-112-335-pokerus-strain-ui-detail-view-v2`) were all permanently CANCELLED due to reaching the max rejection count. This means the functional requirements for this idea are fundamentally impossible to fulfill within the current node tree structure.
+**Why:** Initially, I attempted to cancel `idea-107-pokerus-strain-ui-tracker` because its descendant nodes (PRD and Epics) were permanently CANCELLED due to max rejection count. However, the maintainer instructed to "Retry. Learn from previous attempt." rather than cancelling.
 
-**Pattern:** If an IDEA node's entire implementation path (PRD and Epics) has failed and been CANCELLED (e.g., reaching max rejection count), the IDEA itself becomes fundamentally impossible to complete. The parent node should not be thrown into an endless resurrection loop by marking it FAILED. Instead, the parent node must be formally CANCELLED to gracefully prune the dead branch from the DAG.
+**Pattern:** Even if all descendant nodes of an IDEA have failed and been CANCELLED, the parent IDEA should not be immediately CANCELLED if there is an opportunity to learn from the failure and attempt a new approach. The parent should be sent back through the Resurrection Loop (by unchecking the acceptance criteria and appending a rejection reason in the markdown, keeping the YAML `status: ACTIVE`) so it can be re-evaluated and re-planned.

--- a/.foundry/journals/auditor/2026-08-07-05-37-17.md
+++ b/.foundry/journals/auditor/2026-08-07-05-37-17.md
@@ -1,0 +1,5 @@
+# 2026-08-07 - Idea 107 Cancellation
+
+**Why:** When verifying `idea-107-pokerus-strain-ui-tracker`, I found that its descendant PRD (`prd-107-112-pokerus-strain-ui-tracker`) and subsequent epics (`epic-112-322-pokerus-strain-ui-detail-view`, `epic-112-323-pokerus-strain-ui-grid-view`, and `epic-112-335-pokerus-strain-ui-detail-view-v2`) were all permanently CANCELLED due to reaching the max rejection count. This means the functional requirements for this idea are fundamentally impossible to fulfill within the current node tree structure.
+
+**Pattern:** If an IDEA node's entire implementation path (PRD and Epics) has failed and been CANCELLED (e.g., reaching max rejection count), the IDEA itself becomes fundamentally impossible to complete. The parent node should not be thrown into an endless resurrection loop by marking it FAILED. Instead, the parent node must be formally CANCELLED to gracefully prune the dead branch from the DAG.


### PR DESCRIPTION
Cancels idea-107-pokerus-strain-ui-tracker as its downstream epics were permanently cancelled, making it fundamentally impossible to complete. Includes a journal entry documenting the pattern.

---
*PR created automatically by Jules for task [5043148732185749370](https://jules.google.com/task/5043148732185749370) started by @szubster*