### PR TITLE
chore: decompose epic 071-124 into granular UI migration stories

### DIFF
--- a/.foundry/epics/epic-071-124-migrate-core-tactical-components-v2.md
+++ b/.foundry/epics/epic-071-124-migrate-core-tactical-components-v2.md
@@ -43,3 +43,7 @@ Refactor the fundamental tactical UI components within the `src/components/` dir
 - [ ] Core tactical components are updated to use the new `tactical-*` utilities.
 - [ ] Component aesthetics remain strictly consistent with the tactical hardware style (no visual regressions).
 - [ ] Components pass `pnpm run lint` and `pnpm test`.
+- [ ] story-071-431-migrate-tactical-panel
+- [ ] story-071-432-migrate-tactical-controls
+- [ ] story-071-433-migrate-tactical-segmented
+- [ ] story-071-434-migrate-tactical-components-e2e

--- a/.foundry/journals/story_owner/7125355397537957084.md
+++ b/.foundry/journals/story_owner/7125355397537957084.md
@@ -1,0 +1,4 @@
+# Session 7125355397537957084
+
+- Decomposed epic `epic-071-124-migrate-core-tactical-components-v2` into multiple granular tasks to migrate different sets of components sequentially.
+- This adheres to the rules for granular task breakdown to avoid monolithic nodes, ensuring components like `TacticalPanel`, `TacticalButton`, and `TacticalSegmentedControl` are migrated carefully in separate steps, followed by an integration/e2e testing step.

--- a/.foundry/stories/story-071-431-migrate-tactical-panel.md
+++ b/.foundry/stories/story-071-431-migrate-tactical-panel.md
@@ -1,0 +1,38 @@
+---
+id: story-071-431-migrate-tactical-panel
+type: STORY
+title: Migrate TacticalPanel, TacticalCard, TacticalBadge to Utility Classes
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-19'
+updated_at: '2026-08-19'
+depends_on: []
+jules_session_id: '7125355397537957084'
+pr_number: null
+parent: epic-071-124-migrate-core-tactical-components-v2
+tags:
+  - styling
+  - refactor
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Migrate TacticalPanel, TacticalCard, TacticalBadge to Utility Classes
+
+## Objective
+Refactor `TacticalPanel.tsx`, `TacticalCard.tsx`, and `TacticalBadge.tsx` to utilize the new `@utility` classes (e.g., `tactical-panel`, `tactical-card`, `tactical-badge`) defined in `src/index.css`.
+
+## Scope
+1. **Target Components**:
+   - `src/components/TacticalPanel.tsx`
+   - `src/components/TacticalCard.tsx`
+   - `src/components/TacticalBadge.tsx`
+2. **Refactoring Process**: Replace long strings of repetitive inline Tailwind classes with their equivalent semantic `tactical-*` classes. Ensure variant styles still properly apply and specificity is correct.
+3. **No Visual Regressions**: Ensure that the migration accurately preserves the pre-existing visual appearance.
+
+## Acceptance Criteria
+- [ ] `TacticalPanel`, `TacticalCard`, and `TacticalBadge` use the new utility classes instead of inline classes where applicable.
+- [ ] No visual regressions in the affected components.
+- [ ] Components pass `pnpm run lint` and `pnpm test`.

--- a/.foundry/stories/story-071-432-migrate-tactical-controls.md
+++ b/.foundry/stories/story-071-432-migrate-tactical-controls.md
@@ -1,0 +1,38 @@
+---
+id: story-071-432-migrate-tactical-controls
+type: STORY
+title: Migrate TacticalButton, TacticalInput, TacticalSelect to Utility Classes
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-19'
+updated_at: '2026-08-19'
+depends_on: []
+jules_session_id: '7125355397537957084'
+pr_number: null
+parent: epic-071-124-migrate-core-tactical-components-v2
+tags:
+  - styling
+  - refactor
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Migrate TacticalButton, TacticalInput, TacticalSelect to Utility Classes
+
+## Objective
+Refactor `TacticalButton.tsx`, `TacticalInput.tsx`, and `TacticalSelect.tsx` to utilize the new `@utility` classes (e.g., `tactical-button`, `tactical-input`) defined in `src/index.css`.
+
+## Scope
+1. **Target Components**:
+   - `src/components/TacticalButton.tsx`
+   - `src/components/TacticalInput.tsx`
+   - `src/components/TacticalSelect.tsx`
+2. **Refactoring Process**: Replace long strings of repetitive inline Tailwind classes with their equivalent semantic `tactical-*` classes. Ensure variants still properly apply.
+3. **No Visual Regressions**: Ensure that the migration accurately preserves the pre-existing visual appearance.
+
+## Acceptance Criteria
+- [ ] `TacticalButton`, `TacticalInput`, and `TacticalSelect` use the new utility classes instead of inline classes where applicable.
+- [ ] No visual regressions in the affected components.
+- [ ] Components pass `pnpm run lint` and `pnpm test`.

--- a/.foundry/stories/story-071-433-migrate-tactical-segmented.md
+++ b/.foundry/stories/story-071-433-migrate-tactical-segmented.md
@@ -1,0 +1,37 @@
+---
+id: story-071-433-migrate-tactical-segmented
+type: STORY
+title: Migrate TacticalSegmentedControl and TacticalMultiSelectControl
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-19'
+updated_at: '2026-08-19'
+depends_on: []
+jules_session_id: '7125355397537957084'
+pr_number: null
+parent: epic-071-124-migrate-core-tactical-components-v2
+tags:
+  - styling
+  - refactor
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Migrate TacticalSegmentedControl and TacticalMultiSelectControl
+
+## Objective
+Refactor `TacticalSegmentedControl.tsx` and `TacticalMultiSelectControl.tsx` to utilize the new `@utility` classes defined in `src/index.css`.
+
+## Scope
+1. **Target Components**:
+   - `src/components/TacticalSegmentedControl.tsx`
+   - `src/components/TacticalMultiSelectControl.tsx`
+2. **Refactoring Process**: Replace long strings of repetitive inline Tailwind classes with their equivalent semantic `tactical-*` classes. Ensure that the active and inactive states still function correctly.
+3. **No Visual Regressions**: Ensure that the migration accurately preserves the pre-existing visual appearance.
+
+## Acceptance Criteria
+- [ ] `TacticalSegmentedControl` and `TacticalMultiSelectControl` use the new utility classes instead of inline classes where applicable.
+- [ ] No visual regressions in the affected components.
+- [ ] Components pass `pnpm run lint` and `pnpm test`.

--- a/.foundry/stories/story-071-434-migrate-tactical-components-e2e.md
+++ b/.foundry/stories/story-071-434-migrate-tactical-components-e2e.md
@@ -1,0 +1,39 @@
+---
+id: story-071-434-migrate-tactical-components-e2e
+type: STORY
+title: E2E Verification for Migrated Tactical Components V2
+status: READY
+owner_persona: tech_lead
+created_at: '2026-08-19'
+updated_at: '2026-08-19'
+depends_on:
+  - story-071-431-migrate-tactical-panel
+  - story-071-432-migrate-tactical-controls
+  - story-071-433-migrate-tactical-segmented
+jules_session_id: '7125355397537957084'
+pr_number: null
+parent: epic-071-124-migrate-core-tactical-components-v2
+tags:
+  - e2e
+  - integration
+  - testing
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: E2E Verification for Migrated Tactical Components V2
+
+## Objective
+Perform full E2E and visual regression verification for all core tactical UI components refactored to use the new `@utility` classes, ensuring no visual or functional regressions occurred during the migration.
+
+## Scope
+1. **Target Components**: All core tactical components that were migrated (e.g., TacticalPanel, TacticalButton, TacticalCard, TacticalInput, TacticalSelect, TacticalBadge, TacticalSegmentedControl, TacticalMultiSelectControl).
+2. **Testing**: Write or update Playwright E2E tests and/or Vitest component tests to confirm that these components render correctly with the expected tactical hardware aesthetic styles applied.
+3. **Integration**: Ensure they behave correctly within the context of the application where they are used.
+
+## Acceptance Criteria
+- [ ] Tests successfully cover and verify the styling and functionality of migrated components.
+- [ ] Ensure that E2E integration tests correctly navigate and interact with the elements.
+- [ ] Components pass `pnpm run lint`, `pnpm test`, and `xvfb-run pnpm test:e2e`.


### PR DESCRIPTION
Generated 4 new STORY nodes for the `epic-071-124-migrate-core-tactical-components-v2` macro node, assigning them to the `tech_lead` persona for blueprinting.

This leaves the parent epic's overarching checkboxes unchecked so the orchestrator properly waits for the newly appended child stories to transition to COMPLETED.

---
*PR created automatically by Jules for task [7125355397537957084](https://jules.google.com/task/7125355397537957084) started by @szubster*