### PR TITLE
Update Gen 3 Trainer Defeat Flags Extraction story criteria

### DIFF
--- a/.foundry/journals/tech_lead/9409155726093687431.md
+++ b/.foundry/journals/tech_lead/9409155726093687431.md
@@ -1,0 +1,3 @@
+# Session 9409155726093687431
+
+Verified that the tasks spawned from STORY `story-307-319-gen3-trainer-flags-extraction` have transitioned to `COMPLETED`. Updated the acceptance criteria to reflect the completed state of `task-319-322-gen3-trainer-flags-extraction-impl` and `task-319-323-gen3-trainer-flags-extraction-qa`. Since both implementations and QA validations passed, the story is ready to progress to VERIFYING.

--- a/.foundry/stories/story-307-319-gen3-trainer-flags-extraction.md
+++ b/.foundry/stories/story-307-319-gen3-trainer-flags-extraction.md
@@ -34,5 +34,5 @@ Extract standard and rematch trainer defeat flags from Gen 3 save files to be us
 ## Acceptance Criteria
 - [x] Create Tech Lead Task Blueprints
 
-- [ ] task-319-322-gen3-trainer-flags-extraction-impl
-- [ ] task-319-323-gen3-trainer-flags-extraction-qa
+- [x] task-319-322-gen3-trainer-flags-extraction-impl
+- [x] task-319-323-gen3-trainer-flags-extraction-qa


### PR DESCRIPTION
Update acceptance criteria for story-307-319-gen3-trainer-flags-extraction to check off completed implementation and QA tasks.

---
*PR created automatically by Jules for task [9409155726093687431](https://jules.google.com/task/9409155726093687431) started by @szubster*