### PR TITLE
chore: Update schema documentation with E2E rule

### DIFF
--- a/.foundry/docs/schema.md
+++ b/.foundry/docs/schema.md
@@ -208,6 +208,7 @@ These are the hard rules the orchestrator, heartbeat, and resurrection loop rely
     - You must check off your specific acceptance criteria checkboxes in the parent node WITHOUT modifying its YAML frontmatter.
     - Do NOT submit an Empty PR to transition a parent node to VERIFYING (by checking off its own acceptance criteria) until ALL of its generated child nodes have transitioned to COMPLETED.
     - If a parent node has incomplete children, you must leave its own acceptance criteria checkboxes unchecked to keep it in PENDING status.
+16. **Orchestrator Safeguard (E2E/Integration Requirement)**: When breaking down Epics, generative personas must ensure every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`), even for documentation-focused Epics. An EPIC cannot be COMPLETED without it.
 
 ---
 

--- a/.foundry/tasks/task-420-422-schema-e2e-rule.md
+++ b/.foundry/tasks/task-420-422-schema-e2e-rule.md
@@ -27,4 +27,4 @@ As part of enforcing macro node functional boundaries, we need to update templat
 Update `.foundry/docs/schema.md` to explicitly require an Integration/E2E Story for all new Epics.
 
 ## Acceptance Criteria
-- [ ] Add the following Orchestrator Safeguard to `.foundry/docs/schema.md` under "7. System Invariants": "When breaking down Epics, generative personas must ensure every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`), even for documentation-focused Epics. An EPIC cannot be COMPLETED without it."
+- [x] Add the following Orchestrator Safeguard to `.foundry/docs/schema.md` under "7. System Invariants": "When breaking down Epics, generative personas must ensure every EPIC generates a final STORY dedicated exclusively to Integration and E2E Verification (tagged with `e2e` or `integration`), even for documentation-focused Epics. An EPIC cannot be COMPLETED without it."


### PR DESCRIPTION
Updated `.foundry/docs/schema.md` to explicitly require an Integration/E2E Story for all new Epics as per the acceptance criteria of task `task-420-422-schema-e2e-rule`, and ticked the corresponding checkbox.

---
*PR created automatically by Jules for task [12805486841083500008](https://jules.google.com/task/12805486841083500008) started by @szubster*