### PR TITLE
chore: Empty PR for completed Gen 3 Roamer Unit Tests story

### DIFF
--- a/.foundry/journals/tech_lead/2483211844051615071.md
+++ b/.foundry/journals/tech_lead/2483211844051615071.md
@@ -1,0 +1,5 @@
+# Journal Entry: Anomalous Completed Tasks (Session 2483211844051615071)
+
+During this session, I was assigned to `story-397-359-gen3-roamer-unit-tests.md`. I discovered that the target artifacts (tests in `src/engine/gen3/roamer/parser.test.ts`) were completely implemented, and the child tasks `task-359-415-gen3-roamer-unit-tests-impl.md` and `task-359-416-gen3-roamer-unit-tests-qa.md` were already marked as `COMPLETED` prior to this session beginning.
+
+To address this anomaly and allow the story node to gracefully exit the DAG, I followed the "Handling Cancelled/Replaced Tasks" policy, checked off all the overarching acceptance criteria and child task checkboxes in the story node's markdown body, and will submit an Empty PR.

--- a/.foundry/stories/story-397-359-gen3-roamer-unit-tests.md
+++ b/.foundry/stories/story-397-359-gen3-roamer-unit-tests.md
@@ -26,13 +26,13 @@ notes: ''
 Write unit tests verifying the extraction of the Gen 3 Roamer struct against known good save fixtures for each game version.
 
 ## Acceptance Criteria
-- [ ] Create unit tests for Emerald `Roamer` struct parsing.
-- [ ] Create unit tests for Ruby/Sapphire `Roamer` struct parsing.
-- [ ] Create unit tests for FireRed/LeafGreen `Roamer` struct parsing.
-- [ ] Tests must verify the extraction of IVs, Personality Value, Species, HP, Level, Status, and Active boolean against fixtures.
+- [x] Create unit tests for Emerald `Roamer` struct parsing.
+- [x] Create unit tests for Ruby/Sapphire `Roamer` struct parsing.
+- [x] Create unit tests for FireRed/LeafGreen `Roamer` struct parsing.
+- [x] Tests must verify the extraction of IVs, Personality Value, Species, HP, Level, Status, and Active boolean against fixtures.
 - [x] Tech Lead: Break this Story down into actionable Tasks.
-- [ ] task-359-415-gen3-roamer-unit-tests-impl
-- [ ] task-359-416-gen3-roamer-unit-tests-qa
+- [x] task-359-415-gen3-roamer-unit-tests-impl
+- [x] task-359-416-gen3-roamer-unit-tests-qa
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
This empty PR checks off the Acceptance Criteria for `story-397-359-gen3-roamer-unit-tests.md` because its target artifacts (`src/engine/gen3/roamer/parser.test.ts`) and drafted child tasks were already implemented and `COMPLETED` prior to this session. This satisfies the "Handling Cancelled/Replaced Tasks (Graceful Exit)" policy and allows the Story node to transition correctly.

---
*PR created automatically by Jules for task [2483211844051615071](https://jules.google.com/task/2483211844051615071) started by @szubster*