### PR TITLE
🧹 Fix epic planner instructions test

### DIFF
--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -7,6 +7,7 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 1.  **Establish Context**: When you begin a session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 2.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.
 3.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
+4.  **E2E Verification**: You MUST enforce a process where every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification.
 
 ## Output
 
@@ -23,5 +24,3 @@ Your private journal is `.foundry/journals/epic_planner/<session_id>.md` (if `se
 
 ## Core Policies
 You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-

--- a/.jules/sweeper/31252700754.md
+++ b/.jules/sweeper/31252700754.md
@@ -1,0 +1,7 @@
+# Sweeper Journal — 31252700754
+
+## Lesson: Prompt Verification Alignment
+While maintaining multi-agent DAG architectures (like the Foundry Engine), agent personas are defined by markdown specification files in `.github/agents/`. The orchestrator or test suites may programmatically enforce specific rules within these persona documents to guarantee that spawned nodes (e.g., Epic generation) conform to essential architecture constraints (such as ADR 007 and ADR 009, specifically requiring that every Epic includes an E2E/Integration Story).
+
+## Rule Adaptation
+When modifying, updating, or maintaining agent persona files, it is vital to first verify that all test suites validating these instructions (such as `epic-planner-instructions.test.ts`) are in complete alignment. Any updates to prompt boundaries should be reflected instantly in the matching instruction markdown files using `write_file` with complete, full-content overrides to satisfy the project's strict Specificity Rule.


### PR DESCRIPTION
🎯 What: Added the missing instruction "You MUST enforce a process where every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification." to `.github/agents/epic_planner.md`.

💡 Why: To fix the failing `epic-planner-instructions.test.ts` test suite and satisfy the project's strict E2E verification constraint validation.

✅ Verification: Ran `pnpm --filter foundry-scripts test` to ensure all tests pass successfully.

✨ Result: `epic-planner-instructions.test.ts` test passes, restoring the orchestration suite to a clean passing state.

Fixes #5787

---
*PR created automatically by Jules for task [12061929704627450538](https://jules.google.com/task/12061929704627450538) started by @szubster*