### PR TITLE
feat: implement BikeBadge component

### DIFF
--- a/.foundry/tasks/task-414-422-bike-badge-component-impl.md
+++ b/.foundry/tasks/task-414-422-bike-badge-component-impl.md
@@ -32,5 +32,5 @@ As part of the Route Pre-computation & Mapping Epic, we need UI badges indicatin
 - Write a unit test `src/components/__tests__/BikeBadge.test.tsx` for the component.
 
 ## Acceptance Criteria
-- [ ] Implement `BikeBadge` component.
-- [ ] Implement unit tests for `BikeBadge`.
+- [x] Implement `BikeBadge` component.
+- [x] Implement unit tests for `BikeBadge`.

--- a/src/components/BikeBadge.tsx
+++ b/src/components/BikeBadge.tsx
@@ -1,0 +1,25 @@
+import type React from 'react';
+import { TacticalBadge } from './TacticalBadge';
+
+export interface BikeBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  type: 'mach' | 'acro' | 'both';
+}
+
+export const BikeBadge: React.FC<BikeBadgeProps> = ({ type, className, ...props }) => {
+  let variant: 'emerald' | 'rose' | 'blue' = 'blue';
+  let label = 'BOTH BIKES';
+
+  if (type === 'mach') {
+    variant = 'emerald';
+    label = 'MACH BIKE';
+  } else if (type === 'acro') {
+    variant = 'rose';
+    label = 'ACRO BIKE';
+  }
+
+  return (
+    <TacticalBadge variant={variant} className={className} {...props}>
+      {label}
+    </TacticalBadge>
+  );
+};

--- a/src/components/__tests__/BikeBadge.test.tsx
+++ b/src/components/__tests__/BikeBadge.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { BikeBadge } from '../BikeBadge';
+
+describe('BikeBadge', () => {
+  test('renders mach bike badge correctly', async () => {
+    await render(<BikeBadge type="mach" />);
+    await expect.element(page.getByText('MACH BIKE')).toBeVisible();
+  });
+
+  test('renders acro bike badge correctly', async () => {
+    await render(<BikeBadge type="acro" />);
+    await expect.element(page.getByText('ACRO BIKE')).toBeVisible();
+  });
+
+  test('renders both bikes badge correctly', async () => {
+    await render(<BikeBadge type="both" />);
+    await expect.element(page.getByText('BOTH BIKES')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Implemented `BikeBadge` component matching tactical ui standards for route mapping. Added related vitest browser tests. Updated task markdown.

---
*PR created automatically by Jules for task [14681744318361595638](https://jules.google.com/task/14681744318361595638) started by @szubster*