### PR TITLE
chore: check off story-331-361 in epic-115-331

### DIFF
--- a/.foundry/epics/epic-115-331-remove-orphaned-qa-task-rule-from-docs.md
+++ b/.foundry/epics/epic-115-331-remove-orphaned-qa-task-rule-from-docs.md
@@ -30,4 +30,4 @@ This epic covers scanning the documentation (specifically `core_policies.md` and
 ## Acceptance Criteria
 - [x] Story Owner: Break down this Epic into Stories.
 - [x] story-331-333-remove-orphaned-qa-rule
-- [ ] story-331-361-remove-orphaned-qa-rule-e2e
+- [x] story-331-361-remove-orphaned-qa-rule-e2e


### PR DESCRIPTION
Checking off `story-331-361-remove-orphaned-qa-rule-e2e` in `.foundry/epics/epic-115-331-remove-orphaned-qa-task-rule-from-docs.md` to fulfill the empty PR checkbox policy and allow the DAG to progress, as the target story is completed.

---
*PR created automatically by Jules for task [14264417279972840899](https://jules.google.com/task/14264417279972840899) started by @szubster*