### PR TITLE
feat: living dex duplicate detection logic

### DIFF
--- a/.foundry/tasks/task-274-439-living-dex-evolution-duplicate-logic-impl.md
+++ b/.foundry/tasks/task-274-439-living-dex-evolution-duplicate-logic-impl.md
@@ -25,6 +25,6 @@ notes: ''
 This task implements the core logic to detect when the player possesses duplicate Pokemon across their physical Party and PC box arrays. A duplicate is defined as having more than one instance of the same species ID.
 
 ## Acceptance Criteria
-- [ ] Implement logic in `src/engine/livingDex/ghostTracker.ts` (or related modules) to accurately count the number of physical instances of each Pokemon species ID.
-- [ ] Implement a function to return a map or set of species IDs for which the player possesses duplicates (count > 1).
-- [ ] Maintain O(N) constraints when sweeping across active Party and PC box arrays.
+- [x] Implement logic in `src/engine/livingDex/ghostTracker.ts` (or related modules) to accurately count the number of physical instances of each Pokemon species ID.
+- [x] Implement a function to return a map or set of species IDs for which the player possesses duplicates (count > 1).
+- [x] Maintain O(N) constraints when sweeping across active Party and PC box arrays.

--- a/src/engine/livingDex/ghostTracker.test.ts
+++ b/src/engine/livingDex/ghostTracker.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import * as configModule from '../../utils/generationConfig';
 import type { SaveData } from '../saveParser/parsers/common';
-import { getLivingDexGhosts, getOwnedPokemonLocations } from './ghostTracker';
+import { getLivingDexDuplicates, getLivingDexGhosts, getOwnedPokemonLocations } from './ghostTracker';
 
 // Mock getGenerationConfig
 vi.mock('../../utils/generationConfig', () => ({
@@ -40,6 +40,48 @@ describe('ghostTracker', () => {
       pc: [],
     };
     expect(() => getLivingDexGhosts(mockSave as SaveData, true)).toThrowError(/NotImplemented/);
+  });
+});
+
+describe('getLivingDexDuplicates', () => {
+  it('identifies duplicate physical pokemon correctly up to maxDex', () => {
+    // Mock Gen 1 with 151
+    vi.mocked(configModule.getGenerationConfig).mockReturnValueOnce({
+      maxDex: 151,
+    } as import('../../utils/generationConfig').GenerationConfig);
+
+    const mockSave: Partial<SaveData> = {
+      generation: 1,
+      party: [1, 2, 3, 1, 0, 0], // Bulbasaur x2, Ivysaur, Venusaur
+      pc: [4, 5, 4, 1, 200, 0], // Charmander x2, Charmeleon, Bulbasaur x3 (200 is invalid/egg/beyond maxDex)
+    };
+
+    const duplicates = getLivingDexDuplicates(mockSave as SaveData);
+
+    expect(duplicates.size).toBe(2);
+    expect(duplicates.has(1)).toBe(true); // Bulbasaur is duplicate
+    expect(duplicates.has(4)).toBe(true); // Charmander is duplicate
+    expect(duplicates.has(2)).toBe(false); // Ivysaur is not
+    expect(duplicates.has(3)).toBe(false); // Venusaur is not
+    expect(duplicates.has(5)).toBe(false); // Charmeleon is not
+    expect(duplicates.has(200)).toBe(false); // Out of bounds
+  });
+
+  it('returns empty set if no duplicates exist', () => {
+    // Mock Gen 1 with 151
+    vi.mocked(configModule.getGenerationConfig).mockReturnValueOnce({
+      maxDex: 151,
+    } as import('../../utils/generationConfig').GenerationConfig);
+
+    const mockSave: Partial<SaveData> = {
+      generation: 1,
+      party: [1, 2, 3, 0, 0, 0], // Bulbasaur, Ivysaur, Venusaur
+      pc: [4, 5, 0, 0, 0, 0], // Charmander, Charmeleon
+    };
+
+    const duplicates = getLivingDexDuplicates(mockSave as SaveData);
+
+    expect(duplicates.size).toBe(0);
   });
 });
 

--- a/src/engine/livingDex/ghostTracker.ts
+++ b/src/engine/livingDex/ghostTracker.ts
@@ -48,6 +48,42 @@ export function getLivingDexGhosts(saveData: SaveData, regionalOnly = false): nu
   return ghosts;
 }
 
+/**
+ * Identifies which Pokémon the player possesses duplicates of within their physical Living Dex.
+ *
+ * @param saveData - The parsed binary save data indicating the player's progress and inventory.
+ * @returns A Set of Pokémon species IDs that the player possesses more than one of.
+ */
+export function getLivingDexDuplicates(saveData: SaveData): Set<number> {
+  const genConfig = getGenerationConfig(saveData.generation);
+  const maxDex = genConfig.maxDex;
+
+  const seen = new Set<number>();
+  const duplicates = new Set<number>();
+
+  for (const id of saveData.party) {
+    if (id > 0 && id <= maxDex) {
+      if (seen.has(id)) {
+        duplicates.add(id);
+      } else {
+        seen.add(id);
+      }
+    }
+  }
+
+  for (const id of saveData.pc) {
+    if (id > 0 && id <= maxDex) {
+      if (seen.has(id)) {
+        duplicates.add(id);
+      } else {
+        seen.add(id);
+      }
+    }
+  }
+
+  return duplicates;
+}
+
 export interface PokemonLocation {
   speciesId: number;
   box: number;


### PR DESCRIPTION
Implemented O(N) duplicate tracking logic for physical possession. Updates `getLivingDexDuplicates` in `ghostTracker.ts` and adds comprehensive tests.

---
*PR created automatically by Jules for task [3485909990663108683](https://jules.google.com/task/3485909990663108683) started by @szubster*