### PR TITLE
QA Gen 3 Bike Map Data Parsing

### DIFF
--- a/.foundry/journals/qa/2026-08-18-06-47-59.md
+++ b/.foundry/journals/qa/2026-08-18-06-47-59.md
@@ -1,0 +1,4 @@
+# QA Session: Gen 3 Bike Map Data Parsing
+
+## Artifact Anomaly
+The `parseBikeRequirements`, `hasMachBikeRequirement`, and `hasAcroBikeRequirement` logic, along with their unit tests, were fully implemented and correct. Executed the Empty PR Policy to check off the acceptance criteria for `task-412-425-gen3-bike-map-parsing-qa`.

--- a/.foundry/tasks/task-412-425-gen3-bike-map-parsing-qa.md
+++ b/.foundry/tasks/task-412-425-gen3-bike-map-parsing-qa.md
@@ -29,5 +29,5 @@ Implementation for the Mach and Acro bike map triggers and their integration dat
 QA the implemented parser logic. Verify that map triggers correctly reflect Mach and Acro bike requirements in a structure usable by downstream systems.
 
 ## Acceptance Criteria
-- [ ] Review PR for parser implementations.
-- [ ] Ensure `task-412-422-gen3-mach-bike-parsing-impl`, `task-412-423-gen3-acro-bike-parsing-impl`, and `task-412-424-gen3-bike-data-struct-integration-impl` meet their respective specifications.
+- [x] Review PR for parser implementations.
+- [x] Ensure `task-412-422-gen3-mach-bike-parsing-impl`, `task-412-423-gen3-acro-bike-parsing-impl`, and `task-412-424-gen3-bike-data-struct-integration-impl` meet their respective specifications.


### PR DESCRIPTION
I have reviewed the `parseBikeRequirements`, `hasMachBikeRequirement`, and `hasAcroBikeRequirement` logic and their respective unit tests. All specifications have been correctly met, representing an Artifact Anomaly where the work was already completely implemented. Therefore, I followed the Empty PR Policy by checking off the acceptance criteria checkboxes in `.foundry/tasks/task-412-425-gen3-bike-map-parsing-qa.md` and logging the session to `.foundry/journals/qa/2026-08-18-06-47-59.md` without making unnecessary code modifications. All linters and tests, including e2e, passed successfully.

---
*PR created automatically by Jules for task [1732351232879303952](https://jules.google.com/task/1732351232879303952) started by @szubster*