### PR TITLE
chore(qa): verify SaveData type refactor

### DIFF
--- a/.foundry/tasks/task-362-416-refactor-savedata-type-qa.md
+++ b/.foundry/tasks/task-362-416-refactor-savedata-type-qa.md
@@ -27,9 +27,9 @@ notes: ''
 Verify the implementation of the `SaveData` type refactor in `src/engine/saveParser/parsers/common.ts`. Ensure the discriminated union correctly enforces type safety and that downstream consumers properly handle generation-specific properties without non-null assertions or optional chaining when inappropriate.
 
 ## Acceptance Criteria
-- [ ] Verify `SaveData` is refactored into a discriminated union.
-- [ ] Verify core parser functions return specific generation types.
-- [ ] Verify downstream consumers use proper type guards.
+- [x] Verify `SaveData` is refactored into a discriminated union.
+- [x] Verify core parser functions return specific generation types.
+- [x] Verify downstream consumers use proper type guards.
 
 ### SCHEMA
 https://github.com/szubster/dexhelper/blob/main/.foundry/docs/schema.md


### PR DESCRIPTION
This PR executes the Empty PR Policy to complete the QA task for the SaveData type refactor, as the `SaveData` discriminated union and properly typed parsers/consumers were discovered to be already fully implemented in `src/engine/saveParser/parsers/common.ts` and related files during exploration. The task markdown body has been updated to check off the acceptance criteria checkboxes to satisfy the completeness contract.

No other changes are required. System verified clean via `pnpm lint`, `pnpm test`, and E2E tests.

---
*PR created automatically by Jules for task [7135923792955239708](https://jules.google.com/task/7135923792955239708) started by @szubster*