### PR TITLE
feat: Implement Gen 3 Secret Base Shared Types and Interface

### DIFF
--- a/.foundry/tasks/task-404-407-gen3-secret-base-types-impl.md
+++ b/.foundry/tasks/task-404-407-gen3-secret-base-types-impl.md
@@ -31,6 +31,6 @@ As part of the Gen 3 Secret Base and Mixed Record Viewer Epic, we are breaking d
 - Expose these types for use in subsequent parser and UI implementation tasks.
 
 ## Acceptance Criteria
-- [ ] Define `SecretBase` and related interfaces (e.g., location, decorations) reflecting Gen 3 specific attributes.
-- [ ] Ensure types are exported and available for the parser engine.
-- [ ] Write basic unit tests to verify type shape where applicable (or verify via `type-check`).
+- [x] Define `SecretBase` and related interfaces (e.g., location, decorations) reflecting Gen 3 specific attributes.
+- [x] Ensure types are exported and available for the parser engine.
+- [x] Write basic unit tests to verify type shape where applicable (or verify via `type-check`).

--- a/src/engine/gen3/secretBase/parser.test.ts
+++ b/src/engine/gen3/secretBase/parser.test.ts
@@ -69,6 +69,19 @@ describe('Secret Base Parser', () => {
 
       view.setUint32(9, 1234567, true);
 
+      view.setUint16(0x0e, 42, true); // numSecretBasesReceived
+      view.setUint8(0x10, 5); // numTimesEntered
+
+      // Decorations
+      for (let i = 0; i < 16; i++) {
+        view.setUint8(0x12 + i, i + 1);
+      }
+
+      // Decoration Positions
+      for (let i = 0; i < 16; i++) {
+        view.setUint8(0x22 + i, 16 - i);
+      }
+
       // Let's set some party data
       const partyOffset = 52;
       view.setUint16(partyOffset + 0x48, 1, true); // Bulbasaur
@@ -81,6 +94,10 @@ describe('Secret Base Parser', () => {
       expect(record?.trainerName).toBe('ASH');
       expect(record?.trainerId).toBe(1234567);
       expect(record?.battledOwnerToday).toBe(true);
+      expect(record?.numSecretBasesReceived).toBe(42);
+      expect(record?.numTimesEntered).toBe(5);
+      expect(record?.decorations).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+      expect(record?.decorationPositions).toEqual([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
       expect(record?.party[0]?.species).toBe(1);
     });
 

--- a/src/engine/gen3/secretBase/parser.ts
+++ b/src/engine/gen3/secretBase/parser.ts
@@ -28,6 +28,12 @@ export const POKEMON_HELD_ITEM_SIZE = 2;
 export const POKEMON_LEVEL_SIZE = 1;
 export const POKEMON_EVS_SIZE = 1;
 
+export const DECOR_MAX_SECRET_BASE = 16;
+export const NUM_SECRET_BASES_RECEIVED_OFFSET = 0x0e;
+export const NUM_TIMES_ENTERED_OFFSET = 0x10;
+export const DECORATIONS_OFFSET = 0x12;
+export const DECORATION_POSITIONS_OFFSET = 0x22;
+
 /**
  * Parses the Secret Base Party member structures from a Gen 3 save file.
  *
@@ -106,6 +112,19 @@ export function parseSecretBaseRecord(view: DataView, offset: number) {
     // Read the 4 byte Trainer ID
     const trainerId = view.getUint32(offset + TRAINER_ID_OFFSET, true);
 
+    const numSecretBasesReceived = view.getUint16(offset + NUM_SECRET_BASES_RECEIVED_OFFSET, true);
+    const numTimesEntered = view.getUint8(offset + NUM_TIMES_ENTERED_OFFSET);
+
+    const decorations: number[] = [];
+    for (let i = 0; i < DECOR_MAX_SECRET_BASE; i++) {
+      decorations.push(view.getUint8(offset + DECORATIONS_OFFSET + i));
+    }
+
+    const decorationPositions: number[] = [];
+    for (let i = 0; i < DECOR_MAX_SECRET_BASE; i++) {
+      decorationPositions.push(view.getUint8(offset + DECORATION_POSITIONS_OFFSET + i));
+    }
+
     const party = parseSecretBaseParty(view, offset + PARTY_OFFSET);
 
     return {
@@ -114,6 +133,10 @@ export function parseSecretBaseRecord(view: DataView, offset: number) {
       trainerName,
       trainerId,
       battledOwnerToday,
+      numSecretBasesReceived,
+      numTimesEntered,
+      decorations,
+      decorationPositions,
       party,
     };
   } catch (error) {

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -151,6 +151,10 @@ export interface Gen3SecretBase {
   trainerName: string;
   trainerId: number;
   battledOwnerToday?: boolean;
+  numSecretBasesReceived: number;
+  numTimesEntered: number;
+  decorations: number[];
+  decorationPositions: number[];
   party: Gen3SecretBasePartyMember[];
 }
 


### PR DESCRIPTION
Adds missing fields (`numSecretBasesReceived`, `numTimesEntered`, `decorations`, `decorationPositions`) to the `Gen3SecretBase` interface and implements extraction for them in `parseSecretBaseRecord`. Also checks off the acceptance criteria for `task-404-407-gen3-secret-base-types-impl`.

### What
- Updated `Gen3SecretBase` in `common.ts` with new fields.
- Updated `parser.ts` with constants and `DataView` parsing for new fields.
- Updated `parser.test.ts` to test new fields.
- Checked off Markdown tasks in `.foundry/tasks/task-404-407-gen3-secret-base-types-impl.md`.

### Why
To fulfill the requirements of the task to expose core data structures representing Gen 3 specific attributes of a Secret Base for future parsing and UI components.

### Verification
- `pnpm type-check` passed.
- `pnpm lint` passed (with `check:fix`).
- `xvfb-run -a pnpm test` passed.
- Code review explicitly approved the structure and completion of acceptance criteria.

---
*PR created automatically by Jules for task [14570129440806161122](https://jules.google.com/task/14570129440806161122) started by @szubster*