### PR TITLE
chore: Verify completed child tasks for story-331-361

### DIFF
--- a/.foundry/journals/tech_lead/2026-08-12-10-29-08.md
+++ b/.foundry/journals/tech_lead/2026-08-12-10-29-08.md
@@ -1,0 +1,9 @@
+# Journal Entry: 2026-08-12
+
+## Anomaly: Child Tasks Completed Prior to Parent Verification Session
+
+When assigned to verify a parent node (in this case, `story-331-361-remove-orphaned-qa-rule-e2e.md`) and transition it from ACTIVE to VERIFYING, I noticed an anomaly where the drafted child tasks (`task-361-407`, `task-361-408`, `task-361-409`) were already marked as `COMPLETED` prior to this session.
+
+As per the DAG orchestration policies, since all child tasks have already transitioned to COMPLETED, the parent node's acceptance criteria checkboxes for these children MUST be explicitly checked off (`- [x]`) before submitting the PR. The Late-Binding Orchestrator Demotion Compliance Rule (which requires leaving boxes unchecked to allow the orchestrator to demote the parent to PENDING) applies *exclusively* to PENDING child tasks, not COMPLETED ones.
+
+Failing to check off the completed children's checkboxes results in a violation of the Macro Node Completion Exception and ADR 007's completeness requirements, preventing the parent node from successfully transitioning to the VERIFYING state. Therefore, it is critical to verify the status of the child tasks (e.g., using `grep "^status:"`) before determining whether to check off their corresponding checkboxes in the parent node's markdown body.

--- a/.foundry/stories/story-331-361-remove-orphaned-qa-rule-e2e.md
+++ b/.foundry/stories/story-331-361-remove-orphaned-qa-rule-e2e.md
@@ -29,6 +29,6 @@ This story acts as the E2E integration test for the removal of the obsolete "Orp
 
 ## Acceptance Criteria
 - [x] Tech Lead: Break down into Tasks
-- [ ] task-361-407-remove-orphaned-qa-rule-e2e-setup
-- [ ] task-361-408-remove-orphaned-qa-rule-e2e-impl
-- [ ] task-361-409-remove-orphaned-qa-rule-e2e-qa
+- [x] task-361-407-remove-orphaned-qa-rule-e2e-setup
+- [x] task-361-408-remove-orphaned-qa-rule-e2e-impl
+- [x] task-361-409-remove-orphaned-qa-rule-e2e-qa


### PR DESCRIPTION
This PR updates the markdown body of `story-331-361-remove-orphaned-qa-rule-e2e.md` to check off the acceptance criteria checkboxes for its child tasks (`task-361-407`, `task-361-408`, `task-361-409`). 

These child tasks have already transitioned to the `COMPLETED` state. As per the DAG orchestration policies, since all child tasks are completed, the parent node's checkboxes must be checked off to satisfy ADR 007's completeness requirements and allow the parent node to successfully transition to `VERIFYING`.

---
*PR created automatically by Jules for task [13433951541555983911](https://jules.google.com/task/13433951541555983911) started by @szubster*