### PR TITLE
Tech Lead: Decompose Schema Locks Story

### DIFF
--- a/.foundry/stories/story-411-418-schema-resource-locking.md
+++ b/.foundry/stories/story-411-418-schema-resource-locking.md
@@ -29,4 +29,7 @@ Implement schema updates to introduce the `locks` field into the Foundry DAG orc
 - Update `.github/scripts/schema.ts` to validate this field as an array of strings.
 
 ## Acceptance Criteria
-- [ ] Tech Lead breaks down this STORY into TASK nodes for implementation.
+- [x] Tech Lead breaks down this STORY into TASK nodes for implementation.
+- [ ] task-418-422-document-locks-schema
+- [ ] task-418-423-implement-locks-zod
+- [ ] task-418-424-schema-locks-qa

--- a/.foundry/tasks/task-418-422-document-locks-schema.md
+++ b/.foundry/tasks/task-418-422-document-locks-schema.md
@@ -1,0 +1,33 @@
+---
+id: task-418-422-document-locks-schema
+type: TASK
+title: Document Schema Resource Locking
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-411-418-schema-resource-locking
+tags:
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Document Schema Resource Locking
+
+## Objective
+Document the new `locks` array field in the Foundry DAG orchestrator schema to prevent execution data loss and git merge conflicts in concurrent multi-agent environments.
+
+## Details
+- Update `.foundry/docs/schema.md` to add the `locks` field.
+- The `locks` field should be documented as an optional array of strings.
+- It will be used to hold resource identifiers (like persona names or specific areas of the application) that a given node requires exclusive access to during execution.
+
+## Acceptance Criteria
+- [ ] Coder updates `.foundry/docs/schema.md` to document the `locks` array field.

--- a/.foundry/tasks/task-418-423-implement-locks-zod.md
+++ b/.foundry/tasks/task-418-423-implement-locks-zod.md
@@ -1,0 +1,33 @@
+---
+id: task-418-423-implement-locks-zod
+type: TASK
+title: Implement Schema Resource Locking in Zod
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on:
+  - task-418-422-document-locks-schema
+jules_session_id: null
+pr_number: null
+parent: story-411-418-schema-resource-locking
+tags:
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Schema Resource Locking in Zod
+
+## Objective
+Update `.github/scripts/schema.ts` to implement Zod validation for the new `locks` field.
+
+## Details
+- Update the `NodeFrontmatterSchema` in `.github/scripts/schema.ts`.
+- Add `locks: z.array(z.string()).optional()` to the schema object.
+
+## Acceptance Criteria
+- [ ] Coder updates `.github/scripts/schema.ts` to validate the `locks` field as an array of strings.

--- a/.foundry/tasks/task-418-424-schema-locks-qa.md
+++ b/.foundry/tasks/task-418-424-schema-locks-qa.md
@@ -1,0 +1,34 @@
+---
+id: task-418-424-schema-locks-qa
+type: TASK
+title: QA Schema Resource Locking
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-11'
+updated_at: '2026-08-11'
+depends_on:
+  - task-418-423-implement-locks-zod
+jules_session_id: null
+pr_number: null
+parent: story-411-418-schema-resource-locking
+tags:
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Schema Resource Locking
+
+## Objective
+Verify the schema documentation and Zod implementation for the `locks` array field.
+
+## Details
+- Verify that `.foundry/docs/schema.md` properly documents the new `locks` field as an array of strings.
+- Verify that `NodeFrontmatterSchema` in `.github/scripts/schema.ts` correctly validates the `locks` field as an array of strings (`z.array(z.string()).optional()`).
+
+## Acceptance Criteria
+- [ ] QA verifies schema documentation.
+- [ ] QA verifies Zod implementation.


### PR DESCRIPTION
Breaks down the STORY for schema resource locks into three distinct TASK nodes (document, implement, QA), assigning the proper personas and avoiding DAG deadlocks. Also correctly updates the STORY node acceptance criteria.

---
*PR created automatically by Jules for task [4135588043217249821](https://jules.google.com/task/4135588043217249821) started by @szubster*