### PR TITLE
💡 Visionary: Gen 3 Trick House Progress Tracker

### DIFF
--- a/.foundry/ideas/idea-154-gen3-trick-house-tracker.md
+++ b/.foundry/ideas/idea-154-gen3-trick-house-tracker.md
@@ -1,0 +1,38 @@
+---
+id: idea-154-gen3-trick-house-tracker
+type: IDEA
+title: Gen 3 Trick House Progress Tracker
+status: READY
+owner_persona: product_manager
+created_at: '2026-08-16T00:42:52.000Z'
+updated_at: '2026-08-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: null
+tags:
+  - dexhelper
+  - feature
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Idea: Gen 3 Trick House Progress Tracker
+
+## Context & Problem Statement
+In Pokemon Ruby, Sapphire, and Emerald, the Trick Master's Trick House on Route 110 is a fan-favorite side activity. It consists of 8 distinct puzzles that sequentially unlock as the player earns Gym Badges. However, players often forget their progress—such as how many puzzles they have completed, whether a new puzzle is currently available based on their recent badge acquisition, or what the upcoming reward will be (like the valuable TM12 Taunt or the Red/Blue Tent).
+
+## Proposed Idea
+The Gen 3 Trick House Progress Tracker will be a new feature in DexHelper that helps players manage this side activity. The existing DexHelper save parsing logic already has rudimentary types for `gen3TrickHouse`. By fully extracting and interpreting these specific event flags and variables from the Gen 3 save file, DexHelper can:
+1. **Track Completion:** Display exactly which of the 8 Trick House puzzles have been successfully cleared.
+2. **Availability Notifications:** Compare the player's earned Gym Badges against their Trick House progression to notify them if a new puzzle is currently available to play.
+3. **Reward Preview:** Show the reward for the upcoming puzzle, motivating players to revisit Route 110.
+
+This turns a forgettable side-quest into an trackable, engaging checklist, directly enhancing the Gen 3 playthrough experience.
+
+## Next Steps / Acceptance Criteria
+- [x] Product Manager: Draft this IDEA node to initiate the feature request for the Gen 3 Trick House Progress Tracker.
+- [ ] Product Manager: Convert this IDEA into a PRD detailing the specific save offsets and UI requirements.

--- a/.jules/visionary/2026-08-16-00-42-52.md
+++ b/.jules/visionary/2026-08-16-00-42-52.md
@@ -1,0 +1,10 @@
+# Visionary Journal
+
+- **Active Session/Timestamp:** 2026-08-16-00-42-52
+- **Domain:** Main Project (DexHelper)
+- **Proposed Idea:** Gen 3 Trick House Progress Tracker (IDEA-154)
+- **Rationale & Concept:**
+  In Pokemon Ruby, Sapphire, and Emerald, the Trick House on Route 110 offers a series of puzzles that unlock as the player earns gym badges. Players often lose track of which puzzles they have completed and when the next one is available.
+  The Gen 3 Trick House Progress Tracker will be a DexHelper feature that parses the save file (specifically utilizing the `gen3TrickHouse` variables in the save data, which are already partially typed) to display the player's current progression. It will indicate which puzzles have been cleared, which are currently available based on gym badges, and the rewards for the next challenge.
+- **Strategic Balance:**
+  In the previous session, a Foundry orchestrator idea was proposed (IDEA-153: Foundry Rearchitecture & Code Architect Persona) as well as IDEA-152 (Deterministic DAG Tree Archival). Prior to that was IDEA-151 (Holistic Code Curator Persona). Moving back to a core product feature for DexHelper (Gen 3 Trick House Progress Tracker) successfully maintains the strict 50/50 strategic balance between direct end-user features (DexHelper) and internal pipeline improvements (Foundry).


### PR DESCRIPTION
Proposes a tracker for the Gen 3 Trick House to help players track completion, view availability based on gym badges, and preview upcoming rewards, turning a forgettable side-quest into an engaging checklist.

---
*PR created automatically by Jules for task [4114649584996939039](https://jules.google.com/task/4114649584996939039) started by @szubster*