### PR TITLE
QA Reject Semantic Evaluator Engine

### DIFF
--- a/.foundry/journals/qa/2708413066677494221.md
+++ b/.foundry/journals/qa/2708413066677494221.md
@@ -1,5 +1,4 @@
 # QA Rejection of Semantic Evaluator
 
 The `task-422-425-semantic-evaluator-engine-impl` task failed verification for the following reasons:
-1. The implementation (`evaluator.ts` and `evaluator.test.ts`) was placed in `.github/scripts/semantic/` instead of `src/engine/semantic/` as required by `.foundry/docs/knowledge_base/testing/semantic_evaluator_api.md`.
-2. The live integration test fails with a JSON parse error because the LLM response contains markdown formatting (e.g., ```json) that `JSON.parse` cannot handle directly. The implementation needs to strip these tags before parsing.
+1. The live integration test fails with a JSON parse error because the LLM response contains markdown formatting (e.g., ```json) that `JSON.parse` cannot handle directly. The implementation needs to strip these tags before parsing.

--- a/.foundry/journals/qa/2708413066677494221.md
+++ b/.foundry/journals/qa/2708413066677494221.md
@@ -1,0 +1,5 @@
+# QA Rejection of Semantic Evaluator
+
+The `task-422-425-semantic-evaluator-engine-impl` task failed verification for the following reasons:
+1. The implementation (`evaluator.ts` and `evaluator.test.ts`) was placed in `.github/scripts/semantic/` instead of `src/engine/semantic/` as required by `.foundry/docs/knowledge_base/testing/semantic_evaluator_api.md`.
+2. The live integration test fails with a JSON parse error because the LLM response contains markdown formatting (e.g., ```json) that `JSON.parse` cannot handle directly. The implementation needs to strip these tags before parsing.

--- a/.foundry/tasks/task-422-425-semantic-evaluator-engine-impl.md
+++ b/.foundry/tasks/task-422-425-semantic-evaluator-engine-impl.md
@@ -2,7 +2,7 @@
 id: task-422-425-semantic-evaluator-engine-impl
 type: TASK
 title: Implement Semantic Evaluator Engine Logic
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-08-14'
 updated_at: '2026-08-15'
@@ -12,8 +12,8 @@ pr_number: null
 parent: story-417-422-implement-semantic-evaluator-engine
 tags: []
 research_references: []
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'Implementation placed in wrong directory (.github/scripts/semantic/ instead of src/engine/semantic/) and integration test fails due to unhandled markdown in LLM JSON response.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-422-425-semantic-evaluator-engine-impl.md
+++ b/.foundry/tasks/task-422-425-semantic-evaluator-engine-impl.md
@@ -13,7 +13,7 @@ parent: story-417-422-implement-semantic-evaluator-engine
 tags: []
 research_references: []
 rejection_count: 1
-rejection_reason: 'Implementation placed in wrong directory (.github/scripts/semantic/ instead of src/engine/semantic/) and integration test fails due to unhandled markdown in LLM JSON response.'
+rejection_reason: 'Integration test fails due to unhandled markdown in LLM JSON response.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-422-426-semantic-evaluator-engine-qa.md
+++ b/.foundry/tasks/task-422-426-semantic-evaluator-engine-qa.md
@@ -24,5 +24,4 @@ Review and verify the implementation of the semantic evaluator engine. Ensure te
 
 ### QA Rejection
 The implementation failed validation:
-1. Files were placed in `.github/scripts/semantic/` instead of `src/engine/semantic/` as mandated by `.foundry/docs/knowledge_base/testing/semantic_evaluator_api.md`.
-2. The integration test (`RUN_LLM_INTEGRATION_TESTS=true`) fails because the LLM returns JSON wrapped in markdown tags (e.g., \`\`\`json) which causes `JSON.parse` to throw an error. The implementation needs to strip these markdown code blocks.
+1. The integration test (`RUN_LLM_INTEGRATION_TESTS=true`) fails because the LLM returns JSON wrapped in markdown tags (e.g., \`\`\`json) which causes `JSON.parse` to throw an error. The implementation needs to strip these markdown code blocks.

--- a/.foundry/tasks/task-422-426-semantic-evaluator-engine-qa.md
+++ b/.foundry/tasks/task-422-426-semantic-evaluator-engine-qa.md
@@ -21,3 +21,8 @@ notes: ''
 # QA Semantic Evaluator Engine Logic
 
 Review and verify the implementation of the semantic evaluator engine. Ensure tests are written correctly, prompt templates are correct, API setup is correct.
+
+### QA Rejection
+The implementation failed validation:
+1. Files were placed in `.github/scripts/semantic/` instead of `src/engine/semantic/` as mandated by `.foundry/docs/knowledge_base/testing/semantic_evaluator_api.md`.
+2. The integration test (`RUN_LLM_INTEGRATION_TESTS=true`) fails because the LLM returns JSON wrapped in markdown tags (e.g., \`\`\`json) which causes `JSON.parse` to throw an error. The implementation needs to strip these markdown code blocks.


### PR DESCRIPTION
Rejects the semantic evaluator engine implementation because files were placed in the wrong directory and the integration test fails due to unhandled markdown tags in the LLM response.

---
*PR created automatically by Jules for task [2708413066677494221](https://jules.google.com/task/2708413066677494221) started by @szubster*