### PR TITLE
🧹 Clean up unused gen3 parser exports and engine index file

### DIFF
--- a/.jules/sweeper/31252700756.md
+++ b/.jules/sweeper/31252700756.md
@@ -1,0 +1,6 @@
+# Sweeper Journal — 31252700756
+
+## Lesson: Unused Variable Discovery & Removal
+Using tools like `pnpm knip --include duplicates,enumMembers,namespaceMembers,nsExports,nsTypes` and `pnpm knip --include exports,types,files` can reveal unused exports, which might also turn out to be completely unreferenced variables internally within the module. Removing the `export` keyword can highlight this if the variable is unused, enabling full dead-code removal.
+
+Ensure to fully check and verify using standard `lint` and `test` suites locally to detect if removing those exports/variables accidentally broke downstream types or runtime execution. When completely removed, use `check:biome --write` or the equivalent formatter in your stack to fix whitespace/formatting artifacts left behind from `sed` deletion tools.

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,1 +1,0 @@
-export * from './gen3/roamer/parser';

--- a/src/engine/saveParser/gen3/trainerFlags/parser.ts
+++ b/src/engine/saveParser/gen3/trainerFlags/parser.ts
@@ -10,7 +10,6 @@ export const RSE_FLAGS_OFFSET_RS = 0x1220;
 export const FRLG_FLAGS_OFFSET = 0x0ee0;
 
 // Logical ID start inside flags array
-export const TRAINER_FLAGS_START = 0x500;
 // Since flags start at 0x500 and 1 flag = 1 bit (8 per byte):
 export const TRAINER_FLAGS_BYTE_OFFSET = 0xa0; // (160)
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -212,7 +212,6 @@ export const FLAG_GOT_TM03_FROM_MISTY = 0x297;
 export const FLAG_GOT_TM26_FROM_GIOVANNI = 0x298;
 export const FLAG_GOT_TM04_FROM_SABRINA = 0x29a;
 
-export const GEN3_POKEMON_STRUCT_SIZE = 100;
 export const GEN3_POKEMON_PV_OFFSET = 0;
 export const GEN3_POKEMON_OT_ID_OFFSET = 4;
 export const GEN3_POKEMON_DATA_OFFSET = 32;
@@ -221,8 +220,6 @@ export const SUBSTRUCTURE_SIZE = 12;
 export const PC_BOX_BUFFER_SIZE = 33744;
 export const PC_BOX_CURRENT_BOX_OFFSET = 0x0000;
 export const PC_BOX_POKEMON_LIST_OFFSET = 0x0004;
-export const PC_BOX_NAMES_OFFSET = 0x8344;
-export const PC_BOX_WALLPAPERS_OFFSET = 0x83c2;
 export const PC_BOX_COUNT = 14;
 export const PC_BOX_CAPACITY = 30;
 export const GEN3_PC_POKEMON_STRUCT_SIZE = 80;
@@ -1629,7 +1626,6 @@ export function parseGen3EmeraldMoveTutors(view: DataView, saveBlock1Offset: num
  * @returns An object containing boolean statuses for each RSE NPC trade.
  * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
  */
-export { parseGen3LotteryNumber } from '../gen3/lottery/parser';
 
 export const GEN3_TM_HM_MOVE_MAP: Record<number, number> = {
   289: 264,


### PR DESCRIPTION
🎯 What
Removed unused exports and dead code in `src/engine/saveParser`. Specifically:
- Deleted unused constants `TRAINER_FLAGS_START`, `GEN3_POKEMON_STRUCT_SIZE`, `PC_BOX_NAMES_OFFSET`, and `PC_BOX_WALLPAPERS_OFFSET`.
- Removed an unused re-export of `parseGen3LotteryNumber`.
- Deleted the entirely unused file `src/engine/index.ts`.

💡 Why
To improve codebase health and reduce technical debt by removing code that is never referenced or used anywhere in the application. Identified using `pnpm knip --include duplicates,enumMembers,namespaceMembers,nsExports,nsTypes` and `pnpm knip --include exports,types,files`.

✅ Verification
Ran `pnpm lint`, `pnpm test`, and `xvfb-run -a pnpm test:e2e tests/e2e/home.spec.ts` locally to verify changes. All passed successfully.

✨ Result
A cleaner `saveParser` module with fewer unused constants and dead exports, reducing overall noise and potential confusion for future developers reading the code.

---
*PR created automatically by Jules for task [15068111838625557778](https://jules.google.com/task/15068111838625557778) started by @szubster*