### PR TITLE
🧭 Strategist: Prompt improvement - Cleanup redundant context initialization in Tech Lead and Architect schedules

### DIFF
--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -11,10 +11,9 @@ You are the Architect of The Foundry. Your primary responsibility is to maintain
 ## Workflow
 
 1.  Read the incoming TASK or STORY node assigned to you.
-2.  Review all relevant documentation in `.foundry/docs/` and `.foundry/archive/docs/adrs/`.
-3.  Evaluate proposed changes against ADRs and Schemas.
-4.  Produce architectural reviews, updated schemas, or new ADRs as required.
-5.  Commit your work to the repository.
+2.  Evaluate proposed changes against ADRs and Schemas.
+3.  Produce architectural reviews, updated schemas, or new ADRs as required.
+4.  Commit your work to the repository.
 
 ## Journal
 

--- a/.github/agents/tech_lead.md
+++ b/.github/agents/tech_lead.md
@@ -12,9 +12,8 @@ You are the Tech Lead of The Foundry. Your primary responsibility is to transfor
 ## Workflow
 
 1.  Read the incoming STORY node.
-2.  Review all relevant documentation in `.foundry/docs/` and `.foundry/archive/docs/adrs/`.
-3.  Draft one or more TASK nodes that implement the story, deciding via the Intelligent Verification Protocol whether a separate QA TASK is required.
-4.  Commit the new TASK nodes to the repository.
+2.  Draft one or more TASK nodes that implement the story, deciding via the Intelligent Verification Protocol whether a separate QA TASK is required.
+3.  Commit the new TASK nodes to the repository.
 
 ## Journal
 

--- a/.jules/strategist/2026-08-15-01-44-25.md
+++ b/.jules/strategist/2026-08-15-01-44-25.md
@@ -1,0 +1,5 @@
+## 2026-08-15 - [Accepted] - Prompt improvement - Cleanup redundant context initialization in Tech Lead and Architect schedules
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The rules for mandatory context initialization (reading `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/`) were consolidated into `core_policies.md` on 2026-08-01. However, `.github/agents/tech_lead.md` and `.github/agents/architect.md` still contained redundant `Workflow` steps explicitly instructing the persona to review this documentation manually. This wastes context window space and creates inconsistency.
+**Pattern:** Regularly scrub agent schedules to remove directives that are already enforced globally in `.foundry/docs/knowledge_base/agents/core_policies.md`.


### PR DESCRIPTION
This PR cleans up redundant context initialization steps from `tech_lead.md` and `architect.md`.

**Why:** The rules for mandatory context initialization (reading `.foundry/docs/`, `.foundry/docs/knowledge_base/`, and `.foundry/archive/docs/adrs/`) were consolidated into `core_policies.md` on 2026-08-01. However, `.github/agents/tech_lead.md` and `.github/agents/architect.md` still contained redundant `Workflow` steps explicitly instructing the persona to review this documentation manually. This wastes context window space and creates inconsistency.
**Pattern:** Regularly scrub agent schedules to remove directives that are already enforced globally in `.foundry/docs/knowledge_base/agents/core_policies.md`.

---
*PR created automatically by Jules for task [17651909001188356600](https://jules.google.com/task/17651909001188356600) started by @szubster*