### PR TITLE
chore(orchestrator): demote story-133-273 to pending

### DIFF
--- a/.foundry/journals/tech_lead/11857109944946151209.md
+++ b/.foundry/journals/tech_lead/11857109944946151209.md
@@ -1,0 +1,4 @@
+## Session 11857109944946151209
+- Encountered a scenario where an active STORY node (story-133-273-gen3-lottery-matching-algorithm) was assigned to me, but it already had child TASK nodes in the active directory (`.foundry/tasks/`).
+- Following the Late-Binding Orchestrator Demotion Compliance Rule from `.foundry/docs/knowledge_base/agents/core_policies.md`, I recognized this as a situation requiring an empty PR submission *without* checking off the overarching acceptance criteria.
+- Submitting an empty PR in this state allows the orchestrator to correctly demote the parent node back to PENDING while it waits for its children to finish (or be archived).


### PR DESCRIPTION
Submitting an empty PR as per the Late-Binding Orchestrator Demotion Compliance Rule to allow the orchestrator to correctly demote `story-133-273-gen3-lottery-matching-algorithm` to PENDING while its active child tasks complete.

---
*PR created automatically by Jules for task [11857109944946151209](https://jules.google.com/task/11857109944946151209) started by @szubster*