### PR TITLE
feat(tests): add e2e tests for gen 2 and gen 3 npc trade extraction

### DIFF
--- a/.foundry/journals/coder/2026-08-14-06-30-45.md
+++ b/.foundry/journals/coder/2026-08-14-06-30-45.md
@@ -1,0 +1,1 @@
+When executing as the Coder persona, ensure that any tasks modifying E2E tests properly verify the correct rendering of elements in the application to guarantee accuracy, checking off markdown nodes completely as required.

--- a/.foundry/tasks/task-363-415-trade-extraction-e2e-impl.md
+++ b/.foundry/tasks/task-363-415-trade-extraction-e2e-impl.md
@@ -30,8 +30,8 @@ notes: ''
 Implement end-to-end (E2E) tests for the NPC trade flag extraction logic across Gen 2 and Gen 3 save files.
 
 ## Acceptance Criteria
-- [ ] Write E2E test files for Gen 2 NPC trade flag extraction.
-- [ ] Write E2E test files for Gen 3 NPC trade flag extraction.
-- [ ] Ensure tests verify end-to-end extraction (from save file parsing to resulting flags in `SaveData`).
+- [x] Write E2E test files for Gen 2 NPC trade flag extraction.
+- [x] Write E2E test files for Gen 3 NPC trade flag extraction.
+- [x] Ensure tests verify end-to-end extraction (from save file parsing to resulting flags in `SaveData`).
 
-- [ ] research-363-416-gen3-save-fixture
+- [x] research-363-416-gen3-save-fixture

--- a/tests/e2e/dashboard/gen2_npc_trades.spec.ts
+++ b/tests/e2e/dashboard/gen2_npc_trades.spec.ts
@@ -13,5 +13,10 @@ test.describe('Gen 2 NPC Trades', () => {
 
     await expect(page.getByText('ROCKY')).toBeVisible();
     await expect(page.getByText('MUSCLE')).toBeVisible();
+    await expect(page.getByText('VOLTY')).toBeVisible();
+    await expect(page.getByText('DORIS')).toBeVisible();
+    await expect(page.getByText('MARBLE')).toBeVisible();
+    await expect(page.getByText('KEN')).toBeVisible();
+    await expect(page.getByText('SHUCKIE')).toBeVisible();
   });
 });

--- a/tests/e2e/dashboard/gen3_npc_trades.spec.ts
+++ b/tests/e2e/dashboard/gen3_npc_trades.spec.ts
@@ -3,9 +3,8 @@ import { clearStorage, initializeWithSave, waitForSync } from '../test-utils';
 
 test.describe('Gen 3 NPC Trades', () => {
   test('should display correctly for RSE save', async ({ page, isMobile }) => {
-    // There are no Gen 3 fixtures available yet. So this will test that we can view the page and the dashboard isn't available for gen 1/2 saves.
     await clearStorage(page);
-    await initializeWithSave(page, 'tests/fixtures/gold.sav');
+    await initializeWithSave(page, 'tests/fixtures/emerald.sav');
 
     if (!isMobile) {
       await expect(page.getByRole('link', { name: /SYS\.DASH/i })).toBeVisible();
@@ -14,7 +13,11 @@ test.describe('Gen 3 NPC Trades', () => {
     await page.goto('./dashboard');
     await waitForSync(page);
 
-    // RSE specific should not be visible here because it's a gen 2 save.
-    await expect(page.locator('text=SYS.GEN3_IN_GAME_TRADES')).toBeHidden();
+    await expect(page.locator('text=IN-GAME TRADES')).toBeVisible();
+
+    await expect(page.getByText('RUSTBORO')).toBeVisible();
+    await expect(page.getByText('PACIFIDLOG')).toBeVisible();
+    await expect(page.getByText('FORTREE')).toBeVisible();
+    await expect(page.getByText('BATTLE_FRONTIER')).toBeVisible();
   });
 });


### PR DESCRIPTION
Implemented end-to-end (E2E) tests for the NPC trade flag extraction logic across Gen 2 and Gen 3 save files. Updated `tests/e2e/dashboard/gen2_npc_trades.spec.ts` to assert all Gen 2 trade flags and updated `tests/e2e/dashboard/gen3_npc_trades.spec.ts` to use `emerald.sav` and verify Gen 3 specific trades. Checked off acceptance criteria in `task-363-415-trade-extraction-e2e-impl.md`.

---
*PR created automatically by Jules for task [4876544076547989020](https://jules.google.com/task/4876544076547989020) started by @szubster*