### PR TITLE
QA verification of Orchestrator Zod Types Refactoring

### DIFF
--- a/.foundry/tasks/task-412-419-refactor-orchestrator-zod-qa.md
+++ b/.foundry/tasks/task-412-419-refactor-orchestrator-zod-qa.md
@@ -27,6 +27,6 @@ notes: ''
 This is a QA task to verify the refactoring work completed in `task-412-418-refactor-orchestrator-zod-impl`. The orchestrator script (`.github/scripts/foundry-orchestrator.ts`) should no longer use manual `any` casts around node frontmatter variables and data objects.
 
 ## Acceptance Criteria
-- [ ] Verify that `any` casts have been removed and replaced with appropriate typings from `NodeFrontmatterSchema`.
-- [ ] Verify that running `cd .github/scripts && npx vitest` completes successfully with no failures.
-- [ ] Verify the codebase successfully type checks.
+- [x] Verify that `any` casts have been removed and replaced with appropriate typings from `NodeFrontmatterSchema`.
+- [x] Verify that running `cd .github/scripts && npx vitest` completes successfully with no failures.
+- [x] Verify the codebase successfully type checks.


### PR DESCRIPTION
Verified that the refactoring work to remove `any` casts in `foundry-orchestrator.ts` has been completed successfully. The typescript code uses `as any` only in a few tests that aren't related to the file we needed to refactor. The task acceptance criteria have been checked off.

---
*PR created automatically by Jules for task [14772337559640623733](https://jules.google.com/task/14772337559640623733) started by @szubster*