### PR TITLE
QA: Verify Pokerus State Exfiltration E2E test

### DIFF
--- a/.foundry/tasks/task-415-436-pokerus-state-exfiltration-e2e-qa.md
+++ b/.foundry/tasks/task-415-436-pokerus-state-exfiltration-e2e-qa.md
@@ -27,4 +27,4 @@ notes: ''
 This task is to verify that the E2E test for Pokerus data extraction works correctly and covers the necessary requirements.
 
 ## Acceptance Criteria
-- [ ] Verify the E2E test runs successfully and validates the Pokerus display in the UI.
+- [x] Verify the E2E test runs successfully and validates the Pokerus display in the UI.


### PR DESCRIPTION
Verified the Pokerus State Exfiltration E2E tests pass correctly by running `xvfb-run -a pnpm test:e2e tests/e2e/pokerus.spec.ts`. Checked off the acceptance criteria in the QA task markdown to allow node completion in accordance with the Empty PR and ADR 007 policies.

---
*PR created automatically by Jules for task [16158594650388419080](https://jules.google.com/task/16158594650388419080) started by @szubster*