### PR TITLE
chore(foundry): Add story owner journal entry for late-binding demotion

### DIFF
--- a/.foundry/journals/story_owner/17691412873561250634.md
+++ b/.foundry/journals/story_owner/17691412873561250634.md
@@ -1,0 +1,7 @@
+# Session 17691412873561250634
+
+## Late-Binding Demotion
+
+When encountering a parent macro node that has pending child nodes located in active directories (like `.foundry/stories/`), even if their internal YAML status is `COMPLETED`, they are treated as pending by the Orchestrator. Therefore, their checkboxes must NOT be checked in the parent node's markdown body.
+
+We must submit an Empty PR (with 0 file changes) to allow the orchestrator to correctly demote the parent to PENDING. This satisfies the Late-Binding Orchestrator Demotion Compliance Rule.


### PR DESCRIPTION
Added a journal entry to document the Late-Binding Demotion lesson. Since the target artifact (story-331-361-remove-orphaned-qa-rule-e2e) is in an active directory, its checkbox is left unchecked and we submit to allow the orchestrator to correctly demote the parent to PENDING.

---
*PR created automatically by Jules for task [17691412873561250634](https://jules.google.com/task/17691412873561250634) started by @szubster*