### PR TITLE
Setup E2E Verification for Removed Orphaned QA Rule

### DIFF
--- a/.foundry/tasks/task-361-407-remove-orphaned-qa-rule-e2e-setup.md
+++ b/.foundry/tasks/task-361-407-remove-orphaned-qa-rule-e2e-setup.md
@@ -24,4 +24,7 @@ notes: ''
 Set up the e2e test script requirements to verify that the obsolete "Orphaned QA Task Cancellation Rule" has been completely removed from system documentation.
 
 ## Acceptance Criteria
-- [ ] Coder: Implement script setup.
+- [x] Coder: Implement script setup.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/tests/e2e/orphaned_qa_rule.spec.ts
+++ b/tests/e2e/orphaned_qa_rule.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@playwright/test';
+
+test.describe('Orphaned QA Rule Documentation', () => {
+  test('should not contain any mention of the Orphaned QA Task Cancellation Rule', async () => {
+    // Implementation to be added in the next task
+  });
+});


### PR DESCRIPTION
Added the e2e test script requirements to verify that the obsolete "Orphaned QA Task Cancellation Rule" has been completely removed from system documentation.

---
*PR created automatically by Jules for task [7282405209724107497](https://jules.google.com/task/7282405209724107497) started by @szubster*