### PR TITLE
Extract Gen 3 Active Team Stats

### DIFF
--- a/.foundry/tasks/task-420-427-gen3-extract-active-team-impl.md
+++ b/.foundry/tasks/task-420-427-gen3-extract-active-team-impl.md
@@ -36,5 +36,5 @@ Implement extraction of the player's active team from Gen 3 save files, adhering
 - Implement tests verifying extraction correctly reads the required data. Use vitest and vitest-browser-react, not @testing-library.
 
 ## Acceptance Criteria
-- [ ] Implement team extraction logic as per requirements.
-- [ ] Implement unit tests verifying extraction.
+- [x] Implement team extraction logic as per requirements.
+- [x] Implement unit tests verifying extraction.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,1 @@
+All tests pass. No issues remaining. I'll submit.

--- a/plan.md
+++ b/plan.md
@@ -1,1 +1,0 @@
-All tests pass. No issues remaining. I'll submit.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -61,6 +61,7 @@ export interface PokemonInstance {
   friendship?: number | undefined;
   pokerus?: { strain: number; daysRemaining: number } | undefined;
   currentHp?: number | undefined;
+  stats?: { hp: number; atk: number; def: number; spd: number; spatk: number; spdef: number };
   dvs?: { hp: number; atk: number; def: number; spd: number; spc: number };
   statExp?: { hp: number; atk: number; def: number; spd: number; spc: number };
   caughtData?:

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -678,13 +678,22 @@ export function parseGen3Party(view: DataView, section1Offset: number, gameVersi
       party.push(speciesId);
       partyDetails.push({
         speciesId,
-        level: view.getUint8(offset + 84), // 0x54
+        level: view.getUint8(offset + GEN3_PARTY_LEVEL_OFFSET),
         isShiny: false, // We'll implement shiny calculation separately
         item: item > 0 ? item : undefined,
         moves,
         personalityValue: pv,
         storageLocation: 'Party',
         hash: `${pv}-${otId}`,
+        currentHp: view.getUint16(offset + GEN3_PARTY_HP_OFFSET, true),
+        stats: {
+          hp: view.getUint16(offset + GEN3_PARTY_MAX_HP_OFFSET, true),
+          atk: view.getUint16(offset + GEN3_PARTY_ATTACK_OFFSET, true),
+          def: view.getUint16(offset + GEN3_PARTY_DEFENSE_OFFSET, true),
+          spd: view.getUint16(offset + GEN3_PARTY_SPEED_OFFSET, true),
+          spatk: view.getUint16(offset + GEN3_PARTY_SPATK_OFFSET, true),
+          spdef: view.getUint16(offset + GEN3_PARTY_SPDEF_OFFSET, true),
+        },
       });
     }
   } catch (error) {

--- a/src/engine/saveParser/parsers/gen3_party.test.ts
+++ b/src/engine/saveParser/parsers/gen3_party.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from 'vitest';
+import {
+  GEN3_PARTY_ATTACK_OFFSET,
+  GEN3_PARTY_COUNT_OFFSET,
+  GEN3_PARTY_DEFENSE_OFFSET,
+  GEN3_PARTY_HP_OFFSET,
+  GEN3_PARTY_LEVEL_OFFSET,
+  GEN3_PARTY_MAX_HP_OFFSET,
+  GEN3_PARTY_POKEMON_LIST_OFFSET,
+  GEN3_PARTY_SPATK_OFFSET,
+  GEN3_PARTY_SPDEF_OFFSET,
+  GEN3_PARTY_SPEED_OFFSET,
+  GEN3_POKEMON_DATA_OFFSET,
+  GEN3_POKEMON_OT_ID_OFFSET,
+  GEN3_POKEMON_PV_OFFSET,
+  parseGen3Party,
+} from './gen3';
+
+test('extracts stats and HP from active team', () => {
+  const buffer = new ArrayBuffer(0x3000);
+  const view = new DataView(buffer);
+
+  // Write party count = 1
+  view.setUint32(GEN3_PARTY_COUNT_OFFSET, 1, true);
+
+  // 1st Pokemon
+  const listOffset = GEN3_PARTY_POKEMON_LIST_OFFSET;
+
+  // Set PV = 0, OTID = 1 => decrypt key = 1
+  view.setUint32(listOffset + GEN3_POKEMON_PV_OFFSET, 0, true);
+  view.setUint32(listOffset + GEN3_POKEMON_OT_ID_OFFSET, 1, true);
+
+  // Permutation PV=0 => GAEM => Growth is at offset 32
+  view.setUint16(listOffset + GEN3_POKEMON_DATA_OFFSET, 1 ^ 1, true);
+
+  // Level
+  view.setUint8(listOffset + GEN3_PARTY_LEVEL_OFFSET, 100);
+
+  // Current HP is at offset 86 = 0x56
+  view.setUint16(listOffset + GEN3_PARTY_HP_OFFSET, 12, true);
+
+  // Max HP is at offset 88 = 0x58
+  view.setUint16(listOffset + GEN3_PARTY_MAX_HP_OFFSET, 20, true);
+
+  // Stats
+  view.setUint16(listOffset + GEN3_PARTY_ATTACK_OFFSET, 30, true); // atk
+  view.setUint16(listOffset + GEN3_PARTY_DEFENSE_OFFSET, 40, true); // def
+  view.setUint16(listOffset + GEN3_PARTY_SPEED_OFFSET, 50, true); // spd
+  view.setUint16(listOffset + GEN3_PARTY_SPATK_OFFSET, 60, true); // spatk
+  view.setUint16(listOffset + GEN3_PARTY_SPDEF_OFFSET, 70, true); // spdef
+
+  const result = parseGen3Party(view, 0, 'ruby');
+
+  expect(result.party.length).toBe(1);
+  expect(result.partyDetails.length).toBe(1);
+  const detail = result.partyDetails[0];
+  expect(detail?.level).toBe(100);
+  expect(detail?.currentHp).toBe(12);
+  expect(detail?.stats?.hp).toBe(20);
+  expect(detail?.stats?.atk).toBe(30);
+  expect(detail?.stats?.def).toBe(40);
+  expect(detail?.stats?.spd).toBe(50);
+  expect(detail?.stats?.spatk).toBe(60);
+  expect(detail?.stats?.spdef).toBe(70);
+});


### PR DESCRIPTION
Extracts the player's active team current HP and max stats (HP, Attack, Defense, Speed, Sp. Atk, Sp. Def) from Gen 3 save files, mapping them to the `PokemonInstance` correctly as per `schema.md`. Includes unit test coverage.

---
*PR created automatically by Jules for task [3247212250677973563](https://jules.google.com/task/3247212250677973563) started by @szubster*