### PR TITLE
Research: Investigate E2E test failure for permanent failure dashboard

### DIFF
--- a/.foundry/journals/researcher/7961952418459437431.md
+++ b/.foundry/journals/researcher/7961952418459437431.md
@@ -1,0 +1,6 @@
+# Session 7961952418459437431
+
+## Learnings
+* **Testing against live repository data**: E2E tests targeting features that rely on repository metadata (like the Foundry DAG Dashboard reading `foundry.json`) should NOT rely on live repository state. In clean environments or CI, nodes with specific states (e.g., permanent failures) may not exist, causing non-deterministic timeouts.
+* **Resolution**: Such tests must use Playwright's `page.route` to mock the `**/data/foundry.json` response, providing a deterministic dataset containing the exact edge cases the UI expects.
+* **YAML Frontmatter Integrity**: When successfully completing a node (including RESEARCH nodes), never modify the YAML frontmatter (e.g., changing status to READY or clearing `jules_session_id`). Modifying the frontmatter breaks the Orchestrator's state machine. Only update the markdown body.

--- a/.foundry/research/research-353-404-investigate-lift-rejection-e2e-failure.md
+++ b/.foundry/research/research-353-404-investigate-lift-rejection-e2e-failure.md
@@ -29,6 +29,21 @@ Investigate the root cause of the permanent failure (rejection_count: 3) of task
 2. Are there any existing testing constraints, E2E framework limitations, or UI architectural decisions that the previous implementation failed to account for?
 3. What is the correct approach to writing this test that will successfully pass code review and verification?
 
-## Expected Deliverables
-- A detailed explanation of the failure reason.
-- Recommendations for implementing the E2E test correctly in the retry tasks.
+## Findings & Deliverables
+
+### Explanation of the Failure
+The previous E2E implementation attempts failed because the test relied on the actual, non-deterministic `foundry.json` data generated from the live `.foundry` directory. The test implicitly assumed that a node with `rejection_count >= MAX_REJECTION_THRESHOLD` and `status: FAILED` would always naturally exist in the live repository state to satisfy the assertions. However, in clean environments or different repository states (such as CI), these nodes may not exist or might change, leading to `element not found` timeouts (as Playwright waits for `toBeVisible()` on nodes that are never rendered).
+
+Additionally, the previous test implementation did not account for the fact that the application routes to the DAG dashboard via `./dag`, not the default index or `/dashboard`.
+
+### Recommendations for the Retry Task
+To correctly implement the permanent failure E2E test:
+1. **Deterministic Mocking**: The test must mock the API response for `**/data/foundry.json` using Playwright's `page.route()`. The mocked payload should explicitly return an array containing at least two deterministic nodes:
+   - One node with `status: "FAILED"` and `rejection_count: MAX_REJECTION_THRESHOLD`.
+   - One node with `status: "FAILED"` and `rejection_count: 1` (to ensure the filter works correctly).
+2. **Dashboard Routing**: The test should navigate to `./dag` directly to access the DAG dashboard.
+3. **Wait for Load**: The test must wait for the loading screen (`[ SYSTEM.LOADING_DAG ]`) to disappear to ensure the DAG is fully rendered before asserting UI interactions.
+4. **Visual Assertion**: After clicking the "Toggle permanent failures only" button, the test should assert that the remaining visible node has the expected text and explicitly check for the permanent failure styling classes (e.g., `border-red-500` and `brightness-125`) applied by `DagNode.tsx`.
+
+### SCHEMA
+https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
- Investigated the permanent failure of task-353-393-lift-rejection-constant-e2e-impl.
- Updated research node `research-353-404-investigate-lift-rejection-e2e-failure` with findings and recommendations.
- Identified that the test failed due to relying on non-deterministic live repository state for `foundry.json`.
- Recommended mocking `**/data/foundry.json` using Playwright's `page.route` to return a deterministic DAG containing a node with `rejection_count >= MAX_REJECTION_THRESHOLD`.
- Documented findings in the Researcher persona journal.

---
*PR created automatically by Jules for task [7961952418459437431](https://jules.google.com/task/7961952418459437431) started by @szubster*