### PR TITLE
epic(planner): break down gen3 ai move predictor prd

### DIFF
--- a/.foundry/epics/epic-340-411-gen3-ai-data-extraction.md
+++ b/.foundry/epics/epic-340-411-gen3-ai-data-extraction.md
@@ -1,0 +1,39 @@
+---
+id: epic-340-411-gen3-ai-data-extraction
+type: EPIC
+title: Gen 3 AI Move Predictor - Data Extraction
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-08'
+updated_at: '2026-08-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-136-340-gen3-ai-move-predictor
+tags:
+  - gen3
+  - ai
+  - save-engine
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Gen 3 AI Move Predictor - Data Extraction
+
+## Objective
+Extract the necessary state from Gen 3 save files to feed into the AI move predictor simulation engine.
+
+## Scope
+- Parse the player's active team (Pokémon species, moves, stats).
+- Parse the player's current location from the save file.
+- Identify the nearest upcoming major trainer based on player location.
+- Extract or identify the opponent's team and the AI level/script assigned to that trainer in game memory/constants.
+
+## Constraints
+- Adhere strictly to the "Save File Parsing & Extraction Guidelines" in the schema.
+- Must support Emerald, FireRed, LeafGreen, Ruby, and Sapphire.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break down into actionable STORY nodes.
+- [ ] Story Owner: Generate a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-340-412-gen3-ai-simulation-engine.md
+++ b/.foundry/epics/epic-340-412-gen3-ai-simulation-engine.md
@@ -1,0 +1,40 @@
+---
+id: epic-340-412-gen3-ai-simulation-engine
+type: EPIC
+title: Gen 3 AI Move Predictor - Simulation Engine
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-08'
+updated_at: '2026-08-11'
+depends_on:
+  - epic-340-411-gen3-ai-data-extraction
+jules_session_id: null
+pr_number: null
+parent: prd-136-340-gen3-ai-move-predictor
+tags:
+  - gen3
+  - ai
+  - simulation
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Gen 3 AI Move Predictor - Simulation Engine
+
+## Objective
+Implement the logic to simulate Gen 3 Trainer AI decision making to predict their next move.
+
+## Scope
+- Implement the decision tree simulation based on the opponent's AI script level.
+- Handle type effectiveness, stats, and random rolls according to Gen 3 mechanics.
+- Compare the player's current active Pokémon vs the opponent's active/next Pokémon to calculate move scores and likelihood percentages.
+- Produce a structured output (predictions) consumable by the UI.
+
+## Constraints
+- Focus on single battles for the MVP.
+- Ensure accuracy based on Gen 3 Trainer AI behavior.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break down into actionable STORY nodes.
+- [ ] Story Owner: Generate a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-340-413-gen3-ai-dashboard-ui.md
+++ b/.foundry/epics/epic-340-413-gen3-ai-dashboard-ui.md
@@ -1,0 +1,40 @@
+---
+id: epic-340-413-gen3-ai-dashboard-ui
+type: EPIC
+title: Gen 3 AI Move Predictor - Dashboard UI
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-08'
+updated_at: '2026-08-11'
+depends_on:
+  - epic-340-412-gen3-ai-simulation-engine
+jules_session_id: null
+pr_number: null
+parent: prd-136-340-gen3-ai-move-predictor
+tags:
+  - gen3
+  - ai
+  - ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Gen 3 AI Move Predictor - Dashboard UI
+
+## Objective
+Create the user interface for the Trainer AI Predictor module, displaying the simulation results to the user.
+
+## Scope
+- Create a dashboard displaying the upcoming major trainer.
+- Allow the user to manually override and select a specific trainer.
+- Build a side-by-side battle simulation view showing the player's active Pokémon and the opponent's active/next Pokémon.
+- Display the predicted moves with likelihood percentages (or a deterministic single prediction).
+- Integrate the UI with the save file state and the simulation engine.
+
+## Constraints
+- Adhere strictly to the "tactical hardware/snooping" aesthetic outlined in ADR 008 (sharp edges, dashed borders, monospaced telemetry fonts).
+
+## Acceptance Criteria
+- [ ] Story Owner: Break down into actionable STORY nodes.
+- [ ] Story Owner: Generate a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/journals/epic_planner/6067531488387496095.md
+++ b/.foundry/journals/epic_planner/6067531488387496095.md
@@ -1,0 +1,4 @@
+# Session 6067531488387496095
+
+## Context
+When creating new nodes, it's crucial to map out dependencies strictly using the Node ID, *not* the filepath. Adding `.md` or the directory prefix will break the DAG Orchestrator.

--- a/.foundry/prds/prd-136-340-gen3-ai-move-predictor.md
+++ b/.foundry/prds/prd-136-340-gen3-ai-move-predictor.md
@@ -47,4 +47,7 @@ Implement an AI Move Predictor feature that evaluates an upcoming trainer battle
 - Focuses on single battles initially; double battles can be out of scope for MVP.
 
 ## Acceptance Criteria
-- [ ] Epic Planner: Break down the AI Move Predictor PRD into actionable EPIC nodes.
+- [x] Epic Planner: Break down the AI Move Predictor PRD into actionable EPIC nodes.
+- [ ] epic-340-411-gen3-ai-data-extraction
+- [ ] epic-340-412-gen3-ai-simulation-engine
+- [ ] epic-340-413-gen3-ai-dashboard-ui


### PR DESCRIPTION
This PR fulfills the Epic Planner's mandate to break down the "Gen 3 Trainer AI Move Predictor" PRD (`prd-136-340-gen3-ai-move-predictor`) into actionable EPIC nodes.

**Changes:**
1.  **Data Extraction Epic (`epic-340-411-gen3-ai-data-extraction`)**: Focuses on extracting player and opponent state from the save file.
2.  **Simulation Engine Epic (`epic-340-412-gen3-ai-simulation-engine`)**: Covers the logic for simulating Gen 3 Trainer AI decisions based on extracted state. Depends on the Data Extraction epic.
3.  **Dashboard UI Epic (`epic-340-413-gen3-ai-dashboard-ui`)**: Details the creation of the user interface to display predictions. Depends on the Simulation Engine epic.

**Key Adherences:**
*   **Dependency Mapping:** The `depends_on` relationships are strictly mapped using exact Node IDs (no filepaths or extensions) to ensure proper Orchestrator scheduling.
*   **Orchestrator Safeguard (E2E):** Every generated Epic includes an explicit Acceptance Criterion (`- [ ] Story Owner: Generate a final STORY dedicated exclusively to Integration and E2E Verification.`) to force downstream E2E test coverage.
*   **DAG Constraints:** The parent PRD's YAML frontmatter was left untouched, and child Epics were correctly appended to its Markdown body as unchecked tasks.

---
*PR created automatically by Jules for task [6067531488387496095](https://jules.google.com/task/6067531488387496095) started by @szubster*