### PR TITLE
🧭 Strategist: Prompt improvement - Clean up duplicated architectural constraints in specific agent prompts

### DIFF
--- a/.github/agents/specific/dexhelper.md
+++ b/.github/agents/specific/dexhelper.md
@@ -1,6 +1,3 @@
 ## DexHelper & Pokemon Data Guidelines
 - When serializing/deserializing application data structures (`PokeData`), use MsgPack (`msgpackr`) with `useRecords: true`.
 - Adhere to the PokeData Property Naming Schema (full, readable property names like `captureRate` instead of `cr`, `evolvesTo` instead of `eto`).
-- For save file parsing, define all memory offsets, shifts, and bit locations as reusable constants at the module level. Inline magic numbers are forbidden.
-- For Gen 3 save block extraction, pass and utilize the resolved section offset (e.g., `section1Offset`) to support A/B bank flash memory architecture.
-- Handle `RangeError` from `DataView` out-of-bounds reads and throw a new error: "The save file is corrupted or incomplete."

--- a/.github/agents/specific/react.md
+++ b/.github/agents/specific/react.md
@@ -1,8 +1,3 @@
 ## React & Frontend Guidelines
 - Build functional components with modern React hooks.
-- Adhere strictly to the "tactical hardware/snooping" aesthetic outlined in ADR 008:
-  - Sharp edges only: use `rounded-none`. Do NOT use any rounded corners (e.g., `rounded`, `rounded-sm`, `rounded-md`, etc.).
-  - Use dashed borders (`border-dashed`).
-  - Use monospaced fonts (e.g., `font-mono`) and tabular numbers where appropriate.
 - Ensure all newly created UI components are properly integrated into the application's view hierarchy.
-- For component test cases, explicitly type `vi.fn()` mock callbacks to satisfy TypeScript constraints.

--- a/.jules/strategist/2026-08-20-02-48-56.md
+++ b/.jules/strategist/2026-08-20-02-48-56.md
@@ -1,0 +1,5 @@
+## 2026-08-20-02-48-56 - [Accepted] - Prompt improvement - Clean up duplicated architectural constraints in specific agent prompts
+**Type:** Prompt improvement
+**Outcome:** Merged
+**Why:** The `specific/dexhelper.md` schedule contained redundant save file parsing guidelines (magic numbers, relative offsets, `RangeError` catching) and `specific/react.md` contained redundant frontend guidelines (ADR 008 styling, Vitest mock typing) which had already been migrated to `core_policies.md`. We need to remove these duplicate rules from the specific agent prompts to prevent prompt bloat, reduce redundancy, prevent drift and save context tokens.
+**Pattern:** Always check and verify that older tests checking for prompt specific rules are also cleaned up when a rule is migrated to a central file like `core_policies.md`.


### PR DESCRIPTION
**Proposal:** Remove duplicated save file parsing guidelines from `.github/agents/specific/dexhelper.md` and redundant frontend guidelines from `.github/agents/specific/react.md`. 
**Justification:** These rules are already centralized in `.foundry/docs/knowledge_base/agents/core_policies.md`. Keeping specific prompt files DRY prevents drift, reduces redundancy, and saves context tokens for agents.
**Evidence:** The core policies (`.foundry/docs/knowledge_base/agents/core_policies.md`) clearly contain the exact same guidelines, including Vitest mocks typing, ADR 008 aesthetic constraints, and save file parsing rules (magic numbers, `RangeError`, etc.).

---
*PR created automatically by Jules for task [12050877455018037109](https://jules.google.com/task/12050877455018037109) started by @szubster*