### PR TITLE
Resolve Vite Config Native Loader Warnings

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,11 +9,11 @@ import { VitePWA } from 'vite-plugin-pwa';
 import { browserslistToTargets } from 'lightningcss';
 import browserslist from 'browserslist';
 
-import { pokedataPlugin } from './vite-plugins/pokedata-plugin';
-import { foundryPlugin } from './vite-plugins/foundry-plugin';
+import { pokedataPlugin } from './vite-plugins/pokedata-plugin.ts';
+import { foundryPlugin } from './vite-plugins/foundry-plugin.ts';
 
 export default defineConfig(() => {
-  const sourceDir = path.resolve(__dirname, 'data/db');
+  const sourceDir = path.resolve(import.meta.dirname, 'data/db');
   const target = 'chrome130';
 
   return {
@@ -76,7 +76,7 @@ export default defineConfig(() => {
     ].filter(Boolean),
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, '.'),
+        '@': path.resolve(import.meta.dirname, '.'),
       },
     },
     css: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
-import viteConfigFn from './vite.config';
+import viteConfigFn from './vite.config.ts';
 
 export default defineConfig(async (configEnv) => {
   const baseConfig = typeof viteConfigFn === 'function' 


### PR DESCRIPTION
Vite config loader emits warnings when features unsupported by configLoader 'native' are used. This change replaces __dirname with import.meta.dirname in vite.config.ts, and adds explicit .ts file extensions to local imports in both vite.config.ts and vitest.config.ts to prevent these warnings. All tests pass successfully.

Fixes #6090

---
*PR created automatically by Jules for task [18229361081126863089](https://jules.google.com/task/18229361081126863089) started by @szubster*