### PR TITLE
🖼️ Canvas: Hardware Console AppHeader Redesign

### DIFF
--- a/.jules/canvas/2025-03-01-12-00-00.md
+++ b/.jules/canvas/2025-03-01-12-00-00.md
@@ -1,0 +1,5 @@
+## 2025-03-01 - [Accepted] - 🖼️ Canvas: Hardware Console AppHeader Redesign
+**What:** Redesigned the `AppHeader` from a standard top navigation bar into a heavy, industrial "Hardware Console". Enclosed the logo and system status in thick LCD-styled blocks with diegetic power LEDs. Converted the top navigation tabs into chunky, interlocking mechanical switches that look physically toggled when active. Added thick hazard stripes to the top rim.
+**Outcome:** Accepted -> wait for review
+**Why:** The previous header was functional but lacked physical depth and felt too much like a standard web navbar. The project's aesthetic (tactical/snooping) benefits from interfaces that feel like heavy, real-world hardware consoles.
+**Pattern:** Treat primary navigation as physical hardware controls (levers, toggle switches, heavy buttons) rather than flat text tabs. Wrap top-level layout components in heavy, dashed structural frames to simulate screen bezels and control panels.

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -9,7 +9,6 @@ import { OfflineControls } from './header/OfflineControls';
 import { SystemControls } from './header/SystemControls';
 import { TelemetryMatrix } from './header/TelemetryMatrix';
 import { NavigationTab } from './NavigationTab';
-import { VerticalDivider } from './VerticalDivider';
 
 interface AppHeaderProps {
   saveData: SaveData | null;
@@ -35,55 +34,69 @@ export function AppHeader({
     return total > 0 ? (securedIds.size / total) * 100 : 0;
   }, [saveData]);
   return (
-    <header className="sticky top-0 z-50 flex w-full flex-col border-[var(--theme-primary)]/50 border-b-[4px] border-dashed bg-zinc-950 px-4 py-3 shadow-[0_20px_50px_rgba(0,0,0,0.8)] lg:flex-row lg:items-center lg:justify-between lg:px-8">
-      {/* Hazard Stripes Lip */}
+    <header className="sticky top-0 z-50 flex w-full flex-col border-[var(--theme-primary)]/40 border-b-[6px] border-dashed bg-black px-4 py-3 shadow-[0_20px_50px_rgba(0,0,0,0.8)] lg:flex-row lg:items-center lg:justify-between lg:px-8">
+      {/* Heavy Hazard Stripes Lip */}
       <div
-        className="absolute top-0 right-0 left-0 h-1.5 opacity-30"
+        className="absolute top-0 right-0 left-0 h-2 opacity-80"
         style={{
           backgroundImage:
-            'repeating-linear-gradient(45deg, var(--theme-primary) 25%, transparent 25%, transparent 50%, var(--theme-primary) 50%, var(--theme-primary) 75%, transparent 75%, transparent)',
-          backgroundSize: '20px 20px',
+            'repeating-linear-gradient(45deg, var(--theme-primary) 0px, var(--theme-primary) 10px, transparent 10px, transparent 20px)',
         }}
       />
-      {/* Top hardware lip */}
-      <div className="absolute top-1.5 right-0 left-0 h-[2px] bg-gradient-to-r from-transparent via-[var(--theme-primary)]/40 to-transparent" />
-      <div className="pointer-events-none absolute top-0 right-0 bottom-0 left-0 bg-[radial-gradient(ellipse_at_top,var(--theme-primary)_0%,transparent_70%)] opacity-[0.03]" />
+      {/* Top hardware lip & scanline background */}
+      <div className="absolute top-2 right-0 left-0 h-[2px] bg-[var(--theme-primary)]/60" />
+      <div className="pointer-events-none absolute top-0 right-0 bottom-0 left-0 bg-[url('/scanlines.png')] opacity-20 mix-blend-overlay" />
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-[var(--theme-primary)]/10 to-transparent" />
+
+      {/* Raw text watermark */}
+      <div className="pointer-events-none absolute top-4 left-1/2 -translate-x-1/2 whitespace-nowrap font-mono text-[80px] text-white/5 uppercase tracking-[0.5em] opacity-30 blur-[2px]">
+        DIAGNOSTIC CONSOLE ACTIVE
+      </div>
 
       <div className="relative z-10 flex w-full items-center justify-between gap-8 lg:w-auto">
-        <Link to="/" className="focus-visible:tactical-focus relative flex items-center gap-4 rounded-none px-2 py-1">
-          <CornerCrosshairs className="h-2 w-2 border-[var(--theme-primary)] opacity-50" />
-          <div className="group slide-in-from-left-4 fade-in flex animate-in items-center gap-3 duration-500">
-            <span className="font-black text-3xl text-white tracking-tighter transition-all group-hover:text-[var(--theme-primary)] group-hover:drop-shadow-[0_0_10px_rgba(var(--theme-primary-rgb),0.8)]">
-              DEX<span className="text-[var(--theme-primary)] transition-colors group-hover:text-white">HELPER</span>
-            </span>
-            <div className="mx-1 h-8 w-[2px] border-zinc-900 border-l border-dashed bg-zinc-800" />
-            <div className="flex flex-col justify-center border border-zinc-800 border-dashed bg-zinc-950/80 px-2 py-0.5">
-              <span className="font-retro text-[8px] text-zinc-500 uppercase tracking-[0.3em]">
-                {saveData ? getGenerationConfig(saveData.generation).label : 'Protocol X'}
+        <Link to="/" className="focus-visible:tactical-focus relative flex items-center gap-4 rounded-none p-1">
+          <div className="group relative flex items-center gap-4 border border-[var(--theme-primary)]/40 bg-zinc-950 p-3 shadow-[inset_0_0_20px_rgba(var(--theme-primary-rgb),0.1)]">
+            <CornerCrosshairs className="h-3 w-3 border-[var(--theme-primary)]" thickness={2} />
+
+            <div className="slide-in-from-left-4 fade-in flex animate-in items-center gap-4 duration-500">
+              <span className="font-black text-3xl text-white tracking-tighter drop-shadow-[0_0_15px_rgba(255,255,255,0.3)] transition-all group-hover:text-[var(--theme-primary)] group-hover:drop-shadow-[0_0_15px_rgba(var(--theme-primary-rgb),0.8)]">
+                DEX<span className="text-[var(--theme-primary)] transition-colors group-hover:text-white">HELPER</span>
               </span>
-              <span className="animate-pulse font-black text-[9px] text-[var(--theme-primary)] shadow-[0_0_5px_var(--theme-primary)]">
-                [ SYS_ONLINE ]
-              </span>
+
+              <div className="h-10 w-[2px] border-[var(--theme-primary)]/30 border-l border-dashed" />
+
+              <div className="flex flex-col gap-1">
+                <span className="font-retro text-[8px] text-zinc-500 uppercase tracking-[0.3em]">
+                  {saveData ? getGenerationConfig(saveData.generation).label : 'Protocol X'}
+                </span>
+                <div className="flex items-center gap-2">
+                  <div className="relative flex items-center justify-center">
+                    <div className="absolute h-4 w-4 animate-ping rounded-full bg-[var(--theme-primary)]/40" />
+                    <div className="relative h-2 w-2 rounded-full bg-[var(--theme-primary)] shadow-[0_0_8px_var(--theme-primary)]" />
+                  </div>
+                  <span className="font-black font-mono text-[9px] text-[var(--theme-primary)] tracking-widest">
+                    SYS.PWR
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
         </Link>
 
         {/* Desktop Navigation (Segmented Terminal Matrix) */}
         {saveData && (
-          <nav className="mt-4 hidden lg:mt-0 lg:flex lg:flex-1 lg:justify-center">
-            <div className="flex bg-zinc-900/30">
+          <nav className="relative mt-4 hidden lg:mt-0 lg:flex lg:flex-1 lg:justify-center">
+            {/* Structural bracket for nav */}
+            <div className="absolute -top-3 left-1/2 -translate-x-1/2 font-mono text-[8px] text-[var(--theme-primary)]/60 tracking-[0.4em]">
+              [ DOWNLINK / UPLINK ]
+            </div>
+            <div className="flex border-2 border-zinc-800 border-dashed bg-zinc-950/80 shadow-2xl">
               <NavigationTab to="/" icon={<LayoutGrid size={14} />} label="SYS.DEX" />
-              <VerticalDivider />
               <NavigationTab to="/storage" icon={<Database size={14} />} label="SYS.STRG" />
-              <VerticalDivider />
               <NavigationTab to="/assistant" icon={<Sparkles size={14} />} label="SYS.ASST" />
-              <VerticalDivider />
               <NavigationTab to="/dag" icon={<GitGraph size={14} />} label="SYS.DAG" />
               {(saveData.generation === 3 || saveData.generation === 2) && (
-                <>
-                  <VerticalDivider />
-                  <NavigationTab to="/dashboard" icon={<Swords size={14} />} label="SYS.DASH" />
-                </>
+                <NavigationTab to="/dashboard" icon={<Swords size={14} />} label="SYS.DASH" />
               )}
             </div>
           </nav>

--- a/src/components/NavigationTab.tsx
+++ b/src/components/NavigationTab.tsx
@@ -12,12 +12,17 @@ export function NavigationTab({ icon, label, ...props }: NavigationTabProps) {
     <Link
       {...props}
       activeProps={{
-        className: 'bg-[var(--theme-primary)]/10 text-[var(--theme-primary)] border-b-[var(--theme-primary)]',
+        className:
+          'bg-[var(--theme-primary)] text-black border-[var(--theme-primary)] shadow-[inset_0_4px_10px_rgba(0,0,0,0.4)]',
+        style: {
+          backgroundImage:
+            'repeating-linear-gradient(45deg, rgba(0,0,0,0.1) 0px, rgba(0,0,0,0.1) 2px, transparent 2px, transparent 4px)',
+        },
       }}
       inactiveProps={{
-        className: 'border-b-transparent text-zinc-500 hover:text-zinc-300 hover:bg-white/5',
+        className: 'border-zinc-800 text-zinc-500 bg-black/60 hover:text-zinc-300 hover:bg-zinc-900',
       }}
-      className="group focus-visible:tactical-focus relative flex flex-col items-center gap-1 border-b-2 border-dashed px-8 py-3 font-black font-mono text-[10px] uppercase tracking-[0.2em] transition-all"
+      className="group focus-visible:tactical-focus relative flex flex-col items-center gap-1 border-t border-r border-l border-dashed px-8 py-3 font-black font-mono text-[10px] uppercase tracking-[0.2em] transition-all"
     >
       <CornerCrosshairs className="h-1 w-1 border-current opacity-50" />
       <div className="mb-1">{icon}</div>[ {label} ]


### PR DESCRIPTION
Redesigned the AppHeader from a standard top navigation bar into a heavy, industrial "Hardware Console". Enclosed the logo and system status in thick LCD-styled blocks with diegetic power LEDs. Converted the top navigation tabs into chunky, interlocking mechanical switches that look physically toggled when active. Added thick hazard stripes to the top rim. Includes updated Canvas journal logging this Accepted pattern.

---
*PR created automatically by Jules for task [595482919793839380](https://jules.google.com/task/595482919793839380) started by @szubster*