### PR TITLE
Research Gen 3 Wonder Card Offsets

### DIFF
--- a/.foundry/docs/knowledge_base/engine/save_parsing/gen3_wonder_card_offsets.md
+++ b/.foundry/docs/knowledge_base/engine/save_parsing/gen3_wonder_card_offsets.md
@@ -1,0 +1,46 @@
+# Gen 3 Wonder Card Memory Offsets
+
+This document details the memory offsets and data structures for Wonder Cards in Generation 3 (Emerald, FireRed, LeafGreen). Note that Ruby and Sapphire do not support Mystery Gift/Wonder Cards natively in their save structures.
+
+## 1. Global Offset and Location
+Wonder Card data is part of the `MysteryGiftSave` structure which is located at the end of `SaveBlock1`.
+
+### Base Offsets within `SaveBlock1`
+- **Emerald:** `0x322C`
+- **FireRed / LeafGreen:** `0x3120`
+
+## 2. MysteryGiftSave Structure
+The `MysteryGiftSave` block contains both Wonder News and Wonder Cards. It is `0x36C` (876) bytes long.
+
+| Offset within MysteryGiftSave | Size | Name | Description |
+|---|---|---|---|
+| `0x00` | 4 | `newsCrc` | CRC32 of the Wonder News. |
+| `0x04` | 444 | `news` | `WonderNews` structure. |
+| `0x1C0` | 4 | `cardCrc` | CRC32 of the Wonder Card. |
+| `0x1C4` | 332 | `card` | `WonderCard` structure. |
+| `0x310` | 4 | `cardMetadataCrc` | CRC32 of the Wonder Card metadata. |
+| `0x314` | 36 | `cardMetadata` | `WonderCardMetadata` structure. |
+| `0x338` | 8 | `questionnaireWords` | 4 `u16` words for Mystery Gift questionnaire. |
+| `0x340` | 2 | `newsMetadata` | `WonderNewsMetadata` structure. |
+| `0x344` | 40 | `trainerIds` | 10 `u32` IDs of trainers interacted with. |
+
+## 3. WonderCard Structure Definition
+The `WonderCard` structure is `332` bytes (`0x14C`) long. It starts at offset `0x1C4` within the `MysteryGiftSave` block.
+
+| Offset | Type | Name | Description |
+|---|---|---|---|
+| `0x00` | `u16` | `flagId` | Event flag ID. |
+| `0x02` | `u16` | `iconSpecies` | Species ID of the icon to display. |
+| `0x04` | `u32` | `idNumber` | Unique ID of the Wonder Card. |
+| `0x08` | `u8` (Bitfield) | `type` (2), `bgType` (4), `sendType` (2) | Configuration for the card type and background. |
+| `0x09` | `u8` | `maxStamps` | Maximum number of stamps allowed. |
+| `0x0A` | `u8[40]` | `titleText` | Title of the card. |
+| `0x32` | `u8[40]` | `subtitleText` | Subtitle of the card. |
+| `0x5A` | `u8[4][40]` | `bodyText` | Main body text (4 lines of 40 chars). |
+| `0xFA` | `u8[40]` | `footerLine1Text` | Footer text line 1. |
+| `0x122` | `u8[40]` | `footerLine2Text` | Footer text line 2 (Gift text). |
+
+### Absolute Offsets within `SaveBlock1`
+To calculate the absolute offset of the `WonderCard` block within `SaveBlock1`:
+- **Emerald:** `0x322C` + `0x1C4` = `0x33F0`
+- **FireRed / LeafGreen:** `0x3120` + `0x1C4` = `0x32E4`

--- a/.foundry/journals/researcher/636712015608380424.md
+++ b/.foundry/journals/researcher/636712015608380424.md
@@ -1,0 +1,6 @@
+# Session 636712015608380424 - Gen 3 Wonder Card Offsets
+
+When investigating Gen 3 decompilation code (e.g., `pokeemerald`, `pokefirered`), I discovered that the `MysteryGiftSave` structure contains several variable-length or specific-sized arrays (`WonderNews`, `WonderCard`, `WonderCardMetadata`).
+Because the C source code doesn't explicitly state the exact byte size of these nested structures in comments, it's necessary to manually calculate the sizes using the struct definitions (e.g., tracking `u8`, `u16`, `u32`, and bitfields, plus array lengths) or write a quick calculation script.
+
+**Key Learning:** When writing temporary Node.js scripts in the workspace (which uses `"type": "module"` in `package.json`), use the `.cjs` extension if the script uses CommonJS syntax (like `require()`) to avoid ES module ReferenceErrors. This ensures temporary investigative tools run smoothly.

--- a/.foundry/research/research-391-393-gen3-wonder-card-offsets.md
+++ b/.foundry/research/research-391-393-gen3-wonder-card-offsets.md
@@ -35,5 +35,5 @@ The task `task-354-391-gen3-wonder-card-extraction-impl` requires implementing G
 5. Provide actionable constants and types that can be directly mapped to code.
 
 ## Acceptance Criteria
-- [ ] Researcher: Identify the exact memory offsets and structures for Gen 3 Wonder Cards.
-- [ ] Researcher: Update `.foundry/docs/schema.md` or provide a detailed breakdown in the ticket for the Coder to use.
+- [x] Researcher: Identify the exact memory offsets and structures for Gen 3 Wonder Cards.
+- [x] Researcher: Update `.foundry/docs/schema.md` or provide a detailed breakdown in the ticket for the Coder to use.


### PR DESCRIPTION
Added detailed memory offsets, block locations, and structure definitions for Gen 3 Wonder Cards (Emerald, FireRed, LeafGreen). Marked corresponding research task as complete.

---
*PR created automatically by Jules for task [636712015608380424](https://jules.google.com/task/636712015608380424) started by @szubster*