### PR TITLE
fix(gen2): require hp > 0 for active roamer status

### DIFF
--- a/.foundry/journals/coder/18132436912921752968.md
+++ b/.foundry/journals/coder/18132436912921752968.md
@@ -1,0 +1,1 @@
+# Session: 18132436912921752968\n\n- Fixed Gen 2 Roamer active status detection to explicitly verify HP > 0 in addition to checking valid map groups, resolving issue where defeated/caught roamers were incorrectly flagged as active.

--- a/.foundry/tasks/task-298-440-gen2-roamer-status-hp-check-impl.md
+++ b/.foundry/tasks/task-298-440-gen2-roamer-status-hp-check-impl.md
@@ -32,5 +32,5 @@ The Gen 2 roamer extraction logic currently determines if a roamer is active sol
 - Self-verify the changes by running unit tests.
 
 ## Acceptance Criteria
-- [ ] Determine roamer activity based on both `MapGroup != 0xFF` and `HP > 0`.
-- [ ] Ensure all existing tests pass after the modification.
+- [x] Determine roamer activity based on both `MapGroup != 0xFF` and `HP > 0`.
+- [x] Ensure all existing tests pass after the modification.

--- a/src/engine/saveParser/parsers/gen2.test.ts
+++ b/src/engine/saveParser/parsers/gen2.test.ts
@@ -259,6 +259,7 @@ describe('gen2 parsers', () => {
       view.setUint8(roamingOffset + 1, 40); // Level
       view.setUint8(roamingOffset + 2, 5); // Map Group
       view.setUint8(roamingOffset + 3, 2); // Map ID
+      view.setUint8(roamingOffset + 4, 100); // HP
 
       const data = parseGen2(view, false);
       expect(data.hallOfFameCount).toBe(12);
@@ -269,7 +270,7 @@ describe('gen2 parsers', () => {
         mapGroup: 5,
         mapId: 2,
         isActive: true,
-        hp: 0,
+        hp: 100,
         ivs: { hp: 0, atk: 0, def: 0, spd: 0, spAtk: 0, spDef: 0 },
       });
     });
@@ -289,6 +290,7 @@ describe('gen2 parsers', () => {
       view.setUint8(roamingOffset + 1, 40); // Level
       view.setUint8(roamingOffset + 2, 8); // Map Group
       view.setUint8(roamingOffset + 3, 3); // Map ID
+      view.setUint8(roamingOffset + 4, 120); // HP
 
       const data = parseGen2(view, true);
       expect(data.hallOfFameCount).toBe(5);
@@ -299,7 +301,7 @@ describe('gen2 parsers', () => {
         mapGroup: 8,
         mapId: 3,
         isActive: true,
-        hp: 0,
+        hp: 120,
         ivs: { hp: 0, atk: 0, def: 0, spd: 0, spAtk: 0, spDef: 0 },
       });
     });
@@ -426,6 +428,36 @@ describe('gen2 parsers', () => {
       };
 
       expect(() => parseGen2(view, false)).toThrow('The save file is corrupted or incomplete.');
+    });
+
+    it('should mark a roamer as inactive if hp is 0, even with valid mapGroup', () => {
+      const buffer = new ArrayBuffer(32768);
+      const view = new DataView(buffer);
+      view.setUint8(0x288a, 1);
+      view.setUint8(0x288b, 1);
+      view.setUint8(0x288b + 7, 1);
+
+      view.setUint8(0x248c, 12); // GS HoF count
+
+      // Setup Entei (Species 244) as roaming in GS
+      const roamingOffset = 0x28da;
+      view.setUint8(roamingOffset, 244); // Species
+      view.setUint8(roamingOffset + 1, 40); // Level
+      view.setUint8(roamingOffset + 2, 5); // Map Group
+      view.setUint8(roamingOffset + 3, 2); // Map ID
+      view.setUint8(roamingOffset + 4, 0); // HP is 0 (defeated or caught)
+
+      const data = parseGen2(view, false);
+      expect(data.roamingLegendaries).toHaveLength(1);
+      expect(data.roamingLegendaries?.[0]).toEqual({
+        speciesId: 244,
+        level: 40,
+        mapGroup: 5,
+        mapId: 2,
+        isActive: false, // HP is 0, so should be inactive
+        hp: 0,
+        ivs: { hp: 0, atk: 0, def: 0, spd: 0, spAtk: 0, spDef: 0 },
+      });
     });
 
     it('should handle RangeError gracefully during roaming legendaries extraction', () => {

--- a/src/engine/saveParser/parsers/gen2.ts
+++ b/src/engine/saveParser/parsers/gen2.ts
@@ -776,13 +776,14 @@ function parseRoamingLegendaries(view: DataView, isCrystal: boolean) {
       if (speciesId === 243 || speciesId === 244 || speciesId === 245) {
         const mapGroup = view.getUint8(structOffset + ROAMER_OFFSET_MAP_GROUP);
         const rawDvs = parseDVs(view.getUint16(structOffset + ROAMER_OFFSET_DVS, false));
+        const hp = view.getUint8(structOffset + ROAMER_OFFSET_HP);
         legendaries.push({
           speciesId,
           level: view.getUint8(structOffset + ROAMER_OFFSET_LEVEL),
           mapGroup,
           mapId: view.getUint8(structOffset + ROAMER_OFFSET_MAP_NUMBER),
-          isActive: mapGroup !== ROAMER_INACTIVE_MAP_GROUP,
-          hp: view.getUint8(structOffset + ROAMER_OFFSET_HP),
+          isActive: mapGroup !== ROAMER_INACTIVE_MAP_GROUP && hp > 0,
+          hp,
           ivs: {
             hp: rawDvs.hp,
             atk: rawDvs.atk,


### PR DESCRIPTION
Fixes the Gen 2 Roamer parser to correctly mark roamers with HP 0 (defeated/caught) as inactive. Existing tests were updated to seed non-zero HP, and a new test was added to verify the HP === 0 check. This fulfills the `task-298-440-gen2-roamer-status-hp-check-impl.md` requirements.

---
*PR created automatically by Jules for task [18132436912921752968](https://jules.google.com/task/18132436912921752968) started by @szubster*