### PR TITLE
chore(foundry): QA rejection of Gen 3 Safari Zone parsing impl

### DIFF
--- a/.foundry/archive/tasks/task-340-341-gen3-safari-zone-state-impl.md
+++ b/.foundry/archive/tasks/task-340-341-gen3-safari-zone-state-impl.md
@@ -2,7 +2,7 @@
 id: task-340-341-gen3-safari-zone-state-impl
 type: TASK
 title: Gen 3 Safari Zone State Parsing Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-25'
 updated_at: '2026-08-09'
@@ -15,8 +15,8 @@ tags:
   - safari-zone
   - gen3
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Architectural violations: usage of inline magic numbers for lengths and offsets in parseGen3PCBuffer and parseGen3PCBoxes, and ignoring RangeError exceptions in PC data parsing.'
 notes: ''
 ---
 

--- a/.foundry/journals/qa/2026-08-12-19-05-51.md
+++ b/.foundry/journals/qa/2026-08-12-19-05-51.md
@@ -1,0 +1,27 @@
+# QA Rejection: Gen 3 Safari Zone State Parsing Implementation
+
+**Session ID**: 2026-08-12-19-05-51
+**Target Task**: `task-340-341-gen3-safari-zone-state-impl`
+**Status**: Rejected (FAILED)
+
+## Architectural Violations
+The implementation for `task-340-341-gen3-safari-zone-state-impl` was rejected due to several violations of the architectural guidelines and contracts established for the codebase.
+
+1. **Inline Magic Numbers**:
+   - `parseGen3PCBuffer`: Hardcoded length values `2000` and `3968` instead of using module-level constants.
+   - `parseGen3PCBoxes`: Hardcoded level value `1` and hardcoded offset addition `2`, `4`, `6` for moves instead of module-level constants.
+   - All memory offsets, lengths, bit locations, and shifts must be defined as reusable constants at the module level (ADR 028).
+
+2. **Swallowed Exceptions (RangeError)**:
+   - `parseGen3PCBuffer`: Did not wrap the `DataView` read inside a `try...catch` block to handle `RangeError`.
+   - Out-of-bounds `DataView` reads that throw `RangeError` must be explicitly caught and re-thrown with the exact message: "The save file is corrupted or incomplete." (as defined in the contract). `parseGen3PCBoxes` does this, but `parseGen3PCBuffer` fails to do so. Also in `parseGen3` where PC boxes are parsed it wraps it in an empty catch `catch {}` which swallows all errors.
+
+## Action Taken
+- Transitioned `task-340-341-gen3-safari-zone-state-impl` to `FAILED` status.
+- Added `rejection_reason` explaining the violations.
+- Incremented `rejection_count`.
+- Left Acceptance Criteria checkboxes as they were (per Transient Rejection policy).
+
+## Guidelines Followed
+- **Triggering Transient Rejections**: Failed the target task without checking off checkboxes in its markdown body.
+- **Strict Architecture Check**: Magic number and `RangeError` handling rules were strictly enforced based on task requirements and schema.

--- a/.foundry/tasks/task-340-342-gen3-safari-zone-state-qa.md
+++ b/.foundry/tasks/task-340-342-gen3-safari-zone-state-qa.md
@@ -39,3 +39,9 @@ Verify the Safari Zone state extraction logic for Gen 3 save files, ensuring com
 - [ ] PC Box data extraction logic is verified.
 - [ ] Encounter calculation is verified.
 - [ ] Architectural directives (constants, relative offsets, RangeError handling) are explicitly verified in the implementation.
+
+### QA Rejection
+Implementation for `task-340-341-gen3-safari-zone-state-impl` has been rejected due to architectural violations:
+- Found inline magic numbers used for block lengths in `parseGen3PCBuffer` (2000, 3968) and move offsets in `parseGen3PCBoxes`.
+- `RangeError` from out-of-bounds `DataView` reads is unhandled in `parseGen3PCBuffer` and silently swallowed in `parseGen3`.
+The target task has been transitioned to `FAILED` and sent back to the coder for fixes.

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Biome
-        uses: biomejs/setup-biome@v2
+        uses: biomejs/setup-biome@v2.2.1
         with:
           version: "2.5.7"
 

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Biome
-        uses: biomejs/setup-biome@v2.2.1
+        uses: biomejs/setup-biome@v2.3.0
         with:
           version: "2.5.7"
 

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Biome
-        uses: biomejs/setup-biome@v2.3.0
+        uses: biomejs/setup-biome@v2
         with:
           version: "2.5.7"
 


### PR DESCRIPTION
The QA agent has verified the Safari Zone state extraction logic for Gen 3 save files and discovered architectural violations in the implementation (task-340-341).

Specifically:
- Hardcoded magic numbers were used for lengths and move offsets instead of module-level constants.
- The required `RangeError` exception handling was swallowed or omitted in PC data parsing functions.

In accordance with system policy:
- The target implementation task has been transitioned to `FAILED`.
- The rejection reason has been appended to the task's YAML.
- Rejection count has been incremented.
- A private QA journal entry (`2026-08-12-19-05-51.md`) has been created documenting the rejection context.
- My own QA task markdown has been updated to note the cycle, while its YAML remains untouched.

This PR serves to persist these markdown changes so the Orchestrator can wake up the Coder and resurrect the implementation task.

---
*PR created automatically by Jules for task [5824405856992562778](https://jules.google.com/task/5824405856992562778) started by @szubster*