### PR TITLE
QA: Reject secret base parser for magic number violations

### DIFF
--- a/.foundry/journals/qa/12960983747185356556.md
+++ b/.foundry/journals/qa/12960983747185356556.md
@@ -1,0 +1,6 @@
+# QA Journal - 12960983747185356556
+
+## Learnings
+- **Recurring Issue:** Coders frequently violate Section 13 (No Magic Numbers) of `.foundry/docs/schema.md` when parsing Gen 3 Secret Base data.
+- **Specific Instance:** In `task-404-408-gen3-secret-base-parser-impl`, the implementation hardcoded `0` to check for empty secret bases (`if (secretBaseId === 0)`) and in the bitwise flag check (`(flags & BATTLED_OWNER_TODAY_MASK) !== 0`), instead of defining and using module-level constants for these values.
+- **Action Required:** Ensure coders are explicitly reminded of Section 13 constraints, particularly regarding implicit/magic numbers like `0` in conditional statements.

--- a/.foundry/tasks/task-404-408-gen3-secret-base-parser-impl.md
+++ b/.foundry/tasks/task-404-408-gen3-secret-base-parser-impl.md
@@ -2,7 +2,7 @@
 id: task-404-408-gen3-secret-base-parser-impl
 type: TASK
 title: Gen 3 Secret Base Parsing Engine Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-08-08'
 updated_at: '2026-08-09'
@@ -17,8 +17,8 @@ tags:
   - secret-base
   - save-parsing
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Violates Section 13 (No Magic Numbers) by hardcoding 0 for empty secret bases and in the bitwise check.'
 notes: ''
 ---
 
@@ -33,8 +33,8 @@ Following the definition of the Secret Base types, this task implements the core
 - Adhere to `ADR 010: Gen3 Data Parsing Strategy`.
 
 ## Acceptance Criteria
-- [x] Implement `DataView` based parser for Gen 3 Secret Bases.
-- [x] Ensure all memory offsets, lengths, bit locations, shifts, and masks are defined as reusable module-level constants (No inline magic numbers).
-- [x] Calculate relative memory offsets using the resolved section offset (e.g., `section1Offset`), rather than absolute hardcoded offsets, to support Gen 3 A/B bank flash memory.
-- [x] Catch `RangeError` from out-of-bounds reads and throw a new error with the exact message: 'The save file is corrupted or incomplete.'
-- [x] Write unit tests verifying successful parsing, corrupted file handling (`RangeError`), and correct relative offset usage.
+- [ ] Implement `DataView` based parser for Gen 3 Secret Bases.
+- [ ] Ensure all memory offsets, lengths, bit locations, shifts, and masks are defined as reusable module-level constants (No inline magic numbers).
+- [ ] Calculate relative memory offsets using the resolved section offset (e.g., `section1Offset`), rather than absolute hardcoded offsets, to support Gen 3 A/B bank flash memory.
+- [ ] Catch `RangeError` from out-of-bounds reads and throw a new error with the exact message: 'The save file is corrupted or incomplete.'
+- [ ] Write unit tests verifying successful parsing, corrupted file handling (`RangeError`), and correct relative offset usage.

--- a/.foundry/tasks/task-404-409-gen3-secret-base-parser-qa.md
+++ b/.foundry/tasks/task-404-409-gen3-secret-base-parser-qa.md
@@ -38,3 +38,9 @@ A QA pass is required to verify the complex logic implemented for the Gen 3 Secr
 - [ ] Verify that relative offsets are used correctly, passing in the section offset.
 - [ ] Verify that out-of-bounds `DataView` errors (`RangeError`) are caught and the exact message `'The save file is corrupted or incomplete.'` is thrown.
 - [ ] Verify unit tests cover standard and edge-case (corrupted) save files.
+
+## QA Notes
+- Rejected `task-404-408-gen3-secret-base-parser-impl` for violating Section 13 (No Magic Numbers) of the schema. The implementation hardcoded `0` for empty secret bases (`if (secretBaseId === 0)`) and in the bitwise check (`(flags & BATTLED_OWNER_TODAY_MASK) !== 0`).
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Rejected `task-404-408-gen3-secret-base-parser-impl` for violating Section 13 (No Magic Numbers) of the schema by hardcoding `0` for empty secret base checks and bitwise masking. Updated the QA task with notes and recorded the learning in a private journal.

---
*PR created automatically by Jules for task [12960983747185356556](https://jules.google.com/task/12960983747185356556) started by @szubster*