### PR TITLE
Update TPM archiving rules and add deterministic orchestrator tree archival IDEA node

### DIFF
--- a/.foundry/ideas/idea-152-deterministic-dag-tree-archival.md
+++ b/.foundry/ideas/idea-152-deterministic-dag-tree-archival.md
@@ -1,0 +1,39 @@
+---
+id: idea-152-deterministic-dag-tree-archival
+type: IDEA
+title: Deterministic DAG Tree Archival in Orchestrator
+status: PENDING
+owner_persona: product_manager
+created_at: 2026-08-15T20:00:00.000Z
+updated_at: '2026-08-15'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - foundry
+  - infrastructure
+  - orchestrator
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Deterministic DAG Tree Archival in Orchestrator
+
+## Problem
+Currently, DAG node archival is handled by persona instructions (e.g., TPM agent) or manual sweeps, which can lead to non-deterministic archiving behavior or premature archival of individual completed nodes while their broader DAG tree/family is still active. Non-deterministic archival relies on LLM agent execution, which can be inconsistent or delayed.
+
+## Solution
+Move tree-level archival logic into the DAG orchestrator (or a deterministic automated script step) so that node archival is 100% deterministic and automated:
+1. **Tree Completeness Verification:** The orchestrator evaluates whole DAG trees from root nodes to all leaf descendants.
+2. **Whole-Tree Terminal State Trigger:** A tree is archived if and only if EVERY node in the tree (from root down to all leaves) is in a terminal state (`COMPLETED` or `CANCELLED`).
+3. **Context Preservation:** If any node in a tree's parent chain or descendant hierarchy is in a non-terminal state, no nodes in that tree are moved to `.foundry/archive/`, ensuring full knowledge context remains available to active agents.
+4. **Link Updating:** The orchestrator deterministically updates inline markdown link references across active files when moving nodes to `.foundry/archive/`.
+
+## Why this matters
+Automating DAG tree archival in the orchestrator guarantees strict adherence to the whole-tree terminal state rule, removes reliance on agent prompts for filesystem moves, prevents context loss, and keeps the active `.foundry/` directory clean.
+
+## Acceptance Criteria
+- [ ] prd-152-deterministic-dag-tree-archival

--- a/.github/agents/tpm.md
+++ b/.github/agents/tpm.md
@@ -9,7 +9,8 @@ You are the TPM (Technical Program Manager) agent for The Foundry.
 - **Resolve Minor Deadlocks:** Detect and resolve minor graph deadlocks in the DAG orchestrator.
 
 **ARCHIVING RULES:**
-- Do not archive a parent node (e.g., an EPIC) if any of its child nodes (e.g., STORY, TASK) are still active or pending.
+- Archive nodes only when the entire DAG tree (from the root node down to all leaf descendants) is in a terminal state (`COMPLETED` or `CANCELLED`).
+- If any node in a tree's parent chain or descendant hierarchy is in a non-terminal state (e.g., `PENDING`, `READY`, `ACTIVE`, `VERIFYING`, `BLOCKED`, `DRAFT`), do NOT archive any node in that tree. Every leaf and node can still contribute context and knowledge while any part of its tree is incomplete.
 - When archiving completed nodes to `.foundry/archive/`, you MUST update all active files that reference them in inline markdown links to use the new archived path. **CRITICAL:** Do NOT modify the 'parent' field or 'depends_on' list in the YAML frontmatter to use file paths; they must strictly remain as Node IDs to prevent DAG orchestrator deadlocks.
 
 ## Journal


### PR DESCRIPTION
Updates TPM persona archiving rules in `.github/agents/tpm.md` so that completed or cancelled DAG nodes are archived only when their entire DAG tree (from root down to all leaf descendants) is in a terminal state. Also creates `.foundry/ideas/idea-152-deterministic-dag-tree-archival.md` proposing that whole-tree archival logic be moved into the DAG orchestrator for 100% deterministic execution.

Fixes #6313

---
*PR created automatically by Jules for task [17023017940117727278](https://jules.google.com/task/17023017940117727278) started by @szubster*