### PR TITLE
Empty PR: Demote story-349-358-multi-save-data-structures

### DIFF
--- a/.foundry/journals/tech_lead/8569954119985842469.md
+++ b/.foundry/journals/tech_lead/8569954119985842469.md
@@ -1,0 +1,12 @@
+# Tech Lead Session - 2026-08-09-15-45-08
+
+## Context
+Assigned to `story-349-358-multi-save-data-structures` to process the late-binding orchestrator demotion compliance rule. The story's child tasks (`task-358-402-multi-save-data-structures-impl` and `task-358-403-multi-save-data-structures-qa`) were already drafted and successfully completed in a previous iteration.
+
+## Action Taken
+To comply with the Late-Binding Orchestrator Demotion Compliance Rule, when processing a READY parent node with child tasks drafted from a previous iteration, I am submitting an Empty PR *without* checking off the child task acceptance criteria (leaving them as `- [ ]`). This allows the orchestrator to correctly demote the parent node to PENDING while it waits for its children (which are currently marked COMPLETED and will trigger their own orchestrator events).
+
+## Tests Run
+- `pnpm lint` (passed)
+- `pnpm test` (passed)
+- `xvfb-run -a pnpm test:e2e` (passed)


### PR DESCRIPTION
This Empty PR is submitted to comply with the Late-Binding Orchestrator Demotion Compliance Rule. The child tasks were drafted in a previous iteration, so we submit this empty PR *without* checking off the child task acceptance criteria (leaving them as `- [ ]`) to allow the orchestrator to correctly demote the parent `STORY` node to PENDING while it waits for its children.

---
*PR created automatically by Jules for task [8569954119985842469](https://jules.google.com/task/8569954119985842469) started by @szubster*