### PR TITLE
chore(qa): verify gen 3 roamer unit tests

### DIFF
--- a/.foundry/journals/qa/10130303434836686484.md
+++ b/.foundry/journals/qa/10130303434836686484.md
@@ -1,0 +1,6 @@
+# QA Session - 2026-08-11-21-55-58
+
+- Task `task-359-416-gen3-roamer-unit-tests-qa` was correctly implemented.
+- Unit tests for Emerald, Ruby/Sapphire, and FireRed/LeafGreen `Roamer` struct parsing exist and cover IVs, Personality Value, Species, HP, Level, Status, and Active boolean using DataView mocks.
+- Verified testing suites passing without error.
+- Task criteria successfully signed off.

--- a/.foundry/tasks/task-359-416-gen3-roamer-unit-tests-qa.md
+++ b/.foundry/tasks/task-359-416-gen3-roamer-unit-tests-qa.md
@@ -26,6 +26,6 @@ notes: ''
 Verify the correctness of the Gen 3 Roamer data extraction unit tests.
 
 ## Acceptance Criteria
-- [ ] Verify unit tests exist for Emerald, Ruby/Sapphire, and FireRed/LeafGreen `Roamer` struct parsing.
-- [ ] Verify the tests check the extraction of IVs, Personality Value, Species, HP, Level, Status, and Active boolean using programmatic DataView mocks.
-- [ ] Ensure all tests pass.
+- [x] Verify unit tests exist for Emerald, Ruby/Sapphire, and FireRed/LeafGreen `Roamer` struct parsing.
+- [x] Verify the tests check the extraction of IVs, Personality Value, Species, HP, Level, Status, and Active boolean using programmatic DataView mocks.
+- [x] Ensure all tests pass.


### PR DESCRIPTION
This PR finalizes the QA check for Gen 3 roamer unit tests and checks off the acceptance criteria for `task-359-416-gen3-roamer-unit-tests-qa`. All tests passed, validating Emerald, R/S, and FR/LG data extraction, as well as correctly throwing errors on corruption. 

A QA journal session was also logged for documentation.

---
*PR created automatically by Jules for task [10130303434836686484](https://jules.google.com/task/10130303434836686484) started by @szubster*