### PR TITLE
[Tech Lead] Draft Retry Tasks for Gen3 Static Encounters UI

### DIFF
--- a/.foundry/journals/tech_lead/8236035190226475414.md
+++ b/.foundry/journals/tech_lead/8236035190226475414.md
@@ -1,0 +1,5 @@
+# Tech Lead Journal Entry
+**Session:** 8236035190226475414
+
+QA rejected `task-295-338-gen3-static-encounters-ui-impl` because the UI component `Gen3StaticEncountersDashboard` was successfully built but not integrated into the `src/routes/dashboard.tsx` dashboard page.
+I have spawned `task-295-407-gen3-static-encounters-ui-impl-retry` and `task-295-408-gen3-static-encounters-ui-qa-retry` to ensure the component is actually integrated into the view to complete `story-138-295-gen3-static-encounters-ui`.

--- a/.foundry/stories/story-138-295-gen3-static-encounters-ui.md
+++ b/.foundry/stories/story-138-295-gen3-static-encounters-ui.md
@@ -30,3 +30,5 @@ Implement a UI checklist to track Gen 3 static encounters using the extracted sa
 - [ ] Ensure the component integrates seamlessly with the Gen 3 dashboard.
 - [ ] task-295-338-gen3-static-encounters-ui-impl
 - [ ] task-295-339-gen3-static-encounters-ui-qa
+- [ ] task-295-407-gen3-static-encounters-ui-impl-retry
+- [ ] task-295-408-gen3-static-encounters-ui-qa-retry

--- a/.foundry/tasks/task-295-407-gen3-static-encounters-ui-impl-retry.md
+++ b/.foundry/tasks/task-295-407-gen3-static-encounters-ui-impl-retry.md
@@ -1,0 +1,33 @@
+---
+id: task-295-407-gen3-static-encounters-ui-impl-retry
+type: TASK
+title: Gen 3 Static Encounters UI Integration Retry
+status: READY
+owner_persona: coder
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-138-295-gen3-static-encounters-ui
+tags:
+  - gen3
+  - feature
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Static Encounters UI Integration Retry
+
+Integrate the `Gen3StaticEncountersDashboard` into the main Gen 3 dashboard view.
+
+## Context
+The previous task (`task-295-338-gen3-static-encounters-ui-impl`) correctly created and tested the `Gen3StaticEncountersDashboard` component adhering to ADR 008 constraints. However, it was rejected by QA because it was not integrated into `src/routes/dashboard.tsx` (the central Gen 3 dashboard), rendering it inaccessible.
+
+## Acceptance Criteria
+- [ ] Integrate `<Gen3StaticEncountersDashboard />` into `src/routes/dashboard.tsx`.
+- [ ] Pass the appropriate Gen 3 `saveData` to the component.
+- [ ] Ensure the integration does not break the layout of existing components.

--- a/.foundry/tasks/task-295-408-gen3-static-encounters-ui-qa-retry.md
+++ b/.foundry/tasks/task-295-408-gen3-static-encounters-ui-qa-retry.md
@@ -1,0 +1,31 @@
+---
+id: task-295-408-gen3-static-encounters-ui-qa-retry
+type: TASK
+title: Gen 3 Static Encounters UI Integration Retry QA
+status: READY
+owner_persona: qa
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on:
+  - task-295-407-gen3-static-encounters-ui-impl-retry
+jules_session_id: null
+pr_number: null
+parent: story-138-295-gen3-static-encounters-ui
+tags:
+  - gen3
+  - feature
+  - ui
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Static Encounters UI Integration Retry QA
+
+Verify the integration of the Gen 3 Static Encounters UI.
+
+## Acceptance Criteria
+- [ ] Verify that `Gen3StaticEncountersDashboard` is correctly displayed on the main Gen 3 dashboard (`src/routes/dashboard.tsx`).
+- [ ] Verify the UI correctly displays the static encounter checklist based on save file flags.


### PR DESCRIPTION
Drafted retry tasks for Gen3 Static Encounters UI integration after previous implementation was missing the dashboard connection.

---
*PR created automatically by Jules for task [8236035190226475414](https://jules.google.com/task/8236035190226475414) started by @szubster*