### PR TITLE
📜 Scribe: Document RouteRadarController heatmap density calculation logic

### DIFF
--- a/.jules/scribe/2026-08-19-02-53-56.md
+++ b/.jules/scribe/2026-08-19-02-53-56.md
@@ -1,0 +1,2 @@
+## Scribe Journal - Heatmap Density Logic
+Documented the architectural reason why `RouteRadarController` uses a `Set` to collect unique `areaId`s per suggestion. Without it, Pokémon with multiple sub-encounters on the same map would distort the heatmap density.

--- a/src/engine/radar/RouteRadarController.ts
+++ b/src/engine/radar/RouteRadarController.ts
@@ -17,6 +17,15 @@ export class RouteRadarController {
   /**
    * Calculates the heatmap density data from the provided suggestions.
    *
+   * @remarks
+   * **Why use a Set for `uniqueAreaIds`?**
+   * A single Pokémon might have multiple distinct encounter entries on the exact same map.
+   * If we naively incremented the density score for every raw encounter entry, the heatmap would
+   * become distorted, artificially inflating the "density" of a map just because a Pokémon has many
+   * sub-encounters there. By collecting `areaId`s into a `Set` first, we guarantee that each target
+   * Pokémon only contributes a maximum of `+1` to any given area's density score, ensuring the heatmap
+   * accurately reflects the number of distinct missing Pokémon available in that area.
+   *
    * @param suggestions The raw output from the suggestionEngine.
    * @returns Heatmap data mapping areaId to density score.
    */


### PR DESCRIPTION
Adds architectural documentation to `RouteRadarController.ts` explaining why a `Set` is used to collect unique `areaId`s during heatmap calculation. This prevents distorted density scores.

---
*PR created automatically by Jules for task [6653369735601436261](https://jules.google.com/task/6653369735601436261) started by @szubster*