### PR TITLE
QA Gen 2 Roamer Core Data Extraction

### DIFF
--- a/.foundry/tasks/task-297-339-gen2-roamer-core-extraction-qa.md
+++ b/.foundry/tasks/task-297-339-gen2-roamer-core-extraction-qa.md
@@ -35,5 +35,5 @@ QA verification for the Gen 2 Roamer Core Data Extraction.
 - Verify that map tracking variables (`wRoamMons_CurMapGroup`, `wRoamMons_CurMapNumber`) are properly extracted.
 
 ## Acceptance Criteria
-- [ ] Code review passes, ensuring no magic numbers exist and all ADRs are followed.
-- [ ] Unit tests cover out-of-bounds reads and correct extraction mapping.
+- [x] Code review passes, ensuring no magic numbers exist and all ADRs are followed.
+- [x] Unit tests cover out-of-bounds reads and correct extraction mapping.

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -427,6 +427,25 @@ describe('gen2 parsers', () => {
 
       expect(() => parseGen2(view, false)).toThrow('The save file is corrupted or incomplete.');
     });
+
+    it('should handle RangeError gracefully during roaming legendaries extraction', () => {
+      const buffer = new ArrayBuffer(0x8000);
+      const view = new DataView(buffer);
+      view.setUint8(0x288a, 1);
+      view.setUint8(0x288b, 1);
+      view.setUint8(0x288b + 7, 1);
+
+      // Force view.getUint8 to throw RangeError for roaming legendaries offset (GS = 0x28da)
+      const originalGetUint8 = view.getUint8.bind(view);
+      view.getUint8 = (offset: number) => {
+        if (offset === 0x28da) {
+          throw new RangeError('Out of bounds');
+        }
+        return originalGetUint8(offset);
+      };
+
+      expect(() => parseGen2(view, false)).toThrow('The save file is corrupted or incomplete.');
+    });
   });
 
   describe('Gen 2 Egg Parsing', () => {


### PR DESCRIPTION
QA verification for Gen 2 roamer core data extraction. Verified the use of module level constants, absence of magic numbers, correct extraction mapping for roaming data, and map tracking variables. Added a unit test to handle `RangeError` during roamer extraction, satisfying ADR 010 constraints.

---
*PR created automatically by Jules for task [13607317761982446669](https://jules.google.com/task/13607317761982446669) started by @szubster*