### PR TITLE
Fix frontmatter dependency link in story-138-422-gen3-static-encounters-e2e

### DIFF
--- a/.foundry/stories/story-138-422-gen3-static-encounters-e2e.md
+++ b/.foundry/stories/story-138-422-gen3-static-encounters-e2e.md
@@ -7,7 +7,7 @@ owner_persona: tech_lead
 created_at: '2026-08-14'
 updated_at: '2026-08-14'
 depends_on:
-  - .foundry/stories/story-138-295-gen3-static-encounters-ui.md
+  - story-138-295-gen3-static-encounters-ui
 jules_session_id: null
 pr_number: null
 parent: epic-106-138-gen3-static-encounters


### PR DESCRIPTION
Fixes link-checker failure during orchestration by updating frontmatter dependency reference in story-138-422-gen3-static-encounters-e2e.md to use node ID format.

Fixes #6274

---
*PR created automatically by Jules for task [3666284986842071544](https://jules.google.com/task/3666284986842071544) started by @szubster*