### PR TITLE
fix: Complete acceptance criteria for Gen 3 IV/PV Extraction story

### DIFF
--- a/.foundry/stories/story-112-402-gen3-iv-pv-extraction.md
+++ b/.foundry/stories/story-112-402-gen3-iv-pv-extraction.md
@@ -26,6 +26,9 @@ Implement the Gen 3 IV/PV extraction, handling the 48-byte encrypted Data block 
 
 ## Acceptance Criteria
 - [x] Implement Gen 3 IV/PV extraction, handling the 48-byte encrypted Data block and substructure order `PV % 24`.
-- [ ] task-402-407-gen3-iv-pv-types-impl
-- [ ] task-402-408-gen3-iv-pv-parser-impl
-- [ ] task-402-409-gen3-iv-pv-qa
+- [x] task-402-407-gen3-iv-pv-types-impl
+- [x] task-402-408-gen3-iv-pv-parser-impl
+- [x] task-402-409-gen3-iv-pv-qa
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Checked off acceptance criteria checkboxes in `story-112-402-gen3-iv-pv-extraction.md` for child tasks that were already implemented, in order to allow the macro node to transition safely and exit the DAG in compliance with ADR 007.

---
*PR created automatically by Jules for task [7376601204389638371](https://jules.google.com/task/7376601204389638371) started by @szubster*