### PR TITLE
🗿 Sculptor: Extract item/move magic numbers to constants in player tools

### DIFF
--- a/.jules/sculptor/2026-08-11-01-28-17.md
+++ b/.jules/sculptor/2026-08-11-01-28-17.md
@@ -1,0 +1,13 @@
+# Sculptor Session
+
+## Refactoring Goal
+Improve AI readability by refactoring `extractPlayerTools` to use clear item/move constants rather than magic numbers.
+
+## Actions Taken
+- Extracted constants for headbutt, rock smash, surf, and different fishing rods.
+- Updated `src/engine/assistant/utils/encounterTools.ts` to use these constants.
+- Updated `src/engine/assistant/strategies/gen2Strategy.ts` to use these constants.
+
+## Critical Learnings
+- Magic numbers like `192` (Headbutt TM), `198` (Rock Smash TM), and `399` (Surf HM) scattered throughout item verification logic confuse AI interpretation. Extracting them into clearly named constants (e.g., `ITEM_HEADBUTT_GEN2`) significantly improves semantic readability.
+- When replacing magic numbers, ensure to look at related strategies (like `gen2Strategy.ts`) which might have also duplicated these integer literals.

--- a/src/engine/assistant/strategies/gen2Strategy.ts
+++ b/src/engine/assistant/strategies/gen2Strategy.ts
@@ -3,6 +3,7 @@ import { getGenerationConfig } from '../../../utils/generationConfig';
 import { getGen2UnobtainableReason } from '../../exclusives/gen2Exclusives';
 import { getDistanceToMap, resolveOutdoorMapId } from '../../mapGraph/gen2Graph';
 import type { SaveData } from '../../saveParser/index';
+import { ITEM_HEADBUTT_GEN2, ITEM_ROCK_SMASH_GEN2, MOVE_HEADBUTT, MOVE_ROCK_SMASH } from '../utils/encounterTools';
 import type { AssistantStrategy, Suggestion } from './types';
 import { getRoamerSuggestions } from './utils/roamer';
 
@@ -48,17 +49,16 @@ export const gen2Strategy: AssistantStrategy = {
     // 2. Headbutt / Rock Smash
     // TM08 (Rock Smash) is Item ID 198 (0xC6), TM02 (Headbutt) is Item ID 192 (0xC0)
     // Actually, TMs are stored in TM pocket directly in Gen 2 parsed inventory as item IDs
-    // Headbutt = TM02 = Item ID 192, Rock Smash = TM08 = Item ID 198
     // In Gen 2, these are single-use and do not require badges to use in the field.
     const allInstances = [...(saveData.partyDetails || []), ...(saveData.pcDetails || [])];
     const hasHeadbutt =
-      saveData.inventory.some((i) => i.id === 192 && i.quantity > 0) ||
-      (saveData.pcItems?.some((i) => i.id === 192 && i.quantity > 0) ?? false) ||
-      allInstances.some((p) => p.moves?.includes(29));
+      saveData.inventory.some((i) => i.id === ITEM_HEADBUTT_GEN2 && i.quantity > 0) ||
+      (saveData.pcItems?.some((i) => i.id === ITEM_HEADBUTT_GEN2 && i.quantity > 0) ?? false) ||
+      allInstances.some((p) => p.moves?.includes(MOVE_HEADBUTT));
     const hasRockSmash =
-      saveData.inventory.some((i) => i.id === 198 && i.quantity > 0) ||
-      (saveData.pcItems?.some((i) => i.id === 198 && i.quantity > 0) ?? false) ||
-      allInstances.some((p) => p.moves?.includes(249));
+      saveData.inventory.some((i) => i.id === ITEM_ROCK_SMASH_GEN2 && i.quantity > 0) ||
+      (saveData.pcItems?.some((i) => i.id === ITEM_ROCK_SMASH_GEN2 && i.quantity > 0) ?? false) ||
+      allInstances.some((p) => p.moves?.includes(MOVE_ROCK_SMASH));
 
     if (hasHeadbutt) {
       suggestions.push({

--- a/src/engine/assistant/utils/encounterTools.ts
+++ b/src/engine/assistant/utils/encounterTools.ts
@@ -1,6 +1,23 @@
 import type { PokemonInstance, SaveData } from '../../saveParser/index';
 import type { Suggestion } from '../strategies/types';
 
+export const ITEM_HEADBUTT_GEN2 = 192;
+export const ITEM_ROCK_SMASH_GEN2 = 198;
+export const ITEM_SURF_GEN3 = 399;
+export const ITEM_OLD_ROD_GEN1 = 52;
+export const ITEM_OLD_ROD_GEN2 = 69;
+export const ITEM_OLD_ROD_GEN3 = 260;
+export const ITEM_GOOD_ROD_GEN1 = 53;
+export const ITEM_GOOD_ROD_GEN2 = 70;
+export const ITEM_GOOD_ROD_GEN3 = 261;
+export const ITEM_SUPER_ROD_GEN1 = 54;
+export const ITEM_SUPER_ROD_GEN2 = 71;
+export const ITEM_SUPER_ROD_GEN3 = 262;
+
+export const MOVE_HEADBUTT = 29;
+export const MOVE_ROCK_SMASH = 249;
+export const MOVE_SURF = 57;
+
 /**
  * Represents the set of exploration tools and Hidden Machines (HMs) currently
  * available to the player.
@@ -53,13 +70,14 @@ export function extractPlayerTools(saveData: SaveData, allInstances: PokemonInst
     const item = inventory[i];
     if (item && item.quantity > 0) {
       const id = item.id;
-      if (id === 192) hasHeadbutt = true;
-      else if (id === 198) {
+      if (id === ITEM_HEADBUTT_GEN2) hasHeadbutt = true;
+      else if (id === ITEM_ROCK_SMASH_GEN2) {
         hasRockSmash = true;
-      } else if (id === 399) hasSurf = true;
-      else if (id === 52 || id === 69 || id === 260) hasOldRod = true;
-      else if (id === 53 || id === 70 || id === 261) hasGoodRod = true;
-      else if (id === 54 || id === 71 || id === 262) hasSuperRod = true;
+      } else if (id === ITEM_SURF_GEN3) hasSurf = true;
+      else if (id === ITEM_OLD_ROD_GEN1 || id === ITEM_OLD_ROD_GEN2 || id === ITEM_OLD_ROD_GEN3) hasOldRod = true;
+      else if (id === ITEM_GOOD_ROD_GEN1 || id === ITEM_GOOD_ROD_GEN2 || id === ITEM_GOOD_ROD_GEN3) hasGoodRod = true;
+      else if (id === ITEM_SUPER_ROD_GEN1 || id === ITEM_SUPER_ROD_GEN2 || id === ITEM_SUPER_ROD_GEN3)
+        hasSuperRod = true;
     }
   }
 
@@ -68,13 +86,14 @@ export function extractPlayerTools(saveData: SaveData, allInstances: PokemonInst
     const item = pcItems[i];
     if (item && item.quantity > 0) {
       const id = item.id;
-      if (id === 192) hasHeadbutt = true;
-      else if (id === 198) {
+      if (id === ITEM_HEADBUTT_GEN2) hasHeadbutt = true;
+      else if (id === ITEM_ROCK_SMASH_GEN2) {
         hasRockSmash = true;
-      } else if (id === 399) hasSurf = true;
-      else if (id === 52 || id === 69 || id === 260) hasOldRod = true;
-      else if (id === 53 || id === 70 || id === 261) hasGoodRod = true;
-      else if (id === 54 || id === 71 || id === 262) hasSuperRod = true;
+      } else if (id === ITEM_SURF_GEN3) hasSurf = true;
+      else if (id === ITEM_OLD_ROD_GEN1 || id === ITEM_OLD_ROD_GEN2 || id === ITEM_OLD_ROD_GEN3) hasOldRod = true;
+      else if (id === ITEM_GOOD_ROD_GEN1 || id === ITEM_GOOD_ROD_GEN2 || id === ITEM_GOOD_ROD_GEN3) hasGoodRod = true;
+      else if (id === ITEM_SUPER_ROD_GEN1 || id === ITEM_SUPER_ROD_GEN2 || id === ITEM_SUPER_ROD_GEN3)
+        hasSuperRod = true;
     }
   }
 
@@ -84,9 +103,9 @@ export function extractPlayerTools(saveData: SaveData, allInstances: PokemonInst
       const moves = p.moves || [];
       for (let j = 0; j < moves.length; j++) {
         const m = moves[j];
-        if (m === 29) hasHeadbutt = true;
-        else if (m === 249) hasRockSmash = true;
-        else if (m === 57) hasSurf = true;
+        if (m === MOVE_HEADBUTT) hasHeadbutt = true;
+        else if (m === MOVE_ROCK_SMASH) hasRockSmash = true;
+        else if (m === MOVE_SURF) hasSurf = true;
       }
     }
   }


### PR DESCRIPTION
🎯 What
Extracted magic numbers for item IDs (e.g., Headbutt, Rock Smash, Surf, Rods) and move IDs into clearly named constants in `src/engine/assistant/utils/encounterTools.ts`. Updated `src/engine/assistant/strategies/gen2Strategy.ts` to use these constants.

💡 Why (AI Readability Impact)
Integer literals like `192`, `198`, or `399` lack semantic context and force AI agents (and human developers) to guess their meaning or cross-reference external documentation. Using constants like `ITEM_HEADBUTT_GEN2` makes the conditional logic for checking exploration tools instantly comprehensible.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `xvfb-run -a pnpm test:e2e tests/e2e/home.spec.ts tests/e2e/pokemon-details.spec.ts` successfully, verifying no business logic was changed.

✨ Result
Cleaner, self-documenting conditionals for evaluating player tools, reducing the cognitive load for both human maintainers and AI agents.

---
*PR created automatically by Jules for task [6050854504573820394](https://jules.google.com/task/6050854504573820394) started by @szubster*