### PR TITLE
chore(foundry): complete task-401-409-gen2-dv-extraction-impl

### DIFF
--- a/.foundry/tasks/task-401-409-gen2-dv-extraction-impl.md
+++ b/.foundry/tasks/task-401-409-gen2-dv-extraction-impl.md
@@ -30,5 +30,5 @@ Implement the logic to extract Gen 2 DVs (Attack, Defense, Speed, and Special) f
 - You must catch `RangeError` from out-of-bounds reads using `DataView` and throw a new error with the exact message: `'The save file is corrupted or incomplete.'`
 
 ## Acceptance Criteria
-- [ ] Implement Gen 2 DV extraction logic.
-- [ ] Ensure that `RangeError` is caught during extraction, throwing a new error with the message `'The save file is corrupted or incomplete.'`.
+- [x] Implement Gen 2 DV extraction logic.
+- [x] Ensure that `RangeError` is caught during extraction, throwing a new error with the message `'The save file is corrupted or incomplete.'`.


### PR DESCRIPTION
Completed the Gen 2 DV extraction logic. The target artifact already exists and is fully implemented in `src/engine/saveParser/parsers/gen2.ts`, as well as `src/engine/saveParser/parsers/common.ts` where `parseDVs` handles catching `RangeError`. This PR only checks off the acceptance criteria checkboxes in `.foundry/tasks/task-401-409-gen2-dv-extraction-impl.md` to safely transition the node to `COMPLETED` following ADR 007 and ADR 009 policies.

---
*PR created automatically by Jules for task [10837030634646970626](https://jules.google.com/task/10837030634646970626) started by @szubster*