### PR TITLE
Remove >200 chars auto-completion rule for RESEARCH and ADR nodes

### DIFF
--- a/.github/scripts/foundry-orchestrator.test.ts
+++ b/.github/scripts/foundry-orchestrator.test.ts
@@ -1937,6 +1937,26 @@ vi.doMock('node:url', async (importOriginal) => {
     expect(taskArchitectResult).toContain('status: READY');
   });
 
+  test('RESEARCH/ADR nodes with >200 chars and unchecked tasks are promoted to READY, not auto-completed', () => {
+    const longBody = '## Acceptance Criteria\n- [ ] Task 1\n- [ ] Task 2\n' + 'a'.repeat(250);
+    createValidTestNode(tmpDir, '.foundry/research/research-long.md', {
+      id: "research-long",
+      type: "RESEARCH",
+      title: "Long Research",
+      status: "PENDING",
+      owner_persona: "researcher",
+      created_at: "2026-04-20",
+      updated_at: "2026-04-20",
+      depends_on: [],
+      jules_session_id: null
+    }, longBody);
+
+    main();
+
+    const researchResult = fs.readFileSync(path.join(tmpDir, '.foundry/research/research-long.md'), 'utf-8');
+    expect(researchResult).toContain('status: READY');
+  });
+
   test('Atomic Handoffs: resolves dependencies across single-persona atomic tasks', () => {
     createValidTestNode(tmpDir, '.foundry/tasks/task-atomic-1.md', {
       id: "task-atomic-1",

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -998,11 +998,7 @@ function main(): void {
         info(`Late-Binding Parent: ${node.repoPath} is waiting for children to complete.`);
       } else {
         const hasCheckboxes = /^\s*-\s*\[\s*[xX\s]\s*\]/m.test(acceptanceCriteriaText);
-        const isResearchOrAdr = node.frontmatter.type === 'RESEARCH' || node.frontmatter.type === 'ADR';
-        if (isResearchOrAdr && node.body.trim().length > 200) {
-          info(`Research/ADR node ${node.repoPath} has written content. Promoting directly to COMPLETED.`);
-          promoteNodeStatus(node, 'PENDING', 'COMPLETED');
-        } else if (hasCheckboxes && !hasUncheckedTasks) {
+        if (hasCheckboxes && !hasUncheckedTasks) {
           info(`Leaf node ${node.repoPath} has all acceptance criteria checked. Promoting directly to COMPLETED to prevent reawakening.`);
           promoteNodeStatus(node, 'PENDING', 'COMPLETED');
         } else {


### PR DESCRIPTION
Removed the heuristic in foundry-orchestrator.ts that automatically marked RESEARCH and ADR nodes as COMPLETED if their body text exceeded 200 characters. RESEARCH and ADR nodes now follow standard acceptance criteria completion rules. Added unit test coverage in foundry-orchestrator.test.ts.

Fixes #6228

---
*PR created automatically by Jules for task [2142462020965651142](https://jules.google.com/task/2142462020965651142) started by @szubster*