### PR TITLE
Decompose Save State Read/Write API (Retry) Epic into Story Nodes

### DIFF
--- a/.foundry/epics/epic-099-398-save-state-read-write-api-retry.md
+++ b/.foundry/epics/epic-099-398-save-state-read-write-api-retry.md
@@ -30,4 +30,7 @@ Implement the core read and write APIs to store new save states and retrieve the
 - [ ] Implement write API to store a new save state file along with its metadata (timestamp, playthrough ID).
 - [ ] Implement read API to retrieve the most recent save state for a playthrough.
 - [ ] Implement read API to retrieve the *previous* state relative to a given state for diffing purposes.
-- [ ] Create a final STORY dedicated exclusively to Integration and E2E Verification.
+- [x] Create a final STORY dedicated exclusively to Integration and E2E Verification.
+- [ ] story-398-431-save-state-write-api
+- [ ] story-398-432-save-state-read-api
+- [ ] story-398-433-save-state-read-write-api-e2e

--- a/.foundry/stories/story-398-431-save-state-write-api.md
+++ b/.foundry/stories/story-398-431-save-state-write-api.md
@@ -1,0 +1,32 @@
+---
+id: story-398-431-save-state-write-api
+type: STORY
+title: Implement Save State Write API
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-20'
+updated_at: '2026-08-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: epic-099-398-save-state-read-write-api-retry
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Implement Save State Write API
+
+## Overview
+Implement the write API to store a new save state file along with its metadata (timestamp, playthrough ID) into IndexedDB. This fulfills the first acceptance criteria of `epic-099-398-save-state-read-write-api-retry`.
+
+## Acceptance Criteria
+- [ ] Implement a function to store a `.sav` file in IndexedDB under the `saves` object store.
+- [ ] Implement a function to store associated metadata (e.g., timestamp, playthrough ID) in the `metadata` object store.
+- [ ] Ensure the write operation supports transactions and handles potential errors gracefully.
+- [ ] Write unit tests for the write API.

--- a/.foundry/stories/story-398-432-save-state-read-api.md
+++ b/.foundry/stories/story-398-432-save-state-read-api.md
@@ -1,0 +1,33 @@
+---
+id: story-398-432-save-state-read-api
+type: STORY
+title: Implement Save State Read API
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-20'
+updated_at: '2026-08-20'
+depends_on:
+  - story-398-431-save-state-write-api
+jules_session_id: null
+pr_number: null
+parent: epic-099-398-save-state-read-write-api-retry
+tags:
+  - storage
+  - indexeddb
+  - history
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Implement Save State Read API
+
+## Overview
+Implement the read API to retrieve the most recent save state for a playthrough, as well as the previous state relative to a given state for diffing purposes. This fulfills the second and third acceptance criteria of `epic-099-398-save-state-read-write-api-retry`.
+
+## Acceptance Criteria
+- [ ] Implement a function to retrieve the most recent save state for a specified playthrough ID.
+- [ ] Implement a function to retrieve the previous state relative to a given save state ID (for diffing purposes).
+- [ ] Ensure queries effectively utilize the indexes in the `SaveHistoryDB` schema.
+- [ ] Write unit tests for the read API.

--- a/.foundry/stories/story-398-433-save-state-read-write-api-e2e.md
+++ b/.foundry/stories/story-398-433-save-state-read-write-api-e2e.md
@@ -1,0 +1,34 @@
+---
+id: story-398-433-save-state-read-write-api-e2e
+type: STORY
+title: Save State Read/Write API E2E Verification
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-20'
+updated_at: '2026-08-20'
+depends_on:
+  - story-398-432-save-state-read-api
+jules_session_id: null
+pr_number: null
+parent: epic-099-398-save-state-read-write-api-retry
+tags:
+  - storage
+  - indexeddb
+  - history
+  - e2e
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Save State Read/Write API E2E Verification
+
+## Overview
+Perform E2E verification of the Save State Read/Write APIs, testing the storage and retrieval flows in a realistic browser environment to satisfy the Orchestrator Safeguard requirement.
+
+## Acceptance Criteria
+- [ ] Create an E2E test suite for the Save State Read/Write APIs.
+- [ ] Verify that a series of save files can be written successfully into the mock IndexedDB environment.
+- [ ] Verify that the most recent save state can be accurately read.
+- [ ] Verify that a previous save state relative to a given save can be accurately read for diffing purposes.


### PR DESCRIPTION
Decomposed `epic-099-398-save-state-read-write-api-retry` into three downstream `STORY` nodes for the write API, read API, and a dedicated E2E verification test suite. Updated the parent Epic to correctly append the new stories and satisfied Orchestrator Safeguard requirements.

---
*PR created automatically by Jules for task [8040256086416551575](https://jules.google.com/task/8040256086416551575) started by @szubster*