### PR TITLE
QA: Move DB Schema and Inflation

### DIFF
--- a/.foundry/journals/qa/8634617573454251586.md
+++ b/.foundry/journals/qa/8634617573454251586.md
@@ -1,0 +1,5 @@
+# Session 8634617573454251586
+## Summary
+Verified task-275-435-move-db-schema-inflation.
+- **Moves Integration**: Verified the `moves` data is properly fetched from `pokedata.msgpack`, inflated (including defaults like `acc: 100`), and stored in the IndexedDB `moves` object store (`PokeDB`).
+- **Inflation**: Confirmed that omitted properties default back correctly during the database populating phase (`syncData`).

--- a/.foundry/tasks/task-275-436-move-db-schema-qa.md
+++ b/.foundry/tasks/task-275-436-move-db-schema-qa.md
@@ -27,5 +27,5 @@ locks: []
 Verify DB integration and inflation logic for the `moves` data.
 
 ## Acceptance Criteria
-- [ ] Verify database schema syncs properly.
-- [ ] Verify inflation logic restores omitted defaults.
+- [x] Verify database schema syncs properly.
+- [x] Verify inflation logic restores omitted defaults.

--- a/vite-plugins/pokedata-plugin.ts
+++ b/vite-plugins/pokedata-plugin.ts
@@ -23,6 +23,7 @@ export function pokedataPlugin(options: PokeDataPluginOptions): Plugin {
     const encounters = readJsonl(path.join(sourceDir, 'encounters.jsonl'));
     const locations = readJsonl(path.join(sourceDir, 'locations.jsonl'));
     const items = readJsonl(path.join(sourceDir, 'items.jsonl'));
+    const moves = readJsonl(path.join(sourceDir, 'moves.jsonl'));
     const metadataPath = path.join(sourceDir, 'metadata.json');
     const metadata = fs.existsSync(metadataPath) ? JSON.parse(fs.readFileSync(metadataPath, 'utf-8')) : {};
 
@@ -31,6 +32,7 @@ export function pokedataPlugin(options: PokeDataPluginOptions): Plugin {
       enc: encounters,
       loc: locations,
       items: items,
+      moves: moves,
       sourceSha: metadata.sourceSha,
     };
 


### PR DESCRIPTION
Verified database integration and inflation logic for the `moves` data. Found and patched a data pipeline omission in the Vite plugin to correctly export the moves data into the payload, successfully verifying the client runtime inflation and DB schema.

---
*PR created automatically by Jules for task [8634617573454251586](https://jules.google.com/task/8634617573454251586) started by @szubster*