### PR TITLE
QA: Verify E2E retry implementation for Permanent Failure Dashboard

### DIFF
--- a/.foundry/tasks/task-353-406-lift-rejection-constant-e2e-retry-qa.md
+++ b/.foundry/tasks/task-353-406-lift-rejection-constant-e2e-retry-qa.md
@@ -27,6 +27,6 @@ notes: ''
 Verify the retry implementation of the E2E test for the Permanent Failure Dashboard.
 
 ## Acceptance Criteria
-- [ ] Verify the Playwright test file at `tests/e2e/dashboard/permanent_failures.spec.ts` exists.
-- [ ] Run the E2E tests and ensure the new test passes.
-- [ ] Verify that the test correctly asserts the behaviour of the "Permanent failures only" filter.
+- [x] Verify the Playwright test file at `tests/e2e/dashboard/permanent_failures.spec.ts` exists.
+- [x] Run the E2E tests and ensure the new test passes.
+- [x] Verify that the test correctly asserts the behaviour of the "Permanent failures only" filter.


### PR DESCRIPTION
I've checked the acceptance criteria checkboxes in `.foundry/tasks/task-353-406-lift-rejection-constant-e2e-retry-qa.md`. The target E2E test file (`tests/e2e/dashboard/permanent_failures.spec.ts`) was confirmed to exist, correctly run, and correctly pass locally, adequately covering the "Permanent failures only" filter behavior requirement. Pre-commit tests (`pnpm lint`, `pnpm test`, and `xvfb-run pnpm test:e2e tests/e2e/dashboard/permanent_failures.spec.ts`) passed successfully. Submitting empty PR format for leaf node completion according to ADR 007 and 009.

---
*PR created automatically by Jules for task [9708619538333401112](https://jules.google.com/task/9708619538333401112) started by @szubster*