### PR TITLE
📜 Scribe: Improved JSDoc in saveParser modules

### DIFF
--- a/.jules/scribe/2026-08-14-02-23-33.md
+++ b/.jules/scribe/2026-08-14-02-23-33.md
@@ -1,0 +1,1 @@
+Added JSDoc for parseGen1, parseGen2, and parseGen3 in src/engine/saveParser/parsers/. The changes successfully provided context on memory offsets, flash banks, and heuristics.

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -753,9 +753,9 @@ function parsePCBoxes(
  * 3. **Data Extraction:** Uses the calculated `offsetShift` to align reading of the full party,
  *    PC boxes (WRAM + SRAM), inventory, badges, and event flags.
  *
- * @param view - The raw save file DataView.
- * @param forcedVersion - An optional version override provided by the user.
- * @returns The fully constructed SaveData object.
+ * @param view - The raw binary save file wrapper, initialized with ArrayBuffer from `.sav` file upload.
+ * @param forcedVersion - An optional version override (e.g., 'yellow', 'red') to bypass heuristic detection. Useful for modified ROM saves.
+ * @returns The fully constructed SaveData object mapping binary offsets to structured JSON for the frontend.
  */
 export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData {
   let trainerName = '';

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -772,9 +772,9 @@ function parseRoamingLegendaries(view: DataView, isCrystal: boolean) {
  * 3. **Data Extraction:** Extracts Pokédex, Party, PC Boxes, Daycare, Inventory, and event flags (badges).
  * 4. **Badge Merging:** Merges Kanto and Johto badges.
  *
- * @param view - The raw save file DataView.
- * @param forceCrystal - An optional flag to force Crystal offset parsing.
- * @returns The fully constructed SaveData object.
+ * @param view - The raw binary save file wrapper, mapped to the Gen 2 double-bank payload.
+ * @param forceCrystal - Forces the parser to use `_CRYSTAL` memory offsets, overriding the heuristic `PARTY_COUNT` detection check.
+ * @returns The extracted save state mapped to the universal `SaveData` schema.
  */
 export function parseGen2(view: DataView, forceCrystal = false): SaveData {
   let isCrystal = forceCrystal;

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -1206,9 +1206,9 @@ export function parseGen3TrainerId(view: DataView, section0Offset: number): { tr
  * 3. **Data Extraction:** Extracts Pokémon (decrypting their 48-byte substructures), inventory,
  *    event flags, and metadata specific to Hoenn or Kanto (Gen 3).
  *
- * @param view - The raw save file DataView.
- * @param _forcedVersion - An optional game version override to bypass auto-detection.
- * @returns The fully constructed SaveData object containing the player's progress and Pokémon.
+ * @param view - The DataView of the 128KB binary Flash memory save file.
+ * @param _forcedVersion - An optional version override (unused currently, reserved for future heuristic bypassing).
+ * @returns The fully mapped `SaveData` object, abstracting away the complex encrypted substructures of Gen 3 Pokemon.
  * @throws {Error} If the save file is corrupted, incomplete, or out-of-bounds reads occur.
  */
 export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveData {


### PR DESCRIPTION
Added detailed @param and @returns descriptions for parseGen1, parseGen2, and parseGen3.

---
*PR created automatically by Jules for task [10628314276089790658](https://jules.google.com/task/10628314276089790658) started by @szubster*