### PR TITLE
🧹 clean up unused export and obsolete knip config

### DIFF
--- a/.jules/sweeper/31252701193.md
+++ b/.jules/sweeper/31252701193.md
@@ -1,0 +1,4 @@
+# Sweeper Journal
+
+## Unused Exports & Knip
+When resolving unused exports found via tools like `knip`, be extremely careful about variables implicitly required by unit tests. Before removing an export, explicitly verify its usage by executing a global search (e.g. `grep`) across the repository, especially within test files. Only remove the `export` keyword if it's strictly used internally within the same module and nowhere else. Unused barrel files, like `src/engine/index.ts` which was entirely unused and caught by `knip`, can be safely deleted. Obsolete configs in tools like `knip.json`'s ignore list should also be cleaned up to prevent configuration hints and warnings from the tool.

--- a/knip.json
+++ b/knip.json
@@ -9,7 +9,6 @@
   "ignore": [
     "src/test-setup.ts",
     ".github/scripts/extract-research.ts",
-    ".github/scripts/verify-dag-refs.ts",
     "scripts/gen3-fetch-locations.ts",
     "functions/_middleware.ts",
     "functions/api/saves/index.ts",

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,1 +1,0 @@
-export * from './gen3/roamer/parser';


### PR DESCRIPTION
🎯 **What**:
- Removed the unused `src/engine/index.ts` barrel export file.
- Removed the obsolete `.github/scripts/verify-dag-refs.ts` ignore rule from `knip.json`.

💡 **Why**:
- Technical debt cleanup: The unused export was correctly flagged by `pnpm knip`. Removing it simplifies the source code.
- Removing the obsolete ignore configuration rule stops `knip` from generating configuration hint warnings, keeping the CLI clean and ensuring the script is actually verified.

✅ **Verification**:
- `pnpm knip` runs cleanly without hints or warnings.
- `pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e` pass without issues.

✨ **Result**:
- A cleaner `src/engine` directory with no dead code.
- A clean configuration for the project's unused file checker tool.

---
*PR created automatically by Jules for task [1389577049807839408](https://jules.google.com/task/1389577049807839408) started by @szubster*