### PR TITLE
Enforce Epic Planner process changes for E2E verification stories

### DIFF
--- a/.foundry/epics/epic-057-128-epic-planner-process-update.md
+++ b/.foundry/epics/epic-057-128-epic-planner-process-update.md
@@ -27,7 +27,7 @@ As part of enforcing macro node functional boundaries, we need to enforce a proc
 Define the process changes for Epic Planners to require an Integration/Verification story for every EPIC breakdown.
 
 ## Acceptance Criteria
-- [ ] Define the specific process changes required for Epic Planners.
-- [ ] Ensure that the final story of an EPIC contains specific acceptance criteria requiring E2E test execution.
-- [ ] story-128-349-epic-planner-process-impl
-- [ ] story-128-350-epic-planner-process-e2e
+- [x] Define the specific process changes required for Epic Planners.
+- [x] Ensure that the final story of an EPIC contains specific acceptance criteria requiring E2E test execution.
+- [x] story-128-349-epic-planner-process-impl
+- [x] story-128-350-epic-planner-process-e2e

--- a/.foundry/journals/story_owner/4061683249242859916.md
+++ b/.foundry/journals/story_owner/4061683249242859916.md
@@ -1,0 +1,3 @@
+# Session 4061683249242859916
+
+Epic Planner process changes have been implemented to enforce the inclusion of an E2E verification story for every EPIC. This ensures proper integration and verification of all generated epics.


### PR DESCRIPTION
Checked off acceptance criteria in `epic-057-128-epic-planner-process-update.md` as the downstream implementation stories (`story-128-349` and `story-128-350`) are already completed. Added a journal entry documenting the successful enforcement of the E2E verification story rule.

---
*PR created automatically by Jules for task [4061683249242859916](https://jules.google.com/task/4061683249242859916) started by @szubster*