### PR TITLE
Story Owner: Break down Orchestrator Fuzzer epic into stories

### DIFF
--- a/.foundry/epics/epic-341-414-orchestrator-fuzzer-core.md
+++ b/.foundry/epics/epic-341-414-orchestrator-fuzzer-core.md
@@ -32,4 +32,6 @@ Integrate a fuzzing framework or property-based testing setup into the existing 
 3. This Epic MUST generate a final STORY dedicated exclusively to Integration and E2E Verification.
 
 ## Acceptance Criteria
-- [ ] Break down into Stories.
+- [x] Break down into Stories.
+- [ ] story-414-418-fuzzing-setup-and-properties
+- [ ] story-414-419-fuzzing-integration-and-e2e

--- a/.foundry/journals/story_owner/2026-08-12-20-22-20.md
+++ b/.foundry/journals/story_owner/2026-08-12-20-22-20.md
@@ -1,0 +1,14 @@
+# Story Owner Journal: Generating Child Nodes and Updating Parents
+
+**Date:** $(date +%Y-%m-%d)
+
+## Context
+When dynamically creating downstream child nodes (e.g., STORY nodes from an EPIC), I need to register them with the parent node by appending them as markdown checkboxes.
+
+## Challenge
+In the past, I used multi-line cat commands wrapped in a bash script to rewrite the entire parent file. This technique incorrectly re-evaluated bash variables (\$(date +%Y-%m-%d)) in the YAML frontmatter, corrupting the parent's updated_at field and failing schema validation (a strict policy violation since frontmatter cannot be modified).
+
+## Solution and Process Change
+Moving forward, when generating child nodes and updating the parent's markdown body via bash scripts, I MUST NOT overwrite the entire parent file using a cat block.
+
+Instead, I MUST strictly use appending (>>) to add the new task list items and targeted stream editors (e.g., sed -i) to update the parent's checkboxes. This guarantees the YAML frontmatter is completely untouched, avoiding Automated Code Review rejections and schema failures.

--- a/.foundry/stories/story-414-418-fuzzing-setup-and-properties.md
+++ b/.foundry/stories/story-414-418-fuzzing-setup-and-properties.md
@@ -1,0 +1,29 @@
+---
+id: story-414-418-fuzzing-setup-and-properties
+type: STORY
+title: Fuzzing Setup and Property Definitions
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-12'
+updated_at: '2026-08-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-341-414-orchestrator-fuzzer-core
+tags:
+  - testing
+  - orchestrator
+  - fuzzing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Fuzzing Setup and Property Definitions
+
+## Objective
+Set up `fast-check` and define the initial set of properties to verify the DAG state evaluation logic.
+
+## Acceptance Criteria
+- [ ] Tasks generated.

--- a/.foundry/stories/story-414-419-fuzzing-integration-and-e2e.md
+++ b/.foundry/stories/story-414-419-fuzzing-integration-and-e2e.md
@@ -1,0 +1,30 @@
+---
+id: story-414-419-fuzzing-integration-and-e2e
+type: STORY
+title: Fuzzing Integration and E2E Verification
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-12'
+updated_at: '2026-08-12'
+depends_on:
+  - story-414-418-fuzzing-setup-and-properties
+jules_session_id: null
+pr_number: null
+parent: epic-341-414-orchestrator-fuzzer-core
+tags:
+  - testing
+  - e2e
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Fuzzing Integration and E2E Verification
+
+## Objective
+Integrate the fuzzing framework into the Vitest suite and write E2E tests to ensure it operates correctly in a CI-like environment.
+
+## Acceptance Criteria
+- [ ] Tasks generated.


### PR DESCRIPTION
This PR breaks down the Orchestrator State Machine Fuzzing epic into two modular STORY nodes and delegates them downstream, including a mandatory integration and E2E verification story.

Changes:
1. Created \`story-414-418-fuzzing-setup-and-properties.md\` for setup and property definitions.
2. Created \`story-414-419-fuzzing-integration-and-e2e.md\` for integration and E2E verification.
3. Appended child references as unchecked markdown checkboxes and marked the acceptance criteria as checked on \`.foundry/epics/epic-341-414-orchestrator-fuzzer-core.md\`.
4. Logged learning about updating parent node files to journal to avoid schema violations.

---
*PR created automatically by Jules for task [8228777541194122892](https://jules.google.com/task/8228777541194122892) started by @szubster*