### PR TITLE
feat(gen3): implement Acro Bike map parsing logic

### DIFF
--- a/.foundry/tasks/task-412-423-gen3-acro-bike-parsing-impl.md
+++ b/.foundry/tasks/task-412-423-gen3-acro-bike-parsing-impl.md
@@ -28,5 +28,5 @@ Based on the Route Pre-computation & Mapping Epic, we need to extract Gen 3 map 
 Implement logic in the Gen 3 map extraction engine to parse map attributes corresponding to Acro Bike required areas.
 
 ## Acceptance Criteria
-- [ ] Implement parsing for Acro Bike map triggers.
-- [ ] Write unit tests for Acro Bike map parsing.
+- [x] Implement parsing for Acro Bike map triggers.
+- [x] Write unit tests for Acro Bike map parsing.

--- a/src/engine/gen3/mapParsing/acroBikeParser.test.ts
+++ b/src/engine/gen3/mapParsing/acroBikeParser.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasAcroBikeRequirement,
+  MB_BUMPY_SLOPE,
+  MB_HORIZONTAL_RAIL,
+  MB_ISOLATED_HORIZONTAL_RAIL,
+  MB_ISOLATED_VERTICAL_RAIL,
+  MB_VERTICAL_RAIL,
+} from './acroBikeParser';
+
+describe('hasAcroBikeRequirement', () => {
+  it('should return false for empty or normal metatiles', () => {
+    expect(hasAcroBikeRequirement([])).toBe(false);
+    expect(hasAcroBikeRequirement([0x00, 0x01, 0x02])).toBe(false);
+  });
+
+  it('should return true if MB_BUMPY_SLOPE is present', () => {
+    expect(hasAcroBikeRequirement([0x00, MB_BUMPY_SLOPE, 0x02])).toBe(true);
+  });
+
+  it('should return true if MB_ISOLATED_VERTICAL_RAIL is present', () => {
+    expect(hasAcroBikeRequirement([MB_ISOLATED_VERTICAL_RAIL])).toBe(true);
+  });
+
+  it('should return true if MB_ISOLATED_HORIZONTAL_RAIL is present', () => {
+    expect(hasAcroBikeRequirement([MB_ISOLATED_HORIZONTAL_RAIL])).toBe(true);
+  });
+
+  it('should return true if MB_VERTICAL_RAIL is present', () => {
+    expect(hasAcroBikeRequirement([MB_VERTICAL_RAIL])).toBe(true);
+  });
+
+  it('should return true if MB_HORIZONTAL_RAIL is present', () => {
+    expect(hasAcroBikeRequirement([MB_HORIZONTAL_RAIL])).toBe(true);
+  });
+});

--- a/src/engine/gen3/mapParsing/acroBikeParser.ts
+++ b/src/engine/gen3/mapParsing/acroBikeParser.ts
@@ -1,0 +1,29 @@
+export const MB_BUMPY_SLOPE = 0xd5;
+export const MB_ISOLATED_VERTICAL_RAIL = 0xd7;
+export const MB_ISOLATED_HORIZONTAL_RAIL = 0xd8;
+export const MB_VERTICAL_RAIL = 0xd9;
+export const MB_HORIZONTAL_RAIL = 0xda;
+
+/**
+ * Parses a map grid for Acro Bike required tiles.
+ *
+ * @param metatiles The grid of metatiles (assuming behavior IDs are extracted)
+ * @returns true if the map requires an Acro Bike, false otherwise.
+ */
+export function hasAcroBikeRequirement(metatiles: number[]): boolean {
+  for (let i = 0; i < metatiles.length; i++) {
+    const tile = metatiles[i];
+    if (tile === undefined) continue;
+
+    if (
+      tile === MB_BUMPY_SLOPE ||
+      tile === MB_ISOLATED_VERTICAL_RAIL ||
+      tile === MB_ISOLATED_HORIZONTAL_RAIL ||
+      tile === MB_VERTICAL_RAIL ||
+      tile === MB_HORIZONTAL_RAIL
+    ) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Implemented parsing logic to determine Acro Bike requirements for Gen 3 maps based on `pret/pokeemerald` metatile behavior definitions. Covered with unit tests.

---
*PR created automatically by Jules for task [14285277591022292627](https://jules.google.com/task/14285277591022292627) started by @szubster*