### PR TITLE
Update Orchestrator Types for Experiment Schema

### DIFF
--- a/.foundry/tasks/task-413-422-update-orchestrator-types.md
+++ b/.foundry/tasks/task-413-422-update-orchestrator-types.md
@@ -30,5 +30,5 @@ Update the TypeScript interfaces and Zod validators in `.github/scripts/schema.t
 3. Add corresponding tests in `.github/scripts/schema.test.ts`.
 
 ## Acceptance Criteria
-- [ ] Coder: Update `schema.ts`.
-- [ ] Coder: Update `schema.test.ts`.
+- [x] Coder: Update `schema.ts`.
+- [x] Coder: Update `schema.test.ts`.

--- a/.github/scripts/schema.test.ts
+++ b/.github/scripts/schema.test.ts
@@ -131,4 +131,20 @@ describe('NodeFrontmatterSchema', () => {
     expect(parsed.created_at).toBe("2026-06-16T00:00:00.000Z");
     expect(parsed.updated_at).toBe("2026-07-03T00:00:00.000Z");
   });
+
+  it('validates an EXPERIMENT node with experiment_variants', () => {
+    const node = {
+      id: "experiment-001",
+      type: "EXPERIMENT",
+      title: "New Experiment",
+      status: "PENDING",
+      owner_persona: "product_manager",
+      created_at: "2026-08-14",
+      updated_at: "2026-08-14",
+      depends_on: [],
+      jules_session_id: null,
+      experiment_variants: ["A", "B"]
+    };
+    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow(Error);
+  });
 });

--- a/.github/scripts/schema.ts
+++ b/.github/scripts/schema.ts
@@ -8,6 +8,7 @@ export const NodeTypeEnum = z.enum([
   'TASK',
   'RESEARCH',
   'ADR',
+  'EXPERIMENT',
 ]);
 
 export const NodeStatusEnum = z.enum([
@@ -57,6 +58,7 @@ export const NodeFrontmatterSchema = z.object({
   rejection_count: z.number().int().optional(),
   rejection_reason: z.string().optional(),
   notes: z.string().optional(),
+  experiment_variants: z.array(z.string()).optional(),
 });
 
 export type NodeFrontmatter = z.infer<typeof NodeFrontmatterSchema>;


### PR DESCRIPTION
Updated the TypeScript interfaces and Zod validators in `.github/scripts/schema.ts` to support the new `EXPERIMENT` node type and `experiment_variants` frontmatter field.

- Added `'EXPERIMENT'` to `NodeTypeEnum`.
- Added `experiment_variants: z.array(z.string()).optional()` to `NodeFrontmatterSchema`.
- Updated `.github/scripts/schema.test.ts` to include a validation test for `EXPERIMENT` nodes with `experiment_variants`.

---
*PR created automatically by Jules for task [16421537501581985018](https://jules.google.com/task/16421537501581985018) started by @szubster*