### PR TITLE
🔐 Use crypto.getRandomValues instead of Math.random

### DIFF
--- a/.jules/shield/YYYY-MM-DD-HH-MM-SS.md
+++ b/.jules/shield/YYYY-MM-DD-HH-MM-SS.md
@@ -1,4 +1,6 @@
 # Cryptographic Secure Pseudo-Random Number Generation
 
-During this session, I replaced `Math.random()` with `window.crypto.getRandomValues()` in `src/components/SearchAndFilters.tsx` to generate a random hex string for visual effect.
+During this session, I replaced `Math.random()` with `globalThis.crypto.getRandomValues()` in `src/components/SearchAndFilters.tsx` to generate a random hex string for visual effect.
 I also learned that `window.crypto.getRandomValues()` should be used when purely client-side rendering, but if the component is used in Server-Side Rendering (SSR) environments, `globalThis.crypto.getRandomValues` is a safer cross-environment alternative as `window` might be undefined on the server.
+I fixed the CodeQL warning by using a bitwise AND mask instead of the modulo operator.
+I also fixed the typescript error by using `(randomValues[i] || 0)` instead of `randomValues[i]!`.

--- a/.jules/shield/YYYY-MM-DD-HH-MM-SS.md
+++ b/.jules/shield/YYYY-MM-DD-HH-MM-SS.md
@@ -1,1 +1,4 @@
-Resolved high/moderate dependency vulnerabilities in undici and fast-uri by injecting pnpm overrides into pnpm-workspace.yaml using `pnpm audit --fix override`. Tests passing.
+# Cryptographic Secure Pseudo-Random Number Generation
+
+During this session, I replaced `Math.random()` with `window.crypto.getRandomValues()` in `src/components/SearchAndFilters.tsx` to generate a random hex string for visual effect.
+I also learned that `window.crypto.getRandomValues()` should be used when purely client-side rendering, but if the component is used in Server-Side Rendering (SSR) environments, `globalThis.crypto.getRandomValues` is a safer cross-environment alternative as `window` might be undefined on the server.

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -16,9 +16,9 @@ import { TelemetryDecoration } from './TelemetryDecoration';
 function generateHexStream(length: number) {
   let result = '';
   const characters = '0123456789ABCDEF';
-  const randomValues = window.crypto.getRandomValues(new Uint8Array(length));
+  const randomValues = globalThis.crypto.getRandomValues(new Uint8Array(length));
   for (let i = 0; i < length; i++) {
-    result += characters.charAt(randomValues[i] % characters.length);
+    result += characters.charAt((randomValues[i] || 0) & 0x0f);
   }
   return result;
 }

--- a/src/components/SearchAndFilters.tsx
+++ b/src/components/SearchAndFilters.tsx
@@ -16,8 +16,9 @@ import { TelemetryDecoration } from './TelemetryDecoration';
 function generateHexStream(length: number) {
   let result = '';
   const characters = '0123456789ABCDEF';
+  const randomValues = window.crypto.getRandomValues(new Uint8Array(length));
   for (let i = 0; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * characters.length));
+    result += characters.charAt(randomValues[i] % characters.length);
   }
   return result;
 }


### PR DESCRIPTION
🎯 What: Replaced insecure `Math.random()` with `window.crypto.getRandomValues()` in `SearchAndFilters.tsx`.

⚠️ Risk: Low risk, as this generates a random hex string for visual effect. The character array length is a factor of 256, mitigating modulo bias.

🛡️ Solution: Use native `window.crypto` for cryptographically secure random values instead of `Math.random()`.

---
*PR created automatically by Jules for task [4213842383015192499](https://jules.google.com/task/4213842383015192499) started by @szubster*