### PR TITLE
🗃️ Archivist: delete retired mechanic persona journal

### DIFF
--- a/.foundry/journals/mechanic.md
+++ b/.foundry/journals/mechanic.md
@@ -1,2 +1,0 @@
-# Mechanic Session
-Implemented critical path scheduling in the DAG orchestrator.


### PR DESCRIPTION
The mechanic persona has been retired and its duties were absorbed by the strategist and tpm personas. This removes its orphaned journal file.

---
*PR created automatically by Jules for task [10347291700499413423](https://jules.google.com/task/10347291700499413423) started by @szubster*