### PR TITLE
feat: draft implementation and qa tasks for zod refactoring

### DIFF
--- a/.foundry/stories/story-335-412-integrate-zod-schema.md
+++ b/.foundry/stories/story-335-412-integrate-zod-schema.md
@@ -23,4 +23,6 @@ rejection_reason: ''
 This story focuses on refactoring `.github/scripts/foundry-orchestrator.ts` to utilize the `NodeFrontmatterSchema` from `schema.ts`. We need to replace all ad-hoc YAML type-checking and manual validation logic. Ensure the orchestrator behaves consistently using the Zod-parsed object.
 
 ## Acceptance Criteria
-- [ ] Break down into Tasks
+- [x] Break down into Tasks
+- [ ] task-412-418-refactor-orchestrator-zod-impl
+- [ ] task-412-419-refactor-orchestrator-zod-qa

--- a/.foundry/tasks/task-412-418-refactor-orchestrator-zod-impl.md
+++ b/.foundry/tasks/task-412-418-refactor-orchestrator-zod-impl.md
@@ -1,0 +1,35 @@
+---
+id: task-412-418-refactor-orchestrator-zod-impl
+type: TASK
+title: Refactor Foundry Orchestrator Zod Types (Impl)
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-12'
+updated_at: '2026-08-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-335-412-integrate-zod-schema
+tags:
+  - foundry
+  - orchestrator
+  - typescript
+  - zod
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Refactor Foundry Orchestrator Zod Types (Implementation)
+
+## Description
+The DAG Orchestrator script (`.github/scripts/foundry-orchestrator.ts`) currently uses some manual `any` casts when interacting with the node frontmatter. The `.github/scripts/schema.ts` file already provides the `NodeFrontmatterSchema` Zod schema and corresponding `NodeFrontmatter` type. We need to replace the `any` casts with properly typed property access.
+
+Specifically:
+- Locate `const fmAny = node.frontmatter as any;` (around line 273/274 in `compilePromptForNode`). Update it to use proper typings, perhaps checking if `layers` exists on the frontmatter type. Note that `layers` was added as an optional array to `NodeFrontmatterSchema` in `schema.ts`.
+- Locate `const item: any = {` (around line 727 in `main`). The output node structure should be correctly typed instead of defaulting to `any`. You can define a specific interface for the extended item output or rely on standard intersection types.
+
+## Acceptance Criteria
+- [ ] Replace `any` casts with proper type usage based on `NodeFrontmatterSchema`.
+- [ ] Ensure that TypeScript compiles successfully (`pnpm type-check` or via your editor) after removing the `any` casts.
+- [ ] Ensure tests pass after the refactoring.

--- a/.foundry/tasks/task-412-419-refactor-orchestrator-zod-qa.md
+++ b/.foundry/tasks/task-412-419-refactor-orchestrator-zod-qa.md
@@ -1,0 +1,32 @@
+---
+id: task-412-419-refactor-orchestrator-zod-qa
+type: TASK
+title: Refactor Foundry Orchestrator Zod Types (QA)
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-12'
+updated_at: '2026-08-12'
+depends_on:
+  - task-412-418-refactor-orchestrator-zod-impl
+jules_session_id: null
+pr_number: null
+parent: story-335-412-integrate-zod-schema
+tags:
+  - foundry
+  - orchestrator
+  - typescript
+  - zod
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Refactor Foundry Orchestrator Zod Types (QA)
+
+## Description
+This is a QA task to verify the refactoring work completed in `task-412-418-refactor-orchestrator-zod-impl`. The orchestrator script (`.github/scripts/foundry-orchestrator.ts`) should no longer use manual `any` casts around node frontmatter variables and data objects.
+
+## Acceptance Criteria
+- [ ] Verify that `any` casts have been removed and replaced with appropriate typings from `NodeFrontmatterSchema`.
+- [ ] Verify that running `cd .github/scripts && npx vitest` completes successfully with no failures.
+- [ ] Verify the codebase successfully type checks.


### PR DESCRIPTION
Drafts `task-412-418-refactor-orchestrator-zod-impl` for the coder persona to replace manual `any` casts with proper type usage based on `NodeFrontmatterSchema`, and `task-412-419-refactor-orchestrator-zod-qa` for the qa persona to verify the work. Appends checklist items to the parent story `story-335-412-integrate-zod-schema`.

---
*PR created automatically by Jules for task [16577579250750351928](https://jules.google.com/task/16577579250750351928) started by @szubster*