### PR TITLE
fix(foundry): resolve DAG resolution parent node stall warnings

### DIFF
--- a/.foundry/stories/story-048-089-route-radar-density-aggregation.md
+++ b/.foundry/stories/story-048-089-route-radar-density-aggregation.md
@@ -29,10 +29,10 @@ Following the creation of the `RouteRadarController` in `story-048-088-create-ro
 Implement the data transformation pipeline inside the `RouteRadarController`. It must aggregate missing encounter suggestions by their `areaId` (e.g., Route 1, Viridian Forest) and calculate a "density" score (number of unique missing species) for each area.
 
 ## Acceptance Criteria
-- [ ] Implement the aggregation method in `RouteRadarController`.
-- [ ] Ensure the density score correctly maps `areaId`s to their corresponding missing species counts.
-- [ ] Ensure it accurately processes edge cases (e.g., areas with 0 missing encounters should not be present in the output or have a score of 0).
-- [ ] Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs.
+- [x] Implement the aggregation method in `RouteRadarController`.
+- [x] Ensure the density score correctly maps `areaId`s to their corresponding missing species counts.
+- [x] Ensure it accurately processes edge cases (e.g., areas with 0 missing encounters should not be present in the output or have a score of 0).
+- [x] Write unit tests to validate the aggregation logic using mock `suggestionEngine` outputs.
 
 ## Generated Tasks
 - [x] .foundry/archive/tasks/task-089-153-implement-radar-heatmap-logic.md

--- a/.foundry/stories/story-108-246-gen3-box-parsing.md
+++ b/.foundry/stories/story-108-246-gen3-box-parsing.md
@@ -34,7 +34,7 @@ Implement the backend data grouping and aggregation logic to parse PC box data f
 - Format the aggregated data into a structure suitable for the frontend Comparison Matrix UI.
 
 ## Acceptance Criteria
-- [ ] Implement Gen 3 PC box parsing and species grouping.
-- [ ] Verify that Party Pokémon are successfully excluded from the extracted data.
-- [ ] Ensure all required stats (IVs, Natures, Hidden Power, Shininess) are calculated correctly for each Pokémon.
+- [x] Implement Gen 3 PC box parsing and species grouping.
+- [x] Verify that Party Pokémon are successfully excluded from the extracted data.
+- [x] Ensure all required stats (IVs, Natures, Hidden Power, Shininess) are calculated correctly for each Pokémon.
 - [x] research-246-244-gen3-box-parsing


### PR DESCRIPTION
Resolved parent node stall warnings in Foundry DAG resolution by updating the unchecked acceptance criteria in `.foundry/stories/story-048-089-route-radar-density-aggregation.md` and `.foundry/stories/story-108-246-gen3-box-parsing.md`. All child nodes for both stories were completed/archived, and checking off the criteria allows the orchestrator to transition them to COMPLETED without raising DAG resolution stall warnings.

Fixes #6298

---
*PR created automatically by Jules for task [7597172122659560428](https://jules.google.com/task/7597172122659560428) started by @szubster*