### PR TITLE
Fix orchestrator resolution of archived child nodes

### DIFF
--- a/.github/scripts/foundry-orchestrator.ts
+++ b/.github/scripts/foundry-orchestrator.ts
@@ -507,7 +507,13 @@ function main(): void {
     for (const match of matches) {
       // node.repoPath is the potential parent, match is the potential child
       if (match !== node.repoPath) {
-        const matchedNode = nodeMap.get(match);
+        let matchedNode = nodeMap.get(match);
+        if (!matchedNode && fs.existsSync(path.join(repoRoot, match))) {
+          const parsed = parseNodeFile(path.join(repoRoot, match), repoRoot);
+          if (parsed) {
+            matchedNode = parsed;
+          }
+        }
         if (matchedNode) {
           // Check 1: If matchedNode has an explicit parent in frontmatter, do not add node as parent if it differs
           const explicitParent = resolveNodePath(matchedNode.frontmatter.parent);
@@ -1198,9 +1204,12 @@ function main(): void {
 
       if (links.length > 0) {
         const resolvedLinks = links.map(l => resolveNodePath(l)).filter((l): l is string => !!l);
-        const allExist = resolvedLinks.every(l => nodeMap.has(l));
+        const allExist = resolvedLinks.every(l => nodeMap.has(l) || fs.existsSync(path.join(repoRoot, l)));
         const hasChild = resolvedLinks.some(l => {
-          const childNode = nodeMap.get(l);
+          let childNode = nodeMap.get(l);
+          if (!childNode && fs.existsSync(path.join(repoRoot, l))) {
+            childNode = parseNodeFile(path.join(repoRoot, l), repoRoot) || undefined;
+          }
           if (!childNode) return false;
           const resolvedParentOfChild = resolveNodePath(childNode.frontmatter.parent);
           const resolvedNodePathValue = resolveNodePath(node.repoPath);

--- a/.github/scripts/verify-dag-refs.ts
+++ b/.github/scripts/verify-dag-refs.ts
@@ -53,13 +53,22 @@ for (const fp of files) {
 
 let broken = 0;
 
+function existsOrArchived(ref: string): boolean {
+  if (fs.existsSync(path.join(repoRoot, ref))) return true;
+  if (!ref.startsWith('.foundry/archive/')) {
+    const archived = ref.replace(/^\.foundry\//, '.foundry/archive/');
+    if (fs.existsSync(path.join(repoRoot, archived))) return true;
+  }
+  return false;
+}
+
 for (const node of nodes) {
   const deps = node.fm.depends_on || [];
   for (const dep of deps) {
     if (!idToPath.has(dep) && !dep.startsWith('.foundry/')) {
        process.stderr.write(`BROKEN DEP: ${node.repoPath} -> ${dep}\n`);
        broken++;
-    } else if (dep.startsWith('.foundry/') && !fs.existsSync(path.join(repoRoot, dep))) {
+    } else if (dep.startsWith('.foundry/') && !existsOrArchived(dep)) {
        process.stderr.write(`BROKEN DEP PATH: ${node.repoPath} -> ${dep}\n`);
        broken++;
     }
@@ -70,7 +79,7 @@ for (const node of nodes) {
     if (!idToPath.has(parent) && !parent.startsWith('.foundry/')) {
        process.stderr.write(`BROKEN PARENT: ${node.repoPath} -> ${parent}\n`);
        broken++;
-    } else if (parent.startsWith('.foundry/') && !fs.existsSync(path.join(repoRoot, parent))) {
+    } else if (parent.startsWith('.foundry/') && !existsOrArchived(parent)) {
        process.stderr.write(`BROKEN PARENT PATH: ${node.repoPath} -> ${parent}\n`);
        broken++;
     }


### PR DESCRIPTION
Support resolving archived child nodes from disk during Phase 2 child mapping and Phase 4.5 idempotent checks in foundry-orchestrator.ts when they are not in nodeMap.

Fixes #6271

---
*PR created automatically by Jules for task [6433180413948534056](https://jules.google.com/task/6433180413948534056) started by @szubster*