### PR TITLE
chore(foundry): draft tasks for egg move inventory cross-reference

### DIFF
--- a/.foundry/stories/story-114-413-egg-move-inventory-cross-reference-logic.md
+++ b/.foundry/stories/story-114-413-egg-move-inventory-cross-reference-logic.md
@@ -30,4 +30,6 @@ This story handles the core business logic of checking the calculated breeding c
 - [ ] Implement cross-referencing logic to compare required breeding intermediates against the player's inventory.
 - [ ] Ensure strict gender verification (Male required for passing down the egg move) is applied correctly.
 - [ ] Write unit tests to cover various scenarios, including missing males, present females, and present males with the correct move.
-- [ ] Tech Lead: Draft TASK nodes to execute this story.
+- [x] Tech Lead: Draft TASK nodes to execute this story.
+- [ ] task-413-430-egg-move-inventory-cross-reference-logic-impl
+- [ ] task-413-431-egg-move-inventory-cross-reference-logic-qa

--- a/.foundry/tasks/task-413-430-egg-move-inventory-cross-reference-logic-impl.md
+++ b/.foundry/tasks/task-413-430-egg-move-inventory-cross-reference-logic-impl.md
@@ -1,0 +1,39 @@
+---
+id: task-413-430-egg-move-inventory-cross-reference-logic-impl
+type: TASK
+title: Implement Egg Move Inventory Cross-Reference Logic
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-16'
+updated_at: '2026-08-16'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-114-413-egg-move-inventory-cross-reference-logic
+tags:
+  - feature
+  - mechanics
+  - state
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: Implement Egg Move Inventory Cross-Reference Logic
+
+## Context
+In Gen 2 and Gen 3, only **Male** Pokémon can pass down Egg Moves to their offspring (excluding Ditto, which cannot pass down Egg Moves it has learned). The current logic in `generateBreedingSuggestions` (`src/engine/assistant/generators/breedGenerator.ts`) simply checks if *any* owned instance has the move: `const hasMove = instances.some((inst) => inst.moves?.includes(moveId));` without checking gender.
+
+## Requirements
+1. Update `generateBreedingSuggestions` to verify the gender of the instances that know the egg move.
+2. An instance should only be considered as having the move (`hasMove = true`) if it is **Male**.
+3. For Gen 2 saves, use the existing `calculateGen2Gender(inst.dvs.atk, genderRate)` utility from `src/utils/gender.ts`.
+4. For Gen 3 saves, implement `calculateGen3Gender(personalityValue, genderRate)` in `src/utils/gender.ts` (gender is determined by the lowest 8 bits of PV compared to the gender rate threshold, where `genderRate` in DB is an enum-like value for female ratio, similar to Gen 2).
+5. Fetch the `genderRate` (`gr`) from `apiData.pokemonMetadata`.
+6. Write Vitest tests covering scenarios where the player has a Female with the move (should not pass) vs a Male with the move (should pass).
+
+## Acceptance Criteria
+- [ ] `calculateGen3Gender` is implemented in `src/utils/gender.ts`.
+- [ ] `generateBreedingSuggestions` checks if the instance is male before setting `hasMove = true`.
+- [ ] Unit tests cover gender constraints.

--- a/.foundry/tasks/task-413-431-egg-move-inventory-cross-reference-logic-qa.md
+++ b/.foundry/tasks/task-413-431-egg-move-inventory-cross-reference-logic-qa.md
@@ -1,0 +1,39 @@
+---
+id: task-413-431-egg-move-inventory-cross-reference-logic-qa
+type: TASK
+title: QA - Egg Move Inventory Cross-Reference Logic
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-16'
+updated_at: '2026-08-16'
+depends_on:
+  - task-413-430-egg-move-inventory-cross-reference-logic-impl
+jules_session_id: null
+pr_number: null
+parent: story-114-413-egg-move-inventory-cross-reference-logic
+tags:
+  - qa
+  - mechanics
+  - state
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: QA - Egg Move Inventory Cross-Reference Logic
+
+## Context
+The Coder has implemented strict gender verification logic for passing down egg moves in Gen 2 and Gen 3. In these generations, only Male Pokémon can pass down egg moves.
+
+## Verification Requirements
+1. Review the Coder's implementation in `src/engine/assistant/generators/breedGenerator.ts` and `src/utils/gender.ts`.
+2. Ensure that `calculateGen3Gender` uses the lowest 8 bits of the personality value (`pv & 0xFF`) and correctly compares it against the gender rate thresholds (mapping the 0-8 enum to a 0-255 scale threshold, similar to `calculateGen2Gender`).
+3. Verify that the unit tests cover cases for both Gen 2 (using `dvs.atk`) and Gen 3 (using `personalityValue`), including missing males, present females, and present males with the correct move.
+4. Ensure the tests pass and no regressions are introduced.
+5. If any validation fails, reject the target implementation task following the strict QA Persona Contract.
+
+## Acceptance Criteria
+- [ ] Reviewed the implementation for accuracy.
+- [ ] Validated the test cases for completeness and correctness.
+- [ ] Approved the Coder's work or provided actionable feedback.


### PR DESCRIPTION
Drafted implementation and QA tasks for strictly verifying male gender when passing down egg moves in breeding suggestions (Gen 2/3).
Updated `story-114-413-egg-move-inventory-cross-reference-logic.md` with acceptance criteria and child node references.
- `task-413-430-egg-move-inventory-cross-reference-logic-impl`
- `task-413-431-egg-move-inventory-cross-reference-logic-qa`

---
*PR created automatically by Jules for task [3218120981661404426](https://jules.google.com/task/3218120981661404426) started by @szubster*