### PR TITLE
feat(ideas): propose built-in emulator integration and derived features

### DIFF
--- a/.foundry/ideas/idea-137-builtin-emulator.md
+++ b/.foundry/ideas/idea-137-builtin-emulator.md
@@ -1,0 +1,38 @@
+---
+id: idea-137-builtin-emulator
+type: IDEA
+title: Built-in Emulator Integration
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - emulator
+  - research
+  - core
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Built-in Emulator Integration (No ROMs Included)
+
+## Problem
+Currently, DexHelper relies entirely on users manually exporting and uploading `.sav` files to track their progress. This creates a highly friction-filled user experience and prevents live, turn-by-turn game assistance, route tracking, or reactive combat help during active play.
+
+## Proposed Solution
+Embed a high-performance, open-source Game Boy (GB/GBC) and Game Boy Advance (GBA) emulator directly in the browser using WebAssembly (WASM).
+1. **OSS Core Selection:** Integrate a widely-respected, highly accurate emulator core like `mGBA` or `binjgb` compiled to WASM. Focus on an implementation that provides robust debugging interfaces and exposes clear memory maps.
+2. **Zero ROM Bundling Policy:** For strict legal and copyright compliance, **do not bundle or host any ROMs**. Users must upload their own legal, local ROM files (e.g., via drag-and-drop or file picker) into the application's virtual sandbox.
+3. **Reactive UI:** DexHelper will monitor the active emulator state. If a player walks into a new route, encounters a Pokémon, or enters a gym battle, DexHelper's interface will instantly react, updating stats, recommending optimal paths, or advising on battle strategies in real-time.
+4. **Direct RAM Read Access:** Instead of waiting for a file system write to the save sector, the application will read from the running WebAssembly emulator's memory buffer in real-time, enabling live telemetry.
+
+## Value Proposition
+This upgrades DexHelper from a static post-save analyzer into an interactive, live-reactive companion. Players get a single, unified interface for playing games with professional, real-time advice.
+
+## Acceptance Criteria
+- [ ] Product Manager: Draft a comprehensive PRD outlining the web-emulator integration flow, UI/UX layouts, and the reactive instruction schema.

--- a/.foundry/ideas/idea-138-realtime-memory-sync-extraction.md
+++ b/.foundry/ideas/idea-138-realtime-memory-sync-extraction.md
@@ -1,0 +1,37 @@
+---
+id: idea-138-realtime-memory-sync-extraction
+type: IDEA
+title: Real-Time WebAssembly Memory Sync and Extraction
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - emulator
+  - save-engine
+  - architecture
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Real-Time WebAssembly Memory Sync and Extraction
+
+## Problem
+Even with an embedded emulator, if we only parse save states or wait for in-game saves to occur, we cannot provide turn-by-turn or step-by-step assistance. To be truly reactive, DexHelper must extract game state continuously from active memory (RAM) while the game is running.
+
+## Proposed Solution
+Develop a high-performance WebAssembly Memory Bridge between the embedded emulator core and the DexHelper React state store.
+1. **Memory Polling & Hooking Engine:** Rather than parsing the entire memory space, map critical RAM offsets (WRAM for GB/GBC, IRAM/EWRAM for GBA) for player coordinate structures, battle state blocks, party data, and event flag banks.
+2. **Dynamic Offset Mappings:** Define cross-version memory offset schemas (Red, Blue, Yellow, Gold, Silver, Crystal, Ruby, Sapphire, FireRed, LeafGreen, Emerald) to accurately read state regardless of the active ROM.
+3. **State Sync Middleware:** Feed extracted RAM blocks directly into existing save-file parsers (which already understand the binary structures) but adapted to continuous real-time updates.
+
+## Value Proposition
+Enables absolute synchrony between gameplay and data overlays without CPU performance impact. This serves as the pipeline enabling all other live features.
+
+## Acceptance Criteria
+- [ ] Product Manager: Draft a PRD defining the target RAM offset blocks for Gen 1, Gen 2, and Gen 3, and outline the pub-sub mechanism for the memory bridge.

--- a/.foundry/ideas/idea-139-live-battle-prediction-overlay.md
+++ b/.foundry/ideas/idea-139-live-battle-prediction-overlay.md
@@ -1,0 +1,37 @@
+---
+id: idea-139-live-battle-prediction-overlay
+type: IDEA
+title: Live Battle Advisor and Prediction Overlay
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - emulator
+  - battle
+  - ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Live Battle Advisor and Prediction Overlay
+
+## Problem
+In competitive play and Hardcore Nuzlockes, battles are highly volatile. A single misplay, miscalculated damage roll, or unexpected enemy move can end a run. Calculating damage or predicting moves manually requires constant tab-switching to external calculators.
+
+## Proposed Solution
+Design a modern, HUD-style Battle Advisor overlay that wraps the built-in emulator window.
+1. **Real-Time Combat Scanner:** Read active battle variables from RAM (current enemy Pokémon ID, level, stats, moves, turn count, weather, and status conditions).
+2. **On-the-Fly Damage Calculation:** Feed these live variables into the damage calculation engine to display guaranteed damage ranges, critical hit thresholds, and survival probabilities instantly.
+3. **Deterministic AI Move Predictor:** Ingest the trainer's AI script level and evaluate move priorities against the user's active Pokémon typing and stats to predict the enemy's next move with exact probabilities.
+
+## Value Proposition
+Players can execute perfect battle strategies without tedious manual calculations, elevating DexHelper to the premier tactical guide for challenge runners.
+
+## Acceptance Criteria
+- [ ] Product Manager: Draft a PRD detailing the UX overlay layout, the real-time damage calculator feed, and the move-prediction visualization framework.

--- a/.foundry/ideas/idea-140-auto-checklist-location-tracker.md
+++ b/.foundry/ideas/idea-140-auto-checklist-location-tracker.md
@@ -1,0 +1,37 @@
+---
+id: idea-140-auto-checklist-location-tracker
+type: IDEA
+title: Automated Location Tracking and Checklist Sync
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - emulator
+  - map
+  - checklist
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Automated Location Tracking and Checklist Sync
+
+## Problem
+Using checklists (such as Route Checklist, Hidden Item Checklist, and Trainer checklists) is a core loop of DexHelper. However, players must manually check off items as they play. This is prone to human error, forgetfulness, and breaks the immersive flow of playing the game.
+
+## Proposed Solution
+Create an automation engine that hooks into the emulator's memory to track player progress automatically.
+1. **Map Coordinates and ID Sync:** Continuously poll player X/Y coordinates and current Map ID. Automatically pan and zoom the DexHelper Map UI to highlight the player's exact position.
+2. **Event Flag Tracker:** Read the game's event flag arrays. The instant a hidden item is collected or a trainer is defeated, detect the bit flip and check it off the user's checklist.
+3. **Auto-Nuzlocke Encounter Logger:** In a Nuzlocke, detect wild battle encounters. The instant a wild battle starts, log the species, location, and capture status automatically to the Nuzlocke database.
+
+## Value Proposition
+Eliminates all tedious manual tracking. The player simply plays their game in the emulator, and their entire checklisted state updates organically.
+
+## Acceptance Criteria
+- [ ] Product Manager: Draft a PRD outlining the event-flag-to-checklist mapper architecture, detailing coordinate mappings and wild encounter state detection.

--- a/.foundry/ideas/idea-141-wasm-savestate-timetravel-debugging.md
+++ b/.foundry/ideas/idea-141-wasm-savestate-timetravel-debugging.md
@@ -1,0 +1,37 @@
+---
+id: idea-141-wasm-savestate-timetravel-debugging
+type: IDEA
+title: WASM Savestate Time Travel and Debugging Suite
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - emulator
+  - debug
+  - save-engine
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: WASM Savestate Time Travel and Debugging Suite
+
+## Problem
+Understanding state corruption, testing different branches of battle RNG, or analyzing complex game events is currently impossible without restarting the emulator and re-importing saves.
+
+## Proposed Solution
+Introduce a WASM Savestate Time Travel system.
+1. **Automated State Snapshots:** Take lightweight, in-memory emulator savestate snapshots on critical triggers (e.g., entering a battle, catching a Pokémon, leveling up, or changing maps).
+2. **Timeline Visualization:** Display a visual history tree of the player's run. Let users scroll back in time to inspect exactly what the party stats, items, and event flags looked like at that specific moment.
+3. **Differential Save Analysis:** Build a "Diff" tool to compare the state of two snapshots or saves side-by-side, visualizing precisely which bit events or variables changed during that interval.
+
+## Value Proposition
+Provides unprecedented analytical tools for developers and speedrunners, letting them test strategies and debug game states with absolute precision.
+
+## Acceptance Criteria
+- [ ] Product Manager: Draft a PRD defining the savestate snapshot triggers, diff schema, and interactive timeline visualization UX.

--- a/.foundry/journals/product_manager/2026-08-08-18-32-48.md
+++ b/.foundry/journals/product_manager/2026-08-08-18-32-48.md
@@ -1,0 +1,13 @@
+# Product Manager Journal - Built-in Emulator Ideas Initialization
+*   **Session ID:** 11433354673368983253
+*   **Date:** 2026-08-08
+
+## Why This Matters
+Embedding an open-source Game Boy / Game Boy Advance emulator (like mGBA or binjgb) compiled to WebAssembly represents a paradigm shift for DexHelper.
+Traditionally, our application had a read-only, retroactive connection to local save files. By embedding the execution environment itself, we gain live telemetry via direct memory (RAM) queries.
+This allows us to transition from a retrospective checker to a real-time copilot.
+
+## Core Architectural Insights & Constraints
+1. **Legality & Zero ROM Bundling:** We must enforce a strict sandbox boundary where NO commercial Nintendo assets or ROM files are hosted or loaded by default. The emulator acts strictly as a raw virtual machine, and the client-side user is responsible for drag-and-drop their legally obtained backups.
+2. **Memory Maps over Binary Files:** Reading WRAM/IRAM allows us to hook into events as they occur (such as wild encounter state shifts) rather than polling a filesystem timestamp every 3 seconds, significantly reducing the I/O load on the browser.
+3. **Reactive UI Loop:** This design decouples the heavy UI calculations from the emulator thread, ensuring zero-latency play with highly granular overlay indicators.


### PR DESCRIPTION
This PR proposes five highly detailed, interconnected idea nodes outlining a built-in emulator integration within DexHelper, along with derived features:
1. `idea-137-builtin-emulator`: The core integration of an open-source emulator (GB/GBC/GBA) in the browser via WebAssembly (WASM) under a strict zero-ROM bundling policy.
2. `idea-138-realtime-memory-sync-extraction`: Establishing a high-performance WebAssembly Memory Bridge between the emulator and DexHelper to extract state from RAM in real-time.
3. `idea-139-live-battle-prediction-overlay`: A HUD-style Live Battle Advisor wrapping the emulator to display on-the-fly damage ranges and deterministic AI move prediction.
4. `idea-140-auto-checklist-location-tracker`: Automatically syncing route checklists, map coordinate radars, and Nuzlocke encounter logs based on RAM bit events.
5. `idea-141-wasm-savestate-timetravel-debugging`: Lightweight savestate capturing to enable visual run histories, timeline rewinding, and side-by-side snapshot diffing.

Includes schema and DAG validation checks as well as the Product Manager private journal entry.

Fixes #5800

---
*PR created automatically by Jules for task [16659052159458134058](https://jules.google.com/task/16659052159458134058) started by @szubster*