### PR TITLE
chore: Complete Gen 2 NPC Trade Extraction Implementation task

### DIFF
--- a/.foundry/tasks/task-361-407-gen2-trade-extraction-impl.md
+++ b/.foundry/tasks/task-361-407-gen2-trade-extraction-impl.md
@@ -25,7 +25,7 @@ notes: ''
 Implement extraction of in-game NPC trade completion flags from Generation 2 save files using the `DataView` API. Ensure that memory offsets and magic numbers are strictly extracted as module-level constants, avoiding inline hardcoding.
 
 ## Acceptance Criteria
-- [ ] Define reusable constants `NPC_TRADE_FLAGS_OFFSET_CRYSTAL`, `NPC_TRADE_FLAGS_OFFSET_GS`, and `GEN2_NPC_TRADE_COUNT` for offset handling.
-- [ ] Implement bitwise mapping using `DataView.getUint8` to accurately extract all trade flags.
-- [ ] Ensure that parsing strictly throws a new `Error('The save file is corrupted or incomplete.')` when encountering `RangeError` from the `DataView` API reading out of bounds.
-- [ ] Incorporate extracted `npcTradeFlags` correctly into the mapped `SaveData` output.
+- [x] Define reusable constants `NPC_TRADE_FLAGS_OFFSET_CRYSTAL`, `NPC_TRADE_FLAGS_OFFSET_GS`, and `GEN2_NPC_TRADE_COUNT` for offset handling.
+- [x] Implement bitwise mapping using `DataView.getUint8` to accurately extract all trade flags.
+- [x] Ensure that parsing strictly throws a new `Error('The save file is corrupted or incomplete.')` when encountering `RangeError` from the `DataView` API reading out of bounds.
+- [x] Incorporate extracted `npcTradeFlags` correctly into the mapped `SaveData` output.


### PR DESCRIPTION
Checked off acceptance criteria for task-361-407-gen2-trade-extraction-impl.md.

The underlying functionality (`NPC_TRADE_FLAGS_OFFSET_CRYSTAL`, `GEN2_NPC_TRADE_COUNT`, extraction logic with `DataView.getUint8`, and the `RangeError` safety measure) was already correctly implemented and fully covered by tests in the system. This Empty PR checks off the required markdown checkboxes in the task file to satisfy the ADR 007 completeness contract and allow the node to gracefully exit the DAG.

No application source files were changed.

---
*PR created automatically by Jules for task [14390707968849286605](https://jules.google.com/task/14390707968849286605) started by @szubster*