### PR TITLE
Draft task for orchestrator archive bypass

### DIFF
--- a/.foundry/journals/tech_lead/15624461644370182551.md
+++ b/.foundry/journals/tech_lead/15624461644370182551.md
@@ -1,0 +1,7 @@
+# Tech Lead Journal: Session 15624461644370182551
+
+## Learnings & Constraints
+- **Execution Plan Compliance (Exploration & Groundedness Rules):** All file paths must be explicitly discovered (e.g., using `ls`) and their contents fully read before proposing file modifications in an execution plan. Avoid proposing context-gathering steps (like reading a file to verify its structure) as future actions in the plan.
+- **Handling Truncated Markdown Files:** When retrieving file content (e.g., using `cat`) for exact file replacements in execution plans, verify whether the output is truncated. If so, use `tail -n <lines>` to explicitly read the end of the file (such as the Acceptance Criteria checkboxes and footers) to ensure no structural elements (like `### SCHEMA`) are accidentally lost during the rewrite, satisfying the Groundedness and Specificity rules.
+- **Premature Verification Enforcement:** When appending newly created task IDs to a parent node's `## Acceptance Criteria` section, ensure they are appended as unchecked checkboxes (`- [ ]`). Do not check off any of the parent node's existing Acceptance Criteria checkboxes, as this violates the Premature Verification policy which forbids parent nodes from transitioning to VERIFYING before all their child nodes are COMPLETED.
+- **Intelligent Verification Protocol in Action:** For highly isolated and trivial changes (such as a single-line `if` statement modification), it is acceptable to bypass drafting a separate QA task node, allowing the `coder` persona to self-verify.

--- a/.foundry/stories/story-405-408-orchestrator-archive-bypass-implementation.md
+++ b/.foundry/stories/story-405-408-orchestrator-archive-bypass-implementation.md
@@ -26,3 +26,4 @@ Implement logic in `discoverNodeFiles` in `.github/scripts/foundry-orchestrator.
 ## Acceptance Criteria
 - [ ] Update `discoverNodeFiles` to skip `archive/` directories.
 - [ ] Ensure this exclusion logic covers both `.foundry/archive/stories/` and `.foundry/archive/tasks/`.
+- [ ] task-408-415-orchestrator-archive-bypass-implementation

--- a/.foundry/tasks/task-408-415-orchestrator-archive-bypass-implementation.md
+++ b/.foundry/tasks/task-408-415-orchestrator-archive-bypass-implementation.md
@@ -1,0 +1,31 @@
+---
+id: task-408-415-orchestrator-archive-bypass-implementation
+type: TASK
+title: Orchestrator Archive Bypass Implementation
+status: READY
+owner_persona: coder
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-405-408-orchestrator-archive-bypass-implementation
+tags:
+  - foundry
+  - infrastructure
+  - performance
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# Orchestrator Archive Bypass Implementation
+
+## Context
+The Foundry DAG Orchestrator currently traverses the entire `.foundry` directory structure, which includes the `archive` directory. The archive directory contains thousands of files, slowing down the Orchestrator's discovery phase and wasting resources. The objective is to update `discoverNodeFiles` in `.github/scripts/foundry-orchestrator.ts` to skip the `archive` directory entirely.
+
+## Requirements
+Update `discoverNodeFiles` in `.github/scripts/foundry-orchestrator.ts` to skip `archive` directories. Specifically, update the directory skip logic in the `if (entry.isDirectory())` block to also skip `entry.name === 'archive'`.
+
+## Acceptance Criteria
+- [ ] Update `discoverNodeFiles` to skip `archive/` directories.
+- [ ] Ensure this exclusion logic covers both `.foundry/archive/stories/` and `.foundry/archive/tasks/`.


### PR DESCRIPTION
Drafts `task-408-415-orchestrator-archive-bypass-implementation.md` to update `discoverNodeFiles` in `.github/scripts/foundry-orchestrator.ts` to skip the `archive` directory, and updates `story-405-408-orchestrator-archive-bypass-implementation.md` with the new task dependency.

---
*PR created automatically by Jules for task [15624461644370182551](https://jules.google.com/task/15624461644370182551) started by @szubster*