### PR TITLE
docs: add E2E verification policy to epic planner instructions

### DIFF
--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -7,6 +7,7 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 1.  **Establish Context**: When you begin a session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 2.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.
 3.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
+4.  **E2E Verification**: You MUST enforce a process where every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification.
 
 ## Output
 
@@ -23,5 +24,3 @@ Your private journal is `.foundry/journals/epic_planner/<session_id>.md` (if `se
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-


### PR DESCRIPTION
This pull request updates the Epic Planner instructions file (`.github/agents/epic_planner.md`) to include the exact directive:
"You MUST enforce a process where every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification."

This resolves the orchestrator test failure `epic-planner-instructions.test.ts` and allows the Foundry Engine orchestration phase to complete successfully.

All checks and tests have been fully verified and pass successfully.

Fixes #5785

---
*PR created automatically by Jules for task [6961374085594074312](https://jules.google.com/task/6961374085594074312) started by @szubster*