### PR TITLE
feat(foundry): decompose Gen 3 Trainer Card parsing into tasks

### DIFF
--- a/.foundry/journals/tech_lead/7407366660319062198.md
+++ b/.foundry/journals/tech_lead/7407366660319062198.md
@@ -1,0 +1,1 @@
+The Tech Lead properly decomposed the story into three separate parsing implementation steps, each with a QA pair, avoiding the two-tasks-max anti-pattern. E2E tests for the home page passed after installing playwright browsers.

--- a/.foundry/stories/story-400-358-gen3-trainer-card-parsing-core.md
+++ b/.foundry/stories/story-400-358-gen3-trainer-card-parsing-core.md
@@ -33,7 +33,13 @@ Implement the core parsing logic to extract the Gen 3 Trainer Card upgrade data 
 - [ ] Parse Contest Master Rank flags (Cool, Beauty, Cute, Smart, Tough).
 - [ ] Parse Battle Frontier Gold Symbols flags.
 - [ ] Verify the implementation's exact alignment with the documentation schemas (e.g., Section 13 of .foundry/docs/schema.md) before marking tasks complete.
-- [ ] research-358-406-gen3-trainer-card-offsets
+- [x] research-358-406-gen3-trainer-card-offsets
+- [ ] task-358-424-gen3-pokedex-hof-parsing-impl
+- [ ] task-358-425-gen3-pokedex-hof-parsing-qa
+- [ ] task-358-426-gen3-contest-museum-parsing-impl
+- [ ] task-358-427-gen3-contest-museum-parsing-qa
+- [ ] task-358-428-gen3-battle-frontier-parsing-impl
+- [ ] task-358-429-gen3-battle-frontier-parsing-qa
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md

--- a/.foundry/tasks/task-358-424-gen3-pokedex-hof-parsing-impl.md
+++ b/.foundry/tasks/task-358-424-gen3-pokedex-hof-parsing-impl.md
@@ -1,0 +1,31 @@
+---
+id: task-358-424-gen3-pokedex-hof-parsing-impl
+type: TASK
+title: Task - Gen 3 Pokedex and Hall of Fame Parsing Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-400-358-gen3-trainer-card-parsing-core
+tags:
+  - feature
+  - gen3
+  - completionist
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 3 Pokedex and Hall of Fame Parsing Implementation
+
+## Description
+Implement the core parsing logic to extract the Gen 3 Trainer Card upgrade criteria for the Pokedex and Hall of Fame. Add a `Gen3TrainerCard` interface with `hasHallOfFame`, `hasHoennDex`, and `hasNationalDex` boolean properties, and add `gen3TrainerCard` to `SaveData`. The logic should check for `hallOfFameCount > 0`, `hoennDexCount === 202`, and `nationalDexCount === 386`. Ensure strict adherence to the schema guidelines.
+
+## Acceptance Criteria
+- [ ] Define `Gen3TrainerCard` in `src/engine/saveParser/parsers/common.ts` and add it to `SaveData`.
+- [ ] Construct and return `gen3TrainerCard` object within `parseGen3`.
+- [ ] Verify the implementation using appropriate unit tests.

--- a/.foundry/tasks/task-358-425-gen3-pokedex-hof-parsing-qa.md
+++ b/.foundry/tasks/task-358-425-gen3-pokedex-hof-parsing-qa.md
@@ -1,0 +1,31 @@
+---
+id: task-358-425-gen3-pokedex-hof-parsing-qa
+type: TASK
+title: Task - Gen 3 Pokedex and Hall of Fame Parsing QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - task-358-424-gen3-pokedex-hof-parsing-impl
+jules_session_id: null
+pr_number: null
+parent: story-400-358-gen3-trainer-card-parsing-core
+tags:
+  - qa
+  - gen3
+  - completionist
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 3 Pokedex and Hall of Fame Parsing QA
+
+## Description
+Perform QA validation on the implementation of the Gen 3 Trainer Card upgrade criteria parsing logic for Pokedex and Hall of Fame. Ensure that the logic accurately verifies the Hall of Fame and Pokedex (Hoenn and National) requirements. Ensure no regressions occur in the parser.
+
+## Acceptance Criteria
+- [ ] Verify `Gen3TrainerCard` properties are correctly populated in `SaveData`.
+- [ ] Ensure unit tests adequately cover the extraction logic and edge cases.

--- a/.foundry/tasks/task-358-426-gen3-contest-museum-parsing-impl.md
+++ b/.foundry/tasks/task-358-426-gen3-contest-museum-parsing-impl.md
@@ -1,0 +1,32 @@
+---
+id: task-358-426-gen3-contest-museum-parsing-impl
+type: TASK
+title: Task - Gen 3 Contest Museum Parsing Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-400-358-gen3-trainer-card-parsing-core
+tags:
+  - feature
+  - gen3
+  - completionist
+research_references:
+  - .foundry/research/research-358-406-gen3-trainer-card-offsets.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 3 Contest Museum Parsing Implementation
+
+## Description
+Implement the core parsing logic to extract the Gen 3 Trainer Card upgrade criteria for Contest Master Rank. Add `hasContestMaster` boolean property to `Gen3TrainerCard`. For Contest Master Rank, verify the 5 Museum Contest paintings (flags starting at `0x2e90` in SaveBlock1, index 8). Ensure strict adherence to the schema guidelines.
+
+## Acceptance Criteria
+- [ ] Implement `parseGen3ContestMaster` logic in `src/engine/saveParser/parsers/gen3.ts` using the museum offsets detailed in `.foundry/docs/knowledge_base/gen3_contest_museum_offsets.md`.
+- [ ] Construct and return `gen3TrainerCard.hasContestMaster` object within `parseGen3`.
+- [ ] Verify the implementation using appropriate unit tests.

--- a/.foundry/tasks/task-358-427-gen3-contest-museum-parsing-qa.md
+++ b/.foundry/tasks/task-358-427-gen3-contest-museum-parsing-qa.md
@@ -1,0 +1,31 @@
+---
+id: task-358-427-gen3-contest-museum-parsing-qa
+type: TASK
+title: Task - Gen 3 Contest Museum Parsing QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - task-358-426-gen3-contest-museum-parsing-impl
+jules_session_id: null
+pr_number: null
+parent: story-400-358-gen3-trainer-card-parsing-core
+tags:
+  - qa
+  - gen3
+  - completionist
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 3 Contest Museum Parsing QA
+
+## Description
+Perform QA validation on the implementation of the Gen 3 Trainer Card upgrade criteria parsing logic for Contest Master Rank. Ensure that the logic accurately verifies the Contest Master Rank requirements. Ensure no regressions occur in the parser.
+
+## Acceptance Criteria
+- [ ] Verify `parseGen3ContestMaster` logic precisely matches memory offsets defined in `gen3_contest_museum_offsets.md`.
+- [ ] Ensure unit tests adequately cover the extraction logic and edge cases.

--- a/.foundry/tasks/task-358-428-gen3-battle-frontier-parsing-impl.md
+++ b/.foundry/tasks/task-358-428-gen3-battle-frontier-parsing-impl.md
@@ -1,0 +1,31 @@
+---
+id: task-358-428-gen3-battle-frontier-parsing-impl
+type: TASK
+title: Task - Gen 3 Battle Frontier Parsing Implementation
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-400-358-gen3-trainer-card-parsing-core
+tags:
+  - feature
+  - gen3
+  - completionist
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 3 Battle Frontier Parsing Implementation
+
+## Description
+Implement the core parsing logic to extract the Gen 3 Trainer Card upgrade criteria for Battle Frontier. Add `hasBattleFrontier` boolean property to `Gen3TrainerCard`. Check `gen3BattleFrontierSymbols`. Ensure strict adherence to the schema guidelines.
+
+## Acceptance Criteria
+- [ ] Implement `hasBattleFrontier` check verifying if all Battle Frontier symbols are gold.
+- [ ] Construct and return `gen3TrainerCard.hasBattleFrontier` object within `parseGen3`.
+- [ ] Verify the implementation using appropriate unit tests.

--- a/.foundry/tasks/task-358-429-gen3-battle-frontier-parsing-qa.md
+++ b/.foundry/tasks/task-358-429-gen3-battle-frontier-parsing-qa.md
@@ -1,0 +1,31 @@
+---
+id: task-358-429-gen3-battle-frontier-parsing-qa
+type: TASK
+title: Task - Gen 3 Battle Frontier Parsing QA
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - task-358-428-gen3-battle-frontier-parsing-impl
+jules_session_id: null
+pr_number: null
+parent: story-400-358-gen3-trainer-card-parsing-core
+tags:
+  - qa
+  - gen3
+  - completionist
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Gen 3 Battle Frontier Parsing QA
+
+## Description
+Perform QA validation on the implementation of the Gen 3 Trainer Card upgrade criteria parsing logic for Battle Frontier. Ensure that the logic accurately verifies the Battle Frontier requirements. Ensure no regressions occur in the parser.
+
+## Acceptance Criteria
+- [ ] Verify Battle Frontier Gold Symbols check is correct.
+- [ ] Ensure unit tests adequately cover the extraction logic and edge cases.


### PR DESCRIPTION
This PR fulfills the Tech Lead persona responsibilities by breaking down the Gen 3 Trainer Card Data Parsing Core story into actionable blueprints (TASK nodes).

It avoids the "two-tasks-max" anti-pattern by splitting the parsing logic into three distinct areas:
1. Pokedex and Hall of Fame
2. Contest Museum (Contest Master Rank criteria)
3. Battle Frontier Symbols

Each implementation task is paired with a specific QA task, ensuring adherence to the Intelligent Verification Protocol.

The parent story's markdown body has been updated to track these new descendant nodes as unchecked checkboxes, preventing premature orchestrator verification.

---
*PR created automatically by Jules for task [7407366660319062198](https://jules.google.com/task/7407366660319062198) started by @szubster*