### PR TITLE
chore(foundry): check off completed child tasks for story-070-358

### DIFF
--- a/.foundry/journals/tech_lead/2026-08-12-08-18-15.md
+++ b/.foundry/journals/tech_lead/2026-08-12-08-18-15.md
@@ -1,0 +1,11 @@
+# Session Log: 2026-08-12-08-18-15
+
+## Anomaly Detected: Child Tasks Completed Prior to Parent Verification
+
+While handling the node `story-070-358-orchestrator-strict-completion-e2e`, I encountered a situation where the child tasks (`task-358-407-orchestrator-strict-completion-e2e-impl` and `task-358-408-orchestrator-strict-completion-e2e-qa`) were already located in `.foundry/archive/tasks/` and marked as `COMPLETED`. However, their corresponding tracking checkboxes in the parent story's `Acceptance Criteria` were still unchecked.
+
+This violates the expected state transition flow described in ADR 007 and ADR 009, where a macro node cannot transition to `VERIFYING` until all its children are successfully completed AND its checkboxes are manually marked as checked by an agent.
+
+Because the work is technically finished and the target artifacts are complete, I have manually checked off the remaining boxes in the parent markdown body and will submit an Empty PR to unblock the orchestrator and allow the parent story to properly transition to `COMPLETED` according to the Empty PR Checkbox Policy.
+
+This anomaly suggests a potential timing issue or interruption in a previous session that prevented the parent node from having its markdown updated before the children were archived.

--- a/.foundry/stories/story-070-358-orchestrator-strict-completion-e2e.md
+++ b/.foundry/stories/story-070-358-orchestrator-strict-completion-e2e.md
@@ -27,8 +27,8 @@ Add E2E tests for the orchestrator to ensure strict hierarchical completion logi
 
 ## Acceptance Criteria
 - [x] Implement E2E tests for strict hierarchical completion
-- [ ] task-358-407-orchestrator-strict-completion-e2e-impl
-- [ ] task-358-408-orchestrator-strict-completion-e2e-qa
+- [x] task-358-407-orchestrator-strict-completion-e2e-impl
+- [x] task-358-408-orchestrator-strict-completion-e2e-qa
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
The `task-358-407-orchestrator-strict-completion-e2e-impl` and `task-358-408-orchestrator-strict-completion-e2e-qa` child tasks were completely implemented and archived. However, the overarching story `story-070-358-orchestrator-strict-completion-e2e` remained stuck in an `ACTIVE` state because its markdown `Acceptance Criteria` checkboxes tracking these child nodes were never checked off by the previous session.

This commit safely ticks those boxes and includes a Tech Lead journal entry to unblock the orchestrator and allow the story to correctly transition to `VERIFYING` -> `COMPLETED`, satisfying ADR 007 and ADR 009.

---
*PR created automatically by Jules for task [4572224844960061889](https://jules.google.com/task/4572224844960061889) started by @szubster*