### PR TITLE
Implement Integration Tests for Gen 3 IV/PV Extraction

### DIFF
--- a/.foundry/tasks/task-403-419-gen3-iv-pv-integration-impl.md
+++ b/.foundry/tasks/task-403-419-gen3-iv-pv-integration-impl.md
@@ -35,7 +35,7 @@ As part of `story-112-403-integration-e2e`, we need to write robust integration 
    - Verify that corrupted or artificially small mock saves trigger a standard `RangeError` which the extraction function properly catches and re-throws as "The save file is corrupted or incomplete." as per ADR 010 / schema rules.
 
 ## Acceptance Criteria
-- [ ] Integration tests for Gen 3 IV/PV extraction are written using Vitest.
-- [ ] Tests validate A/B banking logic and relative offsets.
-- [ ] Tests validate correct handling and re-throwing of RangeErrors for bounds issues.
-- [ ] Tests pass via `pnpm test`.
+- [x] Integration tests for Gen 3 IV/PV extraction are written using Vitest.
+- [x] Tests validate A/B banking logic and relative offsets.
+- [x] Tests validate correct handling and re-throwing of RangeErrors for bounds issues.
+- [x] Tests pass via `pnpm test`.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,8 @@
+1. **Add new tests in `src/engine/saveParser/parsers/gen3.test.ts` for A/B bank flash memory architecture logic in `parseGen3PokemonPVAndIVs`.**
+   - Specifically, we want an integration test that verifies extracting IVs and PVs from an offset located in Bank B (`0xE000`) and properly handles offsets simulating out-of-bounds relative errors (e.g. throwing `RangeError` translated to `The save file is corrupted or incomplete.`).
+   - We will write a test similar to the existing `parseGen3PokemonPVAndIVs` known permutation test, but using `const offset = 0xE000` (which is `SAVE_BLOCK_B`) and an ArrayBuffer large enough. This ensures we are testing A/B bank boundaries.
+   - We will check that `parseGen3PokemonPVAndIVs(view, 0xE000)` succeeds and properly parses when Bank B is active.
+2. **Ensure `RangeError` bounds checking specifically checks A/B bank relative offset failures.**
+   - We will add another test `should throw corrupted error on out-of-bounds reads within Bank B` that provides a buffer that fits Bank A but not Bank B (e.g., `new ArrayBuffer(0xE010)` which isn't big enough for a full 100-byte Pokemon at `0xE000`), testing that it correctly throws the corruption error.
+3. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+4. **Submit the changes via empty PR.**

--- a/plan.md
+++ b/plan.md
@@ -1,8 +1,0 @@
-1. **Add new tests in `src/engine/saveParser/parsers/gen3.test.ts` for A/B bank flash memory architecture logic in `parseGen3PokemonPVAndIVs`.**
-   - Specifically, we want an integration test that verifies extracting IVs and PVs from an offset located in Bank B (`0xE000`) and properly handles offsets simulating out-of-bounds relative errors (e.g. throwing `RangeError` translated to `The save file is corrupted or incomplete.`).
-   - We will write a test similar to the existing `parseGen3PokemonPVAndIVs` known permutation test, but using `const offset = 0xE000` (which is `SAVE_BLOCK_B`) and an ArrayBuffer large enough. This ensures we are testing A/B bank boundaries.
-   - We will check that `parseGen3PokemonPVAndIVs(view, 0xE000)` succeeds and properly parses when Bank B is active.
-2. **Ensure `RangeError` bounds checking specifically checks A/B bank relative offset failures.**
-   - We will add another test `should throw corrupted error on out-of-bounds reads within Bank B` that provides a buffer that fits Bank A but not Bank B (e.g., `new ArrayBuffer(0xE010)` which isn't big enough for a full 100-byte Pokemon at `0xE000`), testing that it correctly throws the corruption error.
-3. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
-4. **Submit the changes via empty PR.**

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -1507,6 +1507,47 @@ describe('parseGen3PokemonPVAndIVs', () => {
     const view = new DataView(buffer);
     expect(() => parseGen3PokemonPVAndIVs(view, 0)).toThrowError('The save file is corrupted or incomplete.');
   });
+
+  it('should correctly parse IVs and PVs from an offset located in Bank B', () => {
+    const buffer = new ArrayBuffer(0xe000 + 100);
+    const view = new DataView(buffer);
+    const offset = 0xe000;
+
+    const pv = 0x12345678;
+    const otId = 0xabcdef01;
+    view.setUint32(offset + 0, pv, true);
+    view.setUint32(offset + 4, otId, true);
+
+    const decryptionKey = pv ^ otId;
+
+    const hp = 31;
+    const attack = 30;
+    const defense = 29;
+    const speed = 28;
+    const specialAttack = 27;
+    const specialDefense = 26;
+
+    const ivs =
+      (hp << 0) | (attack << 5) | (defense << 10) | (speed << 15) | (specialAttack << 20) | (specialDefense << 25);
+
+    const encryptedIVs = ivs ^ decryptionKey;
+    view.setUint32(offset + 72, encryptedIVs, true);
+
+    const result = parseGen3PokemonPVAndIVs(view, offset);
+    expect(result.pv).toBe(pv);
+    expect(result.hp).toBe(hp);
+    expect(result.attack).toBe(attack);
+    expect(result.defense).toBe(defense);
+    expect(result.speed).toBe(speed);
+    expect(result.specialAttack).toBe(specialAttack);
+    expect(result.specialDefense).toBe(specialDefense);
+  });
+
+  it('should throw corrupted error on out-of-bounds reads within Bank B', () => {
+    const buffer = new ArrayBuffer(0xe000 + 10);
+    const view = new DataView(buffer);
+    expect(() => parseGen3PokemonPVAndIVs(view, 0xe000)).toThrowError('The save file is corrupted or incomplete.');
+  });
 });
 
 describe('parseGen3MetLocation', () => {


### PR DESCRIPTION
This PR implements integration tests in Vitest for the Generation 3 IV/PV extraction logic. The tests verify that the `parseGen3PokemonPVAndIVs` correctly handles logic relating to A/B bank relative offsets (`0xE000`) and properly re-throws `RangeError` with standard corrupted file messages when attempting out-of-bounds reads within these blocks. Checked off acceptance criteria in the corresponding task node.

---
*PR created automatically by Jules for task [16829471319350996269](https://jules.google.com/task/16829471319350996269) started by @szubster*