### PR TITLE
Feat: Draft Tasks for Schema Role and Status Mapping

### DIFF
--- a/.foundry/stories/story-405-408-schema-role-status-mapping.md
+++ b/.foundry/stories/story-405-408-schema-role-status-mapping.md
@@ -30,4 +30,6 @@ Break down the work into tasks to update `.foundry/docs/schema.md` with the offi
 - Ensure strict adherence to Generation 1 Pokemon.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Generate TASK node(s) for updating schema.md.
+- [x] Tech Lead: Generate TASK node(s) for updating schema.md.
+- [ ] task-408-411-schema-role-mapping
+- [ ] task-408-412-schema-status-mapping

--- a/.foundry/tasks/task-408-411-schema-role-mapping.md
+++ b/.foundry/tasks/task-408-411-schema-role-mapping.md
@@ -1,0 +1,35 @@
+---
+id: task-408-411-schema-role-mapping
+type: TASK
+title: Update Schema.md with Role to Gen 1 Mappings
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-09'
+updated_at: '2026-08-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-405-408-schema-role-status-mapping
+tags:
+  - foundry
+  - schema
+  - gamification
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update Schema.md with Role to Gen 1 Mappings
+
+## Objective
+Update the Owner Persona Enum in `.foundry/docs/schema.md` to map the 13 system roles to their respective Generation 1 Pokémon narrative skins.
+
+## Technical Specifications
+- Edit the `5. Owner Persona Enum` table in `.foundry/docs/schema.md`.
+- Add the Gen 1 Pokémon mappings to each role (e.g. `product_manager` -> Dragonite, `epic_planner` -> Alakazam).
+- Mappings should be creative but make sense for the role in the context of a Gen 1 theme.
+- Ensure all 13 system roles have a mapped Gen 1 Pokémon.
+
+## Acceptance Criteria
+- [ ] Coder: Update `.foundry/docs/schema.md` with Gen 1 mappings for all 13 roles.

--- a/.foundry/tasks/task-408-412-schema-status-mapping.md
+++ b/.foundry/tasks/task-408-412-schema-status-mapping.md
@@ -1,0 +1,36 @@
+---
+id: task-408-412-schema-status-mapping
+type: TASK
+title: Update Schema.md with Status to Gen 1 Mappings
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-09'
+updated_at: '2026-08-09'
+depends_on:
+  - task-408-411-schema-role-mapping
+jules_session_id: null
+pr_number: null
+parent: story-405-408-schema-role-status-mapping
+tags:
+  - foundry
+  - schema
+  - gamification
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Update Schema.md with Status to Gen 1 Mappings
+
+## Objective
+Update the Status Enum in `.foundry/docs/schema.md` to map standard DAG statuses to Gen 1 progression mechanics.
+
+## Technical Specifications
+- Edit the `4.1 Status Enum` table in `.foundry/docs/schema.md`.
+- Add the Gen 1 progression mechanics mappings to each status (e.g. `PENDING` -> Pokémon Egg, `COMPLETED` -> Fully Evolved / Hall of Fame).
+- Mappings should logically follow the lifecycle stages using a Gen 1 theme.
+- Ensure all standard statuses have a mapping.
+
+## Acceptance Criteria
+- [ ] Coder: Update `.foundry/docs/schema.md` with Gen 1 mappings for DAG statuses.


### PR DESCRIPTION
1. Drafted `task-408-411-schema-role-mapping` to map the 13 system roles to their respective Generation 1 Pokémon narrative skins.
2. Drafted `task-408-412-schema-status-mapping` to map standard DAG statuses to Gen 1 progression mechanics.
3. Updated parent STORY `story-405-408-schema-role-status-mapping` with unchecked references to the newly generated children and checked off the acceptance criteria, strictly adhering to macro node generation rules.

---
*PR created automatically by Jules for task [12479413674982632940](https://jules.google.com/task/12479413674982632940) started by @szubster*