### PR TITLE
Epic Planner: Break down built-in emulator PRD into epics

### DIFF
--- a/.foundry/epics/epic-343-423-wasm-emulator-integration.md
+++ b/.foundry/epics/epic-343-423-wasm-emulator-integration.md
@@ -1,0 +1,27 @@
+---
+id: epic-343-423-wasm-emulator-integration
+type: EPIC
+title: WASM Emulator Integration
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: prd-137-343-built-in-emulator
+tags:
+  - emulator
+  - wasm
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: WASM Emulator Integration
+
+## Context
+Integrate mGBA or binjgb via WASM to provide an embedded Game Boy emulator. Handle ROM loading via local file picker/drag-and-drop. ROMs must be securely stored in the browser's persistent storage (IndexedDB/LocalStorage) and never transmitted over the network.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break down this EPIC into STORY nodes. Ensure a final STORY is dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-343-424-live-memory-reading.md
+++ b/.foundry/epics/epic-343-424-live-memory-reading.md
@@ -1,0 +1,28 @@
+---
+id: epic-343-424-live-memory-reading
+type: EPIC
+title: Live Memory Reading
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - epic-343-423-wasm-emulator-integration
+jules_session_id: null
+pr_number: null
+parent: prd-137-343-built-in-emulator
+tags:
+  - emulator
+  - memory
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Live Memory Reading
+
+## Context
+Establish a direct channel to read WASM memory buffers in real-time, mapping standard save blocks and game state variables continuously during emulator execution.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break down this EPIC into STORY nodes. Ensure a final STORY is dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/epics/epic-343-425-reactive-ui-updates.md
+++ b/.foundry/epics/epic-343-425-reactive-ui-updates.md
@@ -1,0 +1,28 @@
+---
+id: epic-343-425-reactive-ui-updates
+type: EPIC
+title: Reactive UI Updates
+status: PENDING
+owner_persona: story_owner
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - epic-343-424-live-memory-reading
+jules_session_id: null
+pr_number: null
+parent: prd-137-343-built-in-emulator
+tags:
+  - ui
+  - emulator
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Epic: Reactive UI Updates
+
+## Context
+Update the existing React UI components to reactively re-render based on the live memory streams from the WASM emulator, transforming the application into a real-time live companion.
+
+## Acceptance Criteria
+- [ ] Story Owner: Break down this EPIC into STORY nodes. Ensure a final STORY is dedicated exclusively to Integration and E2E Verification.

--- a/.foundry/prds/prd-137-343-built-in-emulator.md
+++ b/.foundry/prds/prd-137-343-built-in-emulator.md
@@ -33,4 +33,7 @@ To address this, we want to embed a high-performance, open-source Game Boy (GB/G
 4.  **Reactive UI Foundation**: Ensure the existing React UI components can reactively re-render based on these live memory streams, transforming DexHelper from a static tool to a real-time live companion.
 
 ## Acceptance Criteria
-- [ ] Epic Planner: Break down this PRD into EPIC nodes that address emulator integration, memory reading, and reactive UI updates.
+- [x] Epic Planner: Break down this PRD into EPIC nodes that address emulator integration, memory reading, and reactive UI updates.
+- [ ] epic-343-423-wasm-emulator-integration
+- [ ] epic-343-424-live-memory-reading
+- [ ] epic-343-425-reactive-ui-updates


### PR DESCRIPTION
Break down prd-137-343-built-in-emulator into epic-343-423-wasm-emulator-integration, epic-343-424-live-memory-reading, and epic-343-425-reactive-ui-updates.

---
*PR created automatically by Jules for task [13026451573028062878](https://jules.google.com/task/13026451573028062878) started by @szubster*