### PR TITLE
Draft E2E implementation task for bike requirement route mapping

### DIFF
--- a/.foundry/stories/story-406-415-bike-requirement-e2e.md
+++ b/.foundry/stories/story-406-415-bike-requirement-e2e.md
@@ -30,4 +30,5 @@ As per Orchestrator Safeguard requirements, every EPIC must generate a final STO
 Implement end-to-end integration tests using Playwright to ensure that the bike requirement filtering on the Smart Route Radar and the UI badges on the interactive map are functioning correctly together. Mock data representing maps with Acro and Mach bike requirements should be used to verify visual badges and heatmap data integration.
 
 ## Acceptance Criteria
-- [ ] tech_lead: Break down this Story into Tasks.
+- [x] tech_lead: Break down this Story into Tasks.
+- [ ] task-415-422-bike-requirement-e2e-impl

--- a/.foundry/tasks/task-415-422-bike-requirement-e2e-impl.md
+++ b/.foundry/tasks/task-415-422-bike-requirement-e2e-impl.md
@@ -7,6 +7,9 @@ owner_persona: coder
 parent: story-406-415-bike-requirement-e2e
 depends_on: []
 created_at: '2026-08-13'
+rejection_count: 0
+rejection_reason: ''
+jules_session_id: ''
 updated_at: '2026-08-13'
 ---
 

--- a/.foundry/tasks/task-415-422-bike-requirement-e2e-impl.md
+++ b/.foundry/tasks/task-415-422-bike-requirement-e2e-impl.md
@@ -1,0 +1,26 @@
+---
+id: task-415-422-bike-requirement-e2e-impl
+type: TASK
+title: E2E Verification for Bike Requirement Route Mapping - Implementation
+status: READY
+owner_persona: coder
+parent: story-406-415-bike-requirement-e2e
+depends_on: []
+created_at: '2026-08-13'
+updated_at: '2026-08-13'
+---
+
+# E2E Verification for Bike Requirement Route Mapping - Implementation
+
+## Context
+We need to ensure that the bike requirement filtering on the Smart Route Radar and the UI badges on the interactive map are functioning correctly together using end-to-end integration tests using Playwright.
+
+## Proposal
+Implement an E2E test suite in `tests/e2e/bike_requirement.spec.ts` using Playwright.
+The tests should load Gen 3 mock data (representing maps with Acro and Mach bike requirements), navigate to the map UI, verify that `hoenn-safari-zone-nwmach-bike-area` and `hoenn-safari-zone-neacro-bike-area` are displayed correctly based on the mock data, and confirm the heatmap data integration. Use the `initializeWithSave` utility to set up the test state and ensure the open: 'never' reporter config in Playwright is adhered to.
+
+## Acceptance Criteria
+- [ ] Create `tests/e2e/bike_requirement.spec.ts`.
+- [ ] E2E tests successfully load Gen 3 save state via `initializeWithSave`.
+- [ ] E2E tests verify the presence of Mach and Acro bike area nodes/badges on the UI.
+- [ ] Playwright E2E tests pass headlessly (`xvfb-run -a pnpm test:e2e tests/e2e/bike_requirement.spec.ts`).


### PR DESCRIPTION
Creates `.foundry/tasks/task-415-422-bike-requirement-e2e-impl.md` to map out
the E2E testing strategy for verifying Mach and Acro bike area nodes/badges on
the UI using Playwright. Checks off parent story acceptance criteria.

---
*PR created automatically by Jules for task [5298763863197760482](https://jules.google.com/task/5298763863197760482) started by @szubster*