### PR TITLE
feat: implement Schema Resource Locking in Zod

### DIFF
--- a/.foundry/tasks/task-418-423-implement-locks-zod.md
+++ b/.foundry/tasks/task-418-423-implement-locks-zod.md
@@ -30,4 +30,4 @@ Update `.github/scripts/schema.ts` to implement Zod validation for the new `lock
 - Add `locks: z.array(z.string()).optional()` to the schema object.
 
 ## Acceptance Criteria
-- [ ] Coder updates `.github/scripts/schema.ts` to validate the `locks` field as an array of strings.
+- [x] Coder updates `.github/scripts/schema.ts` to validate the `locks` field as an array of strings.

--- a/.github/scripts/schema.test.ts
+++ b/.github/scripts/schema.test.ts
@@ -147,4 +147,20 @@ describe('NodeFrontmatterSchema', () => {
     };
     expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow(Error);
   });
+
+  it('validates a node with locks', () => {
+    const node = {
+      id: "task-001",
+      type: "TASK",
+      title: "New Task",
+      status: "PENDING",
+      owner_persona: "coder",
+      created_at: "2026-08-14",
+      updated_at: "2026-08-14",
+      depends_on: [],
+      jules_session_id: null,
+      locks: ["lock1", "lock2"]
+    };
+    expect(() => NodeFrontmatterSchema.parse(node)).not.toThrow(Error);
+  });
 });

--- a/.github/scripts/schema.ts
+++ b/.github/scripts/schema.ts
@@ -59,6 +59,7 @@ export const NodeFrontmatterSchema = z.object({
   rejection_reason: z.string().optional(),
   notes: z.string().optional(),
   experiment_variants: z.array(z.string()).optional(),
+  locks: z.array(z.string()).optional(),
 });
 
 export type NodeFrontmatter = z.infer<typeof NodeFrontmatterSchema>;


### PR DESCRIPTION
Implemented Zod validation for the new `locks` field as per task-418-423. Updated `NodeFrontmatterSchema` to include `locks: z.array(z.string()).optional()` and added tests to ensure it passes validation. Completed pre-commit checks and verified all tests pass.

---
*PR created automatically by Jules for task [12432997899201969693](https://jules.google.com/task/12432997899201969693) started by @szubster*