### PR TITLE
🔐 Shield: Fix CWE-209 by sanitizing error logs

### DIFF
--- a/.github/scripts/garbage-collector.ts
+++ b/.github/scripts/garbage-collector.ts
@@ -56,14 +56,14 @@ export async function main() {
         console.info(`[GC] Skipping node ${relativePath}: Session ${sessionId} is TERMINATED (heartbeat will resolve)`);
       }
     } catch (err) {
-      console.error(`[GC] Error processing node ${relativePath}:`, err);
+      console.error(`[GC] Error processing node ${relativePath}:`, err instanceof Error ? err.message : String(err));
     }
   }
 }
 
 if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('garbage-collector.ts')) {
   main().catch(err => {
-    console.error('Fatal GC error:', err);
+    console.error('Fatal GC error:', err instanceof Error ? err.message : String(err));
     process.exit(1);
   });
 }

--- a/.github/scripts/remediate-zombie.ts
+++ b/.github/scripts/remediate-zombie.ts
@@ -57,7 +57,7 @@ export function remediateZombieNode(repoRoot: string, relativeFilePath: string, 
 
     return true;
   } catch (error) {
-    console.error(`Failed to remediate zombie node at ${fullPath}:`, error);
+    console.error(`Failed to remediate zombie node at ${fullPath}:`, error instanceof Error ? error.message : String(error));
     return false;
   }
 }

--- a/.jules/shield/2026-08-20-00-49-38.md
+++ b/.jules/shield/2026-08-20-00-49-38.md
@@ -1,0 +1,6 @@
+# Session Journal
+
+- Focused on preventing sensitive information leakage (CWE-209).
+- Found several instances where raw error objects were being logged directly to `console.error`.
+- Mitigated this by replacing `err` with `err instanceof Error ? err.message : String(err)` in `.github/scripts/remediate-zombie.ts`, `.github/scripts/garbage-collector.ts`, `scripts/check-links.ts`, `scripts/validate-foundry-schema.ts`, and `scripts/gen3-fetch-locations.ts`.
+- Verified all tests pass.

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -151,7 +151,7 @@ function checkLinks() {
       }
 
     } catch (e) {
-      console.error(`Error processing file ${file}:`, e);
+      console.error(`Error processing file ${file}:`, e instanceof Error ? e.message : String(e));
       hasErrors = true;
     }
   }

--- a/scripts/gen3-fetch-locations.ts
+++ b/scripts/gen3-fetch-locations.ts
@@ -262,6 +262,6 @@ async function run() {
 }
 
 run().catch((err) => {
-  console.error(err);
+  console.error(err instanceof Error ? err.message : String(err));
   process.exit(1);
 });

--- a/scripts/validate-foundry-schema.ts
+++ b/scripts/validate-foundry-schema.ts
@@ -95,7 +95,7 @@ function validateSchema() {
       parsed = matter(content);
     } catch (e) {
       console.error(`Error: Failed to parse frontmatter for file ${file}`);
-      console.error(e);
+      console.error(e instanceof Error ? e.message : String(e));
       hasError = true;
       continue;
     }


### PR DESCRIPTION
🎯 What
Replaced raw error object logging with sanitized output in several node scripts (`.github/scripts/remediate-zombie.ts`, `.github/scripts/garbage-collector.ts`, `scripts/check-links.ts`, `scripts/validate-foundry-schema.ts`, `scripts/gen3-fetch-locations.ts`).

⚠️ Risk
Low. It simply standardizes error output to strings instead of relying on the console's stringification of raw error objects.

🛡️ Solution
Used the standard pattern `err instanceof Error ? err.message : String(err)` to safely extract error information.

---
*PR created automatically by Jules for task [3171431435246061227](https://jules.google.com/task/3171431435246061227) started by @szubster*