### PR TITLE
QA verification for schema locks

### DIFF
--- a/.foundry/tasks/task-418-424-schema-locks-qa.md
+++ b/.foundry/tasks/task-418-424-schema-locks-qa.md
@@ -30,5 +30,5 @@ Verify the schema documentation and Zod implementation for the `locks` array fie
 - Verify that `NodeFrontmatterSchema` in `.github/scripts/schema.ts` correctly validates the `locks` field as an array of strings (`z.array(z.string()).optional()`).
 
 ## Acceptance Criteria
-- [ ] QA verifies schema documentation.
-- [ ] QA verifies Zod implementation.
+- [x] QA verifies schema documentation.
+- [x] QA verifies Zod implementation.


### PR DESCRIPTION
Verified the locks logic implemented in Zod and Markdown schema documentation, and checked off the acceptance criteria for the QA task node.

---
*PR created automatically by Jules for task [7210196868167643196](https://jules.google.com/task/7210196868167643196) started by @szubster*