### PR TITLE
Resolve Foundry DAG Hierarchical Deadlocks

### DIFF
--- a/.foundry/research/research-157-369-gen3-party-box-offsets.md
+++ b/.foundry/research/research-157-369-gen3-party-box-offsets.md
@@ -26,7 +26,7 @@ notes: ''
 Research the exact memory offsets and structure for Party Pokémon and PC Box Pokémon in Generation 3 save files to enable accurate data extraction of PIDs.
 
 ## Context
-Task `task-099-157-gen3-extract-pokemon-pids-impl` requires implementing backend data extraction for Gen 3 Party and PC Box PIDs. The exact memory offsets and structure of this data within the save file are currently unknown in the codebase, preventing implementation without risking memory layout errors.
+The Gen 3 PID extraction task requires implementing backend data extraction for Gen 3 Party and PC Box PIDs. The exact memory offsets and structure of this data within the save file are currently unknown in the codebase, preventing implementation without risking memory layout errors.
 
 ## Acceptance Criteria
 - [ ] Research and document the memory offsets and structure for Party Pokémon in Gen 3 saves (Ruby/Sapphire, Emerald, FireRed/LeafGreen).

--- a/.foundry/research/research-249-384-gen3-party-box-integration.md
+++ b/.foundry/research/research-249-384-gen3-party-box-integration.md
@@ -27,7 +27,7 @@ notes: ''
 Investigate how to integrate Gen 3 Party and PC Box parsing into `parseGen3` so that downstream features like contest data mapping can be applied.
 
 ## Context
-Task `task-142-249-gen3-contest-data-mapping-impl` requires mapping contest stats and ribbons to `PokemonInstance` objects in `parseGen3`. However, the Party and PC Box parsing logic is currently stubbed out (returning `[]`). This research node should determine how to properly integrate the pending party/pc extraction logic (once the memory offsets are known from `research-157-369-gen3-party-box-offsets`) into the main parser.
+The Gen 3 Contest Data Mapping task requires mapping contest stats and ribbons to `PokemonInstance` objects in `parseGen3`. However, the Party and PC Box parsing logic is currently stubbed out (returning `[]`). This research node should determine how to properly integrate the pending party/pc extraction logic (once the memory offsets are known from the Gen 3 memory offsets research) into the main parser.
 
 ## Acceptance Criteria
 - [ ] Document the integration strategy for iterating through Gen 3 Party and PC Box Pokémon within `parseGen3`.


### PR DESCRIPTION
Resolved the two hierarchical deadlock warnings between research nodes and task implementation nodes by removing raw ID references from markdown bodies. This prevents the orchestrator from registering incorrect implicit child links and fully eliminates the deadlock cycles. All tests pass successfully.

Fixes #6214

---
*PR created automatically by Jules for task [15056174085063601643](https://jules.google.com/task/15056174085063601643) started by @szubster*