### PR TITLE
docs(foundry): complete story-309-002-dv-overlap-constraint (Empty PR)

### DIFF
--- a/.foundry/journals/tech_lead/7542590417705425224.md
+++ b/.foundry/journals/tech_lead/7542590417705425224.md
@@ -1,0 +1,4 @@
+# Artifact Anomaly: Gen 2 DV Overlap Constraint
+The functionality for `(Defense DV A === Defense DV B) AND ((Special DV A === Special DV B) OR (Math.abs(Special DV A - Special DV B) === 8))` was requested in story `story-309-002-dv-overlap-constraint`.
+Upon inspecting the codebase, specifically `src/engine/breeding/pair_algorithm.ts`, the function `checkDvsIncompatible` already correctly implements this exact incest prevention logic for Gen 2. Additionally, unit tests in `src/engine/breeding/pair_algorithm.test.ts` fully cover these cases.
+Therefore, the target artifacts are already complete. Following the Empty PR policy, I have checked off the acceptance criteria in the story node directly and will submit an empty PR to transition it to COMPLETED.

--- a/.foundry/stories/story-309-002-dv-overlap-constraint.md
+++ b/.foundry/stories/story-309-002-dv-overlap-constraint.md
@@ -28,4 +28,4 @@ Implement the Gen 2 "incest prevention" check that determines if two Pokémon ar
 Condition for Incompatibility: `(Defense DV A === Defense DV B) AND ((Special DV A === Special DV B) OR (Math.abs(Special DV A - Special DV B) === 8))`.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break this STORY down into actionable TASK nodes for the engineering team.
+- [x] Tech Lead: Break this STORY down into actionable TASK nodes for the engineering team.


### PR DESCRIPTION
This PR updates `story-309-002-dv-overlap-constraint.md` to check off the acceptance criteria, as the required Gen 2 DV overlap logic is already implemented in `pair_algorithm.ts` (`checkDvsIncompatible`). It also includes the corresponding journal entry documenting this artifact anomaly, enabling the orchestrator to transition the node to COMPLETED via the Empty PR policy.

---
*PR created automatically by Jules for task [7542590417705425224](https://jules.google.com/task/7542590417705425224) started by @szubster*