### PR TITLE
feat: add semantic prompt validation epics

### DIFF
--- a/.foundry/epics/epic-343-417-semantic-evaluator-core.md
+++ b/.foundry/epics/epic-343-417-semantic-evaluator-core.md
@@ -1,0 +1,29 @@
+---
+id: epic-343-417-semantic-evaluator-core
+type: EPIC
+title: Semantic Evaluator Utility Core
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-145-343-semantic-prompt-validation
+tags:
+  - testing
+  - prompts
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Semantic Evaluator Utility Core
+
+## Description
+Implement the core semantic validation utility using an LLM-based assertion or structured abstract representation evaluator. This utility will evaluate agent prompt tests by verifying intent and presence of a rule rather than enforcing precise textual representation.
+
+## Acceptance Criteria
+- [ ] Break down this Epic into Stories.
+- [ ] Ensure a final STORY dedicated exclusively to Integration and E2E Verification is generated.

--- a/.foundry/epics/epic-343-418-agent-test-migration.md
+++ b/.foundry/epics/epic-343-418-agent-test-migration.md
@@ -1,0 +1,30 @@
+---
+id: epic-343-418-agent-test-migration
+type: EPIC
+title: Agent Test Migration to Semantic Validation
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - epic-343-417-semantic-evaluator-core
+jules_session_id: null
+pr_number: null
+parent: prd-145-343-semantic-prompt-validation
+tags:
+  - testing
+  - prompts
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Agent Test Migration to Semantic Validation
+
+## Description
+Migrate existing tests that verify agent process rules (e.g., in `.github/agents/*.md`) from brittle exact string matching to the new semantic validation utility, ensuring resilience against prompt refactoring.
+
+## Acceptance Criteria
+- [ ] Break down this Epic into Stories.
+- [ ] Ensure a final STORY dedicated exclusively to Integration and E2E Verification is generated.

--- a/.foundry/journals/epic_planner/7654390589700833801.md
+++ b/.foundry/journals/epic_planner/7654390589700833801.md
@@ -1,0 +1,6 @@
+# Epic Planner Session Journal
+
+**Date:** 2026-08-14
+**Session ID:** 7654390589700833801
+
+Created breakdown for PRD `prd-145-343-semantic-prompt-validation` mapping out the implementation of semantic validation utility for agent prompts, and testing integration. Noted importance of explicit dependency between implementation and test migration to ensure validation utility exists prior to migrating brittle tests.

--- a/.foundry/prds/prd-145-343-semantic-prompt-validation.md
+++ b/.foundry/prds/prd-145-343-semantic-prompt-validation.md
@@ -31,4 +31,6 @@ Implement a semantic validation utility (e.g., using an LLM-based assertion or a
 This will make persona instructions and process updates much more resilient to refactoring, reducing the overhead of updating brittle tests every time a prompt's phrasing is improved.
 
 ## Acceptance Criteria
-- [ ] Break down this PRD into Epics.
+- [x] Break down this PRD into Epics.
+- [ ] epic-343-417-semantic-evaluator-core
+- [ ] epic-343-418-agent-test-migration


### PR DESCRIPTION
Generated EPICs to track the implementation of the semantic evaluator core utility for robust prompt testing and the migration of existing brittle tests based on PRD prd-145-343-semantic-prompt-validation.

---
*PR created automatically by Jules for task [7654390589700833801](https://jules.google.com/task/7654390589700833801) started by @szubster*