### PR TITLE
Research: Gen 3 Trainer Card Contest Master Rank Offsets

### DIFF
--- a/.foundry/docs/knowledge_base/gen3_contest_museum_offsets.md
+++ b/.foundry/docs/knowledge_base/gen3_contest_museum_offsets.md
@@ -1,0 +1,51 @@
+# Gen 3 Contest Museum Paintings and Trainer Card Offsets
+
+## Overview
+In Generation 3 (Ruby, Sapphire, Emerald), one of the requirements to upgrade the Trainer Card (earning a star) is related to Pokémon Contests. Specifically, the player must win the Master Rank in all 5 contest categories (Cool, Beauty, Cute, Smart, Tough) with a high enough score to have a painting of their Pokémon displayed in the Lilycove Museum.
+
+## Memory Implementation
+The game **does not** scan the player's party or PC boxes for Contest Master ribbons to determine this requirement. Instead, it relies on an array of `ContestWinner` structures stored in `SaveBlock1`.
+
+### The `contestWinners` Array
+- **Location:** `SaveBlock1`
+- **Offset (Emerald):** `0x2e90`
+- **Total Elements (`NUM_CONTEST_WINNERS`):** `13`
+- **Structure Size:** `32` bytes (`0x20`)
+
+The first 8 elements are used for the Contest Hall paintings (which there are only 6 of, plus 2 unused slots). The final 5 elements are strictly for the Lilycove Museum paintings.
+
+### `MUSEUM_CONTEST_WINNERS_START`
+The Lilycove Museum paintings start at index 8 of the `contestWinners` array.
+The constants used in `pokeemerald` are:
+- `CONTEST_WINNER_MUSEUM_COOL`: `9`
+- `CONTEST_WINNER_MUSEUM_BEAUTY`: `10`
+- `CONTEST_WINNER_MUSEUM_CUTE`: `11`
+- `CONTEST_WINNER_MUSEUM_SMART`: `12`
+- `CONTEST_WINNER_MUSEUM_TOUGH`: `13`
+
+The start index is defined as `MUSEUM_CONTEST_WINNERS_START = (CONTEST_WINNER_MUSEUM_COOL - 1) = 8`.
+
+### `ContestWinner` Struct Definition
+Each struct is 32 bytes (`0x20`):
+
+| Offset | Type | Name | Description |
+|---|---|---|---|
+| `0x00` | `u32` | `personality` | The Personality Value (PV) of the winning Pokémon. |
+| `0x04` | `u32` | `trainerId` | The Original Trainer (OT) ID. |
+| `0x08` | `u16` | `species` | The internal species ID of the Pokémon. |
+| `0x0A` | `u8` | `contestCategory` | The contest category ID. |
+| `0x0B` | `u8[11]` | `monName` | The Pokémon's nickname (10 chars + terminator). |
+| `0x16` | `u8[8]` | `trainerName` | The OT's name (7 chars + terminator). |
+| `0x1E` | `u8` | `contestRank` | The rank of the contest. |
+| `0x1F` | `u8` | `padding` | Structural padding. |
+
+### Trainer Card Verification Logic
+To verify if the player has all 5 museum paintings for the Trainer Card star, the game executes `CountPlayerMuseumPaintings()`. This function loops 5 times starting from index 8 (`MUSEUM_CONTEST_WINNERS_START`).
+
+For each index, it checks if the `species` field (at offset `0x08` within the struct) is non-zero. If the `species` field is greater than `0`, the painting exists.
+
+To parse this from the save file:
+1. Locate `SaveBlock1` and navigate to the `contestWinners` array at `0x2e90` (for Emerald).
+2. Start iterating from index `8` up to index `12` (inclusive).
+3. The byte offset for the `species` field of the first museum painting is `0x2e90 + (8 * 32) + 8 = 0x2f98`.
+4. If all 5 `species` fields (at `0x2f98`, `0x2fb8`, `0x2fd8`, `0x2ff8`, `0x3018`) are non-zero, the player has satisfied the Contest Master Rank criteria for the Trainer Card star.

--- a/.foundry/journals/researcher/9486604902122696726.md
+++ b/.foundry/journals/researcher/9486604902122696726.md
@@ -1,0 +1,17 @@
+# Research Journal - Gen 3 Trainer Card Contest Star
+
+**Session ID:** 9486604902122696726
+
+## Findings
+I investigated how the "Contest Master Rank" star is awarded on the Gen 3 Trainer Card. The initial assumption might be to scan PC boxes or the party for Pokémon with the Contest Master ribbon.
+
+However, `pokeemerald`'s source code (`src/trainer_card.c`) reveals that this requirement is satisfied by the function `CountPlayerMuseumPaintings() >= CONTEST_CATEGORIES_COUNT`.
+
+The function `CountPlayerMuseumPaintings` checks the `contestWinners` array located in `SaveBlock1` (offset `0x2e90` in Emerald). Specifically, it checks the last 5 elements of this 13-element array, starting at index 8 (`MUSEUM_CONTEST_WINNERS_START`).
+
+For each of these 5 slots, if the `species` field (a `u16` at offset `0x08` within the 32-byte `ContestWinner` struct) is non-zero, it means a painting for that category (Cool, Beauty, Cute, Smart, Tough) is on display in the Lilycove Museum.
+
+## Architectural Constraints / Guidelines
+- When implementing Trainer Card validation for the Contest Star, **do not** scan PC boxes for ribbons.
+- You must parse the `contestWinners` array at the end of `SaveBlock1` (Emerald offset `0x2e90`), specifically checking the `species` ID of indices 8 through 12.
+- A new ADR/KB document `.foundry/docs/knowledge_base/gen3_contest_museum_offsets.md` was created to document the exact byte offsets.

--- a/.foundry/research/research-358-406-gen3-trainer-card-offsets.md
+++ b/.foundry/research/research-358-406-gen3-trainer-card-offsets.md
@@ -26,5 +26,5 @@ notes: ''
 Investigate the specific memory offsets and logic required to parse the "Contest Master Rank" requirement for the Gen 3 Trainer Card upgrade. The documentation currently details how individual Pokemon ribbons are stored (`gen3_pokemon_data_structure.md`), but it is unclear if the Trainer Card star is awarded via a global flag (such as the Lilycove Museum painting flags) or if it requires scanning PC boxes for specific ribbons.
 
 ## Acceptance Criteria
-- [ ] Document the memory offsets and bitwise flags representing the Contest Master Rank criteria for the Gen 3 Trainer Card.
-- [ ] Create an ADR or update the Knowledge Base (`.foundry/docs/knowledge_base/`) with the findings.
+- [x] Document the memory offsets and bitwise flags representing the Contest Master Rank criteria for the Gen 3 Trainer Card.
+- [x] Create an ADR or update the Knowledge Base (`.foundry/docs/knowledge_base/`) with the findings.


### PR DESCRIPTION
Research on the Trainer Card Contest Star implementation for Generation 3.

- Investigated `pokeemerald` to determine how the game validates if a player has achieved Master Rank in all 5 contests to award a star on the Trainer Card.
- Discovered it does not scan PC boxes for ribbons, but rather checks the `contestWinners` array in `SaveBlock1` (`CountPlayerMuseumPaintings()`).
- Documented the offsets, array indices, and struct definitions in `.foundry/docs/knowledge_base/gen3_contest_museum_offsets.md`.
- Updated the Researcher journal for session `9486604902122696726`.
- Checked off acceptance criteria in the task node.

---
*PR created automatically by Jules for task [9486604902122696726](https://jules.google.com/task/9486604902122696726) started by @szubster*