### PR TITLE
feat(gen3): implement event inventory items UI dashboard

### DIFF
--- a/.foundry/journals/coder/1371752092130045144.md
+++ b/.foundry/journals/coder/1371752092130045144.md
@@ -1,0 +1,6 @@
+# Session 1371752092130045144
+
+## Learnings
+
+- When testing with `vitest-browser-react` and `vitest/browser`, passing `page.getByText(...)` locators directly to `expect.element()` may cause TypeScript `TS2339: Property 'locator' does not exist on type 'Locator'` errors. Use locators correctly. Alternatively, assign the screen returned by `render()` to a variable (e.g. `const screen = render(<MyComponent/>)`) and use `screen.getByText()`.
+- Use the provided `vitest-browser-react` `render` function directly. The `page` utility is available from `vitest/browser` and provides global page assertions.

--- a/.foundry/tasks/task-409-420-gen3-event-inventory-extraction-ui-impl.md
+++ b/.foundry/tasks/task-409-420-gen3-event-inventory-extraction-ui-impl.md
@@ -32,6 +32,6 @@ Implement the React state/context layer and UI components to expose the extracte
 - Write component tests and verify the UI rendering.
 
 ## Acceptance Criteria
-- [ ] Application state correctly integrates the parser data.
-- [ ] UI components are updated to display the event items.
-- [ ] Component tests verify the integration and rendering.
+- [x] Application state correctly integrates the parser data.
+- [x] UI components are updated to display the event items.
+- [x] Component tests verify the integration and rendering.

--- a/src/components/dashboard/inventory/Gen3EventItemsDashboard.tsx
+++ b/src/components/dashboard/inventory/Gen3EventItemsDashboard.tsx
@@ -1,0 +1,62 @@
+import type React from 'react';
+import {
+  ITEM_AURORA_TICKET,
+  ITEM_EON_TICKET,
+  ITEM_MYSTIC_TICKET,
+  ITEM_OLD_SEA_MAP,
+} from '../../../engine/saveParser/gen3/inventory/constants';
+import type { SaveData } from '../../../engine/saveParser/parsers/common';
+import { TacticalPanel } from '../../TacticalPanel';
+import { TelemetryDecoration } from '../../TelemetryDecoration';
+
+export interface Gen3EventItemsDashboardProps {
+  saveData: SaveData;
+}
+
+const ITEM_NAMES: Record<number, string> = {
+  [ITEM_EON_TICKET]: 'EON TICKET',
+  [ITEM_MYSTIC_TICKET]: 'MYSTIC TICKET',
+  [ITEM_AURORA_TICKET]: 'AURORA TICKET',
+  [ITEM_OLD_SEA_MAP]: 'OLD SEA MAP',
+};
+
+export const Gen3EventItemsDashboard: React.FC<Gen3EventItemsDashboardProps> = ({ saveData }) => {
+  if (saveData.generation !== 3 || !saveData.gen3EventItems) {
+    return null;
+  }
+
+  const entries = Object.entries(saveData.gen3EventItems).map(([id, isClaimed]) => ({
+    id: parseInt(id, 10),
+    isClaimed,
+  }));
+
+  return (
+    <TacticalPanel className="mt-4 flex flex-col gap-4 border-[var(--theme-primary)]/50 border-t-2 p-4 pt-6">
+      <TelemetryDecoration label="SYS.EVENT_ITEMS" className="-top-[17px] left-[-1px]" />
+
+      <div className="z-10 flex items-center justify-between">
+        <span className="tactical-text font-black text-lg text-white">EVENT ITEMS</span>
+      </div>
+
+      <div className="z-10 grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-4">
+        {entries.map(({ id, isClaimed }) => {
+          const displayLabel = ITEM_NAMES[id] || `ITEM ${id}`;
+
+          return (
+            <div
+              key={id}
+              className={`flex items-center justify-between rounded-none border-2 border-dashed p-2 font-mono text-xs ${
+                isClaimed
+                  ? 'border-[var(--theme-primary)] bg-[var(--theme-primary)]/10 text-[var(--theme-primary)]'
+                  : 'border-zinc-700 bg-black/40 text-zinc-500'
+              }`}
+            >
+              <span className="truncate">{displayLabel}</span>
+              <span className="flex-shrink-0 font-black">{isClaimed ? '[X]' : '[ ]'}</span>
+            </div>
+          );
+        })}
+      </div>
+    </TacticalPanel>
+  );
+};

--- a/src/components/dashboard/inventory/__tests__/Gen3EventItemsDashboard.test.tsx
+++ b/src/components/dashboard/inventory/__tests__/Gen3EventItemsDashboard.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import {
+  ITEM_AURORA_TICKET,
+  ITEM_EON_TICKET,
+  ITEM_MYSTIC_TICKET,
+  ITEM_OLD_SEA_MAP,
+} from '../../../../engine/saveParser/gen3/inventory/constants';
+import type { SaveData } from '../../../../engine/saveParser/parsers/common';
+import { Gen3EventItemsDashboard } from '../Gen3EventItemsDashboard';
+
+describe('Gen3EventItemsDashboard', () => {
+  test('renders null if generation is not 3', async () => {
+    const saveData = { generation: 2 } as SaveData;
+    void render(<Gen3EventItemsDashboard saveData={saveData} />);
+    await expect.element(page.getByText('EVENT ITEMS')).not.toBeInTheDocument();
+  });
+
+  test('renders null if gen3EventItems is missing', async () => {
+    const saveData = { generation: 3 } as SaveData;
+    void render(<Gen3EventItemsDashboard saveData={saveData} />);
+    await expect.element(page.getByText('EVENT ITEMS')).not.toBeInTheDocument();
+  });
+
+  test('renders the event items correctly', async () => {
+    const saveData = {
+      generation: 3,
+      gen3EventItems: {
+        [ITEM_EON_TICKET]: true,
+        [ITEM_MYSTIC_TICKET]: false,
+        [ITEM_AURORA_TICKET]: true,
+        [ITEM_OLD_SEA_MAP]: false,
+      },
+    } as unknown as SaveData;
+
+    void render(<Gen3EventItemsDashboard saveData={saveData} />);
+
+    await expect.element(page.getByText('EVENT ITEMS')).toBeVisible();
+
+    const claimed = page.getByText('[X]');
+    const unclaimed = page.getByText('[ ]');
+    expect(claimed.elements().length).toBe(2);
+    expect(unclaimed.elements().length).toBe(2);
+
+    await expect.element(page.getByText('EON TICKET')).toBeVisible();
+    await expect.element(page.getByText('MYSTIC TICKET')).toBeVisible();
+    await expect.element(page.getByText('AURORA TICKET')).toBeVisible();
+    await expect.element(page.getByText('OLD SEA MAP')).toBeVisible();
+  });
+});

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -32,6 +32,12 @@ const Gen3StaticEncountersDashboard = React.lazy(() =>
   })),
 );
 
+const Gen3EventItemsDashboard = React.lazy(() =>
+  import('../components/dashboard/inventory/Gen3EventItemsDashboard').then((m) => ({
+    default: m.Gen3EventItemsDashboard,
+  })),
+);
+
 const GlobalRibbonChecklistDashboard = React.lazy(() =>
   import('../components/dashboard/ribbons/GlobalRibbonChecklistDashboard').then((m) => ({
     default: m.GlobalRibbonChecklistDashboard,
@@ -67,6 +73,7 @@ function DashboardPage() {
             <BattleFrontierDashboard saveData={saveData} />
             <GlobalRibbonChecklistDashboard />
             <Gen3SecretBaseDashboard saveData={saveData} />
+            <Gen3EventItemsDashboard saveData={saveData} />
             <Gen3StaticEncountersDashboard saveData={saveData} />
             <Gen3NpcTrades />
           </>


### PR DESCRIPTION
This PR implements the React state/context layer and UI components to expose the extracted Gen 3 event items data to the UI dashboard.

### Changes
- Implemented `Gen3EventItemsDashboard` component to display extracted Gen 3 event items (Eon Ticket, Mystic Ticket, Aurora Ticket, Old Sea Map).
- Added `Gen3EventItemsDashboard` to the `dashboard.tsx` route inside the Gen 3 dashboard view.
- Wrote component tests for `Gen3EventItemsDashboard` using `vitest-browser-react`.
- Handled edge cases for uninitialized state or non-Gen 3 saves gracefully.
- Marked the Acceptance Criteria checkboxes as completed in the `task-409-420-gen3-event-inventory-extraction-ui-impl.md` file.

---
*PR created automatically by Jules for task [1371752092130045144](https://jules.google.com/task/1371752092130045144) started by @szubster*