### PR TITLE
chore: finalize story-118-286-filter-swarm-item-calls

### DIFF
--- a/.foundry/journals/tech_lead/18396204845909116995.md
+++ b/.foundry/journals/tech_lead/18396204845909116995.md
@@ -1,0 +1,10 @@
+# Tech Lead Journal: 18396204845909116995
+
+## Completed Story: story-118-286-filter-swarm-item-calls
+
+The child tasks `task-286-402-filter-swarm-item-calls-impl` and `task-286-403-filter-swarm-item-calls-qa` for this story were successfully implemented and QA'd in previous iterations.
+
+To gracefully transition this parent `STORY` node to `COMPLETED` and satisfy the completeness contract defined in ADR 007, I checked off the remaining Acceptance Criteria checkboxes in the markdown body. This allows the Orchestrator to unblock downstream dependent tasks or mark the macro Epic as progressing.
+
+## Learnings
+*   **Late-Binding Completeness Protocol:** When a node's dependencies (child tasks) are fully completed, checking off the markdown checkboxes on the parent node is a critical required step before submitting an empty PR. Submitting without doing so triggers rejection due to ADR 007 and ADR 009.

--- a/.foundry/stories/story-118-286-filter-swarm-item-calls.md
+++ b/.foundry/stories/story-118-286-filter-swarm-item-calls.md
@@ -32,5 +32,5 @@ Filter the list of active callers to isolate NPCs that offer rare items or swarm
 - [x] Implement data logic for identifying high-value Pokegear calls
 - [x] task-286-314-filter-swarm-item-calls-impl
 - [x] task-286-315-filter-swarm-item-calls-qa
-- [ ] task-286-402-filter-swarm-item-calls-impl
-- [ ] task-286-403-filter-swarm-item-calls-qa
+- [x] task-286-402-filter-swarm-item-calls-impl
+- [x] task-286-403-filter-swarm-item-calls-qa


### PR DESCRIPTION
Checked off completed tasks in `story-118-286-filter-swarm-item-calls` to satisfy ADR 007 and allow the macro node to transition to COMPLETED since all child tasks (`task-286-402-filter-swarm-item-calls-impl` and `task-286-403-filter-swarm-item-calls-qa`) are completed.

---
*PR created automatically by Jules for task [18396204845909116995](https://jules.google.com/task/18396204845909116995) started by @szubster*