### PR TITLE
[Tech Lead] Break down Gen 2 NPC Trade Extraction

### DIFF
--- a/.foundry/journals/tech_lead/8763873187215868612.md
+++ b/.foundry/journals/tech_lead/8763873187215868612.md
@@ -1,0 +1,13 @@
+# Tech Lead Journal: Handling Pre-Implemented Stories
+
+## Date: 2026-08-08
+## Session ID: 8763873187215868612
+
+### Observation
+While drafting tasks for `story-349-361-gen2-trade-extraction`, I observed that the codebase already contained the implementation and unit tests for Gen 2 NPC trade extraction (in `src/engine/saveParser/parsers/gen2.ts` and `gen2.test.ts`).
+
+### Implication
+If a STORY node's core requirements are already present in the codebase from a prior manual commit or external pull request, the Tech Lead must not prematurely close the STORY or skip the DAG pipeline. Doing so would violate the strict pipeline order and orchestrator expectations for node resolution.
+
+### Action / Rule Adaptation
+When encountering a STORY where the feature is already implemented, the Tech Lead must still explicitly draft the downstream TASK nodes (e.g., `impl`, `test`, and `qa`). This allows the Coder and QA agents to formally adopt, verify, and check off the work within the system. It ensures that the Orchestrator's dependency graph remains intact and all architectural and testing checks (like verifying `RangeError` handling and module-level constants) are officially executed and recorded by the designated personas.

--- a/.foundry/stories/story-349-361-gen2-trade-extraction.md
+++ b/.foundry/stories/story-349-361-gen2-trade-extraction.md
@@ -27,4 +27,7 @@ Implement extraction of in-game NPC trade completion flags from Generation 2 sav
 ## Acceptance Criteria
 - [ ] Gen 2 NPC trade flags are accurately extracted and mapped.
 - [ ] Parsing logic strictly adheres to the `DataView` API and handles `RangeError` for corrupted saves.
-- [ ] Tech Lead: Break down this Story into executable Tasks.
+- [x] Tech Lead: Break down this Story into executable Tasks.
+- [ ] task-361-407-gen2-trade-extraction-impl
+- [ ] task-361-408-gen2-trade-extraction-test
+- [ ] task-361-409-gen2-trade-extraction-qa

--- a/.foundry/tasks/task-361-407-gen2-trade-extraction-impl.md
+++ b/.foundry/tasks/task-361-407-gen2-trade-extraction-impl.md
@@ -1,0 +1,31 @@
+---
+id: task-361-407-gen2-trade-extraction-impl
+type: TASK
+title: Gen 2 NPC Trade Extraction Implementation
+status: READY
+owner_persona: coder
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-349-361-gen2-trade-extraction
+tags:
+  - feature
+  - backend
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Task: Gen 2 NPC Trade Extraction Implementation
+
+## Objective
+Implement extraction of in-game NPC trade completion flags from Generation 2 save files using the `DataView` API. Ensure that memory offsets and magic numbers are strictly extracted as module-level constants, avoiding inline hardcoding.
+
+## Acceptance Criteria
+- [ ] Define reusable constants `NPC_TRADE_FLAGS_OFFSET_CRYSTAL`, `NPC_TRADE_FLAGS_OFFSET_GS`, and `GEN2_NPC_TRADE_COUNT` for offset handling.
+- [ ] Implement bitwise mapping using `DataView.getUint8` to accurately extract all trade flags.
+- [ ] Ensure that parsing strictly throws a new `Error('The save file is corrupted or incomplete.')` when encountering `RangeError` from the `DataView` API reading out of bounds.
+- [ ] Incorporate extracted `npcTradeFlags` correctly into the mapped `SaveData` output.

--- a/.foundry/tasks/task-361-408-gen2-trade-extraction-test.md
+++ b/.foundry/tasks/task-361-408-gen2-trade-extraction-test.md
@@ -1,0 +1,31 @@
+---
+id: task-361-408-gen2-trade-extraction-test
+type: TASK
+title: Gen 2 NPC Trade Extraction Testing
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on:
+  - .foundry/tasks/task-361-407-gen2-trade-extraction-impl.md
+jules_session_id: null
+pr_number: null
+parent: story-349-361-gen2-trade-extraction
+tags:
+  - test
+  - backend
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Task: Gen 2 NPC Trade Extraction Testing
+
+## Objective
+Write robust unit tests for the Gen 2 NPC trade extraction implementation to verify correctness across versions and handling of corrupted saves.
+
+## Acceptance Criteria
+- [ ] Add unit test verifying that Gold/Silver save layouts correctly map the extracted `npcTradeFlags`.
+- [ ] Add unit test verifying that Crystal save layouts correctly map the extracted `npcTradeFlags`.
+- [ ] Add unit test verifying that a specific `Error('The save file is corrupted or incomplete.')` is thrown when `DataView` triggers a `RangeError` on out-of-bounds reads.

--- a/.foundry/tasks/task-361-409-gen2-trade-extraction-qa.md
+++ b/.foundry/tasks/task-361-409-gen2-trade-extraction-qa.md
@@ -1,0 +1,33 @@
+---
+id: task-361-409-gen2-trade-extraction-qa
+type: TASK
+title: Gen 2 NPC Trade Extraction QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on:
+  - .foundry/tasks/task-361-408-gen2-trade-extraction-test.md
+jules_session_id: null
+pr_number: null
+parent: story-349-361-gen2-trade-extraction
+tags:
+  - test
+  - qa
+  - save-parsing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Task: Gen 2 NPC Trade Extraction QA
+
+## Objective
+Verify the Gen 2 NPC trade extraction implementation and testing suite to ensure correctness and adherence to architectural guidelines.
+
+## Acceptance Criteria
+- [ ] Verify that `NPC_TRADE_FLAGS_OFFSET_CRYSTAL`, `NPC_TRADE_FLAGS_OFFSET_GS`, and `GEN2_NPC_TRADE_COUNT` are strictly defined as module-level constants (no inline magic numbers).
+- [ ] Ensure that `DataView.getUint8` is correctly utilized for bitwise parsing without architectural regressions.
+- [ ] Ensure `RangeError` from the `DataView` API gracefully throws `Error('The save file is corrupted or incomplete.')`.
+- [ ] Verify that tests added correctly assert both G/S and Crystal offsets, as well as the error handling behaviors.
+- [ ] Run test suite (`pnpm test`) and confirm it passes.


### PR DESCRIPTION
Drafted three tasks (impl, test, qa) to formally adopt and verify the fully implemented Gen 2 NPC trade extraction logic in the codebase. Updated the Story node and DAG references.

---
*PR created automatically by Jules for task [8763873187215868612](https://jules.google.com/task/8763873187215868612) started by @szubster*