### PR TITLE
QA: Verify Gen 3 TM/HM Parsing

### DIFF
--- a/.foundry/tasks/task-410-431-gen3-tm-hm-parsing-qa.md
+++ b/.foundry/tasks/task-410-431-gen3-tm-hm-parsing-qa.md
@@ -36,7 +36,7 @@ Ensure adherence to `.foundry/docs/schema.md` Section 13:
 - Are Vitest tests present and do they pass?
 
 ## Acceptance Criteria
-- [ ] Verify magic numbers are extracted into module-level constants.
-- [ ] Verify relative section offsets are utilized (no absolute mapping for A/B bank structures).
-- [ ] Verify `RangeError` handling is correctly mapped to "The save file is corrupted or incomplete."
-- [ ] Verify passing Vitest suite for TM/HM extraction.
+- [x] Verify magic numbers are extracted into module-level constants.
+- [x] Verify relative section offsets are utilized (no absolute mapping for A/B bank structures).
+- [x] Verify `RangeError` handling is correctly mapped to "The save file is corrupted or incomplete."
+- [x] Verify passing Vitest suite for TM/HM extraction.

--- a/.jules/qa/session_410.md
+++ b/.jules/qa/session_410.md
@@ -1,0 +1,1 @@
+# Journal


### PR DESCRIPTION
Checked off the acceptance criteria for Gen 3 TM/HM parsing verification as the code uses correct offsets and module level constants. Tests pass successfully.

---
*PR created automatically by Jules for task [11623994909155840394](https://jules.google.com/task/11623994909155840394) started by @szubster*