### PR TITLE
fix(epic): resolve auditor rejection by generating missing integration and E2E stories

### DIFF
--- a/.foundry/epics/epic-045-070-implement-dag-context.md
+++ b/.foundry/epics/epic-045-070-implement-dag-context.md
@@ -36,6 +36,5 @@ As per ADR 013 and ADR 017, the core DAG data state must be lifted into a shared
 - [x] .foundry/archive/stories/story-070-108-create-dag-context-interfaces.md
 - [x] .foundry/archive/stories/story-070-109-implement-dag-provider.md
 - [x] .foundry/archive/stories/story-070-245-implement-dag-provider-state-management.md
-
-### Auditor Rejection
-The generated artifacts do not meet the Acceptance Criteria of the Epic. While DagContext and DagProvider were created, DagProvider does not actually manage the core DAG data state (nodes, edges) by fetching it, nor does it wrap the DAG views. This work was improperly deferred to story-046-120. The Epic cannot be verified until the provider fully manages and provides the state as originally required.
+- [ ] story-070-431-integrate-dag-context-with-views
+- [ ] story-070-432-implement-dag-context-e2e

--- a/.foundry/stories/story-070-431-integrate-dag-context-with-views.md
+++ b/.foundry/stories/story-070-431-integrate-dag-context-with-views.md
@@ -1,0 +1,34 @@
+---
+id: story-070-431-integrate-dag-context-with-views
+type: STORY
+title: Integrate DagContext with Views
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-19'
+updated_at: '2026-08-19'
+depends_on:
+  - story-070-245-implement-dag-provider-state-management
+jules_session_id: null
+pr_number: null
+parent: epic-045-070-implement-dag-context
+tags:
+  - architecture
+  - ui
+  - context
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Integrate DagContext with Views
+
+## Overview
+This story ensures that the DAG views (like React Flow GraphView) are correctly updated to consume the `DagContext` data. This is part of the refactoring to lift the core state up so multiple DAG dashboards can share a single source of truth.
+
+## Requirements
+- Update `DagProvider` (or ensure it is updated) to actually implement the missing fetching logic and fully manage the core DAG data state.
+- The existing React Flow DAG visualizer should consume `nodes` and `edges` from `DagContext`.
+- Ensure no view is managing its own isolated DAG fetching logic anymore.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks

--- a/.foundry/stories/story-070-432-implement-dag-context-e2e.md
+++ b/.foundry/stories/story-070-432-implement-dag-context-e2e.md
@@ -1,0 +1,33 @@
+---
+id: story-070-432-implement-dag-context-e2e
+type: STORY
+title: E2E Verification for DagContext Provider Integration
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-19'
+updated_at: '2026-08-19'
+depends_on:
+  - story-070-431-integrate-dag-context-with-views
+jules_session_id: null
+pr_number: null
+parent: epic-045-070-implement-dag-context
+tags:
+  - e2e
+  - architecture
+  - ui
+  - dashboard
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# E2E Verification for DagContext Provider Integration
+
+## Overview
+This story provides E2E verification to ensure the newly implemented DagContext and DagProvider successfully fetch, manage, and provide the shared DAG state. This satisfies the orchestrator safeguard requiring a final story dedicated exclusively to Integration and E2E verification.
+
+## Requirements
+- Write E2E tests validating that the DagProvider is fetching data correctly and that views (e.g., React Flow) are able to render nodes and edges correctly using this shared context.
+
+## Acceptance Criteria
+- [ ] Break down into Tasks


### PR DESCRIPTION
Resolves the Auditor rejection on `epic-045-070-implement-dag-context` by explicitly generating `story-070-431-integrate-dag-context-with-views` (to mandate the missing fetching logic in `DagProvider`) and `story-070-432-implement-dag-context-e2e` (to satisfy the Orchestrator Safeguard for E2E verification). The Epic is resubmitted to demote it to PENDING while it waits for these child tasks.

---
*PR created automatically by Jules for task [8948418370391020649](https://jules.google.com/task/8948418370391020649) started by @szubster*