### PR TITLE
feat: check off acceptance criteria for pre-existing adr-032-wasm-emulator-selection

### DIFF
--- a/.foundry/journals/architect/3092614035819582561.md
+++ b/.foundry/journals/architect/3092614035819582561.md
@@ -1,0 +1,4 @@
+# Session 3092614035819582561
+
+## Artifact Anomaly
+During task-421-435-wasm-emulator-adr, the target artifact `adr-421-032-wasm-emulator-selection.md` and the required `schema.md` property mappings were discovered to already be completely implemented and published to the archive. Executed Empty PR Policy.

--- a/.foundry/tasks/task-421-435-wasm-emulator-adr.md
+++ b/.foundry/tasks/task-421-435-wasm-emulator-adr.md
@@ -29,4 +29,4 @@ Research into WASM emulator options (mGBA, binjgb, SkyEmu) has been completed. T
 ## Acceptance Criteria
 - [x] Create `adr-421-032-wasm-emulator-selection.md` detailing the choice of a multi-emulator strategy for in-browser play.
 - [x] Document the technical approach for integrating the emulators and extracting save data.
-- [ ] 032-wasm-emulator-selection
+- [x] 032-wasm-emulator-selection


### PR DESCRIPTION
The target ADR `adr-421-032-wasm-emulator-selection.md` and related schema changes were found to be already completely implemented in the repository.
Checked off the Acceptance Criteria checkboxes in the task markdown to comply with the Empty PR Policy and allow the task to transition to COMPLETED.
Created a journal entry to log the Artifact Anomaly.

---
*PR created automatically by Jules for task [3092614035819582561](https://jules.google.com/task/3092614035819582561) started by @szubster*