### PR TITLE
Update Schema.md with Status to Gen 1 Mappings

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -106,16 +106,16 @@ notes: ""               # Optional. Free-form Markdown remarks.
 
 ### 4.1 Status Enum
 
-| Status | Description |
-|---|---|
-| `PENDING` | Node exists but has unresolved `depends_on` entries — not yet eligible for dispatch. |
-| `READY` | **Orchestrator-written only.** All `depends_on` nodes are `COMPLETED`. Node is queued for the next dispatch cycle. |
-| `ACTIVE` | A Jules session (`jules_session_id`) is currently working on this node. This status persists if a PR is open for review. |
-| `VERIFYING` | A PR was merged, and the `auditor` is currently verifying the outcome. |
-| `COMPLETED` | PR merged (or auditor verification passed). TPM archives the node. |
-| `FAILED` | Session crashed silently or PR was rejected/closed without merge. Resurrection Loop re-spawns a fresh session. |
-| `BLOCKED` | DAG deadlock or explicit TPM hold. Requires CEO or TPM intervention to resolve. |
-| `CANCELLED` | Node retired by CEO decision or permanently failed. TPM archives the node. |
+| Status | Gen 1 Mapping | Description |
+|---|---|---|
+| `PENDING` | Pokémon Egg | Node exists but has unresolved `depends_on` entries — not yet eligible for dispatch. |
+| `READY` | Hatched Pokémon | **Orchestrator-written only.** All `depends_on` nodes are `COMPLETED`. Node is queued for the next dispatch cycle. |
+| `ACTIVE` | In Battle / Training | A Jules session (`jules_session_id`) is currently working on this node. This status persists if a PR is open for review. |
+| `VERIFYING` | Gym Leader Evaluation | A PR was merged, and the `auditor` is currently verifying the outcome. |
+| `COMPLETED` | Fully Evolved / Hall of Fame | PR merged (or auditor verification passed). TPM archives the node. |
+| `FAILED` | Fainted / Blacked Out | Session crashed silently or PR was rejected/closed without merge. Resurrection Loop re-spawns a fresh session. |
+| `BLOCKED` | Sleeping (Snorlax) | DAG deadlock or explicit TPM hold. Requires CEO or TPM intervention to resolve. |
+| `CANCELLED` | Released | Node retired by CEO decision or permanently failed. TPM archives the node. |
 
 ### 4.2 Valid State Transitions
 

--- a/.foundry/tasks/task-408-412-schema-status-mapping.md
+++ b/.foundry/tasks/task-408-412-schema-status-mapping.md
@@ -33,4 +33,4 @@ Update the Status Enum in `.foundry/docs/schema.md` to map standard DAG statuses
 - Ensure all standard statuses have a mapping.
 
 ## Acceptance Criteria
-- [ ] Coder: Update `.foundry/docs/schema.md` with Gen 1 mappings for DAG statuses.
+- [x] Coder: Update `.foundry/docs/schema.md` with Gen 1 mappings for DAG statuses.


### PR DESCRIPTION
Updates `.foundry/docs/schema.md` to map standard DAG statuses to Gen 1 progression mechanics and resolves the corresponding task.

---
*PR created automatically by Jules for task [18337688729149320349](https://jules.google.com/task/18337688729149320349) started by @szubster*