### PR TITLE
chore: handle permanent e2e failure via late-binding research and replacement tasks

### DIFF
--- a/.foundry/journals/tech_lead/723613607689792303.md
+++ b/.foundry/journals/tech_lead/723613607689792303.md
@@ -1,0 +1,7 @@
+# Tech Lead Journal Entry
+Date: 2026-08-20
+
+## Recurring E2E Implementation Failures & Fixtures
+When drafting E2E integration tasks for save parsing functionality (like NPC Trade Extraction), there is a recurring pattern of permanent task failures (e.g., `task-363-415-trade-extraction-e2e-impl` reaching Max Rejection Count) when the task relies on a specific save file state (fixtures) that doesn't exist or isn't well understood by the system yet.
+
+**Architectural Constraint:** Before creating an E2E implementation task that depends on a specific save file fixture (e.g. "needs a Gen 3 save with 1 trade completed"), we MUST explicitly spawn a `RESEARCH` node to acquire, verify, and understand the fixture first. Attempting to implement the tests blindly leads to repeated failures and blocked DAG paths. The late-binding pattern must be actively employed here: Research first, then dynamically spawn the implementation task as a dependent node.

--- a/.foundry/research/research-363-440-investigate-trade-extraction-e2e-failure.md
+++ b/.foundry/research/research-363-440-investigate-trade-extraction-e2e-failure.md
@@ -1,0 +1,33 @@
+---
+id: research-363-440-investigate-trade-extraction-e2e-failure
+type: RESEARCH
+title: Investigate NPC Trade Extraction E2E Implementation Failure
+status: READY
+owner_persona: researcher
+created_at: '2026-08-20'
+updated_at: '2026-08-20'
+depends_on: []
+jules_session_id: null
+pr_number: null
+parent: story-349-363-trade-extraction-e2e
+tags:
+  - testing
+  - gen2
+  - gen3
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Research: Investigate NPC Trade Extraction E2E Implementation Failure
+
+## Objective
+Investigate the root cause of the permanent failure of `task-363-415-trade-extraction-e2e-impl` which failed with the reason `[ACKNOWLEDGED] Max rejection count reached`.
+
+## Context
+The implementation task failed permanently. Based on the existence of `research-363-416-gen3-save-fixture`, it's highly likely the E2E test implementation failed due to missing, corrupt, or inadequate save file fixtures, or because the E2E implementation was unable to properly mount/inject these fixtures during the test run.
+
+## Acceptance Criteria
+- [ ] Determine why the previous E2E test implementation failed 3 times.
+- [ ] Document the required steps, tools, or dependencies needed to successfully implement the E2E tests for NPC trade extraction.

--- a/.foundry/stories/story-349-363-trade-extraction-e2e.md
+++ b/.foundry/stories/story-349-363-trade-extraction-e2e.md
@@ -30,5 +30,8 @@ Verify the end-to-end integration of NPC trade flag extraction for Generation 2 
 ## Acceptance Criteria
 - [ ] Ensure end-to-end extraction works for both generations.
 - [x] Tech Lead: Break down this Story into executable Tasks.
-- [ ] task-363-415-trade-extraction-e2e-impl
-- [ ] task-363-416-trade-extraction-e2e-qa
+- [x] task-363-415-trade-extraction-e2e-impl
+- [x] task-363-416-trade-extraction-e2e-qa
+- [ ] research-363-440-investigate-trade-extraction-e2e-failure
+- [ ] task-363-441-trade-extraction-e2e-retry-impl
+- [ ] task-363-442-trade-extraction-e2e-retry-qa

--- a/.foundry/tasks/task-363-441-trade-extraction-e2e-retry-impl.md
+++ b/.foundry/tasks/task-363-441-trade-extraction-e2e-retry-impl.md
@@ -1,0 +1,37 @@
+---
+id: task-363-441-trade-extraction-e2e-retry-impl
+type: TASK
+title: NPC Trade Extraction Integration & E2E Implementation (Retry)
+status: PENDING
+owner_persona: coder
+created_at: '2026-08-20'
+updated_at: '2026-08-20'
+depends_on:
+  - research-363-440-investigate-trade-extraction-e2e-failure
+jules_session_id: null
+pr_number: null
+parent: story-349-363-trade-extraction-e2e
+tags:
+  - feature
+  - backend
+  - save-parsing
+  - e2e
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: NPC Trade Extraction Integration & E2E Implementation (Retry)
+
+## Objective
+Implement end-to-end (E2E) tests for the NPC trade flag extraction logic across Gen 2 and Gen 3 save files, incorporating the findings from the preceding research node.
+
+## Context
+A previous attempt (`task-363-415-trade-extraction-e2e-impl`) failed permanently. A research task (`research-363-440-investigate-trade-extraction-e2e-failure`) was spawned to investigate the root cause. This task must implement the E2E tests ensuring all required fixtures and setup logic identified in the research are correctly utilized.
+
+## Acceptance Criteria
+- [ ] Read the findings of `research-363-440-investigate-trade-extraction-e2e-failure`.
+- [ ] Write E2E test files for Gen 2 NPC trade flag extraction.
+- [ ] Write E2E test files for Gen 3 NPC trade flag extraction.
+- [ ] Ensure tests verify end-to-end extraction (from save file parsing to resulting flags in `SaveData`).

--- a/.foundry/tasks/task-363-442-trade-extraction-e2e-retry-qa.md
+++ b/.foundry/tasks/task-363-442-trade-extraction-e2e-retry-qa.md
@@ -1,0 +1,34 @@
+---
+id: task-363-442-trade-extraction-e2e-retry-qa
+type: TASK
+title: NPC Trade Extraction Integration & E2E QA (Retry)
+status: PENDING
+owner_persona: qa
+created_at: '2026-08-20'
+updated_at: '2026-08-20'
+depends_on:
+  - task-363-441-trade-extraction-e2e-retry-impl
+jules_session_id: null
+pr_number: null
+parent: story-349-363-trade-extraction-e2e
+tags:
+  - feature
+  - backend
+  - save-parsing
+  - e2e
+  - qa
+research_references: []
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Task: NPC Trade Extraction Integration & E2E QA (Retry)
+
+## Objective
+Verify the end-to-end integration and test coverage for the NPC trade flag extraction logic across Gen 2 and Gen 3 save files.
+
+## Acceptance Criteria
+- [ ] Verify E2E test files for Gen 2 NPC trade flag extraction are robust and check expected flags.
+- [ ] Verify E2E test files for Gen 3 NPC trade flag extraction are robust and check expected flags.
+- [ ] Verify the tests cover both RSE and FRLG cases for Gen 3 and GS/Crystal for Gen 2 if applicable.


### PR DESCRIPTION
- Spawns `research-363-440` to investigate missing E2E save fixtures.
- Generates replacement tasks `task-363-441` and `task-363-442` that depend on the research node.
- Checks off permanently failed tasks in `story-349-363-trade-extraction-e2e` to prevent DAG deadlocks.
- Appends new nodes to the story to keep it pending.
- Logs architectural constraint regarding E2E fixtures in journal.

---
*PR created automatically by Jules for task [723613607689792303](https://jules.google.com/task/723613607689792303) started by @szubster*