### PR TITLE
feat: retry bash timeout wrapper

### DIFF
--- a/.foundry/epics/epic-057-420-bash-timeout-wrapper-retry.md
+++ b/.foundry/epics/epic-057-420-bash-timeout-wrapper-retry.md
@@ -1,0 +1,34 @@
+---
+id: epic-057-420-bash-timeout-wrapper-retry
+type: EPIC
+title: Timeout Wrapper for Bash Sessions (Retry)
+status: READY
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - research-057-417-investigate-bash-timeout-failure
+jules_session_id: null
+pr_number: null
+parent: prd-095-057-prevent-blocking-bash-commands
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references:
+  - research-057-417-investigate-bash-timeout-failure
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Timeout Wrapper for Bash Sessions (Retry)
+
+## Context
+Agent sessions executing long-running or blocking bash commands (like `tail -f`) can hang indefinitely. This epic covers the retry of the implementation of the timeout wrapper, based on the findings from the research phase.
+
+## Goal
+Implement a mechanism that wraps any `run_in_bash_session` execution and interrupts it if it runs over a specific threshold (e.g., 30 seconds), returning a clear, user-facing error message describing why it was stopped. Ensure a final STORY dedicated exclusively to Integration and E2E Verification is generated.
+
+## Acceptance Criteria
+- [ ] Break down this epic into stories.

--- a/.foundry/epics/epic-057-421-bash-static-analysis-linter-retry.md
+++ b/.foundry/epics/epic-057-421-bash-static-analysis-linter-retry.md
@@ -1,0 +1,33 @@
+---
+id: epic-057-421-bash-static-analysis-linter-retry
+type: EPIC
+title: Static Analysis Linter for Bash Sessions (Retry)
+status: READY
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - epic-057-420-bash-timeout-wrapper-retry
+jules_session_id: null
+pr_number: null
+parent: prd-095-057-prevent-blocking-bash-commands
+tags:
+  - foundry
+  - system-improvement
+  - resilience
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# EPIC: Static Analysis Linter for Bash Sessions (Retry)
+
+## Context
+Agent sessions executing long-running or blocking bash commands (like `tail -f`) can hang indefinitely. This epic covers the retry of the static analysis linter to proactively block known infinite-blocking commands.
+
+## Goal
+Implement a static analysis linter that optionally analyzes commands before execution to proactively block known infinite-blocking commands like `tail -f`. Ensure a final STORY dedicated exclusively to Integration and E2E Verification is generated.
+
+## Acceptance Criteria
+- [ ] Break down this epic into stories.

--- a/.foundry/journals/epic_planner/25645832560175386.md
+++ b/.foundry/journals/epic_planner/25645832560175386.md
@@ -1,0 +1,7 @@
+# Epic Planner Journal - Session 25645832560175386
+
+## Context
+Assigned to `prd-095-057-prevent-blocking-bash-commands`. The previous implementation attempt failed due to the orchestrator safeguard requiring E2E/integration stories for `EPIC` nodes.
+
+## Learnings
+- **Orchestrator Safeguard (E2E Requirement)**: When replacing permanently failed epics or creating new ones, it is critical to explicitly document the requirement for a final STORY dedicated exclusively to Integration and E2E Verification. If this is not done, the epic will fail to transition to COMPLETED when the orchestrator's safeguard checks the child stories.

--- a/.foundry/prds/prd-095-057-prevent-blocking-bash-commands.md
+++ b/.foundry/prds/prd-095-057-prevent-blocking-bash-commands.md
@@ -43,6 +43,9 @@ Agent sessions executing long-running or blocking bash commands (like `tail -f`)
 - [x] Break down this PRD into Epics mapping out the implementation strategy (e.g., exploring wrapper feasibility, updating bash tool infrastructure).
 - [x] epic-057-127-bash-timeout-wrapper
 - [x] epic-057-128-bash-static-analysis-linter
-- [ ] research-057-346-investigate-bash-timeout-failure
-- [ ] epic-057-347-bash-timeout-wrapper-retry
-- [ ] epic-057-348-bash-static-analysis-linter-retry
+- [x] research-057-346-investigate-bash-timeout-failure
+- [x] epic-057-347-bash-timeout-wrapper-retry
+- [x] epic-057-348-bash-static-analysis-linter-retry
+- [ ] research-057-417-investigate-bash-timeout-failure
+- [ ] epic-057-420-bash-timeout-wrapper-retry
+- [ ] epic-057-421-bash-static-analysis-linter-retry

--- a/.foundry/research/research-057-417-investigate-bash-timeout-failure.md
+++ b/.foundry/research/research-057-417-investigate-bash-timeout-failure.md
@@ -1,0 +1,33 @@
+---
+id: research-057-417-investigate-bash-timeout-failure
+type: RESEARCH
+title: Investigate Bash Timeout Failure
+status: READY
+owner_persona: researcher
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-095-057-prevent-blocking-bash-commands
+tags:
+  - foundry
+  - resilience
+  - failure-analysis
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# RESEARCH: Investigate Bash Timeout Failure
+
+## Context
+Previous attempts at implementing the bash timeout wrapper failed (see `epic-057-347-bash-timeout-wrapper-retry` and `epic-057-127-bash-timeout-wrapper`). We need to investigate the root cause of these failures before retrying the implementation.
+
+## Goal
+Investigate why the bash timeout wrapper implementation failed previously. Analyze previous logs and implementation attempts. Provide a comprehensive summary of the root cause and a proposed solution.
+
+## Acceptance Criteria
+- [ ] Investigate previous failures.
+- [ ] Provide summary and proposed solution.


### PR DESCRIPTION
Generate replacement epic nodes and research node for bash timeout wrapper PRD since the previous attempt failed due to lacking E2E tests, which the orchestrator safeguard blocked. Added the newly generated node tasks to the PRD and correctly checked off the failed parent nodes to allow the DAG to continue. Ensure downstream E2E verification stories are generated.

---
*PR created automatically by Jules for task [25645832560175386](https://jules.google.com/task/25645832560175386) started by @szubster*