### PR TITLE
feat: Implement Gen 3 Contest Museum parsing

### DIFF
--- a/.foundry/tasks/task-358-426-gen3-contest-museum-parsing-impl.md
+++ b/.foundry/tasks/task-358-426-gen3-contest-museum-parsing-impl.md
@@ -27,6 +27,6 @@ notes: ''
 Implement the core parsing logic to extract the Gen 3 Trainer Card upgrade criteria for Contest Master Rank. Add `hasContestMaster` boolean property to `Gen3TrainerCard`. For Contest Master Rank, verify the 5 Museum Contest paintings (flags starting at `0x2e90` in SaveBlock1, index 8). Ensure strict adherence to the schema guidelines.
 
 ## Acceptance Criteria
-- [ ] Implement `parseGen3ContestMaster` logic in `src/engine/saveParser/parsers/gen3.ts` using the museum offsets detailed in `.foundry/docs/knowledge_base/gen3_contest_museum_offsets.md`.
-- [ ] Construct and return `gen3TrainerCard.hasContestMaster` object within `parseGen3`.
-- [ ] Verify the implementation using appropriate unit tests.
+- [x] Implement `parseGen3ContestMaster` logic in `src/engine/saveParser/parsers/gen3.ts` using the museum offsets detailed in `.foundry/docs/knowledge_base/gen3_contest_museum_offsets.md`.
+- [x] Construct and return `gen3TrainerCard.hasContestMaster` object within `parseGen3`.
+- [x] Verify the implementation using appropriate unit tests.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -105,6 +105,7 @@ export interface Gen3TrainerCard {
   hasHallOfFame: boolean;
   hasHoennDex: boolean;
   hasNationalDex: boolean;
+  hasContestMaster: boolean;
 }
 
 export interface Gen3TVShow {

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -15,6 +15,7 @@ import {
   parseGen3BattleFrontierWinStreaks,
   parseGen3BattlePoints,
   parseGen3ConditionStats,
+  parseGen3ContestMaster,
   parseGen3EggSteps,
   parseGen3EmeraldMoveTutors,
   parseGen3EVs,
@@ -1585,6 +1586,37 @@ describe('parseGen3PokemonPVAndIVs', () => {
   });
 });
 
+describe('parseGen3ContestMaster', () => {
+  it('should return true if all 5 museum contest paintings are present', () => {
+    const buffer = new ArrayBuffer(0x4000);
+    const view = new DataView(buffer);
+    const saveBlock1Offset = 0;
+    const baseOffset = saveBlock1Offset + 0x2e90 + 8 * 32;
+    for (let i = 0; i < 5; i++) {
+      view.setUint16(baseOffset + i * 32 + 8, 25, true); // species Pikachu
+    }
+    expect(parseGen3ContestMaster(view, saveBlock1Offset)).toBe(true);
+  });
+
+  it('should return false if any museum contest painting is missing', () => {
+    const buffer = new ArrayBuffer(0x4000);
+    const view = new DataView(buffer);
+    const saveBlock1Offset = 0;
+    const baseOffset = saveBlock1Offset + 0x2e90 + 8 * 32;
+    for (let i = 0; i < 4; i++) {
+      view.setUint16(baseOffset + i * 32 + 8, 25, true);
+    }
+    view.setUint16(baseOffset + 4 * 32 + 8, 0, true); // missing 5th painting
+    expect(parseGen3ContestMaster(view, saveBlock1Offset)).toBe(false);
+  });
+
+  it('should throw an error for corrupted save files', () => {
+    const buffer = new ArrayBuffer(100);
+    const view = new DataView(buffer);
+    expect(() => parseGen3ContestMaster(view, 0)).toThrow('The save file is corrupted or incomplete.');
+  });
+});
+
 describe('parseGen3MetLocation', () => {
   it('should parse the met location byte correctly', () => {
     const buffer = new ArrayBuffer(10);
@@ -2159,6 +2191,7 @@ describe('parseGen3 (trainer flags integration)', () => {
       hasHallOfFame: false,
       hasHoennDex: false,
       hasNationalDex: false,
+      hasContestMaster: false,
     });
   });
 });

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -279,6 +279,12 @@ export const SUBSTRUCTURE_ORDER = [
 export const EMERALD_MOVE_TUTOR_BYTE_1_OFFSET = 0x36;
 export const EMERALD_MOVE_TUTOR_BYTE_2_OFFSET = 0x37;
 
+export const GEN3_CONTEST_WINNERS_OFFSET = 0x2e90;
+export const MUSEUM_CONTEST_WINNERS_START = 8;
+export const NUM_MUSEUM_CONTEST_WINNERS = 5;
+export const CONTEST_WINNER_STRUCT_SIZE = 32;
+export const CONTEST_WINNER_SPECIES_OFFSET = 8;
+
 export const FRLG_MOVE_TUTOR_BYTE_1_OFFSET = 0x58;
 export const FRLG_MOVE_TUTOR_BYTE_2_OFFSET = 0x59;
 export const FRLG_MOVE_TUTOR_BYTE_3_OFFSET = 0x5b;
@@ -1433,10 +1439,13 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
     }
     const nationalDexCount = owned.size;
 
+    const hasContestMaster = parseGen3ContestMaster(view, section1Offset);
+
     const gen3TrainerCard = {
       hasHallOfFame: hallOfFameCount > 0,
       hasHoennDex: hoennDexCount === 202,
       hasNationalDex: nationalDexCount === 386,
+      hasContestMaster,
     };
 
     let pc: number[] = [];
@@ -2095,6 +2104,28 @@ export {
 export function parseGen3MetLocation(view: DataView, miscSubstructureOffset: number): number {
   try {
     return view.getUint8(miscSubstructureOffset + MET_LOCATION_OFFSET_IN_M);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+export function parseGen3ContestMaster(view: DataView, saveBlock1Offset: number): boolean {
+  try {
+    const baseOffset = saveBlock1Offset + GEN3_CONTEST_WINNERS_OFFSET;
+
+    for (let i = 0; i < NUM_MUSEUM_CONTEST_WINNERS; i++) {
+      const index = MUSEUM_CONTEST_WINNERS_START + i;
+      const structOffset = baseOffset + index * CONTEST_WINNER_STRUCT_SIZE;
+      const species = view.getUint16(structOffset + CONTEST_WINNER_SPECIES_OFFSET, true);
+
+      if (species === 0) {
+        return false;
+      }
+    }
+    return true;
   } catch (error) {
     if (error instanceof RangeError) {
       throw new Error('The save file is corrupted or incomplete.');


### PR DESCRIPTION
This PR implements the `parseGen3ContestMaster` logic to extract the Gen 3 Trainer Card upgrade criteria for the Contest Master Rank. It verifies the presence of the 5 Museum Contest paintings in `SaveBlock1` and adds a `hasContestMaster` boolean property to the `Gen3TrainerCard` object. Tests have been included to ensure the parsing logic correctly identifies presence, absence, and handles corrupted save files.

---
*PR created automatically by Jules for task [9329992510588527193](https://jules.google.com/task/9329992510588527193) started by @szubster*