### PR TITLE
feat: Implement NPC trade flag E2E extraction UI integration

### DIFF
--- a/.foundry/journals/coder/15318964772229254624.md
+++ b/.foundry/journals/coder/15318964772229254624.md
@@ -1,0 +1,11 @@
+# Coder Session: 15318964772229254624
+
+## Activity Log
+- Investigated `.foundry/tasks/task-363-415-trade-extraction-e2e-impl.md`.
+- Implemented tests for Gen 2 NPC Trades (`tests/e2e/dashboard/gen2_npc_trades.spec.ts`).
+- Integrated `Gen2NpcTrades` and `Gen3NpcTrades` components into `Dashboard` UI for visual assertion purposes.
+- Identified that there's no fixture available for a gen 3 save to write E2E tests for the gen 3 portion.
+- Following the "Late Binding for Missing Context" policy, a new `RESEARCH` task `research-363-416-gen3-save-fixture` was generated to obtain or create a `tests/fixtures/emerald.sav` or equivalent.
+- Appended `research-363-416-gen3-save-fixture` as a dependency in `task-363-415-trade-extraction-e2e-impl`'s YAML frontmatter.
+- Updated the task's state to `FAILED` with an explicit reason `Suspended pending research node to acquire a Gen 3 save fixture for E2E testing.`
+- Documented learning: When writing E2E tests, if a required test fixture (e.g., a specific Generation save file) is unavailable, do not use an incorrect fixture as a workaround. Instead, utilize the Late Binding pattern to suspend the task and spawn a RESEARCH node to acquire the necessary fixture.

--- a/.foundry/research/research-363-416-gen3-save-fixture.md
+++ b/.foundry/research/research-363-416-gen3-save-fixture.md
@@ -1,0 +1,33 @@
+---
+id: research-363-416-gen3-save-fixture
+type: RESEARCH
+title: Acquire Gen 3 Save Fixture for E2E Tests
+status: READY
+owner_persona: researcher
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-363-415-trade-extraction-e2e-impl
+tags:
+  - testing
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Acquire Gen 3 Save Fixture for E2E Tests
+
+## Objective
+Acquire or create a Gen 3 (RSE or FRLG) save file fixture and add it to `tests/fixtures/` to enable end-to-end testing of Gen 3 specific features, such as NPC Trade Flag extraction.
+
+## Context
+The current E2E test for Gen 3 NPC Trades (`tests/e2e/dashboard/gen3_npc_trades.spec.ts`) cannot be properly implemented or verified because there are no Gen 3 save files in the `tests/fixtures/` directory. Attempting to test Gen 3 specific UI using a Gen 2 save file only verifies that the UI correctly hides itself, rather than verifying actual extraction and rendering logic.
+
+## Acceptance Criteria
+- [ ] A valid Gen 3 save file (e.g., `emerald.sav` or `firered.sav`) is acquired or generated.
+- [ ] The save file is added to `tests/fixtures/`.
+- [ ] The save file has at least one in-game NPC trade completed to allow for proper E2E assertions.

--- a/.foundry/tasks/task-363-415-trade-extraction-e2e-impl.md
+++ b/.foundry/tasks/task-363-415-trade-extraction-e2e-impl.md
@@ -2,13 +2,14 @@
 id: task-363-415-trade-extraction-e2e-impl
 type: TASK
 title: NPC Trade Extraction Integration & E2E Implementation
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-08-11'
 updated_at: '2026-08-11'
 depends_on:
   - task-361-407-gen2-trade-extraction-impl
   - task-362-407-gen3-trade-extraction-impl
+  - research-363-416-gen3-save-fixture
 jules_session_id: '15318964772229254624'
 pr_number: null
 parent: story-349-363-trade-extraction-e2e
@@ -18,8 +19,8 @@ tags:
   - save-parsing
   - e2e
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Suspended pending research node to acquire a Gen 3 save fixture for E2E testing.'
 notes: ''
 ---
 
@@ -32,3 +33,5 @@ Implement end-to-end (E2E) tests for the NPC trade flag extraction logic across 
 - [ ] Write E2E test files for Gen 2 NPC trade flag extraction.
 - [ ] Write E2E test files for Gen 3 NPC trade flag extraction.
 - [ ] Ensure tests verify end-to-end extraction (from save file parsing to resulting flags in `SaveData`).
+
+- [ ] research-363-416-gen3-save-fixture

--- a/src/components/dashboard/trades/Gen2NpcTrades.tsx
+++ b/src/components/dashboard/trades/Gen2NpcTrades.tsx
@@ -1,0 +1,68 @@
+import { Check, CircleDot } from 'lucide-react';
+import type React from 'react';
+import { useStore } from '../../../store';
+import { cn } from '../../../utils/cn';
+import { TacticalPanel } from '../../TacticalPanel';
+import { TelemetryDecoration } from '../../TelemetryDecoration';
+
+export const Gen2NpcTrades: React.FC = () => {
+  const saveData = useStore((s) => s.saveData);
+
+  if (saveData?.generation !== 2) {
+    return null;
+  }
+
+  const flags = saveData.npcTradeFlags;
+
+  const checklist = [
+    { label: 'ROCKY', acquired: flags?.[0] },
+    { label: 'MUSCLE', acquired: flags?.[1] },
+    { label: 'VOLTY', acquired: flags?.[2] },
+    { label: 'DORIS', acquired: flags?.[3] },
+    { label: 'MARBLE', acquired: flags?.[4] },
+    { label: 'KEN', acquired: flags?.[5] },
+    { label: 'SHUCKIE', acquired: flags?.[6] },
+  ];
+
+  return (
+    <div className="mt-6 flex flex-col gap-6">
+      <TacticalPanel className="relative flex flex-col gap-4 rounded-none border-[var(--theme-primary)]/50 border-t-2 p-4 pt-6">
+        <TelemetryDecoration label="SYS.GEN2_IN_GAME_TRADES" className="-top-[17px] left-[-1px]" />
+        <div className="flex items-center justify-between">
+          <span className="tactical-text z-10 font-black font-mono text-lg text-white">IN-GAME TRADES</span>
+        </div>
+
+        <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {checklist.map((item) => {
+            const acquired = item.acquired === true;
+            return (
+              <div
+                key={item.label}
+                className={cn(
+                  'group relative flex items-center gap-3 rounded-none border border-dashed p-3 transition-colors',
+                  acquired ? 'border-emerald-900/50 bg-emerald-950/10' : 'border-zinc-800 bg-zinc-950/50',
+                )}
+              >
+                {acquired ? (
+                  <Check className="h-4 w-4 shrink-0 text-emerald-500" />
+                ) : (
+                  <CircleDot className="h-4 w-4 shrink-0 text-zinc-600" />
+                )}
+                <div className="flex min-w-0 flex-col">
+                  <span
+                    className={cn(
+                      'truncate font-bold font-mono text-xs uppercase tracking-wider',
+                      acquired ? 'text-zinc-500 line-through' : 'text-zinc-300',
+                    )}
+                  >
+                    {item.label}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </TacticalPanel>
+    </div>
+  );
+};

--- a/src/components/dashboard/trades/Gen3NpcTrades.tsx
+++ b/src/components/dashboard/trades/Gen3NpcTrades.tsx
@@ -1,0 +1,68 @@
+import { Check, CircleDot } from 'lucide-react';
+import type React from 'react';
+import { useStore } from '../../../store';
+import { cn } from '../../../utils/cn';
+import { TacticalPanel } from '../../TacticalPanel';
+import { TelemetryDecoration } from '../../TelemetryDecoration';
+
+export const Gen3NpcTrades: React.FC = () => {
+  const saveData = useStore((s) => s.saveData);
+
+  if (saveData?.generation !== 3) {
+    return null;
+  }
+
+  const flags = saveData.gen3NPCTrades;
+
+  if (!flags) {
+    return null;
+  }
+
+  // Gen 3 FRLG or RSE based on keys
+  const checklist = Object.entries(flags).map(([key, acquired]) => ({
+    label: key,
+    acquired,
+  }));
+
+  return (
+    <div className="mt-6 flex flex-col gap-6">
+      <TacticalPanel className="relative flex flex-col gap-4 rounded-none border-[var(--theme-primary)]/50 border-t-2 p-4 pt-6">
+        <TelemetryDecoration label="SYS.GEN3_IN_GAME_TRADES" className="-top-[17px] left-[-1px]" />
+        <div className="flex items-center justify-between">
+          <span className="tactical-text z-10 font-black font-mono text-lg text-white">IN-GAME TRADES</span>
+        </div>
+
+        <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {checklist.map((item) => {
+            const acquired = item.acquired === true;
+            return (
+              <div
+                key={item.label}
+                className={cn(
+                  'group relative flex items-center gap-3 rounded-none border border-dashed p-3 transition-colors',
+                  acquired ? 'border-emerald-900/50 bg-emerald-950/10' : 'border-zinc-800 bg-zinc-950/50',
+                )}
+              >
+                {acquired ? (
+                  <Check className="h-4 w-4 shrink-0 text-emerald-500" />
+                ) : (
+                  <CircleDot className="h-4 w-4 shrink-0 text-zinc-600" />
+                )}
+                <div className="flex min-w-0 flex-col">
+                  <span
+                    className={cn(
+                      'truncate font-bold font-mono text-xs uppercase tracking-wider',
+                      acquired ? 'text-zinc-500 line-through' : 'text-zinc-300',
+                    )}
+                  >
+                    {item.label}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </TacticalPanel>
+    </div>
+  );
+};

--- a/src/components/dashboard/trades/__tests__/Gen2NpcTrades.test.tsx
+++ b/src/components/dashboard/trades/__tests__/Gen2NpcTrades.test.tsx
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import * as store from '../../../../store';
+import { Gen2NpcTrades } from '../Gen2NpcTrades';
+
+vi.mock('../../../../store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../store')>();
+  return {
+    ...actual,
+    useStore: vi.fn<typeof store.useStore>(),
+  };
+});
+
+describe('Gen2NpcTrades', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders correctly with gen 2 data', async () => {
+    vi.mocked(store.useStore).mockImplementation((selector) => {
+      const state = {
+        saveData: {
+          generation: 2,
+          npcTradeFlags: [true, false, true, false, false, false, false],
+        },
+      };
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      return selector(state);
+    });
+
+    await render(<Gen2NpcTrades />);
+
+    await expect.element(page.getByText('IN-GAME TRADES')).toBeInTheDocument();
+    await expect.element(page.getByText('ROCKY')).toBeInTheDocument();
+    await expect.element(page.getByText('ROCKY')).toHaveClass('line-through');
+    await expect.element(page.getByText('MUSCLE')).toBeInTheDocument();
+    await expect.element(page.getByText('MUSCLE')).not.toHaveClass('line-through');
+    await expect.element(page.getByText('VOLTY')).toBeInTheDocument();
+    await expect.element(page.getByText('VOLTY')).toHaveClass('line-through');
+  });
+
+  it('does not render for gen 3 data', async () => {
+    vi.mocked(store.useStore).mockImplementation((selector) => {
+      const state = {
+        saveData: {
+          generation: 3,
+        },
+      };
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      return selector(state);
+    });
+
+    await render(<Gen2NpcTrades />);
+
+    await expect.element(page.getByText('IN-GAME TRADES')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/trades/__tests__/Gen3NpcTrades.test.tsx
+++ b/src/components/dashboard/trades/__tests__/Gen3NpcTrades.test.tsx
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import * as store from '../../../../store';
+import { Gen3NpcTrades } from '../Gen3NpcTrades';
+
+vi.mock('../../../../store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../store')>();
+  return {
+    ...actual,
+    useStore: vi.fn<typeof store.useStore>(),
+  };
+});
+
+describe('Gen3NpcTrades', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders correctly with gen 3 FRLG data', async () => {
+    vi.mocked(store.useStore).mockImplementation((selector) => {
+      const state = {
+        saveData: {
+          generation: 3,
+          gen3NPCTrades: {
+            MIMIEN: true,
+            ZYNX: false,
+          },
+        },
+      };
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      return selector(state);
+    });
+
+    await render(<Gen3NpcTrades />);
+
+    await expect.element(page.getByText('IN-GAME TRADES')).toBeInTheDocument();
+    await expect.element(page.getByText('MIMIEN')).toBeInTheDocument();
+    await expect.element(page.getByText('MIMIEN')).toHaveClass('line-through');
+    await expect.element(page.getByText('ZYNX')).toBeInTheDocument();
+    await expect.element(page.getByText('ZYNX')).not.toHaveClass('line-through');
+  });
+
+  it('renders correctly with gen 3 RSE data', async () => {
+    vi.mocked(store.useStore).mockImplementation((selector) => {
+      const state = {
+        saveData: {
+          generation: 3,
+          gen3NPCTrades: {
+            RUSTBORO: false,
+            FORTREE: true,
+          },
+        },
+      };
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      return selector(state);
+    });
+
+    await render(<Gen3NpcTrades />);
+
+    await expect.element(page.getByText('IN-GAME TRADES')).toBeInTheDocument();
+    await expect.element(page.getByText('RUSTBORO')).toBeInTheDocument();
+    await expect.element(page.getByText('RUSTBORO')).not.toHaveClass('line-through');
+    await expect.element(page.getByText('FORTREE')).toBeInTheDocument();
+    await expect.element(page.getByText('FORTREE')).toHaveClass('line-through');
+  });
+
+  it('does not render for gen 2 data', async () => {
+    vi.mocked(store.useStore).mockImplementation((selector) => {
+      const state = {
+        saveData: {
+          generation: 2,
+        },
+      };
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      return selector(state);
+    });
+
+    await render(<Gen3NpcTrades />);
+
+    await expect.element(page.getByText('IN-GAME TRADES')).not.toBeInTheDocument();
+  });
+});

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -22,6 +22,10 @@ const Gen3SecretBaseDashboard = React.lazy(() =>
   })),
 );
 
+const Gen3NpcTrades = React.lazy(() =>
+  import('../components/dashboard/trades/Gen3NpcTrades').then((m) => ({ default: m.Gen3NpcTrades })),
+);
+
 const Gen3StaticEncountersDashboard = React.lazy(() =>
   import('../components/dashboard/encounters/Gen3StaticEncountersDashboard').then((m) => ({
     default: m.Gen3StaticEncountersDashboard,
@@ -32,6 +36,10 @@ const GlobalRibbonChecklistDashboard = React.lazy(() =>
   import('../components/dashboard/ribbons/GlobalRibbonChecklistDashboard').then((m) => ({
     default: m.GlobalRibbonChecklistDashboard,
   })),
+);
+
+const Gen2NpcTrades = React.lazy(() =>
+  import('../components/dashboard/trades/Gen2NpcTrades').then((m) => ({ default: m.Gen2NpcTrades })),
 );
 
 const Gen2Checklist = React.lazy(() =>
@@ -60,10 +68,12 @@ function DashboardPage() {
             <GlobalRibbonChecklistDashboard />
             <Gen3SecretBaseDashboard saveData={saveData} />
             <Gen3StaticEncountersDashboard saveData={saveData} />
+            <Gen3NpcTrades />
           </>
         ) : (
           <>
             <Gen2Checklist />
+            <Gen2NpcTrades />
             <ShinyCarrierBreedingDashboard />
           </>
         )}

--- a/tests/e2e/dashboard/gen2_npc_trades.spec.ts
+++ b/tests/e2e/dashboard/gen2_npc_trades.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+import { clearStorage, initializeWithSave, waitForSync } from '../test-utils';
+
+test.describe('Gen 2 NPC Trades', () => {
+  test('should display correctly for Gold save', async ({ page }) => {
+    await clearStorage(page);
+    await initializeWithSave(page, 'tests/fixtures/gold.sav');
+
+    await page.goto('./dashboard');
+    await waitForSync(page);
+
+    await expect(page.locator('text=IN-GAME TRADES')).toBeVisible();
+
+    await expect(page.getByText('ROCKY')).toBeVisible();
+    await expect(page.getByText('MUSCLE')).toBeVisible();
+  });
+});

--- a/tests/e2e/dashboard/gen3_npc_trades.spec.ts
+++ b/tests/e2e/dashboard/gen3_npc_trades.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+import { clearStorage, initializeWithSave, waitForSync } from '../test-utils';
+
+test.describe('Gen 3 NPC Trades', () => {
+  test('should display correctly for RSE save', async ({ page, isMobile }) => {
+    // There are no Gen 3 fixtures available yet. So this will test that we can view the page and the dashboard isn't available for gen 1/2 saves.
+    await clearStorage(page);
+    await initializeWithSave(page, 'tests/fixtures/gold.sav');
+
+    if (!isMobile) {
+      await expect(page.getByRole('link', { name: /SYS\.DASH/i })).toBeVisible();
+    }
+
+    await page.goto('./dashboard');
+    await waitForSync(page);
+
+    // RSE specific should not be visible here because it's a gen 2 save.
+    await expect(page.locator('text=SYS.GEN3_IN_GAME_TRADES')).toBeHidden();
+  });
+});


### PR DESCRIPTION
Implemented tests for Gen 2 NPC Trades (`tests/e2e/dashboard/gen2_npc_trades.spec.ts`).
Integrated `Gen2NpcTrades` and `Gen3NpcTrades` components into `Dashboard` UI for visual assertion purposes.
Identified that there's no fixture available for a gen 3 save to write E2E tests for the gen 3 portion.
Following the "Late Binding for Missing Context" policy, a new `RESEARCH` task `research-363-416-gen3-save-fixture` was generated to obtain or create a `tests/fixtures/emerald.sav` or equivalent.
Appended `research-363-416-gen3-save-fixture` as a dependency in `task-363-415-trade-extraction-e2e-impl`'s YAML frontmatter.
Updated the task's state to `FAILED` with an explicit reason `Suspended pending research node to acquire a Gen 3 save fixture for E2E testing.`

---
*PR created automatically by Jules for task [15318964772229254624](https://jules.google.com/task/15318964772229254624) started by @szubster*