### PR TITLE
Create WASM Emulator ADR

### DIFF
--- a/.foundry/docs/adrs/adr-421-032-wasm-emulator-selection.md
+++ b/.foundry/docs/adrs/adr-421-032-wasm-emulator-selection.md
@@ -3,7 +3,7 @@ id: adr-421-032-wasm-emulator-selection
 type: ADR
 title: 'ADR 032: WASM Emulator Selection'
 status: READY
-owner_persona: story_owner
+owner_persona: architect
 created_at: '2026-08-17'
 updated_at: '2026-08-17'
 depends_on: []

--- a/.foundry/docs/adrs/adr-421-032-wasm-emulator-selection.md
+++ b/.foundry/docs/adrs/adr-421-032-wasm-emulator-selection.md
@@ -1,0 +1,49 @@
+---
+id: adr-421-032-wasm-emulator-selection
+type: ADR
+title: 'ADR 032: WASM Emulator Selection'
+status: READY
+owner_persona: story_owner
+created_at: '2026-08-17'
+updated_at: '2026-08-17'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: task-421-435-wasm-emulator-adr
+tags:
+  - architecture
+  - wasm
+  - emulator
+research_references:
+  - .foundry/docs/knowledge_base/architecture/wasm_emulators.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# ADR 032: WASM Emulator Selection
+
+## Status
+Accepted
+
+## Context
+To provide an integrated, in-browser emulation experience with live stat tracking for DexHelper, we evaluated WebAssembly (WASM) and Javascript emulators (mGBA, binjgb, SkyEmu). The primary focus is on Gen 1, Gen 2, and Gen 3 compatibility, performance, and the ability to cleanly extract the `.sav` (SRAM) data during gameplay for our save parser. The CEO has approved a multi-emulator architecture.
+
+## Decision
+We will adopt a multi-emulator architecture to maximize performance and compatibility across different game generations.
+
+1. **Gen 1 & Gen 2**: We will use `binjgb`. It offers a highly optimized, lightweight footprint tailored specifically for browser execution of 8-bit systems, providing extreme lightweight performance and simple WASM memory integration.
+2. **Gen 3**: We will use either `mGBA` or `SkyEmu` (both compiled to WASM) to handle Game Boy Advance titles, as both provide excellent cross-platform web support and high accuracy.
+
+### Technical Approach for Integration and Save Data Extraction
+- **binjgb (Gen 1 & 2)**: Utilize the provided `binjgb.js` and `binjgb.wasm` interface. Extract the save state (`saveStateBuffer`) directly via Javascript bindings to synchronize with our parsing engine.
+- **mGBA / SkyEmu (Gen 3)**: Integrate the WASM build into the client-side Single Page App. Implement a synchronization layer to extract the SRAM/Save data from the emulator's memory or persistent save state slots and pass it to the DexHelper parsing engine.
+
+## Consequences
+- **Positive**: We achieve optimal performance for each specific generation without compromising accuracy.
+- **Positive**: Direct memory access via WASM enables clean, real-time extraction of `.sav` data for the save parser.
+- **Negative**: Increases architectural complexity by requiring the integration and maintenance of multiple distinct emulator engines and their respective memory interfaces.
+
+## Acceptance Criteria
+- [ ] Implement the integration for `binjgb` for Gen 1 & 2.
+- [ ] Implement the integration for Gen 3 emulator (`mGBA` or `SkyEmu`).

--- a/.foundry/docs/adrs/adr-421-032-wasm-emulator-selection.md
+++ b/.foundry/docs/adrs/adr-421-032-wasm-emulator-selection.md
@@ -33,11 +33,11 @@ To provide an integrated, in-browser emulation experience with live stat trackin
 We will adopt a multi-emulator architecture to maximize performance and compatibility across different game generations.
 
 1. **Gen 1 & Gen 2**: We will use `binjgb`. It offers a highly optimized, lightweight footprint tailored specifically for browser execution of 8-bit systems, providing extreme lightweight performance and simple WASM memory integration.
-2. **Gen 3**: We will use either `mGBA` or `SkyEmu` (both compiled to WASM) to handle Game Boy Advance titles, as both provide excellent cross-platform web support and high accuracy.
+2. **Gen 3**: We will use `mGBA` (compiled to WASM) to handle Game Boy Advance titles. It provides high accuracy and robust features for Game Boy Advance and is proven to work in the browser via WASM.
 
-### Technical Approach for Integration and Save Data Extraction
-- **binjgb (Gen 1 & 2)**: Utilize the provided `binjgb.js` and `binjgb.wasm` interface. Extract the save state (`saveStateBuffer`) directly via Javascript bindings to synchronize with our parsing engine.
-- **mGBA / SkyEmu (Gen 3)**: Integrate the WASM build into the client-side Single Page App. Implement a synchronization layer to extract the SRAM/Save data from the emulator's memory or persistent save state slots and pass it to the DexHelper parsing engine.
+### Technical Approach for Integration and Memory/Save Data Extraction
+- **binjgb (Gen 1 & 2)**: Utilize the provided `binjgb.js` and `binjgb.wasm` interface. Extract the save state (`saveStateBuffer`) and directly access the emulator's memory space via Javascript bindings to synchronize with our parsing engine for real-time suggestions.
+- **mGBA (Gen 3)**: Integrate the WASM build into the client-side Single Page App. Implement a synchronization layer to extract the SRAM/Save data and directly access the emulator's memory space to enable real-time extraction for live stat tracking and suggestions, passing this data to the DexHelper parsing engine.
 
 ## Consequences
 - **Positive**: We achieve optimal performance for each specific generation without compromising accuracy.
@@ -46,4 +46,4 @@ We will adopt a multi-emulator architecture to maximize performance and compatib
 
 ## Acceptance Criteria
 - [ ] Implement the integration for `binjgb` for Gen 1 & 2.
-- [ ] Implement the integration for Gen 3 emulator (`mGBA` or `SkyEmu`).
+- [ ] Implement the integration for `mGBA` for Gen 3.

--- a/.foundry/tasks/task-421-435-wasm-emulator-adr.md
+++ b/.foundry/tasks/task-421-435-wasm-emulator-adr.md
@@ -27,5 +27,6 @@ notes: ''
 Research into WASM emulator options (mGBA, binjgb, SkyEmu) has been completed. The CEO has approved a multi-emulator architecture. The Architect must now formalize the decision into an ADR.
 
 ## Acceptance Criteria
-- [ ] Create `adr-421-032-wasm-emulator-selection.md` detailing the choice of a multi-emulator strategy for in-browser play.
-- [ ] Document the technical approach for integrating the emulators and extracting save data.
+- [x] Create `adr-421-032-wasm-emulator-selection.md` detailing the choice of a multi-emulator strategy for in-browser play.
+- [x] Document the technical approach for integrating the emulators and extracting save data.
+- [ ] adr-421-032-wasm-emulator-selection


### PR DESCRIPTION
Creates the ADR `adr-421-032-wasm-emulator-selection.md` detailing the choice of a multi-emulator strategy for in-browser play, based on the research. Documents the technical approach for integrating the emulators (`binjgb` for Gen 1 & 2, `mGBA`/`SkyEmu` for Gen 3) and extracting save data. Also updates the parent task node's acceptance criteria to reflect completion.

---
*PR created automatically by Jules for task [9188044347237264838](https://jules.google.com/task/9188044347237264838) started by @szubster*