### PR TITLE
feat: breakdown librarian schema updates epic

### DIFF
--- a/.foundry/epics/epic-339-409-librarian-schema-updates.md
+++ b/.foundry/epics/epic-339-409-librarian-schema-updates.md
@@ -28,5 +28,7 @@ This epic covers updating `.foundry/docs/schema.md` to formally define the `libr
 - None
 
 ## Acceptance Criteria
-- [ ] Generate stories for updating the schema documentation.
-- [ ] Generate a final STORY dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`).
+- [x] Generate stories for updating the schema documentation.
+- [x] Generate a final STORY dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`).
+- [ ] story-409-412-add-librarian-persona-schema
+- [ ] story-409-413-librarian-schema-e2e

--- a/.foundry/stories/story-409-412-add-librarian-persona-schema.md
+++ b/.foundry/stories/story-409-412-add-librarian-persona-schema.md
@@ -1,0 +1,30 @@
+---
+id: story-409-412-add-librarian-persona-schema
+type: STORY
+title: Add Librarian Persona to Schema
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-339-409-librarian-schema-updates
+tags:
+  - foundry
+  - schema
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Add Librarian Persona to Schema
+
+## Description
+This story covers updating `.foundry/docs/schema.md` to formally define the `librarian` persona in Section 5 (Owner Persona Enum). The new schema entry will define `librarian` as "Mapped to Snorlax (#143). Responsible for context token optimization by digesting historical data and pruning stale entries."
+
+## Acceptance Criteria
+- [ ] Update `schema.md` to define the `librarian` persona in Section 5.
+- [ ] Create TASKS to implement the updates and QA verify.

--- a/.foundry/stories/story-409-413-librarian-schema-e2e.md
+++ b/.foundry/stories/story-409-413-librarian-schema-e2e.md
@@ -1,0 +1,33 @@
+---
+id: story-409-413-librarian-schema-e2e
+type: STORY
+title: Librarian Schema Updates E2E Verification
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on:
+  - story-409-412-add-librarian-persona-schema
+jules_session_id: null
+pr_number: null
+parent: epic-339-409-librarian-schema-updates
+tags:
+  - foundry
+  - schema
+  - documentation
+  - e2e
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Librarian Schema Updates E2E Verification
+
+## Description
+This story is dedicated exclusively to Integration and E2E Verification for the schema updates defining the `librarian` persona, satisfying the orchestrator safeguard.
+
+## Acceptance Criteria
+- [ ] Verify the `librarian` persona is properly integrated in the schema documentation.
+- [ ] Create QA/integration testing TASKS to verify the changes.


### PR DESCRIPTION
As the Story Owner, I have successfully decomposed the `epic-339-409-librarian-schema-updates` EPIC by defining tasks downstream.

The following STORY nodes have been created:
- `story-409-412-add-librarian-persona-schema`: For modifying `schema.md` with the new persona rules.
- `story-409-413-librarian-schema-e2e`: For fulfilling the orchestrator requirement of an explicit E2E evaluation.

These have been properly appended and checked to satisfy the pipeline progression constraints.

---
*PR created automatically by Jules for task [10276800548726137575](https://jules.google.com/task/10276800548726137575) started by @szubster*