### PR TITLE
fix: remove magic numbers in Gen 3 Secret Base parser

### DIFF
--- a/.foundry/journals/coder/12015024896685344229.md
+++ b/.foundry/journals/coder/12015024896685344229.md
@@ -1,0 +1,1 @@
+Session 12015024896685344229: Fixed magic numbers in parseSecretBaseRecord to comply with QA feedback and Section 13 (No Magic Numbers) of .foundry/docs/schema.md, and checked off the task's acceptance criteria to transition it to COMPLETED using an Empty PR.

--- a/.foundry/tasks/task-404-408-gen3-secret-base-parser-impl.md
+++ b/.foundry/tasks/task-404-408-gen3-secret-base-parser-impl.md
@@ -33,8 +33,8 @@ Following the definition of the Secret Base types, this task implements the core
 - Adhere to `ADR 010: Gen3 Data Parsing Strategy`.
 
 ## Acceptance Criteria
-- [ ] Implement `DataView` based parser for Gen 3 Secret Bases.
-- [ ] Ensure all memory offsets, lengths, bit locations, shifts, and masks are defined as reusable module-level constants (No inline magic numbers).
-- [ ] Calculate relative memory offsets using the resolved section offset (e.g., `section1Offset`), rather than absolute hardcoded offsets, to support Gen 3 A/B bank flash memory.
-- [ ] Catch `RangeError` from out-of-bounds reads and throw a new error with the exact message: 'The save file is corrupted or incomplete.'
-- [ ] Write unit tests verifying successful parsing, corrupted file handling (`RangeError`), and correct relative offset usage.
+- [x] Implement `DataView` based parser for Gen 3 Secret Bases.
+- [x] Ensure all memory offsets, lengths, bit locations, shifts, and masks are defined as reusable module-level constants (No inline magic numbers).
+- [x] Calculate relative memory offsets using the resolved section offset (e.g., `section1Offset`), rather than absolute hardcoded offsets, to support Gen 3 A/B bank flash memory.
+- [x] Catch `RangeError` from out-of-bounds reads and throw a new error with the exact message: 'The save file is corrupted or incomplete.'
+- [x] Write unit tests verifying successful parsing, corrupted file handling (`RangeError`), and correct relative offset usage.

--- a/src/engine/gen3/secretBase/parser.ts
+++ b/src/engine/gen3/secretBase/parser.ts
@@ -34,6 +34,9 @@ export const NUM_TIMES_ENTERED_OFFSET = 0x10;
 export const DECORATIONS_OFFSET = 0x12;
 export const DECORATION_POSITIONS_OFFSET = 0x22;
 
+export const EMPTY_SECRET_BASE_ID = 0;
+export const FLAG_FALSE = 0;
+
 /**
  * Parses the Secret Base Party member structures from a Gen 3 save file.
  *
@@ -98,14 +101,14 @@ export function parseSecretBaseRecord(view: DataView, offset: number) {
     const secretBaseId = view.getUint8(offset);
 
     // If ID is 0, the secret base slot is typically empty.
-    if (secretBaseId === 0) {
+    if (secretBaseId === EMPTY_SECRET_BASE_ID) {
       return null;
     }
 
     const mapId = Math.floor(secretBaseId / SECRET_BASE_MAP_ID_DIVISOR);
 
     const flags = view.getUint8(offset + FLAGS_OFFSET);
-    const battledOwnerToday = (flags & BATTLED_OWNER_TODAY_MASK) !== 0;
+    const battledOwnerToday = (flags & BATTLED_OWNER_TODAY_MASK) !== FLAG_FALSE;
 
     const trainerName = decodeGen12String(view, offset + TRAINER_NAME_OFFSET, TRAINER_NAME_LENGTH);
 


### PR DESCRIPTION
Fixes magic numbers usage in Gen 3 Secret Base parser to comply with project schema rules and QA feedback. Checked off acceptance criteria in `task-404-408-gen3-secret-base-parser-impl.md` to trigger empty PR flow for completion.

---
*PR created automatically by Jules for task [12015024896685344229](https://jules.google.com/task/12015024896685344229) started by @szubster*