### PR TITLE
feat(changelog): calculate semantic version release numbers for backfill

### DIFF
--- a/.github/agents/changelogger.md
+++ b/.github/agents/changelogger.md
@@ -12,9 +12,9 @@ Your primary role as Changelogger is to analyze repository commits and author ac
 
 ## Evaluation Procedure
 
-1. Read the assigned task node (`.foundry/tasks/task-000-changelog-backfill.md`) to examine the target commit SHA, message, and modified file list.
+1. Read the assigned task node (`.foundry/tasks/task-000-changelog-backfill.md`) to examine the target commit SHA, message, modified file list, and suggested semver bump/version.
 2. Determine if a changelog entry is warranted:
-   - **Important Feature / Fix / Behavior Change**: Add a concise entry under `## [Unreleased]` in the appropriate changelog file (`CHANGELOG-dexhelper.md` or `CHANGELOG-foundry.md`).
+   - **Important Feature / Fix / Behavior Change**: Add a concise entry under `## [Unreleased]` or a new version release header (e.g., `## [X.Y.Z] - YYYY-MM-DD`) following semantic versioning in the appropriate changelog file (`CHANGELOG-dexhelper.md` or `CHANGELOG-foundry.md`).
    - **Trivial / Maintenance / Non-Idea Sub-Node / Non-User-Facing Change**: Submit an Empty PR (0 files changed).
 
 ## Keep a Changelog Format

--- a/.github/scripts/changelog-engine.test.ts
+++ b/.github/scripts/changelog-engine.test.ts
@@ -4,8 +4,11 @@ import matter from 'gray-matter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type ChangelogState,
+  bumpVersion,
   classifyCommit,
+  determineSemverBump,
   generateContinuousMaintenanceIdeaNode,
+  getLatestVersion,
   loadState,
   saveState,
   updateTaskNodeForCommit
@@ -36,6 +39,29 @@ describe('changelog-engine', () => {
       fs.unlinkSync(testIdeaPath);
     }
     vi.restoreAllMocks();
+  });
+
+  describe('semver functions', () => {
+    it('determines semver bump correctly', () => {
+      expect(determineSemverBump('feat!: breaking change feature')).toBe('major');
+      expect(determineSemverBump('feat!: unscoped breaking change')).toBe('major');
+      expect(determineSemverBump('fix: resolve issue\n\nBREAKING CHANGE: api update')).toBe('major');
+      expect(determineSemverBump('feat(ui): add new button')).toBe('minor');
+      expect(determineSemverBump('fix(parser): fix buffer index')).toBe('patch');
+      expect(determineSemverBump('chore: update dependencies')).toBe('patch');
+    });
+
+    it('extracts latest version from changelog content', () => {
+      const content = '# Changelog\n\n## [1.2.3] - 2026-01-01\n- Feature';
+      expect(getLatestVersion(content)).toBe('1.2.3');
+      expect(getLatestVersion('# Changelog\n\n## [Unreleased]')).toBe('0.1.0');
+    });
+
+    it('bumps versions according to semantic versioning', () => {
+      expect(bumpVersion('1.2.3', 'major')).toBe('2.0.0');
+      expect(bumpVersion('1.2.3', 'minor')).toBe('1.3.0');
+      expect(bumpVersion('1.2.3', 'patch')).toBe('1.2.4');
+    });
   });
 
   describe('state management', () => {

--- a/.github/scripts/changelog-engine.ts
+++ b/.github/scripts/changelog-engine.ts
@@ -217,17 +217,64 @@ export function classifyCommit(details: CommitDetails): CommitClassification {
   return { action: 'skip', reason: 'Non-critical repo modification' };
 }
 
+export function determineSemverBump(message: string): 'major' | 'minor' | 'patch' {
+  const msgLower = message.toLowerCase();
+  if (msgLower.includes('breaking change') || msgLower.includes('breaking-change') || /^[a-z]+(\([a-z0-9_.-]+\))?!:/.test(message)) {
+    return 'major';
+  }
+  if (message.startsWith('feat') || /^feat(\([a-z0-9_.-]+\))?:/.test(message)) {
+    return 'minor';
+  }
+  return 'patch';
+}
+
+export function getLatestVersion(changelogContent: string): string {
+  const match = changelogContent.match(/##\s*\[(\d+\.\d+\.\d+)\]/);
+  return match?.[1] || '0.1.0';
+}
+
+export function bumpVersion(currentVersion: string, bump: 'major' | 'minor' | 'patch'): string {
+  const parts = currentVersion.split('.').map((n) => Number.parseInt(n, 10));
+  let major = parts[0] ?? 0;
+  let minor = parts[1] ?? 1;
+  let patch = parts[2] ?? 0;
+
+  if (bump === 'major') {
+    major += 1;
+    minor = 0;
+    patch = 0;
+  } else if (bump === 'minor') {
+    minor += 1;
+    patch = 0;
+  } else {
+    patch += 1;
+  }
+
+  return `${major}.${minor}.${patch}`;
+}
+
 export function updateTaskNodeForCommit(
   commitDetails: CommitDetails,
   classification: CommitClassification,
   taskPath: string = TASK_NODE_PATH
 ): void {
-  const today = new Date().toISOString().split('T')[0];
+  const today = new Date().toISOString().split('T')[0]!;
 
   let rawContent = '';
   if (fs.existsSync(taskPath)) {
     rawContent = fs.readFileSync(taskPath, 'utf8');
   }
+
+  const domain = classification.domain || 'dexhelper';
+  const changelogFilename = domain === 'foundry' ? 'CHANGELOG-foundry.md' : 'CHANGELOG-dexhelper.md';
+  const changelogPath = path.join(process.cwd(), changelogFilename);
+  let latestVersion = '0.1.0';
+  if (fs.existsSync(changelogPath)) {
+    latestVersion = getLatestVersion(fs.readFileSync(changelogPath, 'utf8'));
+  }
+
+  const bumpType = determineSemverBump(commitDetails.message);
+  const nextVersion = bumpVersion(latestVersion, bumpType);
 
   const parsed = matter(rawContent);
   parsed.data.status = 'READY';
@@ -241,7 +288,8 @@ Target commit details injected by \`changelog-engine.ts\`:
 
 - **Commit SHA:** \`${commitDetails.sha}\`
 - **Classification Reason:** ${classification.reason}
-- **Recommended Domain:** ${classification.domain || 'dexhelper'}
+- **Recommended Domain:** ${domain}
+- **Suggested SemVer Bump:** \`${bumpType}\` (from \`${latestVersion}\` -> \`${nextVersion}\`)
 
 ## Commit Message
 \`\`\`text
@@ -253,7 +301,7 @@ ${commitDetails.files.map((f) => `- \`${f}\``).join('\n')}
 
 ## Evaluation Instructions
 As Changelogger, inspect the commit changes above.
-If a changelog entry is warranted, create a PR adding a concise bullet point under \`## [Unreleased]\` in \`CHANGELOG-dexhelper.md\` or \`CHANGELOG-foundry.md\`.
+If a changelog entry is warranted, create a PR adding a concise bullet point under \`## [Unreleased]\` or new release header \`## [${nextVersion}] - ${today}\` in \`${changelogFilename}\`.
 If no entry is necessary, submit an Empty PR.
 `;
 


### PR DESCRIPTION
Calculates semantic version release numbers during historical changelog backfill evaluations and updates changelogger instructions while preserving commit filtering/ignoring rules.

Fixes #6368

---
*PR created automatically by Jules for task [17962245672578312790](https://jules.google.com/task/17962245672578312790) started by @szubster*