### PR TITLE
🛠️ Infras: Add knip to lefthook pre-commit checks

### DIFF
--- a/.jules/infras/2026-08-18-01-41-52.md
+++ b/.jules/infras/2026-08-18-01-41-52.md
@@ -1,0 +1,3 @@
+## Critical Learnings
+- **Tooling configuration context**: Discovered that Knip was running as part of the `pnpm lint` command but the `--reporter github-actions` was only defined in `.github/workflows/ci.yml`. More critically, Knip wasn't hooked into `lefthook.yml` pre-commits, meaning unused exports or dependencies could easily be committed by a local developer and only flagged once they hit GitHub Actions CI.
+- **Action Taken**: Added `knip` to `lefthook.yml` under `pre-commit` hook (in parallel) to enforce unused export validation before code can be committed locally. Explicitly added `--no-exit-code` so developers receive warnings locally without being totally blocked from making local WIP commits, which balances local DX with codebase hygiene.

--- a/.jules/infras/master.md
+++ b/.jules/infras/master.md
@@ -36,3 +36,7 @@
 
 ## Critical Learnings
 - Upgraded infrastructure tooling versions: @biomejs/biome to 2.5.8, oxlint to 1.78.0, and knip to 6.32.2 to keep the ecosystem current.
+
+## Critical Learnings
+- **Tooling configuration context**: Discovered that Knip was running as part of the `pnpm lint` command but the `--reporter github-actions` was only defined in `.github/workflows/ci.yml`. More critically, Knip wasn't hooked into `lefthook.yml` pre-commits, meaning unused exports or dependencies could easily be committed by a local developer and only flagged once they hit GitHub Actions CI.
+- **Action Taken**: Added `knip` to `lefthook.yml` under `pre-commit` hook (in parallel) to enforce unused export validation before code can be committed locally. Explicitly added `--no-exit-code` so developers receive warnings locally without being totally blocked from making local WIP commits, which balances local DX with codebase hygiene.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,6 +14,8 @@ pre-commit:
       fail_on_changes: ci
     oxlint:
       run: pnpm exec oxlint --type-aware --no-error-on-unmatched-pattern {staged_files}
+    knip:
+      run: pnpm knip --no-exit-code
     type-check:
       run: pnpm type-check
     sort-package-json:


### PR DESCRIPTION
Add knip to lefthook pre-commit checks to automatically flag unused code/dependencies before allowing a commit. This is an analysis and static analysis improvement that ensures codebase remains clean. Use `--no-exit-code` to warn without blocking.

---
*PR created automatically by Jules for task [11581946257461609475](https://jules.google.com/task/11581946257461609475) started by @szubster*