### PR TITLE
🧭 Strategist: Prompt improvement - Consolidate specific agent rules into core policies

### DIFF
--- a/.github/agents/specific/dexhelper.md
+++ b/.github/agents/specific/dexhelper.md
@@ -1,6 +1,3 @@
 ## DexHelper & Pokemon Data Guidelines
 - When serializing/deserializing application data structures (`PokeData`), use MsgPack (`msgpackr`) with `useRecords: true`.
 - Adhere to the PokeData Property Naming Schema (full, readable property names like `captureRate` instead of `cr`, `evolvesTo` instead of `eto`).
-- For save file parsing, define all memory offsets, shifts, and bit locations as reusable constants at the module level. Inline magic numbers are forbidden.
-- For Gen 3 save block extraction, pass and utilize the resolved section offset (e.g., `section1Offset`) to support A/B bank flash memory architecture.
-- Handle `RangeError` from `DataView` out-of-bounds reads and throw a new error: "The save file is corrupted or incomplete."

--- a/.github/agents/specific/react.md
+++ b/.github/agents/specific/react.md
@@ -1,8 +1,3 @@
 ## React & Frontend Guidelines
 - Build functional components with modern React hooks.
-- Adhere strictly to the "tactical hardware/snooping" aesthetic outlined in ADR 008:
-  - Sharp edges only: use `rounded-none`. Do NOT use any rounded corners (e.g., `rounded`, `rounded-sm`, `rounded-md`, etc.).
-  - Use dashed borders (`border-dashed`).
-  - Use monospaced fonts (e.g., `font-mono`) and tabular numbers where appropriate.
 - Ensure all newly created UI components are properly integrated into the application's view hierarchy.
-- For component test cases, explicitly type `vi.fn()` mock callbacks to satisfy TypeScript constraints.

--- a/.jules/strategist/2026-08-19-02-17-41.md
+++ b/.jules/strategist/2026-08-19-02-17-41.md
@@ -1,0 +1,5 @@
+## 2026-08-19 - [Accepted] - Prompt improvement - Consolidate specific agent rules into core policies
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `specific/react.md` and `specific/dexhelper.md` agent prompt fragments contained duplicate rules regarding the ADR 008 "tactical hardware/snooping" UI aesthetic, Vitest mock typing, and Save File Parsing constraints (Section 13). These policies were already centralized in `.foundry/docs/knowledge_base/agents/core_policies.md` and duplicated here, creating a maintenance burden and wasting context tokens.
+**Pattern:** Ensure specific agent prompt files (`.github/agents/specific/*`) only contain genuinely context-specific directives and avoid duplicating global architectural constraints already enforced in `core_policies.md`.


### PR DESCRIPTION
**Proposal**: Consolidate specific agent prompt logic into core policies.
**Justification**: The `specific/react.md` and `specific/dexhelper.md` prompt fragments contained duplicated rules regarding the "tactical hardware/snooping" UI aesthetic, Vitest mock typing, and Save File Parsing constraints. These rules are globally enforced in `.foundry/docs/knowledge_base/agents/core_policies.md`. Removing them from specific fragments reduces context bloat and enforces a single source of truth.
**Evidence**: Agent prompt schedules explicitly referencing UI aesthetic ADR 008, Vitest mocks, and Save Parsing (Section 13) were cleaned up and shifted to `core_policies.md` via past Strategist actions, but these sub-modules still redundantly included them.

---
*PR created automatically by Jules for task [8375893228414971199](https://jules.google.com/task/8375893228414971199) started by @szubster*