### PR TITLE
QA: Verify Gen 3 roamer parsing compliance

### DIFF
--- a/.foundry/tasks/task-358-404-gen3-roamer-parsing-qa.md
+++ b/.foundry/tasks/task-358-404-gen3-roamer-parsing-qa.md
@@ -26,7 +26,10 @@ notes: ''
 Verify the correctness of the Gen 3 Roamer data extraction implementation and strict adherence to save parsing guidelines.
 
 ## Acceptance Criteria
-- [ ] Verify that `Gen3RoamerData` interface accurately reflects extracted data fields (IVs, Personality Value, Species, HP, Level, Status, active boolean).
-- [ ] Verify that the `DataView` parsing logic strictly adheres to Section 13 of `.foundry/docs/schema.md` (module-level constants, no magic numbers, explicit bitwise mapping, `RangeError` catching).
-- [ ] Verify that game-specific extraction functions correctly utilize relative offsets based on the resolved section offset, not absolute offsets.
-- [ ] Ensure that automated tests cover the extraction logic and correctly handle missing/corrupted block scenarios.
+- [x] Verify that `Gen3RoamerData` interface accurately reflects extracted data fields (IVs, Personality Value, Species, HP, Level, Status, active boolean).
+- [x] Verify that the `DataView` parsing logic strictly adheres to Section 13 of `.foundry/docs/schema.md` (module-level constants, no magic numbers, explicit bitwise mapping, `RangeError` catching).
+- [x] Verify that game-specific extraction functions correctly utilize relative offsets based on the resolved section offset, not absolute offsets.
+- [x] Ensure that automated tests cover the extraction logic and correctly handle missing/corrupted block scenarios.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
This PR checks off the acceptance criteria for task-358-404-gen3-roamer-parsing-qa, confirming that the Gen 3 Roamer data extraction implementation correctly adheres to the save parsing guidelines specified in ADRs and `schema.md`, specifically module-level constants and bounds checking.

---
*PR created automatically by Jules for task [8469824578769131854](https://jules.google.com/task/8469824578769131854) started by @szubster*