### PR TITLE
QA Gen 3 NPC Trade Extraction

### DIFF
--- a/.foundry/journals/qa.md
+++ b/.foundry/journals/qa.md
@@ -505,3 +505,4 @@ Verified task-356-397-gen3-trainer-data-extraction-core-impl. No changes needed 
 # QA Session Journal
 
 Verified the bash static analysis linter correctly blocks `tail -f` from executing, ensuring agent processes do not hang indefinitely and preventing useless timeout waiting. It correctly handles legitimate commands such as `tail -n 50`. The e2e tests were successful and confirm the linter logic fails fast when necessary. This aligns with our core policy against executing blocking bash commands in `run_in_bash_session`.
+## Session from 1776390025790580442\nVerified task-362-407-gen3-trade-extraction-impl. Extracted `npcTradeFlags` successfully, implemented without magic numbers and using dataView, throwing exact RangeError, and using relative offsets for Gen 3. The implementation adheres to Section 13.

--- a/.foundry/tasks/task-362-408-gen3-trade-extraction-qa.md
+++ b/.foundry/tasks/task-362-408-gen3-trade-extraction-qa.md
@@ -26,9 +26,12 @@ notes: ''
 Verify the implementation of the Gen 3 NPC trade extraction logic.
 
 ## Acceptance Criteria
-- [ ] Verify `npcTradeFlags` is populated correctly.
-- [ ] Verify implementation strictly adheres to the `DataView` API usage.
-- [ ] Verify `RangeError` is handled correctly and throws exactly "The save file is corrupted or incomplete."
-- [ ] Verify all constants are extracted correctly and no magic numbers are used.
-- [ ] Verify relative offsets are used correctly for Gen 3.
-- [ ] Tests pass locally (`pnpm test`).
+- [x] Verify `npcTradeFlags` is populated correctly.
+- [x] Verify implementation strictly adheres to the `DataView` API usage.
+- [x] Verify `RangeError` is handled correctly and throws exactly "The save file is corrupted or incomplete."
+- [x] Verify all constants are extracted correctly and no magic numbers are used.
+- [x] Verify relative offsets are used correctly for Gen 3.
+- [x] Tests pass locally (`pnpm test`).
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
I have verified that the Gen 3 NPC trade extraction logic in `src/engine/saveParser/parsers/gen3.ts` successfully meets all of its constraints and accurately parses and assigns the `npcTradeFlags` in `SaveData`. I have checked off the acceptance criteria checkboxes in `.foundry/tasks/task-362-408-gen3-trade-extraction-qa.md` and created an Empty PR to complete the process.

---
*PR created automatically by Jules for task [1776390025790580442](https://jules.google.com/task/1776390025790580442) started by @szubster*