### PR TITLE
Draft ADR for SaveData Typed Schema - Implementation

### DIFF
--- a/.foundry/archive/docs/adrs/adr-361-030-savedata-discriminated-union-types.md
+++ b/.foundry/archive/docs/adrs/adr-361-030-savedata-discriminated-union-types.md
@@ -191,6 +191,10 @@ export interface Gen3SaveData extends BaseSaveData {
 export type SaveData = Gen1SaveData | Gen2SaveData | Gen3SaveData;
 ```
 
+## Implementation Impact
+- **Core Parser Updates:** The core generation-specific parsers (`parseGen1Save`, `parseGen2Save`, `parseGen3Save`) must be updated to explicitly return their respective specific types (`Gen1SaveData`, `Gen2SaveData`, `Gen3SaveData`) rather than a generic `SaveData`.
+- **Downstream Consumer Adjustments:** React components and utility functions that consume `SaveData` will need to implement type guards or use type narrowing (e.g., `if (data.generation === 3)`) to securely access generation-specific properties without relying on non-null assertions or encountering type errors.
+
 ## Consequences
 - **Positive:** Increased type safety. TypeScript will automatically narrow the type based on `if (saveData.generation === 3)`, allowing safe access to `saveData.gen3FeebasTiles` without optional chaining or non-null assertions.
 - **Positive:** Better developer experience and self-documenting code.

--- a/.foundry/tasks/task-361-409-draft-savedata-adr-impl.md
+++ b/.foundry/tasks/task-361-409-draft-savedata-adr-impl.md
@@ -26,4 +26,4 @@ notes: ''
 Draft the implementation impact portion of the Architecture Decision Record (ADR) detailing the typed schema and downstream consumer impact for the new discriminated union SaveData type.
 
 ## Acceptance Criteria
-- [ ] Draft the implementation impact in the ADR in `.foundry/archive/docs/adrs/`.
+- [x] Draft the implementation impact in the ADR in `.foundry/archive/docs/adrs/`.


### PR DESCRIPTION
Draft the implementation impact portion of the Architecture Decision Record (ADR) detailing the typed schema and downstream consumer impact for the new discriminated union SaveData type.

---
*PR created automatically by Jules for task [3322343309613951848](https://jules.google.com/task/3322343309613951848) started by @szubster*