### PR TITLE
📜 Scribe: Documented saveParser detection heuristics and Gen 3 stub

### DIFF
--- a/.jules/scribe/2026-08-18-02-34-27.md
+++ b/.jules/scribe/2026-08-18-02-34-27.md
@@ -1,0 +1,3 @@
+# Session Learnings
+
+- **Gen 3 Save Detection Stub**: `isGen3Save` in `src/engine/saveParser/utils/detection.ts` is explicitly stubbed to return `false` because Gen 3 save files use a complex A/B flash bank system with multiple checksums per sector. This requires scanning for signatures across sections, which is handled in a structural fallback path in `index.ts` rather than a contiguous block heuristic. I documented this with JSDoc.

--- a/src/engine/saveParser/utils/detection.ts
+++ b/src/engine/saveParser/utils/detection.ts
@@ -8,6 +8,16 @@ export const GEN2_PARTY_SPECIES_OFFSET_GS = 0x288b;
 export const GEN2_PARTY_COUNT_OFFSET_CRYSTAL = 0x2865;
 export const GEN2_PARTY_SPECIES_OFFSET_CRYSTAL = 0x2866;
 
+/**
+ * Heuristically determines if the provided DataView represents a Generation 1 save file.
+ *
+ * It checks the party count and verifies that the byte immediately following the active
+ * party members is the expected terminator byte (`0xff`), and that no active party ID
+ * is invalid (`0x00` or `0xff`).
+ *
+ * @param view - The raw save file DataView.
+ * @returns True if the file matches the expected Generation 1 structural signatures.
+ */
 export function isGen1Save(view: DataView): boolean {
   try {
     const partyCount = view.getUint8(GEN1_PARTY_COUNT_OFFSET);
@@ -24,6 +34,18 @@ export function isGen1Save(view: DataView): boolean {
   }
 }
 
+/**
+ * Heuristically determines if the provided DataView represents a Generation 2 save file.
+ *
+ * Because Gold/Silver and Crystal use different memory offsets for the party data,
+ * this function accepts a `crystal` boolean to conditionally check the correct memory locations.
+ * It validates that the party count is reasonable (<= 6) and that the expected terminator
+ * byte (`0xff`) appears at the correct offset.
+ *
+ * @param view - The raw save file DataView.
+ * @param crystal - True if the offsets for Pokémon Crystal should be used, False for Gold/Silver.
+ * @returns True if the file matches the expected Generation 2 structural signatures.
+ */
 export function isGen2Save(view: DataView, crystal: boolean): boolean {
   try {
     const countOffset = crystal ? GEN2_PARTY_COUNT_OFFSET_CRYSTAL : GEN2_PARTY_COUNT_OFFSET_GS;
@@ -42,6 +64,19 @@ export function isGen2Save(view: DataView, crystal: boolean): boolean {
   }
 }
 
+/**
+ * Stubs the detection for Generation 3 save files.
+ *
+ * **Architecture Note:**
+ * Generation 3 uses a complex A/B flash bank system with multiple checksums per sector,
+ * so its initial detection heavily relies on a structural fallback path in `index.ts`
+ * (scanning for signatures across sections) rather than a simple contiguous block heuristic here.
+ * As a result, this function is currently stubbed to prevent false positives and will always
+ * return false unless a RangeError occurs during bounds checking.
+ *
+ * @param view - The raw save file DataView.
+ * @returns Always returns false.
+ */
 export function isGen3Save(view: DataView): boolean {
   try {
     if (view.byteLength > 0) {


### PR DESCRIPTION
**What:**
Added JSDoc documentation to `isGen1Save`, `isGen2Save`, and `isGen3Save` in `src/engine/saveParser/utils/detection.ts`.

**Why this module needed docs:**
The `engine/saveParser` module uses complex, hard-coded offsets to heuristically identify Game Boy save files. While Gen 1 and Gen 2 have contiguous block detection, the `isGen3Save` function was merely a stub (`return false;`). Without documentation, it was entirely unclear *why* it was stubbed or how Gen 3 files are actually detected (via A/B flash bank signature scanning in `index.ts`). 

**Summary of additions:**
- Explained terminator byte (`0xff`) checks for Gen 1.
- Explained `crystal` offset ternary logic and bounds checking for Gen 2.
- Added an Architecture Note explaining the A/B bank flash memory system that necessitates stubbing Gen 3 detection at this layer.

---
*PR created automatically by Jules for task [17194206955016363699](https://jules.google.com/task/17194206955016363699) started by @szubster*