### PR TITLE
Reject Gen 3 Ash UI Impl

### DIFF
--- a/.foundry/journals/qa/2026-08-16-02-39-12.md
+++ b/.foundry/journals/qa/2026-08-16-02-39-12.md
@@ -1,0 +1,6 @@
+# QA Rejection: Gen 3 Volcanic Ash UI
+
+- Gen 3 E2E test fails because the Gen 3 parsing engine is broken.
+- Specifically, `isGen3Save` in `src/engine/saveParser/utils/detection.ts` is a stub that strictly returns `false`.
+- This causes `parseSaveFile` to throw an error instead of loading the save, failing E2E tests since the application remains uninitialized.
+- Rejecting the UI implementation task and requesting a fix to the core `isGen3Save` logic before E2E testing can proceed.

--- a/.foundry/tasks/task-348-100-gen3-ash-ui-impl.md
+++ b/.foundry/tasks/task-348-100-gen3-ash-ui-impl.md
@@ -2,7 +2,7 @@
 id: task-348-100-gen3-ash-ui-impl
 type: TASK
 title: 'Task: Implement Gen 3 Volcanic Ash UI Integration'
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-07-29'
 updated_at: '2026-07-30'
@@ -15,8 +15,8 @@ tags:
   - ash
   - ui
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'isGen3Save is just a stub and breaks parsing, preventing e2e tests from running. Please implement it properly in src/engine/saveParser/utils/detection.ts.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-348-101-gen3-ash-ui-qa.md
+++ b/.foundry/tasks/task-348-101-gen3-ash-ui-qa.md
@@ -34,3 +34,6 @@ Implement comprehensive E2E testing to verify the Gen 3 Volcanic Ash UI integrat
 ## Acceptance Criteria
 - [ ] Write an E2E test to verify the Volcanic Ash count renders correctly when a relevant Gen 3 save file is loaded.
 - [ ] Document the test execution and validation results in the `qa` persona journal.
+
+### QA Rejection
+The UI looks fine but `isGen3Save` is a stub returning false which fails to parse the save entirely during e2e. Rejecting task-348-100-gen3-ash-ui-impl so it can be fixed.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+1. Use `replace_with_git_merge_diff` to update `.foundry/tasks/task-348-100-gen3-ash-ui-impl.md` to trigger a transient rejection, setting `status: FAILED` and incrementing `rejection_count`.
+2. Document the failure in a QA journal.
+3. Run core verification commands (`pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e`) to ensure a clean system state.
+4. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. Use the `submit` tool to create the Pull Request with an appropriate title and body.

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,0 @@
-1. Use `replace_with_git_merge_diff` to update `.foundry/tasks/task-348-100-gen3-ash-ui-impl.md` to trigger a transient rejection, setting `status: FAILED` and incrementing `rejection_count`.
-2. Document the failure in a QA journal.
-3. Run core verification commands (`pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e`) to ensure a clean system state.
-4. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-5. Use the `submit` tool to create the Pull Request with an appropriate title and body.


### PR DESCRIPTION
Rejecting Gen 3 Ash UI implementation due to stubbed isGen3Save blocking e2e tests.

---
*PR created automatically by Jules for task [5608445752922908351](https://jules.google.com/task/5608445752922908351) started by @szubster*