### PR TITLE
chore: Demote READY lottery matching story pending child tasks

### DIFF
--- a/.foundry/journals/tech_lead/10515424774121278125.md
+++ b/.foundry/journals/tech_lead/10515424774121278125.md
@@ -1,0 +1,1 @@
+Learned that when assigned a READY parent node that already has pending child tasks drafted from a previous iteration, we must submit an empty PR without checking off its overarching acceptance criteria to allow the orchestrator to correctly demote the parent to PENDING while it waits for its children.


### PR DESCRIPTION
This PR triggers the Orchestrator to correctly demote `story-133-273-gen3-lottery-matching-algorithm` to `PENDING` by submitting an empty PR for it since its child tasks `task-273-307-gen3-lottery-matching-iteration-impl` and `task-273-308-gen3-lottery-matching-iteration-qa` are still active. Added a learning journal log.

---
*PR created automatically by Jules for task [10515424774121278125](https://jules.google.com/task/10515424774121278125) started by @szubster*