### PR TITLE
Add fast-check fuzzing framework to orchestrator

### DIFF
--- a/.foundry/journals/coder/8231477678318992892.md
+++ b/.foundry/journals/coder/8231477678318992892.md
@@ -1,0 +1,6 @@
+# Session 8231477678318992892
+
+## Lessons Learned
+
+- **pnpm Workspace Package Installation**: When installing a dependency into a specific sub-package (e.g., `.github/scripts`) within a pnpm workspace, you must `cd` into that directory and run `pnpm add <pkg>` *without* the `-w` flag. The `-w` flag explicitly tells pnpm to install the package at the workspace root, ignoring the current working directory.
+- **Vitest `toThrowError` Linting**: The `vitest(require-to-throw-message)` lint rule enforces that `.toThrowError()` assertions must include an expected error message or regular expression (e.g., `.toThrowError(/Assertion failed/)`). Calling it without arguments fails the build.

--- a/.foundry/tasks/task-418-430-fuzzing-framework-setup-impl.md
+++ b/.foundry/tasks/task-418-430-fuzzing-framework-setup-impl.md
@@ -26,5 +26,5 @@ notes: ''
 Add `fast-check` to the orchestrator scripts package and configure the base fuzzing utilities.
 
 ## Acceptance Criteria
-- [ ] `fast-check` dependency is added to `.github/scripts/package.json`.
-- [ ] Fuzzing utilities or a placeholder file is set up and tested for `fast-check` execution.
+- [x] `fast-check` dependency is added to `.github/scripts/package.json`.
+- [x] Fuzzing utilities or a placeholder file is set up and tested for `fast-check` execution.

--- a/.github/scripts/fuzzing-utils.test.ts
+++ b/.github/scripts/fuzzing-utils.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'vitest';
+import { fuzzingUtils } from './fuzzing-utils';
+
+test('fuzzingUtils basic fuzzer works', () => {
+  expect(() => fuzzingUtils.basicFuzzer()).not.toThrowError(/Assertion failed/);
+});

--- a/.github/scripts/fuzzing-utils.ts
+++ b/.github/scripts/fuzzing-utils.ts
@@ -1,0 +1,5 @@
+import fc from 'fast-check';
+
+export const fuzzingUtils = {
+  basicFuzzer: () => fc.assert(fc.property(fc.integer(), (n) => typeof n === 'number'))
+};

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.2.0",
+    "fast-check": "^4.9.0",
     "vitest": "^4.1.10"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
+      fast-check:
+        specifier: ^4.9.0
+        version: 4.9.0
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
@@ -3157,6 +3160,10 @@ packages:
     resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
     engines: {node: '>=18'}
 
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4195,6 +4202,9 @@ packages:
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   quote-unquote@1.0.0:
     resolution: {integrity: sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==}
@@ -7796,6 +7806,10 @@ snapshots:
 
   fake-indexeddb@6.2.5: {}
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -8855,6 +8869,8 @@ snapshots:
       long: 5.3.2
 
   proxy-from-env@2.1.0: {}
+
+  pure-rand@8.4.2: {}
 
   quote-unquote@1.0.0: {}
 


### PR DESCRIPTION
Adds `fast-check` to the `.github/scripts` workspace and establishes the base fuzzing utilities and test files for the orchestrator, satisfying the requirements for the fuzzing framework setup.

---
*PR created automatically by Jules for task [8231477678318992892](https://jules.google.com/task/8231477678318992892) started by @szubster*