### PR TITLE
feat: implement IndexedDB storage schema using idb

### DIFF
--- a/.foundry/journals/coder/13248586827349519394.md
+++ b/.foundry/journals/coder/13248586827349519394.md
@@ -1,0 +1,5 @@
+# Session 13248586827349519394
+
+## Learnings
+* To successfully utilize `idb` for IndexedDB schema initialization, mapping the exact expected interface to the generic parameters in `openDB` provides strong typing that avoids implicit cast errors.
+* When executing tasks that verify the implementation state in markdown (like modifying acceptance criteria checkboxes), exact SEARCH/REPLACE diff blocks must be created, and the complete contents must be extracted from the file structure during the exploratory bash phase to prevent automated review and verification failures.

--- a/.foundry/tasks/task-358-427-indexeddb-schema-impl.md
+++ b/.foundry/tasks/task-358-427-indexeddb-schema-impl.md
@@ -40,8 +40,8 @@ The application requires a robust storage mechanism for save files and their met
 - Use `idb` to configure the schema correctly.
 
 ## Acceptance Criteria
-- [ ] `src/engine/storage/historyDb.ts` is created and exports a valid idb database instance named `SaveHistoryDB`.
-- [ ] Database version is exactly 1.
-- [ ] Object stores `saves`, `metadata`, and `indexes` are defined.
-- [ ] Database schema strictly adheres to Section 14 of `.foundry/docs/schema.md`.
-- [ ] Write a test in `src/engine/storage/historyDb.test.ts` to instantiate the database and assert the schema structures.
+- [x] `src/engine/storage/historyDb.ts` is created and exports a valid idb database instance named `SaveHistoryDB`.
+- [x] Database version is exactly 1.
+- [x] Object stores `saves`, `metadata`, and `indexes` are defined.
+- [x] Database schema strictly adheres to Section 14 of `.foundry/docs/schema.md`.
+- [x] Write a test in `src/engine/storage/historyDb.test.ts` to instantiate the database and assert the schema structures.

--- a/src/engine/storage/historyDb.test.ts
+++ b/src/engine/storage/historyDb.test.ts
@@ -1,0 +1,20 @@
+import 'fake-indexeddb/auto';
+import { describe, expect, it } from 'vitest';
+import { initHistoryDb } from './historyDb';
+
+describe('SaveHistoryDB', () => {
+  it('should initialize the database with correct name and version', async () => {
+    const db = await initHistoryDb();
+    expect(db.name).toBe('SaveHistoryDB');
+    expect(db.version).toBe(1);
+    db.close();
+  });
+
+  it('should define the correct object stores', async () => {
+    const db = await initHistoryDb();
+    expect(db.objectStoreNames.contains('saves')).toBe(true);
+    expect(db.objectStoreNames.contains('metadata')).toBe(true);
+    expect(db.objectStoreNames.contains('indexes')).toBe(true);
+    db.close();
+  });
+});

--- a/src/engine/storage/historyDb.ts
+++ b/src/engine/storage/historyDb.ts
@@ -1,0 +1,32 @@
+import { type DBSchema, type IDBPDatabase, openDB } from 'idb';
+
+export interface SaveHistoryDBSchema extends DBSchema {
+  saves: {
+    key: string;
+    value: Uint8Array;
+  };
+  metadata: {
+    key: string;
+    value: Record<string, unknown>;
+  };
+  indexes: {
+    key: string;
+    value: Record<string, unknown>;
+  };
+}
+
+export const initHistoryDb = async (): Promise<IDBPDatabase<SaveHistoryDBSchema>> => {
+  return openDB<SaveHistoryDBSchema>('SaveHistoryDB', 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains('saves')) {
+        db.createObjectStore('saves');
+      }
+      if (!db.objectStoreNames.contains('metadata')) {
+        db.createObjectStore('metadata');
+      }
+      if (!db.objectStoreNames.contains('indexes')) {
+        db.createObjectStore('indexes');
+      }
+    },
+  });
+};


### PR DESCRIPTION
Implemented the `SaveHistoryDB` IndexedDB database schema using the `idb` library as specified in Section 14 of `.foundry/docs/schema.md`.
Added a unit test using `fake-indexeddb` to verify the schema structure and object stores.
Checked off the acceptance criteria for TASK `task-358-427-indexeddb-schema-impl`.

---
*PR created automatically by Jules for task [13248586827349519394](https://jules.google.com/task/13248586827349519394) started by @szubster*