### PR TITLE
Draft PRD for Gen 3 Weather Anomaly Tracker

### DIFF
--- a/.foundry/journals/product_manager/9259650360933596027.md
+++ b/.foundry/journals/product_manager/9259650360933596027.md
@@ -1,0 +1,9 @@
+# Session 9259650360933596027
+
+## Node
+Draft PRD for `idea-147-gen3-weather-anomaly-tracker`
+
+## Learnings & Observations
+- **ES Modules in Scratchpads**: The project uses `"type": "module"`. When creating temporary Node.js scratchpad scripts, `require()` will fail. Always use `import` or the `.cjs` extension.
+- **E2E Test Timeouts**: The full Playwright E2E test suite takes >400s and will time out the bash session. Always explicitly target specific E2E tests (e.g., `tests/e2e/home.spec.ts`) after ensuring `playwright install` has been run.
+- **Bash Curl Failures vs External Sources**: When pulling exact offset/variable definitions from external sources like `pret/pokeemerald`, standard `curl | grep` can sometimes fail or truncate. Downloading the file locally and then running `grep` with context flags (`-A`, `-B`) is more reliable.

--- a/.foundry/prds/prd-147-343-gen3-weather-anomaly-tracker.md
+++ b/.foundry/prds/prd-147-343-gen3-weather-anomaly-tracker.md
@@ -1,26 +1,26 @@
 ---
-id: idea-147-gen3-weather-anomaly-tracker
-type: IDEA
-title: Gen 3 Weather Anomaly Tracker (Groudon & Kyogre)
-status: ACTIVE
-owner_persona: product_manager
-created_at: '2026-08-12'
-updated_at: '2026-08-14'
+id: prd-147-343-gen3-weather-anomaly-tracker
+type: PRD
+title: "Gen 3 Weather Anomaly Tracker (Groudon & Kyogre)"
+status: PENDING
+owner_persona: "epic_planner"
+created_at: "2026-08-14"
+updated_at: "2026-08-14"
 depends_on: []
-jules_session_id: '9259650360933596027'
+jules_session_id: null
 pr_number: null
-parent: null
+parent: idea-147-gen3-weather-anomaly-tracker
 tags:
   - feature
   - gen3
   - tracker
 research_references: []
 rejection_count: 0
-rejection_reason: ''
-notes: ''
+rejection_reason: ""
+notes: ""
 ---
 
-# Idea: Gen 3 Weather Anomaly Tracker (Groudon & Kyogre)
+# PRD: Gen 3 Weather Anomaly Tracker (Groudon & Kyogre)
 
 ## Context & Problem Statement
 In Pokemon Emerald, after defeating the Elite Four, the weather institute occasionally reports severe weather anomalies (heavy rain or intense sunshine) on specific routes. These anomalies indicate the temporary presence of the legendary Pokemon Kyogre (Marine Cave) or Groudon (Terra Cave). The player has to travel to the Weather Institute, speak to the scientist to learn the current active route, and travel there quickly. If they are too slow, the anomaly moves to another route, requiring another trip to the Weather Institute.
@@ -32,9 +32,44 @@ Leverage DexHelper's save parsing engine to read the active weather anomaly even
 - **Anomaly Dashboard/Overlay:** Display whether an anomaly is currently active, what type it is (Drought vs. Drizzle), and exactly which Route it is currently affecting.
 - **Map Integration:** Highlight the affected route on the DexHelper Map UI with a weather icon.
 
+## Technical Specifications & Discovered Memory Addresses
+Based on the `pret/pokeemerald` source code, the active weather anomaly is primarily tracked by the `VAR_ABNORMAL_WEATHER_LOCATION` variable (`0x4037`).
+
+The mapping is as follows:
+
+**Terra Cave (Groudon - Drought)**
+- `VAR_ABNORMAL_WEATHER_LOCATION` between `1` and `8`.
+- 1: Route 114 (North)
+- 2: Route 114 (South)
+- 3: Route 115 (West)
+- 4: Route 115 (East)
+- 5: Route 116 (North)
+- 6: Route 116 (South)
+- 7: Route 118 (East)
+- 8: Route 118 (West)
+
+**Marine Cave (Kyogre - Drizzle)**
+- `VAR_ABNORMAL_WEATHER_LOCATION` between `9` and `16`.
+- 9: Route 105 (North)
+- 10: Route 105 (South)
+- 11: Route 125 (West)
+- 12: Route 125 (East)
+- 13: Route 127 (North)
+- 14: Route 127 (South)
+- 15: Route 129 (West)
+- 16: Route 129 (East)
+
+**None Active**
+- `VAR_ABNORMAL_WEATHER_LOCATION` is `0`.
+
+**Related Contextual Flags (For reference, if needed for validation):**
+- `FLAG_HIDE_TERRA_CAVE_GROUDON` (0x30F)
+- `FLAG_HIDE_MARINE_CAVE_KYOGRE` (0x30E)
+- `FLAG_ARRIVED_AT_TERRA_CAVE_ENTRANCE` (SYSTEM_FLAGS + 0x7A)
+- `FLAG_ARRIVED_AT_MARINE_CAVE_EMERGE_SPOT` (SYSTEM_FLAGS + 0x79)
+
 ## Value Proposition
 This eliminates the need for tedious backtracking to the Weather Institute, streamlining the post-game legendary hunt for Kyogre and Groudon. It perfectly aligns with DexHelper's vision as a premium companion app that exposes hidden or tedious game states to the player in a clean UI.
 
 ## Acceptance Criteria
-- [x] Product Manager: Draft a comprehensive PRD outlining the event flags/variables responsible for Terra Cave and Marine Cave locations and the UI integration strategy.
-- [ ] prd-147-343-gen3-weather-anomaly-tracker
+- [ ] Break down this PRD into Epics.


### PR DESCRIPTION
Creates the PRD for the Gen 3 Weather Anomaly Tracker feature based on the IDEA node.

This PR adds the PRD node `.foundry/prds/prd-147-343-gen3-weather-anomaly-tracker.md` containing the technical specs and `pokeemerald` variable addresses required to track Gen 3 weather anomalies (Kyogre/Groudon). It also updates the parent IDEA node to properly link and track the new PRD.

---
*PR created automatically by Jules for task [9259650360933596027](https://jules.google.com/task/9259650360933596027) started by @szubster*