### PR TITLE
🎨 Palette: hide bracket symbols from screen readers in ClearFiltersBadge

### DIFF
--- a/.jules/palette/YYYY-MM-DD-HH-MM-SS.md
+++ b/.jules/palette/YYYY-MM-DD-HH-MM-SS.md
@@ -1,9 +1,2 @@
-## Task
-Find and implement ONE micro-UX improvement that makes the interface more intuitive, accessible, or pleasant.
-
-## Action Taken
-- Identified that `.glass-card` in `src/index.css` used a solid border (`1px solid`) which violated the project's tactical hardware aesthetic (ADR 008).
-- Replaced the solid border with a dashed border (`1px dashed`) and explicitly added `border-radius: 0;` (sharp edges).
-
-## Learnings & Constraints
-- **Aesthetic Enforcement:** ADR 008 strictly dictates sharp edges (`rounded-none` or `border-radius: 0`) and dashed borders (`border-dashed` or `1px dashed`). Future styling components must ensure these patterns are followed instead of generic styling like solid borders.
+## Critical Learnings:
+- Similar to `FilterBadge`, when a decorative pseudo-element or symbol is part of a button or badge's label (e.g. `[ ALL ]` inside `ClearFiltersBadge`), wrap the decorative elements (e.g., `[ ` and ` ]`) in `<span aria-hidden="true">` to prevent screen readers from redundantly announcing the brackets.

--- a/src/components/ClearFiltersBadge.tsx
+++ b/src/components/ClearFiltersBadge.tsx
@@ -28,7 +28,9 @@ export function ClearFiltersBadge({ isActive, onClick }: ClearFiltersBadgeProps)
           isActive ? 'bg-[var(--theme-primary)] shadow-[0_0_5px_var(--theme-primary)]' : 'bg-zinc-800',
         )}
       />
-      [ ALL ]
+      <span>
+        <span aria-hidden="true">[ </span>ALL<span aria-hidden="true"> ]</span>
+      </span>
     </TacticalButton>
   );
 }


### PR DESCRIPTION
**What**
Modified `ClearFiltersBadge` to wrap the `[ ` and ` ]` brackets in `<span aria-hidden="true">`.

**Why**
Screen readers will read `[ ALL ]` as "left bracket all right bracket" which is annoying and redundant. By hiding the brackets from the screen reader, it will simply read "ALL" (or "ALL, Clear filters" when combining the visually-hidden title), improving the auditory UX. This aligns the `ClearFiltersBadge` with existing accessibility patterns used in `FilterBadge` and `DataPoint`.

**Accessibility notes**
- Prevents redundant/decorative bracket symbols from being read by screen readers.

---
*PR created automatically by Jules for task [17385476762735081402](https://jules.google.com/task/17385476762735081402) started by @szubster*