### PR TITLE
docs(tech_lead): record session journal for story-070-358

### DIFF
--- a/.foundry/journals/tech_lead/1009842629473833134.md
+++ b/.foundry/journals/tech_lead/1009842629473833134.md
@@ -1,0 +1,5 @@
+# Session 1009842629473833134
+
+Assigned to `story-070-358-orchestrator-strict-completion-e2e`. The child tasks `task-358-407-orchestrator-strict-completion-e2e-impl` and `task-358-408-orchestrator-strict-completion-e2e-qa` were already marked `COMPLETED` in `.foundry/archive/tasks/`.
+However, because this is a late-binding parent node that had pending child tasks drafted from a previous iteration, checking off its overarching acceptance criteria prematurely violates the **Late-Binding Orchestrator Demotion Compliance Rule**.
+Thus, I am submitting an empty PR without checking off the overarching acceptance criteria to allow the orchestrator to correctly demote the parent to PENDING while it waits for its children.


### PR DESCRIPTION
The child tasks for this story are already completed. However, per the Late-Binding Orchestrator Demotion Compliance Rule, we submit an empty PR without checking off the overarching acceptance criteria to allow the orchestrator to correctly demote the parent to PENDING. Recorded this in the tech lead journal.

---
*PR created automatically by Jules for task [1009842629473833134](https://jules.google.com/task/1009842629473833134) started by @szubster*