### PR TITLE
Suspend Story 358 and Spawn Research 406 for Trainer Card Offsets

### DIFF
--- a/.foundry/journals/tech_lead/2026-08-09-20-51-38.md
+++ b/.foundry/journals/tech_lead/2026-08-09-20-51-38.md
@@ -1,0 +1,8 @@
+# 6461270398892069517 Session Journal
+
+## Learnings
+The Gen 3 Trainer Card requires the Contest Master Rank flag, but standard documentation does not specify a global flag or offset for it. I utilized the "late binding for missing context" protocol to suspend the story and spawn a RESEARCH node to investigate the correct offsets. This ensures blueprints remain actionable and do not involve guessing or generic fallbacks.
+
+## Changes
+- Suspended `story-400-358-gen3-trainer-card-parsing-core`.
+- Created `research-358-406-gen3-trainer-card-offsets` to discover Contest Master Rank offsets.

--- a/.foundry/research/research-358-406-gen3-trainer-card-offsets.md
+++ b/.foundry/research/research-358-406-gen3-trainer-card-offsets.md
@@ -1,0 +1,30 @@
+---
+id: research-358-406-gen3-trainer-card-offsets
+type: RESEARCH
+title: Research - Gen 3 Trainer Card Contest Master Rank Offsets
+status: PENDING
+owner_persona: researcher
+created_at: '2026-08-09'
+updated_at: '2026-08-09'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-400-358-gen3-trainer-card-parsing-core
+tags:
+  - research
+  - gen3
+  - completionist
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Gen 3 Trainer Card Contest Master Rank Offsets
+
+## Objective
+Investigate the specific memory offsets and logic required to parse the "Contest Master Rank" requirement for the Gen 3 Trainer Card upgrade. The documentation currently details how individual Pokemon ribbons are stored (`gen3_pokemon_data_structure.md`), but it is unclear if the Trainer Card star is awarded via a global flag (such as the Lilycove Museum painting flags) or if it requires scanning PC boxes for specific ribbons.
+
+## Acceptance Criteria
+- [ ] Document the memory offsets and bitwise flags representing the Contest Master Rank criteria for the Gen 3 Trainer Card.
+- [ ] Create an ADR or update the Knowledge Base (`.foundry/docs/knowledge_base/`) with the findings.

--- a/.foundry/stories/story-400-358-gen3-trainer-card-parsing-core.md
+++ b/.foundry/stories/story-400-358-gen3-trainer-card-parsing-core.md
@@ -2,11 +2,12 @@
 id: story-400-358-gen3-trainer-card-parsing-core
 type: STORY
 title: Story - Gen 3 Trainer Card Data Parsing Core
-status: ACTIVE
+status: FAILED
 owner_persona: tech_lead
 created_at: '2026-08-05'
 updated_at: '2026-08-09'
-depends_on: []
+depends_on:
+  - research-358-406-gen3-trainer-card-offsets
 jules_session_id: '6461270398892069517'
 pr_number: null
 parent: epic-111-400-gen3-trainer-card-data-extraction
@@ -17,7 +18,7 @@ tags:
   - completionist
 research_references: []
 rejection_count: 0
-rejection_reason: ''
+rejection_reason: 'Suspended pending research on Contest Master Rank memory offsets.'
 notes: ''
 ---
 
@@ -33,3 +34,7 @@ Implement the core parsing logic to extract the Gen 3 Trainer Card upgrade data 
 - [ ] Parse Contest Master Rank flags (Cool, Beauty, Cute, Smart, Tough).
 - [ ] Parse Battle Frontier Gold Symbols flags.
 - [ ] Verify the implementation's exact alignment with the documentation schemas (e.g., Section 13 of .foundry/docs/schema.md) before marking tasks complete.
+- [ ] research-358-406-gen3-trainer-card-offsets
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Suspended `story-400-358-gen3-trainer-card-parsing-core` pending research on Contest Master Rank memory offsets. Spawned `research-358-406-gen3-trainer-card-offsets` to investigate and document the required bitwise flags for the Gen 3 Trainer Card.

---
*PR created automatically by Jules for task [6461270398892069517](https://jules.google.com/task/6461270398892069517) started by @szubster*