### PR TITLE
feat: implement gen3 contest museum parsing

### DIFF
--- a/.foundry/journals/coder/2026-08-17-23-48-51.md
+++ b/.foundry/journals/coder/2026-08-17-23-48-51.md
@@ -1,0 +1,12 @@
+# Coder Session: 2026-08-17-23-48-51
+
+## Task: Gen 3 Contest Museum Parsing Implementation (task-358-426-gen3-contest-museum-parsing-impl)
+
+### Implementation
+- Added `hasContestMaster` boolean property to `Gen3TrainerCard` interface.
+- Implemented `parseGen3ContestMaster` in `src/engine/saveParser/parsers/gen3.ts` to extract the Contest Master Rank flag.
+- Integrated `parseGen3ContestMaster` into `parseGen3` object constructor for `gen3TrainerCard`.
+- Updated unit tests in `src/engine/saveParser/parsers/gen3.test.ts` to verify positive, negative and boundary cases.
+
+### Learnings
+- **Gen 3 SaveBlock1 Section-Relative Offsets:** When parsing Gen 3 save files, `SaveBlock1` is divided into four 4096-byte sections (Sections 0-3). Each section contains exactly 3968 bytes of data followed by a 128-byte footer. Absolute offsets spanning multiple sections (e.g., `0x2E90`) must be converted to section-relative offsets (e.g., `0x2E90` is in Section 3 at relative offset `0x10`) and combined with the resolved section offset (e.g., via `getLatestSectionOffset`) to avoid incorrectly reading section footers.

--- a/.foundry/tasks/task-358-426-gen3-contest-museum-parsing-impl.md
+++ b/.foundry/tasks/task-358-426-gen3-contest-museum-parsing-impl.md
@@ -27,6 +27,6 @@ notes: ''
 Implement the core parsing logic to extract the Gen 3 Trainer Card upgrade criteria for Contest Master Rank. Add `hasContestMaster` boolean property to `Gen3TrainerCard`. For Contest Master Rank, verify the 5 Museum Contest paintings (flags starting at `0x2e90` in SaveBlock1, index 8). Ensure strict adherence to the schema guidelines.
 
 ## Acceptance Criteria
-- [ ] Implement `parseGen3ContestMaster` logic in `src/engine/saveParser/parsers/gen3.ts` using the museum offsets detailed in `.foundry/docs/knowledge_base/gen3_contest_museum_offsets.md`.
-- [ ] Construct and return `gen3TrainerCard.hasContestMaster` object within `parseGen3`.
-- [ ] Verify the implementation using appropriate unit tests.
+- [x] Implement `parseGen3ContestMaster` logic in `src/engine/saveParser/parsers/gen3.ts` using the museum offsets detailed in `.foundry/docs/knowledge_base/gen3_contest_museum_offsets.md`.
+- [x] Construct and return `gen3TrainerCard.hasContestMaster` object within `parseGen3`.
+- [x] Verify the implementation using appropriate unit tests.

--- a/src/engine/saveParser/parsers/common.ts
+++ b/src/engine/saveParser/parsers/common.ts
@@ -107,6 +107,7 @@ export interface Gen3TrainerCard {
   hasHoennDex: boolean;
   hasNationalDex: boolean;
   hasBattleFrontier: boolean;
+  hasContestMaster: boolean;
 }
 
 export interface Gen3TVShow {

--- a/src/engine/saveParser/parsers/gen3.test.ts
+++ b/src/engine/saveParser/parsers/gen3.test.ts
@@ -15,6 +15,7 @@ import {
   parseGen3BattleFrontierWinStreaks,
   parseGen3BattlePoints,
   parseGen3ConditionStats,
+  parseGen3ContestMaster,
   parseGen3EggSteps,
   parseGen3EmeraldMoveTutors,
   parseGen3EVs,
@@ -2160,6 +2161,7 @@ describe('parseGen3 (trainer flags integration)', () => {
       hasHoennDex: false,
       hasNationalDex: false,
       hasBattleFrontier: false,
+      hasContestMaster: false,
     });
   });
 
@@ -2197,6 +2199,48 @@ describe('parseGen3 (trainer flags integration)', () => {
       hasHoennDex: false,
       hasNationalDex: false,
       hasBattleFrontier: true,
+      hasContestMaster: false,
     });
+  });
+});
+
+describe('parseGen3ContestMaster', () => {
+  it('should return true when all 5 museum paintings exist', () => {
+    const buffer = new ArrayBuffer(0x1000);
+    const view = new DataView(buffer);
+    const section3Offset = 0;
+    const baseOffset = section3Offset + 0x10;
+
+    // Set museum paintings (indices 8 to 12) to have non-zero species
+    for (let i = 0; i < 5; i++) {
+      view.setUint16(baseOffset + (8 + i) * 32 + 8, 25, true); // Pikachu
+    }
+
+    const result = parseGen3ContestMaster(view, section3Offset);
+    expect(result).toBe(true);
+  });
+
+  it('should return false when one of the museum paintings is missing (species is 0)', () => {
+    const buffer = new ArrayBuffer(0x1000);
+    const view = new DataView(buffer);
+    const section3Offset = 0;
+    const baseOffset = section3Offset + 0x10;
+
+    // Set museum paintings (indices 8 to 12)
+    view.setUint16(baseOffset + (8 + 0) * 32 + 8, 25, true); // Pikachu
+    view.setUint16(baseOffset + (8 + 1) * 32 + 8, 25, true); // Pikachu
+    view.setUint16(baseOffset + (8 + 2) * 32 + 8, 0, true); // Missing painting
+    view.setUint16(baseOffset + (8 + 3) * 32 + 8, 25, true); // Pikachu
+    view.setUint16(baseOffset + (8 + 4) * 32 + 8, 25, true); // Pikachu
+
+    const result = parseGen3ContestMaster(view, section3Offset);
+    expect(result).toBe(false);
+  });
+
+  it('should throw an error on out of bounds read', () => {
+    const buffer = new ArrayBuffer(0x10);
+    const view = new DataView(buffer);
+    const section3Offset = 0;
+    expect(() => parseGen3ContestMaster(view, section3Offset)).toThrow('The save file is corrupted or incomplete.');
   });
 });

--- a/src/engine/saveParser/parsers/gen3.ts
+++ b/src/engine/saveParser/parsers/gen3.ts
@@ -266,6 +266,13 @@ export const GEN3_POKEMON_MOVE_4_OFFSET = 0x06;
 export const UPPER_16_BIT_SHIFT = 16;
 export const NUM_SUBSTRUCTURE_PERMUTATIONS = 24;
 
+export const GEN3_CONTEST_WINNERS_SECTION_ID = 3;
+export const GEN3_CONTEST_WINNERS_RELATIVE_OFFSET = 0x10;
+export const MUSEUM_CONTEST_WINNERS_START = 8;
+export const MUSEUM_CONTEST_WINNERS_COUNT = 5;
+export const CONTEST_WINNER_STRUCT_SIZE = 32;
+export const CONTEST_WINNER_SPECIES_OFFSET = 0x08;
+
 /**
  * Maps the 24 possible permutations of a Gen 3 Pokémon's 48-byte data block.
  * The permutation index is determined by `PV % 24`.
@@ -1330,6 +1337,39 @@ export function parseGen3TrainerId(view: DataView, section0Offset: number): { tr
 }
 
 /**
+ * Parses the Contest Winners array to determine if the player has unlocked the
+ * Contest Master Rank on their Trainer Card (earned by having 5 museum paintings).
+ *
+ * @param view - The raw save file DataView.
+ * @param section3Offset - The resolved memory offset to the active Section 3.
+ * @returns True if all 5 museum paintings exist.
+ * @throws Error - "The save file is corrupted or incomplete." on out-of-bounds reads.
+ */
+export function parseGen3ContestMaster(view: DataView, section3Offset: number): boolean {
+  try {
+    const baseOffset = section3Offset + GEN3_CONTEST_WINNERS_RELATIVE_OFFSET;
+
+    for (let i = 0; i < MUSEUM_CONTEST_WINNERS_COUNT; i++) {
+      const winnerIndex = MUSEUM_CONTEST_WINNERS_START + i;
+      const offset = baseOffset + winnerIndex * CONTEST_WINNER_STRUCT_SIZE;
+
+      // Check if the species field is non-zero
+      const species = view.getUint16(offset + CONTEST_WINNER_SPECIES_OFFSET, true);
+      if (species === 0) {
+        return false;
+      }
+    }
+
+    return true;
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('The save file is corrupted or incomplete.');
+    }
+    throw error;
+  }
+}
+
+/**
  * The main orchestrator for parsing a Generation 3 (R/S/E/FR/LG) save file.
  *
  * **Architecture Overview & Orchestration:**
@@ -1366,6 +1406,14 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       section0Offset = getLatestSectionOffset(view, 0);
     } catch {
       throw new RangeError('Out of bounds during block scan');
+    }
+
+    let section3Offset: number;
+    try {
+      section3Offset = getLatestSectionOffset(view, 3);
+    } catch {
+      // Ignored for older Gen 3 games if necessary, or let it fail gracefully
+      section3Offset = -1;
     }
 
     const gen3BerryPatches = extractBerryPatches(view, section1Offset);
@@ -1560,11 +1608,22 @@ export function parseGen3(view: DataView, _forcedVersion?: GameVersion): SaveDat
       gen3BattleFrontierSymbols.pyramid.gold
     );
 
+    let hasContestMaster = false;
+    const version = _forcedVersion || 'ruby';
+    if (section3Offset !== -1 && (version === 'ruby' || version === 'sapphire' || version === 'emerald')) {
+      try {
+        hasContestMaster = parseGen3ContestMaster(view, section3Offset);
+      } catch {
+        // Ignored
+      }
+    }
+
     const gen3TrainerCard = {
       hasHallOfFame: hallOfFameCount > 0,
       hasHoennDex: hoennDexCount === 202,
       hasNationalDex: nationalDexCount === 386,
       hasBattleFrontier,
+      hasContestMaster,
     };
 
     let pc: number[] = [];


### PR DESCRIPTION
Implemented Gen 3 Contest Museum parsing logic to extract the Contest Master Rank upgrade for the Trainer Card by verifying the 5 museum paintings in SaveBlock1. Fixed absolute offset bounds bug to correctly map to Section 3 using a relative offset.

---
*PR created automatically by Jules for task [5773196772398209923](https://jules.google.com/task/5773196772398209923) started by @szubster*