### PR TITLE
feat: Implement Gen 3 Mach Bike map parser

### DIFF
--- a/.foundry/tasks/task-412-422-gen3-mach-bike-parsing-impl.md
+++ b/.foundry/tasks/task-412-422-gen3-mach-bike-parsing-impl.md
@@ -28,5 +28,5 @@ Based on the Route Pre-computation & Mapping Epic, we need to extract Gen 3 map 
 Implement logic in the Gen 3 map extraction engine to parse map attributes corresponding to Mach Bike required areas.
 
 ## Acceptance Criteria
-- [ ] Implement parsing for Mach Bike map triggers.
-- [ ] Write unit tests for Mach Bike map parsing.
+- [x] Implement parsing for Mach Bike map triggers.
+- [x] Write unit tests for Mach Bike map parsing.

--- a/src/engine/gen3/mapParsing/machBikeParser.test.ts
+++ b/src/engine/gen3/mapParsing/machBikeParser.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { hasMachBikeRequirement, MB_CRACKED_FLOOR, MB_MUDDY_SLOPE } from './machBikeParser';
+
+describe('hasMachBikeRequirement', () => {
+  it('should return false for empty or normal metatiles', () => {
+    expect(hasMachBikeRequirement([])).toBe(false);
+    expect(hasMachBikeRequirement([0x00, 0x01, 0x02])).toBe(false);
+  });
+
+  it('should return true if MB_MUDDY_SLOPE is present', () => {
+    expect(hasMachBikeRequirement([0x00, MB_MUDDY_SLOPE, 0x02])).toBe(true);
+  });
+
+  it('should return true if MB_CRACKED_FLOOR is present', () => {
+    expect(hasMachBikeRequirement([MB_CRACKED_FLOOR])).toBe(true);
+  });
+});

--- a/src/engine/gen3/mapParsing/machBikeParser.ts
+++ b/src/engine/gen3/mapParsing/machBikeParser.ts
@@ -1,0 +1,20 @@
+export const MB_MUDDY_SLOPE = 0xd4;
+export const MB_CRACKED_FLOOR = 0xd6;
+
+/**
+ * Parses a map grid for Mach Bike required tiles.
+ *
+ * @param metatiles The grid of metatiles (assuming behavior IDs are extracted)
+ * @returns true if the map requires a Mach Bike, false otherwise.
+ */
+export function hasMachBikeRequirement(metatiles: number[]): boolean {
+  for (let i = 0; i < metatiles.length; i++) {
+    const tile = metatiles[i];
+    if (tile === undefined) continue;
+
+    if (tile === MB_MUDDY_SLOPE || tile === MB_CRACKED_FLOOR) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Description
Implemented a Mach Bike requirement parser for Gen 3 map data extraction to fulfill the acceptance criteria for `task-412-422-gen3-mach-bike-parsing-impl.md`.

- Added `machBikeParser.ts` to `src/engine/gen3/mapParsing/` with definitions for `MB_MUDDY_SLOPE` (`0xd4`) and `MB_CRACKED_FLOOR` (`0xd6`).
- Implemented `hasMachBikeRequirement` using safe `for` loop array traversal.
- Added comprehensive unit tests in `machBikeParser.test.ts`.
- Verified and fixed formatting via `pnpm check:fix`.
- Checked off completion markers in the task node.

---
*PR created automatically by Jules for task [17636230230044930249](https://jules.google.com/task/17636230230044930249) started by @szubster*