### PR TITLE
chore(qa): Reject Gen 3 Safari Zone state parser for ADR 028 violation

### DIFF
--- a/.foundry/journals/qa/3001888926164711260.md
+++ b/.foundry/journals/qa/3001888926164711260.md
@@ -1,0 +1,17 @@
+# QA Session: 3001888926164711260
+
+## Rejection Reason
+The implementation task (`task-340-341-gen3-safari-zone-state-impl`) was rejected during verification.
+The coder successfully implemented the logic for extracting Gen 3 PC Box data, however, they violated the strict architecture check (ADR 028) regarding the use of inline magic numbers.
+
+Specifically, in `src/engine/saveParser/parsers/gen3.ts`, inside the `parseGen3PCBuffer` function, the following inline magic numbers were used to process the PC Box sections:
+* `5` and `13` for the section IDs (`for (let sectionId = 5; sectionId <= 13; sectionId++)`)
+* `2000` and `3968` for the section sizes (`const bytesToCopy = sectionId === 13 ? 2000 : 3968;`)
+
+These should all be extracted into module-level constants.
+
+## Action Taken
+1. Updated `task-340-341-gen3-safari-zone-state-impl.md` to `status: FAILED` with a `rejection_reason` and incremented `rejection_count`. Unchecked its Acceptance Criteria.
+2. Updated `task-340-342-gen3-safari-zone-state-qa.md` with a note explaining the rejection (leaving frontmatter untouched and Acceptance Criteria unchecked).
+3. Created this journal entry.
+4. Submitting an empty PR to transition the QA node and push the implementation task back into the orchestrator queue.

--- a/.foundry/tasks/task-340-341-gen3-safari-zone-state-impl.md
+++ b/.foundry/tasks/task-340-341-gen3-safari-zone-state-impl.md
@@ -2,7 +2,7 @@
 id: task-340-341-gen3-safari-zone-state-impl
 type: TASK
 title: Gen 3 Safari Zone State Parsing Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-25'
 updated_at: '2026-08-09'
@@ -15,8 +15,8 @@ tags:
   - safari-zone
   - gen3
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Magic numbers (5, 13, 2000, 3968) were used in parseGen3PCBuffer in src/engine/saveParser/parsers/gen3.ts, violating the strict architecture check. All memory offsets, lengths, bit locations, and shifts MUST be defined as reusable constants at the module level. Inline magic numbers are strictly forbidden (per ADR 028).'
 notes: ''
 ---
 
@@ -36,9 +36,9 @@ Implement parsing logic to extract Pokédex and PC Box state from Gen 3 save fil
 - **Corrupted Saves**: You MUST catch `RangeError` from out-of-bounds `DataView` reads and throw a new error with the exact message: "The save file is corrupted or incomplete."
 
 ## Acceptance Criteria
-- [x] Implement Pokédex data extraction.
-- [x] Implement PC Box data extraction.
-- [x] Implement Safari Zone missing encounters calculation.
-- [x] All memory offsets are defined as module-level constants.
-- [x] Relative offsets are used with resolved section offsets.
-- [x] RangeError is caught and re-thrown with the correct message.
+- [ ] Implement Pokédex data extraction.
+- [ ] Implement PC Box data extraction.
+- [ ] Implement Safari Zone missing encounters calculation.
+- [ ] All memory offsets are defined as module-level constants.
+- [ ] Relative offsets are used with resolved section offsets.
+- [ ] RangeError is caught and re-thrown with the correct message.

--- a/.foundry/tasks/task-340-342-gen3-safari-zone-state-qa.md
+++ b/.foundry/tasks/task-340-342-gen3-safari-zone-state-qa.md
@@ -39,3 +39,6 @@ Verify the Safari Zone state extraction logic for Gen 3 save files, ensuring com
 - [ ] PC Box data extraction logic is verified.
 - [ ] Encounter calculation is verified.
 - [ ] Architectural directives (constants, relative offsets, RangeError handling) are explicitly verified in the implementation.
+
+### Rejection Note
+**Rejection Reason:** Implementation task rejected due to strict architecture check violation. Magic numbers (`5`, `13`, `2000`, `3968`) were found in `parseGen3PCBuffer` within `src/engine/saveParser/parsers/gen3.ts` when processing PC Box sections. All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level (per ADR 028).


### PR DESCRIPTION
### Rejection of Implementation Task

This empty PR (with state changes) transitions the QA task and formally rejects the target implementation task (`task-340-341-gen3-safari-zone-state-impl`) for violating ADR 028 regarding magic numbers. 

**Root Cause:** The `parseGen3PCBuffer` function utilized inline magic numbers (`5`, `13`, `2000`, `3968`) for PC Box section IDs and size counts instead of module-level constants.

**Actions:**
- `task-340-341-gen3-safari-zone-state-impl.md`: State reverted to `FAILED` with incremented `rejection_count`, explicit `rejection_reason`, and unchecked acceptance criteria.
- `task-340-342-gen3-safari-zone-state-qa.md`: Left as `ACTIVE` but appended the rejection reasoning for context.
- `.foundry/journals/qa/3001888926164711260.md`: Journal entry created outlining the specific magic number failure.

---
*PR created automatically by Jules for task [3001888926164711260](https://jules.google.com/task/3001888926164711260) started by @szubster*