### PR TITLE
Add librarian persona to schema

### DIFF
--- a/.foundry/stories/story-409-412-add-librarian-persona-schema.md
+++ b/.foundry/stories/story-409-412-add-librarian-persona-schema.md
@@ -27,4 +27,6 @@ This story covers updating `.foundry/docs/schema.md` to formally define the `lib
 
 ## Acceptance Criteria
 - [ ] Update `schema.md` to define the `librarian` persona in Section 5.
-- [ ] Create TASKS to implement the updates and QA verify.
+- [x] Create TASKS to implement the updates and QA verify.
+- [ ] task-412-422-implement-librarian-persona-schema
+- [ ] task-412-423-qa-librarian-persona-schema

--- a/.foundry/tasks/task-412-422-implement-librarian-persona-schema.md
+++ b/.foundry/tasks/task-412-422-implement-librarian-persona-schema.md
@@ -1,0 +1,28 @@
+---
+id: task-412-422-implement-librarian-persona-schema
+type: TASK
+title: Implement Librarian Persona in Schema
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-409-412-add-librarian-persona-schema
+tags:
+  - schema
+  - documentation
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Implement Librarian Persona in Schema
+
+## Description
+Update `.foundry/docs/schema.md` to formally define the `librarian` persona in Section 5 (Owner Persona Enum).
+
+## Acceptance Criteria
+- [ ] Add the `librarian` persona to the Owner Persona Enum table in Section 5 of `.foundry/docs/schema.md` with the description: "Mapped to Snorlax (#143). Responsible for context token optimization by digesting historical data and pruning stale entries.".

--- a/.foundry/tasks/task-412-423-qa-librarian-persona-schema.md
+++ b/.foundry/tasks/task-412-423-qa-librarian-persona-schema.md
@@ -1,0 +1,30 @@
+---
+id: task-412-423-qa-librarian-persona-schema
+type: TASK
+title: QA Librarian Persona in Schema
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-10'
+updated_at: '2026-08-10'
+depends_on:
+  - task-412-422-implement-librarian-persona-schema
+jules_session_id: null
+pr_number: null
+parent: story-409-412-add-librarian-persona-schema
+tags:
+  - schema
+  - documentation
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Librarian Persona in Schema
+
+## Description
+QA the implementation of the `librarian` persona in Section 5 of `.foundry/docs/schema.md`.
+
+## Acceptance Criteria
+- [ ] Verify that `librarian` persona is defined in Section 5 of `.foundry/docs/schema.md` with the description: "Mapped to Snorlax (#143). Responsible for context token optimization by digesting historical data and pruning stale entries.".


### PR DESCRIPTION
This PR adds the `librarian` persona to the `owner_persona` enum in `.foundry/docs/schema.md` by creating the technical blueprints (TASKS) for the `coder` and `qa` personas to implement and verify the change, as required by the parent story `story-409-412-add-librarian-persona-schema`.

---
*PR created automatically by Jules for task [11430797882080647600](https://jules.google.com/task/11430797882080647600) started by @szubster*