### PR TITLE
docs(orchestrator): mark hierarchical completion check E2E tests as complete

### DIFF
--- a/.foundry/tasks/task-358-407-orchestrator-strict-completion-e2e-impl.md
+++ b/.foundry/tasks/task-358-407-orchestrator-strict-completion-e2e-impl.md
@@ -34,10 +34,10 @@ Specifically, add tests for the following scenarios:
 3. `Hierarchical Completion: considers VERIFYING child as incomplete and suspends ACTIVE parent`
 
 ## Acceptance Criteria
-- [ ] Implement test: `Hierarchical Completion: suspends VERIFYING parent to PENDING if it has incomplete children`
-- [ ] Implement test: `Hierarchical Completion: suspends READY parent to PENDING if it has incomplete children`
-- [ ] Implement test: `Hierarchical Completion: considers VERIFYING child as incomplete and suspends ACTIVE parent`
-- [ ] Ensure all tests pass.
+- [x] Implement test: `Hierarchical Completion: suspends VERIFYING parent to PENDING if it has incomplete children`
+- [x] Implement test: `Hierarchical Completion: suspends READY parent to PENDING if it has incomplete children`
+- [x] Implement test: `Hierarchical Completion: considers VERIFYING child as incomplete and suspends ACTIVE parent`
+- [x] Ensure all tests pass.
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
The E2E tests for the orchestrator's hierarchical completion logic were already implemented and passing in `.github/scripts/foundry-orchestrator.test.ts`.

This empty PR checks off the Acceptance Criteria in the task markdown file to satisfy the strict completeness contract (ADR 007), allowing the node to gracefully transition out of the DAG.

- Checked off "Implement test: Hierarchical Completion: suspends VERIFYING parent to PENDING if it has incomplete children"
- Checked off "Implement test: Hierarchical Completion: suspends READY parent to PENDING if it has incomplete children"
- Checked off "Implement test: Hierarchical Completion: considers VERIFYING child as incomplete and suspends ACTIVE parent"
- Checked off "Ensure all tests pass"

---
*PR created automatically by Jules for task [8852221145224400288](https://jules.google.com/task/8852221145224400288) started by @szubster*