### PR TITLE
Tech Lead: Draft implementation tasks for SaveData discriminated union

### DIFF
--- a/.foundry/stories/story-404-362-refactor-savedata-type.md
+++ b/.foundry/stories/story-404-362-refactor-savedata-type.md
@@ -27,4 +27,6 @@ notes: ''
 Refactor the `SaveData` type in `src/engine/saveParser/parsers/common.ts` into a discriminated union based on the `generation` field.
 
 ## Acceptance Criteria
-- [ ] Create task to refactor the `SaveData` type.
+- [x] Create task to refactor the `SaveData` type.
+- [ ] task-362-415-refactor-savedata-type-impl
+- [ ] task-362-416-refactor-savedata-type-qa

--- a/.foundry/tasks/task-362-415-refactor-savedata-type-impl.md
+++ b/.foundry/tasks/task-362-415-refactor-savedata-type-impl.md
@@ -1,0 +1,34 @@
+---
+id: task-362-415-refactor-savedata-type-impl
+type: TASK
+title: Implement SaveData Type Refactor
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-404-362-refactor-savedata-type
+tags:
+  - savedata
+  - typescript
+  - refactoring
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement SaveData Type Refactor
+
+## Description
+Implement the refactoring of the `SaveData` type in `src/engine/saveParser/parsers/common.ts` into a discriminated union based on the `generation` field, as defined in `.foundry/archive/docs/adrs/adr-361-030-savedata-discriminated-union-types.md`. Ensure that `parseGen1Save`, `parseGen2Save`, and `parseGen3Save` are updated to explicitly return their respective specific types (`Gen1SaveData`, `Gen2SaveData`, `Gen3SaveData`). Add type guards to consumers to safely access generation-specific properties.
+
+## Acceptance Criteria
+- [ ] Refactor `SaveData` in `src/engine/saveParser/parsers/common.ts` into `BaseSaveData`, `Gen1SaveData`, `Gen2SaveData`, and `Gen3SaveData`.
+- [ ] Update core parser functions to return specific generation types.
+- [ ] Update downstream consumers in the codebase to use type narrowing or type guards when accessing generation-specific properties.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/tasks/task-362-416-refactor-savedata-type-qa.md
+++ b/.foundry/tasks/task-362-416-refactor-savedata-type-qa.md
@@ -1,0 +1,35 @@
+---
+id: task-362-416-refactor-savedata-type-qa
+type: TASK
+title: Verify SaveData Type Refactor
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on:
+  - task-362-415-refactor-savedata-type-impl
+jules_session_id: null
+pr_number: null
+parent: story-404-362-refactor-savedata-type
+tags:
+  - savedata
+  - typescript
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Verify SaveData Type Refactor
+
+## Description
+Verify the implementation of the `SaveData` type refactor in `src/engine/saveParser/parsers/common.ts`. Ensure the discriminated union correctly enforces type safety and that downstream consumers properly handle generation-specific properties without non-null assertions or optional chaining when inappropriate.
+
+## Acceptance Criteria
+- [ ] Verify `SaveData` is refactored into a discriminated union.
+- [ ] Verify core parser functions return specific generation types.
+- [ ] Verify downstream consumers use proper type guards.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
I have broken down the `story-404-362-refactor-savedata-type` into actionable tasks for the `coder` and `qa` personas, in accordance with the ADR `adr-361-030-savedata-discriminated-union-types.md`.

* Created `task-362-415-refactor-savedata-type-impl.md` for the `coder`.
* Created `task-362-416-refactor-savedata-type-qa.md` for the `qa` persona, depending on the implementation task.
* Checked off the story's acceptance criteria and added the newly generated child tasks as unchecked checkboxes, leaving the YAML frontmatter intact to adhere to the strict orchestration rules.

---
*PR created automatically by Jules for task [11932857869913318362](https://jules.google.com/task/11932857869913318362) started by @szubster*