### PR TITLE
fix: repair broken task link in story-268-348-gen3-ash-integration

### DIFF
--- a/.foundry/stories/story-268-348-gen3-ash-integration.md
+++ b/.foundry/stories/story-268-348-gen3-ash-integration.md
@@ -33,5 +33,5 @@ Integrate the extracted Gen 3 Volcanic Ash count into the frontend UI and ensure
 
 ## Acceptance Criteria
 - [x] Break down this Story into TASK nodes outlining frontend implementation and E2E testing.
-- [ ] [task-348-100-gen3-ash-ui-impl](.foundry/archive/tasks/task-348-100-gen3-ash-ui-impl.md)
+- [ ] [task-348-100-gen3-ash-ui-impl](.foundry/tasks/task-348-100-gen3-ash-ui-impl.md)
 - [ ] [task-348-101-gen3-ash-ui-qa](.foundry/tasks/task-348-101-gen3-ash-ui-qa.md)


### PR DESCRIPTION
Fixed a broken link in `.foundry/stories/story-268-348-gen3-ash-integration.md` where `task-348-100-gen3-ash-ui-impl.md` was linked under `.foundry/archive/tasks/` instead of `.foundry/tasks/`, resolving the `link-checker` failure in the pre-commit hook.

Fixes #6361

---
*PR created automatically by Jules for task [10188245182717584328](https://jules.google.com/task/10188245182717584328) started by @szubster*