### PR TITLE
QA: Draft ADR for SaveData Typed Schema

### DIFF
--- a/.foundry/tasks/task-361-410-draft-savedata-adr-qa.md
+++ b/.foundry/tasks/task-361-410-draft-savedata-adr-qa.md
@@ -26,4 +26,7 @@ notes: ''
 Review the Drafted Architecture Decision Record (ADR) detailing the typed schema and downstream consumer impact for the new discriminated union SaveData type.
 
 ## Acceptance Criteria
-- [ ] Review the ADR in `.foundry/archive/docs/adrs/`.
+- [x] Review the ADR in `.foundry/archive/docs/adrs/`.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Reviewed the Drafted Architecture Decision Record (ADR) detailing the typed schema and downstream consumer impact for the new discriminated union SaveData type. Checked off the acceptance criteria in `.foundry/tasks/task-361-410-draft-savedata-adr-qa.md`.

---
*PR created automatically by Jules for task [15950893375840004707](https://jules.google.com/task/15950893375840004707) started by @szubster*