### PR TITLE
Fix canvas persona in orchestrator schema

### DIFF
--- a/.github/scripts/schema.ts
+++ b/.github/scripts/schema.ts
@@ -36,6 +36,7 @@ export const OwnerPersonaEnum = z.enum([
   'mechanic',
   'researcher',
   'auditor',
+  'canvas',
 ]);
 
 export const NodeFrontmatterSchema = z.object({


### PR DESCRIPTION
Adds the canvas persona to the OwnerPersonaEnum in the Zod orchestrator schema to resolve schema validation warnings.

Fixes #5863

---
*PR created automatically by Jules for task [7680931769711736624](https://jules.google.com/task/7680931769711736624) started by @szubster*