### PR TITLE
fix: update broken task link in story-268-348-gen3-ash-integration.md

### DIFF
--- a/.foundry/stories/story-268-348-gen3-ash-integration.md
+++ b/.foundry/stories/story-268-348-gen3-ash-integration.md
@@ -33,5 +33,5 @@ Integrate the extracted Gen 3 Volcanic Ash count into the frontend UI and ensure
 
 ## Acceptance Criteria
 - [x] Break down this Story into TASK nodes outlining frontend implementation and E2E testing.
-- [ ] [task-348-100-gen3-ash-ui-impl](.foundry/archive/tasks/task-348-100-gen3-ash-ui-impl.md)
+- [ ] [task-348-100-gen3-ash-ui-impl](.foundry/tasks/task-348-100-gen3-ash-ui-impl.md)
 - [ ] [task-348-101-gen3-ash-ui-qa](.foundry/tasks/task-348-101-gen3-ash-ui-qa.md)


### PR DESCRIPTION
Fixes a broken relative link in story-268-348-gen3-ash-integration.md that was pointing to .foundry/archive/tasks/ instead of .foundry/tasks/.

Fixes #6364

---
*PR created automatically by Jules for task [4850098962471812428](https://jules.google.com/task/4850098962471812428) started by @szubster*