### PR TITLE
Product Manager: IDEA-136 -> PRD-136-340

### DIFF
--- a/.foundry/journals/product_manager/17749450542018693624.md
+++ b/.foundry/journals/product_manager/17749450542018693624.md
@@ -1,0 +1,3 @@
+# Session 17749450542018693624
+
+Generated PRD for "Split bundles and data by game generation" from idea-136-split-bundles-and-data.

--- a/.foundry/prds/prd-136-340-split-bundles-and-data.md
+++ b/.foundry/prds/prd-136-340-split-bundles-and-data.md
@@ -1,29 +1,29 @@
 ---
-id: idea-136-split-bundles-and-data
-type: IDEA
+id: prd-136-340-split-bundles-and-data
+type: PRD
 title: Split bundles and data by game generation
-status: ACTIVE
-owner_persona: product_manager
-created_at: '2024-08-07'
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-08-08'
 updated_at: '2026-08-08'
 depends_on: []
-jules_session_id: '17749450542018693624'
-parent: null
+jules_session_id: null
+parent: idea-136-split-bundles-and-data
 tags:
   - performance
   - architecture
   - bundles
   - database
 rejection_count: 0
-rejection_reason: ''
-notes: ''
+rejection_reason: ""
+notes: ""
 ---
-# Idea: Split bundles and data by game generation
+# PRD: Split bundles and data by game generation
 
-## Context
+## Context & Objectives
 As DexHelper supports more Pokémon generations, the amount of code (parsers, strategies) and data (encounters, locations) is increasing. Currently, everything is loaded upfront, which affects initial load performance and memory usage.
 
-## Proposal
+## Requirements
 Implement generation-based splitting for JavaScript engine logic, UI components, and static Pokedex data.
 - Use dynamic imports for generation-specific parsers in `src/engine/saveParser/index.ts`.
 - Use dynamic imports for generation-specific assistant strategies in `src/engine/assistant/strategies/index.ts`.
@@ -31,10 +31,8 @@ Implement generation-based splitting for JavaScript engine logic, UI components,
 - Split the monolithic `pokedata.msgpack` into a core bundle and generation-specific extensions in `vite-plugins/pokedata-plugin.ts` by emitting multiple msgpack bundles.
 - Refactor the synchronization logic in `src/db/PokeDB.ts` to support multi-part data synchronization to load extensions and code on demand when a specific generation is detected.
 
-## Value Proposition
-- **Faster Initial Load**: Reduced initial download size by deferring generation-specific assets.
-- **Improved Scalability**: Support for future generations (Gen 4+) without bloating the initial app experience.
-- **Better Resource Management**: Only load the data, code, and UI the user actually needs.
-
 ## Acceptance Criteria
-- [x] prd-136-340-split-bundles-and-data
+- [ ] Breakdown PRD into EPIC nodes.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/prds/prd-136-340-split-bundles-and-data.md
+++ b/.foundry/prds/prd-136-340-split-bundles-and-data.md
@@ -33,6 +33,7 @@ Implement generation-based splitting for JavaScript engine logic, UI components,
 
 ## Acceptance Criteria
 - [ ] Breakdown PRD into EPIC nodes.
+- [ ] research-340-405-background-fetching
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/research/research-340-405-background-fetching.md
+++ b/.foundry/research/research-340-405-background-fetching.md
@@ -1,0 +1,31 @@
+---
+id: research-340-405-background-fetching
+type: RESEARCH
+title: Investigate background fetching and preloading for msgpack files
+status: PENDING
+owner_persona: researcher
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on: []
+jules_session_id: null
+parent: prd-136-340-split-bundles-and-data
+tags:
+  - performance
+  - preloading
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+# Research: Background Fetching and Preloading
+
+## Context
+As part of PRD 136-340 to split bundles and data by game generation, we also want to explore ways to pre-fetch or background fetch the generation-specific msgpack files and assets. This ensures that while initial load is fast, subsequent data is available seamlessly without blocking the main thread or causing noticeable delays when a user navigates to a new generation.
+
+## Objectives
+- Investigate the use of `defer` in script tags.
+- Explore resource hints (like `<link rel="prefetch">` or `<link rel="preload">`) to hint the browser about msgpack files.
+- Document state-of-the-art patterns for background fetching large static data payloads in modern web applications.
+- Produce a recommendation on the best approach to integrate into the DexHelper architecture.
+
+## Acceptance Criteria
+- [ ] Document findings and recommendations in this node.


### PR DESCRIPTION
Transforms IDEA 136 into PRD 136-340 for splitting JS bundles, UI components, and Pokédex data by game generation. Updates parent IDEA checklist and records Product Manager journal entry.

---
*PR created automatically by Jules for task [17749450542018693624](https://jules.google.com/task/17749450542018693624) started by @szubster*