### PR TITLE
🤖 Orchestrator: skip fixtures directory during node discovery

### DIFF
--- a/.github/scripts/extract-research.ts
+++ b/.github/scripts/extract-research.ts
@@ -21,7 +21,7 @@ function discoverNodeFiles(dir: string): string[] {
     for (const entry of entries) {
       const fullPath = path.join(current, entry.name);
       if (entry.isDirectory()) {
-        if (entry.name === 'journals') continue;
+        if (entry.name === 'journals' || entry.name === 'fixtures') continue;
         if (entry.name === 'docs') {
             const adrsPath = path.join(fullPath, 'adrs');
             if (fs.existsSync(adrsPath)) walk(adrsPath);

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -90,8 +90,8 @@ function discoverNodeFiles(dir: string): string[] {
       const fullPath = path.join(current, entry.name);
 
       if (entry.isDirectory()) {
-        // Skip journals entirely. For docs, only explore the adrs/ subdirectory.
-        if (entry.name === 'journals') continue;
+        // Skip journals and fixtures entirely. For docs, only explore the adrs/ subdirectory.
+        if (entry.name === 'journals' || entry.name === 'fixtures') continue;
         if (entry.name === 'docs') {
           const adrsPath = path.join(fullPath, 'adrs');
           if (fs.existsSync(adrsPath)) walk(adrsPath);

--- a/.github/scripts/verify-dag-refs.ts
+++ b/.github/scripts/verify-dag-refs.ts
@@ -13,7 +13,7 @@ function discoverNodeFiles(dir: string): string[] {
     for (const entry of entries) {
       const fullPath = path.join(current, entry.name);
       if (entry.isDirectory()) {
-        if (entry.name === 'journals') continue;
+        if (entry.name === 'journals' || entry.name === 'fixtures') continue;
         if (entry.name === 'docs') {
             const adrsPath = path.join(fullPath, 'adrs');
             if (fs.existsSync(adrsPath)) walk(adrsPath);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Validate Foundry Schema
         run: node --experimental-strip-types scripts/validate-foundry-schema.ts
+      - name: Verify DAG References
+        run: node --experimental-strip-types .github/scripts/verify-dag-refs.ts
       - name: Check Links
         run: node --experimental-strip-types scripts/check-links.ts
       - name: Foundry Orchestrator Dry Run


### PR DESCRIPTION
This PR updates the node discovery logic within `.github/scripts` to explicitly skip the `.foundry/fixtures/` directory. This directory contains test fixtures and invalid/malformed node files for unit tests, which should never be discovered as live backlog nodes in the orchestrator pipeline or verify-dag-refs check.

Fixes #5856

---
*PR created automatically by Jules for task [413043575977737310](https://jules.google.com/task/413043575977737310) started by @szubster*