### PR TITLE
Gen3 Lottery Matching Iteration Implementation

### DIFF
--- a/.foundry/journals/coder/773542908859764608.md
+++ b/.foundry/journals/coder/773542908859764608.md
@@ -1,0 +1,7 @@
+# Session 773542908859764608
+
+## Learnings
+*   When implementing save file parsing for Gen 3, the `PokemonInstance.otId` property stores a 32-bit integer that combines both the 16-bit Secret ID (SID) and 16-bit Trainer ID (TID).
+*   Because the Gen 3 lottery system evaluates only the 16-bit Trainer ID, we must mask it explicitly (`pokemon.otId & 0xFFFF`) before checking matches to prevent the SID from interfering with false matches or missed matches.
+*   As per ADR 028, we must always extract magic numbers into module-level constants (e.g. `GEN3_TRAINER_ID_MASK = 0xFFFF`).
+*   Always ensure any scratchpad or testing files created (`fix.ts`, `plan.md`) are deleted before requesting code reviews or concluding pre-commit steps.

--- a/.foundry/tasks/task-273-307-gen3-lottery-matching-iteration-impl.md
+++ b/.foundry/tasks/task-273-307-gen3-lottery-matching-iteration-impl.md
@@ -38,7 +38,7 @@ Iterate through Party and PC Box Pokémon to find the best lottery match against
 - **Save File Parsing (ADR 028)**: Explicitly require that all memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level. Inline magic numbers are forbidden.
 
 ## Acceptance Criteria
-- [ ] Implement the Party and PC Box iteration logic to collect Pokémon.
-- [ ] Ensure 16-bit OT IDs are extracted safely without magic numbers.
-- [ ] Integrate with the core matching logic to determine the best match.
-- [ ] Add unit tests verifying the iteration over standard and edge-case Party/Box structures.
+- [x] Implement the Party and PC Box iteration logic to collect Pokémon.
+- [x] Ensure 16-bit OT IDs are extracted safely without magic numbers.
+- [x] Integrate with the core matching logic to determine the best match.
+- [x] Add unit tests verifying the iteration over standard and edge-case Party/Box structures.

--- a/src/engine/gen3/lottery/lottery.test.ts
+++ b/src/engine/gen3/lottery/lottery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { PokemonInstance } from '../../saveParser/parsers/common';
-import { calculateLotteryTier, getBestLotteryMatch } from './lottery';
+import type { PokemonInstance, SaveData } from '../../saveParser/parsers/common';
+import { calculateLotteryTier, checkSaveDataForLottery, getBestLotteryMatch } from './lottery';
 
 describe('Lottery Matching Logic', () => {
   describe('calculateLotteryTier', () => {
@@ -39,14 +39,14 @@ describe('Lottery Matching Logic', () => {
     it('should return the best match and corresponding pokemon', () => {
       const pokemonList = [
         { otId: 11111 } as unknown as PokemonInstance, // No match
-        { otId: 99345 } as unknown as PokemonInstance, // Tier 3
-        { otId: 92345 } as unknown as PokemonInstance, // Tier 2
+        { otId: 33809 } as unknown as PokemonInstance, // Tier 3 (33809 & 0xFFFF = 33809 => ends in 345, vs 12345 -> 3 match)
+        { otId: 12345 } as unknown as PokemonInstance, // Tier 1 (12345 & 0xFFFF = 12345 -> 5 match)
       ];
       const winningNumber = 12345;
 
       const result = getBestLotteryMatch(pokemonList, winningNumber);
-      expect(result.tier).toBe(2);
-      expect(result.winningPokemon).toEqual({ otId: 92345 });
+      expect(result.tier).toBe(1);
+      expect(result.winningPokemon).toEqual({ otId: 12345 });
     });
 
     it('should return tier 0 if no match found', () => {
@@ -57,6 +57,73 @@ describe('Lottery Matching Logic', () => {
       const winningNumber = 12345;
 
       const result = getBestLotteryMatch(pokemonList, winningNumber);
+      expect(result.tier).toBe(0);
+      expect(result.winningPokemon).toBeNull();
+    });
+
+    it('should extract the 16-bit Trainer ID and ignore the 16-bit Secret ID', () => {
+      // otId is stored as a 32-bit number (SID << 16 | TID)
+      // SID = 0x8765, TID = 0x4321
+      // otId = 0x87654321 = 2271560481
+      // TID = 0x4321 = 17185
+      const pokemonList = [{ otId: 0x87654321 } as unknown as PokemonInstance];
+
+      // If we match exactly the Trainer ID part (17185), it should be a perfect match (Tier 1).
+      const result1 = getBestLotteryMatch(pokemonList, 17185);
+      expect(result1.tier).toBe(1);
+      expect(result1.winningPokemon).toEqual({ otId: 0x87654321 });
+
+      // If we attempt to match the full 32-bit otId (which is impossible in-game but proves we mask), it shouldn't match.
+      const result2 = getBestLotteryMatch(pokemonList, 2271560481);
+      expect(result2.tier).toBe(0); // Because 17185 != 2271560481 in any of the lower digits
+    });
+  });
+
+  describe('checkSaveDataForLottery', () => {
+    it('should find best match checking both party and pc pokemon', () => {
+      const saveData = {
+        partyDetails: [
+          { otId: 11111 } as unknown as PokemonInstance,
+          { otId: 33809 } as unknown as PokemonInstance, // Tier 3 match
+        ],
+        pcDetails: [
+          { otId: 22222 } as unknown as PokemonInstance,
+          { otId: 32345 } as unknown as PokemonInstance, // Tier 2 match (better)
+        ],
+      } as unknown as SaveData;
+      const winningNumber = 12345;
+
+      const result = checkSaveDataForLottery(saveData, winningNumber);
+      expect(result.tier).toBe(2);
+      expect(result.winningPokemon).toEqual({ otId: 32345 });
+    });
+
+    it('should prioritize Party match if ties occur', () => {
+      const saveData = {
+        partyDetails: [
+          { otId: 32345, speciesId: 1 } as unknown as PokemonInstance, // Tier 2 match
+        ],
+        pcDetails: [
+          { otId: 32345, speciesId: 2 } as unknown as PokemonInstance, // Tier 2 match
+        ],
+      } as unknown as SaveData;
+      const winningNumber = 12345;
+
+      const result = checkSaveDataForLottery(saveData, winningNumber);
+      expect(result.tier).toBe(2);
+      // Party comes first in array concat, so it's matched first. But wait, getBestLotteryMatch only replaces if tier < bestTier.
+      // So the first one found with Tier 2 will be kept.
+      expect(result.winningPokemon).toEqual({ otId: 32345, speciesId: 1 });
+    });
+
+    it('should return tier 0 if lists are empty', () => {
+      const saveData = {
+        partyDetails: [],
+        pcDetails: [],
+      } as unknown as SaveData;
+      const winningNumber = 12345;
+
+      const result = checkSaveDataForLottery(saveData, winningNumber);
       expect(result.tier).toBe(0);
       expect(result.winningPokemon).toBeNull();
     });

--- a/src/engine/gen3/lottery/lottery.ts
+++ b/src/engine/gen3/lottery/lottery.ts
@@ -1,4 +1,6 @@
-import type { PokemonInstance } from '../../saveParser/parsers/common';
+import type { PokemonInstance, SaveData } from '../../saveParser/parsers/common';
+
+export const GEN3_TRAINER_ID_MASK = 0xffff;
 
 export interface LotteryResult {
   tier: 0 | 1 | 2 | 3 | 4;
@@ -31,7 +33,12 @@ export function getBestLotteryMatch(pokemonList: PokemonInstance[], winningNumbe
 
   for (const pokemon of pokemonList) {
     if (pokemon.otId === undefined) continue;
-    const tier = calculateLotteryTier(pokemon.otId, winningNumber);
+
+    // Use only the lower 16 bits of the OT ID, which represents the Trainer ID.
+    // The upper 16 bits (Secret ID) are not used for lottery matching.
+    const trainerId = pokemon.otId & GEN3_TRAINER_ID_MASK;
+
+    const tier = calculateLotteryTier(trainerId, winningNumber);
     if (tier !== 0 && (bestTier === 0 || tier < bestTier)) {
       // tier 1 is best, tier 4 is worst
       bestTier = tier;
@@ -43,4 +50,9 @@ export function getBestLotteryMatch(pokemonList: PokemonInstance[], winningNumbe
   }
 
   return { tier: bestTier, winningPokemon: bestPokemon };
+}
+
+export function checkSaveDataForLottery(saveData: SaveData, winningNumber: number): LotteryResult {
+  const pokemonList = [...saveData.partyDetails, ...saveData.pcDetails];
+  return getBestLotteryMatch(pokemonList, winningNumber);
 }


### PR DESCRIPTION
This PR implements the logic to correctly gather Party and PC Box Pokémon for Gen 3 lottery matching. It introduces a `checkSaveDataForLottery` method which merges lists. Furthermore, it updates the `getBestLotteryMatch` function to correctly isolate the lower 16-bit Trainer ID from the 32-bit `otId` using a module-level constant (`GEN3_TRAINER_ID_MASK`), conforming to ADR 028 rules against inline magic numbers. Unit tests were successfully updated and validated.

---
*PR created automatically by Jules for task [773542908859764608](https://jules.google.com/task/773542908859764608) started by @szubster*