### PR TITLE
feat: implement Gen 3 roamer save extraction logic

### DIFF
--- a/.foundry/tasks/task-358-403-gen3-roamer-game-integrations-impl.md
+++ b/.foundry/tasks/task-358-403-gen3-roamer-game-integrations-impl.md
@@ -29,7 +29,7 @@ Implement game-specific extractions by mapping the correct block offsets for Rub
 Gen 3 games use A/B bank flash memory. Roamer data resides in SaveBlock1, but the relative offset within the block differs across game versions.
 
 ## Acceptance Criteria
-- [ ] Determine correct relative offsets for the Roamer struct in SaveBlock1 for RS, Emerald, and FRLG.
-- [ ] Implement game-specific extraction functions calling `parseGen3RoamerStruct`.
-- [ ] Strictly adhere to `.foundry/docs/schema.md` Section 13 guidelines (use section offsets to calculate relative offsets, no absolute hardcoded offsets, no magic numbers, explicit module-level constants).
-- [ ] Add integration unit tests verifying correct offset resolution and extraction for mock SaveBlock1 structures for all three game engine versions.
+- [x] Determine correct relative offsets for the Roamer struct in SaveBlock1 for RS, Emerald, and FRLG.
+- [x] Implement game-specific extraction functions calling `parseGen3RoamerStruct`.
+- [x] Strictly adhere to `.foundry/docs/schema.md` Section 13 guidelines (use section offsets to calculate relative offsets, no absolute hardcoded offsets, no magic numbers, explicit module-level constants).
+- [x] Add integration unit tests verifying correct offset resolution and extraction for mock SaveBlock1 structures for all three game engine versions.

--- a/src/engine/gen3/roamer/parser.test.ts
+++ b/src/engine/gen3/roamer/parser.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { parseGen3RSRoamer, parseGen3EmeraldRoamer, parseGen3FRLGRoamer } from './parser';
+
+const GEN3_ROAMER_OFFSET_RS = 0x3144;
+const GEN3_ROAMER_OFFSET_EMERALD = 0x31dc;
+const GEN3_ROAMER_OFFSET_FRLG = 0x30d0;
+
+describe('Gen 3 Roamer Parsers', () => {
+  describe('parseGen3RSRoamer', () => {
+    it('correctly parses Ruby/Sapphire roamer with non-zero saveBlock1Offset', () => {
+      const saveBlock1Offset = 100;
+      const buffer = new ArrayBuffer(saveBlock1Offset + GEN3_ROAMER_OFFSET_RS + 36);
+      const view = new DataView(buffer);
+      const baseOffset = saveBlock1Offset + GEN3_ROAMER_OFFSET_RS;
+
+      view.setUint32(baseOffset + 0x00, 0x12345678, true); // IVs
+      view.setUint32(baseOffset + 0x04, 0x87654321, true); // PV
+      view.setUint16(baseOffset + 0x08, 380, true); // Species: Latias
+      view.setUint16(baseOffset + 0x0a, 120, true); // HP
+      view.setUint8(baseOffset + 0x0c, 40); // Level
+      view.setUint8(baseOffset + 0x0d, 0); // Status
+      view.setUint8(baseOffset + 0x13, 1); // Active
+
+      const result = parseGen3RSRoamer(view, saveBlock1Offset);
+
+      expect(result).toEqual({
+        isActive: true,
+        speciesId: 380,
+        level: 40,
+        hp: 120,
+        statusCondition: 0,
+        personalityValue: 0x87654321,
+        ivs: {
+          hp: (0x12345678 >> 0) & 0x1f,
+          atk: (0x12345678 >> 5) & 0x1f,
+          def: (0x12345678 >> 10) & 0x1f,
+          spd: (0x12345678 >> 15) & 0x1f,
+          spAtk: (0x12345678 >> 20) & 0x1f,
+          spDef: (0x12345678 >> 25) & 0x1f,
+        },
+      });
+    });
+
+    it('throws a corrupted file error on out-of-bounds reads', () => {
+      const buffer = new ArrayBuffer(10);
+      const view = new DataView(buffer);
+
+      expect(() => parseGen3RSRoamer(view, 0)).toThrow('The save file is corrupted or incomplete.');
+    });
+  });
+
+  describe('parseGen3EmeraldRoamer', () => {
+    it('correctly parses Emerald roamer with non-zero saveBlock1Offset', () => {
+      const saveBlock1Offset = 200;
+      const buffer = new ArrayBuffer(saveBlock1Offset + GEN3_ROAMER_OFFSET_EMERALD + 36);
+      const view = new DataView(buffer);
+      const baseOffset = saveBlock1Offset + GEN3_ROAMER_OFFSET_EMERALD;
+
+      view.setUint32(baseOffset + 0x00, 0x11111111, true); // IVs
+      view.setUint32(baseOffset + 0x04, 0x22222222, true); // PV
+      view.setUint16(baseOffset + 0x08, 381, true); // Species: Latios
+      view.setUint16(baseOffset + 0x0a, 130, true); // HP
+      view.setUint8(baseOffset + 0x0c, 40); // Level
+      view.setUint8(baseOffset + 0x0d, 0); // Status
+      view.setUint8(baseOffset + 0x13, 1); // Active
+
+      const result = parseGen3EmeraldRoamer(view, saveBlock1Offset);
+
+      expect(result).toEqual({
+        isActive: true,
+        speciesId: 381,
+        level: 40,
+        hp: 130,
+        statusCondition: 0,
+        personalityValue: 0x22222222,
+        ivs: {
+          hp: (0x11111111 >> 0) & 0x1f,
+          atk: (0x11111111 >> 5) & 0x1f,
+          def: (0x11111111 >> 10) & 0x1f,
+          spd: (0x11111111 >> 15) & 0x1f,
+          spAtk: (0x11111111 >> 20) & 0x1f,
+          spDef: (0x11111111 >> 25) & 0x1f,
+        },
+      });
+    });
+
+    it('throws a corrupted file error on out-of-bounds reads', () => {
+      const buffer = new ArrayBuffer(10);
+      const view = new DataView(buffer);
+
+      expect(() => parseGen3EmeraldRoamer(view, 0)).toThrow('The save file is corrupted or incomplete.');
+    });
+  });
+
+  describe('parseGen3FRLGRoamer', () => {
+    it('correctly parses FireRed/LeafGreen roamer with non-zero saveBlock1Offset', () => {
+      const saveBlock1Offset = 300;
+      const buffer = new ArrayBuffer(saveBlock1Offset + GEN3_ROAMER_OFFSET_FRLG + 36);
+      const view = new DataView(buffer);
+      const baseOffset = saveBlock1Offset + GEN3_ROAMER_OFFSET_FRLG;
+
+      view.setUint32(baseOffset + 0x00, 0x33333333, true); // IVs
+      view.setUint32(baseOffset + 0x04, 0x44444444, true); // PV
+      view.setUint16(baseOffset + 0x08, 244, true); // Species: Entei
+      view.setUint16(baseOffset + 0x0a, 140, true); // HP
+      view.setUint8(baseOffset + 0x0c, 50); // Level
+      view.setUint8(baseOffset + 0x0d, 0); // Status
+      view.setUint8(baseOffset + 0x13, 1); // Active
+
+      const result = parseGen3FRLGRoamer(view, saveBlock1Offset);
+
+      expect(result).toEqual({
+        isActive: true,
+        speciesId: 244,
+        level: 50,
+        hp: 140,
+        statusCondition: 0,
+        personalityValue: 0x44444444,
+        ivs: {
+          hp: (0x33333333 >> 0) & 0x1f,
+          atk: (0x33333333 >> 5) & 0x1f,
+          def: (0x33333333 >> 10) & 0x1f,
+          spd: (0x33333333 >> 15) & 0x1f,
+          spAtk: (0x33333333 >> 20) & 0x1f,
+          spDef: (0x33333333 >> 25) & 0x1f,
+        },
+      });
+    });
+
+    it('throws a corrupted file error on out-of-bounds reads', () => {
+      const buffer = new ArrayBuffer(10);
+      const view = new DataView(buffer);
+
+      expect(() => parseGen3FRLGRoamer(view, 0)).toThrow('The save file is corrupted or incomplete.');
+    });
+  });
+});

--- a/src/engine/gen3/roamer/parser.test.ts
+++ b/src/engine/gen3/roamer/parser.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { parseGen3RSRoamer, parseGen3EmeraldRoamer, parseGen3FRLGRoamer } from './parser';
+import { describe, expect, it } from 'vitest';
+import { parseGen3EmeraldRoamer, parseGen3FRLGRoamer, parseGen3RSRoamer } from './parser';
 
 const GEN3_ROAMER_OFFSET_RS = 0x3144;
 const GEN3_ROAMER_OFFSET_EMERALD = 0x31dc;

--- a/src/engine/gen3/roamer/parser.ts
+++ b/src/engine/gen3/roamer/parser.ts
@@ -1,0 +1,65 @@
+import { parseGen3RoamerStruct } from '../../saveParser/parsers/gen3';
+
+const GEN3_ROAMER_OFFSET_RS = 0x3144;
+const GEN3_ROAMER_OFFSET_EMERALD = 0x31dc;
+const GEN3_ROAMER_OFFSET_FRLG = 0x30d0;
+
+/**
+ * Extracts Gen 3 Roamer data for Ruby and Sapphire.
+ *
+ * @param view - The raw save file DataView.
+ * @param saveBlock1Offset - The resolved memory offset to the active SaveBlock1.
+ * @returns The parsed Gen3RoamerData object.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3RSRoamer(view: DataView, saveBlock1Offset: number) {
+  try {
+    const offset = saveBlock1Offset + GEN3_ROAMER_OFFSET_RS;
+    return parseGen3RoamerStruct(view, offset);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+/**
+ * Extracts Gen 3 Roamer data for Emerald.
+ *
+ * @param view - The raw save file DataView.
+ * @param saveBlock1Offset - The resolved memory offset to the active SaveBlock1.
+ * @returns The parsed Gen3RoamerData object.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3EmeraldRoamer(view: DataView, saveBlock1Offset: number) {
+  try {
+    const offset = saveBlock1Offset + GEN3_ROAMER_OFFSET_EMERALD;
+    return parseGen3RoamerStruct(view, offset);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+/**
+ * Extracts Gen 3 Roamer data for FireRed and LeafGreen.
+ *
+ * @param view - The raw save file DataView.
+ * @param saveBlock1Offset - The resolved memory offset to the active SaveBlock1.
+ * @returns The parsed Gen3RoamerData object.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3FRLGRoamer(view: DataView, saveBlock1Offset: number) {
+  try {
+    const offset = saveBlock1Offset + GEN3_ROAMER_OFFSET_FRLG;
+    return parseGen3RoamerStruct(view, offset);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,0 +1,1 @@
+export * from './gen3/roamer/parser';

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -2053,3 +2053,4 @@ export function parseGen3MetLocation(view: DataView, miscSubstructureOffset: num
   }
 }
 export * from '../gen3/trainerFlags/parser';
+export * from '../../gen3/roamer/parser';

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -2052,5 +2052,5 @@ export function parseGen3MetLocation(view: DataView, miscSubstructureOffset: num
     throw error;
   }
 }
-export * from '../gen3/trainerFlags/parser';
 export * from '../../gen3/roamer/parser';
+export * from '../gen3/trainerFlags/parser';

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -2052,5 +2052,5 @@ export function parseGen3MetLocation(view: DataView, miscSubstructureOffset: num
     throw error;
   }
 }
-export * from '../../gen3/roamer/parser';
+
 export * from '../gen3/trainerFlags/parser';


### PR DESCRIPTION
### 🎯 What
Implemented game-specific Gen 3 Roamer data extractions for Ruby/Sapphire, Emerald, and FireRed/LeafGreen.

### 💡 Why
Gen 3 games use A/B bank flash memory, meaning the absolute offset of the roamer data shifts. The relative offset within SaveBlock1 differs across game versions. This implements the necessary logic to reliably map the correct offset based on the game version using the base generic parser.

### ✅ Verification
- Wrote unit tests for `parseGen3RSRoamer`, `parseGen3EmeraldRoamer`, and `parseGen3FRLGRoamer` checking mocked data extractions.
- Verified that `RangeError` is correctly caught and re-thrown as a "corrupted or incomplete" error message.
- Ran all tests suite successfully.

### ✨ Result
The application can now properly parse the Roamer struct from the specific offsets of RS, Emerald, and FRLG save files.

---
*PR created automatically by Jules for task [533419087326145687](https://jules.google.com/task/533419087326145687) started by @szubster*