### PR TITLE
chore: check off gen 2 dv extraction types task

### DIFF
--- a/.foundry/tasks/task-401-408-gen2-dv-extraction-types.md
+++ b/.foundry/tasks/task-401-408-gen2-dv-extraction-types.md
@@ -25,4 +25,4 @@ notes: ''
 Define the TypeScript types and interfaces required for the Gen 2 DV extraction (Attack, Defense, Speed, and Special).
 
 ## Acceptance Criteria
-- [ ] Create or update the types representing the parsed Gen 2 DVs. The interface should at least include: `attack: number`, `defense: number`, `speed: number`, and `special: number`.
+- [x] Create or update the types representing the parsed Gen 2 DVs. The interface should at least include: `attack: number`, `defense: number`, `speed: number`, and `special: number`.


### PR DESCRIPTION
The task requested to create or update types representing parsed Gen 2 DVs, including attack, defense, speed, and special. The interface `PokemonDVs` with these exact properties was already correctly implemented in `src/engine/breeding/pair_algorithm.ts`.

As no new code was required, the acceptance criteria checkbox in the task markdown was checked, and this PR is being submitted as an empty PR to transition the node status, per the orchestrator guidelines.

---
*PR created automatically by Jules for task [8791919044714984589](https://jules.google.com/task/8791919044714984589) started by @szubster*