### PR TITLE
Fix CI GHA Output Evaluation Error

### DIFF
--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -74,7 +74,7 @@ jobs:
             sh -c "exit $exit_code" || true
             exit "$exit_code"
           fi
-          echo "matrix=$output" >> "$GITHUB_OUTPUT"
+          printf 'matrix=%s\n' "$output" >> "$GITHUB_OUTPUT"
 
       - name: Report DAG Warnings
         if: always() && steps.set-matrix.outputs.dag_has_warnings == 'true'


### PR DESCRIPTION
Fixes the GitHub Actions CI failure where a JSON matrix output containing backslash-escaped newlines (\n) was incorrectly parsed, causing an fromJson evaluation error due to echo interpreting escape sequences in dash shell. Using printf '%s\n' prevents backslash expansion.

Fixes #5861

---
*PR created automatically by Jules for task [15607009365696383803](https://jules.google.com/task/15607009365696383803) started by @szubster*