### PR TITLE
Resolve Gen 3 Event Flags Circular Dependency

### DIFF
--- a/.foundry/epics/epic-121-404-gen3-e-reader-event-data-extraction.md
+++ b/.foundry/epics/epic-121-404-gen3-e-reader-event-data-extraction.md
@@ -5,7 +5,7 @@ title: Gen 3 E-Reader Event Data Extraction
 status: PENDING
 owner_persona: story_owner
 created_at: '2026-08-06'
-updated_at: '2026-08-09'
+updated_at: '2026-08-12'
 depends_on: []
 jules_session_id: null
 pr_number: null
@@ -33,6 +33,7 @@ This Epic handles the extraction of specific event flags and inventory data from
 ## Acceptance Criteria
 - [x] Break down into STORY nodes for extraction logic and data structuring.
 - [x] Generate a final STORY dedicated exclusively to Integration and E2E Verification.
+- [ ] research-408-415-gen3-event-flags-bit-indices
 - [ ] story-404-408-gen3-event-flags-extraction
 - [ ] story-404-409-gen3-event-inventory-extraction
 - [ ] story-404-410-gen3-e-reader-data-e2e

--- a/.foundry/research/research-408-415-gen3-event-flags-bit-indices.md
+++ b/.foundry/research/research-408-415-gen3-event-flags-bit-indices.md
@@ -2,21 +2,21 @@
 id: research-408-415-gen3-event-flags-bit-indices
 type: RESEARCH
 title: Research Gen 3 Event Flags Bit Indices
-status: FAILED
+status: PENDING
 owner_persona: researcher
 created_at: '2026-08-10'
 updated_at: '2026-08-12'
 depends_on: []
 jules_session_id: null
 pr_number: null
-parent: story-404-408-gen3-event-flags-extraction
+parent: epic-121-404-gen3-e-reader-event-data-extraction
 tags:
   - gen3
   - extraction
   - research
 research_references: []
 rejection_count: 0
-rejection_reason: Circular dependency detected
+rejection_reason: ''
 notes: ''
 ---
 

--- a/.foundry/stories/story-404-408-gen3-event-flags-extraction.md
+++ b/.foundry/stories/story-404-408-gen3-event-flags-extraction.md
@@ -2,7 +2,7 @@
 id: story-404-408-gen3-event-flags-extraction
 type: STORY
 title: Gen 3 Event Flags Extraction Logic
-status: FAILED
+status: PENDING
 owner_persona: tech_lead
 created_at: '2026-08-08'
 updated_at: '2026-08-12'
@@ -16,7 +16,7 @@ tags:
   - extraction
 research_references: []
 rejection_count: 2
-rejection_reason: Circular dependency detected
+rejection_reason: ''
 notes: ''
 ---
 


### PR DESCRIPTION
This submission resolves the circular dependency warning reported by the Foundry DAG orchestrator:
`[orchestrator] WARN  Detected circular dependency: .foundry/research/research-408-415-gen3-event-flags-bit-indices.md -> .foundry/stories/story-404-408-gen3-event-flags-extraction.md -> .foundry/research/research-408-415-gen3-event-flags-bit-indices.md`

We resolved this by reparenting the research node to its grandparent Epic instead of the parent Story. This breaks the parent-child loop because a story cannot start until its child (research) completes, but a child is blocked by the orchestrator if its parent (story) is pending. Moving the parent reference to the Epic permits the research node to be promoted and completed first, unblocking the story. We also reset the failed statuses to PENDING and added the research node to the Epic's acceptance criteria.

Fixes #6094

---
*PR created automatically by Jules for task [17697267128530656677](https://jules.google.com/task/17697267128530656677) started by @szubster*