### PR TITLE
QA: Verify Gen 3 Trainer Card Extraction

### DIFF
--- a/.foundry/journals/qa/18204348022024804423.md
+++ b/.foundry/journals/qa/18204348022024804423.md
@@ -1,0 +1,10 @@
+# QA Journal - Session 18204348022024804423
+
+Date: 2026-08-17
+
+QA validation performed on the implementation of the Gen 3 Trainer Card upgrade criteria parsing logic (`task-358-424-gen3-pokedex-hof-parsing-impl`).
+- Verified `Gen3TrainerCard` interface definition in `src/engine/saveParser/parsers/common.ts`.
+- Verified extraction logic inside `parseGen3` in `src/engine/saveParser/parsers/gen3.ts`, specifically checking for `hasHallOfFame`, `hasHoennDex` and `hasNationalDex`.
+- Verified unit test coverage in `src/engine/saveParser/parsers/gen3.test.ts`.
+
+Everything was properly implemented and unit tested. The task node was successfully validated and marked as complete (empty PR policy triggered).

--- a/.foundry/tasks/task-358-425-gen3-pokedex-hof-parsing-qa.md
+++ b/.foundry/tasks/task-358-425-gen3-pokedex-hof-parsing-qa.md
@@ -27,5 +27,5 @@ notes: ''
 Perform QA validation on the implementation of the Gen 3 Trainer Card upgrade criteria parsing logic for Pokedex and Hall of Fame. Ensure that the logic accurately verifies the Hall of Fame and Pokedex (Hoenn and National) requirements. Ensure no regressions occur in the parser.
 
 ## Acceptance Criteria
-- [ ] Verify `Gen3TrainerCard` properties are correctly populated in `SaveData`.
-- [ ] Ensure unit tests adequately cover the extraction logic and edge cases.
+- [x] Verify `Gen3TrainerCard` properties are correctly populated in `SaveData`.
+- [x] Ensure unit tests adequately cover the extraction logic and edge cases.


### PR DESCRIPTION
Checked off acceptance criteria after validating implementation of Gen 3 Trainer Card criteria extraction logic

---
*PR created automatically by Jules for task [18204348022024804423](https://jules.google.com/task/18204348022024804423) started by @szubster*