### PR TITLE
chore: mark egg move pathfinding e2e story complete in epic

### DIFF
--- a/.foundry/epics/epic-055-113-egg-move-pathfinding-engine.md
+++ b/.foundry/epics/epic-055-113-egg-move-pathfinding-engine.md
@@ -35,4 +35,4 @@ Develop the core algorithmic engine for calculating valid breeding chains. This 
 - [x] [story-113-259-egg-move-breeding-rules](.foundry/archive/stories/story-113-259-egg-move-breeding-rules.md)
 - [x] [story-113-260-egg-move-multi-step-chains](.foundry/archive/stories/story-113-260-egg-move-multi-step-chains.md)
 - [x] [research-113-248-egg-move-precomputation](.foundry/archive/research/research-113-248-egg-move-precomputation.md)
-- [ ] [story-113-348-egg-move-pathfinding-e2e](.foundry/archive/stories/story-113-348-egg-move-pathfinding-e2e.md)
+- [x] [story-113-348-egg-move-pathfinding-e2e](.foundry/archive/stories/story-113-348-egg-move-pathfinding-e2e.md)


### PR DESCRIPTION
Updates `epic-055-113-egg-move-pathfinding-engine.md` to check off the completed E2E story, allowing the parent macro node to correctly transition out of the READY state in the orchestrator.

---
*PR created automatically by Jules for task [17038802532145424436](https://jules.google.com/task/17038802532145424436) started by @szubster*