### PR TITLE
Generate Epics for Gen 3 Acro Bike / Mach Bike Route Requirements

### DIFF
--- a/.foundry/epics/epic-339-406-gen3-bike-requirement-route-mapping.md
+++ b/.foundry/epics/epic-339-406-gen3-bike-requirement-route-mapping.md
@@ -1,0 +1,31 @@
+---
+id: epic-339-406-gen3-bike-requirement-route-mapping
+type: EPIC
+title: Route Pre-computation & Mapping
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-128-339-gen3-acro-bike-route-planner
+tags:
+  - gen3
+  - map
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Route Pre-computation & Mapping
+
+## Context
+Introduce a "Bike Requirement Filter" to DexHelper's Smart Route Radar or interactive map. By parsing the underlying game map definitions (which DexHelper already uses to map routes and encounters), we can visually highlight which specific paths, items, or hidden areas on a route require a specific bike.
+
+## Proposal
+Route Pre-computation: When a player views a route in DexHelper, clearly tag the route with badges like `[Requires Mach Bike]` or `[Requires Acro Bike]` if significant portions are gated behind those mechanics.
+
+## Acceptance Criteria
+- [ ] story_owner: Break down this Epic into Stories.
+- [ ] story_owner: Ensure one final STORY dedicated exclusively to Integration and E2E Verification is generated.

--- a/.foundry/epics/epic-339-407-gen3-bike-item-gating-integration.md
+++ b/.foundry/epics/epic-339-407-gen3-bike-item-gating-integration.md
@@ -1,0 +1,32 @@
+---
+id: epic-339-407-gen3-bike-item-gating-integration
+type: EPIC
+title: Item Gating Integration
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on:
+  - epic-339-406-gen3-bike-requirement-route-mapping
+jules_session_id: null
+pr_number: null
+parent: prd-128-339-gen3-acro-bike-route-planner
+tags:
+  - gen3
+  - map
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Item Gating Integration
+
+## Context
+Introduce a "Bike Requirement Filter" to DexHelper's Smart Route Radar or interactive map. By parsing the underlying game map definitions (which DexHelper already uses to map routes and encounters), we can visually highlight which specific paths, items, or hidden areas on a route require a specific bike.
+
+## Proposal
+Item Gating: If a route contains hidden items or TMs (tracked via save flags), explicitly note if reaching that item requires a specific bike. For example, "TM13 Ice Beam (Abandoned Ship) - Requires Dive & Storage Key."
+
+## Acceptance Criteria
+- [ ] story_owner: Break down this Epic into Stories.
+- [ ] story_owner: Ensure one final STORY dedicated exclusively to Integration and E2E Verification is generated.

--- a/.foundry/epics/epic-339-408-gen3-bike-save-state-recommendations.md
+++ b/.foundry/epics/epic-339-408-gen3-bike-save-state-recommendations.md
@@ -1,0 +1,33 @@
+---
+id: epic-339-408-gen3-bike-save-state-recommendations
+type: EPIC
+title: Save-State Aware Recommendations
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on:
+  - epic-339-406-gen3-bike-requirement-route-mapping
+  - epic-339-407-gen3-bike-item-gating-integration
+jules_session_id: null
+pr_number: null
+parent: prd-128-339-gen3-acro-bike-route-planner
+tags:
+  - gen3
+  - map
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Save-State Aware Recommendations
+
+## Context
+Introduce a "Bike Requirement Filter" to DexHelper's Smart Route Radar or interactive map. By parsing the underlying game map definitions (which DexHelper already uses to map routes and encounters), we can visually highlight which specific paths, items, or hidden areas on a route require a specific bike.
+
+## Proposal
+Save-State Aware Recommendations: By reading the player's current inventory from the save file (checking if they currently hold the Acro or Mach bike), DexHelper can suggest optimal exploration paths or warn the player that they need to fly back to Mauville City before attempting a specific route.
+
+## Acceptance Criteria
+- [ ] story_owner: Break down this Epic into Stories.
+- [ ] story_owner: Ensure one final STORY dedicated exclusively to Integration and E2E Verification is generated.

--- a/.foundry/journals/epic_planner/15023750986512382605.md
+++ b/.foundry/journals/epic_planner/15023750986512382605.md
@@ -1,0 +1,8 @@
+# Session 15023750986512382605
+
+Read `.foundry/docs/knowledge_base/agents/core_policies.md`.
+Processed PRD `prd-128-339-gen3-acro-bike-route-planner`.
+Broke down the PRD into 3 Epics:
+- `epic-339-406-gen3-bike-requirement-route-mapping`
+- `epic-339-407-gen3-bike-item-gating-integration`
+- `epic-339-408-gen3-bike-save-state-recommendations`

--- a/.foundry/prds/prd-128-339-gen3-acro-bike-route-planner.md
+++ b/.foundry/prds/prd-128-339-gen3-acro-bike-route-planner.md
@@ -33,4 +33,7 @@ Specifically, it will provide:
 3. **Save-State Aware Recommendations:** By reading the player's current inventory from the save file (checking if they currently hold the Acro or Mach bike), DexHelper can suggest optimal exploration paths or warn the player that they need to fly back to Mauville City before attempting a specific route.
 
 ## Acceptance Criteria
-- [ ] epic_planner: Break this PRD down into actionable Epics.
+- [x] epic_planner: Break this PRD down into actionable Epics.
+- [ ] epic-339-406-gen3-bike-requirement-route-mapping
+- [ ] epic-339-407-gen3-bike-item-gating-integration
+- [ ] epic-339-408-gen3-bike-save-state-recommendations


### PR DESCRIPTION
Break down PRD prd-128-339-gen3-acro-bike-route-planner into actionable Epics: epic-339-406-gen3-bike-requirement-route-mapping, epic-339-407-gen3-bike-item-gating-integration, epic-339-408-gen3-bike-save-state-recommendations.

---
*PR created automatically by Jules for task [15023750986512382605](https://jules.google.com/task/15023750986512382605) started by @szubster*