### PR TITLE
feat(foundry): generate epics for persona prompt decoupling

### DIFF
--- a/.foundry/epics/epic-343-417-prompt-fragment-layering.md
+++ b/.foundry/epics/epic-343-417-prompt-fragment-layering.md
@@ -1,0 +1,39 @@
+---
+id: epic-343-417-prompt-fragment-layering
+type: EPIC
+title: Implement Prompt Fragment Layering System
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-137-343-decouple-persona-prompts
+tags:
+  - foundry
+  - orchestrator
+  - prompts
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Implement Prompt Fragment Layering System
+
+## Description
+This Epic focuses on designing and implementing the foundational system for prompt fragment layering. Currently, persona prompts are monolithic files. This system will allow defining prompt fragments (e.g., base roles, tech stack specifics, domain contexts) that can be dynamically combined into a single, cohesive prompt payload.
+
+## Scope
+- Define a standard schema/format for prompt fragments.
+- Implement the core logic to combine and layer these fragments, ensuring precedence rules are established.
+- Create a set of initial standard fragments (e.g., generic Coder role, React tech stack, TypeScript specifics).
+
+## Prerequisites
+- No dependencies. This is the foundational epic for the decoupling effort.
+
+## Acceptance Criteria
+- [ ] Develop the prompt fragment composition engine.
+- [ ] Define the schema for prompt fragment definition files.
+- [ ] Generate an exclusive STORY dedicated to Integration and E2E Verification.

--- a/.foundry/epics/epic-343-418-orchestrator-integration.md
+++ b/.foundry/epics/epic-343-418-orchestrator-integration.md
@@ -1,0 +1,40 @@
+---
+id: epic-343-418-orchestrator-integration
+type: EPIC
+title: Orchestrator Integration for Prompt Resolution
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - epic-343-417-prompt-fragment-layering
+jules_session_id: null
+pr_number: null
+parent: prd-137-343-decouple-persona-prompts
+tags:
+  - foundry
+  - orchestrator
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Orchestrator Integration for Prompt Resolution
+
+## Description
+This Epic addresses updating the Foundry Orchestrator to integrate the new prompt fragment layering system. The orchestrator needs to dynamically resolve and assemble the appropriate prompt fragments based on the node's tags, assigned persona, and context before dispatching a session to a Jules agent.
+
+## Scope
+- Update `.github/scripts/foundry-orchestrator.ts` to utilize the prompt fragment engine.
+- Implement logic to map node properties (like `tags` or `owner_persona`) to specific prompt fragments.
+- Ensure the orchestrator handles missing or conflicting fragments gracefully (e.g., falling back to defaults or logging warnings instead of crashing).
+
+## Prerequisites
+- Requires completion of the prompt fragment layering system (`epic-343-417-prompt-fragment-layering.md`).
+
+## Acceptance Criteria
+- [ ] Orchestrator dynamically resolves and constructs composite prompts based on node context.
+- [ ] Fallback mechanisms are implemented for missing prompt layers.
+- [ ] Generate an exclusive STORY dedicated to Integration and E2E Verification.

--- a/.foundry/epics/epic-343-419-persona-migration.md
+++ b/.foundry/epics/epic-343-419-persona-migration.md
@@ -1,0 +1,41 @@
+---
+id: epic-343-419-persona-migration
+type: EPIC
+title: Persona Prompt Migration and Specialization
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - epic-343-418-orchestrator-integration
+jules_session_id: null
+pr_number: null
+parent: prd-137-343-decouple-persona-prompts
+tags:
+  - foundry
+  - personas
+  - migration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Persona Prompt Migration and Specialization
+
+## Description
+This Epic deals with the migration of existing, monolithic persona prompt files into the newly developed decoupled fragment format. It also covers the process of subdividing broad, monolithic roles into finer-grained, specialized sub-personas (e.g., splitting a monolithic role into frontend/backend focus) to improve agent efficiency and scale.
+
+## Scope
+- Refactor all existing `.md` prompt files into modular fragments.
+- Identify and implement finer-grained persona specializations based on the current workload.
+- Ensure backward compatibility during the migration phase to avoid disrupting active sessions.
+
+## Prerequisites
+- Requires completion of orchestrator integration (`epic-343-418-orchestrator-integration.md`) to effectively utilize the new prompt fragments.
+
+## Acceptance Criteria
+- [ ] Migrate all existing monolithic persona prompts to the new fragment layered format.
+- [ ] Implement and test at least two finer-grained specializations of existing roles.
+- [ ] Maintain backward compatibility during migration.
+- [ ] Generate an exclusive STORY dedicated to Integration and E2E Verification.

--- a/.foundry/journals/epic_planner/10215115551899892429.md
+++ b/.foundry/journals/epic_planner/10215115551899892429.md
@@ -1,0 +1,9 @@
+# Epic Planner Journal: Prompt Layering Migration (Session 10215115551899892429)
+
+## Context
+Broke down PRD `prd-137-343-decouple-persona-prompts` into actionable Epics for decoupling monolithic persona prompts into modular fragments.
+
+## Lessons & Adherence
+1.  **Dependency Mapping:** Effectively chained the Epics. The Orchestrator integration (`epic-343-418`) explicitly depends on the foundational schema/system implementation (`epic-343-417`). The migration (`epic-343-419`) correctly depends on the Orchestrator integration being completed first. This ensures a safe, backward-compatible rollout.
+2.  **E2E Enforcement:** Ensured strict compliance with the Orchestrator Safeguard rule. Every generated Epic explicitly includes `- [ ] Generate an exclusive STORY dedicated to Integration and E2E Verification.` in its Acceptance Criteria, which will force downstream `story_owner` generation to account for it.
+3.  **Strict ID Referencing:** Applied strict ID-only references (`epic-343-417-prompt-fragment-layering`) rather than file paths when appending generated Epics to the parent PRD's unchecked task list, adhering to the latest parent-linking syntax rules.

--- a/.foundry/prds/prd-137-343-decouple-persona-prompts.md
+++ b/.foundry/prds/prd-137-343-decouple-persona-prompts.md
@@ -36,4 +36,7 @@ Currently, Foundry persona prompts are large and monolithic. Decoupling them int
 - Must remain backward compatible during the transition phase.
 
 ## 4. Acceptance Criteria
-- [ ] Epic Planner: Break down this PRD into Epics.
+- [x] Epic Planner: Break down this PRD into Epics.
+- [ ] epic-343-417-prompt-fragment-layering
+- [ ] epic-343-418-orchestrator-integration
+- [ ] epic-343-419-persona-migration


### PR DESCRIPTION
This PR decomposes the PRD for Decoupling Persona Prompts into three distinct Epics:
- **Epic 343-417:** Core prompt fragment system layer.
- **Epic 343-418:** Integrates fragment resolution into the Orchestrator.
- **Epic 343-419:** Migrates monolithic agent files to the layered system.

It adheres to all Foundry orchestrator rules (strict DAG ID references, macro-node completion policies, and mandatory E2E verification task enforcement).

---
*PR created automatically by Jules for task [10215115551899892429](https://jules.google.com/task/10215115551899892429) started by @szubster*