### PR TITLE
Implement Gen 3 Pokemon PID Extraction

### DIFF
--- a/.foundry/journals/coder/17881674746796939603.md
+++ b/.foundry/journals/coder/17881674746796939603.md
@@ -1,0 +1,12 @@
+# Session 17881674746796939603
+
+Successfully implemented Gen 3 Pokemon PID Extraction.
+
+* Extracted PIDs from Gen 3 active party Pokémon.
+* Updated `parseGen3PCBoxes` to extract PIDs from Gen 3 PC Box Pokémon.
+* Gracefully handled `RangeError` within the `parseGen3Party` method to correctly identify truncated/corrupted save files instead of crashing.
+* All changes align with ADR 010.
+
+Lessons learned:
+* Remember to explicitly add new types to shared schemas (like `PokemonInstance.personalityValue`) when extracting data that was previously omitted.
+* When working with specific constants, always ensure the byte-widths are exact (e.g. FRLG uses a 1-byte team size at `0x0034` while RSE uses a 4-byte team size at `0x0234`).

--- a/.foundry/tasks/task-099-157-gen3-extract-pokemon-pids-impl.md
+++ b/.foundry/tasks/task-099-157-gen3-extract-pokemon-pids-impl.md
@@ -33,12 +33,12 @@ As part of the Mirage Island Engine updates, we need to extract the 32-bit Perso
 4.  **Graceful Error Handling**: Do not crash on out-of-bounds reads. Rely on `DataView` throwing `RangeError` and handle it gracefully by propagating specific validation errors (e.g., "Corrupted Save File").
 
 ## Acceptance Criteria
-- [ ] Implement Gen 3 party parsing logic using `DataView` to extract PIDs.
-- [ ] Implement Gen 3 PC box parsing logic using `DataView` to extract PIDs.
-- [ ] Ensure `RangeError` is caught and handled gracefully as per ADR 010.
+- [x] Implement Gen 3 party parsing logic using `DataView` to extract PIDs.
+- [x] Implement Gen 3 PC box parsing logic using `DataView` to extract PIDs.
+- [x] Ensure `RangeError` is caught and handled gracefully as per ADR 010.
 
 ## Coder Persona Reminders
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.
 - If you submit an empty PR for a completed task (e.g., if the work is already done), you MUST check off all Acceptance Criteria checkboxes before submitting. Do not modify the frontmatter in this case.
 
-- [ ] research-157-369-gen3-party-box-offsets
+- [x] research-157-369-gen3-party-box-offsets

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -81,6 +81,7 @@ export interface PokemonInstance {
   unownForm?: string | undefined;
   condition?: Gen3ConditionStats | undefined;
   ribbons?: Gen3Ribbons | undefined;
+  personalityValue?: number | undefined;
   hash: string;
 }
 

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -226,6 +226,10 @@ export const GEN3_POKEMON_PV_OFFSET = 0;
 export const GEN3_POKEMON_OT_ID_OFFSET = 4;
 export const GEN3_POKEMON_DATA_OFFSET = 32;
 export const MISC_IVS_OFFSET = 0x04;
+export const GEN3_PARTY_COUNT_OFFSET = 0x0234;
+export const GEN3_PARTY_COUNT_OFFSET_FRLG = 0x0034;
+export const GEN3_PARTY_POKEMON_LIST_OFFSET = 0x0238;
+export const GEN3_PARTY_POKEMON_LIST_OFFSET_FRLG = 0x0038;
 export const SUBSTRUCTURE_SIZE = 12;
 export const PC_BOX_BUFFER_SIZE = 33744;
 export const PC_BOX_CURRENT_BOX_OFFSET = 0x0000;
@@ -581,6 +585,100 @@ export function parseGen3PCBuffer(view: DataView): Uint8Array {
  * @returns An object containing the simple array of species IDs (`pc`) and the detailed `pcDetails`.
  * @throws Error - "The save file is corrupted or incomplete." on invalid data.
  */
+export function parseGen3Party(view: DataView, section1Offset: number, gameVersion: import('./common').GameVersion) {
+  const party: number[] = [];
+  const partyDetails: import('./common').PokemonInstance[] = [];
+
+  try {
+    const countOffset =
+      section1Offset +
+      (gameVersion === 'firered' || gameVersion === 'leafgreen'
+        ? GEN3_PARTY_COUNT_OFFSET_FRLG
+        : GEN3_PARTY_COUNT_OFFSET);
+    const listOffset =
+      section1Offset +
+      (gameVersion === 'firered' || gameVersion === 'leafgreen'
+        ? GEN3_PARTY_POKEMON_LIST_OFFSET_FRLG
+        : GEN3_PARTY_POKEMON_LIST_OFFSET);
+
+    // team size in FRLG is 1 byte at 0x34 or 4 bytes at 0x234 in RSE
+    const partyCount =
+      gameVersion === 'firered' || gameVersion === 'leafgreen'
+        ? view.getUint8(countOffset)
+        : view.getUint32(countOffset, true);
+
+    for (let i = 0; i < partyCount; i++) {
+      if (i >= 6) break;
+
+      const offset = listOffset + i * GEN3_POKEMON_STRUCT_SIZE;
+
+      const pv = view.getUint32(offset + GEN3_POKEMON_PV_OFFSET, true);
+      const otId = view.getUint32(offset + GEN3_POKEMON_OT_ID_OFFSET, true);
+
+      // If both PV and OTID are 0, it's an empty slot.
+      if (pv === 0 && otId === 0) continue;
+
+      const decryptionKey = pv ^ otId;
+      const permutationIndex = pv % NUM_SUBSTRUCTURE_PERMUTATIONS;
+      const permutation = SUBSTRUCTURE_ORDER[permutationIndex];
+      if (!permutation) {
+        throw new Error('The save file is corrupted or incomplete.');
+      }
+
+      const indexOfG = permutation.indexOf('G');
+      const indexOfA = permutation.indexOf('A');
+
+      const growthSubstructureOffset = offset + GEN3_POKEMON_DATA_OFFSET + indexOfG * SUBSTRUCTURE_SIZE;
+      const attacksSubstructureOffset = offset + GEN3_POKEMON_DATA_OFFSET + indexOfA * SUBSTRUCTURE_SIZE;
+
+      const encryptedSpecies = view.getUint16(growthSubstructureOffset + GEN3_POKEMON_SPECIES_OFFSET_IN_G, true);
+      const encryptedItem = view.getUint16(growthSubstructureOffset + GEN3_POKEMON_ITEM_OFFSET_IN_G, true);
+      const speciesId = encryptedSpecies ^ (decryptionKey & LOWER_16_BIT_MASK);
+      const item = encryptedItem ^ (decryptionKey >>> UPPER_16_BIT_SHIFT);
+
+      const encryptedMove1 = view.getUint16(attacksSubstructureOffset + GEN3_POKEMON_MOVES_OFFSET_IN_A, true);
+      const encryptedMove2 = view.getUint16(
+        attacksSubstructureOffset + GEN3_POKEMON_MOVES_OFFSET_IN_A + GEN3_POKEMON_MOVE_2_OFFSET,
+        true,
+      );
+      const encryptedMove3 = view.getUint16(
+        attacksSubstructureOffset + GEN3_POKEMON_MOVES_OFFSET_IN_A + GEN3_POKEMON_MOVE_3_OFFSET,
+        true,
+      );
+      const encryptedMove4 = view.getUint16(
+        attacksSubstructureOffset + GEN3_POKEMON_MOVES_OFFSET_IN_A + GEN3_POKEMON_MOVE_4_OFFSET,
+        true,
+      );
+
+      const moves = [
+        encryptedMove1 ^ (decryptionKey & LOWER_16_BIT_MASK),
+        encryptedMove2 ^ (decryptionKey >>> UPPER_16_BIT_SHIFT),
+        encryptedMove3 ^ (decryptionKey & LOWER_16_BIT_MASK),
+        encryptedMove4 ^ (decryptionKey >>> UPPER_16_BIT_SHIFT),
+      ].filter((m) => m > 0);
+
+      party.push(speciesId);
+      partyDetails.push({
+        speciesId,
+        level: view.getUint8(offset + 84), // 0x54
+        isShiny: false, // We'll implement shiny calculation separately
+        item: item > 0 ? item : undefined,
+        moves,
+        personalityValue: pv,
+        storageLocation: 'Party',
+        hash: `${pv}-${otId}`,
+      });
+    }
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+
+  return { party, partyDetails };
+}
+
 export function parseGen3PCBoxes(pcBufferView: DataView) {
   const pc: number[] = [];
   const pcDetails: import('./common').PokemonInstance[] = [];
@@ -648,6 +746,7 @@ export function parseGen3PCBoxes(pcBufferView: DataView) {
           isShiny,
           item: item > 0 ? item : undefined,
           moves,
+          personalityValue: pv,
           storageLocation: `Box ${box + 1}`,
           slot,
         };
@@ -1454,14 +1553,16 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       // Ignored, PC data might be missing or corrupt
     }
 
+    const { party, partyDetails } = parseGen3Party(view, section1Offset, _forcedVersion || 'ruby');
+
     // Dummy scaffold values for now until fully implemented
     const result: SaveData = {
       generation: 3,
       owned,
       seen,
-      party: [],
+      party,
       pc,
-      partyDetails: [],
+      partyDetails,
       pcDetails,
       gameVersion: _forcedVersion || 'ruby',
       badges: 0,

--- a/src/engine/saveParser/parsers/saveFixtures.test.ts
+++ b/src/engine/saveParser/parsers/saveFixtures.test.ts
@@ -121,7 +121,7 @@ describe('Real Save Fixtures Verification', () => {
       expectedVersion: 'emerald',
       expectedTrainer: '',
       expectedId: 58646,
-      expectedPartyLength: 0,
+      expectedPartyLength: 5,
     },
   ];
 


### PR DESCRIPTION
Implement Gen 3 Pokemon PID Extraction for Gen 3 saves.
- Added `personalityValue` to `PokemonInstance` interface.
- Extracted PIDs from Gen 3 party Pokémon in `parseGen3Party`.
- Extracted PIDs from Gen 3 PC Box Pokémon in `parseGen3PCBoxes`.
- Gracefully handled out-of-bounds `RangeError` according to ADR 010.
- Updated `saveFixtures.test.ts` party size checks.

---
*PR created automatically by Jules for task [17881674746796939603](https://jules.google.com/task/17881674746796939603) started by @szubster*