### PR TITLE
Epic Plan: Foundry System Statistics

### DIFF
--- a/.foundry/epics/epic-146-417-real-time-statistics-generator.md
+++ b/.foundry/epics/epic-146-417-real-time-statistics-generator.md
@@ -8,6 +8,8 @@ created_at: '2026-08-14'
 updated_at: '2026-08-14'
 depends_on: []
 parent: prd-146-001-foundry-system-statistics
+jules_session_id: '11083204589735225959'
+pr_number: null
 tags:
   - orchestrator
   - metrics

--- a/.foundry/epics/epic-146-417-real-time-statistics-generator.md
+++ b/.foundry/epics/epic-146-417-real-time-statistics-generator.md
@@ -27,7 +27,7 @@ Implement a real-time statistics generation module that runs at the end of each 
 
 ## Requirements
 1. **Module Creation**: Create `.github/scripts/utils/statistics.ts` to house the counting and generation logic.
-2. **Node Scanning**: Scan `.foundry/` recursively to count nodes by type and status, parsing their YAML frontmatter.
+2. **Node Scanning**: Scan `.foundry/` recursively to count nodes by type and status, parsing their YAML frontmatter. Ensure it correctly categorizes and includes archived nodes from `.foundry/archive/`.
 3. **PR Metrics**: Fetch PR metrics via `gh pr list --state all --json` to compile data on total PRs, merged PRs, etc.
 4. **Report Output**: Generate `foundry-statistics.json` and `foundry-statistics.md` at the repository root.
 5. **Orchestrator Integration**: Integrate this module into `.github/scripts/foundry-orchestrator.ts` or `.github/workflows/foundry-heartbeat.yml` to trigger after each run and auto-commit if there are changes.

--- a/.foundry/epics/epic-146-417-real-time-statistics-generator.md
+++ b/.foundry/epics/epic-146-417-real-time-statistics-generator.md
@@ -1,0 +1,34 @@
+---
+id: epic-146-417-real-time-statistics-generator
+type: EPIC
+title: Real-Time Statistics Generator & Orchestrator Integration
+status: READY
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on: []
+parent: prd-146-001-foundry-system-statistics
+tags:
+  - orchestrator
+  - metrics
+  - statistics
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Real-Time Statistics Generator & Orchestrator Integration
+
+## Objective
+Implement a real-time statistics generation module that runs at the end of each Orchestrator or Heartbeat run to compute PR metrics and Node state metrics. It must output a unified JSON schema and Markdown report, automatically committing them to the root directory.
+
+## Requirements
+1. **Module Creation**: Create `.github/scripts/utils/statistics.ts` to house the counting and generation logic.
+2. **Node Scanning**: Scan `.foundry/` recursively to count nodes by type and status, parsing their YAML frontmatter.
+3. **PR Metrics**: Fetch PR metrics via `gh pr list --state all --json` to compile data on total PRs, merged PRs, etc.
+4. **Report Output**: Generate `foundry-statistics.json` and `foundry-statistics.md` at the repository root.
+5. **Orchestrator Integration**: Integrate this module into `.github/scripts/foundry-orchestrator.ts` or `.github/workflows/foundry-heartbeat.yml` to trigger after each run and auto-commit if there are changes.
+
+## Acceptance Criteria
+- [ ] Break down this Epic into Stories, ensuring the final STORY is dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`).

--- a/.foundry/epics/epic-146-418-historical-statistics-backfilling.md
+++ b/.foundry/epics/epic-146-418-historical-statistics-backfilling.md
@@ -9,6 +9,8 @@ updated_at: '2026-08-14'
 depends_on:
   - epic-146-417-real-time-statistics-generator
 parent: prd-146-001-foundry-system-statistics
+jules_session_id: '11083204589735225959'
+pr_number: null
 tags:
   - orchestrator
   - metrics

--- a/.foundry/epics/epic-146-418-historical-statistics-backfilling.md
+++ b/.foundry/epics/epic-146-418-historical-statistics-backfilling.md
@@ -1,0 +1,36 @@
+---
+id: epic-146-418-historical-statistics-backfilling
+type: EPIC
+title: Historical Statistics Backfilling Engine
+status: READY
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - epic-146-417-real-time-statistics-generator
+parent: prd-146-001-foundry-system-statistics
+tags:
+  - orchestrator
+  - metrics
+  - statistics
+  - database
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Historical Statistics Backfilling Engine
+
+## Objective
+Develop a standalone CLI utility that parses the git history of the `main` branch to retroactively compute pipeline statistics and generate a time-series dataset of the Foundry node states over time.
+
+## Requirements
+1. **CLI Utility**: Create a standalone script `.github/scripts/foundry-backfill-stats.ts`.
+2. **Input Parameters**: Accept interval parameters (e.g., `--daily`, or specific commit SHAs).
+3. **Git History Processing**: Iterate through the target commits in the `main` branch, accessing the `.foundry/` tree blob or a checked-out version to parse the state of the nodes at that point in time.
+4. **Data Aggregation**: Extract historical `node_status_counts` and `node_type_counts` for each point in time.
+5. **Time-Series Output**: Generate a time-series dataset file (`foundry-historical-stats.json` or CSV) to facilitate trend analysis.
+
+## Acceptance Criteria
+- [ ] Break down this Epic into Stories, ensuring the final STORY is dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`).

--- a/.foundry/journals/epic_planner/2026-08-14-11-08-24.md
+++ b/.foundry/journals/epic_planner/2026-08-14-11-08-24.md
@@ -1,0 +1,14 @@
+# Epic Planner Journal Entry
+
+Session ID: 11083204589735225959
+Date: 2026-08-14
+
+Successfully broke down PRD `prd-146-001-foundry-system-statistics` into two distinct Epics:
+- `epic-146-417-real-time-statistics-generator`
+- `epic-146-418-historical-statistics-backfilling`
+
+**Key Actions & Compliance:**
+1. Mapped dependencies appropriately (`epic-146-418` depends on `epic-146-417` as real-time needs to be established before historical can accurately reflect schema).
+2. Enforced E2E testing criteria on both generated epics, fulfilling the orchestrator safeguard.
+3. Updated the parent PRD to correctly list the generated children as unchecked markdown boxes without mutating its YAML frontmatter, preserving the orchestrator verification lifecycle.
+4. Correctly installed playwright browser dependencies when vitest failed due to missing headless browser instances.

--- a/.foundry/prds/prd-146-001-foundry-system-statistics.md
+++ b/.foundry/prds/prd-146-001-foundry-system-statistics.md
@@ -108,4 +108,6 @@ This feature transforms the Foundry from an opaque workflow engine into a data-d
 - It provides an extensible framework to easily append new metrics as the team comes up with more ideas during development.
 
 ## Acceptance Criteria
-- [ ] Break down this PRD into an Epic.
+- [x] Break down this PRD into an Epic.
+- [ ] epic-146-417-real-time-statistics-generator
+- [ ] epic-146-418-historical-statistics-backfilling


### PR DESCRIPTION
Breaks down the `Foundry System Statistics` PRD into Epics `epic-146-417-real-time-statistics-generator` and `epic-146-418-historical-statistics-backfilling`. Both epics inherit tags, metadata, and have specific acceptance criteria appended mandating final integration and E2E testing stories. The parent PRD markdown body has been updated accordingly with unchecked checkboxes for the newly created epics to govern transition lifecycle.

---
*PR created automatically by Jules for task [11083204589735225959](https://jules.google.com/task/11083204589735225959) started by @szubster*