### PR TITLE
Demote epic-055-113-egg-move-pathfinding-engine to PENDING

### DIFF
--- a/.foundry/journals/story_owner/10642899106052443585.md
+++ b/.foundry/journals/story_owner/10642899106052443585.md
@@ -1,0 +1,4 @@
+## Session 10642899106052443585
+- Under the Late-Binding Orchestrator Demotion Compliance Rule, when processing a READY parent node (like an EPIC) with pending child tasks, we must generally submit an Empty PR without checking off the child tasks if they are incomplete.
+- However, if ALL descendant nodes (e.g. STORIES) are actually COMPLETED (e.g., they have transitioned to VERIFYING/COMPLETED in the system but the parent node's markdown checkbox is still unchecked), we MUST check off the parent's Acceptance Criteria checkboxes before submitting the PR. This satisfies ADR 007 and allows the macro node to transition to COMPLETED and gracefully exit the DAG.
+- Checking off a child node prematurely when it is not actually completed violates the Premature Verification policy and the MACRO NODE COMPLETION EXCEPTION.


### PR DESCRIPTION
This PR submits zero file changes for `epic-055-113-egg-move-pathfinding-engine`. Following the Late-Binding Orchestrator Demotion Compliance Rule, because this READY epic has pending child tasks (`story-113-348-egg-move-pathfinding-e2e`) drafted from a previous iteration, we must submit an empty PR without checking off its overarching acceptance criteria. This allows the orchestrator to demote the parent to PENDING while it waits for its children.

---
*PR created automatically by Jules for task [10642899106052443585](https://jules.google.com/task/10642899106052443585) started by @szubster*