### PR TITLE
chore: complete experiment schema e2e story

### DIFF
--- a/.foundry/journals/tech_lead/15616364122426030260.md
+++ b/.foundry/journals/tech_lead/15616364122426030260.md
@@ -1,0 +1,3 @@
+# Session 15616364122426030260 - Artifact Anomaly Detection
+
+During the execution of story `story-411-414-experiment-schema-e2e`, it was discovered that the target artifacts (Vitest schema validation tests in `.github/scripts/schema.test.ts` and documentation updates in `.foundry/docs/schema.md`) were already fully implemented prior to this session. No new child tasks were generated, and the Empty PR Policy with the Macro Node Completion Exception Addendum was executed.

--- a/.foundry/stories/story-411-414-experiment-schema-e2e.md
+++ b/.foundry/stories/story-411-414-experiment-schema-e2e.md
@@ -32,4 +32,4 @@ Verify that the `EXPERIMENT` node type and `experiment_variants` frontmatter fie
 2. Confirm `.foundry/docs/schema.md` properly matches the runtime Zod schema logic.
 
 ## Acceptance Criteria
-- [ ] Tech Lead: Break down into Tasks.
+- [x] Tech Lead: Break down into Tasks.


### PR DESCRIPTION
Records the Artifact Anomaly for `story-411-414-experiment-schema-e2e` in the tech lead's journal and checks off the acceptance criteria, as the target artifacts were discovered to be already completely implemented.

---
*PR created automatically by Jules for task [15616364122426030260](https://jules.google.com/task/15616364122426030260) started by @szubster*