### PR TITLE
fix: strip markdown wrappers from LLM JSON response

### DIFF
--- a/.foundry/journals/researcher/15275065586819407345.md
+++ b/.foundry/journals/researcher/15275065586819407345.md
@@ -1,0 +1,4 @@
+# Session 15275065586819407345
+
+- Learned that LLMs may wrap output in markdown code blocks, even when `responseMimeType` is set to `application/json` (e.g., ````json`). It is necessary to strip these tags explicitly using regex or similar before running `JSON.parse`. Trimming whitespace before performing this check handles edge cases.
+- It is important to clean up all temporary scripts, outputs, and patch backup files from the workspace prior to code review or submission to adhere to the strict `Scratchpad Cleanup Enforcement` policy.

--- a/.foundry/research/research-422-440-investigate-llm-json-markdown-tags.md
+++ b/.foundry/research/research-422-440-investigate-llm-json-markdown-tags.md
@@ -20,3 +20,6 @@ notes: ''
 # Investigate LLM JSON Markdown Tags Failure
 
 Investigate the integration test failure where the LLM returns JSON wrapped in markdown tags causing `JSON.parse` to throw an error. Find a robust solution to strip these markdown code blocks.
+
+## Acceptance Criteria
+- [x] Strip markdown wrappers off JSON returned by evaluateSemanticCondition

--- a/.github/scripts/semantic/evaluator.test.ts
+++ b/.github/scripts/semantic/evaluator.test.ts
@@ -73,6 +73,15 @@ describe('evaluateSemanticCondition', () => {
     );
   });
 
+  it('successfully parses json wrapped in markdown code blocks', async () => {
+    mockGenerateContent.mockResolvedValue({
+      text: '```json\n{"isEquivalent": true, "reasoning": "Matches."}\n```',
+    });
+
+    const result = await evaluateSemanticCondition('is greeting', 'hello');
+    expect(result).toEqual({ isEquivalent: true, reasoning: 'Matches.' });
+  });
+
   it('works with a real API request if key is present AND explicitly requested (integration)', async () => {
     // Only run this test if explicitly requested via env var to prevent exhausting API limits in CI
     vi.unstubAllEnvs();

--- a/.github/scripts/semantic/evaluator.ts
+++ b/.github/scripts/semantic/evaluator.ts
@@ -30,10 +30,16 @@ export async function evaluateSemanticCondition(
     },
   });
 
-  const textContent = response.text;
+  let textContent = response.text;
 
   if (!textContent) {
     throw new Error('Failed to extract text content from LLM response.');
+  }
+
+  textContent = textContent.trim();
+
+  if (textContent.startsWith('```')) {
+    textContent = textContent.replace(/^```(?:json)?\n?/, '').replace(/\n?```\n?$/, '');
   }
 
   try {


### PR DESCRIPTION
This PR implements logic in `evaluateSemanticCondition` to gracefully parse JSON returned from the LLM, even when wrapped in markdown code blocks. This resolves an integration failure caused by `JSON.parse` failing on responses containing ````json`.

Changes:
- Added `trim()` and regex replacement in `.github/scripts/semantic/evaluator.ts` to detect and remove markdown blocks.
- Added a unit test in `.github/scripts/semantic/evaluator.test.ts` to verify the stripping logic.
- Checked off the task acceptance criteria in `.foundry/research/research-422-440-investigate-llm-json-markdown-tags.md`.

---
*PR created automatically by Jules for task [15275065586819407345](https://jules.google.com/task/15275065586819407345) started by @szubster*