### PR TITLE
🖼️ Canvas: PokedexCard Target Acquisition Redesign

### DIFF
--- a/.jules/canvas/pokedex_card_redesign.md
+++ b/.jules/canvas/pokedex_card_redesign.md
@@ -1,0 +1,5 @@
+## 2025-02-12 - [Accepted] - 🖼️ Canvas: PokedexCard Target Acquisition Redesign
+**What:** Redesigned the `PokedexCard` component to align with the "tactical hardware" and "snooping" aesthetic. Replaced plain solid borders with layered cyan/emerald/amber dashed frames, added hover effects simulating a matrix target lock (glitch overlays, spinning crosshairs, intense scanlines), and refactored the right-side data container to include dynamic status bars and hex stream overlays on hover. Replaced generic `NO.` with `ID.` for increased tactical flavor.
+**Outcome:** Accepted -> wait for review
+**Why:** The original `PokedexCard` lacked depth and felt generic compared to components like `SearchAndFilters`. This change grounds the card visually in the broader terminal OS theme.
+**Pattern:** For interactive display cards, rely on layered dashed frames, raw data streams (hex/binary), and mechanical hover animations (e.g., crosshairs or pulsing LEDs) rather than generic UI scales or shadows. Ensure custom animations referenced in Tailwind arbitrary values are explicitly defined in `index.css`.

--- a/src/components/PokedexCard.tsx
+++ b/src/components/PokedexCard.tsx
@@ -80,6 +80,10 @@ export const PokedexCard = React.memo(function PokedexCard({
   const { inParty, inPC, hasInStorage, isOwnedInDex, isSeenInDex, isUnseen, isSeenNotOwned, isShiny, variant } =
     getPokemonStatusFlags(pokemon.id, saveData, isLivingDex, partySet, pcSet, shinySpeciesIds);
 
+  // Derive isOwned and isSeen from the status flags
+  const isOwned = isOwnedInDex || hasInStorage;
+  const isSeen = isSeenInDex || isOwned || hasInStorage;
+
   return (
     <TacticalCard
       ariaLabel={`View details for ${pokemon.name}`}
@@ -89,13 +93,41 @@ export const PokedexCard = React.memo(function PokedexCard({
       onClick={() => navigate({ to: `/pokemon/${pokemon.id}`, search: { from: '/' } })}
       variant={variant}
       style={{ animationDelay: `${(idx % 20) * 0.02}s` }}
-      className="!p-0"
+      className={cn(
+        '!p-0 group/card relative overflow-hidden',
+        variant === 'emerald'
+          ? 'border-emerald-500/50'
+          : variant === 'amber'
+            ? 'border-amber-500/50'
+            : 'border-cyan-500/30',
+      )}
     >
-      <div className="flex h-full w-full flex-row">
+      {/* Decorative Target Lock overlay on hover */}
+      <div className="pointer-events-none absolute inset-0 z-20 border-[1px] border-cyan-400/0 transition-colors duration-300 group-hover/card:border-cyan-400/30 group-focus-visible/card:border-cyan-400/30">
+        <div className="absolute top-1 left-1 h-2 w-2 border-cyan-400/0 border-t border-l transition-colors duration-300 group-hover/card:border-cyan-400/80 group-focus-visible/card:border-cyan-400/80" />
+        <div className="absolute top-1 right-1 h-2 w-2 border-cyan-400/0 border-t border-r transition-colors duration-300 group-hover/card:border-cyan-400/80 group-focus-visible/card:border-cyan-400/80" />
+        <div className="absolute bottom-1 left-1 h-2 w-2 border-cyan-400/0 border-b border-l transition-colors duration-300 group-hover/card:border-cyan-400/80 group-focus-visible/card:border-cyan-400/80" />
+        <div className="absolute right-1 bottom-1 h-2 w-2 border-cyan-400/0 border-r border-b transition-colors duration-300 group-hover/card:border-cyan-400/80 group-focus-visible/card:border-cyan-400/80" />
+      </div>
+
+      <div className="relative z-10 flex h-full w-full flex-row">
         {/* Sprite Container - Left Side */}
-        <div className="relative flex aspect-square h-24 w-24 shrink-0 items-center justify-center overflow-hidden border-zinc-800 border-r border-dashed bg-black/40 transition-colors group-hover:bg-black/60">
-          {/* LCD Grid Background */}
-          <LcdGrid className="opacity-[0.05]" />
+        <div
+          className={cn(
+            'relative flex aspect-square h-24 w-24 shrink-0 items-center justify-center overflow-hidden border-r border-dashed bg-black/40 transition-colors group-hover/card:bg-black/60',
+            variant === 'emerald'
+              ? 'border-emerald-900'
+              : variant === 'amber'
+                ? 'border-amber-900'
+                : 'border-cyan-900/50',
+          )}
+        >
+          {/* Enhanced LCD Grid Background */}
+          <LcdGrid className="opacity-[0.05] transition-opacity group-hover/card:opacity-[0.1]" />
+
+          {/* Glitch Overlay on Hover */}
+          <div className="pointer-events-none absolute inset-0 z-0 bg-[repeating-linear-gradient(0deg,transparent,transparent_2px,rgba(34,211,238,0.05)_2px,rgba(34,211,238,0.05)_4px)] opacity-0 transition-opacity duration-300 group-hover/card:opacity-100" />
+          <div className="pointer-events-none absolute inset-0 z-0 opacity-0 mix-blend-overlay transition-opacity duration-300 group-hover/card:animate-[pulse_1s_cubic-bezier(0.4,0,0.6,1)_infinite] group-hover/card:bg-cyan-900/20 group-hover/card:opacity-100" />
 
           {isShiny && (
             <div className="absolute top-1 left-1 z-10 animate-[spin_4s_linear_infinite] text-amber-400 drop-shadow-[0_0_8px_rgba(251,191,36,0.5)]">
@@ -109,6 +141,10 @@ export const PokedexCard = React.memo(function PokedexCard({
 
           <HoverScanner />
 
+          {/* Matrix Targeting Ring (Appears on Hover) */}
+          <div className="absolute inset-2 rounded-full border border-cyan-500/0 opacity-0 transition-all duration-500 group-hover/card:animate-[spin_4s_linear_infinite] group-hover/card:border-cyan-500/30 group-hover/card:opacity-100" />
+          <div className="absolute inset-4 rounded-full border border-cyan-400/0 border-dashed opacity-0 transition-all duration-500 group-hover/card:animate-[spin_3s_linear_infinite_reverse] group-hover/card:border-cyan-400/20 group-hover/card:opacity-100" />
+
           <PokemonSprite
             pokemonId={pokemon.id}
             generation={saveData?.generation ?? 1}
@@ -120,40 +156,89 @@ export const PokedexCard = React.memo(function PokedexCard({
                 ? 'opacity-10 brightness-0'
                 : isSeenNotOwned
                   ? 'opacity-50 grayscale'
-                  : 'drop-shadow-[0_0_15px_rgba(255,255,255,0.1)] group-hover:scale-110',
+                  : 'drop-shadow-[0_0_15px_rgba(255,255,255,0.1)] group-hover/card:scale-110 group-hover/card:drop-shadow-[0_0_20px_rgba(34,211,238,0.3)]',
             )}
           />
 
-          {/* Scanline overlay for sprite */}
-          <ScanlineOverlay opacityClass="opacity-20" />
+          {/* Extra intense scanline on hover */}
+          <ScanlineOverlay opacityClass="opacity-20 group-hover/card:opacity-40" />
         </div>
 
         {/* Data Container - Right Side */}
-        <div className="flex flex-1 flex-col justify-between">
-          <div className="flex flex-col gap-1 p-2">
+        <div className="relative flex flex-1 flex-col justify-between overflow-hidden">
+          {/* Data stream overlay on right side on hover */}
+          <div className="pointer-events-none absolute inset-0 z-0 flex flex-col justify-end p-2 opacity-0 transition-opacity duration-300 group-hover/card:opacity-5">
+            <div className="break-all font-mono text-[8px] text-cyan-400 leading-tight">
+              {'0123456789ABCDEF'.repeat(20)}
+            </div>
+          </div>
+
+          <div className="relative z-10 flex flex-col gap-1 p-2">
             <div className="flex items-center justify-between">
-              <span className="font-mono text-[8px] text-zinc-500 uppercase tracking-widest">
-                NO.{pokemon.id.toString().padStart(3, '0')}
-              </span>
+              <div className="flex items-center gap-1.5">
+                <span
+                  className={cn(
+                    'font-mono text-[8px] uppercase tracking-widest transition-colors',
+                    variant === 'emerald'
+                      ? 'text-emerald-500'
+                      : variant === 'amber'
+                        ? 'text-amber-500'
+                        : 'text-cyan-600 group-hover/card:text-cyan-400',
+                  )}
+                >
+                  ID.{pokemon.id.toString().padStart(3, '0')}
+                </span>
+              </div>
               {saveData && !isUnseen && (
-                <div className="flex gap-1.5">
+                <div className="flex items-center gap-1.5">
                   {inParty && <CircleDot size={10} className="animate-pulse text-rose-500" />}
-                  {inPC && <Monitor size={10} className="text-[var(--theme-primary)]" />}
+                  {inPC && (
+                    <Monitor size={10} className={variant === 'emerald' ? 'text-emerald-400' : 'text-cyan-400'} />
+                  )}
                 </div>
               )}
             </div>
-            <h3
-              className={cn(
-                'truncate font-bold font-mono text-sm uppercase tracking-tight',
-                isUnseen ? 'text-zinc-700' : isShiny ? 'text-amber-400' : 'text-white',
+
+            <div className="flex items-baseline gap-2">
+              <h3
+                className={cn(
+                  'truncate font-bold font-mono text-sm uppercase tracking-tight',
+                  isUnseen ? 'text-zinc-700' : isShiny ? 'text-amber-400' : 'text-white',
+                )}
+              >
+                {pokemon.name}
+              </h3>
+              {/* Fake Status indicators next to name */}
+              {!isUnseen && (
+                <div className="hidden h-1 w-1 rounded-none bg-cyan-500/50 shadow-[0_0_5px_rgba(34,211,238,0)] group-hover/card:animate-pulse group-hover/card:bg-cyan-400 group-hover/card:shadow-[0_0_5px_rgba(34,211,238,0.8)] sm:flex" />
               )}
-            >
-              {pokemon.name}
-            </h3>
+            </div>
+
+            {/* Tactical data readouts */}
+            <div className="mt-1 hidden items-center gap-2 opacity-0 transition-opacity duration-300 group-hover/card:opacity-100 sm:flex">
+              <span className="font-mono text-[7px] text-zinc-500">
+                STS: {isOwned ? 'SECURED' : isSeen ? 'LOGGED' : 'UNKNOWN'}
+              </span>
+              <div className="relative h-[2px] w-full flex-1 overflow-hidden bg-zinc-800">
+                <div
+                  className="absolute inset-y-0 left-0 w-full -translate-x-full bg-cyan-500/50 group-hover/card:animate-[slide_2s_ease-in-out_infinite]"
+                  style={{ animationName: 'slideRight' }}
+                />
+              </div>
+            </div>
           </div>
 
           {saveData && (
-            <div className="mt-auto border-zinc-800 border-t border-dashed">
+            <div
+              className={cn(
+                'mt-auto border-t border-dashed transition-colors',
+                variant === 'emerald'
+                  ? 'border-emerald-900/50'
+                  : variant === 'amber'
+                    ? 'border-amber-900/50'
+                    : 'border-zinc-800 group-hover/card:border-cyan-900/50',
+              )}
+            >
               <PokemonStatusBadge
                 hasInStorage={hasInStorage}
                 isOwnedInDex={isOwnedInDex}

--- a/src/components/__tests__/PokedexCard.test.tsx
+++ b/src/components/__tests__/PokedexCard.test.tsx
@@ -54,7 +54,7 @@ describe('PokedexCard', () => {
     await render(<RouterProvider router={router} />);
 
     // Test for ID styling
-    await expect.element(page.getByText('NO.001', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('ID.001', { exact: true })).toBeInTheDocument();
   });
 
   test('renders [ SECURED ] when in storage', async () => {

--- a/src/index.css
+++ b/src/index.css
@@ -131,6 +131,12 @@ body {
   animation: screen-flicker 0.1s infinite;
 }
 
+@keyframes slideRight {
+  0% { transform: translateX(-100%); }
+  50% { transform: translateX(100%); }
+  100% { transform: translateX(100%); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, ::before, ::after {
     /* biome-ignore lint/complexity/noImportantStyles: A11y override */


### PR DESCRIPTION
This PR introduces a bold, tactical redesign to the `PokedexCard` component to better match the "snooping / terminal" aesthetic of the application. 

Changes include:
- Removing plain solid borders in favor of layered, dashed tactical frames that match the Pokémon's storage status (e.g., cyan, emerald, amber).
- Adding complex hover animations that simulate a "matrix target lock," including glitch overlays, pulsing scanlines, and spinning crosshairs.
- Overhauling the right-side data readout with scrolling hexadecimal data streams and dynamic status LEDs that activate on hover.
- Updating `NO.` to `ID.` to increase immersion.
- Updating `PokedexCard.test.tsx` to prevent test failures due to the string change.
- Injecting a new `slideRight` animation into `index.css`.
- Creating the required journal entry in `.jules/canvas/pokedex_card_redesign.md`.

---
*PR created automatically by Jules for task [13664922512185316943](https://jules.google.com/task/13664922512185316943) started by @szubster*