### PR TITLE
feat: integrate moves dataset into IndexedDB schema

### DIFF
--- a/.foundry/tasks/task-275-435-move-db-schema-inflation.md
+++ b/.foundry/tasks/task-275-435-move-db-schema-inflation.md
@@ -30,5 +30,5 @@ The `moves.jsonl` data has been generated. We need to integrate this dataset int
 2. Implement inflation logic in the client runtime.
 
 ## Acceptance Criteria
-- [ ] Integrate `moves` dataset into database schema and sync.
-- [ ] Implement inflation logic for move data.
+- [x] Integrate `moves` dataset into database schema and sync.
+- [x] Implement inflation logic for move data.

--- a/src/db/PokeDB.ts
+++ b/src/db/PokeDB.ts
@@ -6,6 +6,7 @@ import {
   DB_CONFIG,
   type ItemMetadata,
   type LocationAreaEncounters,
+  type MoveMetadata,
   type PokeDataExport,
   type PokeDBSchema,
   type PokemonMetadata,
@@ -70,6 +71,10 @@ const DEFAULT_LOCATION = {
   dist: {},
 };
 
+const DEFAULT_MOVE_METADATA = {
+  acc: 100,
+};
+
 type ValidStoreName = (typeof DB_CONFIG.STORES)[keyof typeof DB_CONFIG.STORES];
 
 /**
@@ -95,6 +100,7 @@ export const getDB = () => {
           [DB_CONFIG.STORES.LOCATIONS]: 'id',
           [DB_CONFIG.STORES.METADATA]: 'key',
           [DB_CONFIG.STORES.ITEMS]: 'id',
+          [DB_CONFIG.STORES.MOVES]: 'id',
         };
 
         // Always delete existing stores to ensure keyPaths are applied correctly
@@ -175,6 +181,7 @@ const syncData = async () => {
         DB_CONFIG.STORES.ENCOUNTERS,
         DB_CONFIG.STORES.LOCATIONS,
         DB_CONFIG.STORES.ITEMS,
+        DB_CONFIG.STORES.MOVES,
         DB_CONFIG.STORES.METADATA,
       ],
       'readwrite',
@@ -185,12 +192,20 @@ const syncData = async () => {
     const eStore = tx.objectStore(DB_CONFIG.STORES.ENCOUNTERS);
     const lStore = tx.objectStore(DB_CONFIG.STORES.LOCATIONS);
     const iStore = tx.objectStore(DB_CONFIG.STORES.ITEMS);
+    const mvStore = tx.objectStore(DB_CONFIG.STORES.MOVES);
     const mStore = tx.objectStore(DB_CONFIG.STORES.METADATA);
 
     // Clear old data
-    await Promise.all([pStore.clear(), eStore.clear(), lStore.clear(), iStore.clear(), mStore.clear()]);
+    await Promise.all([
+      pStore.clear(),
+      eStore.clear(),
+      lStore.clear(),
+      iStore.clear(),
+      mvStore.clear(),
+      mStore.clear(),
+    ]);
 
-    emit(1, 4, 'Pokemon');
+    emit(1, 5, 'Pokemon');
     const inflateChain = (links: CompactChainLink[] | undefined): CompactChainLink[] => {
       return (links || []).map((l) => ({
         ...l,
@@ -216,7 +231,7 @@ const syncData = async () => {
       });
     }
 
-    emit(2, 4, 'Encounters');
+    emit(2, 5, 'Encounters');
     for (const e of data.enc) {
       const inflatedEnc = e.enc.map((enc) => ({
         ...enc,
@@ -229,7 +244,7 @@ const syncData = async () => {
       void eStore.put({ pid: e.pid, enc: inflatedEnc });
     }
 
-    emit(3, 4, 'Locations');
+    emit(3, 5, 'Locations');
     for (const l of data.loc) {
       void lStore.put({
         ...DEFAULT_LOCATION,
@@ -238,9 +253,17 @@ const syncData = async () => {
       });
     }
 
-    emit(4, 4, 'Items');
+    emit(4, 5, 'Items');
     for (const item of data.items || []) {
       void iStore.put(item);
+    }
+
+    emit(5, 5, 'Moves');
+    for (const move of data.moves || []) {
+      void mvStore.put({
+        ...DEFAULT_MOVE_METADATA,
+        ...move,
+      });
     }
 
     await mStore.put({ key: 'hash', value: data.hash });
@@ -311,6 +334,15 @@ export const pokeDB = {
     await pokeDB.ready();
     if (id === undefined || id === null || Number.isNaN(id)) return undefined;
     return (await getDB()).get(DB_CONFIG.STORES.ITEMS, id);
+  },
+
+  /**
+   * Fetches a single Move's metadata by its ID.
+   */
+  getMove: async (id: number): Promise<MoveMetadata | undefined> => {
+    await pokeDB.ready();
+    if (id === undefined || id === null || Number.isNaN(id)) return undefined;
+    return (await getDB()).get(DB_CONFIG.STORES.MOVES, id);
   },
 
   /**
@@ -438,6 +470,33 @@ export const pokeDB = {
     await pokeDB.ready();
     return (await getDB()).getAll(DB_CONFIG.STORES.POKEMON);
   },
+  /**
+   * Fetches multiple Move records in a single database transaction using `bulkGet`.
+   * Designed to be called exclusively by `DexDataLoader` to prevent N+1 IDB query bottlenecks.
+   */
+  getMovesBulk: async (ids: number[]): Promise<(MoveMetadata | Error)[]> => {
+    await pokeDB.ready();
+    const db = await getDB();
+    const validIds = ids.filter((id) => typeof id === 'number' && !Number.isNaN(id));
+    if (validIds.length === 0) return ids.map(() => new Error('Invalid ID provided'));
+
+    const tx = db.transaction(DB_CONFIG.STORES.MOVES, 'readonly');
+    const store = unwrap(tx.objectStore(DB_CONFIG.STORES.MOVES));
+    const fetched = await bulkGet<MoveMetadata>(store, validIds);
+    await tx.done;
+
+    const resultMap = new Map<number, MoveMetadata>();
+    for (const mv of fetched) {
+      if (mv) resultMap.set(mv.id, mv);
+    }
+
+    return ids.map((id) => {
+      if (typeof id !== 'number' || Number.isNaN(id)) return new Error('Invalid ID');
+      const found = resultMap.get(id);
+      return found ?? new Error(`Move not found for ${id}`);
+    });
+  },
+
   /**
    * Fetches multiple Encounter records in a single database transaction using `bulkGet`.
    * Designed to be called exclusively by `DexDataLoader` to prevent N+1 IDB query bottlenecks.

--- a/src/db/__tests__/PokeDB.test.ts
+++ b/src/db/__tests__/PokeDB.test.ts
@@ -214,6 +214,62 @@ describe('PokeDB', () => {
     expect(item?.gen1_id).toBe(10);
   });
 
+  it('retrieves single moves correctly', async () => {
+    const mockData = {
+      items: [],
+      moves: [{ id: 10, name: 'Scratch', type: 1, p: 40, pp: 35, dmg_class: 1, effect: 0 }],
+      hash: 'move-hash',
+      poke: [],
+      enc: [],
+      loc: [],
+    };
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => pack(mockData),
+    } as unknown as Response);
+    await pokeDB.sync();
+
+    const move = await pokeDB.getMove(10);
+    expect(move?.name).toBe('Scratch');
+    expect(move?.p).toBe(40);
+    expect(move?.acc).toBe(100); // Check inflation
+  });
+
+  it('performs bulk operations for moves', async () => {
+    const mockData = {
+      items: [],
+      moves: [
+        { id: 1, name: 'M1', type: 1, p: 40, pp: 35, dmg_class: 1, effect: 0 },
+        { id: 2, name: 'M2', type: 1, p: 40, pp: 35, dmg_class: 1, effect: 0 },
+      ],
+      hash: 'bulk-move-hash',
+      poke: [],
+      enc: [],
+      loc: [],
+    };
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => pack(mockData),
+    } as unknown as Response);
+
+    await pokeDB.sync();
+
+    const results = await pokeDB.getMovesBulk([1, 2, 999]);
+    expect(results).toHaveLength(3);
+
+    const r1 = results[0];
+    if (!r1 || r1 instanceof Error) throw r1 ?? new Error('r1 undefined');
+    expect(r1.name).toBe('M1');
+
+    const r2 = results[1];
+    if (!r2 || r2 instanceof Error) throw r2 ?? new Error('r2 undefined');
+    expect(r2.name).toBe('M2');
+
+    expect(results[2]).toBeInstanceOf(Error);
+  });
+
   it('performs bulk operations for pokemons', async () => {
     const mockData = {
       items: [],

--- a/src/db/__tests__/PokeDB.test.ts
+++ b/src/db/__tests__/PokeDB.test.ts
@@ -153,11 +153,12 @@ describe('PokeDB', () => {
     const events = dispatchEventMock.mock.calls.map((call) => call[0] as CustomEvent);
     const progressEvents = events.filter((e) => e.type === 'pokedata-sync-progress');
 
-    expect(progressEvents).toHaveLength(4);
-    expect(progressEvents[0]?.detail).toEqual({ current: 1, total: 4, stage: 'Pokemon' });
-    expect(progressEvents[1]?.detail).toEqual({ current: 2, total: 4, stage: 'Encounters' });
-    expect(progressEvents[2]?.detail).toEqual({ current: 3, total: 4, stage: 'Locations' });
-    expect(progressEvents[3]?.detail).toEqual({ current: 4, total: 4, stage: 'Items' });
+    expect(progressEvents).toHaveLength(5);
+    expect(progressEvents[0]?.detail).toEqual({ current: 1, total: 5, stage: 'Pokemon' });
+    expect(progressEvents[1]?.detail).toEqual({ current: 2, total: 5, stage: 'Encounters' });
+    expect(progressEvents[2]?.detail).toEqual({ current: 3, total: 5, stage: 'Locations' });
+    expect(progressEvents[3]?.detail).toEqual({ current: 4, total: 5, stage: 'Items' });
+    expect(progressEvents[4]?.detail).toEqual({ current: 5, total: 5, stage: 'Moves' });
 
     global.window = originalWindow;
   });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -7,12 +7,13 @@ import type { DBSchema } from 'idb';
 
 export const DB_CONFIG = {
   NAME: 'PokeDB',
-  VERSION: 10,
+  VERSION: 11,
   STORES: {
     POKEMON: 'pokemon',
     ENCOUNTERS: 'encounters',
     LOCATIONS: 'locations',
     ITEMS: 'items',
+    MOVES: 'moves',
     METADATA: 'metadata',
   },
 } as const;
@@ -233,6 +234,17 @@ export interface PokemonMetadata {
   em?: Record<number, number[]> | undefined; // Precomputed shortest breeding chains for egg moves: MoveID -> chain of Pokemon IDs
 }
 
+export interface MoveMetadata {
+  id: number;
+  name: string;
+  type: number;
+  p?: number | undefined; // power
+  acc?: number | undefined; // accuracy
+  pp: number;
+  dmg_class: number;
+  effect?: number | undefined;
+}
+
 export interface ItemMetadata {
   id: number;
   name: string;
@@ -259,6 +271,7 @@ export interface PokeDataExport {
   enc: LocationAreaEncounters[];
   loc: UnifiedLocation[];
   items: ItemMetadata[];
+  moves: MoveMetadata[];
   hash: string;
   sourceSha?: string;
 }
@@ -275,6 +288,10 @@ export interface PokeDBSchema extends DBSchema {
   [DB_CONFIG.STORES.ITEMS]: {
     key: number;
     value: ItemMetadata;
+  };
+  [DB_CONFIG.STORES.MOVES]: {
+    key: number;
+    value: MoveMetadata;
   };
   [DB_CONFIG.STORES.LOCATIONS]: {
     key: number;


### PR DESCRIPTION
This PR fulfills the requirements of `task-275-435-move-db-schema-inflation`. It integrates the dynamically generated `moves.jsonl` data into the client-side IndexedDB schema. This involves creating a new `moves` object store, configuring its key path, updating the schema definitions, and implementing inflation logic during data sync to restore omitted default values (such as accuracy = 100) to minimize the final bundle size. Additionally, query methods `getMove` and `getMovesBulk` are exposed.

---
*PR created automatically by Jules for task [9330737274448347349](https://jules.google.com/task/9330737274448347349) started by @szubster*