### PR TITLE
Fix Foundry Engine Orchestrator and DAG Validation Skip Fixtures

### DIFF
--- a/.github/scripts/extract-research.ts
+++ b/.github/scripts/extract-research.ts
@@ -22,6 +22,7 @@ function discoverNodeFiles(dir: string): string[] {
       const fullPath = path.join(current, entry.name);
       if (entry.isDirectory()) {
         if (entry.name === 'journals') continue;
+        if (entry.name === 'fixtures') continue;
         if (entry.name === 'docs') {
             const adrsPath = path.join(fullPath, 'adrs');
             if (fs.existsSync(adrsPath)) walk(adrsPath);

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -90,8 +90,9 @@ function discoverNodeFiles(dir: string): string[] {
       const fullPath = path.join(current, entry.name);
 
       if (entry.isDirectory()) {
-        // Skip journals entirely. For docs, only explore the adrs/ subdirectory.
+        // Skip journals and fixtures entirely. For docs, only explore the adrs/ subdirectory.
         if (entry.name === 'journals') continue;
+        if (entry.name === 'fixtures') continue;
         if (entry.name === 'docs') {
           const adrsPath = path.join(fullPath, 'adrs');
           if (fs.existsSync(adrsPath)) walk(adrsPath);

--- a/.github/scripts/verify-dag-refs.ts
+++ b/.github/scripts/verify-dag-refs.ts
@@ -14,6 +14,7 @@ function discoverNodeFiles(dir: string): string[] {
       const fullPath = path.join(current, entry.name);
       if (entry.isDirectory()) {
         if (entry.name === 'journals') continue;
+        if (entry.name === 'fixtures') continue;
         if (entry.name === 'docs') {
             const adrsPath = path.join(fullPath, 'adrs');
             if (fs.existsSync(adrsPath)) walk(adrsPath);


### PR DESCRIPTION
This change updates .github/scripts/verify-dag-refs.ts, .github/scripts/foundry-orchestrator.ts, and .github/scripts/extract-research.ts to explicitly skip the fixtures/ subdirectory of .foundry/ during node discovery. This prevents invalid/malformed test fixture files from triggering standard validation failures or warnings.

Fixes #5854

---
*PR created automatically by Jules for task [7992480780140703286](https://jules.google.com/task/7992480780140703286) started by @szubster*