### PR TITLE
📜 Scribe: Document encounterTools.ts

### DIFF
--- a/.jules/scribe/2026-08-16-01-37-12.md
+++ b/.jules/scribe/2026-08-16-01-37-12.md
@@ -1,0 +1,10 @@
+# Scribe Session: 2026-08-16-01-37-12
+
+## Task
+
+Add documentation to a complex engine module (`encounterTools.ts`) focusing on the "why" and architectural design choices, without altering logic.
+
+## Critical Learnings & Architectural Constraints
+
+- **In-Place Array Mutation for Performance**: The core suggestion engine generation loop avoids using declarative array methods like `.filter()`, `.map()`, or `.some()` and instead heavily relies on manual `for` loops. Furthermore, arrays like `suggestions` and `localPids` are mutated *in-place* (using `splice` while iterating backwards, or `delete` on Sets). This is a critical and deliberate architectural constraint to prevent intermediate O(N) array allocations, which cause severe garbage collection overhead during the hot path. Functions like `filterSuggestionsByMissingTools` and `extractPlayerTools` perfectly demonstrate this requirement and have been documented accordingly.
+- **Pre-calculation for O(1) Lookups**: Tool availability (`extractPlayerTools`) is calculated once per suggestion generation cycle and passed down as a `PlayerTools` object to sub-generators, avoiding the need to repeatedly scan the player's full inventory for every individual wild encounter evaluation.

--- a/src/engine/assistant/utils/encounterTools.ts
+++ b/src/engine/assistant/utils/encounterTools.ts
@@ -46,6 +46,9 @@ export interface PlayerTools {
  * Used to determine if the player can access certain map areas or encounter methods
  * (e.g., using Surf to cross water, or Old Rod to fish).
  *
+ * By pre-calculating this once per suggestion loop, we avoid repeatedly scanning the
+ * player's inventory for every single wild encounter.
+ *
  * @param saveData - The parsed save data containing the player's inventory and PC items.
  * @param allInstances - An array of all Pokémon currently owned by the player (Party + PC), used to check for learned HM moves.
  * @returns A `PlayerTools` object indicating which tools and HMs are currently accessible.
@@ -122,6 +125,11 @@ export function extractPlayerTools(saveData: SaveData, allInstances: PokemonInst
 
 /**
  * Filters out HM/Item dependent encounters (like Headbutt, Surf, Fishing) if the player lacks the required tools.
+ *
+ * **Architecture Note: In-Place Mutation**
+ * This function mutates the `suggestions` array directly instead of returning a new array.
+ * This is a deliberate performance optimization to prevent intermediate O(N) array allocations
+ * during the hot path of the suggestion generation loop.
  *
  * If a Pokémon requires a missing tool to be encountered but is still conceptually valid,
  * its priority is heavily penalized rather than being removed entirely, serving as a hint


### PR DESCRIPTION
Added JSDoc to `filterSuggestionsByMissingTools` and `extractPlayerTools` in `encounterTools.ts` to clarify the performance constraints and architectural reasoning (in-place mutation, O(N) allocation avoidance) behind the logic.

---
*PR created automatically by Jules for task [6547858219163730627](https://jules.google.com/task/6547858219163730627) started by @szubster*