### PR TITLE
Research: Google Drive Webhooks on Cloudflare Workers

### DIFF
--- a/.foundry/docs/knowledge_base/infrastructure/google_drive_cloudflare_integration.md
+++ b/.foundry/docs/knowledge_base/infrastructure/google_drive_cloudflare_integration.md
@@ -1,0 +1,19 @@
+# Google Drive & Cloudflare Workers Integration
+
+This document outlines architectural constraints and facts when integrating Google Drive Push Notifications (webhooks) with Cloudflare Workers.
+
+## Domain Verification
+- Google Drive webhooks require a verified domain.
+- Cloudflare Workers can serve as the webhook endpoint if a custom domain is mapped to the worker.
+- The most robust verification method is using a DNS TXT record for the custom domain within Cloudflare.
+
+## Execution Time Mitigation
+- Cloudflare Workers have strict CPU limits (10ms-50ms).
+- The webhook payload from Google Drive is lightweight and only contains metadata (resource IDs, state changes), not the file itself.
+- Downloading and processing `.sav` files via the Drive API inside the worker risks hitting the execution time limit.
+- **Rule:** The Worker MUST use `ctx.waitUntil()` to asynchronously download and process the `.sav` file. The Worker MUST immediately respond to the webhook with a 200 OK to prevent Google from retrying the request and to free up the main execution thread.
+
+## Polling Constraints
+- If webhooks are not used, Cloudflare Scheduled Workers (Cron Triggers) can be used for polling.
+- The minimum interval for Cron Triggers is 1 minute.
+- **Limitation:** A 1-minute polling interval introduces latency that degrades the "live tracker" experience and can rapidly consume Google Drive API quotas. Webhooks are the preferred architecture.

--- a/.foundry/journals/researcher/18001398838651776536.md
+++ b/.foundry/journals/researcher/18001398838651776536.md
@@ -1,0 +1,3 @@
+# Session 18001398838651776536
+- Discovered that using `ctx.waitUntil()` is a critical architectural constraint when integrating Google Drive Webhooks with Cloudflare Workers due to strict CPU limits.
+- Established that webhooks are vastly superior to polling for the "live tracker" use case because Cloudflare's 1-minute Cron limit and Drive API quotas make polling impractical.

--- a/.foundry/research/research-336-400-cloudflare-drive-webhooks.md
+++ b/.foundry/research/research-336-400-cloudflare-drive-webhooks.md
@@ -34,6 +34,19 @@ Investigate if Cloudflare Workers can robustly handle Google Drive Webhooks.
 3. **Polling Fallback:** If webhooks are not viable, what are the rate limits and overhead of implementing a polling mechanism for Google Drive API within a Cloudflare Worker?
 
 ## Acceptance Criteria
-- [ ] Document findings on the feasibility of Google Drive Webhooks on Cloudflare Workers.
-- [ ] Document any limitations or workarounds discovered.
-- [ ] Determine if a polling fallback is necessary and document its feasibility.
+ - [x] Document findings on the feasibility of Google Drive Webhooks on Cloudflare Workers.
+ - [x] Document any limitations or workarounds discovered.
+ - [x] Determine if a polling fallback is necessary and document its feasibility.
+
+## Findings
+
+### Webhook Registration
+Google Drive Push Notifications (webhooks) require a verified domain. Cloudflare Workers can act as the webhook endpoint, provided the custom domain mapped to the Worker is verified in Google Search Console. Google Drive verifies ownership by requiring a specific `google-site-verification` HTML file or meta tag, or a DNS TXT record. Using a custom domain with a DNS TXT record on Cloudflare is the most robust way to achieve this for a Worker.
+
+### Payload & Execution Limitations
+Cloudflare Workers have strict CPU time limits (10ms-50ms depending on the plan, though Unbound allows more). A Google Drive webhook payload is a lightweight HTTP POST request containing resource IDs and state change information, not the file payload itself. The Worker must then use the Drive API to fetch the updated `.sav` file.
+The primary risk is the execution time limit when downloading and processing the `.sav` file. If the file is large or processing takes too long, the Worker might timeout. To mitigate this, the Worker can use `ctx.waitUntil()` to perform the download and sync asynchronously, responding to Google's webhook immediately with a 200 OK to prevent retries and avoid blocking.
+
+### Polling Fallback
+If webhooks are deemed too complex to maintain (e.g., handling push channel expirations which happen frequently with Drive API), polling is a viable fallback. However, Cloudflare Workers do not have a built-in `setInterval`. A Scheduled Worker (Cron Trigger) can run every minute.
+Polling introduces latency (up to 1 minute delay) and rapidly consumes Google Drive API quota if querying frequently for changes across many users. Given the "live tracker" requirement, a 1-minute polling interval might degrade the user experience compared to webhooks. Therefore, Webhooks are highly recommended, despite the added complexity of managing push channels.


### PR DESCRIPTION
This PR completes the RESEARCH node `research-336-400-cloudflare-drive-webhooks`.

It investigates the constraints and architectures involved in integrating Google Drive Push Notifications (webhooks) into Cloudflare Workers for `.sav` syncing on emulators. 

Key changes:
1. Documented findings inside the task file and marked its acceptance criteria.
2. Abstracted actionable constraints (such as domain verification and the necessity of using `ctx.waitUntil()` to avoid CPU time-limit timeouts) into the general knowledge base at `.foundry/docs/knowledge_base/infrastructure/google_drive_cloudflare_integration.md`.
3. Documented long-term session learnings in the Researcher's private journal.

---
*PR created automatically by Jules for task [18001398838651776536](https://jules.google.com/task/18001398838651776536) started by @szubster*