### PR TITLE
Break down Live Memory Reading epic into stories

### DIFF
--- a/.foundry/epics/epic-343-424-live-memory-reading.md
+++ b/.foundry/epics/epic-343-424-live-memory-reading.md
@@ -25,4 +25,7 @@ notes: ''
 Establish a direct channel to read WASM memory buffers in real-time, mapping standard save blocks and game state variables continuously during emulator execution.
 
 ## Acceptance Criteria
-- [ ] Story Owner: Break down this EPIC into STORY nodes. Ensure a final STORY is dedicated exclusively to Integration and E2E Verification.
+- [x] Story Owner: Break down this EPIC into STORY nodes. Ensure a final STORY is dedicated exclusively to Integration and E2E Verification.
+- [ ] story-424-435-wasm-memory-buffer-hook
+- [ ] story-424-436-save-block-mapping
+- [ ] story-424-437-live-memory-e2e

--- a/.foundry/stories/story-424-435-wasm-memory-buffer-hook.md
+++ b/.foundry/stories/story-424-435-wasm-memory-buffer-hook.md
@@ -1,0 +1,29 @@
+---
+id: story-424-435-wasm-memory-buffer-hook
+type: STORY
+title: WASM Memory Buffer Hook
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - epic-343-423-wasm-emulator-integration
+jules_session_id: null
+pr_number: null
+parent: epic-343-424-live-memory-reading
+tags:
+  - emulator
+  - memory
+  - wasm
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: WASM Memory Buffer Hook
+
+## Context
+As part of the Built-in Emulator Integration PRD (prd-137-343-built-in-emulator) and Live Memory Reading Epic (epic-343-424-live-memory-reading), we need to establish a direct channel to read WASM memory buffers in real-time. This story focuses on the foundational layer: safely hooking into the WASM instance to extract raw memory buffers continuously during emulator execution without causing performance degradation.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break down this STORY into TASK nodes, separating the memory hooking logic from integration tests.

--- a/.foundry/stories/story-424-436-save-block-mapping.md
+++ b/.foundry/stories/story-424-436-save-block-mapping.md
@@ -1,0 +1,29 @@
+---
+id: story-424-436-save-block-mapping
+type: STORY
+title: Save Block Mapping
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - story-424-435-wasm-memory-buffer-hook
+jules_session_id: null
+pr_number: null
+parent: epic-343-424-live-memory-reading
+tags:
+  - emulator
+  - memory
+  - parsing
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Save Block Mapping
+
+## Context
+Following the establishment of a real-time raw WASM memory buffer channel (story-424-435-wasm-memory-buffer-hook), we need to interpret this data. This story focuses on continuously mapping standard save blocks and game state variables from the live memory buffer and routing them through our existing standard save block parsers (adhering strictly to ADR 010 and related guidelines for Gen 3 data).
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break down this STORY into TASK nodes, ensuring discrete tasks for the mapping logic, state variables extraction, and integration with existing parsers.

--- a/.foundry/stories/story-424-437-live-memory-e2e.md
+++ b/.foundry/stories/story-424-437-live-memory-e2e.md
@@ -1,0 +1,29 @@
+---
+id: story-424-437-live-memory-e2e
+type: STORY
+title: Live Memory Integration and E2E Verification
+status: PENDING
+owner_persona: tech_lead
+created_at: '2026-08-14'
+updated_at: '2026-08-14'
+depends_on:
+  - story-424-436-save-block-mapping
+jules_session_id: null
+pr_number: null
+parent: epic-343-424-live-memory-reading
+tags:
+  - emulator
+  - memory
+  - e2e
+rejection_count: 0
+rejection_reason: ''
+notes: ''
+---
+
+# Story: Live Memory Integration and E2E Verification
+
+## Context
+As required by the Orchestrator Safeguard (E2E/Integration Requirement), this final story is dedicated exclusively to Integration and E2E Verification for the Live Memory Reading epic. We must verify that the raw WASM memory buffer hooking and subsequent save block mapping work continuously and correctly across simulated gameplay scenarios.
+
+## Acceptance Criteria
+- [ ] Tech Lead: Break down this STORY into a single TASK node for writing automated E2E and integration tests (Intelligent Verification Protocol).


### PR DESCRIPTION
Broke down epic-343-424-live-memory-reading into discrete STORY nodes:
- story-424-435-wasm-memory-buffer-hook
- story-424-436-save-block-mapping
- story-424-437-live-memory-e2e (Dedicated E2E Verification)

Ensured parent node markdown was updated with checkboxes without modifying YAML frontmatter, complying with orchestrator rules.

---
*PR created automatically by Jules for task [1081015487575046997](https://jules.google.com/task/1081015487575046997) started by @szubster*