### PR TITLE
Epic Planner: Draft Epics for Distillation and Archival

### DIFF
--- a/.foundry/epics/epic-339-405-orchestrator-archive-bypass.md
+++ b/.foundry/epics/epic-339-405-orchestrator-archive-bypass.md
@@ -1,0 +1,36 @@
+---
+id: epic-339-405-orchestrator-archive-bypass
+type: EPIC
+title: Orchestrator Archive Bypass
+status: READY
+owner_persona: story_owner
+created_at: '2026-08-07'
+updated_at: '2026-08-07'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-129-339-epic-level-distillation-archival
+tags:
+  - foundry
+  - infrastructure
+  - performance
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Orchestrator Archive Bypass
+
+## Context
+The DAG orchestrator currently traverses the entire `.foundry` directory (excluding `journals` and `docs`). When completed nodes are archived, they will be moved to cold storage (e.g., `.foundry/archive/`). The orchestrator must be updated to skip this archive directory during the discovery phase to maintain performance.
+
+## Objective
+Update the `foundry-orchestrator.ts` script to ignore the `.foundry/archive/` directory during its parsing and discovery process.
+
+## Requirements
+1. Update `discoverNodeFiles` in `foundry-orchestrator.ts` (and any related utility scripts) to explicitly skip `archive/` directories.
+2. Ensure this exclusion logic covers both `.foundry/archive/stories/` and `.foundry/archive/tasks/`.
+
+## Acceptance Criteria
+- [ ] Implement bypass logic in the orchestrator discovery phase.
+- [ ] Delegate the generation of the E2E STORY to the `story_owner`.

--- a/.foundry/epics/epic-339-406-tpm-distillation-logic.md
+++ b/.foundry/epics/epic-339-406-tpm-distillation-logic.md
@@ -1,0 +1,41 @@
+---
+id: epic-339-406-tpm-distillation-logic
+type: EPIC
+title: TPM Distillation and Archival Logic
+status: READY
+owner_persona: story_owner
+created_at: '2026-08-07'
+updated_at: '2026-08-07'
+depends_on:
+  - epic-339-405-orchestrator-archive-bypass
+jules_session_id: null
+pr_number: null
+parent: prd-129-339-epic-level-distillation-archival
+tags:
+  - foundry
+  - infrastructure
+  - performance
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# TPM Distillation and Archival Logic
+
+## Context
+When an EPIC node completes, its granular child nodes (STORY and TASK) are no longer needed by the orchestrator but contain valuable learnings. We need the TPM persona to distill these learnings into the EPIC and move the files into cold storage.
+
+## Objective
+Implement logic that the TPM persona will execute to synthesize child node learnings into the parent EPIC and archive the processed node files.
+
+## Requirements
+1. The TPM agent script must identify `COMPLETED` EPIC nodes and trigger distillation.
+2. The process must aggregate content, outcomes, and journals from child STORY and TASK nodes.
+3. It must append a "Changelog & Learnings" summary section to the EPIC node.
+4. Processed child nodes must be moved from `.foundry/stories/` and `.foundry/tasks/` to `.foundry/archive/stories/` and `.foundry/archive/tasks/`.
+
+## Acceptance Criteria
+- [ ] Implement logic to detect completed EPICs and trigger distillation.
+- [ ] Implement text aggregation and synthesis to create the Changelog & Learnings summary.
+- [ ] Implement file system operations to append to the EPIC and move child files to `.foundry/archive/`.
+- [ ] Delegate the generation of the E2E STORY to the `story_owner`.

--- a/.foundry/journals/epic_planner/2026-08-07-tpm.md
+++ b/.foundry/journals/epic_planner/2026-08-07-tpm.md
@@ -1,0 +1,3 @@
+# Session Log
+
+I generated two epics (epic-339-405-orchestrator-archive-bypass and epic-339-406-tpm-distillation-logic) from prd-129-339-epic-level-distillation-archival. To comply with the Orchestrator Safeguard, I ensured that each EPIC includes an explicit acceptance criterion delegating the generation of the final E2E verification STORY to the `story_owner` persona, instead of creating a separate E2E epic myself.

--- a/.foundry/prds/prd-129-339-epic-level-distillation-archival.md
+++ b/.foundry/prds/prd-129-339-epic-level-distillation-archival.md
@@ -48,3 +48,5 @@ To implement an archival strategy that maintains crucial historical context whil
 - [ ] Implement synthesis logic to append "Changelog & Learnings" to the EPIC node.
 - [ ] Implement file system logic to move child node files to `.foundry/archive/`.
 - [ ] Ensure the orchestrator is updated to ignore `.foundry/archive/` during DAG parsing.
+- [ ] epic-339-405-orchestrator-archive-bypass
+- [ ] epic-339-406-tpm-distillation-logic


### PR DESCRIPTION
Transforms PRD 129-339 into two epics: one for orchestrator bypass logic, and one for the TPM distillation logic. The orchestrator must bypass the archive directory before TPM can start archiving nodes to prevent DAG errors.

---
*PR created automatically by Jules for task [1517778892017773348](https://jules.google.com/task/1517778892017773348) started by @szubster*