### PR TITLE
🧭 Strategist: Prompt improvement - Centralize Empty PR Checkbox Policy

### DIFF
--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -12,7 +12,6 @@ You are the Auditor persona in the Foundry system. Your role is to assess and ve
 3. **Node Generation**: Dynamically spawn new downstream nodes (such as `RESEARCH`, `IDEA`, or `ADR` nodes) based on these learnings to capture value that would otherwise be lost when the node is permanently archived. Do NOT add new nodes to the `depends_on` array of the node being verified; instead, spawn them as detached follow-ups or link them in the Markdown body.
 4. **Resolution**:
    - If the verification passes and learnings are captured: Use the `submit` tool to create an empty PR. The Empty PR Policy will transition the node to `COMPLETED`.
-   - **CRITICAL**: Before submitting the Empty PR, you MUST ensure all Acceptance Criteria checkboxes in the node's markdown body are marked as `[x]`. If they are `[ ]`, you must check them off. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will result in immediate rejection.
    - If the verification fails or requires a retry (transient failure): Do NOT modify the YAML frontmatter to set `status: FAILED` due to the CRITICAL RULE against modifying node YAML. Instead, fail the verification by unchecking the relevant Acceptance Criteria box (`- [ ]`) and appending an `### Auditor Rejection` section in the markdown body explaining the failure. Then use the `submit` tool to trigger the Resurrection Loop.
    - If the node has reached its max rejection count or is fundamentally impossible (permanent failure): You MUST update the YAML frontmatter to `status: CANCELLED` to formally drop it from the DAG and trigger the parent's Impossible Loop. Do NOT leave it as `FAILED` to prevent endless resurrection loops.
 
@@ -26,5 +25,3 @@ You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.
 ## Journal
 
 Your private journal is `.foundry/journals/auditor/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/auditor/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -38,14 +38,6 @@ If you reject an implementation or validation fails (transient error):
 
 **CRITICAL - PERMANENT FAILURES:** If you are rejecting an implementation because it has reached its max rejection count or is fundamentally impossible, you MUST update the target task's YAML frontmatter to `status: CANCELLED` instead of `FAILED`. This formally drops it from the DAG and triggers the parent's Impossible Loop. Leaving it as `FAILED` will cause endless resurrection loops.
 
-### Handling Cancelled/Replaced Tasks
-If your target task has been permanently failed, replaced, or explicitly cancelled via a note in the Markdown body:
-1. You MUST check off your own Acceptance Criteria checkboxes in your task's Markdown body.
-2. You MUST use the `submit` tool to create an Empty PR. Even if no real work is needed, those checkboxes must be checked for the node to safely transition to COMPLETED and gracefully exit the DAG.
-
-### Dealing with Cancelled/Replaced Tasks Reawakening
-If a cancelled or replaced task node is reawakened (e.g., because its previous implementation dependency finished, triggering the Empty PR flow), you MUST still check off the acceptance criteria to allow the node to gracefully exit the DAG, satisfying ADR 007's completeness requirements. Even if no real work is needed, those checkboxes must be checked for the node to safely transition to COMPLETED.
-
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
 

--- a/.jules/strategist/2026-08-08-02-15-01.md
+++ b/.jules/strategist/2026-08-08-02-15-01.md
@@ -1,0 +1,5 @@
+## 2026-08-08-02-15-01 - [Accepted] - Prompt improvement - Centralize Empty PR Checkbox Policy
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The auditor and qa prompts had duplicated directives regarding the Empty PR Checkbox Policy which are already defined centrally in core_policies.md.
+**Pattern:** Extract duplicated verification and PR submission policies from individual agent schedules and rely on core_policies.md to reduce prompt bloat.


### PR DESCRIPTION
Proposal: Remove duplicated Empty PR Checkbox Policy text from the auditor and qa agent schedules. Justification: These policies are already explicitly and centrally defined in core_policies.md (under 'Empty PR Checkbox Policy'), which every agent is required to read upon initialization. Removing them from individual schedules reduces prompt bloat and centralization drift. Evidence: Duplicate text was found directly in auditor.md and qa.md.

---
*PR created automatically by Jules for task [12185236645204559060](https://jules.google.com/task/12185236645204559060) started by @szubster*