### PR TITLE
QA: Reject Nuzlocke Death Tracking E2E Implementation

### DIFF
--- a/.foundry/journals/qa/16272564245202199728.md
+++ b/.foundry/journals/qa/16272564245202199728.md
@@ -1,0 +1,16 @@
+# QA Journal Entry - Session 16272564245202199728
+
+## Context
+Validating `task-351-385-nuzlocke-death-tracking-e2e-qa` which depends on the implementation task `task-351-384-nuzlocke-death-tracking-e2e-impl`.
+
+## Findings
+The target implementation task claims to have implemented E2E tests for the Nuzlocke death tracking logic. However, review of the test file `tests/e2e/nuzlocke_death_tracking.spec.ts` reveals that the coder explicitly skipped validating the UI rendering for dead Pokemon (the `isDead` prop, causing opacity and grayscale visual effects). The coder left a comment stating they were skipping it to avoid "fighting Playwright locator syntax for the specific layout of storage grids."
+
+This is a direct violation of the acceptance criteria to adequately cover identifying Pokemon as dead. UI tests must verify the actual UI effects, not just assume the internal state works.
+
+## Action Taken
+- Rejected the implementation task `task-351-384-nuzlocke-death-tracking-e2e-impl`.
+- Set its status to `FAILED`.
+- Incremented its `rejection_count`.
+- Added a `rejection_reason` explaining the missing UI validation.
+- Triggered the Resurrection Loop by appending a rejection note to my own QA task without checking off any acceptance criteria.

--- a/.foundry/tasks/task-351-384-nuzlocke-death-tracking-e2e-impl.md
+++ b/.foundry/tasks/task-351-384-nuzlocke-death-tracking-e2e-impl.md
@@ -2,7 +2,7 @@
 id: task-351-384-nuzlocke-death-tracking-e2e-impl
 type: TASK
 title: Nuzlocke Death Tracking E2E Tests Implementation
-status: COMPLETED
+status: FAILED
 owner_persona: coder
 created_at: '2026-08-01'
 updated_at: '2026-08-15'
@@ -14,8 +14,8 @@ tags:
   - e2e
   - nuzlocke
   - verification
-rejection_count: 0
-rejection_reason: ''
+rejection_count: 1
+rejection_reason: 'The E2E tests skip actually verifying the UI rendering of dead styling (isDead prop, opacity/grayscale effects) for party Pokemon at 0 HP and Graveyard box members, instead opting to skip tests due to Playwright locator difficulty.'
 notes: ''
 ---
 

--- a/.foundry/tasks/task-351-385-nuzlocke-death-tracking-e2e-qa.md
+++ b/.foundry/tasks/task-351-385-nuzlocke-death-tracking-e2e-qa.md
@@ -35,3 +35,6 @@ Verify the Playwright End-to-End tests for the automated death tracking logic an
 - **Transient Failures:** If you experience a transient failure requiring a retry, you MUST update the YAML frontmatter to `status: FAILED` with a `rejection_reason`.
 - **Permanent Aborts:** If you must abort or permanently fail a task (impossible or max rejections reached), you MUST update the YAML frontmatter to `status: CANCELLED` with a `rejection_reason`.
 - **Empty PRs:** If you submit an empty PR for a completed task, you MUST check off all Acceptance Criteria checkboxes before submitting.
+
+### QA Rejection
+The implemented E2E tests skip actual UI validation of the `isDead` state (opacity and grayscale visual effects) for party Pokemon with 0 HP and Pokemon in the Graveyard box, stating that Playwright locator syntax for the storage grid is too complex. This violates the acceptance criteria to adequately cover identifying these Pokemon as dead. The implementation has been rejected and the Resurrection Loop has been triggered.


### PR DESCRIPTION
The target implementation task claims to have implemented E2E tests for the Nuzlocke death tracking logic. However, review of the test file `tests/e2e/nuzlocke_death_tracking.spec.ts` reveals that the coder explicitly skipped validating the UI rendering for dead Pokemon (the `isDead` prop, causing opacity and grayscale visual effects). The coder left a comment stating they were skipping it to avoid "fighting Playwright locator syntax for the specific layout of storage grids."

This is a direct violation of the acceptance criteria to adequately cover identifying Pokemon as dead. UI tests must verify the actual UI effects, not just assume the internal state works.

- Rejected the implementation task `task-351-384-nuzlocke-death-tracking-e2e-impl`.
- Set its status to `FAILED`.
- Incremented its `rejection_count`.
- Added a `rejection_reason` explaining the missing UI validation.
- Triggered the Resurrection Loop by appending a rejection note to my own QA task without checking off any acceptance criteria.

---
*PR created automatically by Jules for task [16272564245202199728](https://jules.google.com/task/16272564245202199728) started by @szubster*