### PR TITLE
feat: Implement Gen 3 Trainer Flags Integration Tests

### DIFF
--- a/.foundry/journals/coder/9435376775466367264.md
+++ b/.foundry/journals/coder/9435376775466367264.md
@@ -1,0 +1,3 @@
+# Session 9435376775466367264
+
+When modifying files using bash utilities like `patch` or `sed`, ensure all temporary artifacts such as `.diff`, `.orig`, and `.rej` files are completely deleted from the repository before executing pre-commit steps or requesting code review to avoid repository hygiene rejections.

--- a/.foundry/tasks/task-408-415-gen3-trainer-flags-integration-impl.md
+++ b/.foundry/tasks/task-408-415-gen3-trainer-flags-integration-impl.md
@@ -30,6 +30,6 @@ Implement integration tests for the Gen 3 Trainer Flags Extraction logic to ensu
 3. **Environment**: Utilize the established vitest setup in the repository for integration tests.
 
 ## Acceptance Criteria
-- [ ] Implement integration tests verifying Gen 3 standard trainer defeat flag extractions.
-- [ ] Implement integration tests verifying Gen 3 rematch trainer flag extractions.
-- [ ] Ensure all tests pass in the CI environment (`pnpm test`).
+- [x] Implement integration tests verifying Gen 3 standard trainer defeat flag extractions.
+- [x] Implement integration tests verifying Gen 3 rematch trainer flag extractions.
+- [x] Ensure all tests pass in the CI environment (`pnpm test`).

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -358,6 +358,10 @@ export interface SaveData {
   gen3TMEventFlags?: Record<string, boolean>;
   /** Gen 3 specific: Static encounters completion flags */
   gen3StaticEncounters?: Gen3StaticEncounters;
+  /** Gen 3 specific: Standard trainer defeat flags */
+  gen3TrainerDefeatFlags?: boolean[];
+  /** Gen 3 specific: Rematch trainer state flags */
+  gen3TrainerRematchFlags?: number[];
 }
 
 // Removed byte helper as DataView provides getUint8 natively.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -1931,3 +1931,96 @@ describe('Gen3 PC Box Parsing', () => {
     expect(saveData.pcDetails[0]?.moves).toContain(33);
   });
 });
+
+describe('parseGen3 (trainer flags integration)', () => {
+  const initMockSectionsLocal = (view: DataView) => {
+    const section0Offset = 0;
+    view.setUint32(section0Offset + 4088, 0x08012025, true);
+    view.setUint16(section0Offset + 4084, 0, true);
+    view.setUint32(section0Offset + 4092, 1, true);
+
+    const section1Offset = 4096;
+    view.setUint32(section1Offset + 4088, 0x08012025, true);
+    view.setUint16(section1Offset + 4084, 1, true);
+    view.setUint32(section1Offset + 4092, 1, true);
+
+    const section2Offset = 8192;
+    view.setUint32(section2Offset + 4088, 0x08012025, true);
+    view.setUint16(section2Offset + 4084, 2, true);
+    view.setUint32(section2Offset + 4092, 1, true);
+  };
+
+  const initMockSaveBlock1 = (view: DataView) => {
+    // Section 1 offsets: we use sector index 1 mapping to saveblock1 offset
+    // Let's place sector 1 at offset 4096 (1 * 4096)
+    const block1Offset = 1 * 4096;
+
+    // Emerald base flags offset is 0x1270, RS is 0x1220, FRLG is 0x0ee0
+    // Emerald max trainers 864, RS 693, FRLG 768
+    // We will test emerald and ruby.
+
+    // For Emerald: RSE_FLAGS_OFFSET_E + TRAINER_FLAGS_BYTE_OFFSET = 0x1270 + 0xa0 = 0x1310
+    const emeraldFlagsOffset = block1Offset + 0x1310;
+    if (emeraldFlagsOffset + Math.ceil(864 / 8) < view.byteLength) {
+      view.setUint8(emeraldFlagsOffset, 0b00000001); // Trainer 0 defeated
+      view.setUint8(emeraldFlagsOffset + 107, 0b10000000); // Trainer 863 defeated
+    }
+
+    // For Emerald rematch: REMATCH_OFFSET_E = 0x09ca
+    const emeraldRematchOffset = block1Offset + 0x09ca;
+    if (emeraldRematchOffset + 100 < view.byteLength) {
+      view.setUint8(emeraldRematchOffset, 5); // Entry 0
+      view.setUint8(emeraldRematchOffset + 99, 12); // Entry 99
+    }
+
+    // For Ruby: RSE_FLAGS_OFFSET_RS + TRAINER_FLAGS_BYTE_OFFSET = 0x1220 + 0xa0 = 0x12c0
+    const rubyFlagsOffset = block1Offset + 0x12c0;
+    if (rubyFlagsOffset + Math.ceil(693 / 8) < view.byteLength) {
+      view.setUint8(rubyFlagsOffset, 0b00000010); // Trainer 1 defeated
+    }
+
+    // For Ruby rematch: REMATCH_OFFSET_RS = 0x097a
+    const rubyRematchOffset = block1Offset + 0x097a;
+    if (rubyRematchOffset + 100 < view.byteLength) {
+      view.setUint8(rubyRematchOffset, 3); // Entry 0
+    }
+  };
+
+  it('should successfully attach trainer defeat and rematch flags to the SaveData for emerald', () => {
+    const buffer = new ArrayBuffer(57344);
+    const view = new DataView(buffer);
+    initMockSectionsLocal(view);
+    initMockSaveBlock1(view);
+
+    const result = parseGen3(view, 'emerald');
+
+    expect(result.gen3TrainerDefeatFlags).toBeDefined();
+    expect(result.gen3TrainerDefeatFlags?.length).toBe(864);
+    expect(result.gen3TrainerDefeatFlags?.[0]).toBe(true);
+    expect(result.gen3TrainerDefeatFlags?.[1]).toBe(false);
+    expect(result.gen3TrainerDefeatFlags?.[863]).toBe(true);
+
+    expect(result.gen3TrainerRematchFlags).toBeDefined();
+    expect(result.gen3TrainerRematchFlags?.length).toBe(100);
+    expect(result.gen3TrainerRematchFlags?.[0]).toBe(5);
+    expect(result.gen3TrainerRematchFlags?.[99]).toBe(12);
+  });
+
+  it('should successfully attach trainer defeat and rematch flags to the SaveData for ruby', () => {
+    const buffer = new ArrayBuffer(57344);
+    const view = new DataView(buffer);
+    initMockSectionsLocal(view);
+    initMockSaveBlock1(view);
+
+    const result = parseGen3(view, 'ruby');
+
+    expect(result.gen3TrainerDefeatFlags).toBeDefined();
+    expect(result.gen3TrainerDefeatFlags?.length).toBe(693);
+    expect(result.gen3TrainerDefeatFlags?.[0]).toBe(false);
+    expect(result.gen3TrainerDefeatFlags?.[1]).toBe(true);
+
+    expect(result.gen3TrainerRematchFlags).toBeDefined();
+    expect(result.gen3TrainerRematchFlags?.length).toBe(100);
+    expect(result.gen3TrainerRematchFlags?.[0]).toBe(3);
+  });
+});

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -29,6 +29,7 @@ import {
   parseGen3TotalBattlePoints,
 } from '../gen3/battleFrontier/parser';
 import { parseGen3Pokeblocks } from '../gen3/pokeblock/parser';
+import { parseGen3TrainerDefeatFlags, parseGen3TrainerRematchFlags } from '../gen3/trainerFlags/parser';
 import { parseTrickHouse } from '../gen3/trickHouse/parser';
 import type {
   GameVersion,
@@ -1342,6 +1343,24 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       }
     }
 
+    let gen3TrainerDefeatFlags: boolean[] | undefined;
+    let gen3TrainerRematchFlags: number[] | undefined;
+
+    if (
+      _forcedVersion === 'ruby' ||
+      _forcedVersion === 'sapphire' ||
+      _forcedVersion === 'emerald' ||
+      _forcedVersion === 'firered' ||
+      _forcedVersion === 'leafgreen'
+    ) {
+      try {
+        gen3TrainerDefeatFlags = parseGen3TrainerDefeatFlags(view, section1Offset, _forcedVersion);
+        gen3TrainerRematchFlags = parseGen3TrainerRematchFlags(view, section1Offset, _forcedVersion);
+      } catch {
+        // Ignored
+      }
+    }
+
     const { trainerId, secretId } = parseGen3TrainerId(view, section0Offset);
     const securityKey = parseGen3SecurityKey(view, section0Offset, _forcedVersion || 'ruby');
     const gen3TMHMs = parseGen3TMHMs(view, section1Offset, _forcedVersion || 'ruby', securityKey);
@@ -1470,6 +1489,12 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     if (gen3NPCTrades !== undefined) {
       result.gen3NPCTrades = gen3NPCTrades;
       result.npcTradeFlags = Object.values(gen3NPCTrades);
+    }
+    if (gen3TrainerDefeatFlags !== undefined) {
+      result.gen3TrainerDefeatFlags = gen3TrainerDefeatFlags;
+    }
+    if (gen3TrainerRematchFlags !== undefined) {
+      result.gen3TrainerRematchFlags = gen3TrainerRematchFlags;
     }
     return result;
   } catch (error) {


### PR DESCRIPTION
This PR resolves `#task-408-415-gen3-trainer-flags-integration-impl`.

- Updated `SaveData` interface to include `gen3TrainerDefeatFlags` and `gen3TrainerRematchFlags`.
- Imported and utilized `parseGen3TrainerDefeatFlags` and `parseGen3TrainerRematchFlags` in the `parseGen3` core parser logic.
- Implemented corresponding integration tests verifying the extraction.

---
*PR created automatically by Jules for task [9435376775466367264](https://jules.google.com/task/9435376775466367264) started by @szubster*