### PR TITLE
🔐 [security fix] upgrade vulnerable nanoid dependency

### DIFF
--- a/.jules/shield/YYYY-MM-DD-HH-MM-SS.md
+++ b/.jules/shield/YYYY-MM-DD-HH-MM-SS.md
@@ -1,0 +1,7 @@
+# Vulnerable dependency upgrade
+
+During this session, I ran pnpm audit and found a vulnerable dependency (nanoid < 3.3.18) with a high-severity vulnerability (custom generators can loop indefinitely when size is zero, GHSA-2v37-7h3g-55p8). I used pnpm's built-in overrides in pnpm-workspace.yaml to upgrade nanoid to ^3.3.18. All tests and audits pass successfully now.
+
+# Codebase Review
+
+No explicit application code vulnerabilities matching the constraints were found (no non-native crypto logic, XSS vectors, unsafe links, or url.includes()).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   fast-uri@>=3.0.0 <3.1.5: ^3.1.5
   undici@>=7.0.0 <7.29.0: ^7.29.0
   js-yaml@>=3.0.0 <3.15.1: ^3.15.1
+  nanoid@<3.3.18: ^3.3.18
 
 importers:
 
@@ -3890,11 +3891,6 @@ packages:
 
   nanoclone@0.2.1:
     resolution: {integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==}
-
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -8361,8 +8357,6 @@ snapshots:
 
   nanoclone@0.2.1: {}
 
-  nanoid@3.3.17: {}
-
   nanoid@3.3.18: {}
 
   node-gyp-build-optional-packages@5.2.2:
@@ -8565,7 +8559,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,29 +1,25 @@
 packages:
-  - "."
-  - ".github/scripts"
-
+- .
+- .github/scripts
 legacyPeerDeps: true
-
 minimumReleaseAgeExclude:
-  - "@oxlint-tsgolint/*"
-  - "oxlint-tsgolint"
-  - "serialize-javascript"
-  - undici@7.29.0
-  - fast-uri@3.1.5
-
+- '@oxlint-tsgolint/*'
+- oxlint-tsgolint
+- serialize-javascript
+- undici@7.29.0
+- fast-uri@3.1.5
 allowBuilds:
   esbuild: true
   lefthook: true
   sharp: true
   msgpackr-extract: true
   workerd: true
-
 auditConfig:
   ignoreGhsas:
-    - GHSA-rmmr-r34h-pfm5
-
+  - GHSA-rmmr-r34h-pfm5
 overrides:
-  "brace-expansion@<2.1.3": "^2.1.3"
+  brace-expansion@<2.1.3: ^2.1.3
   fast-uri@>=3.0.0 <3.1.5: ^3.1.5
   undici@>=7.0.0 <7.29.0: ^7.29.0
   js-yaml@>=3.0.0 <3.15.1: ^3.15.1
+  nanoid@<3.3.18: ^3.3.18


### PR DESCRIPTION
🎯 What: Upgraded nanoid to resolve high-severity CodeQL vulnerability (GHSA-2v37-7h3g-55p8).

⚠️ Risk: Custom generators can loop indefinitely when size is zero.

🛡️ Solution: Added a pnpm override for nanoid@<3.3.18 to resolve to ^3.3.18.

---
*PR created automatically by Jules for task [9063768856294907872](https://jules.google.com/task/9063768856294907872) started by @szubster*