### PR TITLE
feat(epic-planner): decompose orchestrator resource locking PRD into Epics

### DIFF
--- a/.foundry/epics/epic-340-411-schema-resource-locking.md
+++ b/.foundry/epics/epic-340-411-schema-resource-locking.md
@@ -1,0 +1,33 @@
+---
+id: epic-340-411-schema-resource-locking
+type: EPIC
+title: Schema Update for Orchestrator Resource Locking
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-131-340-orchestrator-resource-locking-mutex
+tags:
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Schema Update for Orchestrator Resource Locking
+
+## Overview
+This EPIC covers the schema updates required to introduce the new `locks` field into the Foundry DAG orchestrator, allowing nodes to specify the file paths they intend to modify exclusively. This is necessary to prevent git merge conflicts and execution data loss in concurrent multi-agent environments.
+
+## Objectives
+- Add a new `locks` field to the `.foundry/docs/schema.md` template for nodes.
+- Update any necessary schema validators to ensure the `locks` field is correctly parsed as an array of string file paths.
+
+## Acceptance Criteria
+- [ ] Story Owner completes EPIC decomposition.
+- [ ] Story Owner generates a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-340-412-orchestrator-resource-locking.md
+++ b/.foundry/epics/epic-340-412-orchestrator-resource-locking.md
@@ -1,0 +1,37 @@
+---
+id: epic-340-412-orchestrator-resource-locking
+type: EPIC
+title: Orchestrator Logic for Resource Locking
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on:
+  - epic-340-411-schema-resource-locking
+jules_session_id: null
+pr_number: null
+parent: prd-131-340-orchestrator-resource-locking-mutex
+tags:
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Orchestrator Logic for Resource Locking
+
+## Overview
+This EPIC covers the implementation of the core orchestrator logic (`.github/scripts/foundry-orchestrator.ts`) required to parse, aggregate, and evaluate node `locks` during the RESOLVE phase, temporarily holding nodes in `PENDING` status if lock intersections occur with currently `ACTIVE` nodes.
+
+## Objectives
+- Update the orchestrator script to parse the new `locks` field.
+- In the `RESOLVE` phase (Phase 4), aggregate all `locks` declared by currently `ACTIVE` nodes.
+- For every `PENDING` node eligible to transition to `READY`, check its declared `locks` against aggregated active locks.
+- Block the `PENDING` node if there's an intersection.
+- Ensure deadlocks are prevented and locks are released appropriately when a node transitions from `ACTIVE` to `COMPLETED` or `FAILED`.
+
+## Acceptance Criteria
+- [ ] Story Owner completes EPIC decomposition.
+- [ ] Story Owner generates a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-340-413-orchestrator-locking-e2e.md
+++ b/.foundry/epics/epic-340-413-orchestrator-locking-e2e.md
@@ -1,0 +1,38 @@
+---
+id: epic-340-413-orchestrator-locking-e2e
+type: EPIC
+title: E2E Verification for Orchestrator Resource Locking
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on:
+  - epic-340-412-orchestrator-resource-locking
+jules_session_id: null
+pr_number: null
+parent: prd-131-340-orchestrator-resource-locking-mutex
+tags:
+  - orchestrator
+  - architecture
+  - e2e
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# E2E Verification for Orchestrator Resource Locking
+
+## Overview
+This EPIC covers the end-to-end integration and verification testing required to ensure the newly introduced resource locking mutex within the Foundry DAG orchestrator functions correctly. It serves as the mandated E2E testing phase for the entire feature set.
+
+## Objectives
+- Create end-to-end test scenarios simulating multiple agents attempting to lock intersecting resources.
+- Ensure the orchestrator correctly prevents `PENDING` nodes from transitioning to `READY` when locks intersect with `ACTIVE` nodes.
+- Validate that locks are correctly released when a node's status changes from `ACTIVE`.
+- Ensure tests run cleanly as part of the orchestrator test suite.
+
+## Acceptance Criteria
+- [ ] Story Owner completes EPIC decomposition into integration stories.
+- [ ] Story Owner generates a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/journals/epic_planner/3429537633230405371.md
+++ b/.foundry/journals/epic_planner/3429537633230405371.md
@@ -1,0 +1,5 @@
+# Epic Planner Session Learnings
+
+- When decomposing PRDs into Epics, I must explicitly enforce the Orchestrator Safeguard rule (E2E/Integration Requirement) by explicitly adding an Acceptance Criteria step to **each** generated Epic mandating that the downstream Story Owner generates a final STORY dedicated exclusively to Integration and E2E Verification.
+- When drafting the `depends_on` array in the YAML frontmatter for newly generated nodes, I must strictly use the exact Node IDs (e.g., `epic-340-411-schema-resource-locking`), and NOT the relative file paths (e.g., `.foundry/epics/epic-340-411-schema-resource-locking.md`). Using file paths breaks the dependency graph resolution mechanism.
+- When generating children in the markdown body of a parent, I must also use just the node IDs without file paths.

--- a/.foundry/prds/prd-131-340-orchestrator-resource-locking-mutex.md
+++ b/.foundry/prds/prd-131-340-orchestrator-resource-locking-mutex.md
@@ -37,6 +37,9 @@ Currently, multiple active agents may attempt to modify the same shared files si
 
 ## Next Steps
 - [ ] Epic Planner: Draft the EPIC breaking this PRD down into architecture, orchestrator modifications, and schema updates.
+- [ ] epic-340-411-schema-resource-locking
+- [ ] epic-340-412-orchestrator-resource-locking
+- [ ] epic-340-413-orchestrator-locking-e2e
 
 ## Acceptance Criteria
-- [ ] Epic Planner completes PRD decomposition.
+- [x] Epic Planner completes PRD decomposition.


### PR DESCRIPTION
- Broke down `prd-131-340-orchestrator-resource-locking-mutex` into three detailed Epics (`epic-340-411`, `epic-340-412`, `epic-340-413`) representing schema changes, orchestrator core logic changes, and E2E verifications.
- Added E2E verification mandate as an acceptance criterion to each generated Epic to guide the Story Owner.
- Ensured strict compliance with DAG Node ID references in `depends_on` and PRD child tasks.
- Checked off acceptance criteria in PRD to resolve the node.
- Added learnings to the Epic Planner journal.

---
*PR created automatically by Jules for task [3429537633230405371](https://jules.google.com/task/3429537633230405371) started by @szubster*