### PR TITLE
test(orchestrator): verify strict hierarchical completion E2E logic

### DIFF
--- a/.foundry/tasks/task-358-408-orchestrator-strict-completion-e2e-qa.md
+++ b/.foundry/tasks/task-358-408-orchestrator-strict-completion-e2e-qa.md
@@ -30,10 +30,10 @@ Verify the E2E tests for the strict hierarchical completion checks in the orches
 The coder has implemented E2E tests for strict hierarchical completion logic to ensure it blocks VERIFYING nodes appropriately. Review the implementation in `.github/scripts/foundry-orchestrator.test.ts`.
 
 ## Acceptance Criteria
-- [ ] Verify test exists and passes: `Hierarchical Completion: suspends VERIFYING parent to PENDING if it has incomplete children`
-- [ ] Verify test exists and passes: `Hierarchical Completion: suspends READY parent to PENDING if it has incomplete children`
-- [ ] Verify test exists and passes: `Hierarchical Completion: considers VERIFYING child as incomplete and suspends ACTIVE parent`
-- [ ] Ensure `pnpm run test` passes without errors.
+- [x] Verify test exists and passes: `Hierarchical Completion: suspends VERIFYING parent to PENDING if it has incomplete children`
+- [x] Verify test exists and passes: `Hierarchical Completion: suspends READY parent to PENDING if it has incomplete children`
+- [x] Verify test exists and passes: `Hierarchical Completion: considers VERIFYING child as incomplete and suspends ACTIVE parent`
+- [x] Ensure `pnpm run test` passes without errors.
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
This PR checks off the acceptance criteria for `task-358-408-orchestrator-strict-completion-e2e-qa.md` after verifying the implementation of E2E tests for the strict hierarchical completion checks in `.github/scripts/foundry-orchestrator.test.ts`.

Verification steps performed:
- Checked all test cases defined in the Acceptance Criteria (`suspends VERIFYING parent...`, `suspends READY parent...`, `considers VERIFYING child as incomplete...`) exist and pass correctly.
- Ran `pnpm run test`, `npx vitest run foundry-orchestrator.test.ts`, and `xvfb-run -a pnpm test:e2e tests/e2e/setup.spec.ts` to ensure system stability.

This fulfills the strict completeness contract (ADR 007) and safely transitions the node out of the DAG.

---
*PR created automatically by Jules for task [5300636595240783325](https://jules.google.com/task/5300636595240783325) started by @szubster*