### PR TITLE
Log anomaly for existing downstream PRD and complete idea

### DIFF
--- a/.foundry/ideas/idea-115-remove-obsolete-orphaned-node-manual-cancellation.md
+++ b/.foundry/ideas/idea-115-remove-obsolete-orphaned-node-manual-cancellation.md
@@ -23,4 +23,4 @@ The Agile Coach identified friction caused by the obsolete "Orphaned QA Task Can
 
 ## Acceptance Criteria
 - [x] Product Manager: Convert this idea into a PRD to formalize the removal of manual orphaned node cancellation rules across the documentation.
-- [ ] prd-115-115-remove-obsolete-orphaned-node-manual-cancellation
+- [x] prd-115-115-remove-obsolete-orphaned-node-manual-cancellation

--- a/.foundry/journals/product_manager/6766818860312597532.md
+++ b/.foundry/journals/product_manager/6766818860312597532.md
@@ -1,0 +1,1 @@
+Anomaly: The target downstream PRD `prd-115-115-remove-obsolete-orphaned-node-manual-cancellation` already existed prior to this session.


### PR DESCRIPTION
Found the downstream PRD already existed for this idea. Logged the anomaly in the PM journal and checked off the Idea's acceptance criteria to allow graceful exit.

---
*PR created automatically by Jules for task [6766818860312597532](https://jules.google.com/task/6766818860312597532) started by @szubster*