### PR TITLE
Break down Fame Checker Research epic into execution stories

### DIFF
--- a/.foundry/epics/epic-115-331-gen3-fame-checker-research.md
+++ b/.foundry/epics/epic-115-331-gen3-fame-checker-research.md
@@ -36,3 +36,7 @@ Before we can extract this data, we need to know exactly which bits or event fla
 ## Scope
 - Focus exclusively on Pokémon FireRed and LeafGreen save files.
 - Produce documentation detailing the findings.
+
+## Acceptance Criteria
+- [ ] story-331-431-conduct-fame-checker-research
+- [ ] story-331-432-fame-checker-research-e2e

--- a/.foundry/stories/story-331-431-conduct-fame-checker-research.md
+++ b/.foundry/stories/story-331-431-conduct-fame-checker-research.md
@@ -1,0 +1,35 @@
+---
+id: story-331-431-conduct-fame-checker-research
+type: STORY
+title: Conduct Fame Checker Research
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-19'
+updated_at: '2026-08-19'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-115-331-gen3-fame-checker-research
+tags:
+  - gen3
+  - firered
+  - leafgreen
+  - fame-checker
+  - research
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Conduct Fame Checker Research
+
+## Context
+As part of the effort to extract Fame Checker progress from Pokémon FireRed and LeafGreen save files (`epic-115-331-gen3-fame-checker-research`), we need to investigate and document the exact event flags and bitmasks used. This data will later power the extraction logic.
+
+## Description
+This story entails identifying the specific event flags that correlate with the Fame Checker entries (e.g., Oak, Daisy, Bill) in the Gen 3 save structure.
+
+## Acceptance Criteria
+- [ ] Investigate FireRed/LeafGreen save file memory layouts for Fame Checker event flags.
+- [ ] Document the mappings between in-game entries and event flags in a markdown document.

--- a/.foundry/stories/story-331-432-fame-checker-research-e2e.md
+++ b/.foundry/stories/story-331-432-fame-checker-research-e2e.md
@@ -1,0 +1,37 @@
+---
+id: story-331-432-fame-checker-research-e2e
+type: STORY
+title: Fame Checker Research E2E Verification
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-19'
+updated_at: '2026-08-19'
+depends_on:
+  - story-331-431-conduct-fame-checker-research
+jules_session_id: null
+pr_number: null
+parent: epic-115-331-gen3-fame-checker-research
+tags:
+  - gen3
+  - firered
+  - leafgreen
+  - fame-checker
+  - research
+  - e2e
+  - integration
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Fame Checker Research E2E Verification
+
+## Context
+As part of the effort to extract Fame Checker progress from Pokémon FireRed and LeafGreen save files (`epic-115-331-gen3-fame-checker-research`), this story is dedicated to the integration and verification of the research findings to ensure they meet the Orchestrator Safeguards.
+
+## Description
+This story covers the end-to-end verification of the research documentation gathered in `story-331-431-conduct-fame-checker-research`.
+
+## Acceptance Criteria
+- [ ] Task to verify the research documentation has been created and covers all Fame Checker entries.


### PR DESCRIPTION
Decomposes `epic-115-331-gen3-fame-checker-research` into structured STORY nodes.

The following changes were made:
- Created `story-331-431-conduct-fame-checker-research` for identifying event flags.
- Created `story-331-432-fame-checker-research-e2e` for orchestrator-mandated integration verification.
- Appended both nodes as unchecked tasks to the parent epic body.
- Purposefully leaves the Epic's acceptance criteria checkboxes unchecked to ensure it transitions to PENDING while awaiting child node execution via the late-binding strategy.

---
*PR created automatically by Jules for task [14440157345016907615](https://jules.google.com/task/14440157345016907615) started by @szubster*