### PR TITLE
🗃️ Archivist: merge duplicate and contradictory knowledge in infras and sweeper journals

### DIFF
--- a/.jules/archivist/YYYY-MM-DD-HH-MM-SS.md
+++ b/.jules/archivist/YYYY-MM-DD-HH-MM-SS.md
@@ -1,0 +1,5 @@
+# Master Journal: Archivist
+
+## Critical Learnings
+- **Cleanups execution constraints**: I must ensure that any temporary scripts I use to assist with finding and replacing string patterns are removed and do not leak into the commit history.
+- **Journal Organization**: Cleaned up repetitive, contradictory logs in `.jules/infras.md` and `.jules/sweeper.md`.

--- a/.jules/infras.md
+++ b/.jules/infras.md
@@ -2,9 +2,6 @@
 - **CI Synchronization**: The local `pnpm lint` script in `package.json` was running `pnpm check:biome`, but the GitHub Actions CI workflow (`.github/workflows/ci.yml`) was completely missing the Biome check step, allowing unformatted code to bypass CI. When adding or modifying tools in the `lint` script, ensure they are also mirrored as discrete steps in the CI pipeline.
 
 ## Critical Learnings
-- **CI Synchronization**: Discovered that the Playwright end-to-end tests (which are comprehensive and essential for ensuring no regressions in the UI workflow) were omitted from the GitHub Actions CI pipeline because `vitest` explicitly excludes `tests/e2e/`. Added a parallel `e2e` job in `.github/workflows/ci.yml` that sets up Playwright browsers and runs `pnpm test:e2e`. Also included uploading the `playwright-report` directory as an artifact to improve debugging DX in CI.
-
-## Critical Learnings
 - **Tooling configuration context**: Discovered that Playwright end-to-end tests are already being run by a separate, dedicated GitHub Action workflow. Therefore, they should NOT be added as an extra job to the main CI workflow (`.github/workflows/ci.yml`), as this would lead to duplicate test executions.
 - **Action Required**: The proposed PR must be reverted to keep the CI pipeline clean and avoid redundant e2e test executions.
 
@@ -14,10 +11,6 @@
 - Fixed `resolveNodePath` in `.github/scripts/foundry-orchestrator.ts` to automatically attempt to resolve paths to their archived counterparts if the original file does not exist.
 - Updated Phase 3 matches, Phase 4 target artifacts, and Phase 4.5 idempotent links to resolve using the updated helper.
 - Added extensive regression tests to prevent similar issues in the future.
-
-## Critical Learnings
-- The GitHub Actions  pipeline runs multiple linters (Biome, Oxlint, Knip) without configuring their reporters, making PR review DX suboptimal since logs must be read manually.
-- Configured each linter in  to output in Github Annotations format (e.g.  for Biome,  for Oxlint,  for Knip). This will directly flag the relevant lines of code in a PR's 'Files Changed' tab.
 
 ## Critical Learnings
 - **GitHub Annotations DX:** The GitHub Actions pipeline runs multiple linters (Biome, Oxlint, Knip) without configuring their reporters, making PR review DX suboptimal since logs must be read manually.

--- a/.jules/sweeper.md
+++ b/.jules/sweeper.md
@@ -1,10 +1,3 @@
 ## Learnings
-* **Leftover knip config**: `.github/scripts/schema.ts` was still listed in `ignore` in `knip.json` even though it is actively used and correctly imported. Removing it from `knip.json` safely resolves the warning and ensures it correctly gets type-checked and tracked by knip.
-
-## Learnings
-* **Implicit File Dependencies (`test-setup.ts`)**: I initially removed `src/test-setup.ts` without fully reading the context and ignored the warning that test setups implicitly depend on files (even if `knip` flagged it as unused). After realizing the test-suite failure, I investigated its usages and removed it from `knip.json` safely without deleting the actual environment configuration.
-* **Knip Error Fixing**: `knip` will surface errors if files in its `ignore` block do not exist. Therefore, we should only clean it up.
-
-## Learnings
-* **Leftover knip config**: `zod` was still listed in `ignoreDependencies` in `knip.json` even though it was not in `package.json`. Knip flagged this as a configuration issue (`Module load error` or similar warning, although it actually just showed `zod` next to `Remove from ignoreDependencies`). Removing it from `knip.json` safely resolves the warning.
-* **Implicit File Dependencies (`test-setup.ts`)**: I recalled that previously removing `src/test-setup.ts` without full context caused test-suite failures, so checking implicit usages is always important, even for seemingly simple config changes.
+* **Leftover knip config**: Obsolete file references (like `.github/scripts/schema.ts`) and dependencies (like `zod`) left in `knip.json` `ignore` or `ignoreDependencies` blocks will cause `knip` to flag errors if they do not exist or are correctly imported. Removing them safely resolves the warnings.
+* **Implicit File Dependencies (`test-setup.ts`)**: Knip may flag test setup files as unused because they are implicitly loaded by test runners rather than explicitly imported. Do not delete them without checking test-suite context; instead, adjust the knip configuration safely.


### PR DESCRIPTION
Cleaned up .jules/infras.md to remove duplicate entries about Github Annotations DX and a stale/contradictory entry about adding Playwright to ci.yml. Merged redundant duplicate learnings in .jules/sweeper.md about knip config and implicit file dependencies. Verified changes using pnpm lint and pnpm test. Also created appropriate archivist journal entry.

---
*PR created automatically by Jules for task [14516063274487023026](https://jules.google.com/task/14516063274487023026) started by @szubster*