### PR TITLE
feat: implement librarian persona in schema

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -164,6 +164,7 @@ No persona should ever manually set `status: READY`. The orchestrator calculates
 | `mechanic` | Ensures the Foundry is working as intended. Analyzes history and nodes to resolve deadlocks and loops. | Magnemite |
 | `researcher` | Responsible for exploratory tasks. Late-bound research nodes can be dynamically created by active nodes. Multiple researchers can be assigned to different sibling research nodes. | Omanyte |
 | `auditor` | Verifies artifacts against original intent, extracts learnings, and dynamically spawns follow-up nodes before archiving. | Pidgeot |
+| `librarian` | Mapped to Snorlax (#143). Responsible for context token optimization by digesting historical data and pruning stale entries. | Snorlax |
 
 ---
 

--- a/.foundry/tasks/task-412-422-implement-librarian-persona-schema.md
+++ b/.foundry/tasks/task-412-422-implement-librarian-persona-schema.md
@@ -25,4 +25,4 @@ notes: ''
 Update `.foundry/docs/schema.md` to formally define the `librarian` persona in Section 5 (Owner Persona Enum).
 
 ## Acceptance Criteria
-- [ ] Add the `librarian` persona to the Owner Persona Enum table in Section 5 of `.foundry/docs/schema.md` with the description: "Mapped to Snorlax (#143). Responsible for context token optimization by digesting historical data and pruning stale entries.".
+- [x] Add the `librarian` persona to the Owner Persona Enum table in Section 5 of `.foundry/docs/schema.md` with the description: "Mapped to Snorlax (#143). Responsible for context token optimization by digesting historical data and pruning stale entries.".


### PR DESCRIPTION
Update schema.md to formally define the librarian persona in Section 5 (Owner Persona Enum).

---
*PR created automatically by Jules for task [11217044717195847381](https://jules.google.com/task/11217044717195847381) started by @szubster*