### PR TITLE
docs(foundry): log anomaly for pre-existing prd and prepare empty pr

### DIFF
--- a/.foundry/journals/product_manager/9284848879758577313.md
+++ b/.foundry/journals/product_manager/9284848879758577313.md
@@ -1,0 +1,6 @@
+# Product Manager Journal - Session 9284848879758577313
+
+## Anomaly: Target Artifact Already Exists
+During the execution of `idea-086-fix-orchestrator-phase-3-6`, it was observed that the target downstream PRD artifact (`prd-086-108-fix-orchestrator-phase-3-6`) already existed prior to the session.
+
+This anomaly is being logged for later review as per the Product Manager persona Core Directives. The `idea-086-fix-orchestrator-phase-3-6.md` file's checkboxes were updated and an empty PR submitted to allow the orchestrator to correctly demote the parent, following the Empty PR Policy and Late-Binding Orchestrator Demotion Compliance Rule.


### PR DESCRIPTION
This PR addresses the task for `idea-086-fix-orchestrator-phase-3-6` by the Product Manager persona. 

Upon inspection, the target downstream artifact `prd-086-108-fix-orchestrator-phase-3-6` already existed. As per the Core Directives, this anomaly has been logged in the persona's journal (`.foundry/journals/product_manager/9284848879758577313.md`). 

To allow the orchestrator to correctly demote the parent node while waiting for children, the acceptance criteria checkboxes in `idea-086-fix-orchestrator-phase-3-6.md` were checked without altering the YAML frontmatter, complying with the Empty PR Checkbox Policy and Macro Node Completion Exception.

---
*PR created automatically by Jules for task [9284848879758577313](https://jules.google.com/task/9284848879758577313) started by @szubster*