### PR TITLE
feat: implement TacticalCallerCard component

### DIFF
--- a/.foundry/journals/coder/10681144955246699899.md
+++ b/.foundry/journals/coder/10681144955246699899.md
@@ -1,0 +1,5 @@
+# Session 10681144955246699899
+
+## Learnings
+*   When applying conditional Tailwind CSS classes to UI components, always use complete literal class name strings in theme configurations or mapping objects instead of string interpolation (e.g., `'border-cyan-900/30'` instead of `'border-' + color + '-900'`). This ensures the Tailwind compiler can successfully parse and include the specific classes during the build process, preventing them from being purged.
+*   To test components using Playwright's visual verification process in this repository efficiently, one useful pattern is rendering the target component inside an ephemeral, dedicated `-TestRoute.tsx` or similar route, rendering variations to inspect their visual correctness, and capturing that isolated screen.

--- a/.foundry/tasks/task-287-415-tactical-caller-component-impl.md
+++ b/.foundry/tasks/task-287-415-tactical-caller-component-impl.md
@@ -29,16 +29,16 @@ Implement a reusable `TacticalCallerCard` UI component to visually differentiate
 We need to visually highlight high-value callers (those offering swarms or items) in the Active Callers Dashboard. This task focuses purely on building the underlying reusable React component for an individual caller card, ensuring it encapsulates the styling logic. A subsequent task will integrate this component into the dashboard.
 
 ## Acceptance Criteria
-- [ ] Create `src/components/dashboard/pokegear/TacticalCallerCard.tsx`.
-- [ ] The component must accept props for a `Contact` (id, name), its `CallerType` (or `HighValueContact` data), and `probability`.
-- [ ] Implement conditional styling based on `CallerType`:
+- [x] Create `src/components/dashboard/pokegear/TacticalCallerCard.tsx`.
+- [x] The component must accept props for a `Contact` (id, name), its `CallerType` (or `HighValueContact` data), and `probability`.
+- [x] Implement conditional styling based on `CallerType`:
   - E.g., `SWARM` uses a specific color scheme (like fuchsia or purple).
   - E.g., `ITEM` uses another specific color scheme (like amber or orange).
   - Standard/null types use the default cyan aesthetic.
-- [ ] The card must strictly adhere to ADR 008 (tactical hardware aesthetic):
+- [x] The card must strictly adhere to ADR 008 (tactical hardware aesthetic):
   - Must use `rounded-none`.
   - Must use `border-dashed` (where applicable).
   - Must use monospaced fonts (`font-mono` / `tactical-text`).
-- [ ] Render a badge indicating the caller's type (e.g., `[ SWARM ]` or `[ ITEM ]`) and any associated `details` (e.g., 'Dunsparce' or 'Leaf Stone') if it is a high-value contact.
-- [ ] Include the `HoverScanner`, `CornerCrosshairs`, and `LcdGrid` components within the card layout to maintain consistency with the existing dashboard items.
-- [ ] Write Vitest unit tests in `src/components/dashboard/pokegear/__tests__/TacticalCallerCard.test.tsx` to verify correct rendering of SWARM, ITEM, and STANDARD variants.
+- [x] Render a badge indicating the caller's type (e.g., `[ SWARM ]` or `[ ITEM ]`) and any associated `details` (e.g., 'Dunsparce' or 'Leaf Stone') if it is a high-value contact.
+- [x] Include the `HoverScanner`, `CornerCrosshairs`, and `LcdGrid` components within the card layout to maintain consistency with the existing dashboard items.
+- [x] Write Vitest unit tests in `src/components/dashboard/pokegear/__tests__/TacticalCallerCard.test.tsx` to verify correct rendering of SWARM, ITEM, and STANDARD variants.

--- a/src/components/dashboard/pokegear/TacticalCallerCard.tsx
+++ b/src/components/dashboard/pokegear/TacticalCallerCard.tsx
@@ -1,0 +1,97 @@
+import type { CallerType } from '../../../engine/saveParser/parsers/gen2/phone/constants';
+import type { Contact } from '../../../engine/saveParser/parsers/gen2/phone/predictor';
+import { CornerCrosshairs } from '../../CornerCrosshairs';
+import { HoverScanner } from '../../HoverScanner';
+import { LcdGrid } from '../../LcdGrid';
+
+interface TacticalCallerCardProps {
+  contact: Contact;
+  type: CallerType;
+  details?: string;
+  probability: number;
+}
+
+export function TacticalCallerCard({ contact, type, details, probability }: TacticalCallerCardProps) {
+  let themeColors = {
+    border: 'border-cyan-900/30 hover:border-cyan-500/50',
+    hoverScanner: 'via-cyan-500/10',
+    crosshairs: 'border-cyan-900/50 group-hover:border-cyan-500/50',
+    probBg: 'bg-cyan-950/80',
+    probBorder: 'border-cyan-900/50',
+    probText: 'text-cyan-400',
+    targetLock: 'text-cyan-700',
+    badgeBg: '',
+    badgeText: '',
+  };
+
+  if (type === 'SWARM') {
+    themeColors = {
+      border: 'border-fuchsia-900/30 hover:border-fuchsia-500/50',
+      hoverScanner: 'via-fuchsia-500/10',
+      crosshairs: 'border-fuchsia-900/50 group-hover:border-fuchsia-500/50',
+      probBg: 'bg-fuchsia-950/80',
+      probBorder: 'border-fuchsia-900/50',
+      probText: 'text-fuchsia-400',
+      targetLock: 'text-fuchsia-700',
+      badgeBg: 'bg-fuchsia-950/80 border-fuchsia-900/50',
+      badgeText: 'text-fuchsia-400',
+    };
+  } else if (type === 'ITEM') {
+    themeColors = {
+      border: 'border-amber-900/30 hover:border-amber-500/50',
+      hoverScanner: 'via-amber-500/10',
+      crosshairs: 'border-amber-900/50 group-hover:border-amber-500/50',
+      probBg: 'bg-amber-950/80',
+      probBorder: 'border-amber-900/50',
+      probText: 'text-amber-400',
+      targetLock: 'text-amber-700',
+      badgeBg: 'bg-amber-950/80 border-amber-900/50',
+      badgeText: 'text-amber-400',
+    };
+  }
+
+  const isCoolingDown = probability === 0;
+
+  return (
+    <div
+      className={`group relative flex flex-col gap-2 rounded-none border-2 border-dashed bg-black/60 p-3 font-mono text-xs transition-colors ${themeColors.border}`}
+    >
+      <LcdGrid className="opacity-10" />
+      <HoverScanner colorClass={themeColors.hoverScanner} />
+      <CornerCrosshairs className={`h-2 w-2 ${themeColors.crosshairs}`} thickness={2} />
+
+      <div
+        className={`absolute top-0 right-0 rounded-none border-b-2 border-l-2 border-dashed px-2 py-1 text-[9px] ${themeColors.probBg} ${themeColors.probBorder} ${themeColors.probText}`}
+      >
+        PROB: {probability}%
+      </div>
+
+      <div className="flex w-full flex-col gap-2 pt-2">
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <span className={`tactical-text text-[10px] ${themeColors.targetLock}`}>[ TARGET_LOCK ]</span>
+            <span className="font-bold text-white uppercase tracking-widest">{contact.name}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div
+              className={`h-2 w-2 rounded-full ${isCoolingDown ? 'bg-amber-500/50' : 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.8)]'}`}
+            />
+          </div>
+        </div>
+
+        {(type === 'SWARM' || type === 'ITEM') && (
+          <div className="z-10 mt-1 flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <span
+                className={`tactical-text rounded-none border border-dashed px-1.5 py-0.5 text-[9px] ${themeColors.badgeBg} ${themeColors.badgeText}`}
+              >
+                [ {type} ]
+              </span>
+              {details && <span className="truncate text-[10px] text-zinc-300">{details}</span>}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/pokegear/__tests__/TacticalCallerCard.test.tsx
+++ b/src/components/dashboard/pokegear/__tests__/TacticalCallerCard.test.tsx
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import type { Contact } from '../../../../engine/saveParser/parsers/gen2/phone/predictor';
+import { TacticalCallerCard } from '../TacticalCallerCard';
+
+const mockContact: Contact = { id: 17, name: 'Fisher Ralph' };
+
+test('renders correctly for SWARM variant with ADR 008 aesthetic classes', async () => {
+  const { container } = await render(
+    <TacticalCallerCard contact={mockContact} type="SWARM" details="Qwilfish" probability={50} />,
+  );
+
+  await expect.element(page.getByText('Fisher Ralph')).toBeInTheDocument();
+  await expect.element(page.getByText('[ TARGET_LOCK ]')).toBeInTheDocument();
+  await expect.element(page.getByText('PROB: 50%')).toBeInTheDocument();
+  await expect.element(page.getByText('[ SWARM ]')).toBeInTheDocument();
+  await expect.element(page.getByText('Qwilfish')).toBeInTheDocument();
+
+  // Check ADR 008 aesthetic classes
+  expect(container.innerHTML).toContain('tactical-text');
+  expect(container.innerHTML).toContain('border-dashed');
+  expect(container.innerHTML).toContain('font-mono');
+  expect(container.innerHTML).toContain('rounded-none');
+});
+
+test('renders correctly for ITEM variant', async () => {
+  const itemContact: Contact = { id: 24, name: 'Schoolboy Alan' };
+  await render(<TacticalCallerCard contact={itemContact} type="ITEM" details="Fire Stone" probability={0} />);
+
+  await expect.element(page.getByText('Schoolboy Alan')).toBeInTheDocument();
+  await expect.element(page.getByText('PROB: 0%')).toBeInTheDocument();
+  await expect.element(page.getByText('[ ITEM ]')).toBeInTheDocument();
+  await expect.element(page.getByText('Fire Stone')).toBeInTheDocument();
+});
+
+test('renders correctly for STANDARD variant with no details', async () => {
+  const standardContact: Contact = { id: 1, name: 'Mom' };
+  await render(<TacticalCallerCard contact={standardContact} type="NONE" probability={15} />);
+
+  await expect.element(page.getByText('Mom')).toBeInTheDocument();
+  await expect.element(page.getByText('PROB: 15%')).toBeInTheDocument();
+  // Ensure badge for SWARM/ITEM is not rendered
+  const swarmElements = page.getByText('[ SWARM ]').elements();
+  expect(swarmElements.length).toBe(0);
+  const itemElements = page.getByText('[ ITEM ]').elements();
+  expect(itemElements.length).toBe(0);
+});


### PR DESCRIPTION
Implement a reusable TacticalCallerCard UI component to visually differentiate callers based on their CallerType (SWARM, ITEM, STANDARD), strictly adhering to the tactical hardware aesthetic. Include related Vitest browser tests for validation.

---
*PR created automatically by Jules for task [10681144955246699899](https://jules.google.com/task/10681144955246699899) started by @szubster*