### PR TITLE
Draft task blueprints for Gen 3 Move Tutor parsing

### DIFF
--- a/.foundry/journals/tech_lead/17030692349781794310.md
+++ b/.foundry/journals/tech_lead/17030692349781794310.md
@@ -1,0 +1,2 @@
+# Session 17030692349781794310
+- When troubleshooting or targeting specific tests, ensure you do not mistakenly target Vitest unit tests (e.g., `src/*.test.ts`) with the Playwright test command (`pnpm test:e2e`), as this will result in a 'No tests found' error.

--- a/.foundry/stories/story-406-412-gen3-move-tutor-parsing-core.md
+++ b/.foundry/stories/story-406-412-gen3-move-tutor-parsing-core.md
@@ -42,3 +42,6 @@ The parsing implementation must use `DataView` for all byte reading, as per ADR 
 - [ ] The core extraction logic uses `DataView`.
 - [ ] Logic gracefully handles `RangeError` during out-of-bounds `DataView` access.
 - [ ] Unit tests cover parsing valid and malformed structures for both game versions.
+- [ ] task-412-422-gen3-move-tutor-constants
+- [ ] task-412-423-gen3-move-tutor-extractor
+- [ ] task-412-424-gen3-move-tutor-qa

--- a/.foundry/tasks/task-412-422-gen3-move-tutor-constants.md
+++ b/.foundry/tasks/task-412-422-gen3-move-tutor-constants.md
@@ -1,0 +1,43 @@
+---
+id: task-412-422-gen3-move-tutor-constants
+type: TASK
+title: Gen 3 Move Tutor Constants Implementation
+status: READY
+owner_persona: coder
+created_at: '2026-08-12'
+updated_at: '2026-08-12'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-406-412-gen3-move-tutor-parsing-core
+tags:
+  - feature
+  - gen3
+  - save-parsing
+  - constants
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 3 Move Tutor Constants Implementation
+
+## Objective
+Define the necessary module-level constants for Gen 3 one-time Move Tutor event flags according to the specifications in `.foundry/docs/knowledge_base/gen3_move_tutor_offsets.md`.
+
+## Context
+Move Tutor availability is determined by specific bit flags stored in the `SaveBlock1` event flags array. We must avoid magic numbers in the parsing logic by explicitly defining these flags, byte offsets, and bit positions for both Emerald and FireRed/LeafGreen.
+Section 13 of `.foundry/docs/schema.md` states: "All memory offsets, lengths, bit locations, shifts, and array bounds checking limits must be explicitly defined as reusable constants at the module level." and "No Magic Numbers".
+
+## Requirements
+1. Implement constants for Move Tutor event flags for Emerald based on `.foundry/docs/knowledge_base/gen3_move_tutor_offsets.md` (e.g., Swagger, Rollout, Fury Cutter, etc., with their respective byte offset and bit position from the base Event Flags offset).
+2. Implement constants for Move Tutor event flags for FireRed/LeafGreen based on `.foundry/docs/knowledge_base/gen3_move_tutor_offsets.md` (e.g., Double-Edge, Thunder Wave, etc., with their respective byte offset and bit position).
+3. The base offset for Emerald's event flags (`0x1270` within `SaveBlock1`) and the FireRed/LeafGreen equivalents must be properly defined.
+4. All constants must be defined at the module level to avoid magic numbers in parsing logic.
+5. Write unit tests to ensure these constants are correct.
+
+## Acceptance Criteria
+- [ ] Module-level constants for Emerald Move Tutor flags are correctly defined.
+- [ ] Module-level constants for FireRed/LeafGreen Move Tutor flags are correctly defined.
+- [ ] Base event flag offsets for `SaveBlock1` are defined.
+- [ ] Unit tests are passing for these constants.

--- a/.foundry/tasks/task-412-423-gen3-move-tutor-extractor.md
+++ b/.foundry/tasks/task-412-423-gen3-move-tutor-extractor.md
@@ -1,0 +1,45 @@
+---
+id: task-412-423-gen3-move-tutor-extractor
+type: TASK
+title: Gen 3 Move Tutor Extractor Implementation
+status: READY
+owner_persona: coder
+created_at: '2026-08-12'
+updated_at: '2026-08-12'
+depends_on:
+  - task-412-422-gen3-move-tutor-constants
+jules_session_id: null
+pr_number: null
+parent: story-406-412-gen3-move-tutor-parsing-core
+tags:
+  - feature
+  - gen3
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 3 Move Tutor Extractor Implementation
+
+## Objective
+Implement extraction functions using `DataView` to parse the status of each Gen 3 one-time Move Tutor.
+
+## Context
+Move Tutor availability is determined by specific bit flags stored in the `SaveBlock1` event flags array. The previous task implemented the constants for these flags.
+As per ADR 010, the parsing implementation must use `DataView` for all byte reading. Section 13 of `.foundry/docs/schema.md` states: "When extracting Gen 3 save blocks, you must pass and utilize the resolved section offset (e.g., `section1Offset` or `section2Offset`) to calculate relative memory offsets rather than absolute hardcoded offsets...". It also states: "When using the `DataView` API, you MUST catch `RangeError` for out-of-bounds reads and throw a new error with the message 'The save file is corrupted or incomplete.'".
+
+## Requirements
+1. Implement a function to extract the one-time Move Tutor status for Emerald. It must take a `DataView` and the resolved section offset for `SaveBlock1`.
+2. Implement a function to extract the one-time Move Tutor status for FireRed/LeafGreen. It must take a `DataView` and the resolved section offset for `SaveBlock1`.
+3. The functions must use the constants defined in the previous task.
+4. The functions must catch `RangeError` from the `DataView` API and throw a new error with the message "The save file is corrupted or incomplete.".
+5. Write unit tests to cover parsing valid structures for both game versions.
+6. Write unit tests to cover parsing malformed structures (out-of-bounds `DataView` access) for both game versions to ensure `RangeError` is handled properly.
+
+## Acceptance Criteria
+- [ ] Extraction function for Emerald is correctly implemented using `DataView` and relative offsets.
+- [ ] Extraction function for FireRed/LeafGreen is correctly implemented using `DataView` and relative offsets.
+- [ ] Both functions catch `RangeError` and throw the expected error message.
+- [ ] Unit tests cover parsing valid structures for both games.
+- [ ] Unit tests cover parsing malformed structures (out-of-bounds) for both games.

--- a/.foundry/tasks/task-412-424-gen3-move-tutor-qa.md
+++ b/.foundry/tasks/task-412-424-gen3-move-tutor-qa.md
@@ -1,0 +1,44 @@
+---
+id: task-412-424-gen3-move-tutor-qa
+type: TASK
+title: Gen 3 Move Tutor Extractor QA Verification
+status: READY
+owner_persona: qa
+created_at: '2026-08-12'
+updated_at: '2026-08-12'
+depends_on:
+  - task-412-423-gen3-move-tutor-extractor
+jules_session_id: null
+pr_number: null
+parent: story-406-412-gen3-move-tutor-parsing-core
+tags:
+  - qa
+  - gen3
+  - save-parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 3 Move Tutor Extractor QA Verification
+
+## Objective
+Verify the correctness of the Gen 3 one-time Move Tutor extraction implementation and ensure strict adherence to ADR 010 and Section 13 of `.foundry/docs/schema.md`.
+
+## Context
+As per the Intelligent Verification Protocol, a QA task is needed due to the strictness of the bitwise operations and relative memory offset handling. We must ensure no regressions and full compliance with architecture rules.
+
+## Requirements
+1. Review the constants module to ensure all flags, byte offsets, and bit positions are correct and match `.foundry/docs/knowledge_base/gen3_move_tutor_offsets.md`.
+2. Ensure there are no magic numbers used in the parsing logic.
+3. Review the extraction functions to confirm they strictly use `DataView` and compute offsets relative to the `SaveBlock1` section offset.
+4. Verify that `RangeError` is caught during out-of-bounds `DataView` access and the exact error message "The save file is corrupted or incomplete." is thrown.
+5. Review the test suite to ensure comprehensive coverage for both valid and malformed save structures for both Emerald and FireRed/LeafGreen.
+6. Verify no architectural rules were broken in the implementation.
+
+## Acceptance Criteria
+- [ ] Constants are correct and match specifications.
+- [ ] No magic numbers are used in parsing.
+- [ ] `DataView` and relative offsets are strictly used.
+- [ ] `RangeError` is handled correctly with the specified error message.
+- [ ] Unit tests are comprehensive and pass.


### PR DESCRIPTION
Drafted three actionable task nodes for the Gen 3 Move Tutor Parsing Core story:
1. `task-412-422-gen3-move-tutor-constants`: Defines bitwise and offset constants, avoiding magic numbers.
2. `task-412-423-gen3-move-tutor-extractor`: Defines extraction logic using DataView and relative offsets.
3. `task-412-424-gen3-move-tutor-qa`: QA task to enforce Intelligent Verification Protocol on strict bitwise and schema rules.

Appended these to the parent STORY (`story-406-412`) as unchecked items to prevent premature orchestration. All tests pass, zero architectural violations.

---
*PR created automatically by Jules for task [17030692349781794310](https://jules.google.com/task/17030692349781794310) started by @szubster*