### PR TITLE
feat: Breakdown Gen 3 Move Tutor Epic into STORY nodes

### DIFF
--- a/.foundry/epics/epic-055-406-gen3-move-tutor-save-parsing.md
+++ b/.foundry/epics/epic-055-406-gen3-move-tutor-save-parsing.md
@@ -33,4 +33,6 @@ Implement save parsing logic to read specific event flags associated with one-ti
 
 ## Acceptance Criteria
 - [ ] Move Tutor flags are correctly parsed from Emerald and FireRed/LeafGreen save files using `DataView`.
-- [ ] A final STORY dedicated exclusively to Integration and E2E Verification is generated.
+- [x] A final STORY dedicated exclusively to Integration and E2E Verification is generated.
+- [ ] story-406-412-gen3-move-tutor-parsing-core
+- [ ] story-406-413-gen3-move-tutor-parsing-e2e

--- a/.foundry/stories/story-406-412-gen3-move-tutor-parsing-core.md
+++ b/.foundry/stories/story-406-412-gen3-move-tutor-parsing-core.md
@@ -1,0 +1,44 @@
+---
+id: story-406-412-gen3-move-tutor-parsing-core
+type: STORY
+title: Gen 3 Move Tutor Parsing Core
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-055-406-gen3-move-tutor-save-parsing
+tags:
+  - feature
+  - gen3
+  - save-parsing
+research_references:
+  - .foundry/docs/knowledge_base/gen3_move_tutor_offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Move Tutor Parsing Core
+
+## Objective
+Implement the core logic for extracting Gen 3 one-time Move Tutor event flags using `DataView`.
+
+## Context
+Based on `.foundry/docs/knowledge_base/gen3_move_tutor_offsets.md`, Move Tutor availability is determined by specific bit flags stored in the `SaveBlock1` event flags array.
+- In Emerald, the base offset for event flags is `0x1270`.
+- In FireRed/LeafGreen, the flags use different IDs and offsets.
+The parsing implementation must use `DataView` for all byte reading, as per ADR 010.
+
+## Implementation Details
+1. Define the specific bytes and bitmasks corresponding to each Move Tutor flag for both Emerald and FireRed/LeafGreen.
+2. Implement extraction functions taking a `DataView` of the event flags block and parsing out the status of each tutor.
+3. Incorporate `RangeError` handling for robust parsing of potentially malformed or smaller-than-expected save structures.
+
+## Acceptance Criteria
+- [ ] Move Tutor constants are correctly defined for Emerald and FireRed/LeafGreen.
+- [ ] The core extraction logic uses `DataView`.
+- [ ] Logic gracefully handles `RangeError` during out-of-bounds `DataView` access.
+- [ ] Unit tests cover parsing valid and malformed structures for both game versions.

--- a/.foundry/stories/story-406-413-gen3-move-tutor-parsing-e2e.md
+++ b/.foundry/stories/story-406-413-gen3-move-tutor-parsing-e2e.md
@@ -1,0 +1,41 @@
+---
+id: story-406-413-gen3-move-tutor-parsing-e2e
+type: STORY
+title: Gen 3 Move Tutor Parsing E2E Verification
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on:
+  - story-406-412-gen3-move-tutor-parsing-core
+jules_session_id: null
+pr_number: null
+parent: epic-055-406-gen3-move-tutor-save-parsing
+tags:
+  - feature
+  - gen3
+  - save-parsing
+  - e2e
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Gen 3 Move Tutor Parsing E2E Verification
+
+## Objective
+Implement End-to-End and Integration tests to ensure Gen 3 Move Tutor save parsing behaves as expected across different components and flows within the application.
+
+## Context
+As part of the Gen 3 Move Tutor Save Parsing Epic, we need to ensure that the parsing logic implemented in `story-406-412-gen3-move-tutor-parsing-core` integrates correctly into the broader system. This fulfills the Orchestrator E2E verification requirement for the Epic.
+
+## Implementation Details
+1. Create integration tests mocking Save Files and validating the end-to-end extraction pipeline.
+2. Ensure Playwright/Vitest configurations correctly run tests against both Emerald and FireRed/LeafGreen parsing flows.
+3. Validate that parsing failures/corrupted states reflect gracefully in simulated UI environments.
+
+## Acceptance Criteria
+- [ ] End-to-end integration tests are implemented for Move Tutor parsing.
+- [ ] Tests successfully pass against mocked or simulated Gen 3 save states.
+- [ ] UI gracefully handles extraction failures (e.g., malformed save file).


### PR DESCRIPTION
Generated downstream STORY nodes for the `epic-055-406-gen3-move-tutor-save-parsing` epic, adhering strictly to the late-binding generation rules.
- **Core Implementation Node:** Created `story-406-412-gen3-move-tutor-parsing-core`.
- **E2E/Integration Node:** Created `story-406-413-gen3-move-tutor-parsing-e2e` to fulfill orchestrator E2E mandates.
- **Parent State Integrity:** Appended both child nodes as unchecked task checkboxes inside the parent EPIC's body, and checked off the E2E milestone, leaving the frontmatter unmodified.

---
*PR created automatically by Jules for task [18138721058434539470](https://jules.google.com/task/18138721058434539470) started by @szubster*