### PR TITLE
Refactor Foundry Orchestrator Zod Types

### DIFF
--- a/.foundry/tasks/task-412-418-refactor-orchestrator-zod-impl.md
+++ b/.foundry/tasks/task-412-418-refactor-orchestrator-zod-impl.md
@@ -30,6 +30,6 @@ Specifically:
 - Locate `const item: any = {` (around line 727 in `main`). The output node structure should be correctly typed instead of defaulting to `any`. You can define a specific interface for the extended item output or rely on standard intersection types.
 
 ## Acceptance Criteria
-- [ ] Replace `any` casts with proper type usage based on `NodeFrontmatterSchema`.
-- [ ] Ensure that TypeScript compiles successfully (`pnpm type-check` or via your editor) after removing the `any` casts.
-- [ ] Ensure tests pass after the refactoring.
+- [x] Replace `any` casts with proper type usage based on `NodeFrontmatterSchema`.
+- [x] Ensure that TypeScript compiles successfully (`pnpm type-check` or via your editor) after removing the `any` casts.
+- [x] Ensure tests pass after the refactoring.

--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -37,6 +37,12 @@ const matter = require('gray-matter') as typeof import('gray-matter');
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+export interface ReadyNodeItem extends NodeFrontmatter {
+  repo_path: string;
+  critical_weight: number;
+  compiled_prompt?: string;
+}
+
 interface ParsedNode {
   /** Absolute path on disk */
   filePath: string;
@@ -322,9 +328,8 @@ function compilePromptForNode(node: ParsedNode, repoRoot: string): string {
       layers.add(tag.toLowerCase());
     }
   }
-  const fmAny = node.frontmatter as any;
-  if (fmAny.layers && Array.isArray(fmAny.layers)) {
-    for (const layer of fmAny.layers) {
+  if (node.frontmatter.layers && Array.isArray(node.frontmatter.layers)) {
+    for (const layer of node.frontmatter.layers) {
       layers.add(layer.toLowerCase());
     }
   }
@@ -1271,7 +1276,7 @@ function main(): void {
   const readyNodes = nodes
     .filter((n) => n.frontmatter.status === 'READY' || n.frontmatter.status === 'VERIFYING')
     .map((n) => {
-      const item: any = {
+      const item: ReadyNodeItem = {
         ...n.frontmatter,
         repo_path: n.repoPath,
         owner_persona: n.frontmatter.status === 'VERIFYING' ? 'auditor' : n.frontmatter.owner_persona,


### PR DESCRIPTION
Replaced `any` casts with proper type usage based on `NodeFrontmatterSchema` in `.github/scripts/foundry-orchestrator.ts`.
Added `ReadyNodeItem` interface to properly type the generated ready nodes array.

---
*PR created automatically by Jules for task [9256054614234195746](https://jules.google.com/task/9256054614234195746) started by @szubster*