### PR TITLE
Update epic-106-137-gen2-static-encounters.md

### DIFF
--- a/.foundry/epics/epic-106-137-gen2-static-encounters.md
+++ b/.foundry/epics/epic-106-137-gen2-static-encounters.md
@@ -32,7 +32,7 @@ Break down the Gen 2 static encounter checklist into stories.
 - [x] research-137-330-investigate-gen2-event-flag-failure
 - [x] story-137-333-gen2-event-flag-parsing-retry
 - [x] story-137-334-gen2-checklist-ui-retry
-- [ ] story-137-356-gen2-static-encounters-e2e
+- [x] story-137-356-gen2-static-encounters-e2e
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
Check off the final acceptance criteria (`- [x] story-137-356-gen2-static-encounters-e2e`) on the epic node `epic-106-137-gen2-static-encounters.md` because all generated descendant nodes (including the final E2E story and its child QA tasks) have transitioned to `COMPLETED`. This allows the orchestrator to correctly demote the epic to `VERIFYING` without modifying the yaml frontmatter.

---
*PR created automatically by Jules for task [12208666194853430420](https://jules.google.com/task/12208666194853430420) started by @szubster*