### PR TITLE
Fix: Gen 3 egg move gender checks in breeding suggestions

### DIFF
--- a/src/engine/assistant/__tests__/generateSuggestions.test.ts
+++ b/src/engine/assistant/__tests__/generateSuggestions.test.ts
@@ -1129,6 +1129,7 @@ describe('generateSuggestions', () => {
           id: 274,
           n: 'Nuzleaf',
           cr: 45,
+          gr: 4,
           baby: false,
           eto: [],
           efrm: [],
@@ -1172,6 +1173,7 @@ describe('generateSuggestions', () => {
           isShiny: false,
           hash: '',
           moves: [13], // Knows Razor Leaf
+          dvs: { atk: 15, hp: 15, def: 15, spd: 15, spc: 15 }, // Male DV
           storageLocation: 'Box 1',
           otName: 'ASH',
         },
@@ -1196,6 +1198,7 @@ describe('generateSuggestions', () => {
           id: 274,
           n: 'Nuzleaf',
           cr: 45,
+          gr: 4,
           baby: false,
           eto: [],
           efrm: [],
@@ -1263,6 +1266,7 @@ describe('generateSuggestions', () => {
           id: 100,
           n: 'TestBase',
           cr: 45,
+          gr: 4,
           baby: false,
           eto: [],
           efrm: [],
@@ -1307,6 +1311,7 @@ describe('generateSuggestions', () => {
           isShiny: false,
           hash: '',
           moves: [20], // Knows the Egg Move
+          dvs: { atk: 15, hp: 15, def: 15, spd: 15, spc: 15 }, // Male DV
           storageLocation: 'Box 1',
           otName: 'ASH',
         },
@@ -1331,6 +1336,7 @@ describe('generateSuggestions', () => {
           id: 100,
           n: 'TestBase',
           cr: 45,
+          gr: 4,
           baby: false,
           eto: [],
           efrm: [],

--- a/src/engine/assistant/generators/breedGenerator.ts
+++ b/src/engine/assistant/generators/breedGenerator.ts
@@ -1,3 +1,4 @@
+import { calculateGen2Gender, calculateGen3Gender } from '../../../utils/gender';
 import { getGenerationConfig } from '../../../utils/generationConfig';
 import type { PokemonInstance, SaveData } from '../../saveParser/index';
 import type { Suggestion } from '../strategies/types';
@@ -118,7 +119,20 @@ export function generateBreedingSuggestions(
               if (nextStepSpeciesId === undefined) continue;
 
               const instances = instancesBySpecies.get(stepSpeciesId) || [];
-              const hasMove = instances.some((inst) => inst.moves?.includes(moveId));
+              const hasMove = instances.some((inst) => {
+                if (!inst.moves?.includes(moveId)) return false;
+
+                const metadata = apiData.pokemonMetadata?.[inst.speciesId];
+                if (!metadata || metadata.gr === undefined) return false;
+
+                let gender: 'male' | 'female' | 'genderless' = 'genderless';
+                if (saveData.generation === 2) {
+                  gender = calculateGen2Gender(inst.dvs?.atk ?? 0, metadata.gr);
+                } else if (saveData.generation === 3) {
+                  gender = calculateGen3Gender(inst.personalityValue ?? 0, metadata.gr);
+                }
+                return gender === 'male';
+              });
 
               // If it doesn't have the move, and it's not the base of the chain, keep traversing
               if (!hasMove && k > 0) continue;

--- a/src/utils/gender.test.ts
+++ b/src/utils/gender.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { calculateGen2Gender } from './gender.ts';
+import { calculateGen2Gender, calculateGen3Gender } from './gender.ts';
 
 describe('calculateGen2Gender', () => {
   it('should return genderless for gender rate -1', () => {
@@ -43,5 +43,50 @@ describe('calculateGen2Gender', () => {
     expect(calculateGen2Gender(11, 6)).toBe('female');
     expect(calculateGen2Gender(12, 6)).toBe('male');
     expect(calculateGen2Gender(15, 6)).toBe('male');
+  });
+});
+
+describe('calculateGen3Gender', () => {
+  it('should return genderless for gender rate -1', () => {
+    expect(calculateGen3Gender(255, -1)).toBe('genderless');
+    expect(calculateGen3Gender(0, -1)).toBe('genderless');
+  });
+
+  it('should return male for gender rate 0 (male only)', () => {
+    expect(calculateGen3Gender(0, 0)).toBe('male');
+    expect(calculateGen3Gender(255, 0)).toBe('male');
+  });
+
+  it('should return female for gender rate 8 (female only)', () => {
+    expect(calculateGen3Gender(0, 8)).toBe('female');
+    expect(calculateGen3Gender(255, 8)).toBe('female');
+  });
+
+  it('should correctly calculate gender for 7:1 ratio (gender rate 1)', () => {
+    expect(calculateGen3Gender(0, 1)).toBe('female');
+    expect(calculateGen3Gender(31, 1)).toBe('female');
+    expect(calculateGen3Gender(32, 1)).toBe('male');
+    expect(calculateGen3Gender(255, 1)).toBe('male');
+  });
+
+  it('should correctly calculate gender for 3:1 ratio (gender rate 2)', () => {
+    expect(calculateGen3Gender(0, 2)).toBe('female');
+    expect(calculateGen3Gender(63, 2)).toBe('female');
+    expect(calculateGen3Gender(64, 2)).toBe('male');
+    expect(calculateGen3Gender(255, 2)).toBe('male');
+  });
+
+  it('should correctly calculate gender for 1:1 ratio (gender rate 4)', () => {
+    expect(calculateGen3Gender(0, 4)).toBe('female');
+    expect(calculateGen3Gender(127, 4)).toBe('female');
+    expect(calculateGen3Gender(128, 4)).toBe('male');
+    expect(calculateGen3Gender(255, 4)).toBe('male');
+  });
+
+  it('should correctly calculate gender for 1:3 ratio (gender rate 6)', () => {
+    expect(calculateGen3Gender(0, 6)).toBe('female');
+    expect(calculateGen3Gender(191, 6)).toBe('female');
+    expect(calculateGen3Gender(192, 6)).toBe('male');
+    expect(calculateGen3Gender(255, 6)).toBe('male');
   });
 });

--- a/src/utils/gender.ts
+++ b/src/utils/gender.ts
@@ -40,3 +40,47 @@ export function calculateGen2Gender(attackDv: number, genderRate: number): 'male
 
   return attackDv <= femaleThreshold ? 'female' : 'male';
 }
+
+/**
+ * Calculates the gender of a Generation 3 Pokémon based on its Personality Value and gender ratio.
+ *
+ * @param personalityValue The 32-bit personality value of the Pokémon.
+ * @param genderRate The gender rate of the species (PokeAPI format, representing eighths of female chance. -1 for genderless).
+ * @returns 'male', 'female', or 'genderless'
+ */
+export function calculateGen3Gender(personalityValue: number, genderRate: number): 'male' | 'female' | 'genderless' {
+  if (genderRate === -1) {
+    return 'genderless';
+  }
+  if (genderRate === 0) {
+    return 'male';
+  }
+  if (genderRate === 8) {
+    return 'female';
+  }
+
+  // Determine the threshold for female based on the gender rate
+  // Gender is determined by the lowest 8 bits of the personality value
+  let femaleThreshold = 0;
+  switch (genderRate) {
+    case 1: // 1/8 female
+      femaleThreshold = 31;
+      break;
+    case 2: // 1/4 female
+      femaleThreshold = 63;
+      break;
+    case 4: // 1/2 female
+      femaleThreshold = 127;
+      break;
+    case 6: // 3/4 female
+      femaleThreshold = 191;
+      break;
+    default:
+      // Approximation for other rates
+      femaleThreshold = Math.floor((genderRate / 8) * 256) - 1;
+      break;
+  }
+
+  const lowestByte = personalityValue & 0xff;
+  return lowestByte <= femaleThreshold ? 'female' : 'male';
+}


### PR DESCRIPTION
In Gen 2 and 3, only Male Pokemon can pass down egg moves.
The `generateBreedingSuggestions` function previously ignored this requirement, incorrectly suggesting Female or Genderless Pokemon to breed if they knew an egg move. 

This PR implements `calculateGen3Gender` which determines the gender from the lowest 8 bits of a Pokemon's Personality Value, and correctly maps PokeAPI's `genderRate` format to the internal threshold logic. 

`generateBreedingSuggestions` now cross-references the instance's DVs (Gen 2) or PV (Gen 3) to ensure it is male before setting `hasMove = true`. Unit tests have also been updated/added to ensure it triggers correctly.

---
*PR created automatically by Jules for task [1826126204150583312](https://jules.google.com/task/1826126204150583312) started by @szubster*