### PR TITLE
QA Gen 3 Pokemon PID Extraction

### DIFF
--- a/.foundry/journals/qa/5586949025564325789.md
+++ b/.foundry/journals/qa/5586949025564325789.md
@@ -1,0 +1,10 @@
+# QA Persona Journal
+## Session ID: 5586949025564325789
+## Date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+### Task: task-099-158-gen3-extract-pokemon-pids-qa
+
+- The QA task required ensuring that Gen 3 Pokemon PID extraction correctly used `DataView`, handled out of bounds errors using `RangeError`, and was fully tested.
+- I verified that `parseGen3Party` and `parseGen3PCBoxes` correctly implemented these requirements using the `DataView` API. I wrote a suite of Vitest tests located at `src/engine/saveParser/parsers/gen3_pokemon_pids.test.ts` to assert against Party extraction, PC Box extraction, and the graceful error catching behavior when provided with smaller (out of bounds) buffers.
+- Remember: `pnpm check:fix` fixes biome formatting and `pnpm lint` catches unused imports and vars (if any).
+- Checked off task acceptance criteria and preparing for PR submission.

--- a/.foundry/tasks/task-099-158-gen3-extract-pokemon-pids-qa.md
+++ b/.foundry/tasks/task-099-158-gen3-extract-pokemon-pids-qa.md
@@ -32,9 +32,9 @@ Verify the implementation of Gen 3 32-bit PID extraction for both party and PC b
 3.  **Test Coverage**: Write unit tests to verify correct extraction of 32-bit PIDs for Party and PC box Pokémon in Gen 3 saves.
 
 ## Acceptance Criteria
-- [ ] Verify the usage of `DataView` API.
-- [ ] Verify graceful error handling of out-of-bounds reads.
-- [ ] Write and pass tests for the PID extraction logic.
+- [x] Verify the usage of `DataView` API.
+- [x] Verify graceful error handling of out-of-bounds reads.
+- [x] Write and pass tests for the PID extraction logic.
 
 ## QA Persona Reminders
 - If you abort or permanently fail this task, you MUST update the YAML frontmatter to `status: FAILED` or `status: CANCELLED` and provide a clear `rejection_reason`.

--- a/src/engine/saveParser/parsers/gen3_pokemon_pids.test.ts
+++ b/src/engine/saveParser/parsers/gen3_pokemon_pids.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from 'vitest';
+import {
+  GEN3_PARTY_COUNT_OFFSET,
+  GEN3_PARTY_POKEMON_LIST_OFFSET,
+  GEN3_PC_POKEMON_STRUCT_SIZE,
+  GEN3_POKEMON_DATA_OFFSET,
+  GEN3_POKEMON_OT_ID_OFFSET,
+  GEN3_POKEMON_PV_OFFSET,
+  GEN3_POKEMON_STRUCT_SIZE,
+  PC_BOX_POKEMON_LIST_OFFSET,
+  parseGen3Party,
+  parseGen3PCBoxes,
+} from './gen3';
+
+test('extracts PIDs from party correctly', () => {
+  const buffer = new ArrayBuffer(0x3000);
+  const view = new DataView(buffer);
+
+  view.setUint32(GEN3_PARTY_COUNT_OFFSET, 2, true);
+
+  const listOffset = GEN3_PARTY_POKEMON_LIST_OFFSET;
+
+  view.setUint32(listOffset + GEN3_POKEMON_PV_OFFSET, 0x12345678, true);
+  view.setUint32(listOffset + GEN3_POKEMON_OT_ID_OFFSET, 1, true);
+  view.setUint16(listOffset + GEN3_POKEMON_DATA_OFFSET, 1 ^ 1, true);
+
+  view.setUint32(listOffset + GEN3_POKEMON_STRUCT_SIZE + GEN3_POKEMON_PV_OFFSET, 0xabcdef01, true);
+  view.setUint32(listOffset + GEN3_POKEMON_STRUCT_SIZE + GEN3_POKEMON_OT_ID_OFFSET, 2, true);
+  view.setUint16(listOffset + GEN3_POKEMON_STRUCT_SIZE + GEN3_POKEMON_DATA_OFFSET, 1 ^ 1, true);
+
+  const result = parseGen3Party(view, 0, 'ruby');
+
+  expect(result.partyDetails.length).toBe(2);
+  expect(result.partyDetails[0]?.personalityValue).toBe(0x12345678);
+  expect(result.partyDetails[1]?.personalityValue).toBe(0xabcdef01);
+});
+
+test('extracts PIDs from PC boxes correctly', () => {
+  const buffer = new ArrayBuffer(0x9000);
+  const view = new DataView(buffer);
+
+  view.setUint32(PC_BOX_POKEMON_LIST_OFFSET + GEN3_POKEMON_PV_OFFSET, 0x11111111, true);
+  view.setUint32(PC_BOX_POKEMON_LIST_OFFSET + GEN3_POKEMON_OT_ID_OFFSET, 1, true);
+  view.setUint16(PC_BOX_POKEMON_LIST_OFFSET + GEN3_POKEMON_DATA_OFFSET, 1 ^ 1, true);
+
+  view.setUint32(PC_BOX_POKEMON_LIST_OFFSET + GEN3_PC_POKEMON_STRUCT_SIZE + GEN3_POKEMON_PV_OFFSET, 0x22222222, true);
+  view.setUint32(PC_BOX_POKEMON_LIST_OFFSET + GEN3_PC_POKEMON_STRUCT_SIZE + GEN3_POKEMON_OT_ID_OFFSET, 2, true);
+  view.setUint16(PC_BOX_POKEMON_LIST_OFFSET + GEN3_PC_POKEMON_STRUCT_SIZE + GEN3_POKEMON_DATA_OFFSET, 1 ^ 1, true);
+
+  const result = parseGen3PCBoxes(view);
+
+  expect(result.pcDetails.length).toBe(2);
+  expect(result.pcDetails[0]?.personalityValue).toBe(0x11111111);
+  expect(result.pcDetails[1]?.personalityValue).toBe(0x22222222);
+});
+
+test('handles out-of-bounds reads gracefully for party parsing', () => {
+  const buffer = new ArrayBuffer(10); // Too small
+  const view = new DataView(buffer);
+
+  expect(() => parseGen3Party(view, 0, 'ruby')).toThrow('The save file is corrupted or incomplete.');
+});
+
+test('handles out-of-bounds reads gracefully for PC parsing', () => {
+  const buffer = new ArrayBuffer(10); // Too small
+  const view = new DataView(buffer);
+
+  expect(() => parseGen3PCBoxes(view)).toThrow('The save file is corrupted or incomplete.');
+});


### PR DESCRIPTION
This PR satisfies `task-099-158-gen3-extract-pokemon-pids-qa`.

- Implemented tests in `src/engine/saveParser/parsers/gen3_pokemon_pids.test.ts`.
- Verified `DataView` is correctly utilized for both `parseGen3Party` and `parseGen3PCBoxes`.
- Verified out-of-bounds error handling via `RangeError`.
- Marked all acceptance criteria as completed in the node `task-099-158-gen3-extract-pokemon-pids-qa.md`.

---
*PR created automatically by Jules for task [5586949025564325789](https://jules.google.com/task/5586949025564325789) started by @szubster*