### PR TITLE
test(foundry): implement zod schema e2e test suite

### DIFF
--- a/.foundry/journals/coder/4132758074467685081.md
+++ b/.foundry/journals/coder/4132758074467685081.md
@@ -1,0 +1,5 @@
+# 2026-08-09-15-40-45
+
+- Learned that when creating tests for the Foundry Orchestrator (.github/scripts/foundry-orchestrator.ts), the `.foundry/fixtures` directory is explicitly ignored during node discovery.
+- Learned to explicitly write E2E schemas for testing orchestrator parsing (like checking valid vs. invalid zod schemas against Markdown fixtures) in `.github/scripts/schema-e2e.test.ts` instead of directly modifying `schema-fixtures.test.ts` to keep concerns separated.
+- Confirmed that modifying `.github/scripts/` requires installing dependencies internally (`cd .github/scripts && pnpm install`) and running tests explicitly via `npx vitest`.

--- a/.foundry/tasks/task-356-397-zod-schema-e2e-suite-impl.md
+++ b/.foundry/tasks/task-356-397-zod-schema-e2e-suite-impl.md
@@ -21,5 +21,8 @@ rejection_reason: ''
 Write a test suite for the Zod schema orchestrator integration using the test fixtures. Ensure that the orchestrator rejects the invalid schemas gracefully and accepts the valid schemas.
 
 ## Acceptance Criteria
-- [ ] Test orchestrator behavior with valid node fixtures.
-- [ ] Test orchestrator behavior with invalid node fixtures.
+- [x] Test orchestrator behavior with valid node fixtures.
+- [x] Test orchestrator behavior with invalid node fixtures.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.github/scripts/schema-e2e.test.ts
+++ b/.github/scripts/schema-e2e.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { parseNodeFile } from './foundry-orchestrator';
+
+const rootDir = path.resolve(__dirname, '../../');
+const fixturesDir = path.join(rootDir, '.foundry/fixtures');
+
+describe('Zod Schema E2E Test Suite', () => {
+  it('orchestrator accepts valid node fixtures', () => {
+    const validTask = parseNodeFile(path.join(fixturesDir, 'task-001-valid.md'), rootDir);
+    expect(validTask).not.toBeNull();
+    expect(validTask?.frontmatter.id).toBe('task-001-valid');
+
+    const validIdea = parseNodeFile(path.join(fixturesDir, 'idea-001-valid.md'), rootDir);
+    expect(validIdea).not.toBeNull();
+    expect(validIdea?.frontmatter.id).toBe('idea-001-valid');
+
+    const validEpic = parseNodeFile(path.join(fixturesDir, 'epic-001-valid.md'), rootDir);
+    expect(validEpic).not.toBeNull();
+    expect(validEpic?.frontmatter.id).toBe('epic-001-valid');
+  });
+
+  it('orchestrator rejects invalid node fixtures gracefully', () => {
+    const invalidTask = parseNodeFile(path.join(fixturesDir, 'task-002-invalid.md'), rootDir);
+    expect(invalidTask).toBeNull();
+
+    const invalidIdea = parseNodeFile(path.join(fixturesDir, 'idea-002-invalid.md'), rootDir);
+    expect(invalidIdea).toBeNull();
+
+    const invalidEpic = parseNodeFile(path.join(fixturesDir, 'epic-002-invalid.md'), rootDir);
+    expect(invalidEpic).toBeNull();
+  });
+});


### PR DESCRIPTION
Implemented the Zod schema E2E test suite to verify the Foundry Orchestrator's behavior with valid and invalid Markdown node fixtures.
- Created `.github/scripts/schema-e2e.test.ts`
- Verified valid fixtures (`task-001-valid`, `idea-001-valid`, `epic-001-valid`) return successfully parsed node data.
- Verified invalid fixtures (`task-002-invalid`, `idea-002-invalid`, `epic-002-invalid`) return `null` and gracefully handle validation errors.
- Checked off acceptance criteria in the parent TASK node.

---
*PR created automatically by Jules for task [4132758074467685081](https://jules.google.com/task/4132758074467685081) started by @szubster*