### PR TITLE
chore(qa): Verify multi-save data structures implementation

### DIFF
--- a/.foundry/tasks/task-358-403-multi-save-data-structures-qa.md
+++ b/.foundry/tasks/task-358-403-multi-save-data-structures-qa.md
@@ -30,6 +30,6 @@ Verify the implementation of the multi-save data structures in the Zustand store
 - Verify that `saves` and `activeSaveId` are not included in the `partialize` configuration for localStorage persistence.
 
 ## Acceptance Criteria
-- [ ] Verify `saves` and `activeSaveId` are present and correctly typed in the store.
-- [ ] Verify `saveData` backwards compatibility is maintained.
-- [ ] Verify heavy save data is not persisted to localStorage.
+- [x] Verify `saves` and `activeSaveId` are present and correctly typed in the store.
+- [x] Verify `saveData` backwards compatibility is maintained.
+- [x] Verify heavy save data is not persisted to localStorage.


### PR DESCRIPTION
This PR checks off the Acceptance Criteria checkboxes in `task-358-403-multi-save-data-structures-qa.md` to indicate successful QA validation of the multi-save data structures implementation in the Zustand store. This Empty PR allows the Orchestrator to safely transition the node to COMPLETED, according to the Empty PR Checkbox Policy and Specificity Rules.

---
*PR created automatically by Jules for task [13792724653168687435](https://jules.google.com/task/13792724653168687435) started by @szubster*