### PR TITLE
Reject move tutor extraction task for missing constants

### DIFF
--- a/.foundry/journals/qa/12809178804391646443.md
+++ b/.foundry/journals/qa/12809178804391646443.md
@@ -1,0 +1,4 @@
+## 12809178804391646443
+* Verified Gen 3 move tutor implementation.
+* Detected architectural violation: the coder used a magic number `8` instead of the required `BITS_PER_BYTE` module-level constant from `src/engine/saveParser/gen3/moveTutor/constants.ts` when implementing `readFlag` in `extractor.ts`. This violates Section 13 of the save parsing schema.
+* Rejected the implementation task `task-412-423-gen3-move-tutor-extractor` back to the coder for remediation by updating its frontmatter and appending a rejection note in its body.

--- a/.foundry/tasks/task-412-423-gen3-move-tutor-extractor.md
+++ b/.foundry/tasks/task-412-423-gen3-move-tutor-extractor.md
@@ -2,7 +2,7 @@
 id: task-412-423-gen3-move-tutor-extractor
 type: TASK
 title: Gen 3 Move Tutor Extractor Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-08-12'
 updated_at: '2026-08-15'
@@ -15,12 +15,15 @@ tags:
   - feature
   - gen3
   - save-parsing
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Architectural violation: using magic number 8 instead of BITS_PER_BYTE'
 notes: ''
 ---
 
 # Task: Gen 3 Move Tutor Extractor Implementation
+
+### QA Rejection
+The implementation uses a magic number `8` instead of the `BITS_PER_BYTE` constant during bitwise extraction in `src/engine/saveParser/gen3/moveTutor/extractor.ts`, violating Section 13 "No Magic Numbers" architectural constraint in `.foundry/docs/schema.md`. Please import `BITS_PER_BYTE` from `src/engine/saveParser/gen3/moveTutor/constants.ts` (or define it there if it doesn't exist) and use it.
 
 ## Objective
 Implement extraction functions using `DataView` to parse the status of each Gen 3 one-time Move Tutor.
@@ -38,8 +41,8 @@ As per ADR 010, the parsing implementation must use `DataView` for all byte read
 6. Write unit tests to cover parsing malformed structures (out-of-bounds `DataView` access) for both game versions to ensure `RangeError` is handled properly.
 
 ## Acceptance Criteria
-- [x] Extraction function for Emerald is correctly implemented using `DataView` and relative offsets.
-- [x] Extraction function for FireRed/LeafGreen is correctly implemented using `DataView` and relative offsets.
-- [x] Both functions catch `RangeError` and throw the expected error message.
-- [x] Unit tests cover parsing valid structures for both games.
-- [x] Unit tests cover parsing malformed structures (out-of-bounds) for both games.
+- [ ] Extraction function for Emerald is correctly implemented using `DataView` and relative offsets.
+- [ ] Extraction function for FireRed/LeafGreen is correctly implemented using `DataView` and relative offsets.
+- [ ] Both functions catch `RangeError` and throw the expected error message.
+- [ ] Unit tests cover parsing valid structures for both games.
+- [ ] Unit tests cover parsing malformed structures (out-of-bounds) for both games.

--- a/.foundry/tasks/task-412-424-gen3-move-tutor-qa.md
+++ b/.foundry/tasks/task-412-424-gen3-move-tutor-qa.md
@@ -36,6 +36,9 @@ As per the Intelligent Verification Protocol, a QA task is needed due to the str
 5. Review the test suite to ensure comprehensive coverage for both valid and malformed save structures for both Emerald and FireRed/LeafGreen.
 6. Verify no architectural rules were broken in the implementation.
 
+### Validation Failed
+Detected an architectural violation: magic number `8` is used for bit shifts and module logic instead of the mandated `BITS_PER_BYTE` constant.
+
 ## Acceptance Criteria
 - [ ] Constants are correct and match specifications.
 - [ ] No magic numbers are used in parsing.


### PR DESCRIPTION
* Detected architectural violation: the coder used a magic number `8` instead of the required `BITS_PER_BYTE` module-level constant from `src/engine/saveParser/gen3/moveTutor/constants.ts` when implementing `readFlag` in `extractor.ts`. This violates Section 13 of the save parsing schema.
* Rejected the implementation task `task-412-423-gen3-move-tutor-extractor` back to the coder for remediation by updating its frontmatter and appending a rejection note in its body.
* Updated `task-412-424-gen3-move-tutor-qa` with validation failure message and unchecked checkboxes.

---
*PR created automatically by Jules for task [12809178804391646443](https://jules.google.com/task/12809178804391646443) started by @szubster*