### PR TITLE
Fix Foundry DAG Circular Dependency Warning

### DIFF
--- a/.foundry/stories/story-400-358-gen3-trainer-card-parsing-core.md
+++ b/.foundry/stories/story-400-358-gen3-trainer-card-parsing-core.md
@@ -6,8 +6,7 @@ status: PENDING
 owner_persona: tech_lead
 created_at: '2026-08-05'
 updated_at: '2026-08-10'
-depends_on:
-  - research-358-406-gen3-trainer-card-offsets
+depends_on: []
 jules_session_id: null
 pr_number: null
 parent: epic-111-400-gen3-trainer-card-data-extraction


### PR DESCRIPTION
Resolves the Foundry Engine DAG resolution warnings by removing the circular dependency between story-400-358-gen3-trainer-card-parsing-core.md and research-358-406-gen3-trainer-card-offsets.md. The child node was redundantly listed in the parent node's depends_on list, which created a circular loop in Phase 3.9 of the orchestrator since children are already implicitly tracked as blocking their parent's completion.

Fixes #5967

---
*PR created automatically by Jules for task [17439050749523656508](https://jules.google.com/task/17439050749523656508) started by @szubster*