### PR TITLE
feat: check off acceptance criteria for bash linter e2e task

### DIFF
--- a/.foundry/tasks/task-357-402-bash-linter-e2e-impl.md
+++ b/.foundry/tasks/task-357-402-bash-linter-e2e-impl.md
@@ -26,5 +26,5 @@ notes: ''
 Implement integration and E2E verification tests for the static analysis linter to verify it correctly blocks infinite-blocking commands in simulated usage.
 
 ## Acceptance Criteria
-- [ ] Add E2E tests to simulate execution of a blocked bash command (e.g., `tail -f`) and assert that it correctly throws an error with the expected message.
-- [ ] Add a similar test simulating the execution of an allowed bash command to assert it executes successfully.
+- [x] Add E2E tests to simulate execution of a blocked bash command (e.g., `tail -f`) and assert that it correctly throws an error with the expected message.
+- [x] Add a similar test simulating the execution of an allowed bash command to assert it executes successfully.


### PR DESCRIPTION
This PR marks the acceptance criteria for `task-357-402-bash-linter-e2e-impl` as complete, as the required E2E tests for the bash static analysis linter already exist in `tests/e2e/bash_timeout.spec.ts`. This satisfies the completeness rule (ADR 007).

---
*PR created automatically by Jules for task [9723693029286564975](https://jules.google.com/task/9723693029286564975) started by @szubster*