### PR TITLE
Integrate TacticalCallerCard into Dashboard

### DIFF
--- a/src/components/dashboard/pokegear/ActiveCallersDashboard.tsx
+++ b/src/components/dashboard/pokegear/ActiveCallersDashboard.tsx
@@ -1,9 +1,9 @@
+import { GEN2_PHONE_CALLER_REGISTRY } from '../../../engine/saveParser/parsers/gen2/phone/constants';
 import type { Contact, TimerState } from '../../../engine/saveParser/parsers/gen2/phone/predictor';
 import { CornerCrosshairs } from '../../CornerCrosshairs';
-import { HoverScanner } from '../../HoverScanner';
-import { LcdGrid } from '../../LcdGrid';
 import { TacticalPanel } from '../../TacticalPanel';
 import { TelemetryDecoration } from '../../TelemetryDecoration';
+import { TacticalCallerCard } from './TacticalCallerCard';
 
 interface ActiveCallersDashboardProps {
   contacts: Contact[];
@@ -45,34 +45,18 @@ export function ActiveCallersDashboard({ contacts, timerState }: ActiveCallersDa
           </div>
         ) : (
           <div className="z-10 grid grid-cols-1 gap-4 lg:grid-cols-2">
-            {contacts.map((contact) => (
-              <div
-                key={contact.id}
-                className="group relative flex flex-col gap-2 rounded-none border-2 border-cyan-900/30 border-dashed bg-black/60 p-3 font-mono text-xs transition-colors hover:border-cyan-500/50"
-              >
-                <LcdGrid className="opacity-10" />
-                <HoverScanner colorClass="via-cyan-500/10" />
-                <CornerCrosshairs className="h-2 w-2 border-cyan-900/50 group-hover:border-cyan-500/50" thickness={2} />
-
-                <div className="absolute top-0 right-0 rounded-none border-cyan-900/50 border-b-2 border-l-2 border-dashed bg-cyan-950/80 px-2 py-1 text-[9px] text-cyan-400">
-                  PROB: {probability}%
-                </div>
-
-                <div className="flex w-full flex-col gap-2 pt-2">
-                  <div className="flex items-center justify-between">
-                    <div className="flex flex-col">
-                      <span className="tactical-text text-[10px] text-cyan-700">[ TARGET_LOCK ]</span>
-                      <span className="font-bold text-white uppercase tracking-widest">{contact.name}</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <div
-                        className={`h-2 w-2 rounded-full ${isCoolingDown ? 'bg-amber-500/50' : 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.8)]'}`}
-                      ></div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ))}
+            {contacts.map((contact) => {
+              const registryEntry = GEN2_PHONE_CALLER_REGISTRY[contact.id];
+              return (
+                <TacticalCallerCard
+                  key={contact.id}
+                  contact={contact}
+                  type={registryEntry ? registryEntry.type : 'NONE'}
+                  details={registryEntry ? registryEntry.details : undefined}
+                  probability={probability}
+                />
+              );
+            })}
           </div>
         )}
       </TacticalPanel>

--- a/src/components/dashboard/pokegear/TacticalCallerCard.tsx
+++ b/src/components/dashboard/pokegear/TacticalCallerCard.tsx
@@ -7,7 +7,7 @@ import { LcdGrid } from '../../LcdGrid';
 interface TacticalCallerCardProps {
   contact: Contact;
   type: CallerType;
-  details?: string;
+  details?: string | undefined;
   probability: number;
 }
 

--- a/src/components/dashboard/pokegear/__tests__/ActiveCallersDashboard.test.tsx
+++ b/src/components/dashboard/pokegear/__tests__/ActiveCallersDashboard.test.tsx
@@ -6,7 +6,8 @@ import { ActiveCallersDashboard } from '../ActiveCallersDashboard';
 
 const mockContacts: Contact[] = [
   { id: 1, name: 'Mom' },
-  { id: 2, name: 'Prof. Elm' },
+  { id: 17, name: 'Fisher Ralph' },
+  { id: 6, name: 'Pokefan Beverly' },
 ];
 
 test('renders correctly with contacts and shows 50% probability when active', async () => {
@@ -16,10 +17,16 @@ test('renders correctly with contacts and shows 50% probability when active', as
   await expect.element(page.getByText('ACTIVE CALLERS MATRIX')).toBeInTheDocument();
   await expect.element(page.getByText('ACTIVE', { exact: true })).toBeInTheDocument();
   await expect.element(page.getByText(/Mom/i)).toBeInTheDocument();
-  await expect.element(page.getByText(/Prof\. Elm/i)).toBeInTheDocument();
+  await expect.element(page.getByText(/Fisher Ralph/i)).toBeInTheDocument();
+  await expect.element(page.getByText(/Pokefan Beverly/i)).toBeInTheDocument();
+
+  await expect.element(page.getByText('[ SWARM ]')).toBeInTheDocument();
+  await expect.element(page.getByText('Qwilfish')).toBeInTheDocument();
+  await expect.element(page.getByText('[ ITEM ]')).toBeInTheDocument();
+  await expect.element(page.getByText('Nugget')).toBeInTheDocument();
 
   const probabilityElements = page.getByText('PROB: 50%').elements();
-  expect(probabilityElements.length).toBe(2);
+  expect(probabilityElements.length).toBe(3);
 });
 
 test('shows 0% probability when cooling down', async () => {
@@ -28,7 +35,7 @@ test('shows 0% probability when cooling down', async () => {
 
   await expect.element(page.getByText('COOLING_DOWN')).toBeInTheDocument();
   const probabilityElements = page.getByText('PROB: 0%').elements();
-  expect(probabilityElements.length).toBe(2);
+  expect(probabilityElements.length).toBe(3);
 });
 
 test('renders empty state correctly', async () => {


### PR DESCRIPTION
Integrate the newly created `TacticalCallerCard` into the `ActiveCallersDashboard`.

This uses the `GEN2_PHONE_CALLER_REGISTRY` to determine high-value status (e.g., SWARM, ITEM) for each contact, which is then rendered by the card component instead of the previous inline markup. Tests are updated with relevant IDs to verify that the badges render correctly.

---
*PR created automatically by Jules for task [14225188113793861849](https://jules.google.com/task/14225188113793861849) started by @szubster*