### PR TITLE
Fix Foundry Engine output size limit error

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -2877,7 +2877,10 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     // Mock console.log to intercept orchestrator stdout output
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
+    // Pass --include-prompt to the main orchestrator test to run exactly as before
+    process.argv.push('--include-prompt');
     main();
+    process.argv.splice(process.argv.indexOf('--include-prompt'), 1);
 
     expect(logSpy).toHaveBeenCalled();
     const lastCall = logSpy.mock.calls[logSpy.mock.calls.length - 1][0];

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -56,6 +56,9 @@ const MAX_REJECTION_THRESHOLD = 3; // Hardcoded fallback for isolated test envir
 const DRY_RUN: boolean = process.argv.includes('--dry-run');
 const STRICT: boolean = process.argv.includes('--strict');
 
+const COMPILE_ARG_INDEX = process.argv.indexOf('--compile');
+const COMPILE_PATH = COMPILE_ARG_INDEX !== -1 ? process.argv[COMPILE_ARG_INDEX + 1] : null;
+
 // ─── Logging (all diagnostic output → stderr; only the matrix JSON → stdout) ─
 
 function warn(msg: string): void {
@@ -349,6 +352,22 @@ function compilePromptForNode(node: ParsedNode, repoRoot: string): string {
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 function main(): void {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = process.env.VITEST ? process.cwd() : path.resolve(__dirname, '..', '..');
+
+  if (COMPILE_PATH) {
+    const fullPath = path.resolve(repoRoot, COMPILE_PATH);
+    const node = parseNodeFile(fullPath, repoRoot);
+    if (!node) {
+      warn(`Could not parse node at compile path: ${COMPILE_PATH}`);
+      process.exitCode = 1;
+      return;
+    }
+    const compiled = compilePromptForNode(node, repoRoot);
+    process.stdout.write(compiled);
+    return;
+  }
+
   if (DRY_RUN) {
     info('🔍 Dry-run mode active — no files will be modified.');
   }
@@ -356,8 +375,6 @@ function main(): void {
     info('⚠️  Strict mode active — unresolvable deps will cause exit(1).');
   }
 
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const repoRoot = process.env.VITEST ? process.cwd() : path.resolve(__dirname, '..', '..');
   const foundryDir = path.join(repoRoot, '.foundry');
 
   if (!fs.existsSync(foundryDir)) {
@@ -1202,17 +1219,20 @@ function main(): void {
 
   // Include both freshly-promoted nodes AND any that were already READY before
   // this run (idempotent: re-running the orchestrator is always safe).
+  const includePrompt = process.argv.includes('--include-prompt');
   const readyNodes = nodes
     .filter((n) => n.frontmatter.status === 'READY' || n.frontmatter.status === 'VERIFYING')
     .map((n) => {
-      const compiledPrompt = compilePromptForNode(n, repoRoot);
-      return {
+      const item: any = {
         ...n.frontmatter,
         repo_path: n.repoPath,
         owner_persona: n.frontmatter.status === 'VERIFYING' ? 'auditor' : n.frontmatter.owner_persona,
         critical_weight: getWeight(n.repoPath),
-        compiled_prompt: compiledPrompt,
       };
+      if (includePrompt) {
+        item.compiled_prompt = compilePromptForNode(n, repoRoot);
+      }
+      return item;
     })
     .sort((a, b) => {
       // 1. Sort by Critical Path Weight descending (highest weight first)

--- a/.github/workflows/foundry-engine.yml
+++ b/.github/workflows/foundry-engine.yml
@@ -182,16 +182,16 @@ jobs:
           NODE_TITLE: ${{ matrix.node.title }}
           GITHUB_REPO: ${{ github.repository }}
           NODE_ID: ${{ matrix.node.id }}
-          NODE_COMPILED_PROMPT: ${{ matrix.node.compiled_prompt }}
         run: |
           set -o pipefail
           {
             # 1. Capture task content for the prompt
             task_content=$(cat "$NODE_REPO_PATH")
             
-            if [[ -n "$NODE_COMPILED_PROMPT" ]]; then
-              agent_context="$NODE_COMPILED_PROMPT"
-            else
+            # Compile the multi-layered prompt on the fly
+            agent_context=$(node --experimental-strip-types .github/scripts/foundry-orchestrator.ts --compile "$NODE_REPO_PATH")
+
+            if [[ -z "$agent_context" ]]; then
               owner_persona="$NODE_OWNER_PERSONA"
               agent_file=".github/agents/${owner_persona}.md"
 


### PR DESCRIPTION
This PR resolves the GitHub Actions job output size limit error by removing the `compiled_prompt` from the global DAG JSON output matrix by default, reducing the matrix size from 1.27MB down to ~28KB, and instead compiling the prompts dynamically on the fly during the execution job.

Fixes #5869

---
*PR created automatically by Jules for task [351451765444603410](https://jules.google.com/task/351451765444603410) started by @szubster*