### PR TITLE
Add Idea Node for Foundry System Statistics

### DIFF
--- a/.foundry/ideas/idea-146-foundry-system-statistics.md
+++ b/.foundry/ideas/idea-146-foundry-system-statistics.md
@@ -35,8 +35,10 @@ As the system evolves, new metrics and ideas will inevitably emerge. Therefore, 
 ## Proposed Solution
 We propose adding an automated statistics generator to the Foundry Orchestrator.
 
-### 1. Unified Statistics Document
-A structured statistics file (e.g., `.foundry/docs/statistics.json`, `.foundry/docs/statistics.yaml`, or `.foundry/docs/statistics.md` containing markdown tables and JSON blocks) will serve as the single source of truth for current metrics. It will contain:
+### 1. Unified Statistics Document (Root Location)
+A structured statistics file (e.g., `foundry-statistics.json`, `foundry-statistics.yaml`, or `foundry-statistics.md` containing markdown tables and JSON blocks) **must be stored in the root directory of the repository** (not in any subdirectory like `.foundry/docs/` or `.foundry/`). This keeps the statistics immediately accessible and prominent at the top level of the workspace.
+
+The file will contain:
 - **PR Metrics**: Total PRs, Auto-merged PRs, Auto-merge success rate.
 - **Node Status Counts**: A flat dictionary or table of statuses and their counts.
 - **Node Type Counts**: A flat dictionary or table of types and their counts.
@@ -61,8 +63,8 @@ This feature transforms the Foundry from an opaque workflow engine into a data-d
 
 ## Acceptance Criteria
 - [ ] Product Manager: Draft a comprehensive PRD detailing the statistics schema, git history parser, and real-time generation triggers.
-- [ ] Implement an automated statistics calculation script under `.github/scripts/` that parses the current state of `.foundry/` and outputs metrics.
-- [ ] Integrate statistics generation into the orchestrator/heartbeat workflow so that statistics are updated and auto-committed to the `main` branch.
+- [ ] Implement an automated statistics calculation script under `.github/scripts/` that parses the current state of `.foundry/` and outputs metrics to a root file (e.g., `foundry-statistics.json`, `foundry-statistics.yaml` or `foundry-statistics.md`).
+- [ ] Integrate statistics generation into the orchestrator/heartbeat workflow so that statistics are updated and auto-committed to the `main` branch at the root of the repository.
 - [ ] Implement a backfilling CLI script capable of reconstructing historical statistics by parsing git history and commit states.
 
 ### Downstream Graph Nodes

--- a/.foundry/ideas/idea-146-foundry-system-statistics.md
+++ b/.foundry/ideas/idea-146-foundry-system-statistics.md
@@ -1,0 +1,69 @@
+---
+id: idea-146-foundry-system-statistics
+type: IDEA
+title: Implement Foundry System Statistics Reporting and Backfilling
+status: PENDING
+owner_persona: product_manager
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - orchestrator
+  - metrics
+  - statistics
+  - database
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Implement Foundry System Statistics Reporting and Backfilling
+
+## Context & Problem Statement
+The Foundry operates as an autonomous software factory where a DAG of node files (Ideas, PRDs, Epics, Stories, Tasks) determines the software lifecycle. Currently, there is no centralized, real-time reporting of high-level performance and structural metrics of this system.
+
+To evaluate pipeline health and productivity, we need visibility into:
+1. **Pull Request Metrics**: The volume of pull requests opened and merged, including the fraction of pull requests that were auto-merged by the system vs. those requiring manual intervention.
+2. **Node Metrics**: The absolute counts and breakdowns of Foundry nodes by status (e.g., `PENDING`, `READY`, `ACTIVE`, `VERIFYING`, `COMPLETED`, `FAILED`, `BLOCKED`, `CANCELLED`), by type (e.g., `IDEA`, `PRD`, `EPIC`, `STORY`, `TASK`), and a matrix of type-then-status (e.g., how many `TASK` nodes are currently `ACTIVE` or `COMPLETED`).
+
+As the system evolves, new metrics and ideas will inevitably emerge. Therefore, we also need a robust way to backfill these statistics from the repository's git history.
+
+## Proposed Solution
+We propose adding an automated statistics generator to the Foundry Orchestrator.
+
+### 1. Unified Statistics Document
+A structured statistics file (e.g., `.foundry/docs/statistics.json`, `.foundry/docs/statistics.yaml`, or `.foundry/docs/statistics.md` containing markdown tables and JSON blocks) will serve as the single source of truth for current metrics. It will contain:
+- **PR Metrics**: Total PRs, Auto-merged PRs, Auto-merge success rate.
+- **Node Status Counts**: A flat dictionary or table of statuses and their counts.
+- **Node Type Counts**: A flat dictionary or table of types and their counts.
+- **Type-then-Status Breakdown Matrix**: A 2D breakdown (e.g., `type` as rows, `status` as columns).
+
+### 2. Almost Real-Time Orchestrator Integration
+The statistics generator script will be integrated directly into the orchestrator runner or as a GitHub Actions workflow step. Each time the orchestrator executes a cycle and commits state changes, it will dynamically recalculate the statistics and commit them directly to the `main` branch, ensuring they are kept in almost real-time.
+
+### 3. Git History Backfilling Engine
+We will develop a standalone backfilling CLI utility. This utility will:
+- Traverse the repository's Git history (commits on `main`).
+- Check out or analyze the files at each commit or daily intervals.
+- Parse the state of the `.foundry/` directory at each historical point.
+- Query GitHub API or inspect git reflogs to extract historical PR and merge events.
+- Generate a timeline of historical statistics, enabling retro-active trend analysis.
+
+## Value Proposition
+This feature transforms the Foundry from an opaque workflow engine into a data-driven factory. By providing immediate metrics and historical backfilling:
+- Engineers and product managers can pinpoint bottlenecks (e.g., disproportionately high numbers of `BLOCKED` or `FAILED` nodes).
+- The Agile Coach and TPM can track autonomous throughput (e.g., auto-merge ratios and cycle velocities).
+- It provides an extensible framework to easily append new metrics as the team comes up with more ideas during development.
+
+## Acceptance Criteria
+- [ ] Product Manager: Draft a comprehensive PRD detailing the statistics schema, git history parser, and real-time generation triggers.
+- [ ] Implement an automated statistics calculation script under `.github/scripts/` that parses the current state of `.foundry/` and outputs metrics.
+- [ ] Integrate statistics generation into the orchestrator/heartbeat workflow so that statistics are updated and auto-committed to the `main` branch.
+- [ ] Implement a backfilling CLI script capable of reconstructing historical statistics by parsing git history and commit states.
+
+### Downstream Graph Nodes
+- [ ] `.foundry/prds/prd-146-001-foundry-system-statistics.md`

--- a/.jules/visionary/2026-08-11-foundry-system-statistics.md
+++ b/.jules/visionary/2026-08-11-foundry-system-statistics.md
@@ -1,0 +1,12 @@
+# Visionary Journal
+
+- **Active Session/Timestamp:** 2026-08-11
+- **Domain:** Foundry system
+- **Proposed Idea:** Foundry System Statistics Reporting and Backfilling (IDEA-146)
+- **Rationale & Concept:**
+  The Foundry autonomous software factory manages multiple concurrent agent pipelines across a graph of Ideas, PRDs, Epics, Stories, and Tasks. However, we have lacked a high-level operational reporting system for key factory metrics like pull requests (including auto-merge success rate) and node counts categorized by status and type.
+
+  To address this, we proposed a unified statistics specification file updated by the orchestrator in real-time, coupled with a history-backfilling parser to analyze Git repository history. This will empower personas like the Agile Coach and TPM to analyze bottleneck points and monitor pipeline efficiency.
+
+- **How this idea maintains the 50/50 balance between DexHelper and Foundry:**
+  In the preceding sessions, a sequence of DexHelper product ideas were proposed (including the Gen 2 Bug Catching Contest Analyzer (IDEA-144) and the Component Variants and Theming Consolidation (IDEA-145)). Moving back to a core platform orchestration feature for the autonomous software factory (such as statistics and backfilling) successfully maintains the 50/50 strategic balance between direct end-user features (DexHelper) and internal pipeline improvements (Foundry).


### PR DESCRIPTION
Introduces a new IDEA node (.foundry/ideas/idea-146-foundry-system-statistics.md) proposing simple metrics for the Foundry autonomous software factory (PR counts, auto-merge rate, node counts by status/type/matrix) updated dynamically by the orchestrator. It also outlines a CLI backfilling engine using Git commit history. Follows up with a session log in the Visionary Persona journal maintaining the 50/50 balance.

Fixes #5965

---
*PR created automatically by Jules for task [11891554959470023523](https://jules.google.com/task/11891554959470023523) started by @szubster*