### PR TITLE
🔐 [security fix] Prevent sensitive information leakage in error logs (CWE-209)

### DIFF
--- a/.github/scripts/garbage-collector.ts
+++ b/.github/scripts/garbage-collector.ts
@@ -56,14 +56,14 @@ export async function main() {
         console.info(`[GC] Skipping node ${relativePath}: Session ${sessionId} is TERMINATED (heartbeat will resolve)`);
       }
     } catch (err) {
-      console.error(`[GC] Error processing node ${relativePath}:`, err);
+      console.error(`[GC] Error processing node ${relativePath}:`, err instanceof Error ? err.message : String(err));
     }
   }
 }
 
 if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('garbage-collector.ts')) {
   main().catch(err => {
-    console.error('Fatal GC error:', err);
+    console.error('Fatal GC error:', err instanceof Error ? err.message : String(err));
     process.exit(1);
   });
 }

--- a/.github/scripts/remediate-zombie.ts
+++ b/.github/scripts/remediate-zombie.ts
@@ -57,7 +57,7 @@ export function remediateZombieNode(repoRoot: string, relativeFilePath: string, 
 
     return true;
   } catch (error) {
-    console.error(`Failed to remediate zombie node at ${fullPath}:`, error);
+    console.error(`Failed to remediate zombie node at ${fullPath}:`, error instanceof Error ? error.message : String(error));
     return false;
   }
 }

--- a/.jules/shield/2026-08-19-00-49-29.md
+++ b/.jules/shield/2026-08-19-00-49-29.md
@@ -1,0 +1,16 @@
+# Shield Session Log - 2026-08-19-00-49-29
+
+## Security Fix: Information Leakage (CWE-209)
+
+Identified and resolved several instances of raw error object logging across the utility and automation scripts:
+- `.github/scripts/remediate-zombie.ts`
+- `.github/scripts/garbage-collector.ts`
+- `scripts/gen3-fetch-locations.ts`
+- `scripts/validate-foundry-schema.ts`
+- `scripts/check-links.ts`
+
+**Pattern identified:** The use of `console.error(err)` or `console.error("Context:", err)` can leak internal system details, paths, or environmental variables if the caught exception is an object.
+**Resolution:** Standardized on the sanitization pattern: `err instanceof Error ? err.message : String(err)`. This satisfies CWE-209 guidelines.
+
+## Process Notes
+- Re-installed Playwright browsers and dependencies to prevent false positive test failures during `pnpm test`.

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -151,7 +151,7 @@ function checkLinks() {
       }
 
     } catch (e) {
-      console.error(`Error processing file ${file}:`, e);
+      console.error(`Error processing file ${file}:`, e instanceof Error ? e.message : String(e));
       hasErrors = true;
     }
   }

--- a/scripts/gen3-fetch-locations.ts
+++ b/scripts/gen3-fetch-locations.ts
@@ -262,6 +262,6 @@ async function run() {
 }
 
 run().catch((err) => {
-  console.error(err);
+  console.error(err instanceof Error ? err.message : String(err));
   process.exit(1);
 });

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -95,7 +95,7 @@ function validateSchema() {
       parsed = matter(content);
     } catch (e) {
       console.error(`Error: Failed to parse frontmatter for file ${file}`);
-      console.error(e);
+      console.error(e instanceof Error ? e.message : String(e));
       hasError = true;
       continue;
     }


### PR DESCRIPTION
🎯 What
Refactored multiple utility and automation scripts to stop passing raw error objects to `console.error` and `console.warn`. The new pattern safely extracts the error message using `err instanceof Error ? err.message : String(err)`.

⚠️ Risk
Low. This changes only affects console output in Node.js build/CI scripts and does not impact application source logic.

🛡️ Solution
Implemented CWE-209 sanitization patterns in:
- `.github/scripts/remediate-zombie.ts`
- `.github/scripts/garbage-collector.ts`
- `scripts/gen3-fetch-locations.ts`
- `scripts/validate-foundry-schema.ts`
- `scripts/check-links.ts`

---
*PR created automatically by Jules for task [4512068568207212834](https://jules.google.com/task/4512068568207212834) started by @szubster*