### PR TITLE
🗿 Sculptor: Refactor inline magic numbers to named constants

### DIFF
--- a/.jules/sculptor/2026-08-15-00-51-58.md
+++ b/.jules/sculptor/2026-08-15-00-51-58.md
@@ -1,0 +1,4 @@
+## Critical Learnings
+* **Inline magic numbers obfuscate bitwise and data logic:** Using inline hex values (like `0xff`, `0xffff`) deeply embedded in parsing logic makes it extremely difficult for AI to grasp the binary architecture and bounds of save files.
+* **Top-level constants provide semantic mapping:** Extracting these to named constants (`GEN1_EMPTY_SLOT`, `COMMON_EMPTY_SLOT`, etc.) immediately clarifies their purpose and limits.
+* **Refactoring Strategy:** Using Node `.js` scripts is significantly safer and more precise than standard bash `sed` or `grep` tools for manipulating large TypeScript parsing files.

--- a/fix_gen1_placement.cjs
+++ b/fix_gen1_placement.cjs
@@ -1,0 +1,7 @@
+const fs = require('fs');
+let code = fs.readFileSync('src/engine/saveParser/parsers/gen1.ts', 'utf-8');
+
+code = code.replace(/const GEN1_EMPTY_SLOT = 0xff;\n/, '');
+code = code.replace(/const BANK_1_BOX_1_OFFSET = 0x4000;/, 'const GEN1_EMPTY_SLOT = 0xff;\n\nconst BANK_1_BOX_1_OFFSET = 0x4000;');
+
+fs.writeFileSync('src/engine/saveParser/parsers/gen1.ts', code);

--- a/fix_gen1_placement.cjs
+++ b/fix_gen1_placement.cjs
@@ -1,7 +1,0 @@
-const fs = require('fs');
-let code = fs.readFileSync('src/engine/saveParser/parsers/gen1.ts', 'utf-8');
-
-code = code.replace(/const GEN1_EMPTY_SLOT = 0xff;\n/, '');
-code = code.replace(/const BANK_1_BOX_1_OFFSET = 0x4000;/, 'const GEN1_EMPTY_SLOT = 0xff;\n\nconst BANK_1_BOX_1_OFFSET = 0x4000;');
-
-fs.writeFileSync('src/engine/saveParser/parsers/gen1.ts', code);

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -476,7 +476,7 @@ export function decodeGen12String(view: DataView, offset: number, maxLength: num
       throw e;
     }
 
-    if (charCode === 0x50 || charCode === 0x00 || charCode === 0xff) break;
+    if (charCode === 0x50 || charCode === 0x00 || charCode === COMMON_EMPTY_SLOT) break;
     result += GEN12_CHAR_MAP[charCode] ?? '?';
   }
   return result.trim();
@@ -573,6 +573,7 @@ export function checkShinyGene(dvs: { atk: number; def: number; spd: number; spc
 
 const POKERUS_STRAIN_SHIFT = 4;
 const POKERUS_DAYS_MASK = 0x0f;
+const COMMON_EMPTY_SLOT = 0xff;
 
 /**
  * Parses the Pokerus byte.

--- a/src/engine/saveParser/parsers/gen1.ts
+++ b/src/engine/saveParser/parsers/gen1.ts
@@ -78,6 +78,8 @@ const PIKACHU_HAPPINESS_OFFSET = 0x271d;
 const PC_BOX_NUM_MASK = 0x7f;
 const PC_MAX_ITEMS = 50;
 
+const GEN1_EMPTY_SLOT = 0xff;
+
 const BANK_1_BOX_1_OFFSET = 0x4000;
 const BANK_1_BOX_2_OFFSET = 0x4462;
 const BANK_1_BOX_3_OFFSET = 0x48c4;
@@ -279,7 +281,10 @@ function hasYellowPikachuMarkers(view: DataView): boolean {
 
   // If these are non-zero and not FF (unitialized), it's almost certainly Yellow.
   // We use > 0 and < 0xFF to be safe against garbage data.
-  return (followingPikachu > 0 && followingPikachu < 0xff) || (pikachuHappiness > 0 && pikachuHappiness < 0xff);
+  return (
+    (followingPikachu > 0 && followingPikachu < GEN1_EMPTY_SLOT) ||
+    (pikachuHappiness > 0 && pikachuHappiness < GEN1_EMPTY_SLOT)
+  );
 }
 
 /**
@@ -423,7 +428,7 @@ function parseGen1HallOfFameRecords(view: DataView, hallOfFameCount: number, tra
         const offset = HOF_BASE_OFFSET + recordIndex * HOF_RECORD_LENGTH + pokemonIndex * HOF_POKEMON_LENGTH;
         const internalId = view.getUint8(offset);
 
-        if (internalId === 0x00 || internalId === 0xff) {
+        if (internalId === 0x00 || internalId === GEN1_EMPTY_SLOT) {
           continue;
         }
 
@@ -821,7 +826,7 @@ export function parseGen1(view: DataView, forcedVersion?: GameVersion): SaveData
 
   const mapIdStr = currentMapId.toString();
   const currentMapName = isValidMapId(mapIdStr) ? gen1MapLocations[mapIdStr] : 'Unknown Map';
-  const hallOfFameCount = hallOfFameRaw === 0xff ? 0 : hallOfFameRaw;
+  const hallOfFameCount = hallOfFameRaw === GEN1_EMPTY_SLOT ? 0 : hallOfFameRaw;
   const hallOfFameRecords = parseGen1HallOfFameRecords(view, hallOfFameCount, trainerName);
 
   const eventFlagsOffset = EVENT_FLAGS_OFFSET + offsetShift;

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -208,6 +208,7 @@ const CAUGHT_TIME_DAY = 2;
 const CAUGHT_TIME_NIGHT = 3;
 const CAUGHT_LOC_EVENT = 0x7e;
 const CAUGHT_LOC_TRADED = 0x7f;
+const GEN2_EMPTY_SLOT = 0xff;
 
 const MAX_VALID_SPECIES_ID = 251;
 const POKEMON_MOVE_COUNT = 4;
@@ -637,7 +638,7 @@ function parseDaycare(view: DataView, isCrystal: boolean) {
     const offset = offsets[i];
     if (offset === undefined) continue;
     const speciesId = view.getUint8(offset);
-    if (speciesId !== 0 && speciesId !== 0xff) {
+    if (speciesId !== 0 && speciesId !== GEN2_EMPTY_SLOT) {
       const p = parseGen2PokemonInstance(view, offset, isCrystal, 'Daycare', i + 1);
       if (p) {
         daycare.push(p);

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -84,6 +84,7 @@ const SECRET_BASE_OFFSET_EMERALD = 0x1a9c;
 const SAVE_BLOCK_A = 0x0000;
 const SAVE_BLOCK_B = 0xe000;
 const LOWER_16_BIT_MASK = 0xffff;
+const LOWER_8_BIT_MASK = 0xff;
 
 const GEN3_ROAMER_OFFSET_RS = 0x3144;
 const GEN3_ROAMER_OFFSET_EMERALD = 0x31dc;
@@ -603,7 +604,7 @@ export function parseGen3PCBoxes(pcBufferView: DataView) {
           true,
         );
         const encryptedItem = pcBufferView.getUint16(growthSubstructureOffset + GEN3_POKEMON_ITEM_OFFSET_IN_G, true);
-        const speciesId = encryptedSpecies ^ (decryptionKey & 0xffff);
+        const speciesId = encryptedSpecies ^ (decryptionKey & LOWER_16_BIT_MASK);
         const item = encryptedItem ^ (decryptionKey >>> 16);
 
         const encryptedMove1 = pcBufferView.getUint16(attacksSubstructureOffset + GEN3_POKEMON_MOVES_OFFSET_IN_A, true);
@@ -621,9 +622,9 @@ export function parseGen3PCBoxes(pcBufferView: DataView) {
         );
 
         const moves = [
-          encryptedMove1 ^ (decryptionKey & 0xffff),
+          encryptedMove1 ^ (decryptionKey & LOWER_16_BIT_MASK),
           encryptedMove2 ^ (decryptionKey >>> 16),
-          encryptedMove3 ^ (decryptionKey & 0xffff),
+          encryptedMove3 ^ (decryptionKey & LOWER_16_BIT_MASK),
           encryptedMove4 ^ (decryptionKey >>> 16),
         ].filter((m) => m > 0);
 
@@ -1255,7 +1256,7 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     for (let i = 0; i < 14; i++) {
       const currentByte = view.getUint8(flagsOffset + HIDDEN_ITEM_FLAGS_OFFSET + i);
       const nextByte = view.getUint8(flagsOffset + HIDDEN_ITEM_FLAGS_OFFSET + i + 1);
-      hiddenItemFlags[i] = ((currentByte >> 4) | ((nextByte & NIBBLE_MASK) << 4)) & 0xff;
+      hiddenItemFlags[i] = ((currentByte >> 4) | ((nextByte & NIBBLE_MASK) << 4)) & LOWER_8_BIT_MASK;
     }
 
     const mirageIslandOffset = _forcedVersion === 'emerald' ? MIRAGE_ISLAND_OFFSET_EMERALD : MIRAGE_ISLAND_OFFSET_RS;


### PR DESCRIPTION
## 🎯 What
Refactored inline hex magic numbers (like `0xff` and `0xffff`) into well-named top-level constants (`GEN1_EMPTY_SLOT`, `GEN2_EMPTY_SLOT`, `COMMON_EMPTY_SLOT`, `LOWER_16_BIT_MASK`, and `LOWER_8_BIT_MASK`) across `gen1.ts`, `gen2.ts`, `gen3.ts`, and `common.ts`.

## 💡 Why (AI Readability Impact)
Inline literal numbers deeply embedded in binary parsing logic (especially for bounds checking or bitwise XOR decryption) obfuscate the actual meaning of the condition. By extracting them into explicit named constants, AI agents can immediately infer their purpose, boundaries, and logic without having to re-read the context lines. 

## ✅ Verification
Ran `pnpm lint`, `pnpm test` and `xvfb-run pnpm test:e2e` (all passing). Verified no regressions were introduced since these constants perfectly map to the original primitive values.

## ✨ Result
A much cleaner, structurally separated, and self-documenting implementation of save data parsers.

---
*PR created automatically by Jules for task [16018573270009285626](https://jules.google.com/task/16018573270009285626) started by @szubster*