### PR TITLE
fix: resolve broken foundry dependency path

### DIFF
--- a/.foundry/archive/tasks/task-336-343-zod-schema-definition-qa.md
+++ b/.foundry/archive/tasks/task-336-343-zod-schema-definition-qa.md
@@ -7,7 +7,7 @@ owner_persona: qa
 created_at: '2026-07-25'
 updated_at: '2026-07-27'
 depends_on:
-  - .foundry/tasks/task-336-342-zod-schema-definition-impl.md
+  - .foundry/archive/tasks/task-336-342-zod-schema-definition-impl.md
 jules_session_id: null
 pr_number: null
 parent: story-334-336-zod-schema-definition


### PR DESCRIPTION
Fixes the broken dependency path pointing to .foundry/tasks/task-336-342-zod-schema-definition-impl.md in .foundry/archive/tasks/task-336-343-zod-schema-definition-qa.md by correctly resolving it to the archive directory.

Fixes #5789

---
*PR created automatically by Jules for task [9028431367113790150](https://jules.google.com/task/9028431367113790150) started by @szubster*