### PR TITLE
Add semantic evaluator json fix nodes

### DIFF
--- a/.foundry/research/research-422-440-investigate-llm-json-markdown-tags.md
+++ b/.foundry/research/research-422-440-investigate-llm-json-markdown-tags.md
@@ -1,0 +1,22 @@
+---
+id: research-422-440-investigate-llm-json-markdown-tags
+type: RESEARCH
+title: Investigate LLM JSON Markdown Tags Failure
+status: ACTIVE
+owner_persona: researcher
+created_at: '2026-08-18'
+updated_at: '2026-08-18'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-417-422-implement-semantic-evaluator-engine
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Investigate LLM JSON Markdown Tags Failure
+
+Investigate the integration test failure where the LLM returns JSON wrapped in markdown tags causing `JSON.parse` to throw an error. Find a robust solution to strip these markdown code blocks.

--- a/.foundry/stories/story-417-422-implement-semantic-evaluator-engine.md
+++ b/.foundry/stories/story-417-422-implement-semantic-evaluator-engine.md
@@ -27,4 +27,7 @@ Implement the core engine that leverages an LLM to perform semantic evaluations.
 ## Acceptance Criteria
 - [x] Break down into Tasks
 - [x] task-422-425-semantic-evaluator-engine-impl
-- [ ] task-422-426-semantic-evaluator-engine-qa
+- [x] task-422-426-semantic-evaluator-engine-qa
+- [ ] research-422-440-investigate-llm-json-markdown-tags
+- [ ] task-422-441-semantic-evaluator-engine-fix
+- [ ] task-422-442-semantic-evaluator-engine-fix-qa

--- a/.foundry/tasks/task-422-441-semantic-evaluator-engine-fix.md
+++ b/.foundry/tasks/task-422-441-semantic-evaluator-engine-fix.md
@@ -1,0 +1,23 @@
+---
+id: task-422-441-semantic-evaluator-engine-fix
+type: TASK
+title: Fix Semantic Evaluator Engine JSON Parsing
+status: READY
+owner_persona: coder
+created_at: '2026-08-18'
+updated_at: '2026-08-18'
+depends_on:
+  - research-422-440-investigate-llm-json-markdown-tags
+jules_session_id: null
+pr_number: null
+parent: story-417-422-implement-semantic-evaluator-engine
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Fix Semantic Evaluator Engine JSON Parsing
+
+Implement the fix for the semantic evaluator engine based on the research. Ensure the engine properly strips markdown code blocks from the LLM JSON response before parsing it.

--- a/.foundry/tasks/task-422-442-semantic-evaluator-engine-fix-qa.md
+++ b/.foundry/tasks/task-422-442-semantic-evaluator-engine-fix-qa.md
@@ -1,0 +1,23 @@
+---
+id: task-422-442-semantic-evaluator-engine-fix-qa
+type: TASK
+title: QA Semantic Evaluator Engine JSON Parsing Fix
+status: READY
+owner_persona: qa
+created_at: '2026-08-18'
+updated_at: '2026-08-18'
+depends_on:
+  - task-422-441-semantic-evaluator-engine-fix
+jules_session_id: null
+pr_number: null
+parent: story-417-422-implement-semantic-evaluator-engine
+tags: []
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# QA Semantic Evaluator Engine JSON Parsing Fix
+
+Review and verify the implementation of the semantic evaluator engine fix. Ensure tests are written correctly, integration tests pass when `RUN_LLM_INTEGRATION_TESTS=true` is set.


### PR DESCRIPTION
- Checked off failed tasks in `story-417-422-implement-semantic-evaluator-engine.md` and appended new ones
- Created `research-422-440-investigate-llm-json-markdown-tags.md` to investigate the JSON parsing issue with LLM outputs
- Created `task-422-441-semantic-evaluator-engine-fix.md` to implement the fix
- Created `task-422-442-semantic-evaluator-engine-fix-qa.md` for QA verification

---
*PR created automatically by Jules for task [2656849608160803410](https://jules.google.com/task/2656849608160803410) started by @szubster*