### PR TITLE
chore(foundry): check off archive bypass acceptance criteria

### DIFF
--- a/.foundry/journals/tech_lead/3717664814262300051.md
+++ b/.foundry/journals/tech_lead/3717664814262300051.md
@@ -1,0 +1,4 @@
+# Session 3717664814262300051
+
+## Artifact Anomaly
+The `story-405-408-orchestrator-archive-bypass-implementation` node has unchecked acceptance criteria, however the logic to bypass the `archive` directory is already fully implemented in `.github/scripts/foundry-orchestrator.ts`, and the child task `task-408-415-orchestrator-archive-bypass-implementation` is already marked COMPLETED and moved to `.foundry/archive/tasks/`. The Orchestrator's Late-Binding logic or an unexpected workflow cancellation failed to transition the parent STORY. Proceeding with the Empty PR Policy to check off the remaining acceptance criteria.

--- a/.foundry/stories/story-405-408-orchestrator-archive-bypass-implementation.md
+++ b/.foundry/stories/story-405-408-orchestrator-archive-bypass-implementation.md
@@ -24,6 +24,6 @@ notes: ''
 Implement logic in `discoverNodeFiles` in `.github/scripts/foundry-orchestrator.ts` to ignore the `.foundry/archive/` directory during its parsing and discovery process.
 
 ## Acceptance Criteria
-- [ ] Update `discoverNodeFiles` to skip `archive/` directories.
-- [ ] Ensure this exclusion logic covers both `.foundry/archive/stories/` and `.foundry/archive/tasks/`.
+- [x] Update `discoverNodeFiles` to skip `archive/` directories.
+- [x] Ensure this exclusion logic covers both `.foundry/archive/stories/` and `.foundry/archive/tasks/`.
 - [x] task-408-415-orchestrator-archive-bypass-implementation


### PR DESCRIPTION
Resolves the `story-405-408-orchestrator-archive-bypass-implementation` node by checking off the acceptance criteria, as the logic is already fully implemented.

---
*PR created automatically by Jules for task [3717664814262300051](https://jules.google.com/task/3717664814262300051) started by @szubster*