### PR TITLE
feat(foundry): breakdown epic epic-339-406-gen3-bike-requirement-route-mapping into stories

### DIFF
--- a/.foundry/epics/epic-339-406-gen3-bike-requirement-route-mapping.md
+++ b/.foundry/epics/epic-339-406-gen3-bike-requirement-route-mapping.md
@@ -27,5 +27,9 @@ Introduce a "Bike Requirement Filter" to DexHelper's Smart Route Radar or intera
 Route Pre-computation: When a player views a route in DexHelper, clearly tag the route with badges like `[Requires Mach Bike]` or `[Requires Acro Bike]` if significant portions are gated behind those mechanics.
 
 ## Acceptance Criteria
-- [ ] story_owner: Break down this Epic into Stories.
-- [ ] story_owner: Ensure one final STORY dedicated exclusively to Integration and E2E Verification is generated.
+- [x] story_owner: Break down this Epic into Stories.
+- [x] story_owner: Ensure one final STORY dedicated exclusively to Integration and E2E Verification is generated.
+- [ ] story-406-412-gen3-bike-map-parsing
+- [ ] story-406-413-bike-requirement-heatmap
+- [ ] story-406-414-bike-requirement-ui-badges
+- [ ] story-406-415-bike-requirement-e2e

--- a/.foundry/stories/story-406-412-gen3-bike-map-parsing.md
+++ b/.foundry/stories/story-406-412-gen3-bike-map-parsing.md
@@ -1,0 +1,31 @@
+---
+id: story-406-412-gen3-bike-map-parsing
+type: STORY
+title: Core Map Data Parsing Logic for Bike Requirements
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-339-406-gen3-bike-requirement-route-mapping
+tags:
+  - gen3
+  - map
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Core Map Data Parsing Logic for Bike Requirements
+
+## Context
+As part of the Route Pre-computation & Mapping Epic, we need to extract and parse game map definitions to identify specific paths, items, or hidden areas on a route that require a specific bike (Mach Bike or Acro Bike) in Generation 3 games.
+
+## Proposal
+Implement parsing logic within the map data extraction engine that specifically looks for map layout attributes or objects that are gated by either Mach or Acro bike mechanics. This data should be structured in a way that downstream consumers (like the Route Radar controller) can utilize.
+
+## Acceptance Criteria
+- [ ] tech_lead: Break down this Story into Tasks.

--- a/.foundry/stories/story-406-413-bike-requirement-heatmap.md
+++ b/.foundry/stories/story-406-413-bike-requirement-heatmap.md
@@ -1,0 +1,31 @@
+---
+id: story-406-413-bike-requirement-heatmap
+type: STORY
+title: Expose Bike Requirements Through Heatmap Data Structure
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-339-406-gen3-bike-requirement-route-mapping
+tags:
+  - gen3
+  - map
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Expose Bike Requirements Through Heatmap Data Structure
+
+## Context
+As part of the Route Pre-computation & Mapping Epic, we need to expose the parsed bike requirements through the Route Radar heatmap data structure.
+
+## Proposal
+Update `RouteRadarController` or related mapping components to consume the newly parsed map data that indicates bike requirements, and structure it so that the frontend can easily read which areas (or significant portions) require which bikes.
+
+## Acceptance Criteria
+- [ ] tech_lead: Break down this Story into Tasks.

--- a/.foundry/stories/story-406-414-bike-requirement-ui-badges.md
+++ b/.foundry/stories/story-406-414-bike-requirement-ui-badges.md
@@ -1,0 +1,32 @@
+---
+id: story-406-414-bike-requirement-ui-badges
+type: STORY
+title: Implement UI Badges for Bike Requirements
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-339-406-gen3-bike-requirement-route-mapping
+tags:
+  - gen3
+  - map
+  - ui
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement UI Badges for Bike Requirements
+
+## Context
+As part of the Route Pre-computation & Mapping Epic, players should visually see which specific paths, items, or hidden areas on a route require a specific bike.
+
+## Proposal
+Implement UI badges (e.g., `[Requires Mach Bike]` or `[Requires Acro Bike]`) on the interactive map and Smart Route Radar. These badges should be displayed when a player views a route where significant portions are gated by these mechanics, utilizing the newly exposed heatmap data. Ensure adherence to the tactical hardware aesthetic guidelines.
+
+## Acceptance Criteria
+- [ ] tech_lead: Break down this Story into Tasks.

--- a/.foundry/stories/story-406-415-bike-requirement-e2e.md
+++ b/.foundry/stories/story-406-415-bike-requirement-e2e.md
@@ -1,0 +1,33 @@
+---
+id: story-406-415-bike-requirement-e2e
+type: STORY
+title: E2E Verification for Bike Requirement Route Mapping
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-339-406-gen3-bike-requirement-route-mapping
+tags:
+  - gen3
+  - map
+  - e2e
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# E2E Verification for Bike Requirement Route Mapping
+
+## Context
+As per Orchestrator Safeguard requirements, every EPIC must generate a final STORY dedicated exclusively to Integration and E2E Verification. This story fulfills that requirement for the "Route Pre-computation & Mapping" epic.
+
+## Proposal
+Implement end-to-end integration tests using Playwright to ensure that the bike requirement filtering on the Smart Route Radar and the UI badges on the interactive map are functioning correctly together. Mock data representing maps with Acro and Mach bike requirements should be used to verify visual badges and heatmap data integration.
+
+## Acceptance Criteria
+- [ ] tech_lead: Break down this Story into Tasks.


### PR DESCRIPTION
This PR breaks down the `epic-339-406-gen3-bike-requirement-route-mapping` EPIC into four granular STORY nodes to fulfill the Story Owner persona's role.

- `story-406-412-gen3-bike-map-parsing`: Handles core mapping logic.
- `story-406-413-bike-requirement-heatmap`: Maps the requirements to the heatmap structure.
- `story-406-414-bike-requirement-ui-badges`: Introduces the frontend tactical badges.
- `story-406-415-bike-requirement-e2e`: Provides the mandated final E2E verification story.

The Epic's markdown body has been appropriately updated with the unchecked tasks, and its Acceptance Criteria have been marked as complete in accordance with the node generation rules.

---
*PR created automatically by Jules for task [13517574185344680176](https://jules.google.com/task/13517574185344680176) started by @szubster*