### PR TITLE
Resolve Hierarchical DAG Deadlocks & Implement Deadlock Detector

### DIFF
--- a/.foundry/prds/prd-132-340-gen3-pal-park-migration-planner.md
+++ b/.foundry/prds/prd-132-340-gen3-pal-park-migration-planner.md
@@ -6,8 +6,7 @@ status: PENDING
 owner_persona: epic_planner
 created_at: '2026-08-07'
 updated_at: '2026-08-07'
-depends_on:
-  - idea-132-gen3-pal-park-migration-planner
+depends_on: []
 jules_session_id: null
 pr_number: null
 parent: idea-132-gen3-pal-park-migration-planner

--- a/.foundry/research/research-145-001-component-variant-libraries.md
+++ b/.foundry/research/research-145-001-component-variant-libraries.md
@@ -6,8 +6,7 @@ status: PENDING
 owner_persona: researcher
 created_at: '2026-08-11'
 updated_at: '2026-08-11'
-depends_on:
-  - .foundry/ideas/idea-145-component-variants-theming-consolidation.md
+depends_on: []
 jules_session_id: null
 pr_number: null
 parent: idea-145-component-variants-theming-consolidation

--- a/.foundry/research/research-145-002-component-theming-mechanisms.md
+++ b/.foundry/research/research-145-002-component-theming-mechanisms.md
@@ -6,8 +6,7 @@ status: PENDING
 owner_persona: researcher
 created_at: '2026-08-11'
 updated_at: '2026-08-11'
-depends_on:
-  - .foundry/ideas/idea-145-component-variants-theming-consolidation.md
+depends_on: []
 jules_session_id: null
 pr_number: null
 parent: idea-145-component-variants-theming-consolidation

--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -2776,6 +2776,42 @@ Target artifact: [.foundry/tasks/task-completed.md](.foundry/tasks/task-complete
     expect(cContent).toContain("rejection_reason: Circular dependency detected");
   });
 
+  test('Hierarchical Deadlock: warns when child depends on parent and parent has unchecked checkbox for child', () => {
+    createValidTestNode(tmpDir, '.foundry/ideas/idea-001.md', {
+      id: "idea-001",
+      type: "IDEA",
+      title: "Idea A",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null,
+    }, `# Title
+## Acceptance Criteria
+- [ ] Child Story: [.foundry/stories/story-001.md](.foundry/stories/story-001.md)`);
+
+    createValidTestNode(tmpDir, '.foundry/stories/story-001.md', {
+      id: "story-001",
+      type: "STORY",
+      title: "Story 1",
+      status: "PENDING",
+      owner_persona: "tech_lead",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: ["idea-001"],
+      parent: "idea-001",
+      jules_session_id: null,
+    });
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write');
+    main();
+
+    const output = stderrSpy.mock.calls.map(call => call[0] as string).join('');
+    expect(output).toContain("Hierarchical deadlock detected: Parent 'idea-001'");
+    expect(output).toContain("has unchecked/incomplete child 'story-001'");
+  });
+
   test('Late-Binding Completion: EPIC fails if it lacks E2E story', () => {
     createValidTestNode(tmpDir, '.foundry/epics/epic-001.md', {
       id: "epic-001",

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -783,6 +783,44 @@ function main(): void {
     }
   }
 
+  // ── Phase 3.10: HIERARCHICAL DEADLOCK DETECTION ────────────────────────────
+  info('Phase 3.10: Detecting hierarchical deadlocks...');
+  for (const node of nodes) {
+    if (node.frontmatter.status === 'COMPLETED' || node.frontmatter.status === 'CANCELLED') continue;
+
+    const children = parentToChildren.get(node.repoPath) || [];
+    for (const child of children) {
+      if (child.frontmatter.status === 'COMPLETED' || child.frontmatter.status === 'CANCELLED') continue;
+
+      const queue = [child.repoPath];
+      const visited = new Set<string>();
+      let isCyclic = false;
+
+      while (queue.length > 0) {
+        const curr = queue.shift()!;
+        if (visited.has(curr)) continue;
+        visited.add(curr);
+
+        if (curr === node.repoPath) {
+          isCyclic = true;
+          break;
+        }
+
+        const currNode = nodeMap.get(curr);
+        if (currNode) {
+          for (const depRef of currNode.frontmatter.depends_on) {
+            const depPath = resolveNodePath(depRef);
+            if (depPath) queue.push(depPath);
+          }
+        }
+      }
+
+      if (isCyclic) {
+        warn(`Hierarchical deadlock detected: Parent '${node.frontmatter.id}' (${node.repoPath}) has unchecked/incomplete child '${child.frontmatter.id}' (${child.repoPath}), but '${child.frontmatter.id}' transitively depends on '${node.frontmatter.id}' via its depends_on array!`);
+      }
+    }
+  }
+
   // ── Phase 4: RESOLVE ───────────────────────────────────────────────────────
   info('Phase 4: Resolving DAG — finding eligible PENDING nodes...');
   const eligible: ParsedNode[] = [];


### PR DESCRIPTION
Resolved multiple circular/hierarchical deadlocks in the Foundry DAG (specifically for idea-145 and idea-132) by removing parent nodes from downstream/child nodes' depends_on arrays as dictated by core system policies. Added Phase 3.10 Hierarchical Deadlock Detection to the orchestrator to prevent these silent failures from being hidden, and wrote full unit tests ensuring coverage of the detection mechanism. All workspace and orchestrator tests pass cleanly.

Fixes #6211

---
*PR created automatically by Jules for task [1471873338387441293](https://jules.google.com/task/1471873338387441293) started by @szubster*