### PR TITLE
fix: submit empty pr for story-405-408-schema-role-status-mapping to trigger orchestrator demotion

### DIFF
--- a/.foundry/journals/tech_lead/14013119587186182010.md
+++ b/.foundry/journals/tech_lead/14013119587186182010.md
@@ -1,0 +1,3 @@
+# 14013119587186182010
+
+- **Orchestrator Demotion Compliance**: When assigned a `READY` parent node (like a STORY) that already has pending child tasks drafted (e.g. from a previous iteration by a late-binding pattern), I MUST submit an empty PR *without* checking off their overarching acceptance criteria checkboxes. Checking them off prematurely violates the MACRO NODE COMPLETION EXCEPTION, preventing the orchestrator from correctly demoting the parent to `PENDING` to wait for its children.


### PR DESCRIPTION
Submitting an empty PR to allow the orchestrator to correctly demote the parent node (`story-405-408-schema-role-status-mapping`) to PENDING, as it already has pending child tasks drafted. Checking off the acceptance criteria checkboxes was explicitly reverted as it violated the LATE-BINDING ORCHESTRATOR DEMOTION COMPLIANCE RULE.

---
*PR created automatically by Jules for task [14013119587186182010](https://jules.google.com/task/14013119587186182010) started by @szubster*