### PR TITLE
Decompose Epic for Schema Resource Locking

### DIFF
--- a/.foundry/epics/epic-340-411-schema-resource-locking.md
+++ b/.foundry/epics/epic-340-411-schema-resource-locking.md
@@ -29,5 +29,7 @@ This EPIC covers the schema updates required to introduce the new `locks` field 
 - Update any necessary schema validators to ensure the `locks` field is correctly parsed as an array of string file paths.
 
 ## Acceptance Criteria
-- [ ] Story Owner completes EPIC decomposition.
-- [ ] Story Owner generates a final STORY dedicated exclusively to Integration and E2E Verification.
+- [x] Story Owner completes EPIC decomposition.
+- [x] Story Owner generates a final STORY dedicated exclusively to Integration and E2E Verification.
+- [ ] story-411-418-schema-resource-locking
+- [ ] story-411-419-schema-resource-locking-e2e

--- a/.foundry/journals/story_owner/6207212354005436450.md
+++ b/.foundry/journals/story_owner/6207212354005436450.md
@@ -1,0 +1,3 @@
+# Session 6207212354005436450
+
+Decomposed epic-340-411-schema-resource-locking into story-411-418-schema-resource-locking and story-411-419-schema-resource-locking-e2e.

--- a/.foundry/stories/story-411-418-schema-resource-locking.md
+++ b/.foundry/stories/story-411-418-schema-resource-locking.md
@@ -1,0 +1,32 @@
+---
+id: story-411-418-schema-resource-locking
+type: STORY
+title: Schema Resource Locking
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-340-411-schema-resource-locking
+tags:
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Schema Resource Locking
+
+## Objective
+Implement schema updates to introduce the `locks` field into the Foundry DAG orchestrator, preventing execution data loss and git merge conflicts in concurrent multi-agent environments.
+
+## Details
+- Add a new `locks` array field to `.foundry/docs/schema.md`.
+- Update `.github/scripts/schema.ts` to validate this field as an array of strings.
+
+## Acceptance Criteria
+- [ ] Tech Lead breaks down this STORY into TASK nodes for implementation.

--- a/.foundry/stories/story-411-419-schema-resource-locking-e2e.md
+++ b/.foundry/stories/story-411-419-schema-resource-locking-e2e.md
@@ -1,0 +1,34 @@
+---
+id: story-411-419-schema-resource-locking-e2e
+type: STORY
+title: Schema Resource Locking E2E Verification
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on:
+  - story-411-418-schema-resource-locking
+jules_session_id: null
+pr_number: null
+parent: epic-340-411-schema-resource-locking
+tags:
+  - orchestrator
+  - architecture
+  - e2e
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Schema Resource Locking E2E Verification
+
+## Objective
+Verify the `locks` field schema changes via unit and integration tests.
+
+## Details
+- Update relevant orchestrator/schema test files (e2e or unit) to ensure the `locks` array is validated properly (e.g. `schema.test.ts` or related testing artifacts in `.github/scripts/`).
+
+## Acceptance Criteria
+- [ ] Tech Lead breaks down this STORY into TASK nodes for test verification.


### PR DESCRIPTION
Decomposed the epic for adding the `locks` field into two stories:
1. `story-411-418-schema-resource-locking` for the core implementation
2. `story-411-419-schema-resource-locking-e2e` for the integration and e2e verification

---
*PR created automatically by Jules for task [6207212354005436450](https://jules.google.com/task/6207212354005436450) started by @szubster*