### PR TITLE
Epic Planner: Break down Shoal Cave PRD into Epics

### DIFF
--- a/.foundry/epics/epic-340-411-shoal-cave-data-extraction.md
+++ b/.foundry/epics/epic-340-411-shoal-cave-data-extraction.md
@@ -1,0 +1,48 @@
+---
+id: epic-340-411-shoal-cave-data-extraction
+type: EPIC
+title: Data Extraction Layer (RTC & Shoal Items)
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-130-340-shoal-cave-tide-tracker
+tags:
+  - feature
+  - gen3
+  - time-based
+  - item-tracker
+  - data-extraction
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: Data Extraction Layer (RTC & Shoal Items)
+
+## Description
+This epic focuses on the backend parsing logic for extracting necessary data from Gen 3 save files to power the Shoal Cave Dashboard. We need to accurately extract the Real Time Clock (RTC) value and item inventory counts for Shoal Shells and Shoal Salts.
+
+## Prerequisites & Constraints
+- Must follow Section 13 ("Save File Parsing & Extraction Guidelines") in `schema.md`.
+- All memory offsets, lengths, bit locations, shifts, and array bounds checking limits must be explicitly defined as reusable constants at the module level.
+- No magic numbers.
+- Must use relative offsets to support the A/B bank flash memory architecture for Gen 3.
+- RangeError must be handled properly during parsing with the `DataView` API.
+
+## Requirements
+1. **RTC Value Extraction:**
+   - Locate and extract the RTC value from the Gen 3 save structure.
+2. **Item Count Extraction:**
+   - Parse the Items pocket of the Gen 3 save file to retrieve counts for Shoal Shells and Shoal Salt.
+3. **Daily Flag (Optional):**
+   - Investigate and potentially extract the daily flag for Shell Bell crafting.
+
+## Acceptance Criteria
+- [ ] Implement RTC data extraction logic complying with Section 13 guidelines.
+- [ ] Implement item pocket parsing for Shoal Shells and Shoal Salts.
+- [ ] E2E / Integration Verification STORY must be drafted to integrate extracted data with dashboard and test it end-to-end.

--- a/.foundry/epics/epic-340-412-shoal-cave-ui-dashboard.md
+++ b/.foundry/epics/epic-340-412-shoal-cave-ui-dashboard.md
@@ -1,0 +1,48 @@
+---
+id: epic-340-412-shoal-cave-ui-dashboard
+type: EPIC
+title: UI Dashboard Implementation (Shoal Cave Tracker)
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on:
+  - epic-340-411-shoal-cave-data-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-130-340-shoal-cave-tide-tracker
+tags:
+  - feature
+  - gen3
+  - time-based
+  - item-tracker
+  - ui-dashboard
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Epic: UI Dashboard Implementation (Shoal Cave Tracker)
+
+## Description
+This epic focuses on building the React components and UI dashboard to display the Shoal Cave tide information and item counts. It consumes the parsed RTC data and item counts from the Data Extraction Layer.
+
+## Prerequisites & Constraints
+- The UI MUST follow the tactical hardware aesthetic constraints (`rounded-none`, `border-dashed`, monospaced telemetry fonts) outlined in ADR 008.
+- Consumes extracted data for RTC and item counts.
+
+## Requirements
+1. **Tide Display:**
+   - Display the current in-game tide (High/Low) and a countdown to the next tide change.
+2. **Item Count Display:**
+   - Display quantities of collected Shoal Shells and Shoal Salts.
+3. **Crafting Readiness:**
+   - Provide a readiness indicator for crafting the Shell Bell (requires 4 Shoal Shells and 4 Shoal Salts).
+
+## Acceptance Criteria
+- [ ] Implement React components for Shoal Cave Dashboard adhering to ADR 008 constraints.
+- [ ] Render current tide and countdown correctly.
+- [ ] Render collected item counts for Shoal Shells and Shoal Salts.
+- [ ] Add visual readiness indicator for Shell Bell crafting.
+- [ ] E2E / Integration Verification STORY must be drafted to integrate extracted data with dashboard and test it end-to-end.

--- a/.foundry/journals/epic_planner/15420332520704113323.md
+++ b/.foundry/journals/epic_planner/15420332520704113323.md
@@ -1,0 +1,6 @@
+# Session 15420332520704113323 (epic_planner)
+
+**Key Learnings / Reminders:**
+- Always ensure to add an acceptance criterion in new Epics delegating E2E testing/verification to `story_owner` to fulfill the orchestrator safeguard.
+- Late-binding compliance: When a parent PRD is marked to have unchecked sub-tasks (newly added Epics), leave those unchecked so the system properly blocks the PRD completion until the child nodes finish, enforcing the hierarchical DAG completion.
+- Dependency Mapping: Always explicitly map dependencies between sibling generated Epics. When a UI dashboard consumes data from a data extraction layer, the UI Epic must have the Data Extraction Epic ID in its `depends_on` array in the YAML frontmatter to prevent parallel scheduling issues.

--- a/.foundry/prds/prd-130-340-shoal-cave-tide-tracker.md
+++ b/.foundry/prds/prd-130-340-shoal-cave-tide-tracker.md
@@ -48,5 +48,8 @@ The `epic_planner` should decompose this PRD into distinct, modular epics (and d
 *Orchestrator Safeguard:* The `epic_planner` MUST ensure that an explicit acceptance criterion is added to drafted EPICs delegating the generation of the final E2E Integration Verification STORY to the `story_owner`.
 
 ## Acceptance Criteria
-- [ ] Break down into EPIC(s) for Data Extraction.
-- [ ] Break down into EPIC(s) for UI Dashboard.
+- [x] Break down into EPIC(s) for Data Extraction.
+- [x] Break down into EPIC(s) for UI Dashboard.
+
+- [ ] epic-340-411-shoal-cave-data-extraction
+- [ ] epic-340-412-shoal-cave-ui-dashboard


### PR DESCRIPTION
This PR breaks down `prd-130-340-shoal-cave-tide-tracker` into two distinct epics:
1. `epic-340-411-shoal-cave-data-extraction`: Handles extracting RTC and item counts from Gen 3 save files.
2. `epic-340-412-shoal-cave-ui-dashboard`: Handles the UI implementation.

The UI Epic correctly relies on the Data Extraction Epic via its `depends_on` array. Both epics contain E2E verification requirements. 
The PRD has been updated to list the new child epics as unchecked boxes for orchestrator hierarchical DAG completion.

---
*PR created automatically by Jules for task [15420332520704113323](https://jules.google.com/task/15420332520704113323) started by @szubster*