### PR TITLE
chore: empty PR to demote parent epic while waiting for child node

### DIFF
--- a/.foundry/journals/story_owner/3965440180567252160.md
+++ b/.foundry/journals/story_owner/3965440180567252160.md
@@ -1,0 +1,3 @@
+# Session 3965440180567252160
+
+Submitted an empty PR for `epic-055-113-egg-move-pathfinding-engine` because its child task `story-113-348-egg-move-pathfinding-e2e` is technically COMPLETED but has not been archived yet by the TPM (still located in `.foundry/stories/`). According to the Late-Binding Orchestrator Demotion Compliance Rule, when assigned a READY parent node that already has pending/active child tasks drafted from a previous iteration, the agent must submit an empty PR *without* checking off its overarching acceptance criteria. This allows the orchestrator to correctly demote the parent to PENDING while it waits for its children.


### PR DESCRIPTION
Empty PR to allow the orchestrator to correctly demote the parent node `epic-055-113-egg-move-pathfinding-engine` back to `PENDING` while it waits for its pending child node `story-113-348-egg-move-pathfinding-e2e` (which is in `.foundry/stories/`, not `.foundry/archive/`) to be fully processed/archived by the TPM, in compliance with the Late-Binding Orchestrator Demotion Compliance Rule.

---
*PR created automatically by Jules for task [3965440180567252160](https://jules.google.com/task/3965440180567252160) started by @szubster*