### PR TITLE
chore: suspend Gen 3 Wonder Card Extraction task pending research

### DIFF
--- a/.foundry/tasks/task-354-391-gen3-wonder-card-extraction-impl.md
+++ b/.foundry/tasks/task-354-391-gen3-wonder-card-extraction-impl.md
@@ -2,11 +2,12 @@
 id: task-354-391-gen3-wonder-card-extraction-impl
 type: TASK
 title: Gen 3 Wonder Card Extraction Implementation
-status: ACTIVE
+status: FAILED
 owner_persona: coder
 created_at: '2026-08-02'
 updated_at: '2026-08-16'
-depends_on: []
+depends_on:
+  - research-391-393-gen3-wonder-card-offsets
 jules_session_id: '2444734361635274119'
 pr_number: null
 parent: story-345-354-gen3-wonder-card-extraction
@@ -15,8 +16,8 @@ tags:
   - mystery-gift
   - data-extraction
 research_references: []
-rejection_count: 1
-rejection_reason: ''
+rejection_count: 2
+rejection_reason: 'Suspended pending research for exact memory offsets'
 notes: ''
 ---
 


### PR DESCRIPTION
This PR suspends the task `task-354-391-gen3-wonder-card-extraction-impl` because it lacks the necessary context to complete (exact memory offsets, structure, etc., for Gen 3 Wonder Cards are unknown).

Following the **Late Binding for Missing Context** system policy:
1. Changed `status` to `FAILED`.
2. Updated `rejection_reason` to explain the suspension.
3. Appended `research-391-393-gen3-wonder-card-offsets` to `depends_on`.

Tests:
- `pnpm lint` passed.
- `pnpm test` passed.
- `xvfb-run pnpm test:e2e` timed out but this is expected per known issues during an Empty PR verification sequence.

---
*PR created automatically by Jules for task [2444734361635274119](https://jules.google.com/task/2444734361635274119) started by @szubster*