### PR TITLE
feat(foundry): transform idea-137 into prd-137-343 for composite prompts

### DIFF
--- a/.foundry/ideas/idea-137-decouple-persona-prompts.md
+++ b/.foundry/ideas/idea-137-decouple-persona-prompts.md
@@ -22,4 +22,5 @@ rejection_reason: ''
 Currently, Foundry persona prompts are large and monolithic. Decoupling them into generic roles (e.g., Coder, QA) and highly-focused, reusable technology/context specific layers (e.g., React, TypeScript, DexHelper) combined dynamically by the orchestrator will make Foundry extremely portable across different projects and environments. We should also explore breaking personas into finer-grained specializations (e.g., splitting a monolithic role into frontend/backend or domain specific sub-personas) to scale development.
 
 ## Acceptance Criteria
-- [ ] Product Manager: Break down this idea into a PRD to formalize the decoupling of persona prompts and splitting of roles.
+- [x] Product Manager: Break down this idea into a PRD to formalize the decoupling of persona prompts and splitting of roles.
+- [ ] prd-137-343-decouple-persona-prompts

--- a/.foundry/prds/prd-137-343-decouple-persona-prompts.md
+++ b/.foundry/prds/prd-137-343-decouple-persona-prompts.md
@@ -1,0 +1,39 @@
+---
+id: prd-137-343-decouple-persona-prompts
+type: PRD
+title: Decouple Persona Prompts and Support Composite Multi-Layered Prompts
+status: PENDING
+owner_persona: epic_planner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: idea-137-decouple-persona-prompts
+tags:
+  - foundry
+  - orchestrator
+  - architecture
+research_references: []
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# PRD: Decouple Persona Prompts and Support Composite Multi-Layered Prompts
+
+## 1. Context & Motivation
+Currently, Foundry persona prompts are large and monolithic. Decoupling them into generic roles (e.g., Coder, QA) and highly-focused, reusable technology/context specific layers (e.g., React, TypeScript, DexHelper) combined dynamically by the orchestrator will make Foundry extremely portable across different projects and environments. We should also explore breaking personas into finer-grained specializations (e.g., splitting a monolithic role into frontend/backend or domain specific sub-personas) to scale development.
+
+## 2. Product Requirements
+- **Prompt Fragment Layering:** Introduce a system for defining prompt fragments (base roles, tech stack specifics, domain contexts) and combining them into a single coherent prompt payload.
+- **Orchestrator Integration:** Update the Foundry Orchestrator to dynamically resolve and combine these prompt fragments based on node tags or context before dispatching to an agent session.
+- **Finer-Grained Specializations:** Subdivide broad monolithic roles into specialized sub-personas.
+- **Migration of Existing Personas:** Refactor existing monolithic `.md` prompt files into the new layered format.
+
+## 3. Scope & Constraints
+- The orchestrator must handle missing or conflicting prompt layers gracefully.
+- Must remain backward compatible during the transition phase.
+
+## 4. Acceptance Criteria
+- [ ] Epic Planner: Break down this PRD into Epics.


### PR DESCRIPTION
This PR transforms the Product Manager idea `idea-137-decouple-persona-prompts` into a concrete PRD (`prd-137-343-decouple-persona-prompts`).

Changes:
- Created new PRD `.foundry/prds/prd-137-343-decouple-persona-prompts.md` specifying the requirements for decoupling agent persona prompts into composite, reusable fragments (roles, tech stack, domain context) combined dynamically by the Orchestrator.
- Adhered to the `owner_persona: epic_planner` handoff requirement in the frontmatter.
- Updated the parent `idea-137` node by checking off its acceptance criteria and explicitly linking to the generated child PRD as an unchecked task (`- [ ] prd-137-343-decouple-persona-prompts`) according to Foundry appending children rules.

---
*PR created automatically by Jules for task [11580169431922696554](https://jules.google.com/task/11580169431922696554) started by @szubster*