### PR TITLE
𗂃 QA: Verify Gen 3 Static Encounters UI

### DIFF
--- a/.foundry/journals/qa/8427761960184787152.md
+++ b/.foundry/journals/qa/8427761960184787152.md
@@ -1,0 +1,6 @@
+# QA Session 8427761960184787152
+
+Verified the implementation of the Gen 3 Static Encounters UI (`task-295-408-gen3-static-encounters-ui-qa-retry`).
+The `Gen3StaticEncountersDashboard` is correctly displayed on the main Gen 3 dashboard (`src/routes/dashboard.tsx`).
+The UI correctly displays the static encounter checklist based on save file flags as verified by the Vitest unit tests in `src/components/dashboard/encounters/__tests__/Gen3StaticEncountersDashboard.test.tsx`.
+Checked off the acceptance criteria in the task markdown file.

--- a/.foundry/tasks/task-295-408-gen3-static-encounters-ui-qa-retry.md
+++ b/.foundry/tasks/task-295-408-gen3-static-encounters-ui-qa-retry.md
@@ -27,5 +27,5 @@ notes: ''
 Verify the integration of the Gen 3 Static Encounters UI.
 
 ## Acceptance Criteria
-- [ ] Verify that `Gen3StaticEncountersDashboard` is correctly displayed on the main Gen 3 dashboard (`src/routes/dashboard.tsx`).
-- [ ] Verify the UI correctly displays the static encounter checklist based on save file flags.
+- [x] Verify that `Gen3StaticEncountersDashboard` is correctly displayed on the main Gen 3 dashboard (`src/routes/dashboard.tsx`).
+- [x] Verify the UI correctly displays the static encounter checklist based on save file flags.


### PR DESCRIPTION
Verified the implementation of the Gen 3 Static Encounters UI (`task-295-408-gen3-static-encounters-ui-qa-retry`).
The `Gen3StaticEncountersDashboard` is correctly displayed on the main Gen 3 dashboard (`src/routes/dashboard.tsx`).
The UI correctly displays the static encounter checklist based on save file flags as verified by the Vitest unit tests in `src/components/dashboard/encounters/__tests__/Gen3StaticEncountersDashboard.test.tsx`.
Checked off the acceptance criteria in the task markdown file to satisfy ADR 007 completeness contract.

---
*PR created automatically by Jules for task [8427761960184787152](https://jules.google.com/task/8427761960184787152) started by @szubster*