### PR TITLE
feat: Gen 3 Friendship extraction in PC Box Parser

### DIFF
--- a/.foundry/journals/coder/2026-08-15-12-46-21.md
+++ b/.foundry/journals/coder/2026-08-15-12-46-21.md
@@ -1,0 +1,1 @@
+Learned to strictly clean up scratchpad files before submitting a PR to avoid failing the code review for polluted workspace. Also ensuring tests are cleanly added to existing test blocks.

--- a/.foundry/tasks/task-152-258-gen3-friendship-impl.md
+++ b/.foundry/tasks/task-152-258-gen3-friendship-impl.md
@@ -40,8 +40,8 @@ Friendship is located at offset 4 of the **Growth (G)** substructure. The order 
 *   If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
 
 ## Acceptance Criteria
-- [ ] Create constants for all memory offsets (e.g., Growth substructure offset, Friendship offset within Growth, etc.).
-- [ ] Implement utility/logic to determine the `PV % 24` permutation.
-- [ ] Implement logic to extract the Friendship byte from the Data block using the `DataView` API.
-- [ ] Integrate or prepare the logic for Party and PC Box parsing.
-- [ ] Write unit tests verifying Friendship extraction works for various `PV % 24` permutations.
+- [x] Create constants for all memory offsets (e.g., Growth substructure offset, Friendship offset within Growth, etc.).
+- [x] Implement utility/logic to determine the `PV % 24` permutation.
+- [x] Implement logic to extract the Friendship byte from the Data block using the `DataView` API.
+- [x] Integrate or prepare the logic for Party and PC Box parsing.
+- [x] Write unit tests verifying Friendship extraction works for various `PV % 24` permutations.

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -22,6 +22,7 @@ import {
   parseGen3MetLocation,
   parseGen3MirageIslandValue,
   parseGen3MixRecords,
+  parseGen3PCBoxes,
   parseGen3PersonalityValue,
   parseGen3PokeNews,
   parseGen3Ribbons,
@@ -35,6 +36,40 @@ import {
 } from './gen3';
 
 describe('gen3 parser scaffolding', () => {
+  it('should extract friendship properly from PC Boxes with correct PV permutations', () => {
+    const buffer = new ArrayBuffer(83744); // At least PC_BOX_BUFFER_SIZE
+    const view = new DataView(buffer);
+
+    // Box 0, Slot 0
+    // PV = 0 (Permutation 0: GAEM) -> G is at offset 0
+    const slot0Offset = 4; // PC_BOX_POKEMON_LIST_OFFSET
+    view.setUint32(slot0Offset + 0, 0, true); // PV
+    view.setUint32(slot0Offset + 4, 0x12345678, true); // OTID
+    // KEY = 0x12345678
+    // Friendship offset in G = 4. Since G is at 0, offset in data = 4. Data starts at 32. Total offset = 4 + 32 = 36.
+    // We want decrypted friendship = 255.
+    // Encrypted = 255 ^ (0x12345678 & 0xFF) = 255 ^ 0x78 = 135
+    view.setUint8(slot0Offset + 36, 135);
+
+    // Box 0, Slot 1
+    // PV = 6 (Permutation 6: AGEM) -> G is at offset 12
+    const slot1Offset = 4 + 80;
+    view.setUint32(slot1Offset + 0, 6, true); // PV
+    view.setUint32(slot1Offset + 4, 0x87654321, true); // OTID
+    // KEY = 6 ^ 0x87654321
+    // Friendship offset in G = 4. Since G is at 12, offset in data = 16. Total offset = 84 + 32 + 16 = 132.
+    // We want decrypted friendship = 100.
+    // Encrypted = 100 ^ (KEY & 0xFF) = 100 ^ 39 = 67
+    view.setUint8(slot1Offset + 16 + 32, 67);
+
+    // Mock current box count for parseGen3PCBoxes buffer parsing logic if needed
+    view.setUint32(0, 0, true); // PC_BOX_CURRENT_BOX_OFFSET
+
+    const result = parseGen3PCBoxes(view);
+    expect(result.pcDetails[0]?.friendship).toBe(255);
+    expect(result.pcDetails[1]?.friendship).toBe(100);
+  });
+
   it('isGen3Save should return false normally', () => {
     const buffer = new ArrayBuffer(8);
     const view = new DataView(buffer);

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -230,6 +230,7 @@ export const PC_BOX_CAPACITY = 30;
 export const GEN3_PC_POKEMON_STRUCT_SIZE = 80;
 export const GEN3_POKEMON_SPECIES_OFFSET_IN_G = 0x00;
 export const GEN3_POKEMON_ITEM_OFFSET_IN_G = 0x02;
+export const GEN3_POKEMON_FRIENDSHIP_OFFSET_IN_G = 0x04;
 export const GEN3_POKEMON_MOVES_OFFSET_IN_A = 0x00;
 export const NUM_SUBSTRUCTURE_PERMUTATIONS = 24;
 
@@ -604,8 +605,13 @@ export function parseGen3PCBoxes(pcBufferView: DataView) {
           true,
         );
         const encryptedItem = pcBufferView.getUint16(growthSubstructureOffset + GEN3_POKEMON_ITEM_OFFSET_IN_G, true);
+        const encryptedFriendship = pcBufferView.getUint8(
+          growthSubstructureOffset + GEN3_POKEMON_FRIENDSHIP_OFFSET_IN_G,
+        );
+
         const speciesId = encryptedSpecies ^ (decryptionKey & LOWER_16_BIT_MASK);
         const item = encryptedItem ^ (decryptionKey >>> 16);
+        const friendship = encryptedFriendship ^ (decryptionKey & 0xff);
 
         const encryptedMove1 = pcBufferView.getUint16(attacksSubstructureOffset + GEN3_POKEMON_MOVES_OFFSET_IN_A, true);
         const encryptedMove2 = pcBufferView.getUint16(
@@ -637,6 +643,7 @@ export function parseGen3PCBoxes(pcBufferView: DataView) {
           isShiny,
           item: item > 0 ? item : undefined,
           moves,
+          friendship,
           storageLocation: `Box ${box + 1}`,
           slot,
         };


### PR DESCRIPTION
Implements the extraction of Gen 3 Friendship (Happiness) data from the 48-byte encrypted Data block. By locating the Growth (G) substructure via `PV % 24` permutation logic, the parser correctly targets offset `0x04` and extracts the byte, decrypting it with the lowest 8-bits of the Pokemon's 32-bit `decryptionKey`. Tests have been added mapping various PVs against known values.

---
*PR created automatically by Jules for task [5293937151359834047](https://jules.google.com/task/5293937151359834047) started by @szubster*