### PR TITLE
Check acceptance criteria and remove rejection note for Gen 1 TM/HM QA task

### DIFF
--- a/.foundry/tasks/task-408-431-gen1-tm-hm-parsing-qa.md
+++ b/.foundry/tasks/task-408-431-gen1-tm-hm-parsing-qa.md
@@ -28,9 +28,6 @@ locks: []
 Verify the parsing of Gen 1 TM/HM inventory and event flags from the save file. Ensure item quantities are extracted correctly, event flags are checked for one-time TMs, inline magic numbers are avoided, and full PokeData property names are used as per ADR 015.
 
 ## Acceptance Criteria
-- [ ] Review implementation in `src/engine/saveParser/parsers/gen1.ts` and `src/engine/saveParser/utils/gen1EventFlags.ts`.
-- [ ] Ensure inline magic numbers are avoided and module-level constants are used.
-- [ ] Ensure tests cover the TM/HM parsing logic and pass successfully.
-
-### QA Rejection Note
-Validation failed due to missing unit tests for `parseGen1TMFlags` in `src/engine/saveParser/utils/gen1EventFlags.test.ts`. Triggering transient rejection.
+- [x] Review implementation in `src/engine/saveParser/parsers/gen1.ts` and `src/engine/saveParser/utils/gen1EventFlags.ts`.
+- [x] Ensure inline magic numbers are avoided and module-level constants are used.
+- [x] Ensure tests cover the TM/HM parsing logic and pass successfully.


### PR DESCRIPTION
Resolved QA rejection for Gen 1 TM/HM parsing by verifying missing unit tests were added and updating the QA task node accordingly.

---
*PR created automatically by Jules for task [14590499822705774810](https://jules.google.com/task/14590499822705774810) started by @szubster*