### PR TITLE
Foundry: Complete QA for task-408-418-schema-role-mapping-qa

### DIFF
--- a/.foundry/journals/qa/2026-08-12-21-17-31.md
+++ b/.foundry/journals/qa/2026-08-12-21-17-31.md
@@ -1,0 +1,8 @@
+# QA Journal Entry
+
+## Verified Task
+task-408-418-schema-role-mapping-qa
+
+## Learnings & Observations
+- The `test_list.sh` scratchpad file must be removed before PR creation.
+- Checked off the Markdown box for the empty PR rule safely without modifying YAML frontmatter.

--- a/.foundry/tasks/task-408-418-schema-role-mapping-qa.md
+++ b/.foundry/tasks/task-408-418-schema-role-mapping-qa.md
@@ -33,4 +33,4 @@ Verify the updates made to `.foundry/docs/schema.md` regarding the mappings of t
 - Ensure strict adherence to Generation 1 Pokemon (no Pokemon from later generations).
 
 ## Acceptance Criteria
-- [ ] QA: Verify `.foundry/docs/schema.md` has been correctly updated with Gen 1 mappings for all 13 system roles.
+- [x] QA: Verify `.foundry/docs/schema.md` has been correctly updated with Gen 1 mappings for all 13 system roles.


### PR DESCRIPTION
Checked off acceptance criteria confirming Gen 1 mapping updates.

---
*PR created automatically by Jules for task [16334656260523065090](https://jules.google.com/task/16334656260523065090) started by @szubster*