### PR TITLE
feat(saveParser): implement Gen 3 Move Tutor extraction functions

### DIFF
--- a/.foundry/tasks/task-412-423-gen3-move-tutor-extractor.md
+++ b/.foundry/tasks/task-412-423-gen3-move-tutor-extractor.md
@@ -38,8 +38,8 @@ As per ADR 010, the parsing implementation must use `DataView` for all byte read
 6. Write unit tests to cover parsing malformed structures (out-of-bounds `DataView` access) for both game versions to ensure `RangeError` is handled properly.
 
 ## Acceptance Criteria
-- [ ] Extraction function for Emerald is correctly implemented using `DataView` and relative offsets.
-- [ ] Extraction function for FireRed/LeafGreen is correctly implemented using `DataView` and relative offsets.
-- [ ] Both functions catch `RangeError` and throw the expected error message.
-- [ ] Unit tests cover parsing valid structures for both games.
-- [ ] Unit tests cover parsing malformed structures (out-of-bounds) for both games.
+- [x] Extraction function for Emerald is correctly implemented using `DataView` and relative offsets.
+- [x] Extraction function for FireRed/LeafGreen is correctly implemented using `DataView` and relative offsets.
+- [x] Both functions catch `RangeError` and throw the expected error message.
+- [x] Unit tests cover parsing valid structures for both games.
+- [x] Unit tests cover parsing malformed structures (out-of-bounds) for both games.

--- a/src/engine/saveParser/gen3/moveTutor/extractor.test.ts
+++ b/src/engine/saveParser/gen3/moveTutor/extractor.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { extractEmeraldMoveTutors, extractFRLGMoveTutors } from './extractor';
+
+describe('Gen 3 Move Tutor Extractor', () => {
+  describe('extractEmeraldMoveTutors', () => {
+    it('should parse valid Emerald Move Tutor flags set to 0', () => {
+      const buffer = new ArrayBuffer(0x2000);
+      const dataView = new DataView(buffer);
+      const sectionOffset = 0x0000;
+
+      const result = extractEmeraldMoveTutors(dataView, sectionOffset);
+
+      expect(result).toEqual({
+        swagger: false,
+        rollout: false,
+        furyCutter: false,
+        mimic: false,
+        metronome: false,
+        sleepTalk: false,
+        substitute: false,
+        dynamicPunch: false,
+        doubleEdge: false,
+        explosion: false,
+      });
+    });
+
+    it('should parse valid Emerald Move Tutor flags set to 1', () => {
+      const buffer = new ArrayBuffer(0x2000);
+      const dataView = new DataView(buffer);
+      const sectionOffset = 0x0000;
+
+      const baseOffset = 0x1270;
+
+      dataView.setUint8(baseOffset + Math.floor(433 / 8), 0b11111110);
+      dataView.setUint8(baseOffset + Math.floor(440 / 8), 0b00000111);
+
+      const result = extractEmeraldMoveTutors(dataView, sectionOffset);
+
+      expect(result).toEqual({
+        swagger: true,
+        rollout: true,
+        furyCutter: true,
+        mimic: true,
+        metronome: true,
+        sleepTalk: true,
+        substitute: true,
+        dynamicPunch: true,
+        doubleEdge: true,
+        explosion: true,
+      });
+    });
+
+    it('should throw "The save file is corrupted or incomplete." on RangeError', () => {
+      const buffer = new ArrayBuffer(10);
+      const dataView = new DataView(buffer);
+      const sectionOffset = 0;
+
+      expect(() => extractEmeraldMoveTutors(dataView, sectionOffset)).toThrow(
+        'The save file is corrupted or incomplete.',
+      );
+    });
+  });
+
+  describe('extractFRLGMoveTutors', () => {
+    it('should parse valid FireRed/LeafGreen Move Tutor flags set to 0', () => {
+      const buffer = new ArrayBuffer(0x2000);
+      const dataView = new DataView(buffer);
+      const sectionOffset = 0x0000;
+
+      const result = extractFRLGMoveTutors(dataView, sectionOffset);
+
+      expect(result).toEqual({
+        doubleEdge: false,
+        thunderWave: false,
+        rockSlide: false,
+        explosion: false,
+        megaPunch: false,
+        megaKick: false,
+        dreamEater: false,
+        softBoiled: false,
+        substitute: false,
+        swordsDance: false,
+        seismicToss: false,
+        counter: false,
+        metronome: false,
+        mimic: false,
+        bodySlam: false,
+        frenzyPlant: false,
+        blastBurn: false,
+        hydroCannon: false,
+      });
+    });
+
+    it('should parse valid FireRed/LeafGreen Move Tutor flags set to 1', () => {
+      const buffer = new ArrayBuffer(0x2000);
+      const dataView = new DataView(buffer);
+      const sectionOffset = 0x0000;
+
+      const baseOffset = 0x0ee0;
+
+      dataView.setUint8(baseOffset + Math.floor(704 / 8), 0b11111111);
+      dataView.setUint8(baseOffset + Math.floor(712 / 8), 0b01111111);
+      dataView.setUint8(baseOffset + Math.floor(734 / 8), 0b11000000);
+      dataView.setUint8(baseOffset + Math.floor(736 / 8), 0b00000001);
+
+      const result = extractFRLGMoveTutors(dataView, sectionOffset);
+
+      expect(result).toEqual({
+        doubleEdge: true,
+        thunderWave: true,
+        rockSlide: true,
+        explosion: true,
+        megaPunch: true,
+        megaKick: true,
+        dreamEater: true,
+        softBoiled: true,
+        substitute: true,
+        swordsDance: true,
+        seismicToss: true,
+        counter: true,
+        metronome: true,
+        mimic: true,
+        bodySlam: true,
+        frenzyPlant: true,
+        blastBurn: true,
+        hydroCannon: true,
+      });
+    });
+
+    it('should throw "The save file is corrupted or incomplete." on RangeError', () => {
+      const buffer = new ArrayBuffer(10);
+      const dataView = new DataView(buffer);
+      const sectionOffset = 0;
+
+      expect(() => extractFRLGMoveTutors(dataView, sectionOffset)).toThrow('The save file is corrupted or incomplete.');
+    });
+  });
+});

--- a/src/engine/saveParser/gen3/moveTutor/extractor.ts
+++ b/src/engine/saveParser/gen3/moveTutor/extractor.ts
@@ -1,0 +1,94 @@
+import {
+  EMERALD_EVENT_FLAGS_BASE_OFFSET,
+  EMERALD_MOVE_TUTOR_DOUBLE_EDGE_FLAG,
+  EMERALD_MOVE_TUTOR_DYNAMIC_PUNCH_FLAG,
+  EMERALD_MOVE_TUTOR_EXPLOSION_FLAG,
+  EMERALD_MOVE_TUTOR_FURY_CUTTER_FLAG,
+  EMERALD_MOVE_TUTOR_METRONOME_FLAG,
+  EMERALD_MOVE_TUTOR_MIMIC_FLAG,
+  EMERALD_MOVE_TUTOR_ROLLOUT_FLAG,
+  EMERALD_MOVE_TUTOR_SLEEP_TALK_FLAG,
+  EMERALD_MOVE_TUTOR_SUBSTITUTE_FLAG,
+  EMERALD_MOVE_TUTOR_SWAGGER_FLAG,
+  FRLG_EVENT_FLAGS_BASE_OFFSET,
+  FRLG_MOVE_TUTOR_BLAST_BURN_FLAG,
+  FRLG_MOVE_TUTOR_BODY_SLAM_FLAG,
+  FRLG_MOVE_TUTOR_COUNTER_FLAG,
+  FRLG_MOVE_TUTOR_DOUBLE_EDGE_FLAG,
+  FRLG_MOVE_TUTOR_DREAM_EATER_FLAG,
+  FRLG_MOVE_TUTOR_EXPLOSION_FLAG,
+  FRLG_MOVE_TUTOR_FRENZY_PLANT_FLAG,
+  FRLG_MOVE_TUTOR_HYDRO_CANNON_FLAG,
+  FRLG_MOVE_TUTOR_MEGA_KICK_FLAG,
+  FRLG_MOVE_TUTOR_MEGA_PUNCH_FLAG,
+  FRLG_MOVE_TUTOR_METRONOME_FLAG,
+  FRLG_MOVE_TUTOR_MIMIC_FLAG,
+  FRLG_MOVE_TUTOR_ROCK_SLIDE_FLAG,
+  FRLG_MOVE_TUTOR_SEISMIC_TOSS_FLAG,
+  FRLG_MOVE_TUTOR_SOFT_BOILED_FLAG,
+  FRLG_MOVE_TUTOR_SUBSTITUTE_FLAG,
+  FRLG_MOVE_TUTOR_SWORDS_DANCE_FLAG,
+  FRLG_MOVE_TUTOR_THUNDER_WAVE_FLAG,
+} from './constants';
+
+const readFlag = (dataView: DataView, baseOffset: number, flagId: number): boolean => {
+  const byteOffset = Math.floor(flagId / 8);
+  const bitPosition = flagId % 8;
+  return (dataView.getUint8(baseOffset + byteOffset) & (1 << bitPosition)) !== 0;
+};
+
+export const extractEmeraldMoveTutors = (dataView: DataView, sectionOffset: number) => {
+  try {
+    const baseOffset = sectionOffset + EMERALD_EVENT_FLAGS_BASE_OFFSET;
+
+    return {
+      swagger: readFlag(dataView, baseOffset, EMERALD_MOVE_TUTOR_SWAGGER_FLAG),
+      rollout: readFlag(dataView, baseOffset, EMERALD_MOVE_TUTOR_ROLLOUT_FLAG),
+      furyCutter: readFlag(dataView, baseOffset, EMERALD_MOVE_TUTOR_FURY_CUTTER_FLAG),
+      mimic: readFlag(dataView, baseOffset, EMERALD_MOVE_TUTOR_MIMIC_FLAG),
+      metronome: readFlag(dataView, baseOffset, EMERALD_MOVE_TUTOR_METRONOME_FLAG),
+      sleepTalk: readFlag(dataView, baseOffset, EMERALD_MOVE_TUTOR_SLEEP_TALK_FLAG),
+      substitute: readFlag(dataView, baseOffset, EMERALD_MOVE_TUTOR_SUBSTITUTE_FLAG),
+      dynamicPunch: readFlag(dataView, baseOffset, EMERALD_MOVE_TUTOR_DYNAMIC_PUNCH_FLAG),
+      doubleEdge: readFlag(dataView, baseOffset, EMERALD_MOVE_TUTOR_DOUBLE_EDGE_FLAG),
+      explosion: readFlag(dataView, baseOffset, EMERALD_MOVE_TUTOR_EXPLOSION_FLAG),
+    };
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+};
+
+export const extractFRLGMoveTutors = (dataView: DataView, sectionOffset: number) => {
+  try {
+    const baseOffset = sectionOffset + FRLG_EVENT_FLAGS_BASE_OFFSET;
+
+    return {
+      doubleEdge: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_DOUBLE_EDGE_FLAG),
+      thunderWave: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_THUNDER_WAVE_FLAG),
+      rockSlide: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_ROCK_SLIDE_FLAG),
+      explosion: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_EXPLOSION_FLAG),
+      megaPunch: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_MEGA_PUNCH_FLAG),
+      megaKick: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_MEGA_KICK_FLAG),
+      dreamEater: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_DREAM_EATER_FLAG),
+      softBoiled: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_SOFT_BOILED_FLAG),
+      substitute: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_SUBSTITUTE_FLAG),
+      swordsDance: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_SWORDS_DANCE_FLAG),
+      seismicToss: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_SEISMIC_TOSS_FLAG),
+      counter: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_COUNTER_FLAG),
+      metronome: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_METRONOME_FLAG),
+      mimic: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_MIMIC_FLAG),
+      bodySlam: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_BODY_SLAM_FLAG),
+      frenzyPlant: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_FRENZY_PLANT_FLAG),
+      blastBurn: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_BLAST_BURN_FLAG),
+      hydroCannon: readFlag(dataView, baseOffset, FRLG_MOVE_TUTOR_HYDRO_CANNON_FLAG),
+    };
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+};


### PR DESCRIPTION
Implements extraction functions using `DataView` to parse the status of each Gen 3 one-time Move Tutor for Emerald, FireRed, and LeafGreen. Includes unit tests and checks off the acceptance criteria in `.foundry/tasks/task-412-423-gen3-move-tutor-extractor.md`.

---
*PR created automatically by Jules for task [17286648015479346063](https://jules.google.com/task/17286648015479346063) started by @szubster*