### PR TITLE
chore(dag): resolve Pokerus Tracker impossible loop and generate retry nodes

### DIFF
--- a/.foundry/epics/epic-038-411-pokerus-state-exfiltration-retry.md
+++ b/.foundry/epics/epic-038-411-pokerus-state-exfiltration-retry.md
@@ -1,0 +1,31 @@
+---
+id: epic-038-411-pokerus-state-exfiltration-retry
+type: EPIC
+title: Pokerus State Exfiltration Epic (Retry)
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on:
+  - research-038-407-investigate-pokerus-state-exfiltration-failure
+jules_session_id: null
+pr_number: null
+parent: prd-069-038-pokerus-tracker
+tags:
+  - gen2
+  - save-engine
+  - pokerus
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: 'Retry of the cancelled epic-038-061-pokerus-state-exfiltration'
+---
+
+# Pokerus State Exfiltration Epic (Retry)
+
+## Description
+Read the specific byte flags for Pokerus for every Pokemon in the party and PC from the Gen 2 sav files. This retry depends on the successful investigation of the previous implementation failure.
+
+## Acceptance Criteria
+- [ ] Extract pokerus data
+- [ ] Story Owner: Generate a final STORY node dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-038-412-pokerus-visual-tracker-retry.md
+++ b/.foundry/epics/epic-038-412-pokerus-visual-tracker-retry.md
@@ -1,0 +1,30 @@
+---
+id: epic-038-412-pokerus-visual-tracker-retry
+type: EPIC
+title: Pokerus Visual Tracker Epic (Retry)
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on:
+  - epic-038-411-pokerus-state-exfiltration-retry
+jules_session_id: null
+pr_number: null
+parent: prd-069-038-pokerus-tracker
+tags:
+  - ui
+  - pokerus
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: 'Retry of the cancelled epic-038-062-pokerus-visual-tracker'
+---
+
+# Pokerus Visual Tracker Epic (Retry)
+
+## Description
+Add UI badges indicating Pokerus status (Uninfected, Infected/Contagious, Cured/Immune) and explicitly calculate and display remaining days for contagious Pokemon using RTC.
+
+## Acceptance Criteria
+- [ ] Add UI badges for pokerus status
+- [ ] Story Owner: Generate a final STORY node dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-038-413-pokerus-spread-planner-retry.md
+++ b/.foundry/epics/epic-038-413-pokerus-spread-planner-retry.md
@@ -1,0 +1,31 @@
+---
+id: epic-038-413-pokerus-spread-planner-retry
+type: EPIC
+title: Pokerus Spread Planner Epic (Retry)
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on:
+  - epic-038-411-pokerus-state-exfiltration-retry
+jules_session_id: null
+pr_number: null
+parent: prd-069-038-pokerus-tracker
+tags:
+  - ui
+  - pokerus
+  - planner
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: 'Retry of the cancelled epic-038-063-pokerus-spread-planner'
+---
+
+# Pokerus Spread Planner Epic (Retry)
+
+## Description
+Create a dedicated tool to strategically plan Pokerus spread, suggesting party configurations and warning before a cure.
+
+## Acceptance Criteria
+- [ ] Create spread planner tool
+- [ ] Story Owner: Generate a final STORY node dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/journals/epic_planner/7913571649282040390.md
+++ b/.foundry/journals/epic_planner/7913571649282040390.md
@@ -1,0 +1,11 @@
+# Epic Planner Session 7913571649282040390
+
+Investigated the permanent failure of `epic-038-061-pokerus-state-exfiltration`, which had caused its dependent downstream Epics to be cancelled (The Impossible Loop).
+
+To resolve this and resurrect the feature, I:
+1. Created a new RESEARCH node (`research-038-407-investigate-pokerus-state-exfiltration-failure`) to investigate the root cause of the previous failure.
+2. Created a new set of retry Epics (`epic-038-411-pokerus-state-exfiltration-retry`, `epic-038-412-pokerus-visual-tracker-retry`, `epic-038-413-pokerus-spread-planner-retry`).
+3. Explicitly wired the first retry Epic to depend on the RESEARCH node's completion, enabling the "late-binding" resolution pattern for failure recovery.
+4. Checked off the cancelled child Epics in the parent `prd-069-038-pokerus-tracker` body to allow proper DAG progress.
+
+All new Epics strictly enforce the Orchestrator safeguard requirement to generate an E2E STORY for verification.

--- a/.foundry/prds/prd-069-038-pokerus-tracker.md
+++ b/.foundry/prds/prd-069-038-pokerus-tracker.md
@@ -25,6 +25,10 @@ Add UI badges indicating Pokerus status (Uninfected, Infected/Contagious, Cured/
 Create a dedicated tool to strategically plan Pokerus spread, suggesting party configurations and warning before a cure.
 
 ## Generated Epics
-- [ ] epic-038-061-pokerus-state-exfiltration
-- [ ] epic-038-062-pokerus-visual-tracker
-- [ ] epic-038-063-pokerus-spread-planner
+- [x] epic-038-061-pokerus-state-exfiltration
+- [x] epic-038-062-pokerus-visual-tracker
+- [x] epic-038-063-pokerus-spread-planner
+- [ ] research-038-407-investigate-pokerus-state-exfiltration-failure
+- [ ] epic-038-411-pokerus-state-exfiltration-retry
+- [ ] epic-038-412-pokerus-visual-tracker-retry
+- [ ] epic-038-413-pokerus-spread-planner-retry

--- a/.foundry/research/research-038-407-investigate-pokerus-state-exfiltration-failure.md
+++ b/.foundry/research/research-038-407-investigate-pokerus-state-exfiltration-failure.md
@@ -1,0 +1,30 @@
+---
+id: research-038-407-investigate-pokerus-state-exfiltration-failure
+type: RESEARCH
+title: Investigate Pokerus State Exfiltration Failure
+status: PENDING
+owner_persona: researcher
+created_at: "2026-08-10"
+updated_at: "2026-08-10"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-069-038-pokerus-tracker
+tags:
+  - pokerus
+  - failure-investigation
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Investigate Pokerus State Exfiltration Failure
+
+## Description
+The `epic-038-061-pokerus-state-exfiltration` implementation failed permanently with a maximum rejection count. This research node is tasked with investigating the root cause of this failure to unblock the pokerus tracker feature.
+
+## Acceptance Criteria
+- [ ] Read the failure logs and related node journals to determine the root cause of the failure.
+- [ ] Document the findings and propose a technical solution or workaround.
+- [ ] Create subsequent implementation nodes (e.g. ADR or TASKS) required to correctly exfiltrate Pokerus state based on the research.


### PR DESCRIPTION
This PR resolves the Impossible Loop encountered in the Pokerus Tracker PRD (`prd-069-038-pokerus-tracker`) caused by the permanent failure of the initial state exfiltration epic (`epic-038-061`). 

It follows the Late-Binding for Missing Context and Handling Permanent Child Failures rules by:
1. Spawning a `RESEARCH` node to investigate the root cause.
2. Generating a new set of replacement `EPIC` nodes that depend on the research.
3. Updating the parent PRD to check off the failed children and append the new nodes.
4. Enforcing the Orchestrator E2E safeguard in the new Epics.

---
*PR created automatically by Jules for task [7913571649282040390](https://jules.google.com/task/7913571649282040390) started by @szubster*