### PR TITLE
Story Owner: Gen 3 AI Data Extraction Story Generation

### DIFF
--- a/.foundry/epics/epic-340-411-gen3-ai-data-extraction.md
+++ b/.foundry/epics/epic-340-411-gen3-ai-data-extraction.md
@@ -35,5 +35,9 @@ Extract the necessary state from Gen 3 save files to feed into the AI move predi
 - Must support Emerald, FireRed, LeafGreen, Ruby, and Sapphire.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Break down into actionable STORY nodes.
-- [ ] Story Owner: Generate a final STORY dedicated exclusively to Integration and E2E Verification.
+- [x] Story Owner: Break down into actionable STORY nodes.
+- [x] Story Owner: Generate a final STORY dedicated exclusively to Integration and E2E Verification.
+- [ ] story-411-420-extract-player-team
+- [ ] story-411-421-extract-player-location
+- [ ] story-411-422-extract-opponent-data
+- [ ] story-411-423-gen3-ai-data-extraction-e2e

--- a/.foundry/journals/story_owner/10951981620713216813.md
+++ b/.foundry/journals/story_owner/10951981620713216813.md
@@ -1,0 +1,1 @@
+- Created story nodes for extracting Gen 3 AI data: active team, location, opponent data, and e2e verification. Appended unchecked tasks to the parent epic-340-411-gen3-ai-data-extraction.

--- a/.foundry/stories/story-411-420-extract-player-team.md
+++ b/.foundry/stories/story-411-420-extract-player-team.md
@@ -1,0 +1,31 @@
+---
+id: story-411-420-extract-player-team
+type: STORY
+title: Extract Player's Active Team
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-08-13"
+updated_at: "2026-08-13"
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-340-411-gen3-ai-data-extraction
+tags:
+  - gen3
+  - ai
+  - save-engine
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Extract Player's Active Team
+
+## Objective
+Implement extraction of the player's active team from Gen 3 save files, adhering to the save file extraction constraints.
+
+## Scope
+- Extract Pokémon species for the active team.
+- Extract moves for the active team.
+- Extract stats for the active team.
+- Implement tests verifying extraction correctly reads the required data.

--- a/.foundry/stories/story-411-421-extract-player-location.md
+++ b/.foundry/stories/story-411-421-extract-player-location.md
@@ -1,0 +1,31 @@
+---
+id: story-411-421-extract-player-location
+type: STORY
+title: Extract Player's Location and Upcoming Trainer
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-08-13"
+updated_at: "2026-08-13"
+depends_on:
+  - story-411-420-extract-player-team
+jules_session_id: null
+pr_number: null
+parent: epic-340-411-gen3-ai-data-extraction
+tags:
+  - gen3
+  - ai
+  - save-engine
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Extract Player's Location and Upcoming Trainer
+
+## Objective
+Parse the player's current location from Gen 3 save files and identify the nearest upcoming major trainer based on that location.
+
+## Scope
+- Parse the location block from Gen 3 save data.
+- Map the location to the nearest upcoming major trainer.
+- Add tests to ensure location and trainer mapping work.

--- a/.foundry/stories/story-411-422-extract-opponent-data.md
+++ b/.foundry/stories/story-411-422-extract-opponent-data.md
@@ -1,0 +1,31 @@
+---
+id: story-411-422-extract-opponent-data
+type: STORY
+title: Extract Opponent Data and AI Script
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-08-13"
+updated_at: "2026-08-13"
+depends_on:
+  - story-411-421-extract-player-location
+jules_session_id: null
+pr_number: null
+parent: epic-340-411-gen3-ai-data-extraction
+tags:
+  - gen3
+  - ai
+  - save-engine
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Extract Opponent Data and AI Script
+
+## Objective
+Extract or identify the opponent's team and the AI level/script assigned to the identified nearest trainer in Gen 3 game memory/constants.
+
+## Scope
+- Identify the opponent's team for the mapped trainer.
+- Extract AI level and script for the opponent.
+- Ensure extraction logic correctly identifies scripts based on trainer data.

--- a/.foundry/stories/story-411-423-gen3-ai-data-extraction-e2e.md
+++ b/.foundry/stories/story-411-423-gen3-ai-data-extraction-e2e.md
@@ -1,0 +1,31 @@
+---
+id: story-411-423-gen3-ai-data-extraction-e2e
+type: STORY
+title: Integration and E2E Verification for Gen 3 AI Data Extraction
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-08-13"
+updated_at: "2026-08-13"
+depends_on:
+  - story-411-422-extract-opponent-data
+jules_session_id: null
+pr_number: null
+parent: epic-340-411-gen3-ai-data-extraction
+tags:
+  - gen3
+  - ai
+  - save-engine
+  - e2e
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Story: Integration and E2E Verification for Gen 3 AI Data Extraction
+
+## Objective
+Verify all components of Gen 3 AI Data Extraction are integrated and work end-to-end.
+
+## Scope
+- Write E2E test verifying full extraction of player team, location, trainer, and opponent data from a Gen 3 save file.
+- Verify correct AI script mapping.


### PR DESCRIPTION
This PR fulfills the acceptance criteria for `epic-340-411-gen3-ai-data-extraction` by decomposing it into actionable `STORY` nodes assigned to the `tech_lead`:
1. `story-411-420-extract-player-team`: Extract player's active team.
2. `story-411-421-extract-player-location`: Extract player location and upcoming trainer.
3. `story-411-422-extract-opponent-data`: Extract opponent data and AI script.
4. `story-411-423-gen3-ai-data-extraction-e2e`: Integration and E2E verification.

The parent epic's markdown body has been updated to check off the completed acceptance criteria and append the newly generated stories as unchecked checkboxes, in adherence with DAG ID Strictness and the Macro Node Completion constraints.

No code modifications were made. Tests and linting were run to verify project state.

---
*PR created automatically by Jules for task [10951981620713216813](https://jules.google.com/task/10951981620713216813) started by @szubster*