### PR TITLE
📜 Scribe: Document PlayerTools in encounterTools.ts

### DIFF
--- a/.jules/scribe/2024-08-10-02-12-00.md
+++ b/.jules/scribe/2024-08-10-02-12-00.md
@@ -1,0 +1,7 @@
+# Scribe Session Journal: 2024-08-10
+
+## Focus
+Added documentation to `src/engine/assistant/utils/encounterTools.ts`.
+
+## Learnings
+* **Bash Truncation:** When reading files to include the complete content in a `write_file` step (to comply with the Specificity Rule), bash output via `cat` can truncate if the file is too large. Instead of relying on a single `cat`, either pipe the output to a temp file and read it, or use `sed -n` sequentially (e.g., `sed -n '1,100p'`, `sed -n '101,200p'`) to bypass the truncation and safely retrieve the complete file contents without hallucinating.

--- a/src/engine/assistant/utils/encounterTools.ts
+++ b/src/engine/assistant/utils/encounterTools.ts
@@ -1,12 +1,26 @@
 import type { PokemonInstance, SaveData } from '../../saveParser/index';
 import type { Suggestion } from '../strategies/types';
 
+/**
+ * Represents the set of exploration tools and Hidden Machines (HMs) currently
+ * available to the player.
+ *
+ * This object is used by the suggestion engine to evaluate whether the player
+ * can physically reach or trigger specific encounters. If a tool is missing,
+ * dependent encounters are either penalized in priority or removed entirely.
+ */
 export interface PlayerTools {
+  /** Can the player use Headbutt on special trees? */
   hasHeadbutt: boolean;
+  /** Can the player use Rock Smash on cracked boulders? */
   hasRockSmash: boolean;
+  /** Can the player travel across water using Surf? */
   hasSurf: boolean;
+  /** Can the player fish for low-level Pokémon with an Old Rod? */
   hasOldRod: boolean;
+  /** Can the player fish for mid-level Pokémon with a Good Rod? */
   hasGoodRod: boolean;
+  /** Can the player fish for high-level Pokémon with a Super Rod? */
   hasSuperRod: boolean;
 }
 


### PR DESCRIPTION
**What:** Added JSDoc comments to the `PlayerTools` interface and its fields inside `src/engine/assistant/utils/encounterTools.ts`.

**Why this module needed docs:** `encounterTools.ts` is central to the assistant's ability to filter suggestions based on player HM progress (like Surf or Rock Smash) and available tools (like fishing rods). While the functions `extractPlayerTools` and `filterSuggestionsByMissingTools` were already documented, the primary data structure (`PlayerTools`) lacked context explaining its role in the engine's prioritization system.

**Summary of additions:**
- Added a class-level JSDoc to `PlayerTools` explaining its role in filtering and penalizing encounters.
- Added specific property JSDocs for `hasHeadbutt`, `hasRockSmash`, `hasSurf`, `hasOldRod`, `hasGoodRod`, and `hasSuperRod`.

---
*PR created automatically by Jules for task [16017380220792396480](https://jules.google.com/task/16017380220792396480) started by @szubster*