### PR TITLE
Add E2E Verification Story for Dynamic Generation of Items PokeData Epic

### DIFF
--- a/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
+++ b/.foundry/epics/epic-049-087-dynamic-item-list-parsing.md
@@ -38,3 +38,4 @@ Currently, valid item lists are either manually maintained or fetched ad-hoc. Ma
 - [x] story-087-128-dynamic-item-list-parsing
 - [x] story-087-245-item-list-validation
 - [x] story-087-280-item-runtime-integration
+- [ ] story-087-427-dynamic-item-list-parsing-e2e

--- a/.foundry/journals/story_owner/master.md
+++ b/.foundry/journals/story_owner/master.md
@@ -159,3 +159,6 @@ When writing STORY nodes dynamically, always list the existing files in the dire
 ## Learnings
 - **ADR 025 Enforcement:** When breaking down epics, it is critical to cross-reference architectural decisions (ADRs). In this session, an epic required extracting the internal RTC from a Gen 3 save file. However, ADR 025 explicitly mandates an "RTC-Independent Fallback Strategy" utilizing system time and UI overrides. The RTC extraction requirement was therefore bypassed and documented via a RESEARCH node to maintain architectural compliance.
 - **Late Binding Pattern:** Utilized the late-binding pattern to dynamically generate a RESEARCH node to investigate the RTC conflict and subsequently generated the correct implementation stories for parsing the Shoal items and the mandated E2E verification story.
+
+## 2026-08-16: E2E Requirement for Epics
+Learned that Epics must always have a final STORY dedicated exclusively to Integration and E2E Verification to avoid rejection from the orchestrator.

--- a/.foundry/stories/story-087-427-dynamic-item-list-parsing-e2e.md
+++ b/.foundry/stories/story-087-427-dynamic-item-list-parsing-e2e.md
@@ -1,0 +1,30 @@
+---
+id: story-087-427-dynamic-item-list-parsing-e2e
+type: STORY
+title: "Dynamic Generation of Items PokeData E2E Verification"
+status: PENDING
+owner_persona: tech_lead
+created_at: "2026-08-16"
+updated_at: "2026-08-16"
+depends_on:
+  - story-087-280-item-runtime-integration
+jules_session_id: null
+pr_number: null
+parent: epic-049-087-dynamic-item-list-parsing
+tags:
+  - e2e
+  - integration
+  - db
+rejection_count: 0
+rejection_reason: ""
+notes: ""
+---
+
+# Dynamic Generation of Items PokeData E2E Verification
+
+## Context
+Integration and E2E Verification for the dynamic generation of items PokeData. This satisfies the Orchestrator Safeguard E2E/Integration Requirement for `epic-049-087-dynamic-item-list-parsing`.
+
+## Acceptance Criteria
+- [ ] Write E2E tests for item dynamic generation and integration.
+- [ ] Break down this STORY into TASK nodes.


### PR DESCRIPTION
Added an e2e story for epic-049-087-dynamic-item-list-parsing to fulfill the Orchestrator Safeguard E2E/Integration Requirement.

---
*PR created automatically by Jules for task [12722708596711389038](https://jules.google.com/task/12722708596711389038) started by @szubster*