### PR TITLE
chore: complete gen2 trade extraction story

### DIFF
--- a/.foundry/stories/story-349-361-gen2-trade-extraction.md
+++ b/.foundry/stories/story-349-361-gen2-trade-extraction.md
@@ -25,9 +25,9 @@ notes: ''
 Implement extraction of in-game NPC trade completion flags from Generation 2 save files.
 
 ## Acceptance Criteria
-- [ ] Gen 2 NPC trade flags are accurately extracted and mapped.
-- [ ] Parsing logic strictly adheres to the `DataView` API and handles `RangeError` for corrupted saves.
+- [x] Gen 2 NPC trade flags are accurately extracted and mapped.
+- [x] Parsing logic strictly adheres to the `DataView` API and handles `RangeError` for corrupted saves.
 - [x] Tech Lead: Break down this Story into executable Tasks.
-- [ ] task-361-407-gen2-trade-extraction-impl
-- [ ] task-361-408-gen2-trade-extraction-test
-- [ ] task-361-409-gen2-trade-extraction-qa
+- [x] task-361-407-gen2-trade-extraction-impl
+- [x] task-361-408-gen2-trade-extraction-test
+- [x] task-361-409-gen2-trade-extraction-qa


### PR DESCRIPTION
This empty PR checks off the acceptance criteria checkboxes in `.foundry/stories/story-349-361-gen2-trade-extraction.md`. All child tasks have been verified as completed, allowing the orchestrator to transition this macro node out of the DAG safely.

---
*PR created automatically by Jules for task [5493710222847896762](https://jules.google.com/task/5493710222847896762) started by @szubster*