### PR TITLE
feat(epic-planner): Breakdown PRD 136-340 into EPIC nodes

### DIFF
--- a/.foundry/epics/epic-340-417-engine-code-splitting.md
+++ b/.foundry/epics/epic-340-417-engine-code-splitting.md
@@ -1,0 +1,30 @@
+---
+id: epic-340-417-engine-code-splitting
+type: EPIC
+title: Implement generation-specific code splitting for the engine
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-13'
+updated_at: '2026-08-13'
+depends_on: []
+jules_session_id: null
+parent: prd-136-340-split-bundles-and-data
+tags:
+  - performance
+  - architecture
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# EPIC: Implement generation-specific code splitting for the engine
+
+## Context & Objectives
+To improve performance, generation-specific logic should be separated and lazily loaded.
+
+## Requirements
+- Split JS engine logic by generation using dynamic imports in `src/engine/saveParser/index.ts`.
+- Split JS assistant logic by generation using dynamic imports in `src/engine/assistant/strategies/index.ts`.
+
+## Acceptance Criteria
+- [ ] Break down this epic into stories.
+- [ ] Generate a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-340-418-ui-component-splitting.md
+++ b/.foundry/epics/epic-340-418-ui-component-splitting.md
@@ -1,0 +1,29 @@
+---
+id: epic-340-418-ui-component-splitting
+type: EPIC
+title: Implement React.lazy code splitting for UI components
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-13'
+updated_at: '2026-08-13'
+depends_on: []
+jules_session_id: null
+parent: prd-136-340-split-bundles-and-data
+tags:
+  - performance
+  - ui
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# EPIC: Implement React.lazy code splitting for UI components
+
+## Context & Objectives
+Components exclusively used for specific generations should not be bundled in the initial load payload.
+
+## Requirements
+- Utilize `React.lazy` for UI components that are only relevant to specific generations (e.g. Gen 3 RTC, Contests).
+
+## Acceptance Criteria
+- [ ] Break down this epic into stories.
+- [ ] Generate a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-340-419-data-splitting.md
+++ b/.foundry/epics/epic-340-419-data-splitting.md
@@ -1,0 +1,31 @@
+---
+id: epic-340-419-data-splitting
+type: EPIC
+title: Implement static Pokedex data splitting
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-13'
+updated_at: '2026-08-13'
+depends_on: []
+jules_session_id: null
+parent: prd-136-340-split-bundles-and-data
+tags:
+  - performance
+  - bundles
+  - database
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# EPIC: Implement static Pokedex data splitting
+
+## Context & Objectives
+Split the large static Pokedex payload into core and extension bundles, loading extensions on demand.
+
+## Requirements
+- Update `vite-plugins/pokedata-plugin.ts` to emit multiple msgpack bundles (core and extensions).
+- Refactor `src/db/PokeDB.ts` synchronization logic to support multi-part synchronization when specific generations are required.
+
+## Acceptance Criteria
+- [ ] Break down this epic into stories.
+- [ ] Generate a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-340-420-background-fetching.md
+++ b/.foundry/epics/epic-340-420-background-fetching.md
@@ -1,0 +1,29 @@
+---
+id: epic-340-420-background-fetching
+type: EPIC
+title: Implement background fetching and preloading
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-13'
+updated_at: '2026-08-13'
+depends_on: []
+jules_session_id: null
+parent: prd-136-340-split-bundles-and-data
+tags:
+  - performance
+  - preloading
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# EPIC: Implement background fetching and preloading
+
+## Context & Objectives
+Improve UX by seamlessly background pre-fetching extension msgpack files.
+
+## Requirements
+- Implement pre-fetching or background fetching for generation-specific msgpack files and assets to ensure subsequent data is available seamlessly without blocking the main thread.
+
+## Acceptance Criteria
+- [ ] Break down this epic into stories.
+- [ ] Generate a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-340-421-e2e-verification.md
+++ b/.foundry/epics/epic-340-421-e2e-verification.md
@@ -1,0 +1,35 @@
+---
+id: epic-340-421-e2e-verification
+type: EPIC
+title: Bundle and Data splitting E2E Verification
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-13'
+updated_at: '2026-08-13'
+depends_on:
+  - epic-340-417-engine-code-splitting
+  - epic-340-418-ui-component-splitting
+  - epic-340-419-data-splitting
+  - epic-340-420-background-fetching
+jules_session_id: null
+parent: prd-136-340-split-bundles-and-data
+tags:
+  - e2e
+  - integration
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+# EPIC: Bundle and Data splitting E2E Verification
+
+## Context & Objectives
+Ensure the system functionality has not been compromised by code and data splitting.
+
+## Requirements
+- Provide verification logic and end to end automated tests that guarantee that generation-specific logic remains functional after splitting.
+- Generate tests validating all components correctly lazy-load via `React.lazy`.
+- Validate that the correct background fetching functions seamlessly without issues.
+
+## Acceptance Criteria
+- [ ] Break down this epic into stories.
+- [ ] Generate a final STORY dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/prds/prd-136-340-split-bundles-and-data.md
+++ b/.foundry/prds/prd-136-340-split-bundles-and-data.md
@@ -32,7 +32,12 @@ Implement generation-based splitting for JavaScript engine logic, UI components,
 - Refactor the synchronization logic in `src/db/PokeDB.ts` to support multi-part data synchronization to load extensions and code on demand when a specific generation is detected.
 
 ## Acceptance Criteria
-- [ ] Breakdown PRD into EPIC nodes.
+- [x] Breakdown PRD into EPIC nodes.
+- [ ] epic-340-417-engine-code-splitting
+- [ ] epic-340-418-ui-component-splitting
+- [ ] epic-340-419-data-splitting
+- [ ] epic-340-420-background-fetching
+- [ ] epic-340-421-e2e-verification
 - [ ] research-340-405-background-fetching
 
 ### SCHEMA


### PR DESCRIPTION
Created 5 EPIC nodes derived from prd-136-340-split-bundles-and-data:
- epic-340-417-engine-code-splitting
- epic-340-418-ui-component-splitting
- epic-340-419-data-splitting
- epic-340-420-background-fetching
- epic-340-421-e2e-verification

Updated prd-136-340-split-bundles-and-data to reflect the breakdown and checked off the acceptance criteria.

---
*PR created automatically by Jules for task [8715656735150770150](https://jules.google.com/task/8715656735150770150) started by @szubster*