### PR TITLE
feat(contests): integrate ContestRecommendationPanel for Gen 3 details

### DIFF
--- a/.foundry/tasks/task-151-342-contest-advisor-ui-integration-impl.md
+++ b/.foundry/tasks/task-151-342-contest-advisor-ui-integration-impl.md
@@ -33,5 +33,5 @@ Integrate the newly developed `ContestRecommendationPanel` into the `src/compone
 4. Ensure you pass required props to `ContestRecommendationPanel`: `recommendations` and `sheen`.
 
 ## Acceptance Criteria
-- [ ] `ContestRecommendationPanel` is integrated into `PokemonDetails.tsx`.
-- [ ] It renders correctly for Gen 3 Pokemon in the details view.
+- [x] `ContestRecommendationPanel` is integrated into `PokemonDetails.tsx`.
+- [x] It renders correctly for Gen 3 Pokemon in the details view.

--- a/src/components/pokemon/details/PokemonCaughtDetails.tsx
+++ b/src/components/pokemon/details/PokemonCaughtDetails.tsx
@@ -1,9 +1,12 @@
 import { Activity, Dna, MapPin, Sparkles } from 'lucide-react';
 import { gen2Items, gen2Locations } from '../../../engine/data/gen2/legacyNameMap';
+import { getContestRecommendations } from '../../../engine/gen3/contests/recommendation';
+import { getNature } from '../../../engine/gen3/nature';
 import type { PokemonInstance } from '../../../engine/saveParser/index';
 import { useStore } from '../../../store';
 import { getTimeCapsuleValidation } from '../../../utils/timeCapsule';
 import { ContestConditionStats } from '../../ContestConditionStats';
+import { ContestRecommendationPanel } from '../../ContestRecommendationPanel';
 import { DataLabel } from '../../DataLabel';
 import { HoverScanner } from '../../HoverScanner';
 import { LcdGrid } from '../../LcdGrid';
@@ -137,6 +140,16 @@ export function PokemonCaughtDetails({ yourPokemon }: PokemonCaughtDetailsProps)
                   tough={p.condition.tough}
                 />
                 {p.condition.sheen !== undefined && <ContestSheenDisplay sheen={p.condition.sheen} />}
+                {p.personalityValue !== undefined && (
+                  <ContestRecommendationPanel
+                    recommendations={getContestRecommendations(
+                      getNature(p.personalityValue),
+                      p.condition,
+                      p.condition.sheen ?? 0,
+                    )}
+                    sheen={p.condition.sheen}
+                  />
+                )}
               </div>
             )}
           </TacticalPanel>

--- a/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
+++ b/src/components/pokemon/details/__tests__/PokemonCaughtDetails.test.tsx
@@ -149,6 +149,34 @@ describe('PokemonCaughtDetails', () => {
     await expect.element(page.getByText('200')).toBeInTheDocument();
   });
 
+  it('renders ContestRecommendationPanel for pokemon with condition and personalityValue', async () => {
+    (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
+      (selector: unknown) =>
+        (selector as (state: unknown) => unknown)({
+          saveData: {
+            generation: 3,
+          },
+        }),
+    );
+
+    const pokemonWithConditionAndPV = {
+      ...mockPokemon,
+      personalityValue: 0, // hardy
+      condition: {
+        cool: 50,
+        beauty: 60,
+        cute: 70,
+        smart: 80,
+        tough: 90,
+        sheen: 200,
+      },
+    };
+
+    await render(<PokemonCaughtDetails yourPokemon={[pokemonWithConditionAndPV]} />);
+
+    await expect.element(page.getByText('SYS.STRATEGY_MATRIX')).toBeInTheDocument();
+  });
+
   it('renders Pokerus strain when present', async () => {
     (useStore as unknown as { mockImplementation: (fn: (selector: unknown) => unknown) => void }).mockImplementation(
       (selector: unknown) =>

--- a/src/engine/gen3/nature.test.ts
+++ b/src/engine/gen3/nature.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { getNature } from './nature';
+
+describe('nature', () => {
+  it('correctly maps PVs to natures', () => {
+    expect(getNature(0)).toBe('hardy');
+    expect(getNature(1)).toBe('lonely');
+    expect(getNature(24)).toBe('quirky');
+    expect(getNature(25)).toBe('hardy');
+  });
+});

--- a/src/engine/gen3/nature.ts
+++ b/src/engine/gen3/nature.ts
@@ -1,0 +1,33 @@
+import type { Nature } from './contests/types';
+
+export const NATURES: readonly Nature[] = [
+  'hardy',
+  'lonely',
+  'brave',
+  'adamant',
+  'naughty',
+  'bold',
+  'docile',
+  'relaxed',
+  'impish',
+  'lax',
+  'timid',
+  'hasty',
+  'serious',
+  'jolly',
+  'naive',
+  'modest',
+  'mild',
+  'quiet',
+  'bashful',
+  'rash',
+  'calm',
+  'gentle',
+  'sassy',
+  'careful',
+  'quirky',
+] as const;
+
+export function getNature(personalityValue: number): Nature {
+  return NATURES[personalityValue % 25] as Nature;
+}


### PR DESCRIPTION
Integrates the `ContestRecommendationPanel` into the Pokémon details view to display contest recommendations alongside existing stats for Gen 3 Pokémon. Includes a new `getNature` utility.

---
*PR created automatically by Jules for task [2424326705415073517](https://jules.google.com/task/2424326705415073517) started by @szubster*