### PR TITLE
feat: implement multi-save comparison algorithms

### DIFF
--- a/.foundry/tasks/task-359-411-multi-save-comparison-algorithms-impl.md
+++ b/.foundry/tasks/task-359-411-multi-save-comparison-algorithms-impl.md
@@ -32,6 +32,6 @@ As part of the Multi-Save Trade Planner, this task creates comparison algorithms
 - Write unit tests in `src/utils/saveComparison.test.ts` to verify the logic of the comparison functions.
 
 ## Acceptance Criteria
-- [ ] Implement `compareSaves` function in `src/utils/saveComparison.ts`.
-- [ ] Implement `findTradePossibilities` function in `src/utils/saveComparison.ts`.
-- [ ] Write unit tests for `compareSaves` and `findTradePossibilities`.
+- [x] Implement `compareSaves` function in `src/utils/saveComparison.ts`.
+- [x] Implement `findTradePossibilities` function in `src/utils/saveComparison.ts`.
+- [x] Write unit tests for `compareSaves` and `findTradePossibilities`.

--- a/src/utils/saveComparison.test.ts
+++ b/src/utils/saveComparison.test.ts
@@ -12,6 +12,14 @@ describe('saveComparison', () => {
       pc: [],
       partyDetails: [],
       pcDetails: [],
+      gameVersion: 'red',
+      badges: 0,
+      trainerName: 'Ash',
+      trainerId: 12345,
+      currentMapId: 0,
+      inventory: [],
+      currentBoxCount: 0,
+      hallOfFameCount: 0,
     };
   };
 

--- a/src/utils/saveComparison.test.ts
+++ b/src/utils/saveComparison.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import type { SaveData } from '../engine/saveParser';
+import { compareSaves, findTradePossibilities } from './saveComparison';
+
+describe('saveComparison', () => {
+  const createMockSave = (ownedIds: number[]): SaveData => {
+    return {
+      generation: 1,
+      owned: new Set(ownedIds),
+      seen: new Set(),
+      party: [],
+      pc: [],
+      partyDetails: [],
+      pcDetails: [],
+    };
+  };
+
+  describe('compareSaves', () => {
+    it('correctly identifies missing species for both saves', () => {
+      const save1 = createMockSave([1, 2, 3]);
+      const save2 = createMockSave([2, 3, 4]);
+
+      const result = compareSaves(save1, save2);
+
+      expect(result.save1Missing).toEqual([4]);
+      expect(result.save2Missing).toEqual([1]);
+    });
+
+    it('returns empty arrays when saves are identical', () => {
+      const save1 = createMockSave([1, 2, 3]);
+      const save2 = createMockSave([1, 2, 3]);
+
+      const result = compareSaves(save1, save2);
+
+      expect(result.save1Missing).toEqual([]);
+      expect(result.save2Missing).toEqual([]);
+    });
+
+    it('handles disjoint saves', () => {
+      const save1 = createMockSave([1, 2]);
+      const save2 = createMockSave([3, 4]);
+
+      const result = compareSaves(save1, save2);
+
+      expect(result.save1Missing).toEqual([3, 4]);
+      expect(result.save2Missing).toEqual([1, 2]);
+    });
+
+    it('handles empty saves', () => {
+      const save1 = createMockSave([]);
+      const save2 = createMockSave([]);
+
+      const result = compareSaves(save1, save2);
+
+      expect(result.save1Missing).toEqual([]);
+      expect(result.save2Missing).toEqual([]);
+    });
+
+    it('handles one empty save', () => {
+      const save1 = createMockSave([1, 2]);
+      const save2 = createMockSave([]);
+
+      const result = compareSaves(save1, save2);
+
+      expect(result.save1Missing).toEqual([]);
+      expect(result.save2Missing).toEqual([1, 2]);
+    });
+  });
+
+  describe('findTradePossibilities', () => {
+    it('correctly identifies trade possibilities among multiple saves', () => {
+      const saves: Record<string, SaveData> = {
+        saveA: createMockSave([1, 2, 3]),
+        saveB: createMockSave([3, 4, 5]),
+        saveC: createMockSave([1, 5, 6]),
+      };
+
+      const result = findTradePossibilities(saves);
+
+      expect(result).toHaveLength(6);
+
+      // saveA -> saveB (B needs 1, 2)
+      expect(result).toContainEqual({
+        sourceSaveId: 'saveA',
+        targetSaveId: 'saveB',
+        speciesIds: [1, 2],
+      });
+
+      // saveA -> saveC (C needs 2, 3)
+      expect(result).toContainEqual({
+        sourceSaveId: 'saveA',
+        targetSaveId: 'saveC',
+        speciesIds: [2, 3],
+      });
+
+      // saveB -> saveA (A needs 4, 5)
+      expect(result).toContainEqual({
+        sourceSaveId: 'saveB',
+        targetSaveId: 'saveA',
+        speciesIds: [4, 5],
+      });
+
+      // saveB -> saveC (C needs 3, 4)
+      expect(result).toContainEqual({
+        sourceSaveId: 'saveB',
+        targetSaveId: 'saveC',
+        speciesIds: [3, 4],
+      });
+
+      // saveC -> saveA (A needs 5, 6)
+      expect(result).toContainEqual({
+        sourceSaveId: 'saveC',
+        targetSaveId: 'saveA',
+        speciesIds: [5, 6],
+      });
+
+      // saveC -> saveB (B needs 1, 6)
+      expect(result).toContainEqual({
+        sourceSaveId: 'saveC',
+        targetSaveId: 'saveB',
+        speciesIds: [1, 6],
+      });
+    });
+
+    it('returns empty array when there are no trade possibilities', () => {
+      const saves: Record<string, SaveData> = {
+        saveA: createMockSave([1, 2]),
+        saveB: createMockSave([1, 2]),
+      };
+
+      const result = findTradePossibilities(saves);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array with a single save', () => {
+      const saves: Record<string, SaveData> = {
+        saveA: createMockSave([1, 2]),
+      };
+
+      const result = findTradePossibilities(saves);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array with no saves', () => {
+      const saves: Record<string, SaveData> = {};
+
+      const result = findTradePossibilities(saves);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/utils/saveComparison.ts
+++ b/src/utils/saveComparison.ts
@@ -1,0 +1,70 @@
+import type { SaveData } from '../engine/saveParser';
+
+export interface SaveComparisonResult {
+  save1Missing: number[];
+  save2Missing: number[];
+}
+
+export interface TradePossibility {
+  sourceSaveId: string;
+  targetSaveId: string;
+  speciesIds: number[];
+}
+
+export function compareSaves(save1: SaveData, save2: SaveData): SaveComparisonResult {
+  const save1Missing: number[] = [];
+  const save2Missing: number[] = [];
+
+  for (const speciesId of save2.owned) {
+    if (!save1.owned.has(speciesId)) {
+      save1Missing.push(speciesId);
+    }
+  }
+
+  for (const speciesId of save1.owned) {
+    if (!save2.owned.has(speciesId)) {
+      save2Missing.push(speciesId);
+    }
+  }
+
+  return {
+    save1Missing,
+    save2Missing,
+  };
+}
+
+export function findTradePossibilities(saves: Record<string, SaveData>): TradePossibility[] {
+  const possibilities: TradePossibility[] = [];
+  const saveIds = Object.keys(saves);
+
+  for (let i = 0; i < saveIds.length; i++) {
+    for (let j = 0; j < saveIds.length; j++) {
+      if (i === j) continue;
+
+      const sourceId = saveIds[i];
+      const targetId = saveIds[j];
+      const sourceSave = saves[sourceId];
+      const targetSave = saves[targetId];
+
+      if (sourceId && targetId && sourceSave && targetSave) {
+        const targetNeeds: number[] = [];
+
+        for (const speciesId of sourceSave.owned) {
+          if (!targetSave.owned.has(speciesId)) {
+            targetNeeds.push(speciesId);
+          }
+        }
+
+        if (targetNeeds.length > 0) {
+          possibilities.push({
+            sourceSaveId: sourceId,
+            targetSaveId: targetId,
+            speciesIds: targetNeeds,
+          });
+        }
+      }
+    }
+  }
+
+  return possibilities;
+}

--- a/src/utils/saveComparison.ts
+++ b/src/utils/saveComparison.ts
@@ -43,10 +43,13 @@ export function findTradePossibilities(saves: Record<string, SaveData>): TradePo
 
       const sourceId = saveIds[i];
       const targetId = saveIds[j];
+
+      if (!sourceId || !targetId) continue;
+
       const sourceSave = saves[sourceId];
       const targetSave = saves[targetId];
 
-      if (sourceId && targetId && sourceSave && targetSave) {
+      if (sourceSave && targetSave) {
         const targetNeeds: number[] = [];
 
         for (const speciesId of sourceSave.owned) {


### PR DESCRIPTION
Implemented the multi-save comparison algorithms in `src/utils/saveComparison.ts` to support the Multi-Save Trade Planner.

- Created `compareSaves(save1, save2)` to efficiently return species missing from each save compared to the other.
- Created `findTradePossibilities(saves)` to analyze a collection of saves and determine which saves have Pokémon that other saves need.
- Added comprehensive unit tests in `src/utils/saveComparison.test.ts` covering missing species, trade possibilities, and edge cases.
- Both functions leverage `Set.has()` for O(1) lookups on the `owned` arrays.
- Checked off the acceptance criteria checkboxes in `.foundry/tasks/task-359-411-multi-save-comparison-algorithms-impl.md`.

---
*PR created automatically by Jules for task [570164945438249273](https://jules.google.com/task/570164945438249273) started by @szubster*