### PR TITLE
🎨 Palette: Add focus-visible tactical focus to MapUI buttons

### DIFF
--- a/.jules/palette/2026-08-16-01-03-26.md
+++ b/.jules/palette/2026-08-16-01-03-26.md
@@ -1,0 +1,1 @@
+Learned that the e2e test takes a long time and times out, skipping per memory.

--- a/src/components/assistant/MapUI.tsx
+++ b/src/components/assistant/MapUI.tsx
@@ -36,7 +36,7 @@ export function MapUI({ heatmap, areaNames }: MapUIProps) {
             <button
               type="button"
               key={areaId}
-              className="flex items-center justify-between rounded-none border border-zinc-800 border-dashed bg-zinc-950/50 p-3 transition-colors hover:border-[var(--theme-primary)]/50"
+              className="focus-visible:tactical-focus flex items-center justify-between rounded-none border border-zinc-800 border-dashed bg-zinc-950/50 p-3 transition-colors hover:border-[var(--theme-primary)]/50"
             >
               <span className="font-mono text-xs text-zinc-300">{areaNames?.[areaId] || `AREA #${areaId}`}</span>
               <div className="flex items-center gap-2">


### PR DESCRIPTION
Added the `focus-visible:tactical-focus` class to the interactive area suggestion buttons in `src/components/assistant/MapUI.tsx`.

### What
Added `focus-visible:tactical-focus` to the interactive button elements in the Route Radar MapUI.

### Why
These buttons lacked visual focus states for keyboard users, making keyboard navigation less intuitive.

### Accessibility Notes
Applying the existing `tactical-focus` design primitive restores clear visual indication of focus for accessibility while adhering to the sharp, tactical visual aesthetic specified in ADR 024.

---
*PR created automatically by Jules for task [9135397337037215015](https://jules.google.com/task/9135397337037215015) started by @szubster*