### PR TITLE
🧭 Strategist: prompt improvement - add journal section to changelogger

### DIFF
--- a/.github/agents/changelogger.md
+++ b/.github/agents/changelogger.md
@@ -27,3 +27,7 @@ Group entries under Keep a Changelog headings:
 - `### Security`
 
 Keep bullet points concise and focused on value delivered. Do not modify task frontmatter except as permitted by system rules.
+
+## Journal
+
+Your private journal is `.foundry/journals/changelogger/<session_id>.md` (if `session_id` is available in your prompt, otherwise use `.foundry/journals/changelogger/YYYY-MM-DD-HH-MM-SS.md`). You MUST adhere to the **Journaling Policies** defined in `.foundry/docs/knowledge_base/agents/core_policies.md`.

--- a/.jules/strategist/2026-08-18-03-54-48.md
+++ b/.jules/strategist/2026-08-18-03-54-48.md
@@ -1,0 +1,5 @@
+## 2026-08-18 - [Accepted] - Prompt improvement: Add Journal section to Changelogger
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `changelogger.md` schedule was completely missing the standard "Journal" section and its associated directives. Because of this omission, the Changelogger agent lacked strict instructions on where to save its private journal (`.foundry/journals/changelogger/`) and an explicit requirement to adhere to the core journaling policies defined in `.foundry/docs/knowledge_base/agents/core_policies.md`. The journal section is standard across all other agent prompts and is necessary for long term learning and debugging.
+**Pattern:** Ensure all agent prompts contain the required "Journal" section specifying the correct journal location and mandating adherence to the `core_policies.md` rules to maintain consistency across the agent roster.


### PR DESCRIPTION
The `changelogger.md` schedule was missing the standard "Journal" section and its associated directives. Because of this omission, the Changelogger agent lacked strict instructions on where to save its private journal (`.foundry/journals/changelogger/`) and an explicit requirement to adhere to the core journaling policies defined in `.foundry/docs/knowledge_base/agents/core_policies.md`. The journal section is standard across all other agent prompts and is necessary for long-term learning and debugging.

---
*PR created automatically by Jules for task [8900170080017941001](https://jules.google.com/task/8900170080017941001) started by @szubster*