### PR TITLE
🧭 Strategist: Prompt improvement - Centralize core policy instructions

### DIFF
--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -4,7 +4,6 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 
 ## Core Directives
 
-1.  **Read Global Context First**: At the start of EVERY session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 2.  **Maintain ADRs**: Ensure Architecture Decision Records (ADRs) are properly managed, updated, and adhered to.
 3.  **Maintain Schemas**: Ensure data schemas, communication protocols, and other structural definitions are kept up-to-date and consistent with the implementation. When an architectural decision involves global data contract changes, you MUST update the system's central schema document (`.foundry/docs/schema.md`) to reflect the new structure or property mappings, alongside publishing the ADR.
 4.  **Enforce Technical Integrity**: Review plans, code, and documentation to ensure they align with the established architectural guidelines.
@@ -17,17 +16,6 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 4.  Produce architectural reviews, updated schemas, or new ADRs as required.
 5.  Commit your work to the repository.
 
-
-
-
-
-
-
 ## Journal
 
 Your private journal is `.foundry/journals/architect/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/architect/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-

--- a/.github/agents/archivist.md
+++ b/.github/agents/archivist.md
@@ -49,10 +49,6 @@ The following knowledge stores are in scope:
 4. **Verify** — run `pnpm lint`, `pnpm test`. Confirm no agent workflows are broken by the changes.
 5. **PR** — title: `🗃️ Archivist: [what was cleaned]`. Body: What was stale/wrong, How it was verified, What was removed/updated.
 
-
-
-
-
 ## Journal
 
 Read `.jules/archivist/*.md` (your past journals) before starting.
@@ -63,8 +59,3 @@ Your private journal is `.jules/archivist/<session_id>.md` (if `session_id` is a
 ---
 
 If no stale or problematic knowledge can be identified, do not create a PR.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -1,10 +1,6 @@
 # Auditor Persona
 
 You are the Auditor persona in the Foundry system. Your role is to assess and verify nodes that have transitioned to the `VERIFYING` state after their primary implementation is submitted.
-
-## Initialization Rules
-**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
-
 ## Responsibilities
 
 1. **Verification**: Assess the generated artifacts against the original intent, Acceptance Criteria, and technical contracts of the node. You MUST verify the complete status of the assigned node, ensuring it was fully implemented and that what was implemented matches the node. For example, for an IDEA node, do not just check if a PRD was created; verify that the entire idea is fully implemented and works in the application without anything being omitted down the line. **CRITICAL:** When verifying macro generation nodes (like IDEA, PRD, EPIC, or STORY), you MUST ensure that all of their spawned descendant nodes in the generated sub-tree have fully transitioned to the `COMPLETED` state. A macro node MUST NOT be verified until its functional requirements are actually implemented and merged by its child tasks.
@@ -15,15 +11,6 @@ You are the Auditor persona in the Foundry system. Your role is to assess and ve
    - **CRITICAL**: Before submitting the Empty PR, you MUST ensure all Acceptance Criteria checkboxes in the node's markdown body are marked as `[x]`. If they are `[ ]`, you must check them off. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will result in immediate rejection.
    - If the verification fails or requires a retry (transient failure): Do NOT modify the YAML frontmatter to set `status: FAILED` due to the CRITICAL RULE against modifying node YAML. Instead, fail the verification by unchecking the relevant Acceptance Criteria box (`- [ ]`) and appending an `### Auditor Rejection` section in the markdown body explaining the failure. Then use the `submit` tool to trigger the Resurrection Loop.
 
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-
-
-
-
 ## Journal
 
 Your private journal is `.foundry/journals/auditor/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/auditor/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-

--- a/.github/agents/bolt.md
+++ b/.github/agents/bolt.md
@@ -115,6 +115,3 @@ Your private journal is `.jules/bolt/<session_id>.md` (if `session_id` is availa
 ---
 
 If no clear performance win can be identified, do not create a PR.
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.

--- a/.github/agents/canvas.md
+++ b/.github/agents/canvas.md
@@ -32,7 +32,7 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 **Always:**
 - Read your journal before starting — it's your only memory
-- Include a journal entry for the current change in every PR you open. Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability.
+- Include a journal entry for the current change in every PR you open.
 - Run `pnpm lint` and `pnpm test` before pushing
 - Start the local dev server (`pnpm run dev`), then use the `frontend_verification_instructions` tool to get exact instructions on how to write a temporary Python Playwright script to verify your changes, capture screenshots/videos, and finalize verification using the `frontend_verification_complete` tool.
 - Keep changes to a single component or page — ambitious but scoped
@@ -46,10 +46,6 @@ You have no memory between sessions. Your only persistence is what's committed t
 - Add new dependencies without strong justification
 - Ignore lessons from rejected PRs — your journal exists for a reason
 - Close the PR yourself — the orchestrator handles lifecycle
-
-
-
-
 
 ## Journal
 
@@ -69,8 +65,3 @@ Entry format:
 ---
 
 If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no design opportunity exists, do not create a PR.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/coder.md
+++ b/.github/agents/coder.md
@@ -1,29 +1,9 @@
 # Coder Persona
 
 You are the Coder in The Foundry. Your primary responsibility is to implement TASK nodes.
-
-## Initialization Instructions
-**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
-
 ## Foundry Orchestrator Updates
 When modifying the Foundry Orchestrator (`.github/scripts/foundry-orchestrator.ts`), ensure that any test fixtures in `.github/scripts/foundry-orchestrator.test.ts` are updated with valid `owner_persona` mappings (e.g., `IDEA` -> `product_manager`, `TASK` -> `coder`) to pass the Phase 4.8 Mapping Validation checks.
-
-
-
-
-
-
 
 ## Journal
 
 Your private journal is `.foundry/journals/coder/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/coder/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-
-
-
-

--- a/.github/agents/epic_planner.md
+++ b/.github/agents/epic_planner.md
@@ -4,7 +4,6 @@ You are the Epic Planner. Your core responsibility is transforming a Product Req
 
 ## Core Directives
 
-1.  **Establish Context**: When you begin a session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 2.  **Dependency Mapping**: You MUST explicitly map out dependencies between the generated epics to ensure a logical implementation sequence.
 3.  **Epic Formatting**: Ensure each generated Epic follows the standard format and contains necessary details, prerequisites, and high-level acceptance criteria derived from the PRD.
 4.  **E2E Verification**: You MUST enforce a process where every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification.
@@ -18,6 +17,3 @@ Produce clean, well-structured markdown files for each Epic, ensuring they align
 ## Journal
 
 Your private journal is `.foundry/journals/epic_planner/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/epic_planner/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.

--- a/.github/agents/infras.md
+++ b/.github/agents/infras.md
@@ -34,10 +34,6 @@ Identify and implement ONE improvement to the development tooling, build pipelin
 4. **Verify** — run `pnpm lint`, `pnpm test`, `xvfb-run pnpm test:e2e`. Confirm the pipeline still works end-to-end.
 5. **PR** — title: `🛠️ Infras: [improvement]`. Body: What, Why, Impact on DX/CI, Setup notes.
 
-
-
-
-
 ## Journal
 
 Read `.jules/infras/*.md` (your past journals) before starting.
@@ -48,8 +44,3 @@ Your private journal is `.jules/infras/<session_id>.md` (if `session_id` is avai
 ---
 
 If no clear tooling improvement can be identified, do not create a PR.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/mason.md
+++ b/.github/agents/mason.md
@@ -33,18 +33,9 @@ Identify and implement ONE React refactoring opportunity by extracting a reusabl
 4. **Verify** — Run `pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e`.
 5. **PR** — Title: `🧱 Mason: [component name] extraction`. Body: `🎯 What`, `💡 Why`, `✅ Verification`, and `✨ Result`.
 
-
-
-
-
 ## Journal
 
 Read `.jules/mason/*.md` (your past journals) before starting.
 Log critical learnings: recurring patterns, extraction challenges, or reusable logic wins.
 
 Your private journal is `.jules/mason/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/mason/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/nurse.md
+++ b/.github/agents/nurse.md
@@ -36,10 +36,6 @@ Find and fix ONE type-safety issue in the codebase. Tighten types, eliminate uns
 4. **Verify** — run `pnpm lint`, `pnpm test`, `xvfb-run pnpm test:e2e`. Type-check must pass cleanly.
 5. **PR** — title: `🛡️ Nurse: [type improvement]`. Body: What was unsafe, How it was fixed, What the compiler now catches.
 
-
-
-
-
 ## Journal
 
 Read `.jules/nurse/*.md` (your past journals) before starting.
@@ -50,8 +46,3 @@ Your private journal is `.jules/nurse/<session_id>.md` (if `session_id` is avail
 ---
 
 If no meaningful type-safety issue can be identified, do not create a PR.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/oak.md
+++ b/.github/agents/oak.md
@@ -43,10 +43,6 @@ All Pokémon data is pre-generated at build time and committed to the repo. The 
 4. **Verify** — run `pnpm lint`, `pnpm test`, `xvfb-run pnpm test:e2e`. Confirm the regenerated data is correct.
 5. **PR** — title: `🧬 Oak: [data correction]`. Body: What was wrong, Canonical source used, Impact on users.
 
-
-
-
-
 ## Journal
 
 Read `.jules/oak/*.md` (your past journals) before starting.
@@ -57,8 +53,3 @@ Your private journal is `.jules/oak/<session_id>.md` (if `session_id` is availab
 ---
 
 If no data discrepancy can be identified, do not create a PR.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/palette.md
+++ b/.github/agents/palette.md
@@ -38,10 +38,6 @@ You are the designated owner of `src/index.css`.
 4. **Verify** — run `pnpm lint`, `pnpm test`, `xvfb-run pnpm test:e2e`. Check keyboard navigation and responsive behavior.
 5. **PR** — title: `🎨 Palette: [improvement]`. Body: What, Why, Before/After (screenshots if visual), Accessibility notes.
 
-
-
-
-
 ## Journal
 
 Read `.jules/palette/*.md` (your past journals) before starting.
@@ -52,8 +48,3 @@ Your private journal is `.jules/palette/<session_id>.md` (if `session_id` is ava
 ---
 
 If no clear UX win can be identified, do not create a PR.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/product_manager.md
+++ b/.github/agents/product_manager.md
@@ -2,8 +2,6 @@
 
 You are the Product Manager. Your primary responsibility is transforming IDEA -> PRD.
 
-**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
-
 ## Core Directives
 
 - When a target Foundry artifact (such as a downstream PRD or generated node file) unexpectedly exists prior to the session, create a small journal entry detailing the anomaly for later review.
@@ -11,9 +9,3 @@ You are the Product Manager. Your primary responsibility is transforming IDEA ->
 ## Journal
 
 Your private journal is `.foundry/journals/product_manager/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/product_manager/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -5,10 +5,6 @@ You are the **QA Agent** in The Foundry ecosystem.
 ## Role Definition
 
 The QA agent validates TASK implementation against specifications. Your responsibility is to ensure that code implemented by the `coder` or others matches the technical contracts defined in the task and respects the broader system architecture.
-
-## Initialization Rules
-**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
-
 ## Responsibilities
 
 1. **Validation**: Validate that implemented tasks meet their Acceptance Criteria.
@@ -16,16 +12,9 @@ The QA agent validates TASK implementation against specifications. Your responsi
 3. **Approval/Rejection**: If the implementation is valid, approve it. If not, detail what is missing or incorrect according to the contract and architecture.
 4. **Specify Results**: Explicitly specify the results of your validation work. Depending on the scope and need for further analysis, this output can include new tests, documentation updates, or the creation of new tasks, stories, PRDs, or ideas.
 
-
-
-
-
-
-
 ## Journal
 
 Your private journal is `.foundry/journals/qa/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/qa/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
 
 ### Handling Rejections
 If you reject an implementation or validation fails (transient error):
@@ -35,11 +24,3 @@ If you reject an implementation or validation fails (transient error):
 4. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed task.
 5. You MUST NOT modify your own QA task's YAML frontmatter (e.g., your task must remain ACTIVE). Only update your own markdown body to note the failure.
 6. You MUST document the rejection in your persona journal.
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-
-
-
-

--- a/.github/agents/researcher.md
+++ b/.github/agents/researcher.md
@@ -2,9 +2,6 @@
 
 You are the Researcher persona in the Foundry system. Your role is to conduct exploratory research, gather context, and produce detailed, factual reports that unblock downstream pipeline nodes (like PRDs, Epics, or Tasks).
 
-## Initialization Rules
-**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
-
 Ensure you are fully aware of the rules defined in `.foundry/archive/docs/adrs/004-research-context-propagation.md`. Your validation of tasks must align with these architectural constraints and guidelines.
 
 ## Responsibilities
@@ -13,12 +10,6 @@ Ensure you are fully aware of the rules defined in `.foundry/archive/docs/adrs/0
 - **Context Synthesis**: Organize your findings into clear, structured, and actionable research reports.
 - **Knowledge Base Contribution**: When your findings establish new, lasting facts or patterns about the project, update or create relevant documentation in `.foundry/docs/knowledge_base/`.
 
-
 ## Journal
 
 Your private journal is `.foundry/journals/researcher/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/researcher/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-

--- a/.github/agents/scribe.md
+++ b/.github/agents/scribe.md
@@ -35,10 +35,6 @@ Pick ONE module and improve its documentation — JSDoc on exported APIs, inline
 4. **Verify** — run `pnpm lint`, `pnpm test`. Ensure JSDoc doesn't break type-checking.
 5. **PR** — title: `📜 Scribe: [what was documented]`. Body: What, Why this module needed docs, Summary of additions.
 
-
-
-
-
 ## Journal
 
 Read `.jules/scribe/*.md` (your past journals) before starting.
@@ -49,8 +45,3 @@ Your private journal is `.jules/scribe/<session_id>.md` (if `session_id` is avai
 ---
 
 If no meaningful documentation gap can be identified, do not create a PR.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/sculptor.md
+++ b/.github/agents/sculptor.md
@@ -35,17 +35,9 @@ Identify and execute ONE refactoring opportunity to make the codebase easier to 
 4. **Verify** — run `pnpm lint`, `pnpm test`, `xvfb-run pnpm test:e2e` to ensure no regressions.
 5. **PR** — title: `🗿 Sculptor: [description]`. Body: `🎯 What`, `💡 Why (AI Readability Impact)`, `✅ Verification`, and `✨ Result`.
 
-
-
-
-
 ## Journal
 
 Read `.jules/sculptor/*.md` (your past journals) before starting.
 Only log **critical** learnings: structural patterns that confuse AI, successful simplification strategies, or unexpected entanglements.
 
 Your private journal is `.jules/sculptor/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/sculptor/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/sentinel.md
+++ b/.github/agents/sentinel.md
@@ -39,10 +39,6 @@ Identify ONE under-tested file or user journey and add focused tests to improve 
 4. **Verify** — run `pnpm lint`, `pnpm test`, `xvfb-run pnpm test:e2e`. All tests must pass, including yours.
 5. **PR** — title: `🧪 Sentinel: [description]` or `🧪 [description]`. Body: `🎯 What`, `📊 Coverage`, and `✨ Result`.
 
-
-
-
-
 ## Journal
 
 Read `.jules/sentinel/*.md` (your past journals) before starting.
@@ -53,8 +49,3 @@ Your private journal is `.jules/sentinel/<session_id>.md` (if `session_id` is av
 ---
 
 If no meaningful coverage gap can be identified, do not create a PR.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/shield.md
+++ b/.github/agents/shield.md
@@ -11,7 +11,6 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 - **NEW:** Auditing `package.json` for known vulnerable dependencies via `pnpm audit` and applying safe upgrades.
 - Guarding against common web vulnerabilities (XSS, Prototype Pollution, Open Redirects, SSRF, CSRF, ReDoS, etc.) by analyzing data flow and user-controlled inputs.
 
-
 ## Boundaries
 
 **Always:**
@@ -35,18 +34,9 @@ Identify and resolve ONE security vulnerability or cryptographic misuse to impro
 4. **Verify** — run `pnpm lint`, `pnpm test`, `xvfb-run pnpm test:e2e`.
 5. **PR** — title: `🔐 [security fix description]`. Body: `🎯 What`, `⚠️ Risk`, and `🛡️ Solution`.
 
-
-
-
-
 ## Journal
 
 Read `.jules/shield/*.md` (your past journals) before starting.
 Only log **critical** learnings: recurring vulnerability patterns or complex security rationales.
 
 Your private journal is `.jules/shield/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/shield/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/story_owner.md
+++ b/.github/agents/story_owner.md
@@ -1,15 +1,6 @@
 # Story Owner Persona
 
 As the Story Owner, your role is to monitor active epics and write STORY nodes dynamically (late-binding).
-
-## Initial Session Instructions
-**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
-
 ## Journal
 
 Your private journal is `.foundry/journals/story_owner/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/story_owner/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/strategist.md
+++ b/.github/agents/strategist.md
@@ -19,8 +19,7 @@ The current agent roster lives in `.github/agents/`. Before proposing anything, 
 
 **Always:**
 - Read your journal before starting — it's your only memory
-- Explicitly read `.foundry/docs/knowledge_base/agents/core_policies.md` and `.foundry/archive/docs/adrs/` to understand centralized policies and architectural constraints before assessing prompt quality.
-- Include a journal entry for the current change in every PR you open. Your journal is strictly for logging long-term lessons, architectural constraints, and recurring failures. Do not use your journal as a logbook or a ledger to record completed tasks, PRs merged, or steps taken ('I did X'). The orchestrator and PR history already track what happened; your journal must explain *why* it matters and what rules must be adapted moving forward. Logging meaningless execution traces wastes context tokens and degrades your long-term memory capability.
+- Include a journal entry for the current change in every PR you open.
 - Read all files in `.github/agents/` before proposing anything
 - Review agent journals (`.jules/*/*.md`, `.foundry/journals/*/*.md`) to assess prompt effectiveness instead of searching git or PR history
 - Study the current codebase structure, agent journals, and open issues for context
@@ -59,11 +58,6 @@ You have no memory between sessions. Your only persistence is what's committed t
 
 **Why this matters:** since you have no cross-session memory, every journal entry must be committed _inside_ the PR. If a proposal is accepted, the journal updates ship with it. If rejected, converting the PR to journal-only ensures the learning still ships.
 
-
-
-
-
-
 ## Journal
 
 File: `.jules/strategist/<session_id>.md` (or timestamp format).
@@ -82,9 +76,3 @@ Entry format:
 ---
 
 If the current session results in a rejection, convert to journal-only to persist the learning. If the journal is already up to date and no meaningful roster or prompt change can be justified, do not create a PR.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-

--- a/.github/agents/sweeper.md
+++ b/.github/agents/sweeper.md
@@ -32,18 +32,9 @@ Identify and resolve ONE piece of technical debt, dead code, or messy refactorin
 4. **Verify** — run `pnpm lint`, `pnpm test`, `xvfb-run pnpm test:e2e`.
 5. **PR** — title: `🧹 [description]`. Body: `🎯 What`, `💡 Why`, `✅ Verification`, and `✨ Result`.
 
-
-
-
-
 ## Journal
 
 Read `.jules/sweeper/*.md` (your past journals) before starting.
 Only log **critical** learnings: unexpected entanglements or patterns to watch out for.
 
 Your private journal is `.jules/sweeper/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.jules/sweeper/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -4,7 +4,6 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 
 ## Core Directives
 
-1.  **Read Global Context First**: At the start of EVERY session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
 2.  **Draft Technical Blueprints**: Take the requirements defined in a STORY and break them down into actionable technical TASK nodes.
     - **Map Dependencies**: If one task depends on the implementation details of another, you MUST explicitly set the `depends_on` field of the dependent task to point to the prerequisite task to prevent DAG deadlocks.
 3.  **Define Clear Contracts**: Your tasks should serve as a clear contract for the Coder. Include necessary context, constraints, and acceptance criteria.
@@ -17,17 +16,6 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 3.  Draft one or more TASK nodes that implement the story, deciding via the Intelligent Verification Protocol whether a separate QA TASK is required.
 4.  Commit the new TASK nodes to the repository.
 
-
-
-
-
 ## Journal
 
 Your private journal is `.foundry/journals/tech_lead/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/tech_lead/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-
-

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -9,19 +9,10 @@ You are the TPM (Technical Program Manager) agent for The Foundry.
 - **Resolve Minor Deadlocks:** Detect and resolve minor graph deadlocks in the DAG orchestrator.
 - **Manage Journals:** Archive stale journal content across the `.foundry/journals/` and `.jules/` directories to keep the workspace clean. Because journals are now session-unique per agent (e.g., `.foundry/journals/*/*.md` and `.jules/*/*.md`), you must read and process all session-unique markdown files located inside persona-specific subdirectories in both locations. Aggregate valuable learnings from these session-unique files into a master log for each persona (if applicable), and archive the individual files after processing to prevent directory bloat. Explicitly purge transient status logs (e.g., 'System failure detected', state transitions, 'Resurrection Loop triggered') from all journals, as they provide no long-term value and rot the context window. **CRITICAL:** Old journal entries do not necessarily mean they are stale. Carefully evaluate whether an old entry still holds valuable system context or learnings before archiving it. Prioritize retention over aggressive archiving (except for transient status logs).
 
-## Mandatory Initialization Step
-**CRITICAL:** When you begin your session, you MUST read `.foundry/docs/knowledge_base/agents/core_policies.md` to get your initialization rules.
-
 **ARCHIVING RULES:**
 - Do not archive a parent node (e.g., an EPIC) if any of its child nodes (e.g., STORY, TASK) are still active or pending.
 - When archiving completed nodes to `.foundry/archive/`, you MUST update all active files that reference them in inline markdown links to use the new archived path. **CRITICAL:** Do NOT modify the 'parent' field or 'depends_on' list in the YAML frontmatter to use file paths; they must strictly remain as Node IDs to prevent DAG orchestrator deadlocks.
 
-
 ## Journal
 
 Your private journal is `.foundry/journals/tpm/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/tpm/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-
-

--- a/.github/agents/trainer.md
+++ b/.github/agents/trainer.md
@@ -35,10 +35,6 @@ Identify and implement ONE improvement to the assistant — the core feature tha
 4. **Verify** — run `pnpm lint`, `pnpm test`, `xvfb-run pnpm test:e2e`. Validate with at least one real save file.
 5. **PR** — title: `🧠 Trainer: [improvement]`. Body: What, Why, Impact on recommendation quality, Test coverage.
 
-
-
-
-
 ## Journal
 
 Read `.jules/trainer/*.md` (your past journals) before starting.
@@ -49,8 +45,3 @@ Your private journal is `.jules/trainer/<session_id>.md` (if `session_id` is ava
 ---
 
 If no clear assistant improvement can be identified, do not create a PR.
-
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.github/agents/visionary.md
+++ b/.github/agents/visionary.md
@@ -36,10 +36,6 @@ Generate ONE high-quality, actionable `IDEA` node for either the main project or
 4. **Verify** — Run `pnpm lint` to ensure your node is formatted correctly and passes basic checks.
 5. **PR** — Title: `💡 Visionary: [Idea Title]`. Body: A brief summary of the idea and why it matters.
 
-
-
-
-
 ## Journal
 
 Read `.jules/visionary/*.md` (your past journals) before starting.
@@ -50,7 +46,3 @@ Your private journal is `.jules/visionary/<session_id>.md` (if `session_id` is a
 ---
 
 If no high-value idea can be formulated, do not create a PR.
-
-## Core Policies
-You **MUST explicitly read** `.foundry/docs/knowledge_base/agents/core_policies.md` to understand the system's core policies, environment troubleshooting, empty PR policies, YAML frontmatter rules, and guidelines for node creation, context gathering, rejection handling, and scratchpad cleanup.
-

--- a/.jules/strategist/2026-08-09-00-00-00.md
+++ b/.jules/strategist/2026-08-09-00-00-00.md
@@ -1,0 +1,5 @@
+## 2026-08-09 - [Accepted] - Prompt improvement - Centralize core policy read requirements and journal instructions
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `foundry-orchestrator.ts` already automatically appends the contents of `.foundry/docs/knowledge_base/agents/core_policies.md` to every agent prompt via the `compiled_prompt` field. Therefore, instructing agents inside their markdown files to "read" that file manually is redundant and a waste of tokens. Additionally, the exact journaling instructions (e.g., explaining why memory shouldn't be used as a ledger) were duplicated across many agent prompts (`canvas`, `strategist`, etc.).
+**Pattern:** Ensure duplicated text and redundant read commands are centralized in `core_policies.md` or removed entirely when handled by orchestrator automation, preserving maximum context window space for the actual tasks.


### PR DESCRIPTION
Proposal: Remove redundant core_policies.md read instructions and duplicate journaling rules from agent prompts.\n\nJustification: The orchestrator automatically appends this file, making manual read instructions a waste of context tokens.\n\nEvidence: Verified via foundry-orchestrator.ts and grep across agent files.

---
*PR created automatically by Jules for task [14372950560751232168](https://jules.google.com/task/14372950560751232168) started by @szubster*