### PR TITLE
🖼️ Canvas: Redesign PokemonCatchProbability

### DIFF
--- a/.jules/canvas/2026-08-19-02-06-57.md
+++ b/.jules/canvas/2026-08-19-02-06-57.md
@@ -1,0 +1,5 @@
+## 2026-08-19 - [Accepted] - 🖼️ Canvas: Redesign PokemonCatchProbability
+**What:** Redesigned the `PokemonCatchProbability` component to utilize a digital capacity gauge for HP and a hardware toggle array with diagnostic LEDs for target status, adding a visual scanning 'CALC...' effect when probability recomputes.
+**Outcome:** Accepted -> wait for review
+**Why:** The previous `PokemonCatchProbability` design used standard UI toggle segments. To push the tactical snooping aesthetic, a capacity gauge with color-coded hazard zones and custom LED indicators are more diegetic to the hardware interface.
+**Pattern:** For data adjustment inputs, lean towards digital gauges with multi-color segmented thresholds (green -> amber -> red) and hardware-like toggles with inset LED indicators instead of flat segmented controls.

--- a/src/components/pokemon/details/PokemonCatchProbability.tsx
+++ b/src/components/pokemon/details/PokemonCatchProbability.tsx
@@ -1,13 +1,11 @@
 import { Target } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { PokeballType } from '../../../store';
 import { cn } from '../../../utils/cn';
-import { DataPoint } from '../../DataPoint';
 import { PanelWatermark } from '../../PanelWatermark';
 import { SectionHeader } from '../../SectionHeader';
 import { TacticalBadge } from '../../TacticalBadge';
 import { TacticalPanel } from '../../TacticalPanel';
-import { TacticalSegmentedControl } from '../../TacticalSegmentedControl';
 
 interface PokemonCatchProbabilityProps {
   catchRate: number;
@@ -25,6 +23,7 @@ type StatusType = (typeof STATUS_OPTIONS)[number]['id'];
 export function PokemonCatchProbability({ catchRate, effectivePokeball }: PokemonCatchProbabilityProps) {
   const [hpPercent, setHpPercent] = useState<number>(100);
   const [status, setStatus] = useState<StatusType>('none');
+  const [isCalculating, setIsCalculating] = useState(false);
 
   const { finalChance, valueClassName } = useMemo(() => {
     let ballMult = 1;
@@ -46,6 +45,15 @@ export function PokemonCatchProbability({ catchRate, effectivePokeball }: Pokemo
     return { finalChance: chance.toFixed(1), valueClassName: colorClass };
   }, [catchRate, effectivePokeball, hpPercent, status]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: we want to trigger recalculate effect when input changes
+  useEffect(() => {
+    setIsCalculating(true);
+    const timeout = setTimeout(() => {
+      setIsCalculating(false);
+    }, 400);
+    return () => clearTimeout(timeout);
+  }, [hpPercent, status]);
+
   return (
     <TacticalPanel variant="emerald" className="space-y-8 rounded-none border border-dashed p-8">
       <PanelWatermark icon={<Target size={120} />} />
@@ -66,10 +74,17 @@ export function PokemonCatchProbability({ catchRate, effectivePokeball }: Pokemo
             <span className="font-mono text-emerald-400">{hpPercent}% HP</span>
           </div>
 
-          <div className="flex w-full items-center gap-1">
+          <div className="relative flex w-full items-center gap-1 border border-white/5 border-dashed bg-black/60 p-1">
             {Array.from({ length: 10 }).map((_, i) => {
               const segmentValue = (i + 1) * 10;
               const isActive = hpPercent >= segmentValue;
+              let segmentColor = 'bg-emerald-500 shadow-[0_0_10px_rgba(16,185,129,0.3)]';
+              if (segmentValue <= 20) {
+                segmentColor = 'bg-red-500 shadow-[0_0_10px_rgba(239,68,68,0.3)]';
+              } else if (segmentValue <= 50) {
+                segmentColor = 'bg-amber-500 shadow-[0_0_10px_rgba(245,158,11,0.3)]';
+              }
+
               return (
                 <button
                   // biome-ignore lint/suspicious/noArrayIndexKey: Array index is stable
@@ -80,10 +95,8 @@ export function PokemonCatchProbability({ catchRate, effectivePokeball }: Pokemo
                   aria-pressed={isActive}
                   onClick={() => setHpPercent(segmentValue)}
                   className={cn(
-                    'focus-visible:tactical-focus h-3 flex-1 rounded-none border border-white/5 border-dashed transition-all',
-                    isActive
-                      ? 'bg-emerald-500 shadow-[0_0_10px_rgba(16,185,129,0.3)]'
-                      : 'bg-black/40 hover:bg-emerald-500/20',
+                    'focus-visible:tactical-focus h-4 flex-1 rounded-none border-black border-r transition-all last:border-r-0',
+                    isActive ? segmentColor : 'bg-zinc-800/40 hover:bg-white/10',
                   )}
                 />
               );
@@ -91,29 +104,72 @@ export function PokemonCatchProbability({ catchRate, effectivePokeball }: Pokemo
           </div>
         </div>
 
-        <TacticalSegmentedControl<StatusType>
-          ariaLabel="Target Status"
-          containerClassName="grid grid-cols-3 gap-2 [&>div]:grid [&>div]:grid-cols-3 [&>div]:gap-2 [&>div]:border-none [&>button]:border"
-          buttonBaseClassName="!border-dashed !border focus-visible:ring-emerald-500 py-3 text-[9px] active:scale-95"
-          defaultActiveClassName="border-emerald-400 bg-emerald-500 text-zinc-950 shadow-[0_5px_15px_rgba(16,185,129,0.3)]"
-          defaultInactiveClassName="border-white/10 bg-black/40 text-emerald-500/50 hover:border-emerald-500/40 hover:bg-emerald-500/10"
-          selectedValue={status}
-          onValueChange={(val) => setStatus(val)}
-          items={STATUS_OPTIONS.map((item) => ({
-            id: item.id,
-            label: item.label,
-          }))}
-        />
+        <div className="space-y-3 pt-2">
+          <div className="flex font-black text-[10px] text-emerald-500/60 uppercase tracking-widest">
+            <span>Target Status</span>
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            {STATUS_OPTIONS.map((option) => {
+              const isActive = status === option.id;
+              let ledColor = 'bg-zinc-700 shadow-none';
+              if (isActive) {
+                if (option.id === 'none') ledColor = 'bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.8)]';
+                else if (option.id === 'paralyze_burn_poison')
+                  ledColor = 'bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.8)]';
+                else if (option.id === 'sleep_freeze') ledColor = 'bg-cyan-400 shadow-[0_0_8px_rgba(34,211,238,0.8)]';
+              }
+
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => setStatus(option.id)}
+                  className={cn(
+                    'group relative flex flex-col items-center justify-center gap-2 border border-dashed p-3 transition-all active:scale-95',
+                    isActive
+                      ? 'border-white/30 bg-white/5'
+                      : 'border-white/10 bg-black/40 hover:border-white/20 hover:bg-white/5',
+                  )}
+                >
+                  <div className="mb-1 flex h-1 w-8 items-center justify-center border border-white/10 bg-black/80">
+                    <div className={cn('h-full w-full transition-colors duration-300', ledColor)} />
+                  </div>
+                  <span
+                    className={cn(
+                      'font-mono text-[9px] uppercase tracking-widest transition-colors',
+                      isActive ? 'text-white' : 'text-zinc-500 group-hover:text-zinc-400',
+                    )}
+                  >
+                    {option.label}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </div>
 
       <div className="flex flex-col gap-2 border-emerald-500/10 border-t pt-8">
         <div className="flex items-end justify-between">
-          <DataPoint
-            label="Estimated Success"
-            labelClassName="mb-1 text-[10px] text-emerald-500/40"
-            valueClassName={cn('font-black font-display text-5xl normal-case tracking-tighter', valueClassName)}
-            value={`${finalChance}%`}
-          />
+          <div className="relative flex flex-col">
+            <span className="mb-1 font-mono text-[10px] text-emerald-500/40 uppercase tracking-widest">
+              Estimated Success
+            </span>
+            <div className="relative overflow-hidden">
+              {isCalculating && (
+                <div className="pointer-events-none absolute inset-0 z-10 animate-pulse bg-emerald-500/20 mix-blend-screen before:absolute before:inset-0 before:animate-[scan_1s_ease-in-out_infinite] before:bg-[linear-gradient(transparent,rgba(16,185,129,0.5),transparent)]" />
+              )}
+              <span
+                className={cn(
+                  'block font-black font-display text-5xl normal-case tracking-tighter transition-opacity duration-150',
+                  valueClassName,
+                  isCalculating ? 'opacity-30 blur-[2px]' : 'opacity-100 blur-0',
+                )}
+              >
+                {isCalculating ? 'CALC...' : `${finalChance}%`}
+              </span>
+            </div>
+          </div>
           <div className="flex flex-col items-end text-right">
             <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-none border border-white/10 border-dashed bg-black/40">
               <div


### PR DESCRIPTION
This PR proposes a bold redesign of the `PokemonCatchProbability` component. The previous design relied on standard `TacticalSegmentedControl` elements. To lean harder into the "snooping terminal / hardware interface" aesthetic, this PR introduces:

- A digital capacity gauge for HP selection that changes colors based on the threshold (e.g., turning red below 20%).
- Hardware-inspired toggle buttons for status selection, complete with inset diagnostic LED indicators that glow according to the selected state.
- A "CALC..." visual scanning effect overlay that briefly obscures the probability number during recalculation.

Also includes a private `.jules/canvas/2026-08-19-02-06-57.md` journal entry.

---
*PR created automatically by Jules for task [17163879206758652016](https://jules.google.com/task/17163879206758652016) started by @szubster*