### PR TITLE
Resolve Foundry DAG deadlocks on Idea 145 and resurrect zombie epic

### DIFF
--- a/.foundry/docs/adrs/adr-145-031-component-variant-theming.md
+++ b/.foundry/docs/adrs/adr-145-031-component-variant-theming.md
@@ -2,10 +2,10 @@
 id: adr-145-031-component-variant-theming
 type: ADR
 title: 'ADR: Unified Component Variants and Theming'
-status: PENDING
+status: COMPLETED
 owner_persona: architect
 created_at: '2026-08-11'
-updated_at: '2026-08-11'
+updated_at: '2026-08-14'
 depends_on:
   - .foundry/research/research-145-001-component-variant-libraries.md
   - .foundry/research/research-145-002-component-theming-mechanisms.md

--- a/.foundry/epics/epic-343-417-semantic-evaluator-core.md
+++ b/.foundry/epics/epic-343-417-semantic-evaluator-core.md
@@ -2,12 +2,12 @@
 id: epic-343-417-semantic-evaluator-core
 type: EPIC
 title: Semantic Evaluator Utility Core
-status: ACTIVE
+status: READY
 owner_persona: story_owner
 created_at: '2026-08-14'
 updated_at: '2026-08-14'
 depends_on: []
-jules_session_id: '10222618806438349124'
+jules_session_id: null
 pr_number: null
 parent: prd-145-343-semantic-prompt-validation
 tags:

--- a/.foundry/ideas/idea-145-component-variants-theming-consolidation.md
+++ b/.foundry/ideas/idea-145-component-variants-theming-consolidation.md
@@ -2,10 +2,10 @@
 id: idea-145-component-variants-theming-consolidation
 type: IDEA
 title: Component Variants and Theming Consolidation
-status: PENDING
+status: COMPLETED
 owner_persona: product_manager
 created_at: '2026-08-11'
-updated_at: '2026-08-11'
+updated_at: '2026-08-14'
 depends_on: []
 jules_session_id: null
 pr_number: null
@@ -43,11 +43,11 @@ The research will investigate:
 Rather than committing to a single library immediately, the investigation will present multiple well-reasoned architectural options in the graph, backed by extensive research, to allow decision-makers to choose the most sustainable path forward.
 
 ## Acceptance Criteria
-- [ ] Create deep-dive research evaluating component-variant management libraries.
-- [ ] Create deep-dive research evaluating dynamic multi-theming delivery mechanisms.
-- [ ] Draft an Architecture Decision Record (ADR) presenting multiple architecture paths.
+- [x] Create deep-dive research evaluating component-variant management libraries.
+- [x] Create deep-dive research evaluating dynamic multi-theming delivery mechanisms.
+- [x] Draft an Architecture Decision Record (ADR) presenting multiple architecture paths.
 
 ### Downstream Graph Nodes
-- [ ] `.foundry/research/research-145-001-component-variant-libraries.md`
-- [ ] `.foundry/research/research-145-002-component-theming-mechanisms.md`
-- [ ] `.foundry/docs/adrs/adr-145-031-component-variant-theming.md`
+- [x] `.foundry/research/research-145-001-component-variant-libraries.md`
+- [x] `.foundry/research/research-145-002-component-theming-mechanisms.md`
+- [x] `.foundry/docs/adrs/adr-145-031-component-variant-theming.md`

--- a/.foundry/research/research-145-001-component-variant-libraries.md
+++ b/.foundry/research/research-145-001-component-variant-libraries.md
@@ -2,10 +2,10 @@
 id: research-145-001-component-variant-libraries
 type: RESEARCH
 title: Research Component Variant Libraries
-status: PENDING
+status: COMPLETED
 owner_persona: researcher
 created_at: '2026-08-11'
-updated_at: '2026-08-11'
+updated_at: '2026-08-14'
 depends_on:
   - .foundry/ideas/idea-145-component-variants-theming-consolidation.md
 jules_session_id: null

--- a/.foundry/research/research-145-002-component-theming-mechanisms.md
+++ b/.foundry/research/research-145-002-component-theming-mechanisms.md
@@ -2,10 +2,10 @@
 id: research-145-002-component-theming-mechanisms
 type: RESEARCH
 title: Research Component Theming Mechanisms
-status: PENDING
+status: COMPLETED
 owner_persona: researcher
 created_at: '2026-08-11'
-updated_at: '2026-08-11'
+updated_at: '2026-08-14'
 depends_on:
   - .foundry/ideas/idea-145-component-variants-theming-consolidation.md
 jules_session_id: null


### PR DESCRIPTION
Resolved two distinct deadlocks involving the 'idea 145' files in .foundry/ directory:
1. Mutual dependency deadlock on idea-145-component-variants-theming-consolidation: The children research/ADR nodes (research-145-001, research-145-002, adr-145-031) had already been fully implemented but remained PENDING and had the parent idea in their 'depends_on' list. This created a circular block since the parent remains PENDING until all child nodes are COMPLETED. We resolved this by checking off the parent's AC and marking all of them as COMPLETED.
2. Stale zombie session on epic-343-417-semantic-evaluator-core: This node, which is a child of the other Idea 145 (idea-145-semantic-prompt-validation), was stuck as ACTIVE with a stale jules_session_id. We resurrected it to READY and cleared the stale session ID, which allows the pipeline to pick it up and progress.

Fixes #6210

---
*PR created automatically by Jules for task [9207510220853973880](https://jules.google.com/task/9207510220853973880) started by @szubster*