### PR TITLE
🧩 Story Owner: Breakdown - Orchestrator Fuzzer State Simulation

### DIFF
--- a/.foundry/epics/epic-341-415-orchestrator-fuzzer-simulation.md
+++ b/.foundry/epics/epic-341-415-orchestrator-fuzzer-simulation.md
@@ -33,4 +33,7 @@ Implement logic within the fuzzing framework to generate randomized DAG graphs a
 4. This Epic MUST generate a final STORY dedicated exclusively to Integration and E2E Verification.
 
 ## Acceptance Criteria
-- [ ] Break down into Stories.
+- [x] Break down into Stories.
+- [ ] story-415-415-fuzzer-dag-generation
+- [ ] story-415-416-fuzzer-state-simulation
+- [ ] story-415-417-fuzzer-simulation-e2e

--- a/.foundry/journals/story_owner/2026-08-12-19-06-04.md
+++ b/.foundry/journals/story_owner/2026-08-12-19-06-04.md
@@ -1,0 +1,10 @@
+# Session 2026-08-12-19-06-04
+
+Broke down the `epic-341-415-orchestrator-fuzzer-simulation` into three distinct stories to tackle DAG generation, state simulation, and E2E integration:
+- `story-415-415-fuzzer-dag-generation`
+- `story-415-416-fuzzer-state-simulation`
+- `story-415-417-fuzzer-simulation-e2e`
+
+Notes for Future:
+- When appending generated child nodes to a parent's markdown body, strictly use the exact Node ID without file extensions.
+- Ensuring there's a dedicated E2E verification story for complex features like fuzzing is critical for ensuring orchestration components operate as a cohesive unit.

--- a/.foundry/stories/story-415-415-fuzzer-dag-generation.md
+++ b/.foundry/stories/story-415-415-fuzzer-dag-generation.md
@@ -1,0 +1,37 @@
+---
+id: story-415-415-fuzzer-dag-generation
+type: STORY
+title: Orchestrator Fuzzer - DAG Generation
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-12'
+updated_at: '2026-08-12'
+depends_on:
+  - epic-341-414-orchestrator-fuzzer-core
+jules_session_id: null
+pr_number: null
+parent: epic-341-415-orchestrator-fuzzer-simulation
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Orchestrator Fuzzer - DAG Generation
+
+## Objective
+Implement logic within the fuzzing framework to generate randomized directed acyclic graphs (DAGs).
+
+## Requirements
+1. Implement a generator that produces randomized node structures.
+2. The generator must support varying DAG properties, including depth, width, and random dependency patterns.
+3. Validate that generated graphs are strictly acyclic.
+4. Integrate the DAG generation logic with the fuzzer framework introduced in `epic-341-414-orchestrator-fuzzer-core`.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks.

--- a/.foundry/stories/story-415-416-fuzzer-state-simulation.md
+++ b/.foundry/stories/story-415-416-fuzzer-state-simulation.md
@@ -1,0 +1,37 @@
+---
+id: story-415-416-fuzzer-state-simulation
+type: STORY
+title: Orchestrator Fuzzer - State Transitions & Fault Injection
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-12'
+updated_at: '2026-08-12'
+depends_on:
+  - story-415-415-fuzzer-dag-generation
+jules_session_id: null
+pr_number: null
+parent: epic-341-415-orchestrator-fuzzer-simulation
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Orchestrator Fuzzer - State Transitions & Fault Injection
+
+## Objective
+Simulate node state transitions across the full lifecycle and inject failures, simulate session timeouts/crashes, and test max rejection scenarios during runs.
+
+## Requirements
+1. Implement a state simulator capable of moving randomly generated graphs through their lifecycles.
+2. Simulate valid state transitions (READY, ACTIVE, PENDING, VERIFYING, COMPLETED, FAILED, CANCELLED).
+3. Inject faults randomly: session timeouts, crashes, rejections, and test max rejection behaviors.
+4. Ensure the orchestrator's state machine logic gracefully handles these transitions and anomalies.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks.

--- a/.foundry/stories/story-415-417-fuzzer-simulation-e2e.md
+++ b/.foundry/stories/story-415-417-fuzzer-simulation-e2e.md
@@ -1,0 +1,38 @@
+---
+id: story-415-417-fuzzer-simulation-e2e
+type: STORY
+title: Orchestrator Fuzzer - Simulation E2E & Integration
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-12'
+updated_at: '2026-08-12'
+depends_on:
+  - story-415-416-fuzzer-state-simulation
+jules_session_id: null
+pr_number: null
+parent: epic-341-415-orchestrator-fuzzer-simulation
+tags:
+  - foundry
+  - orchestrator
+  - resilience
+  - testing
+  - e2e
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Orchestrator Fuzzer - Simulation E2E & Integration
+
+## Objective
+Verify the end-to-end functionality of DAG generation and state simulation within the fuzzer framework.
+
+## Requirements
+1. Develop an integration test suite validating that the DAG generation and state transition simulation work together seamlessly.
+2. Confirm the fuzzer accurately represents the behavior of the orchestrator state machine.
+3. Validate that generated tests properly resolve to either complete success or complete failure, asserting on deadlock detection.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks.


### PR DESCRIPTION
# Orchestrator Fuzzer Epic Breakdown

As the Story Owner, I have broken down the `epic-341-415-orchestrator-fuzzer-simulation` node into three downstream `STORY` nodes:
1. `story-415-415-fuzzer-dag-generation`: Tackles generating random Directed Acyclic Graphs.
2. `story-415-416-fuzzer-state-simulation`: Simulates node lifecycles and injects faults/rejections.
3. `story-415-417-fuzzer-simulation-e2e`: The mandatory E2E/Integration test validating the full framework.

All IDs follow the strict schema. The YAML frontmatter for the parent epic remains untouched, and the children were appended to its markdown body successfully. Temporary scratchpads have been cleaned up.

---
*PR created automatically by Jules for task [14983270230859506161](https://jules.google.com/task/14983270230859506161) started by @szubster*