### PR TITLE
feat: Draft stories for schema role and status mapping

### DIFF
--- a/.foundry/epics/epic-339-405-schema-role-mapping.md
+++ b/.foundry/epics/epic-339-405-schema-role-mapping.md
@@ -30,5 +30,7 @@ Update the `.foundry/docs/schema.md` to officially define the Pokemon Gen 1 narr
 - Ensure strict adherence to Generation 1 Pokemon.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Generate STORY node(s) for updating schema.md with role and status mappings.
-- [ ] Story Owner: Generate a final STORY node dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`).
+- [x] Story Owner: Generate STORY node(s) for updating schema.md with role and status mappings.
+- [x] Story Owner: Generate a final STORY node dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`).
+- [ ] story-405-408-schema-role-status-mapping
+- [ ] story-405-409-schema-role-mapping-e2e

--- a/.foundry/stories/story-405-408-schema-role-status-mapping.md
+++ b/.foundry/stories/story-405-408-schema-role-status-mapping.md
@@ -1,0 +1,33 @@
+---
+id: story-405-408-schema-role-status-mapping
+type: STORY
+title: 'Draft Tasks for Schema Role and Status Mapping'
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-339-405-schema-role-mapping
+tags:
+  - foundry
+  - schema
+  - gamification
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Draft Tasks for Schema Role and Status Mapping
+
+## Objective
+Break down the work into tasks to update `.foundry/docs/schema.md` with the official Pokemon Gen 1 narrative skin mappings for the 13 system roles and lifecycle statuses.
+
+## Functional Requirements
+- Draft TASK nodes to map the 13 system roles to respective Gen 1 entities (e.g. `product_manager` -> Dragonite, `epic_planner` -> Alakazam).
+- Draft TASK nodes to map standard DAG statuses to Gen 1 progression mechanics (e.g., PENDING -> Pokémon Egg, COMPLETED -> Fully Evolved / Hall of Fame).
+- Ensure strict adherence to Generation 1 Pokemon.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Generate TASK node(s) for updating schema.md.

--- a/.foundry/stories/story-405-409-schema-role-mapping-e2e.md
+++ b/.foundry/stories/story-405-409-schema-role-mapping-e2e.md
@@ -1,0 +1,31 @@
+---
+id: story-405-409-schema-role-mapping-e2e
+type: STORY
+title: 'Schema Role and Status Mapping E2E Verification'
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-08'
+updated_at: '2026-08-08'
+depends_on:
+  - story-405-408-schema-role-status-mapping
+jules_session_id: null
+pr_number: null
+parent: epic-339-405-schema-role-mapping
+tags:
+  - e2e
+  - integration
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Schema Role and Status Mapping E2E Verification
+
+## Objective
+Break down the work to verify that the schema mappings have been applied successfully and don't introduce any logical regression or break internal tools.
+
+## Functional Requirements
+- Draft TASK nodes for verifying the schema correctness.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Generate QA/Integration TASK node(s) for verifying schema mappings.


### PR DESCRIPTION
Drafts stories `story-405-408-schema-role-status-mapping` and `story-405-409-schema-role-mapping-e2e` under `epic-339-405-schema-role-mapping` to start updating schema mappings for system roles and lifecycle statuses to Gen 1 Pokemon terms. The parent EPIC has also been updated with the tracking links.

---
*PR created automatically by Jules for task [11206536485884555630](https://jules.google.com/task/11206536485884555630) started by @szubster*