### PR TITLE
chore: generate Gen 3 data structure extraction stories

### DIFF
--- a/.foundry/epics/epic-097-130-gen3-data-structure-extraction.md
+++ b/.foundry/epics/epic-097-130-gen3-data-structure-extraction.md
@@ -29,3 +29,7 @@ Implement functionality to extract the raw 100-byte Pokémon data structure for 
 1. Extract the 100-byte structure.
 2. Must use `DataView` API exclusively.
 3. Handle gracefully and properly parse across Ruby, Sapphire, Emerald, FireRed, LeafGreen.
+
+## Acceptance Criteria
+- [ ] story-130-440-extract-gen3-party-data-structure
+- [ ] story-130-441-gen3-data-extraction-e2e

--- a/.foundry/journals/story_owner/8601309936583911484.md
+++ b/.foundry/journals/story_owner/8601309936583911484.md
@@ -1,0 +1,6 @@
+# Session 8601309936583911484
+
+## Story Owner Reflection
+When breaking down Gen 3 epic `epic-097-130-gen3-data-structure-extraction` for the party data structure extraction, we must decouple the core parsing (handling the decryption and 100-byte block extraction) from the downstream feature (like Pokerus extraction).
+
+By actively applying the Orchestrator Safeguard (E2E/Integration Requirement), I ensured the parsing logic story `story-130-440-extract-gen3-party-data-structure` is followed by an explicitly dependent E2E verification story `story-130-441-gen3-data-extraction-e2e`. This ensures the foundation is robust across all 5 Gen 3 games before we attempt specific attribute exfiltration.

--- a/.foundry/stories/story-130-440-extract-gen3-party-data-structure.md
+++ b/.foundry/stories/story-130-440-extract-gen3-party-data-structure.md
@@ -1,0 +1,38 @@
+---
+id: story-130-440-extract-gen3-party-data-structure
+type: STORY
+title: Extract Gen 3 Party Data Structure
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-19'
+updated_at: '2026-08-19'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-097-130-gen3-data-structure-extraction
+tags:
+  - gen3
+  - save-engine
+research_references:
+  - .foundry/archive/research/research-175-176-gen3-pokerus-extraction.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Extract Gen 3 Party Data Structure
+
+## Objective
+Implement functionality to extract the raw 100-byte Pokémon data structure for each party Pokémon from an active Gen 3 save file section. This includes ensuring correct offset parsing across all Gen 3 games using the DataView API.
+
+## Description
+To support features like Pokérus extraction, we first need a robust way to extract the 100-byte structure for a given Pokémon from Gen 3 save files. The core details are stored within a 48-byte encrypted Data block inside this 100-byte structure.
+
+This story should implement the foundational Gen 3 Pokémon extraction and decryption logic, including:
+1. Extracting the 100-byte structure.
+2. Using the `DataView` API exclusively.
+3. Handling Gracefully and parsing across Ruby, Sapphire, Emerald, FireRed, and LeafGreen.
+
+## Technical Details
+- Follow `src/engine/saveParser/parsers/gen3.ts` constraints.
+- Do not implement specific stat/attribute extraction (like Pokérus) yet, this story is strictly about scaffolding the 100-byte data block structure and managing decryption.

--- a/.foundry/stories/story-130-441-gen3-data-extraction-e2e.md
+++ b/.foundry/stories/story-130-441-gen3-data-extraction-e2e.md
@@ -1,0 +1,37 @@
+---
+id: story-130-441-gen3-data-extraction-e2e
+type: STORY
+title: Gen 3 Data Extraction E2E Validation
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-19'
+updated_at: '2026-08-19'
+depends_on:
+  - story-130-440-extract-gen3-party-data-structure
+jules_session_id: null
+pr_number: null
+parent: epic-097-130-gen3-data-structure-extraction
+tags:
+  - gen3
+  - save-engine
+  - e2e
+  - integration
+research_references:
+  - .foundry/archive/research/research-175-176-gen3-pokerus-extraction.md
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Gen 3 Data Extraction E2E Validation
+
+## Objective
+Verify the end-to-end integration of the Gen 3 Pokémon 100-byte structure extraction and parsing logic across all supported Gen 3 games.
+
+## Description
+This story is dedicated to the integration and E2E verification of the extraction logic built in `story-130-440-extract-gen3-party-data-structure`. It must ensure the engine reliably parses the party structure from actual save files or fixtures.
+
+## Technical Details
+- Implement E2E tests validating the Gen 3 data block structure extraction against standard Gen 3 saves (Ruby, Sapphire, Emerald, FireRed, LeafGreen).
+- Verify the use of `initializeWithSave` in Playwright tests.
+- Ensure the extraction reliably locates and reads the 100-byte boundaries.


### PR DESCRIPTION
Generated `story-130-440-extract-gen3-party-data-structure` and its corresponding E2E verification story `story-130-441-gen3-data-extraction-e2e` for epic `epic-097-130-gen3-data-structure-extraction`. Follows the Orchestrator Safeguards (E2E Integration Requirement) and the late-binding generation pattern. Parent acceptance criteria left unchecked to ensure proper demotion.

---
*PR created automatically by Jules for task [8601309936583911484](https://jules.google.com/task/8601309936583911484) started by @szubster*