### PR TITLE
🗃️ Auditor: Cancel idea-107-pokerus-strain-ui-tracker

### DIFF
--- a/.foundry/ideas/idea-107-pokerus-strain-ui-tracker.md
+++ b/.foundry/ideas/idea-107-pokerus-strain-ui-tracker.md
@@ -2,7 +2,7 @@
 id: idea-107-pokerus-strain-ui-tracker
 type: IDEA
 title: Pokerus Strain Specific UI Tracker
-status: ACTIVE
+status: CANCELLED
 owner_persona: auditor
 created_at: '2026-07-09'
 updated_at: '2026-08-08'

--- a/test_script.js
+++ b/test_script.js
@@ -1,0 +1,1 @@
+console.log("Testing");

--- a/test_script.js
+++ b/test_script.js
@@ -1,1 +1,0 @@
-console.log("Testing");


### PR DESCRIPTION
Cancel idea-107-pokerus-strain-ui-tracker because its descendant nodes are permanently cancelled.

---
*PR created automatically by Jules for task [15979013511075526022](https://jules.google.com/task/15979013511075526022) started by @szubster*