### PR TITLE
🧭 Strategist: Prompt improvement - Centralize Transient Rejections

### DIFF
--- a/.foundry/docs/knowledge_base/agents/core_policies.md
+++ b/.foundry/docs/knowledge_base/agents/core_policies.md
@@ -69,6 +69,15 @@ When explicitly reading these contextual documents, you MUST use the `read_file`
 ## Node Creation Guidelines
 While the system does not strictly block node creation, ANY scheduled or foundry agent can dynamically create new `IDEA`, `TASK`, `RESEARCH`, or `ADR` nodes in the `.foundry/` directory. If you encounter larger architectural changes, find technical debt, realize a task needs an idea/research, or lack context, you should create a node. For example, a task could result in an idea, and scheduled agents can create nodes in foundry. When creating downstream nodes, ensure you set the `owner_persona` correctly (e.g., `researcher` for RESEARCH nodes, `architect` for ADRs).
 
+## Triggering Transient Rejections
+If you reject an implementation or validation fails (transient error):
+1. You MUST update the target task's YAML frontmatter to `status: FAILED`.
+2. You MUST provide a clear `rejection_reason` in the target task's YAML frontmatter.
+3. You MUST increment the target task's `rejection_count` in its YAML frontmatter (if it doesn't exist, initialize it to 1).
+4. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed task.
+5. You MUST NOT modify your own task's YAML frontmatter (e.g., your QA or Auditor task must remain ACTIVE). Only update your own markdown body to note the failure.
+6. You MUST document the rejection in your persona journal.
+
 ## Handling Rejections & Aborts
 **CRITICAL - RESUMING FAILED NODES/TASKS:** If you are assigned to a node that was previously FAILED and has been resurrected, you MUST explicitly read its `rejection_reason` in the YAML frontmatter and explicitly read the Auditor or QA persona's journal (`.foundry/journals/auditor/*.md` or `.foundry/journals/qa/*.md`) using `read_file` to understand the exact root cause of the previous failure. You must ensure you address the reviewer's feedback and remove the `### Auditor Rejection` block (and its contents) from the markdown body rather than blindly resubmitting.
 

--- a/.github/agents/auditor.md
+++ b/.github/agents/auditor.md
@@ -9,7 +9,7 @@ You are the Auditor persona in the Foundry system. Your role is to assess and ve
 4. **Resolution**:
    - If the verification passes and learnings are captured: Use the `submit` tool to create an empty PR. The Empty PR Policy will transition the node to `COMPLETED`.
    - **CRITICAL**: Before submitting the Empty PR, you MUST ensure all Acceptance Criteria checkboxes in the node's markdown body are marked as `[x]`. If they are `[ ]`, you must check them off. Submitting an empty PR with unchecked boxes violates ADR 007 and ADR 009 and will result in immediate rejection.
-   - If the verification fails or requires a retry (transient failure): Do NOT modify the YAML frontmatter to set `status: FAILED` due to the CRITICAL RULE against modifying node YAML. Instead, fail the verification by unchecking the relevant Acceptance Criteria box (`- [ ]`) and appending an `### Auditor Rejection` section in the markdown body explaining the failure. Then use the `submit` tool to trigger the Resurrection Loop.
+   - If the verification fails or requires a retry (transient failure): You MUST follow the **Triggering Transient Rejections** protocol defined in `.foundry/docs/knowledge_base/agents/core_policies.md` (which includes updating the target node's YAML frontmatter to `status: FAILED` and appending an `### Auditor Rejection` section in the target node's markdown body). Then use the `submit` tool to trigger the Resurrection Loop.
 
 ## Journal
 

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -17,10 +17,4 @@ The QA agent validates TASK implementation against specifications. Your responsi
 Your private journal is `.foundry/journals/qa/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/qa/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.
 
 ### Handling Rejections
-If you reject an implementation or validation fails (transient error):
-1. You MUST update the target task's YAML frontmatter to `status: FAILED`.
-2. You MUST provide a clear `rejection_reason` in the target task's YAML frontmatter.
-3. You MUST increment the target task's `rejection_count` in its YAML frontmatter (if it doesn't exist, initialize it to 1).
-4. You MUST NOT check off the Acceptance Criteria checkboxes in the markdown body of the failed task.
-5. You MUST NOT modify your own QA task's YAML frontmatter (e.g., your task must remain ACTIVE). Only update your own markdown body to note the failure.
-6. You MUST document the rejection in your persona journal.
+If you reject an implementation or validation fails (transient error), you MUST follow the **Triggering Transient Rejections** protocol defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.

--- a/.jules/strategist/2026-08-10-02-30-15.md
+++ b/.jules/strategist/2026-08-10-02-30-15.md
@@ -1,0 +1,5 @@
+## 2026-08-10 - [Accepted] - Prompt improvement - Centralize Transient Rejections
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `qa.md` schedule contained specific instructions for failing a node (transient rejection), which are universally applicable to any verification agent (QA, Auditor). The `auditor.md` schedule contained contradictory instructions (falsely claiming modifying node YAML to set status to FAILED was forbidden).
+**Pattern:** Extracted the "Handling Rejections" step-by-step logic from `qa.md` and centralized it as "Triggering Transient Rejections" in `core_policies.md`. Updated `qa.md` and `auditor.md` to reference this single source of truth, resolving the contradiction and standardizing agent behavior.


### PR DESCRIPTION
This PR centralizes the protocol for triggering transient rejections (failing a node). Previously, the explicit steps (setting status to FAILED, incrementing rejection count, unchecking boxes, etc.) were deeply nested in the QA persona's schedule prompt (`qa.md`), while the Auditor persona (`auditor.md`) had contradictory instructions that falsely claimed modifying node YAML was forbidden.

This change:
1. Extracts the exact rejection steps into a new `## Triggering Transient Rejections` section in `core_policies.md`.
2. Updates `qa.md` to reference the central policy instead of holding duplicated logic.
3. Fixes `auditor.md` to reference the central policy, removing the contradictory rule.
4. Includes a journal entry for the Strategist persona detailing the change and the rationale.

---
*PR created automatically by Jules for task [522181781652350891](https://jules.google.com/task/522181781652350891) started by @szubster*